### PR TITLE
Bugfix: Lbank infinite loop

### DIFF
--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -400,13 +400,10 @@ func (l *Lbank) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) ([]
 	var finalResp []exchange.OrderDetail
 	var resp exchange.OrderDetail
 	var tempCurr currency.Pairs
-	var x int
 	if len(getOrdersRequest.Currencies) == 0 {
 		tempCurr = l.GetEnabledCurrencies()
 	} else {
-		for x < len(getOrdersRequest.Currencies) {
-			tempCurr = getOrdersRequest.Currencies
-		}
+		tempCurr = getOrdersRequest.Currencies
 	}
 	for a := range tempCurr {
 		p := exchange.FormatExchangeCurrency(l.Name, tempCurr[a])


### PR DESCRIPTION

![around1](https://user-images.githubusercontent.com/9261323/64831642-f4236e80-d619-11e9-9a60-867190a444c4.gif)

Fixes an infinite loop when running `GetOrderHistory` on LBank. Discovered when testing https://github.com/thrasher-corp/gocryptotrader/pull/353

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
https://github.com/thrasher-corp/gocryptotrader/pull/353
GetOrderHistory finishes executing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules