### PR TITLE
Bugfix: Hadax API url changes

### DIFF
--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -343,7 +343,7 @@ func (h *HUOBIHADAX) GetSymbols() ([]Symbol, error) {
 	}
 
 	var result response
-	urlPath := fmt.Sprintf("%s/v%s/%s/%s", h.APIUrl, huobihadaxAPIVersion, huobihadaxAPIName, huobihadaxSymbols)
+	urlPath := fmt.Sprintf("%s/v%s/%s", h.APIUrl, huobihadaxAPIVersion, huobihadaxSymbols)
 
 	err := h.SendHTTPRequest(urlPath, &result)
 	if result.ErrorMessage != "" {
@@ -360,7 +360,7 @@ func (h *HUOBIHADAX) GetCurrencies() ([]string, error) {
 	}
 
 	var result response
-	urlPath := fmt.Sprintf("%s/v%s/%s/%s", h.APIUrl, huobihadaxAPIVersion, huobihadaxAPIName, huobihadaxCurrencies)
+	urlPath := fmt.Sprintf("%s/v%s/%s", h.APIUrl, huobihadaxAPIVersion, huobihadaxCurrencies)
 
 	err := h.SendHTTPRequest(urlPath, &result)
 	if result.ErrorMessage != "" {


### PR DESCRIPTION
# Description
Hadax has made some secret API changes that make it more inline with huobi. It removes the double naming.
old:
https://api.hadax.com/v1/common/hadax/currencys `// nolint: misspell`
new:
https://api.hadax.com/v1/common/currencys `// nolint: misspell`
old:
https://api.hadax.com/v1/common/hadax/symbols
new:
https://api.hadax.com/v1/common/symbols

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Running tests. No more 404s for currencies and symbols...
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules