### PR TITLE
Engine: bugfix: OKEX Future swap panic

### DIFF
--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -143,7 +143,7 @@ func (o *OKEX) Run() {
 
 	if o.Config.CurrencyPairs.Pairs[asset.Spot].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Spot].RequestFormat == nil ||
 		o.Config.CurrencyPairs.Pairs[asset.Index].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Index].RequestFormat == nil {
-		fmt := currency.PairStore{
+		currFmt := currency.PairStore{
 			RequestFormat: &currency.PairFormat{
 				Uppercase: true,
 				Delimiter: "-",
@@ -153,15 +153,15 @@ func (o *OKEX) Run() {
 				Delimiter: "-",
 			},
 		}
-		o.CurrencyPairs.Store(asset.Spot, fmt)
-		o.Config.CurrencyPairs.Store(asset.Spot, fmt)
-		o.CurrencyPairs.Store(asset.Index, fmt)
-		o.Config.CurrencyPairs.Store(asset.Index, fmt)
+		o.CurrencyPairs.Store(asset.Spot, currFmt)
+		o.Config.CurrencyPairs.Store(asset.Spot, currFmt)
+		o.CurrencyPairs.Store(asset.Index, currFmt)
+		o.Config.CurrencyPairs.Store(asset.Index, currFmt)
 	}
 
 	if o.Config.CurrencyPairs.Pairs[asset.Futures].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Futures].RequestFormat == nil ||
 		o.Config.CurrencyPairs.Pairs[asset.PerpetualSwap].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.PerpetualSwap].RequestFormat == nil {
-		fmt := currency.PairStore{
+		currFmt := currency.PairStore{
 			RequestFormat: &currency.PairFormat{
 				Uppercase: true,
 				Delimiter: "-",
@@ -171,10 +171,10 @@ func (o *OKEX) Run() {
 				Delimiter: "_",
 			},
 		}
-		o.CurrencyPairs.Store(asset.Futures, fmt)
-		o.Config.CurrencyPairs.Store(asset.Futures, fmt)
-		o.CurrencyPairs.Store(asset.PerpetualSwap, fmt)
-		o.Config.CurrencyPairs.Store(asset.PerpetualSwap, fmt)
+		o.CurrencyPairs.Store(asset.Futures, currFmt)
+		o.Config.CurrencyPairs.Store(asset.Futures, currFmt)
+		o.CurrencyPairs.Store(asset.PerpetualSwap, currFmt)
+		o.Config.CurrencyPairs.Store(asset.PerpetualSwap, currFmt)
 	}
 
 	if !common.StringDataContains(o.Config.CurrencyPairs.Pairs[asset.Spot].Enabled.Strings(), o.CurrencyPairs.Pairs[asset.Spot].RequestFormat.Delimiter) {

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -140,7 +140,9 @@ func (o *OKEX) Run() {
 	if o.Verbose {
 		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", o.GetName(), common.IsEnabled(o.Websocket.IsEnabled()), o.API.Endpoints.WebsocketURL)
 	}
-	if o.Config.CurrencyPairs.Pairs[asset.Spot].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Spot].RequestFormat == nil {
+
+	if o.Config.CurrencyPairs.Pairs[asset.Spot].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Spot].RequestFormat == nil ||
+		o.Config.CurrencyPairs.Pairs[asset.Index].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Index].RequestFormat == nil {
 		fmt := currency.PairStore{
 			RequestFormat: &currency.PairFormat{
 				Uppercase: true,
@@ -153,6 +155,26 @@ func (o *OKEX) Run() {
 		}
 		o.CurrencyPairs.Store(asset.Spot, fmt)
 		o.Config.CurrencyPairs.Store(asset.Spot, fmt)
+		o.CurrencyPairs.Store(asset.Index, fmt)
+		o.Config.CurrencyPairs.Store(asset.Index, fmt)
+	}
+
+	if o.Config.CurrencyPairs.Pairs[asset.Futures].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.Futures].RequestFormat == nil ||
+		o.Config.CurrencyPairs.Pairs[asset.PerpetualSwap].ConfigFormat == nil || o.Config.CurrencyPairs.Pairs[asset.PerpetualSwap].RequestFormat == nil {
+		fmt := currency.PairStore{
+			RequestFormat: &currency.PairFormat{
+				Uppercase: true,
+				Delimiter: "-",
+			},
+			ConfigFormat: &currency.PairFormat{
+				Uppercase: true,
+				Delimiter: "_",
+			},
+		}
+		o.CurrencyPairs.Store(asset.Futures, fmt)
+		o.Config.CurrencyPairs.Store(asset.Futures, fmt)
+		o.CurrencyPairs.Store(asset.PerpetualSwap, fmt)
+		o.Config.CurrencyPairs.Store(asset.PerpetualSwap, fmt)
 	}
 
 	if !common.StringDataContains(o.Config.CurrencyPairs.Pairs[asset.Spot].Enabled.Strings(), o.CurrencyPairs.Pairs[asset.Spot].RequestFormat.Delimiter) {


### PR DESCRIPTION
# Description

My previous PR included changes concerning config upscaling for OKEX. While it can successfully update a master branch `config_example.json`, it fails when dealing with a config that has already been updated to `engine` style - causing widespread `panic`.

This PR fixes that by being explicit about the config delimiter styles for OKEX and not just trying to deal with SPOT.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
-`go test ./...`
- Running GCT with a `config_example.json` 
- Running GCT with an upscaled config and an OKEX currency pair configuration like the following (where ... are the default currencies):

```
"currencyPairs": {
    "requestFormat": {
     "uppercase": false,
     "delimiter": "_"
    },
    "configFormat": {
     "uppercase": true,
     "delimiter": "_"
    },
    "useGlobalFormat": true,
    "assetTypes": [
     "spot",
     "futures",
     "perpetualswap",
     "index"
    ],
    "pairs": {
     "futures": {
      "enabled": "...",
      "available": "..."
     },
     "index": {
      "enabled": "...",
      "available": "..."
     },
     "perpetualswap": {
      "enabled": "...",
      "available": "..."
     },
     "spot": {
      "enabled": "...",
      "available": "..."
     }
    }
   },
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules