### PR TITLE
NTP out of sync prompt fix if logger is disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,6 @@ func main() {
 	}
 
 	ActivateNTP()
-
 	ActivateConnectivityMonitor()
 	AdjustGoMaxProcs()
 

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 	}
 
 	ActivateNTP()
+
 	ActivateConnectivityMonitor()
 	AdjustGoMaxProcs()
 
@@ -223,7 +224,7 @@ func ActivateNTP() {
 			configNTPNegativeTime := (*bot.config.NTPClient.AllowedNegativeDifference - (*bot.config.NTPClient.AllowedNegativeDifference * 2))
 			if NTPcurrentTimeDifference > configNTPTime || NTPcurrentTimeDifference < configNTPNegativeTime {
 				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, configNTPTime, configNTPNegativeTime)
-				if bot.config.NTPClient.Level == 0 {
+				if *bot.config.Logging.Enabled == true && bot.config.NTPClient.Level == 0 {
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", errNTP)

--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func ActivateNTP() {
 			configNTPNegativeTime := (*bot.config.NTPClient.AllowedNegativeDifference - (*bot.config.NTPClient.AllowedNegativeDifference * 2))
 			if NTPcurrentTimeDifference > configNTPTime || NTPcurrentTimeDifference < configNTPNegativeTime {
 				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, configNTPTime, configNTPNegativeTime)
-				if *bot.config.Logging.Enabled == true && bot.config.NTPClient.Level == 0 {
+				if *bot.config.Logging.Enabled && bot.config.NTPClient.Level == 0 {
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", errNTP)


### PR DESCRIPTION
# Description

Currently if logging output is disabled and your local time is out of sync from one of the network servers it will still prompt for you to confirm if you wish to alert/warn or disable in future but wont display this message to output

This adds an additional check to only prompt if logging is enabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules