### PR TITLE
Feature+Bugfix: Engine websocket management

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ const (
 	configDefaultWebsocketResponseCheckTimeout = time.Millisecond * 30
 	configDefaultWebsocketResponseMaxLimit     = time.Second * 7
 	configDefaultWebsocketOrderbookBufferLimit = 5
+	configDefaultWebsocketTrafficTimeout       = time.Second * 120
 	configMaxAuthFailures                      = 3
 	defaultNTPAllowedDifference                = 50000000
 	defaultNTPAllowedNegativeDifference        = 50000000
@@ -1023,6 +1024,11 @@ func (c *Config) CheckExchangeConfigValues() error {
 				log.Warnf(log.ExchangeSys, "Exchange %s Websocket response max limit value not set, defaulting to %v.",
 					c.Exchanges[i].Name, configDefaultWebsocketResponseMaxLimit)
 				c.Exchanges[i].WebsocketResponseMaxLimit = configDefaultWebsocketResponseMaxLimit
+			}
+			if c.Exchanges[i].WebsocketTrafficTimeout <= 0 {
+				log.Warnf(log.ExchangeSys, "Exchange %s Websocket response traffic timeout value not set, defaulting to %v.",
+					c.Exchanges[i].Name, configDefaultWebsocketTrafficTimeout)
+				c.Exchanges[i].WebsocketTrafficTimeout = configDefaultWebsocketTrafficTimeout
 			}
 			if c.Exchanges[i].WebsocketOrderbookBufferLimit <= 0 {
 				log.Warnf(log.ExchangeSys, "Exchange %s Websocket orderbook buffer limit value not set, defaulting to %v.",

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ const (
 	configDefaultWebsocketResponseCheckTimeout = time.Millisecond * 30
 	configDefaultWebsocketResponseMaxLimit     = time.Second * 7
 	configDefaultWebsocketOrderbookBufferLimit = 5
-	configDefaultWebsocketTrafficTimeout       = time.Second * 15
+	configDefaultWebsocketTrafficTimeout       = time.Second * 30
 	configMaxAuthFailures                      = 3
 	defaultNTPAllowedDifference                = 50000000
 	defaultNTPAllowedNegativeDifference        = 50000000

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ const (
 	configDefaultWebsocketResponseCheckTimeout = time.Millisecond * 30
 	configDefaultWebsocketResponseMaxLimit     = time.Second * 7
 	configDefaultWebsocketOrderbookBufferLimit = 5
-	configDefaultWebsocketTrafficTimeout       = time.Second * 120
+	configDefaultWebsocketTrafficTimeout       = time.Minute * 2
 	configMaxAuthFailures                      = 3
 	defaultNTPAllowedDifference                = 50000000
 	defaultNTPAllowedNegativeDifference        = 50000000

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ const (
 	configDefaultWebsocketResponseCheckTimeout = time.Millisecond * 30
 	configDefaultWebsocketResponseMaxLimit     = time.Second * 7
 	configDefaultWebsocketOrderbookBufferLimit = 5
-	configDefaultWebsocketTrafficTimeout       = time.Minute * 2
+	configDefaultWebsocketTrafficTimeout       = time.Second * 15
 	configMaxAuthFailures                      = 3
 	defaultNTPAllowedDifference                = 50000000
 	defaultNTPAllowedNegativeDifference        = 50000000

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1451,6 +1451,7 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 	cfg.Exchanges[0].WebsocketResponseMaxLimit = 0
 	cfg.Exchanges[0].WebsocketResponseCheckTimeout = 0
 	cfg.Exchanges[0].WebsocketOrderbookBufferLimit = 0
+	cfg.Exchanges[0].WebsocketTrafficTimeout = 0
 	cfg.Exchanges[0].HTTPTimeout = 0
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
@@ -1463,6 +1464,10 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 	}
 	if cfg.Exchanges[0].WebsocketOrderbookBufferLimit == 0 {
 		t.Errorf("expected exchange %s to have updated WebsocketOrderbookBufferLimit value",
+			cfg.Exchanges[0].Name)
+	}
+	if cfg.Exchanges[0].WebsocketTrafficTimeout == 0 {
+		t.Errorf("expected exchange %s to have updated WebsocketTrafficTimeout value",
 			cfg.Exchanges[0].Name)
 	}
 	if cfg.Exchanges[0].HTTPTimeout == 0 {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -59,6 +59,7 @@ type ExchangeConfig struct {
 	HTTPRateLimiter               *HTTPRateLimitConfig   `json:"httpRateLimiter,omitempty"`
 	WebsocketResponseCheckTimeout time.Duration          `json:"websocketResponseCheckTimeout"`
 	WebsocketResponseMaxLimit     time.Duration          `json:"websocketResponseMaxLimit"`
+	WebsocketTrafficTimeout       time.Duration          `json:"websocketTrafficTimeout"`
 	WebsocketOrderbookBufferLimit int                    `json:"websocketOrderbookBufferLimit"`
 	ProxyAddress                  string                 `json:"proxyAddress,omitempty"`
 	BaseCurrencies                currency.Currencies    `json:"baseCurrencies"`

--- a/engine/exchange.go
+++ b/engine/exchange.go
@@ -228,7 +228,6 @@ func LoadExchange(name string, useWG bool, wg *sync.WaitGroup) error {
 			if exchCfg.Features.Supports.RESTCapabilities.AutoPairUpdates {
 				exchCfg.Features.Enabled.AutoPairUpdates = false
 			}
-
 		}
 	}
 

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -380,14 +380,7 @@ func WebsocketDataHandler(ws *wshandler.Websocket) {
 				}
 
 			case error:
-				switch {
-				case strings.Contains(d.Error(), "close 1006"):
-					go ws.Connect()
-					continue
-				default:
-					log.Errorf(log.WebsocketMgr, "routines.go exchange %s websocket error - %s", ws.GetName(), data)
-				}
-
+				log.Errorf(log.WebsocketMgr, "routines.go exchange %s websocket error - %s", ws.GetName(), data)
 			case wshandler.TradeData:
 				// Trade Data
 				// if Bot.Settings.Verbose {

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -354,42 +354,11 @@ func Websocketshutdown(ws *wshandler.Websocket) error {
 	}
 }
 
-// streamDiversion is a diversion switch from websocket to REST or other
-// alternative feed
-func streamDiversion(ws *wshandler.Websocket) {
-	wg.Add(1)
-	defer wg.Done()
-	var connectedMessageSent, switchMessageSent bool
-	for {
-		select {
-		case <-shutdowner:
-			return
-		default:
-			if ws.IsConnected() {
-				if Bot.Settings.Verbose && !connectedMessageSent {
-					log.Debugf(log.WebsocketMgr, "exchange %s websocket feed connected\n", ws.GetName())
-					connectedMessageSent = true
-				}
-				switchMessageSent = false
-			} else {
-				if Bot.Settings.Verbose && !switchMessageSent {
-					log.Debugf(log.WebsocketMgr, "exchange %s websocket feed disconnected, switching to REST functionality\n",
-						ws.GetName())
-					switchMessageSent = true
-				}
-				connectedMessageSent = false
-			}
-		}
-	}
-}
-
 // WebsocketDataHandler handles websocket data coming from a websocket feed
 // associated with an exchange
 func WebsocketDataHandler(ws *wshandler.Websocket) {
 	wg.Add(1)
 	defer wg.Done()
-
-	go streamDiversion(ws)
 
 	for {
 		select {

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -359,21 +359,25 @@ func Websocketshutdown(ws *wshandler.Websocket) error {
 func streamDiversion(ws *wshandler.Websocket) {
 	wg.Add(1)
 	defer wg.Done()
-
+	var connectedMessageSent, switchMessageSent bool
 	for {
 		select {
 		case <-shutdowner:
 			return
-
-		case <-ws.Connected:
-			if Bot.Settings.Verbose {
-				log.Debugf(log.WebsocketMgr, "exchange %s websocket feed connected\n", ws.GetName())
-			}
-
-		case <-ws.Disconnected:
-			if Bot.Settings.Verbose {
-				log.Debugf(log.WebsocketMgr, "exchange %s websocket feed disconnected, switching to REST functionality\n",
-					ws.GetName())
+		default:
+			if ws.IsConnected() {
+				if Bot.Settings.Verbose && !connectedMessageSent {
+					log.Debugf(log.WebsocketMgr, "exchange %s websocket feed connected\n", ws.GetName())
+					connectedMessageSent = true
+				}
+				switchMessageSent = false
+			} else {
+				if Bot.Settings.Verbose && !switchMessageSent {
+					log.Debugf(log.WebsocketMgr, "exchange %s websocket feed disconnected, switching to REST functionality\n",
+						ws.GetName())
+					switchMessageSent = true
+				}
+				connectedMessageSent = false
 			}
 		}
 	}

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -409,7 +409,7 @@ func WebsocketDataHandler(ws *wshandler.Websocket) {
 			case error:
 				switch {
 				case strings.Contains(d.Error(), "close 1006"):
-					go ws.WebsocketReset()
+					go ws.Connect()
 					continue
 				default:
 					log.Errorf(log.WebsocketMgr, "routines.go exchange %s websocket error - %s", ws.GetName(), data)

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -286,7 +286,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 			supportsRESTTickerBatching := Bot.Exchanges[x].SupportsRESTTickerBatchUpdates()
 			var usingREST bool
 			var usingWebsocket bool
-
+			var switchedToRest bool
 			if Bot.Exchanges[x].SupportsWebsocket() && Bot.Exchanges[x].IsWebsocketEnabled() {
 				ws, err := Bot.Exchanges[x].GetWebsocket()
 				if err != nil {
@@ -346,7 +346,12 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 						log.Errorf(log.SyncMgr, "failed to get item. Err: %s\n", err)
 						continue
 					}
-
+					if switchedToRest && usingWebsocket {
+						log.Infof(log.SyncMgr,
+							"%s %s: Websocket re-enabled, switching from rest to websocket\n",
+							c.Exchange, FormatCurrency(p).String())
+						switchedToRest = false
+					}
 					if e.Cfg.SyncTicker {
 						if !e.isProcessing(exchangeName, c.Pair, c.AssetType, SyncItemTicker) {
 							if c.Ticker.LastUpdated.IsZero() || time.Since(c.Ticker.LastUpdated) > defaultSyncerTimeout {
@@ -362,6 +367,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 										log.Warnf(log.SyncMgr,
 											"%s %s: No ticker update after 10 seconds, switching from websocket to rest\n",
 											c.Exchange, FormatCurrency(p).String())
+										switchedToRest = true
 										e.setProcessing(c.Exchange, c.Pair, c.AssetType, SyncItemTicker, false)
 									}
 								}
@@ -425,6 +431,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 										log.Warnf(log.SyncMgr,
 											"%s %s: No orderbook update after 15 seconds, switching from websocket to rest\n",
 											c.Exchange, FormatCurrency(c.Pair).String())
+										switchedToRest = true
 										e.setProcessing(c.Exchange, c.Pair, c.AssetType, SyncItemOrderbook, false)
 									}
 								}

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -491,7 +491,7 @@ func (e *ExchangeCurrencyPairSyncer) Start() {
 				usingREST = true
 			}
 
-			if !ws.IsConnected() {
+			if !ws.IsConnected() && !ws.IsConnecting() {
 				go WebsocketDataHandler(ws)
 
 				err = ws.Connect()

--- a/exchanges/alphapoint/alphapoint_websocket.go
+++ b/exchanges/alphapoint/alphapoint_websocket.go
@@ -38,6 +38,7 @@ func (a *Alphapoint) WebsocketClient() {
 		for a.Enabled {
 			msgType, resp, err := a.WebsocketConn.ReadMessage()
 			if err != nil {
+				a.Websocket.ReadMessageErrors <- err
 				log.Error(log.ExchangeSys, err)
 				break
 			}

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -248,7 +248,7 @@ func (b *Binance) SeedLocalCache(p currency.Pair) error {
 	newOrderBook.Pair = p
 	newOrderBook.AssetType = asset.Spot
 
-	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }
 
 // UpdateLocalCache updates and returns the most recent iteration of the orderbook

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -21,8 +21,8 @@ const (
 	binanceDefaultWebsocketURL = "wss://stream.binance.com:9443"
 )
 
-// WSConnect intiates a websocket connection
-func (b *Binance) WSConnect() error {
+// WsConnect intiates a websocket connection
+func (b *Binance) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
 		return errors.New(wshandler.WebsocketNotEnabled)
 	}
@@ -87,7 +87,7 @@ func (b *Binance) WsHandleData() {
 		default:
 			read, err := b.WebsocketConn.ReadMessage()
 			if err != nil {
-				b.Websocket.DataHandler <- err
+				b.Websocket.ReadMessageErrors <- err
 				return
 			}
 			b.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -123,8 +123,6 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) error {
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,
 			Connector:                        b.WsConnect,
-			Subscriber:                       nil,
-			UnSubscriber:                     nil,
 		})
 
 	if err != nil {

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -113,15 +113,20 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = b.Websocket.Setup(b.WSConnect,
-		nil,
-		nil,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		binanceDefaultWebsocketURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = b.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       binanceDefaultWebsocketURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        b.WsConnect,
+			Subscriber:                       nil,
+			UnSubscriber:                     nil,
+		})
+
 	if err != nil {
 		return err
 	}

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -118,7 +118,7 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       binanceDefaultWebsocketURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -115,7 +115,7 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) error {
 
 	err = b.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -482,7 +482,7 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 	newOrderBook.AssetType = assetType
 	newOrderBook.Bids = bid
 	newOrderBook.Pair = p
-	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 	if err != nil {
 		return fmt.Errorf("bitfinex.go error - %s", err)
 	}

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -133,6 +133,7 @@ func (b *Bitfinex) WsConnect() error {
 
 	resp, err := b.WebsocketConn.ReadMessage()
 	if err != nil {
+		b.Websocket.ReadMessageErrors <- err
 		return fmt.Errorf("%v unable to read from Websocket. Error: %s", b.Name, err)
 	}
 	b.Websocket.TrafficAlert <- struct{}{}
@@ -177,7 +178,7 @@ func (b *Bitfinex) WsDataHandler() {
 		default:
 			stream, err := b.WebsocketConn.ReadMessage()
 			if err != nil {
-				b.Websocket.DataHandler <- err
+				b.Websocket.ReadMessageErrors <- err
 				return
 			}
 			b.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -116,7 +116,7 @@ func (b *Bitfinex) Setup(exch *config.ExchangeConfig) error {
 
 	err = b.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -114,15 +114,19 @@ func (b *Bitfinex) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = b.Websocket.Setup(b.WsConnect,
-		b.Subscribe,
-		b.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		bitfinexWebsocket,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = b.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       bitfinexWebsocket,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        b.WsConnect,
+			Subscriber:                       b.Subscribe,
+			UnSubscriber:                     b.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -119,7 +119,7 @@ func (b *Bitfinex) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       bitfinexWebsocket,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -66,8 +66,8 @@ var (
 	pongChan = make(chan int, 1)
 )
 
-// WsConnector initiates a new websocket connection
-func (b *Bitmex) WsConnector() error {
+// WsConnect initiates a new websocket connection
+func (b *Bitmex) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
 		return errors.New(wshandler.WebsocketNotEnabled)
 	}
@@ -79,6 +79,7 @@ func (b *Bitmex) WsConnector() error {
 
 	p, err := b.WebsocketConn.ReadMessage()
 	if err != nil {
+		b.Websocket.ReadMessageErrors <- err
 		return err
 	}
 	b.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -361,7 +361,7 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPai
 		newOrderBook.Bids = bids
 		newOrderBook.AssetType = assetType
 		newOrderBook.Pair = currencyPair
-		err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+		err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 		if err != nil {
 			return fmt.Errorf("bitmex_websocket.go process orderbook error -  %s",
 				err)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -139,7 +139,7 @@ func (b *Bitmex) Setup(exch *config.ExchangeConfig) error {
 
 	err = b.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -142,7 +142,7 @@ func (b *Bitmex) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       bitmexWSURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -137,15 +137,19 @@ func (b *Bitmex) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = b.Websocket.Setup(b.WsConnector,
-		b.Subscribe,
-		b.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		bitmexWSURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = b.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       bitmexWSURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        b.WsConnect,
+			Subscriber:                       b.Subscribe,
+			UnSubscriber:                     b.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -248,7 +248,7 @@ func (b *Bitstamp) seedOrderBook() error {
 		newOrderBook.Pair = p[x]
 		newOrderBook.AssetType = asset.Spot
 
-		err = b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+		err = b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 		if err != nil {
 			return err
 		}

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -62,7 +62,7 @@ func (b *Bitstamp) WsHandleData() {
 		default:
 			resp, err := b.WebsocketConn.ReadMessage()
 			if err != nil {
-				b.Websocket.DataHandler <- err
+				b.Websocket.ReadMessageErrors <- err
 				return
 			}
 			b.Websocket.TrafficAlert <- struct{}{}
@@ -78,7 +78,7 @@ func (b *Bitstamp) WsHandleData() {
 				if b.Verbose {
 					log.Debugf(log.ExchangeSys, "%v - Websocket reconnection request received", b.GetName())
 				}
-				go b.Websocket.WebsocketReset()
+				go b.Websocket.Shutdown() // Connection monitor will reconnect
 
 			case "data":
 				wsOrderBookTemp := websocketOrderBookResponse{}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -112,7 +112,7 @@ func (b *Bitstamp) Setup(exch *config.ExchangeConfig) error {
 
 	err = b.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -110,15 +110,19 @@ func (b *Bitstamp) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = b.Websocket.Setup(b.WsConnect,
-		b.Subscribe,
-		b.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		bitstampWSURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = b.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       bitstampWSURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        b.WsConnect,
+			Subscriber:                       b.Subscribe,
+			UnSubscriber:                     b.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -115,7 +115,7 @@ func (b *Bitstamp) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       bitstampWSURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -54,7 +54,7 @@ func (b *BTSE) WsHandleData() {
 		default:
 			resp, err := b.WebsocketConn.ReadMessage()
 			if err != nil {
-				b.Websocket.DataHandler <- err
+				b.Websocket.ReadMessageErrors <- err
 				return
 			}
 			b.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -162,7 +162,7 @@ func (b *BTSE) wsProcessSnapshot(snapshot *websocketOrderbookSnapshot) error {
 	base.LastUpdated = time.Now()
 	base.ExchangeName = b.Name
 
-	err := b.Websocket.Orderbook.LoadSnapshot(&base, true)
+	err := b.Websocket.Orderbook.LoadSnapshot(&base)
 	if err != nil {
 		return err
 	}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -114,7 +114,7 @@ func (b *BTSE) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       btseWebsocket,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -111,7 +111,7 @@ func (b *BTSE) Setup(exch *config.ExchangeConfig) error {
 
 	err = b.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -109,15 +109,19 @@ func (b *BTSE) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = b.Websocket.Setup(b.WsConnect,
-		b.Subscribe,
-		b.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		btseWebsocket,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = b.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       btseWebsocket,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        b.WsConnect,
+			Subscriber:                       b.Subscribe,
+			UnSubscriber:                     b.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -217,7 +217,7 @@ func (c *CoinbasePro) ProcessSnapshot(snapshot *WebsocketOrderbookSnapshot) erro
 	base.AssetType = asset.Spot
 	base.Pair = pair
 
-	err := c.Websocket.Orderbook.LoadSnapshot(&base, false)
+	err := c.Websocket.Orderbook.LoadSnapshot(&base)
 	if err != nil {
 		return err
 	}

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -54,7 +54,7 @@ func (c *CoinbasePro) WsHandleData() {
 		default:
 			resp, err := c.WebsocketConn.ReadMessage()
 			if err != nil {
-				c.Websocket.DataHandler <- err
+				c.Websocket.ReadMessageErrors <- err
 				return
 			}
 			c.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -120,7 +120,7 @@ func (c *CoinbasePro) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       coinbaseproWebsocketURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -117,7 +117,7 @@ func (c *CoinbasePro) Setup(exch *config.ExchangeConfig) error {
 
 	err = c.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -115,15 +115,19 @@ func (c *CoinbasePro) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = c.Websocket.Setup(c.WsConnect,
-		c.Subscribe,
-		c.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		coinbaseproWebsocketURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = c.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       coinbaseproWebsocketURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        c.WsConnect,
+			Subscriber:                       c.Subscribe,
+			UnSubscriber:                     c.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -289,7 +289,7 @@ func (c *COINUT) WsProcessOrderbookSnapshot(ob *WsOrderbookSnapshot) error {
 	)
 	newOrderBook.AssetType = asset.Spot
 
-	return c.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+	return c.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }
 
 // WsProcessOrderbookUpdate process an orderbook update

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -77,7 +77,7 @@ func (c *COINUT) WsHandleData() {
 		default:
 			resp, err := c.WebsocketConn.ReadMessage()
 			if err != nil {
-				c.Websocket.DataHandler <- err
+				c.Websocket.ReadMessageErrors <- err
 				return
 			}
 			c.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -121,7 +121,7 @@ func (c *COINUT) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       coinutWebsocketURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -118,7 +118,7 @@ func (c *COINUT) Setup(exch *config.ExchangeConfig) error {
 
 	err = c.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -116,15 +116,19 @@ func (c *COINUT) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = c.Websocket.Setup(c.WsConnect,
-		c.Subscribe,
-		c.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		coinutWebsocketURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = c.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       coinutWebsocketURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        c.WsConnect,
+			Subscriber:                       c.Subscribe,
+			UnSubscriber:                     c.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -453,7 +453,7 @@ func (e *Base) SetupDefaults(exch *config.ExchangeConfig) error {
 	}
 
 	if e.Features.Supports.Websocket {
-		e.Websocket.SetWsStatusAndConnection(exch.Features.Enabled.Websocket)
+		e.Websocket.Initialise()
 	}
 	return nil
 }

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -924,7 +924,10 @@ func TestIsWebsocketEnabled(t *testing.T) {
 	}
 
 	b.Websocket = wshandler.New()
-	b.Websocket.Setup(nil, nil, nil, "", true, false, "", "", false)
+	err := b.Websocket.Setup(&wshandler.WebsocketSetup{Enabled: true})
+	if err != nil {
+		t.Error(err)
+	}
 	if !b.IsWebsocketEnabled() {
 		t.Error("websocket should be enabled")
 	}

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -462,7 +462,7 @@ type WebSocketOrderQueryRecords struct {
 
 // WebsocketAuthenticationResponse contains the result of a login request
 type WebsocketAuthenticationResponse struct {
-	Error  string `json:"error"`
+	Error  string `json:"error,omitempty"`
 	Result struct {
 		Status string `json:"status"`
 	} `json:"result"`

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -238,8 +238,7 @@ func (g *Gateio) WsHandleData() {
 					newOrderBook.AssetType = asset.Spot
 					newOrderBook.Pair = currency.NewPairFromString(c)
 
-					err = g.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
-						true)
+					err = g.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 					if err != nil {
 						g.Websocket.DataHandler <- err
 					}

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -92,7 +92,7 @@ func (g *Gateio) WsHandleData() {
 		default:
 			resp, err := g.WebsocketConn.ReadMessage()
 			if err != nil {
-				g.Websocket.DataHandler <- err
+				g.Websocket.ReadMessageErrors <- err
 				return
 			}
 			g.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -119,7 +119,7 @@ func (g *Gateio) Setup(exch *config.ExchangeConfig) error {
 
 	err = g.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -117,15 +117,19 @@ func (g *Gateio) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = g.Websocket.Setup(g.WsConnect,
-		g.Subscribe,
-		g.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		gateioWebsocketEndpoint,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = g.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       gateioWebsocketEndpoint,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        g.WsConnect,
+			Subscriber:                       g.Subscribe,
+			UnSubscriber:                     g.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -122,7 +122,7 @@ func (g *Gateio) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       gateioWebsocketEndpoint,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -282,8 +282,7 @@ func (g *Gemini) wsProcessUpdate(result WsMarketUpdateResponse, pair currency.Pa
 		newOrderBook.Bids = bids
 		newOrderBook.AssetType = asset.Spot
 		newOrderBook.Pair = pair
-		err := g.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
-			false)
+		err := g.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 		if err != nil {
 			g.Websocket.DataHandler <- err
 			return

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -118,7 +118,7 @@ func (g *Gemini) Setup(exch *config.ExchangeConfig) error {
 
 	err = g.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -116,15 +116,17 @@ func (g *Gemini) Setup(exch *config.ExchangeConfig) error {
 		g.API.Endpoints.URL = geminiSandboxAPIURL
 	}
 
-	err = g.Websocket.Setup(g.WsConnect,
-		nil,
-		nil,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		geminiWebsocketEndpoint,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = g.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       geminiWebsocketEndpoint,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        g.WsConnect,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -121,7 +121,7 @@ func (g *Gemini) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       geminiWebsocketEndpoint,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -251,7 +251,7 @@ func (h *HitBTC) WsProcessOrderbookSnapshot(ob WsOrderbook) error {
 	newOrderBook.AssetType = asset.Spot
 	newOrderBook.Pair = p
 
-	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 	if err != nil {
 		return err
 	}

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -65,7 +65,7 @@ func (h *HitBTC) WsHandleData() {
 		default:
 			resp, err := h.WebsocketConn.ReadMessage()
 			if err != nil {
-				h.Websocket.DataHandler <- err
+				h.Websocket.ReadMessageErrors <- err
 				return
 			}
 			h.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -120,7 +120,7 @@ func (h *HitBTC) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       hitbtcWebsocketAddress,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -115,15 +115,19 @@ func (h *HitBTC) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = h.Websocket.Setup(h.WsConnect,
-		h.Subscribe,
-		h.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		hitbtcWebsocketAddress,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = h.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       hitbtcWebsocketAddress,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        h.WsConnect,
+			Subscriber:                       h.Subscribe,
+			UnSubscriber:                     h.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -117,7 +117,7 @@ func (h *HitBTC) Setup(exch *config.ExchangeConfig) error {
 
 	err = h.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -313,7 +313,7 @@ func (h *HUOBI) WsProcessOrderbook(update *WsDepth, symbol string) error {
 	newOrderBook.Asks = asks
 	newOrderBook.Bids = bids
 	newOrderBook.Pair = p
-	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook, true)
+	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 	if err != nil {
 		return err
 	}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -121,7 +121,7 @@ func (h *HUOBI) Setup(exch *config.ExchangeConfig) error {
 
 	err = h.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -124,7 +124,7 @@ func (h *HUOBI) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       wsMarketURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -119,15 +119,19 @@ func (h *HUOBI) Setup(exch *config.ExchangeConfig) error {
 	h.API.PEMKeySupport = exch.API.PEMKeySupport
 	h.API.Credentials.PEMKey = exch.API.Credentials.PEMKey
 
-	err = h.Websocket.Setup(h.WsConnect,
-		h.Subscribe,
-		h.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		wsMarketURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = h.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       wsMarketURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        h.WsConnect,
+			Subscriber:                       h.Subscribe,
+			UnSubscriber:                     h.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -507,7 +507,7 @@ func (k *Kraken) Subscribe(channelToSubscribe wshandler.WebsocketChannelSubscrip
 		Subscription: WebsocketSubscriptionData{
 			Name: channelToSubscribe.Channel,
 		},
-		RequestID: k.WebsocketConn.GenerateMessageID(true),
+		RequestID: k.WebsocketConn.GenerateMessageID(false),
 	}
 	_, err := k.WebsocketConn.SendMessageReturnResponse(resp.RequestID, resp)
 	return err
@@ -521,7 +521,7 @@ func (k *Kraken) Unsubscribe(channelToSubscribe wshandler.WebsocketChannelSubscr
 		Subscription: WebsocketSubscriptionData{
 			Name: channelToSubscribe.Channel,
 		},
-		RequestID: k.WebsocketConn.GenerateMessageID(true),
+		RequestID: k.WebsocketConn.GenerateMessageID(false),
 	}
 	_, err := k.WebsocketConn.SendMessageReturnResponse(resp.RequestID, resp)
 	return err

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -382,7 +382,7 @@ func (k *Kraken) wsProcessOrderBookPartial(channelData *WebsocketChannelData, ob
 		}
 	}
 	base.LastUpdated = highestLastUpdate
-	err := k.Websocket.Orderbook.LoadSnapshot(&base, true)
+	err := k.Websocket.Orderbook.LoadSnapshot(&base)
 	if err != nil {
 		k.Websocket.DataHandler <- err
 		return

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -110,9 +110,7 @@ func (k *Kraken) WsHandleData() {
 		default:
 			resp, err := k.WebsocketConn.ReadMessage()
 			if err != nil {
-				k.Websocket.DataHandler <- fmt.Errorf("%v WsHandleData: %v",
-					k.Name,
-					err)
+				k.Websocket.ReadMessageErrors <- err
 				return
 			}
 			k.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -124,7 +124,7 @@ func (k *Kraken) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       krakenWSURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -119,15 +119,19 @@ func (k *Kraken) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = k.Websocket.Setup(k.WsConnect,
-		k.Subscribe,
-		k.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		krakenWSURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = k.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       krakenWSURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        k.WsConnect,
+			Subscriber:                       k.Subscribe,
+			UnSubscriber:                     k.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -121,7 +121,7 @@ func (k *Kraken) Setup(exch *config.ExchangeConfig) error {
 
 	err = k.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/lakebtc/lakebtc_websocket.go
+++ b/exchanges/lakebtc/lakebtc_websocket.go
@@ -205,7 +205,7 @@ func (l *LakeBTC) processOrderbook(obUpdate, channel string) error {
 			Price:  price,
 		})
 	}
-	return l.Websocket.Orderbook.LoadSnapshot(&book, true)
+	return l.Websocket.Orderbook.LoadSnapshot(&book)
 }
 
 func (l *LakeBTC) getCurrencyFromChannel(channel string) currency.Pair {

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -112,7 +112,7 @@ func (l *LakeBTC) Setup(exch *config.ExchangeConfig) error {
 
 	err = l.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -115,7 +115,7 @@ func (l *LakeBTC) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       lakeBTCWSURL,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -110,15 +110,18 @@ func (l *LakeBTC) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = l.Websocket.Setup(l.WsConnect,
-		l.Subscribe,
-		nil,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		lakeBTCWSURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = l.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       lakeBTCWSURL,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        l.WsConnect,
+			Subscriber:                       l.Subscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -193,6 +193,9 @@ func (o *OKGroup) wsPingHandler(wg *sync.WaitGroup) {
 			return
 
 		case <-ticker.C:
+			if !o.Websocket.IsConnected() {
+				continue
+			}
 			err := o.WebsocketConn.Connection.WriteMessage(websocket.TextMessage, []byte("ping"))
 			if o.Verbose {
 				log.Debugf(log.ExchangeSys, "%v sending ping", o.GetName())

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -475,7 +475,7 @@ func (o *OKGroup) WsProcessPartialOrderBook(wsEventData *WebsocketDataWrapper, i
 		ExchangeName: o.GetName(),
 	}
 
-	err := o.Websocket.Orderbook.LoadSnapshot(&newOrderBook, true)
+	err := o.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 	if err != nil {
 		return err
 	}

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -221,7 +221,7 @@ func (o *OKGroup) WsHandleData(wg *sync.WaitGroup) {
 		default:
 			resp, err := o.WebsocketConn.ReadMessage()
 			if err != nil {
-				o.Websocket.DataHandler <- err
+				o.Websocket.ReadMessageErrors <- err
 				return
 			}
 			o.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -32,7 +32,7 @@ func (o *OKGroup) Setup(exch *config.ExchangeConfig) error {
 	}
 
 	err = o.Websocket.Setup(&wshandler.WebsocketSetup{
-		WsEnabled:                        exch.Features.Enabled.Websocket,
+		Enabled:                          exch.Features.Enabled.Websocket,
 		Verbose:                          exch.Verbose,
 		AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 		WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -31,15 +31,18 @@ func (o *OKGroup) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = o.Websocket.Setup(o.WsConnect,
-		o.Subscribe,
-		o.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		o.API.Endpoints.WebsocketURL,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = o.Websocket.Setup(&wshandler.WebsocketSetup{
+		WsEnabled:                        exch.Features.Enabled.Websocket,
+		Verbose:                          exch.Verbose,
+		AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+		WebsocketTimeout:                 0,
+		DefaultURL:                       o.API.Endpoints.WebsocketURL,
+		ExchangeName:                     exch.Name,
+		RunningURL:                       exch.API.Endpoints.WebsocketURL,
+		Connector:                        o.WsConnect,
+		Subscriber:                       o.Subscribe,
+		UnSubscriber:                     o.Unsubscribe,
+	})
 	if err != nil {
 		return err
 	}

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -35,7 +35,7 @@ func (o *OKGroup) Setup(exch *config.ExchangeConfig) error {
 		WsEnabled:                        exch.Features.Enabled.Websocket,
 		Verbose:                          exch.Verbose,
 		AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-		WebsocketTimeout:                 0,
+		WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 		DefaultURL:                       o.API.Endpoints.WebsocketURL,
 		ExchangeName:                     exch.Name,
 		RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -88,7 +88,7 @@ func (p *Poloniex) WsHandleData() {
 		default:
 			resp, err := p.WebsocketConn.ReadMessage()
 			if err != nil {
-				p.Websocket.DataHandler <- err
+				p.Websocket.ReadMessageErrors <- err
 				return
 			}
 			p.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -330,7 +330,7 @@ func (p *Poloniex) WsProcessOrderbookSnapshot(ob []interface{}, symbol string) e
 	newOrderBook.AssetType = asset.Spot
 	newOrderBook.Pair = currency.NewPairFromString(symbol)
 
-	return p.Websocket.Orderbook.LoadSnapshot(&newOrderBook, false)
+	return p.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }
 
 // WsProcessOrderbookUpdate processes new orderbook updates

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -115,7 +115,7 @@ func (p *Poloniex) Setup(exch *config.ExchangeConfig) error {
 
 	err = p.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -113,15 +113,19 @@ func (p *Poloniex) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = p.Websocket.Setup(p.WsConnect,
-		p.Subscribe,
-		p.Unsubscribe,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		poloniexWebsocketAddress,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = p.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       poloniexWebsocketAddress,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        p.WsConnect,
+			Subscriber:                       p.Subscribe,
+			UnSubscriber:                     p.Unsubscribe,
+		})
 	if err != nil {
 		return err
 	}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -118,7 +118,7 @@ func (p *Poloniex) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       poloniexWebsocketAddress,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -36,20 +36,19 @@ func (w *Websocket) Setup(setupData *WebsocketSetup) error {
 	w.DataHandler = make(chan interface{}, 1)
 	w.TrafficAlert = make(chan struct{}, 1)
 	w.verbose = setupData.Verbose
-
 	w.SetChannelSubscriber(setupData.Subscriber)
 	w.SetChannelUnsubscriber(setupData.UnSubscriber)
-	w.enabled = setupData.WsEnabled
-	err := w.Initialise()
-	if err != nil {
-		return err
-	}
+	w.enabled = setupData.Enabled
 	w.SetDefaultURL(setupData.DefaultURL)
 	w.SetConnector(setupData.Connector)
 	w.SetWebsocketURL(setupData.RunningURL)
 	w.SetExchangeName(setupData.ExchangeName)
 	w.SetCanUseAuthenticatedEndpoints(setupData.AuthenticatedWebsocketAPISupport)
 	w.trafficTimeout = setupData.WebsocketTimeout
+	err := w.Initialise()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -207,7 +207,7 @@ func (w *Websocket) trafficMonitor(wg *sync.WaitGroup) {
 			if w.verbose {
 				log.Warnf(log.WebsocketMgr, "%v has not received a traffic alert in 2 minutes. Reconnecting", w.exchangeName)
 			}
-			w.Shutdown()
+			go w.Shutdown()
 		}
 	}
 }
@@ -482,7 +482,7 @@ func (w *Websocket) manageSubscriptions() {
 			}
 			// Subscribe to channels Pending a subscription
 			if w.SupportsFunctionality(WebsocketSubscribeSupported) {
-				err := w.subscribeToChannels()
+				err := w.appendSubscribedChannels()
 				if err != nil {
 					w.DataHandler <- err
 				}
@@ -497,9 +497,9 @@ func (w *Websocket) manageSubscriptions() {
 	}
 }
 
-// subscribeToChannels compares channelsToSubscribe to subscribedChannels
+// appendSubscribedChannels compares channelsToSubscribe to subscribedChannels
 // and subscribes to any channels not present in subscribedChannels
-func (w *Websocket) subscribeToChannels() error {
+func (w *Websocket) appendSubscribedChannels() error {
 	w.subscriptionLock.Lock()
 	defer w.subscriptionLock.Unlock()
 	for i := 0; i < len(w.channelsToSubscribe); i++ {

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -107,9 +107,7 @@ func (w *Websocket) connectionMonitor() {
 	timer := time.NewTimer(connectionMonitorDelay)
 
 	defer func() {
-		if !timer.Stop() {
-			<-timer.C
-		}
+		timer.Stop()
 		w.setConnectionMonitorRunning(false)
 		if w.verbose {
 			log.Debugf(log.WebsocketMgr, "%v websocket connection monitor exiting",
@@ -205,9 +203,7 @@ func (w *Websocket) trafficMonitor(wg *sync.WaitGroup) {
 	trafficTimer := time.NewTimer(w.trafficTimeout)
 
 	defer func() {
-		if !trafficTimer.Stop() {
-			<-trafficTimer.C
-		}
+		trafficTimer.Stop()
 		w.Wg.Done()
 	}()
 

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -182,6 +182,8 @@ func (w *Websocket) Shutdown() error {
 	}
 	close(w.ShutdownC)
 	w.Wg.Wait()
+	w.setConnectedStatus(false)
+	w.setConnectingStatus(false)
 	if w.verbose {
 		log.Debugf(log.WebsocketMgr, "%v completed websocket channel shutdown", w.exchangeName)
 	}

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -107,7 +107,9 @@ func (w *Websocket) connectionMonitor() {
 	timer := time.NewTimer(connectionMonitorDelay)
 
 	defer func() {
-		timer.Stop()
+		if !timer.Stop() {
+			<-timer.C
+		}
 		w.setConnectionMonitorRunning(false)
 		if w.verbose {
 			log.Debugf(log.WebsocketMgr, "%v websocket connection monitor exiting",
@@ -178,7 +180,7 @@ func (w *Websocket) Shutdown() error {
 		w.Orderbook.FlushCache()
 		w.m.Unlock()
 	}()
-	if !w.IsConnected() && w.ShutdownC == nil {
+	if !w.IsConnected() {
 		return fmt.Errorf("%v cannot shutdown a disconnected websocket", w.exchangeName)
 	}
 	if w.verbose {
@@ -203,7 +205,9 @@ func (w *Websocket) trafficMonitor(wg *sync.WaitGroup) {
 	trafficTimer := time.NewTimer(w.trafficTimeout)
 
 	defer func() {
-		trafficTimer.Stop()
+		if !trafficTimer.Stop() {
+			<-trafficTimer.C
+		}
 		w.Wg.Done()
 	}()
 

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -658,6 +658,7 @@ func (w *WebsocketConnection) Dial(dialer *websocket.Dialer, headers http.Header
 		}
 		return fmt.Errorf("%v Error: %v", w.URL, err)
 	}
+	log.Infof(log.WebsocketMgr, "%v - Websocket connected", w.ExchangeName)
 	return nil
 }
 

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -381,11 +381,11 @@ func TestManageSubscriptions(t *testing.T) {
 	time.Sleep(8 * time.Second)
 	w.setConnectedStatus(false)
 	time.Sleep(manageSubscriptionsDelay)
-	w.subscriptionLock.Lock()
+	w.subscriptionMutex.Lock()
 	if len(w.subscribedChannels) > 0 {
 		t.Error("Expected empty subscribed channels")
 	}
-	w.subscriptionLock.Unlock()
+	w.subscriptionMutex.Unlock()
 }
 
 // TestConnectionMonitorNoConnection logic test

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -114,23 +114,18 @@ outer:
 
 func TestWebsocket(t *testing.T) {
 	ws := Websocket{}
+	ws.setInit(true)
 	err := ws.Setup(&WebsocketSetup{
-		ExchangeName: "test",
-	})
-	if err.Error() != WebsocketNotEnabled {
-		t.Errorf("Expected '%v', received %v", WebsocketNotEnabled, err)
-	}
-	ws = Websocket{}
-	err = ws.Setup(&WebsocketSetup{
 		ExchangeName: "test",
 		Enabled:      true,
 	})
-	if err.Error() != "test Websocket already initialised" {
+	if err != nil && err.Error() != "test Websocket already initialised" {
 		t.Errorf("Expected 'test Websocket already initialised', received %v", err)
 	}
 
 	ws = *New()
-	if err = ws.SetProxyAddress("testProxy"); err != nil {
+	err = ws.SetProxyAddress("testProxy")
+	if err != nil {
 		t.Error("test failed - SetProxyAddress", err)
 	}
 
@@ -173,7 +168,6 @@ func TestWebsocket(t *testing.T) {
 	if ws.trafficTimeout != time.Duration(2) {
 		t.Error("test failed - WebsocketSetup")
 	}
-
 	// -- Not connected shutdown
 	err = ws.Shutdown()
 	if err == nil {

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -23,9 +23,8 @@ func TestTrafficMonitorTimeout(t *testing.T) {
 	ws.Setup(
 		&WebsocketSetup{
 			WsEnabled:                        true,
-			Verbose:                          true,
 			AuthenticatedWebsocketAPISupport: true,
-			WebsocketTimeout:                 1,
+			WebsocketTimeout:                 10000,
 			DefaultURL:                       "testDefaultURL",
 			ExchangeName:                     "exchangeName",
 			RunningURL:                       "testRunningURL",
@@ -114,7 +113,6 @@ func TestWebsocket(t *testing.T) {
 	ws.Setup(
 		&WebsocketSetup{
 			WsEnabled:                        true,
-			Verbose:                          false,
 			AuthenticatedWebsocketAPISupport: true,
 			WebsocketTimeout:                 2,
 			DefaultURL:                       "testDefaultURL",
@@ -327,7 +325,6 @@ func TestManageSubscriptions(t *testing.T) {
 	w := Websocket{
 		ShutdownC:     make(chan struct{}),
 		Functionality: WebsocketSubscribeSupported | WebsocketUnsubscribeSupported,
-		verbose:       true,
 		subscribedChannels: []WebsocketChannelSubscription{
 			{
 				Channel: "hello",
@@ -523,7 +520,6 @@ type testResponse struct {
 func TestMain(m *testing.M) {
 	wc = &WebsocketConnection{
 		ExchangeName:         "test",
-		Verbose:              true,
 		URL:                  returnResponseURL,
 		ResponseMaxLimit:     7000000000,
 		ResponseCheckTimeout: 30000000,

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -130,7 +130,7 @@ func TestWebsocket(t *testing.T) {
 	}
 
 	ws = *New()
-	if err := ws.SetProxyAddress("testProxy"); err != nil {
+	if err = ws.SetProxyAddress("testProxy"); err != nil {
 		t.Error("test failed - SetProxyAddress", err)
 	}
 

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -142,24 +142,6 @@ func TestWebsocket(t *testing.T) {
 
 	ws.SetWebsocketURL("")
 
-	// -- Set true when already true
-	err = ws.SetWsStatusAndConnection(true)
-	if err == nil {
-		t.Fatal("test failed - setting enabled should not work")
-	}
-
-	// -- Set false normal
-	err = ws.SetWsStatusAndConnection(false)
-	if err != nil {
-		t.Fatal("test failed - setting enabled should not work")
-	}
-
-	// -- Set true normal
-	err = ws.SetWsStatusAndConnection(true)
-	if err != nil {
-		t.Fatal("test failed - setting enabled should not work")
-	}
-
 	// -- Normal shutdown
 	err = ws.Shutdown()
 	if err != nil {

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -13,10 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
-
-	"github.com/gorilla/websocket"
 )
 
 func TestTrafficMonitorTimeout(t *testing.T) {
@@ -168,9 +167,7 @@ func TestWebsocket(t *testing.T) {
 	if err != nil {
 		t.Fatal("test failed - WebsocketSetup", err)
 	}
-
 	ws.SetWebsocketURL("ws://demos.kaazing.com/echo")
-
 	// -- Already connected connect
 	err = ws.Connect()
 	if err == nil {
@@ -494,10 +491,6 @@ func TestRemoveSubscribedChannels(t *testing.T) {
 		t.Error("Did not remove subscription")
 	}
 }
-
-// --------------------------------------------
-// WebsocketConnection stuff here
-// --------------------------------------------
 
 const (
 	websocketTestURL  = "wss://www.bitmex.com/realtime"

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -82,7 +82,7 @@ func TestTrafficMonitorTimeout(t *testing.T) {
 			Subscriber:                       func(test WebsocketChannelSubscription) error { return nil },
 			UnSubscriber:                     func(test WebsocketChannelSubscription) error { return nil },
 		})
-	ws.setConnectionStatus(true)
+	ws.setConnectedStatus(true)
 	ws.TrafficAlert = make(chan struct{}, 2)
 	ws.ShutdownC = make(chan struct{})
 	var anotherWG sync.WaitGroup
@@ -393,10 +393,10 @@ func TestManageSubscriptions(t *testing.T) {
 	}
 	w.SetChannelUnsubscriber(placeholderSubscriber)
 	w.SetChannelSubscriber(placeholderSubscriber)
-	w.setConnectionStatus(true)
+	w.setConnectedStatus(true)
 	go w.manageSubscriptions()
 	time.Sleep(8 * time.Second)
-	w.setConnectionStatus(false)
+	w.setConnectedStatus(false)
 	time.Sleep(manageSubscriptionsDelay)
 	if len(w.subscribedChannels) > 0 {
 		t.Error("Expected empty subscribed channels")

--- a/exchanges/websocket/wshandler/wshandler_test.go
+++ b/exchanges/websocket/wshandler/wshandler_test.go
@@ -62,6 +62,17 @@ func TestIsDisconnectionError(t *testing.T) {
 	if !isADisconnectionError {
 		t.Error("It is")
 	}
+
+	isADisconnectionError = isDisconnectionError(&net.OpError{
+		Op:     "",
+		Net:    "",
+		Source: nil,
+		Addr:   nil,
+		Err:    errors.New("errorText"),
+	})
+	if !isADisconnectionError {
+		t.Error("It is")
+	}
 }
 
 func TestConnectionMessageErrors(t *testing.T) {
@@ -83,30 +94,13 @@ func TestConnectionMessageErrors(t *testing.T) {
 		Code: 1006,
 		Text: "errorText",
 	}
-outer1:
+outer:
 	for {
 		select {
 		case <-ws.DataHandler:
 			t.Fatal("Error is a disconnection error")
 		case <-timer.C:
-			break outer1
-		}
-	}
-	timer.Reset(900 * time.Millisecond)
-	ws.ReadMessageErrors <- &net.OpError{
-		Op:     "",
-		Net:    "",
-		Source: nil,
-		Addr:   nil,
-		Err:    errors.New("errorText"),
-	}
-outer2:
-	for {
-		select {
-		case <-ws.DataHandler:
-			t.Fatal("Error is a disconnection error")
-		case <-timer.C:
-			break outer2
+			break outer
 		}
 	}
 }

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -53,7 +53,7 @@ const (
 	WebsocketNotEnabled = "exchange_websocket_not_enabled"
 	// WebsocketTrafficLimitTime defines a standard time for no traffic from the
 	// websocket connection
-	WebsocketTrafficLimitTime     = 5 * time.Second
+	WebsocketTrafficLimitTime     = 2 * time.Minute
 	websocketRestablishConnection = time.Second
 	manageSubscriptionsDelay      = 5 * time.Second
 	// connection monitor time delays and limits
@@ -102,6 +102,8 @@ type Websocket struct {
 	Wg sync.WaitGroup
 	// TrafficAlert monitors if there is a halt in traffic throughput
 	TrafficAlert chan struct{}
+	// ReadMessageErrors will received all errors from ws.ReadMessage() and verify if its a disconnection
+	ReadMessageErrors chan error
 	// Functionality defines websocket stream capabilities
 	Functionality                uint32
 	canUseAuthenticatedEndpoints bool

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -48,17 +48,11 @@ const (
 	WebsocketMessageCorrelationSupportedText     = "WEBSOCKET MESSAGE CORRELATION SUPPORTED"
 	WebsocketSequenceNumberSupportedText         = "WEBSOCKET SEQUENCE NUMBER SUPPORTED"
 	WebsocketDeadMansSwitchSupportedText         = "WEBSOCKET DEAD MANS SWITCH SUPPORTED"
-
 	// WebsocketNotEnabled alerts of a disabled websocket
-	WebsocketNotEnabled = "exchange_websocket_not_enabled"
-	// websocket connection
-	websocketRestablishConnection = time.Second
-	manageSubscriptionsDelay      = 5 * time.Second
+	WebsocketNotEnabled      = "exchange_websocket_not_enabled"
+	manageSubscriptionsDelay = 5 * time.Second
 	// connection monitor time delays and limits
 	connectionMonitorDelay = 2 * time.Second
-	// WebsocketStateTimeout defines a const for when a websocket connection
-	// times out, will be handled by the routine management system
-	WebsocketStateTimeout = "TIMEOUT"
 )
 
 // Websocket defines a return type for websocket connections via the interface
@@ -86,12 +80,7 @@ type Websocket struct {
 	channelsToSubscribe          []WebsocketChannelSubscription
 	channelSubscriber            func(channelToSubscribe WebsocketChannelSubscription) error
 	channelUnsubscriber          func(channelToUnsubscribe WebsocketChannelSubscription) error
-	// Connected denotes a channel switch for diversion of request flow
-	Connected chan struct{}
-	// Disconnected denotes a channel switch for diversion of request flow
-	Disconnected chan struct{}
-	// DataHandler pipes websocket data to an exchange websocket data handler
-	DataHandler chan interface{}
+	DataHandler                  chan interface{}
 	// ShutdownC is the main shutdown channel which controls all websocket go funcs
 	ShutdownC chan struct{}
 	// Orderbook is a local cache of orderbooks

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -66,28 +66,27 @@ const (
 // Websocket defines a return type for websocket connections via the interface
 // wrapper for routine processing in routines.go
 type Websocket struct {
-	proxyAddr                string
-	defaultURL               string
-	runningURL               string
-	exchangeName             string
-	enabled                  bool
-	init                     bool
-	connected                bool
-	connecting               bool
-	verbose                  bool
-	connector                func() error
-	m                        sync.Mutex
-	subscriptionLock         sync.Mutex
-	connectionMutex          sync.RWMutex
-	connectionMonitorRunning bool
-	reconnectionLimit        int
-	noConnectionChecks       int
-	reconnectionChecks       int
-	noConnectionCheckLimit   int
-	subscribedChannels       []WebsocketChannelSubscription
-	channelsToSubscribe      []WebsocketChannelSubscription
-	channelSubscriber        func(channelToSubscribe WebsocketChannelSubscription) error
-	channelUnsubscriber      func(channelToUnsubscribe WebsocketChannelSubscription) error
+	// Functionality defines websocket stream capabilities
+	Functionality                uint32
+	canUseAuthenticatedEndpoints bool
+	enabled                      bool
+	init                         bool
+	connected                    bool
+	connecting                   bool
+	verbose                      bool
+	connectionMonitorRunning     bool
+	proxyAddr                    string
+	defaultURL                   string
+	runningURL                   string
+	exchangeName                 string
+	m                            sync.Mutex
+	subscriptionLock             sync.Mutex
+	connectionMutex              sync.RWMutex
+	connector                    func() error
+	subscribedChannels           []WebsocketChannelSubscription
+	channelsToSubscribe          []WebsocketChannelSubscription
+	channelSubscriber            func(channelToSubscribe WebsocketChannelSubscription) error
+	channelUnsubscriber          func(channelToUnsubscribe WebsocketChannelSubscription) error
 	// Connected denotes a channel switch for diversion of request flow
 	Connected chan struct{}
 	// Disconnected denotes a channel switch for diversion of request flow
@@ -105,9 +104,19 @@ type Websocket struct {
 	TrafficAlert chan struct{}
 	// ReadMessageErrors will received all errors from ws.ReadMessage() and verify if its a disconnection
 	ReadMessageErrors chan error
-	// Functionality defines websocket stream capabilities
-	Functionality                uint32
-	canUseAuthenticatedEndpoints bool
+}
+
+type WebsocketSetup struct {
+	WsEnabled                        bool
+	Verbose                          bool
+	AuthenticatedWebsocketAPISupport bool
+	WebsocketTimeout                 time.Duration
+	DefaultURL                       string
+	ExchangeName                     string
+	RunningURL                       string
+	Connector                        func() error
+	Subscriber                       func(channelToSubscribe WebsocketChannelSubscription) error
+	UnSubscriber                     func(channelToUnsubscribe WebsocketChannelSubscription) error
 }
 
 // WebsocketChannelSubscription container for websocket subscriptions

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -95,7 +95,7 @@ type Websocket struct {
 }
 
 type WebsocketSetup struct {
-	WsEnabled                        bool
+	Enabled                          bool
 	Verbose                          bool
 	AuthenticatedWebsocketAPISupport bool
 	WebsocketTimeout                 time.Duration

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -51,9 +51,7 @@ const (
 
 	// WebsocketNotEnabled alerts of a disabled websocket
 	WebsocketNotEnabled = "exchange_websocket_not_enabled"
-	// WebsocketTrafficLimitTime defines a standard time for no traffic from the
 	// websocket connection
-	WebsocketTrafficLimitTime     = 2 * time.Minute
 	websocketRestablishConnection = time.Second
 	manageSubscriptionsDelay      = 5 * time.Second
 	// connection monitor time delays and limits
@@ -75,6 +73,7 @@ type Websocket struct {
 	connecting                   bool
 	verbose                      bool
 	connectionMonitorRunning     bool
+	trafficTimeout               time.Duration
 	proxyAddr                    string
 	defaultURL                   string
 	runningURL                   string
@@ -213,4 +212,5 @@ type WebsocketConnection struct {
 	IDResponses          map[int64][]byte
 	ResponseCheckTimeout time.Duration
 	ResponseMaxLimit     time.Duration
+	TrafficTimeout       time.Duration
 }

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -78,6 +78,7 @@ type Websocket struct {
 	connector                func() error
 	m                        sync.Mutex
 	subscriptionLock         sync.Mutex
+	connectionMutex          sync.RWMutex
 	connectionMonitorRunning bool
 	reconnectionLimit        int
 	noConnectionChecks       int

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -199,14 +199,16 @@ type WebsocketPositionUpdated struct {
 // WebsocketConnection contains all the data needed to send a message to a WS
 type WebsocketConnection struct {
 	sync.Mutex
-	Verbose      bool
-	RateLimit    float64
-	ExchangeName string
-	URL          string
-	ProxyURL     string
-	Wg           sync.WaitGroup
-	Connection   *websocket.Conn
-	Shutdown     chan struct{}
+	Verbose         bool
+	connected       bool
+	connectionMutex sync.RWMutex
+	RateLimit       float64
+	ExchangeName    string
+	URL             string
+	ProxyURL        string
+	Wg              sync.WaitGroup
+	Connection      *websocket.Conn
+	Shutdown        chan struct{}
 	// These are the request IDs and the corresponding response JSON
 	IDResponses          map[int64][]byte
 	ResponseCheckTimeout time.Duration

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -65,6 +65,7 @@ type Websocket struct {
 	init                         bool
 	connected                    bool
 	connecting                   bool
+	trafficMonitorRunning        bool
 	verbose                      bool
 	connectionMonitorRunning     bool
 	trafficTimeout               time.Duration
@@ -73,7 +74,7 @@ type Websocket struct {
 	runningURL                   string
 	exchangeName                 string
 	m                            sync.Mutex
-	subscriptionLock             sync.Mutex
+	subscriptionMutex            sync.Mutex
 	connectionMutex              sync.RWMutex
 	connector                    func() error
 	subscribedChannels           []WebsocketChannelSubscription

--- a/exchanges/websocket/wsorderbook/wsorderbook.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook.go
@@ -201,7 +201,7 @@ func (w *WebsocketOrderbookLocal) updateByIDAndAction(orderbookUpdate *Websocket
 // LoadSnapshot loads initial snapshot of ob data, overwrite allows full
 // ob to be completely rewritten because the exchange is a doing a full
 // update not an incremental one
-func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook *orderbook.Base, overwrite bool) error {
+func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook *orderbook.Base) error {
 	if len(newOrderbook.Asks) == 0 || len(newOrderbook.Bids) == 0 {
 		return fmt.Errorf("%v snapshot ask and bids are nil", w.exchangeName)
 	}
@@ -216,11 +216,8 @@ func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook *orderbook.Base, ove
 	if w.ob[newOrderbook.Pair][newOrderbook.AssetType] != nil &&
 		(len(w.ob[newOrderbook.Pair][newOrderbook.AssetType].Asks) > 0 ||
 			len(w.ob[newOrderbook.Pair][newOrderbook.AssetType].Bids) > 0) {
-		if overwrite {
-			w.ob[newOrderbook.Pair][newOrderbook.AssetType] = newOrderbook
-			return newOrderbook.Process()
-		}
-		return fmt.Errorf("%v snapshot instance already found", w.exchangeName)
+		w.ob[newOrderbook.Pair][newOrderbook.AssetType] = newOrderbook
+		return newOrderbook.Process()
 	}
 	w.ob[newOrderbook.Pair][newOrderbook.AssetType] = newOrderbook
 	return newOrderbook.Process()

--- a/exchanges/websocket/wsorderbook/wsorderbook_test.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook_test.go
@@ -410,10 +410,9 @@ func TestLoadSnapshot(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 }
 
-// TestInsertWithIDs logic test
+// TestFlushCache logic test
 func TestFlushCache(t *testing.T) {
 	obl, curr, _, _, err := createSnapshot()
 	if err != nil {

--- a/exchanges/websocket/wsorderbook/wsorderbook_test.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook_test.go
@@ -38,7 +38,7 @@ func createSnapshot() (obl *WebsocketOrderbookLocal, curr currency.Pair, asks, b
 	snapShot1.AssetType = asset.Spot
 	snapShot1.Pair = curr
 	obl = &WebsocketOrderbookLocal{}
-	err = obl.LoadSnapshot(&snapShot1, false)
+	err = obl.LoadSnapshot(&snapShot1)
 	return
 }
 
@@ -382,8 +382,7 @@ func TestRunSnapshotWithNoData(t *testing.T) {
 	snapShot1.Pair = curr
 	snapShot1.ExchangeName = "test"
 	obl.exchangeName = "test"
-	err := obl.LoadSnapshot(&snapShot1,
-		false)
+	err := obl.LoadSnapshot(&snapShot1)
 	if err == nil {
 		t.Fatal("expected an error loading a snapshot")
 	}
@@ -392,8 +391,8 @@ func TestRunSnapshotWithNoData(t *testing.T) {
 	}
 }
 
-// TestLoadSnapshotWithOverride logic test
-func TestLoadSnapshotWithOverride(t *testing.T) {
+// TestLoadSnapshot logic test
+func TestLoadSnapshot(t *testing.T) {
 	var obl WebsocketOrderbookLocal
 	var snapShot1 orderbook.Base
 	curr := currency.NewPairFromString("BTCUSD")
@@ -407,18 +406,11 @@ func TestLoadSnapshotWithOverride(t *testing.T) {
 	snapShot1.Bids = bids
 	snapShot1.AssetType = asset.Spot
 	snapShot1.Pair = curr
-	err := obl.LoadSnapshot(&snapShot1, false)
+	err := obl.LoadSnapshot(&snapShot1)
 	if err != nil {
 		t.Error(err)
 	}
-	err = obl.LoadSnapshot(&snapShot1, false)
-	if err == nil {
-		t.Error("expected error: 'snapshot instance already found'")
-	}
-	err = obl.LoadSnapshot(&snapShot1, true)
-	if err != nil {
-		t.Error(err)
-	}
+
 }
 
 // TestInsertWithIDs logic test
@@ -473,7 +465,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot1.Bids = bids
 	snapShot1.AssetType = asset.Spot
 	snapShot1.Pair = currency.NewPairFromString("BTCUSD")
-	err := obl.LoadSnapshot(&snapShot1, false)
+	err := obl.LoadSnapshot(&snapShot1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +502,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot2.Bids = bids
 	snapShot2.AssetType = asset.Spot
 	snapShot2.Pair = currency.NewPairFromString("LTCUSD")
-	err = obl.LoadSnapshot(&snapShot2, false)
+	err = obl.LoadSnapshot(&snapShot2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +539,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot3.Bids = bids
 	snapShot3.AssetType = "FUTURES"
 	snapShot3.Pair = currency.NewPairFromString("LTCUSD")
-	err = obl.LoadSnapshot(&snapShot3, false)
+	err = obl.LoadSnapshot(&snapShot3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -143,8 +143,7 @@ func (z *ZB) WsHandleData() {
 				newOrderBook.AssetType = asset.Spot
 				newOrderBook.Pair = cPair
 
-				err = z.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
-					true)
+				err = z.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 				if err != nil {
 					z.Websocket.DataHandler <- err
 					continue

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -58,7 +58,7 @@ func (z *ZB) WsHandleData() {
 		default:
 			resp, err := z.WebsocketConn.ReadMessage()
 			if err != nil {
-				z.Websocket.DataHandler <- err
+				z.Websocket.ReadMessageErrors <- err
 				return
 			}
 			z.Websocket.TrafficAlert <- struct{}{}

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -119,7 +119,7 @@ func (z *ZB) Setup(exch *config.ExchangeConfig) error {
 
 	err = z.Websocket.Setup(
 		&wshandler.WebsocketSetup{
-			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Enabled:                          exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
 			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -122,7 +122,7 @@ func (z *ZB) Setup(exch *config.ExchangeConfig) error {
 			WsEnabled:                        exch.Features.Enabled.Websocket,
 			Verbose:                          exch.Verbose,
 			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
-			WebsocketTimeout:                 0,
+			WebsocketTimeout:                 exch.WebsocketTrafficTimeout,
 			DefaultURL:                       zbWebsocketAPI,
 			ExchangeName:                     exch.Name,
 			RunningURL:                       exch.API.Endpoints.WebsocketURL,

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -117,15 +117,18 @@ func (z *ZB) Setup(exch *config.ExchangeConfig) error {
 		return err
 	}
 
-	err = z.Websocket.Setup(z.WsConnect,
-		z.Subscribe,
-		nil,
-		exch.Name,
-		exch.Features.Enabled.Websocket,
-		exch.Verbose,
-		zbWebsocketAPI,
-		exch.API.Endpoints.WebsocketURL,
-		exch.API.AuthenticatedWebsocketSupport)
+	err = z.Websocket.Setup(
+		&wshandler.WebsocketSetup{
+			WsEnabled:                        exch.Features.Enabled.Websocket,
+			Verbose:                          exch.Verbose,
+			AuthenticatedWebsocketAPISupport: exch.API.AuthenticatedWebsocketSupport,
+			WebsocketTimeout:                 0,
+			DefaultURL:                       zbWebsocketAPI,
+			ExchangeName:                     exch.Name,
+			RunningURL:                       exch.API.Endpoints.WebsocketURL,
+			Connector:                        z.WsConnect,
+			Subscriber:                       z.Subscribe,
+		})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

![image](https://thumbs.gfycat.com/ImperturbableActiveBullfrog-size_restricted.gif)


# Description

Many of the websocket improvements I've been making have been for `master` branch. The `engine` branch introduces features like `syncer.go` which alleviates a lot of the self-managed handling of the websocket traffic and connection statuses. This PR removes a lot of the self-management, relies on `syncer.go` to manage when to use websocket for data and simplifies the connection manager to only care about the connection.

One of the biggest bugs I introduced was the shutdown channel closure timeout. If `go` could not close the `websocket.ShutdownC` channel in 15 seconds, it would give up. The following test demonstrates that even if a channel is busy and a close is called, it will eventually close successfully.

https://play.golang.org/p/RYiouqq2Twk

Another issue was that if the websocket was disconnected and failed to reconnect, it would eventually reach a situation where it would just output logs saying that it can't reconnect anymore. The new connection manager will try to reconnect forever unless the websocket is disabled.

More minor things have been cleaned up like the traffic monitor. It doesn't use channels to manage status and doesn't have a flow-on timeout tier of disconnections. By default, if the websocket hasn't received data for 2 minutes, it will call a shutdown, which the connection monitor will reconnect and the subscription handler will resubscribe to everything.

I've also re-added all the websocket connection tests that were removed in https://github.com/thrasher-corp/gocryptotrader/pull/328 which none of us noticed 😆 

## Type of change
Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
wshandler_test has fancy new tests. Running the application, killing the connection, enabling connection and watching all exchanges reconnect to the websocket and resubscribe
Also the usual `go test ./... -racerino`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules