### PR TITLE
Bugfix - Coinut currency pair format panic

### DIFF
--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -47,6 +47,7 @@ type COINUT struct {
 	exchange.Base
 	WebsocketConn *wshandler.WebsocketConnection
 	InstrumentMap map[string]int
+	CurrencyMap   map[int]string
 }
 
 // GetInstruments returns instruments

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -551,10 +551,8 @@ func (c *COINUT) GetActiveOrders(getOrdersRequest *exchange.GetOrdersRequest) ([
 	for instrument, allInstrumentData := range instruments.Instruments {
 		for _, instrumentData := range allInstrumentData {
 			for _, currency := range getOrdersRequest.Currencies {
-				currStr := fmt.Sprintf("%v%v%v",
-					currency.Base.String(),
-					c.CurrencyPairs.Get(asset.Spot).ConfigFormat.Delimiter,
-					currency.Quote.String())
+				currStr := currency.Format(c.CurrencyPairs.RequestFormat.Delimiter,
+					c.CurrencyPairs.RequestFormat.Uppercase).String()
 				if strings.EqualFold(currStr, instrument) {
 					openOrders, err := c.GetOpenOrders(instrumentData.InstID)
 					if err != nil {


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/9261323/64931078-72318080-d879-11e9-9259-5185c21abd80.png)

During testing of https://github.com/thrasher-corp/gocryptotrader/pull/353 I noticed Coinut kept failing. Since Coinut uses a global currency pair format, it cannot use specific asset formatting as it will cause a panic.  I refer to the global currency request format instead.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Using https://github.com/thrasher-corp/gocryptotrader/pull/353

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings