### PR TITLE
(Engine) Logger - fixes issues with multiwriter go routine 

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -34,11 +34,15 @@ func (l *Logger) newLogEvent(data, header string, w io.Writer) error {
 	if data == "" || data[len(data)-1] != '\n' {
 		e.data = append(e.data, '\n')
 	}
-	e.output.Write(e.data)
+	_, err := e.output.Write(e.data)
+	if err != nil {
+		fmt.Printf("Log Write failed: %v\n", err)
+	}
+
 	e.data = e.data[:0]
 	eventPool.Put(e)
 
-	return nil
+	return err
 }
 
 // CloseLogger is called on shutdown of application
@@ -58,6 +62,7 @@ func validSubLogger(s string) (bool, *subLogger) {
 	return false, nil
 }
 
+// Level retries the current sublogger levels
 func Level(s string) (*Levels, error) {
 	found, logger := validSubLogger(s)
 	if !found {
@@ -67,6 +72,7 @@ func Level(s string) (*Levels, error) {
 	return &logger.Levels, nil
 }
 
+// SetLevel sets sublogger levels
 func SetLevel(s, level string) (*Levels, error) {
 	found, logger := validSubLogger(s)
 	if !found {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,6 +22,7 @@ func (l *Logger) newLogEvent(data, header string, w io.Writer) error {
 	if w == nil {
 		return errors.New("io.Writer not set")
 	}
+
 	e := eventPool.Get().(*LogEvent)
 	e.output = w
 	e.data = append(e.data, []byte(header)...)
@@ -35,9 +36,6 @@ func (l *Logger) newLogEvent(data, header string, w io.Writer) error {
 		e.data = append(e.data, '\n')
 	}
 	_, err := e.output.Write(e.data)
-	if err != nil {
-		fmt.Printf("Log Write failed: %v\n", err)
-	}
 
 	e.data = e.data[:0]
 	eventPool.Put(e)

--- a/logger/logger_rotate.go
+++ b/logger/logger_rotate.go
@@ -75,8 +75,7 @@ func (r *Rotate) openNew() error {
 	_, err := os.Stat(name)
 
 	if err == nil {
-		t := time.Now()
-		timestamp := t.Format("2006-01-02T15-04-05")
+		timestamp := time.Now().Format("2006-01-02T15-04-05")
 		newName := filepath.Join(LogPath, timestamp+"-"+r.FileName)
 
 		err = os.Rename(name, newName)

--- a/logger/logger_rotate.go
+++ b/logger/logger_rotate.go
@@ -72,13 +72,13 @@ func (r *Rotate) openOrCreateFile(n int64) error {
 
 func (r *Rotate) openNew() error {
 	name := filepath.Join(LogPath, r.FileName)
-
-	t := time.Now()
-	timestamp := t.Format("2006-01-02T15-04-05")
-	newName := filepath.Join(LogPath, timestamp+"-"+r.FileName)
 	_, err := os.Stat(name)
 
 	if err == nil {
+		t := time.Now()
+		timestamp := t.Format("2006-01-02T15-04-05")
+		newName := filepath.Join(LogPath, timestamp+"-"+r.FileName)
+
 		err = os.Rename(name, newName)
 		if err != nil {
 			return fmt.Errorf("can't rename log file: %s", err)
@@ -105,6 +105,7 @@ func (r *Rotate) close() (err error) {
 	return err
 }
 
+// Close handler for open file
 func (r *Rotate) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/logger/logger_setup.go
+++ b/logger/logger_setup.go
@@ -27,7 +27,6 @@ func getWriters(s *SubLoggerConfig) io.Writer {
 			m.Add(ioutil.Discard)
 		}
 	}
-
 	return m
 }
 

--- a/logger/logger_types.go
+++ b/logger/logger_types.go
@@ -51,6 +51,7 @@ type Logger struct {
 	Spacer                                           string
 }
 
+// Levels flags for each sub logger type
 type Levels struct {
 	Info, Debug, Warn, Error bool
 }
@@ -61,6 +62,7 @@ type subLogger struct {
 	output io.Writer
 }
 
+// LogEvent holds the data sent to the log and which multiwriter to send to
 type LogEvent struct {
 	data   []byte
 	output io.Writer
@@ -68,14 +70,17 @@ type LogEvent struct {
 
 type multiWriter struct {
 	writers []io.Writer
-	mu      sync.Mutex
+	mu      sync.RWMutex
 }
 
 var (
-	logger                         = &Logger{}
+	logger = &Logger{}
+	// FileLoggingConfiguredCorrectly flag set during config check if file logging meets requirements
 	FileLoggingConfiguredCorrectly bool
-	GlobalLogConfig                = &Config{} // GlobalLogConfig hold global configuration options for logger
-	GlobalLogFile                  = &Rotate{}
+	// GlobalLogConfig holds global configuration options for logger
+	GlobalLogConfig = &Config{}
+	// GlobalLogFile hold global configuration options for file logger
+	GlobalLogFile = &Rotate{}
 
 	eventPool = &sync.Pool{
 		New: func() interface{} {
@@ -85,5 +90,6 @@ var (
 		},
 	}
 
+	// LogPath system path to store log files in
 	LogPath string
 )

--- a/logger/loggers.go
+++ b/logger/loggers.go
@@ -163,6 +163,6 @@ func Errorf(sl *subLogger, data string, v ...interface{}) {
 
 func displayError(err error) {
 	if err != nil {
-		log.Printf("logger write error: %v", err)
+		log.Printf("Logger write error: %v\n", err)
 	}
 }

--- a/logger/loggers.go
+++ b/logger/loggers.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"log"
 )
 
 // Info takes a pointer subLogger struct and string sends to newLogEvent
@@ -14,7 +15,7 @@ func Info(sl *subLogger, data string) {
 		return
 	}
 
-	logger.newLogEvent(data, logger.InfoHeader, sl.output)
+	displayError(logger.newLogEvent(data, logger.InfoHeader, sl.output))
 }
 
 // Infoln takes a pointer subLogger struct and interface sends to newLogEvent
@@ -27,7 +28,7 @@ func Infoln(sl *subLogger, v ...interface{}) {
 		return
 	}
 
-	logger.newLogEvent(fmt.Sprintln(v...), logger.InfoHeader, sl.output)
+	displayError(logger.newLogEvent(fmt.Sprintln(v...), logger.InfoHeader, sl.output))
 }
 
 // Infof takes a pointer subLogger struct, string & interface formats and sends to Info()
@@ -53,7 +54,7 @@ func Debug(sl *subLogger, data string) {
 		return
 	}
 
-	logger.newLogEvent(data, logger.DebugHeader, sl.output)
+	displayError(logger.newLogEvent(data, logger.DebugHeader, sl.output))
 }
 
 // Debugln  takes a pointer subLogger struct, string and interface sends to newLogEvent
@@ -66,7 +67,7 @@ func Debugln(sl *subLogger, v ...interface{}) {
 		return
 	}
 
-	logger.newLogEvent(fmt.Sprintln(v...), logger.DebugHeader, sl.output)
+	displayError(logger.newLogEvent(fmt.Sprintln(v...), logger.DebugHeader, sl.output))
 }
 
 // Debugf takes a pointer subLogger struct, string & interface formats and sends to Info()
@@ -92,7 +93,7 @@ func Warn(sl *subLogger, data string) {
 		return
 	}
 
-	logger.newLogEvent(data, logger.WarnHeader, sl.output)
+	displayError(logger.newLogEvent(data, logger.WarnHeader, sl.output))
 }
 
 // Warnln takes a pointer subLogger struct & interface formats and sends to newLogEvent()
@@ -105,7 +106,7 @@ func Warnln(sl *subLogger, v ...interface{}) {
 		return
 	}
 
-	logger.newLogEvent(fmt.Sprintln(v...), logger.WarnHeader, sl.output)
+	displayError(logger.newLogEvent(fmt.Sprintln(v...), logger.WarnHeader, sl.output))
 }
 
 // Warnf takes a pointer subLogger struct, string & interface formats and sends to Warn()
@@ -131,7 +132,7 @@ func Error(sl *subLogger, data ...interface{}) {
 		return
 	}
 
-	logger.newLogEvent(fmt.Sprint(data...), logger.ErrorHeader, sl.output)
+	displayError(logger.newLogEvent(fmt.Sprint(data...), logger.ErrorHeader, sl.output))
 }
 
 // Errorln takes a pointer subLogger struct, string & interface formats and sends to newLogEvent()
@@ -144,7 +145,7 @@ func Errorln(sl *subLogger, v ...interface{}) {
 		return
 	}
 
-	logger.newLogEvent(fmt.Sprintln(v...), logger.ErrorHeader, sl.output)
+	displayError(logger.newLogEvent(fmt.Sprintln(v...), logger.ErrorHeader, sl.output))
 }
 
 // Errorf takes a pointer subLogger struct, string & interface formats and sends to Debug()
@@ -158,4 +159,10 @@ func Errorf(sl *subLogger, data string, v ...interface{}) {
 	}
 
 	Error(sl, fmt.Sprintf(data, v...))
+}
+
+func displayError(err error) {
+	if err != nil {
+		log.Printf("logger write error: %v", err)
+	}
 }

--- a/logger/sublogger_types.go
+++ b/logger/sublogger_types.go
@@ -1,5 +1,6 @@
 package logger
 
+//nolint
 var (
 	subLoggers = map[string]*subLogger{}
 


### PR DESCRIPTION
# Description

This PR Fixes an issue with unbuffered channels and multiwriter

Also some general improvements and added some comments


_please ignore the nolint in sublogger_types.go I didn't want to comment 16 times_
```go
        // ConnectionMgr sublogger does stuff and things
	ConnectionMgr    *subLogger
        // CommunicationMgr sublogger does stuff and things
	CommunicationMgr *subLogger
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Automated testing using go test ./..
Manual testing of application running
pprof monitoring

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules