### PR TITLE
(Engine) Gate-IO Websocket subscription pairs case sensitivity 

### DIFF
--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -373,7 +373,7 @@ func (g *Gateio) Unsubscribe(channelToSubscribe wshandler.WebsocketChannelSubscr
 		ID:     g.WebsocketConn.GenerateMessageID(true),
 		Method: unsbuscribeText,
 		Params: []interface{}{g.FormatExchangeCurrency(channelToSubscribe.Currency,
-			asset.Spot).String(), 1800},
+			asset.Spot).Upper(), 1800},
 	}
 	resp, err := g.WebsocketConn.SendMessageReturnResponse(subscribe.ID, subscribe)
 	if err != nil {

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -339,7 +339,8 @@ func (g *Gateio) GenerateDefaultSubscriptions() {
 // Subscribe sends a websocket message to receive data from the channel
 func (g *Gateio) Subscribe(channelToSubscribe wshandler.WebsocketChannelSubscription) error {
 	params := []interface{}{g.FormatExchangeCurrency(channelToSubscribe.Currency,
-		asset.Spot).String()}
+		asset.Spot).Upper()}
+
 	for i := range channelToSubscribe.Params {
 		params = append(params, channelToSubscribe.Params[i])
 	}


### PR DESCRIPTION
# Description

Fun happy little accident i ran into while testing 

GateIO pairs are upper case & case sensitive on Websocket for Orderbook/ticker (and lower case on REST :D)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Automated unit tets all pass as required

Manual confirmation of valid output being received 

Before:
```sh
[DEBUG] |  12/09/2019 10:29:06  | GateIO Subscribing to ticker.subscribe BTC_USDT
[DEBUG] |  12/09/2019 10:29:06  | GateIO sending message to websocket {"id":1568248146292412809,"method":"ticker.subscribe","params":["btc_usdt"]}
[DEBUG] |  12/09/2019 10:29:06  | GateIO Websocket message received: {"error": null, "result": {"status": "success"}, "id": 1568248146292412809}
[DEBUG] |  12/09/2019 10:29:06  | GateIO has received a traffic alert. Setting status to connected
[DEBUG] |  12/09/2019 10:29:07  | GateIO checking connection
[DEBUG] |  12/09/2019 10:29:09  | GateIO checking connection
[DEBUG] |  12/09/2019 10:29:11  | GateIO checking connection
[DEBUG] |  12/09/2019 10:29:12  | GateIO has not received a traffic alert in 5 seconds.
[DEBUG] |  12/09/2019 10:29:12  | GateIO checking subscriptions
[DEBUG] |  12/09/2019 10:29:13  | GateIO checking connection
[DEBUG] |  12/09/2019 10:29:13  | GateIO no connection. Attempt 0/5
[DEBUG] |  12/09/2019 10:29:15  | GateIO checking connection
[DEBUG] |  12/09/2019 10:29:15  | GateIO no connection. Attempt 1/5
[WARN]  |  12/09/2019 10:29:16  | GateIO BTC-USDT: No ticker update after 10 seconds, switching from websocket to rest

```
After:
```sh
[DEBUG] |  12/09/2019 10:24:48  | GateIO sending message to websocket {"id":1568247888896569975,"method":"ticker.subscribe","params":["BTC_USDT"]}
[DEBUG] |  12/09/2019 10:24:49  | GateIO Websocket message received: {"error": null, "result": {"status": "success"}, "id": 1568247888896569975}
[DEBUG] |  12/09/2019 10:24:49  | GateIO Websocket message received: {"method": "ticker.update", "params": ["BTC_USDT", {"period": 86400, "open": "10173.38", "close": "10136.6", "high": "10200", "low": "9899", "last": "10136.6", "change": "-0.35", "quoteVolume": "1321.8949363485", "baseVolume": "13283036.563626742516130837"}], "id": null}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules