### PR TITLE
Fix unnecessary log.Fatals and os.Exits

### DIFF
--- a/currency/coinmarketcap/coinmarketcap.go
+++ b/currency/coinmarketcap/coinmarketcap.go
@@ -8,7 +8,6 @@ package coinmarketcap
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -80,18 +79,15 @@ func (c *Coinmarketcap) SetDefaults() {
 }
 
 // Setup sets user configuration
-func (c *Coinmarketcap) Setup(conf Settings) {
+func (c *Coinmarketcap) Setup(conf Settings) error {
 	if !conf.Enabled {
 		c.Enabled = false
-	} else {
-		c.Enabled = true
-		c.Verbose = conf.Verbose
-		c.APIkey = conf.APIkey
-		err := c.SetAccountPlan(conf.AccountPlan)
-		if err != nil {
-			log.Fatal(err)
-		}
 	}
+
+	c.Enabled = true
+	c.Verbose = conf.Verbose
+	c.APIkey = conf.APIkey
+	return c.SetAccountPlan(conf.AccountPlan)
 }
 
 // GetCryptocurrencyInfo returns all static metadata for one or more

--- a/currency/coinmarketcap/coinmarketcap_test.go
+++ b/currency/coinmarketcap/coinmarketcap_test.go
@@ -41,7 +41,14 @@ func TestSetup(t *testing.T) {
 	cfg.Enabled = true
 	cfg.AccountPlan = "basic"
 
-	c.Setup(cfg)
+	if err := c.Setup(cfg); err != nil {
+		t.Error(err)
+	}
+
+	cfg.AccountPlan = "meow"
+	if err := c.Setup(cfg); err == nil {
+		t.Error("expected err when invalid account plan is specified")
+	}
 }
 
 func TestCheckAccountPlan(t *testing.T) {

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -116,15 +116,20 @@ func (s *Storage) RunUpdater(overrides BotOverrides, settings *MainConfiguration
 		log.Debugf("Setting up currency analysis system with Coinmarketcap...")
 		c := &coinmarketcap.Coinmarketcap{}
 		c.SetDefaults()
-		c.Setup(coinmarketcap.Settings{
+		err := c.Setup(coinmarketcap.Settings{
 			Name:        settings.CryptocurrencyProvider.Name,
 			Enabled:     true,
 			AccountPlan: settings.CryptocurrencyProvider.AccountPlan,
 			APIkey:      settings.CryptocurrencyProvider.APIkey,
 			Verbose:     settings.CryptocurrencyProvider.Verbose,
 		})
-
-		s.currencyAnalysis = c
+		if err != nil {
+			log.Errorf("Unable to setup CoinMarketCap analysis. Error: %s", err)
+			c = nil
+			settings.CryptocurrencyProvider.Enabled = false
+		} else {
+			s.currencyAnalysis = c
+		}
 	}
 
 	if filePath == "" {

--- a/exchange.go
+++ b/exchange.go
@@ -258,7 +258,4 @@ func SetupExchanges() {
 		)
 	}
 	wg.Wait()
-	if len(bot.exchanges) == 0 {
-		log.Fatalf("No exchanges were able to be loaded. Exiting")
-	}
 }

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -163,7 +162,7 @@ func HTTPRecord(res *http.Response, service string, respContents []byte) error {
 
 						mockRespVals, urlErr := url.ParseQuery(mockResponses[i].BodyParams)
 						if urlErr != nil {
-							log.Fatal(urlErr)
+							return urlErr
 						}
 
 						if MatchURLVals(respQueryVals, mockRespVals) {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,9 @@ func main() {
 	log.Debugf("Global HTTP request timeout: %v.\n", common.HTTPClient.Timeout)
 
 	SetupExchanges()
+	if len(bot.exchanges) == 0 {
+		log.Fatal("No exchanges were able to be loaded. Exiting")
+	}
 
 	log.Debugf("Starting communication mediums..")
 	cfg := bot.config.GetCommunicationsConfig()


### PR DESCRIPTION
# Description

Cleans up unnecessary log.Fatals around the codebase where neccessary. There still exists some for exchange loading via Setup but these have all been fixed in engine branch.

Also moves the os.Exit(1) if number of loaded exchanges == 0 from SetupExchanges to main, so developers don't have to look through the code too far if they find out their programs exits on them unexpectedly. 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

go test ./... -race

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules