### PR TITLE
(Engine) Bump Golangci-lint to 1.19.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ environment:
   NODEJS_VER: 10.15.3
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
-stack: go 1.12.3
+stack: go 1.13.1
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ before_test:
 
 test_script:
   # test back-end
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
   - '%GOPATH%\bin\golangci-lint.exe run --verbose'
   - ps: >-
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'true') {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,8 @@ linters:
 #   - gochecknoinits
 #   - gochecknoglobals
 #   - funlen
+    - dogsled
+    - whitespace
 
 linters-settings:
   govet:
@@ -79,4 +81,4 @@ issues:
         - gosec
 
 service:
-  golangci-lint-version: 1.16.x 
+  golangci-lint-version: 1.19.x

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 1m0s
+  deadline: 1m5s
   issues-exit-code: 1
   tests: true
   skip-dirs:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -40,7 +40,6 @@ func openDbConnection(driver string) (err error) {
 		dbConn.SQL.SetMaxOpenConns(2)
 		dbConn.SQL.SetMaxIdleConns(1)
 		dbConn.SQL.SetConnMaxLifetime(time.Hour)
-
 	} else if driver == "sqlite" {
 		dbConn, err = dbsqlite3.Connect()
 

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -345,7 +345,6 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 			if err != nil {
 				msg = err.Error()
 				responseContainer.ErrorCount++
-
 			}
 			responseContainer.EndpointResponses = append(responseContainer.EndpointResponses, EndpointResponse{
 				SentParams: jsonifyInterface([]interface{}{p, assetTypes[i]}),
@@ -360,7 +359,6 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 			if err != nil {
 				msg = err.Error()
 				responseContainer.ErrorCount++
-
 			}
 			responseContainer.EndpointResponses = append(responseContainer.EndpointResponses, EndpointResponse{
 				SentParams: jsonifyInterface([]interface{}{p, assetTypes[i]}),

--- a/cmd/huobi_auth/main.go
+++ b/cmd/huobi_auth/main.go
@@ -98,7 +98,6 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-
 	} else {
 		var pubKeyData []byte
 		pubKeyData, err = ioutil.ReadFile("publickey.pem")

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -80,7 +80,6 @@ func TestGetMD5(t *testing.T) {
 		t.Errorf("Test failed. Expected '%s'. Actual '%s'",
 			expectedOutput, []byte(actualStr))
 	}
-
 }
 
 func TestGetSHA512(t *testing.T) {
@@ -166,7 +165,6 @@ func TestGetHMAC(t *testing.T) {
 			expectedmd5, md5,
 		)
 	}
-
 }
 
 func TestSha1Tohex(t *testing.T) {

--- a/communications/slack/slack.go
+++ b/communications/slack/slack.go
@@ -219,7 +219,6 @@ func (s *Slack) WebsocketReader() {
 		}
 
 		switch data.Type {
-
 		case "error":
 			err = s.handleErrorResponse(data)
 			if err != nil {

--- a/communications/slack/slack_test.go
+++ b/communications/slack/slack_test.go
@@ -143,7 +143,6 @@ func TestGetUsernameByID(t *testing.T) {
 	if username != "cranktakular" {
 		t.Error("test failed - slack GetUsernameByID() error")
 	}
-
 }
 
 func TestGetIDByName(t *testing.T) {
@@ -178,7 +177,6 @@ func TestGetGroupIDByName(t *testing.T) {
 		t.Errorf("test failed - slack GetGroupIDByName() Expected '11223344' Actual '%s' Error: %s",
 			id, err)
 	}
-
 }
 
 func TestGetChannelIDByName(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -141,7 +141,6 @@ func (c *Config) GetClientBankAccounts(exchangeName, targetCurrency string) (Ban
 			c.BankAccounts[x].SupportedExchanges == "ALL") &&
 			strings.Contains(c.BankAccounts[x].SupportedCurrencies, targetCurrency) {
 			return c.BankAccounts[x], nil
-
 		}
 	}
 	return BankAccount{}, fmt.Errorf("client banking details not found for %s and currency %s",
@@ -317,7 +316,6 @@ func (c *Config) CheckCommunicationsConfig() {
 				},
 			}
 		}
-
 	} else {
 		if c.Communications.SMSGlobalConfig.From == "" {
 			c.Communications.SMSGlobalConfig.From = c.Name
@@ -1647,7 +1645,6 @@ func (c *Config) CheckRemoteControlConfig() {
 		// Then flush the old webserver settings
 		c.Webserver = nil
 	}
-
 }
 
 // CheckConfig checks all config settings

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -195,7 +195,6 @@ func TestCheckClientBankAccounts(t *testing.T) {
 	if !cfg.BankAccounts[0].Enabled {
 		t.Error("unexpected result")
 	}
-
 }
 
 func TestPurgeExchangeCredentials(t *testing.T) {

--- a/currency/code.go
+++ b/currency/code.go
@@ -804,9 +804,9 @@ var (
 	STQ        = NewCode("STQ")
 	INK        = NewCode("INK")
 	HBZ        = NewCode("HBZ")
-	USDT_ETH   = NewCode("USDT_ETH") // nolint: golint
-	QTUM_ETH   = NewCode("QTUM_ETH") // nolint: golint
-	BTM_ETH    = NewCode("BTM_ETH")  // nolint: golint
+	USDT_ETH   = NewCode("USDT_ETH") // nolint: golint, stylecheck
+	QTUM_ETH   = NewCode("QTUM_ETH") // nolint: golint, stylecheck
+	BTM_ETH    = NewCode("BTM_ETH")  // nolint: golint, stylecheck
 	FIL        = NewCode("FIL")
 	STX        = NewCode("STX")
 	BOT        = NewCode("BOT")
@@ -819,7 +819,7 @@ var (
 	GOD        = NewCode("GOD")
 	SMT        = NewCode("SMT")
 	BTF        = NewCode("BTF")
-	NAS_ETH    = NewCode("NAS_ETH") // nolint: golint
+	NAS_ETH    = NewCode("NAS_ETH") // nolint: golint, stylecheck
 	TSL        = NewCode("TSL")
 	BIFI       = NewCode("BIFI")
 	BNTY       = NewCode("BNTY")
@@ -845,7 +845,7 @@ var (
 	MOBI       = NewCode("MOBI")
 	LEDU       = NewCode("LEDU")
 	DBC        = NewCode("DBC")
-	MKR_OLD    = NewCode("MKR_OLD") // nolint: golint
+	MKR_OLD    = NewCode("MKR_OLD") // nolint: golint, stylecheck
 	DPY        = NewCode("DPY")
 	BCDN       = NewCode("BCDN")
 	EOSDAC     = NewCode("EOSDAC") // nolint: golint
@@ -854,7 +854,7 @@ var (
 	PPS        = NewCode("PPS")
 	BOE        = NewCode("BOE")
 	MEDX       = NewCode("MEDX")
-	SMT_ETH    = NewCode("SMT_ETH") // nolint: golint
+	SMT_ETH    = NewCode("SMT_ETH") // nolint: golint, stylecheck
 	CS         = NewCode("CS")
 	MAN        = NewCode("MAN")
 	REM        = NewCode("REM")
@@ -874,7 +874,7 @@ var (
 	SWTH       = NewCode("SWTH")
 	NKN        = NewCode("NKN")
 	SOUL       = NewCode("SOUL")
-	GALA_NEO   = NewCode("GALA_NEO") // nolint: golint
+	GALA_NEO   = NewCode("GALA_NEO") // nolint: golint, stylecheck
 	LRN        = NewCode("LRN")
 	GSE        = NewCode("GSE")
 	RATING     = NewCode("RATING")
@@ -2099,5 +2099,5 @@ var (
 	YER        = NewCode("YER")
 	ZWD        = NewCode("ZWD")
 	XETH       = NewCode("XETH")
-	FX_BTC     = NewCode("FX_BTC") // nolint: golint
+	FX_BTC     = NewCode("FX_BTC") // nolint: golint, stylecheck
 )

--- a/currency/manager_test.go
+++ b/currency/manager_test.go
@@ -87,7 +87,6 @@ func TestDelete(t *testing.T) {
 	if p.Get(asset.Spot) != nil {
 		t.Error("Test failed. Delete should have deleted AssetTypeSpot")
 	}
-
 }
 
 func TestGetPairs(t *testing.T) {

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -389,7 +389,6 @@ func (s *Storage) WriteCurrencyDataToFile(path string, mainUpdate bool) error {
 
 // LoadFileCurrencyData loads currencies into the currency codes
 func (s *Storage) LoadFileCurrencyData(f *File) error {
-
 	for i := range f.Contracts {
 		err := s.currencyCodes.LoadItem(&f.Contracts[i])
 		if err != nil {

--- a/currency/symbol_test.go
+++ b/currency/symbol_test.go
@@ -17,5 +17,4 @@ func TestGetSymbolByCurrencyName(t *testing.T) {
 	if err == nil {
 		t.Errorf("Test failed. TestGetSymbolByCurrencyNam returned nil on non-existent currency")
 	}
-
 }

--- a/database/repository/audit/sqlite/audit.go
+++ b/database/repository/audit/sqlite/audit.go
@@ -49,5 +49,4 @@ func (pg *auditRepo) AddEventTx(event []*models.AuditEvent) {
 		}
 		return
 	}
-
 }

--- a/database/tests/audit_test.go
+++ b/database/tests/audit_test.go
@@ -49,7 +49,6 @@ func TestAudit(t *testing.T) {
 		test := tests
 
 		t.Run(test.name, func(t *testing.T) {
-
 			mg.MigrationDir = filepath.Join("../migration", "migrations")
 
 			if !checkValidConfig(t, &test.config.ConnectionDetails) {
@@ -88,7 +87,6 @@ func TestAudit(t *testing.T) {
 			}
 
 			switch v := test.output.(type) {
-
 			case error:
 				if v.Error() != test.output.(error).Error() {
 					t.Fatal(err)

--- a/engine/exchange.go
+++ b/engine/exchange.go
@@ -295,7 +295,6 @@ func SetupExchanges() {
 				continue
 			}
 			return
-
 		}
 		if !exch.Enabled && !Bot.Settings.EnableAllExchanges {
 			log.Debugf(log.ExchangeSys, "%s: Exchange support: Disabled\n", exch.Name)

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -523,7 +523,6 @@ func SeedExchangeAccountInfo(data []exchange.AccountInfo) {
 		var currencies []exchange.AccountCurrencyInfo
 		for _, account := range exchangeData.Accounts {
 			for _, info := range account.Currencies {
-
 				var update bool
 				for i := range currencies {
 					if info.CurrencyName == currencies[i].CurrencyName {
@@ -566,7 +565,6 @@ func SeedExchangeAccountInfo(data []exchange.AccountInfo) {
 						CoinType:    currencyName,
 						Balance:     total,
 						Description: portfolio.PortfolioAddressExchange})
-
 			} else {
 				if total <= 0 {
 					log.Debugf(log.PortfolioMgr, "Portfolio: Removing %s %s entry.\n",
@@ -635,7 +633,6 @@ func GetCryptocurrenciesByExchange(exchangeName string, enabledExchangesOnly, en
 				cryptocurrencies = append(cryptocurrencies, pairs[y].Quote.String())
 			}
 		}
-
 	}
 	return cryptocurrencies, nil
 }

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -926,7 +926,6 @@ func (s *RPCServer) EnableExchangePair(ctx context.Context, r *gctrpc.ExchangePa
 	err = GetExchangeByName(r.Exchange).GetBase().CurrencyPairs.EnablePair(
 		asset.Item(r.AssetType), p)
 	return &gctrpc.GenericExchangeNameResponse{}, err
-
 }
 
 // DisableExchangePair disables the specified pair on an exchange

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -404,7 +404,8 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 									}
 									printTickerSummary(&result, c.Pair, c.AssetType, exchangeName, err)
 									if err == nil {
-										//nolint:gocritic Bot.CommsRelayer.StageTickerData(exchangeName, c.AssetType, result)
+										// nolint:gocritic
+										// Bot.CommsRelayer.StageTickerData(exchangeName, c.AssetType, result)
 										if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
 											relayWebsocketEvent(result, "ticker_update", c.AssetType.String(), exchangeName)
 										}
@@ -440,7 +441,8 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 								result, err := Bot.Exchanges[x].UpdateOrderbook(c.Pair, c.AssetType)
 								printOrderbookSummary(&result, c.Pair, c.AssetType, exchangeName, err)
 								if err == nil {
-									//nolint:gocritic Bot.CommsRelayer.StageOrderbookData(exchangeName, c.AssetType, result)
+									// nolint: gocritic
+									// Bot.CommsRelayer.StageOrderbookData(exchangeName, c.AssetType, result)
 									if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
 										relayWebsocketEvent(result, "orderbook_update", c.AssetType.String(), exchangeName)
 									}
@@ -463,7 +465,6 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 			}
 		}
 	}
-
 }
 
 // Start starts an exchange currency pair syncer

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -132,7 +132,6 @@ func (a *ANX) GetDataToken() (string, error) {
 // NewOrder sends a new order request to the exchange.
 func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, tradedCurrencyAmount float64, settlementCurrency string, settlementCurrencyAmount, limitPriceSettlement float64,
 	replace bool, replaceUUID string, replaceIfActive bool) (string, error) {
-
 	req := make(map[string]interface{})
 	var order Order
 	order.OrderType = orderType

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -240,7 +240,6 @@ func TestGetFee(t *testing.T) {
 			t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0), resp)
 			t.Error(err)
 		}
-
 	}
 
 	// CryptocurrencyWithdrawalFee Basic

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -242,7 +242,6 @@ func TestGetSymbols(t *testing.T) {
 		"rrtusd",
 	}
 	if len(expectedCurrencies) <= len(symbols) {
-
 		for _, explicitSymbol := range expectedCurrencies {
 			if common.StringDataCompare(expectedCurrencies, explicitSymbol) {
 				break

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -205,7 +205,6 @@ func (b *Bitfinex) WsDataHandler() {
 						if status == "OK" {
 							b.Websocket.DataHandler <- eventData
 							b.WsAddSubscriptionChannel(0, "account", "N/A")
-
 						} else if status == "fail" {
 							b.Websocket.DataHandler <- fmt.Errorf("bitfinex.go error - Websocket unable to AUTH. Error code: %s",
 								eventData["code"].(string))

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -186,7 +186,6 @@ func (b *Bitmex) wsHandleIncomingData() {
 
 				b.Websocket.DataHandler <- fmt.Errorf("%s websocket error: Unable to subscribe %s",
 					b.Name, decodedResp.Subscribe)
-
 			} else if _, ok := quickCapture["table"]; ok {
 				var decodedResp WebsocketMainResponse
 				err := common.JSONDecode(resp.Raw, &decodedResp)

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -247,7 +247,6 @@ func (b *Bitstamp) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)
-
 }
 
 // FetchOrderbook returns the orderbook for a currency pair

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -507,5 +507,4 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 // calculateTradingFee returns the fee for trading any currency on Bittrex
 func calculateTradingFee(price, amount float64) float64 {
 	return 0.0025 * price * amount
-
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -415,7 +415,6 @@ func (b *Bittrex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error)
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)
-
 }
 
 // GetActiveOrders retrieves any orders that are active/open

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -55,7 +55,6 @@ func (b *BTSE) GetTrades(symbol string) (*Trades, error) {
 	var t Trades
 	endpoint := fmt.Sprintf("%s/%s", btseTrades, symbol)
 	return &t, b.SendHTTPRequest(http.MethodGet, endpoint, &t)
-
 }
 
 // GetTicker returns the ticker for a specified symbol

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -114,7 +114,6 @@ func TestGetFills(t *testing.T) {
 	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
-
 }
 
 func TestGetActiveOrders(t *testing.T) {

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -94,7 +94,6 @@ func (b *BTSE) SetDefaults() {
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit
-
 }
 
 // Setup takes in the supplied exchange configuration details and sets params
@@ -213,7 +212,6 @@ func (b *BTSE) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 		assetType).String())
 	if err != nil {
 		return tickerPrice, err
-
 	}
 
 	tickerPrice.Pair = p

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -367,7 +367,6 @@ func TestCalculateTradingFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	c.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
 
@@ -449,7 +448,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 
@@ -476,7 +474,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -454,7 +454,7 @@ type WebsocketTicker struct {
 	BestBid   float64       `json:"best_bid,string"`
 	BestAsk   float64       `json:"best_ask,string"`
 	Side      string        `json:"side"`
-	Time      time.Time     `json:"time,string"`
+	Time      time.Time     `json:"time"`
 	TradeID   int64         `json:"trade_id"`
 	LastSize  float64       `json:"last_size,string"`
 }

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -247,7 +247,6 @@ func TestGetFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	c.SetDefaults()
 	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 
@@ -322,7 +321,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 
@@ -349,7 +347,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -102,7 +102,6 @@ func (c *COINUT) WsHandleData() {
 					}
 					c.wsProcessResponse(individualJSON)
 				}
-
 			} else {
 				var incoming wsResponse
 				err = common.JSONDecode(resp.Raw, &incoming)
@@ -113,7 +112,6 @@ func (c *COINUT) WsHandleData() {
 
 				c.wsProcessResponse(resp.Raw)
 			}
-
 		}
 	}
 }

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -336,7 +336,6 @@ func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 	}
 
 	return ticker.GetTicker(c.Name, p, assetType)
-
 }
 
 // FetchTicker returns the ticker for a currency pair
@@ -704,7 +703,6 @@ func (c *COINUT) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) ([
 				CurrencyPair: p,
 			})
 		}
-
 	}
 
 	exchange.FilterOrdersByTickRange(&allOrders, getOrdersRequest.StartTicks,

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -254,7 +254,6 @@ func TestGetFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	e.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.NoFiatWithdrawalsText
 
@@ -334,7 +333,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	e.SetDefaults()
 	TestSetup(t)
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
@@ -360,7 +358,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	e.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/hitbtc/hitbtc_types.go
+++ b/exchanges/hitbtc/hitbtc_types.go
@@ -61,7 +61,7 @@ type TradeHistory struct {
 
 // ChartData contains chart data
 type ChartData struct {
-	Timestamp   time.Time `json:"timestamp,string"`
+	Timestamp   time.Time `json:"timestamp"`
 	Max         float64   `json:"max,string"`         // Max price
 	Min         float64   `json:"min,string"`         // Min price
 	Open        float64   `json:"open,string"`        // Open price
@@ -74,7 +74,7 @@ type ChartData struct {
 type Currencies struct {
 	ID                 string `json:"id"`                 // Currency identifier.
 	FullName           string `json:"fullName"`           // Currency full name
-	Crypto             bool   `json:"crypto,boolean"`     // Is currency belongs to blockchain (false for ICO and fiat, like EUR)
+	Crypto             bool   `json:"crypto"`             // Is currency belongs to blockchain (false for ICO and fiat, like EUR)
 	PayinEnabled       bool   `json:"payinEnabled"`       // Is allowed for deposit (false for ICO)
 	PayinPaymentID     bool   `json:"payinPaymentId"`     // Is required to provide additional information other than the address for deposit
 	PayinConfirmations int64  `json:"payinConfirmations"` // Blocks confirmations count for deposit
@@ -134,10 +134,10 @@ type Order struct {
 	Quantity    float64   `json:"quantity,string"`    // Order quantity
 	Price       float64   `json:"price,string"`       // Order price
 	CumQuantity float64   `json:"cumQuantity,string"` // Cumulative executed quantity
-	CreatedAt   time.Time `json:"createdAt,string"`
-	UpdatedAt   time.Time `json:"updatedAt,string"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 	StopPrice   float64   `json:"stopPrice,string"`
-	ExpireTime  time.Time `json:"expireTime,string"`
+	ExpireTime  time.Time `json:"expireTime"`
 }
 
 // OpenOrdersResponseAll holds the full open order response
@@ -260,7 +260,7 @@ type LoanOffer struct {
 	Rate      float64 `json:"rate,string"`
 	Amount    float64 `json:"amount,string"`
 	Duration  int     `json:"duration"`
-	AutoRenew bool    `json:"autoRenew,int"`
+	AutoRenew bool    `json:"autoRenew"`
 	Date      string  `json:"date"`
 }
 

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -469,7 +469,6 @@ func (k *Kraken) GetTradeBalance(args ...TradeBalanceOptions) (TradeBalanceInfo,
 		if len(args[0].Asset) > 0 {
 			params.Set("asset", args[0].Asset)
 		}
-
 	}
 
 	var response struct {

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -360,7 +360,6 @@ func (l *LakeBTC) CancelAllOrders(_ *exchange.OrderCancellation) (exchange.Cance
 	}
 
 	return cancelAllOrdersResponse, l.CancelExistingOrders(ordersToCancel)
-
 }
 
 // GetOrderInfo returns information on a current open order

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -169,7 +169,6 @@ func (l *Lbank) GetKlines(symbol, size, klineType, time string) ([]KlineResponse
 				} else {
 					tempResp.TradingVolume = resp2[x].(float64)
 				}
-
 			}
 		}
 		k = append(k, tempResp)

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -643,7 +643,6 @@ func (l *Lbank) getAllOpenOrderID() (map[string][]string, error) {
 
 			for c := 0; c < tempData; c++ {
 				resp[p] = append(resp[p], tempResp.Orders[c].OrderID)
-
 			}
 			tempData = len(tempResp.Orders)
 			b++

--- a/exchanges/localbitcoins/localbitcoins_types.go
+++ b/exchanges/localbitcoins/localbitcoins_types.go
@@ -106,7 +106,7 @@ type AdEdit struct {
 	MaxAmount          int      `json:"max_amount"`
 	OpeningHours       []string `json:"opening_hours"`
 	LimitToFiatAmounts string   `json:"limit_to_fiat_amounts"`
-	Visible            bool     `json:"visible,int"`
+	Visible            bool     `json:"visibleq"`
 
 	// Optional Arguments ONLINE_SELL ads
 	RequireTradeVolume   int    `json:"require_trade_volume"`
@@ -114,13 +114,13 @@ type AdEdit struct {
 	FirstTimeLimitBTC    int    `json:"first_time_limit_btc"`
 	VolumeCoefficientBTC int    `json:"volume_coefficient_btc"`
 	ReferenceType        string `json:"reference_type"`
-	DisplayReference     bool   `json:"display_reference,int"`
+	DisplayReference     bool   `json:"display_reference"`
 
 	// Optional Arguments ONLINE_BUY
 	PaymentWindowMinutes int `json:"payment_window_minutes"`
 
 	// Optional Arguments LOCAL_SELL
-	Floating bool `json:"floating,int"`
+	Floating bool `json:"floating"`
 }
 
 // AdCreate references an outgoing paramater type for CreateAd() method
@@ -148,7 +148,7 @@ type AdCreate struct {
 	MaxAmount          int      `json:"max_amount"`
 	OpeningHours       []string `json:"opening_hours"`
 	LimitToFiatAmounts string   `json:"limit_to_fiat_amounts"`
-	Visible            bool     `json:"visible,int"`
+	Visible            bool     `json:"visible"`
 
 	// Optional Arguments ONLINE_SELL ads
 	RequireTradeVolume   int    `json:"require_trade_volume"`
@@ -156,13 +156,13 @@ type AdCreate struct {
 	FirstTimeLimitBTC    int    `json:"first_time_limit_btc"`
 	VolumeCoefficientBTC int    `json:"volume_coefficient_btc"`
 	ReferenceType        string `json:"reference_type"`
-	DisplayReference     bool   `json:"display_reference,int"`
+	DisplayReference     bool   `json:"display_reference"`
 
 	// Optional Arguments ONLINE_BUY
 	PaymentWindowMinutes int `json:"payment_window_minutes"`
 
 	// Optional Arguments LOCAL_SELL
-	Floating bool `json:"floating,int"`
+	Floating bool `json:"floating"`
 }
 
 // Message holds the returned message data from a contact

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -420,7 +420,6 @@ func GetExcludedItems() (Exclusion, error) {
 			if mErr != nil {
 				return excludedList, mErr
 			}
-
 		} else {
 			err = json.Unmarshal(file, &excludedList)
 			if err != nil {

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1085,7 +1085,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	err := o.CancelOrder(&orderCancellation)
 	testStandardErrorHandling(t, err)
-
 }
 
 // TestCancelAllExchangeOrders Wrapper test

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1852,7 +1852,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	err := o.CancelOrder(&orderCancellation)
 	testStandardErrorHandling(t, err)
-
 }
 
 // TestCancelAllExchangeOrders Wrapper test

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -601,7 +601,6 @@ func (o *OKGroup) SendHTTPRequest(httpMethod, requestType, requestPath string, d
 		if !errCap.Result {
 			return errors.New("unspecified error occurred")
 		}
-
 	}
 
 	return common.JSONDecode(intermediary, result)

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -320,7 +320,6 @@ func (o *OKGroup) GetAssetTypeFromTableName(table string) asset.Item {
 // WsHandleDataResponse classifies the WS response and sends to appropriate handler
 func (o *OKGroup) WsHandleDataResponse(response *WebsocketDataResponse) {
 	switch o.GetWsChannelWithoutOrderType(response.Table) {
-
 	case okGroupWsCandle60s, okGroupWsCandle180s, okGroupWsCandle300s, okGroupWsCandle900s,
 		okGroupWsCandle1800s, okGroupWsCandle3600s, okGroupWsCandle7200s, okGroupWsCandle14400s,
 		okGroupWsCandle21600s, okGroupWsCandle43200s, okGroupWsCandle86400s, okGroupWsCandle604900s:
@@ -515,7 +514,6 @@ func (o *OKGroup) WsProcessUpdateOrderbook(wsEventData *WebsocketDataWrapper, in
 			Asset:    o.GetAssetTypeFromTableName(tableName),
 			Pair:     instrument,
 		}
-
 	} else {
 		if o.Verbose {
 			log.Warnln(log.ExchangeSys, "Orderbook invalid")
@@ -540,7 +538,6 @@ func (o *OKGroup) CalculatePartialOrderbookChecksum(orderbookData *WebsocketData
 		}
 		if len(orderbookData.Asks)-1 >= i {
 			askMessage = fmt.Sprintf("%v:%v:", orderbookData.Asks[i][0], orderbookData.Asks[i][1])
-
 		}
 		if checksum == "" {
 			checksum = fmt.Sprintf("%v%v", bidsMessage, askMessage)

--- a/exchanges/orderbook/calculator.go
+++ b/exchanges/orderbook/calculator.go
@@ -20,19 +20,19 @@ type WhaleBombResult struct {
 }
 
 // WhaleBomb finds the amount required to target a price
-func (o *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error) {
+func (b *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error) {
 	if priceTarget < 0 {
 		return nil, errors.New("price target is invalid")
 	}
 	if buy {
-		a, orders := o.findAmount(priceTarget, true)
+		a, orders := b.findAmount(priceTarget, true)
 		min, max := orders.MinimumPrice(false), orders.MaximumPrice(true)
 		var err error
 		if max < priceTarget {
 			err = errors.New("unable to hit price target due to insufficient orderbook items")
 		}
 		status := fmt.Sprintf("Buying %.2f %v worth of %v will send the price from %v to %v [%.2f%%] and take %v orders.",
-			a, o.Pair.Quote.String(), o.Pair.Base.String(), min, max,
+			a, b.Pair.Quote.String(), b.Pair.Base.String(), min, max,
 			math.CalculatePercentageGainOrLoss(max, min), len(orders))
 		return &WhaleBombResult{
 			Amount:       a,
@@ -43,14 +43,14 @@ func (o *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error
 		}, err
 	}
 
-	a, orders := o.findAmount(priceTarget, false)
+	a, orders := b.findAmount(priceTarget, false)
 	min, max := orders.MinimumPrice(false), orders.MaximumPrice(true)
 	var err error
 	if min > priceTarget {
 		err = errors.New("unable to hit price target due to insufficient orderbook items")
 	}
 	status := fmt.Sprintf("Selling %.2f %v worth of %v will send the price from %v to %v [%.2f%%] and take %v orders.",
-		a, o.Pair.Base.String(), o.Pair.Quote.String(), max, min,
+		a, b.Pair.Base.String(), b.Pair.Quote.String(), max, min,
 		math.CalculatePercentageGainOrLoss(min, max), len(orders))
 	return &WhaleBombResult{
 		Amount:       a,
@@ -65,13 +65,13 @@ func (o *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error
 type OrderSimulationResult WhaleBombResult
 
 // SimulateOrder simulates an order
-func (o *Base) SimulateOrder(amount float64, buy bool) *OrderSimulationResult {
+func (b *Base) SimulateOrder(amount float64, buy bool) *OrderSimulationResult {
 	if buy {
-		orders, amt := o.buy(amount)
+		orders, amt := b.buy(amount)
 		min, max := orders.MinimumPrice(false), orders.MaximumPrice(true)
 		pct := math.CalculatePercentageGainOrLoss(max, min)
 		status := fmt.Sprintf("Buying %.2f %v worth of %v will send the price from %v to %v [%.2f%%] and take %v orders.",
-			amount, o.Pair.Quote.String(), o.Pair.Base.String(), min, max,
+			amount, b.Pair.Quote.String(), b.Pair.Base.String(), min, max,
 			pct, len(orders))
 		return &OrderSimulationResult{
 			Orders:               orders,
@@ -82,11 +82,11 @@ func (o *Base) SimulateOrder(amount float64, buy bool) *OrderSimulationResult {
 			Status:               status,
 		}
 	}
-	orders, amt := o.sell(amount)
+	orders, amt := b.sell(amount)
 	min, max := orders.MinimumPrice(false), orders.MaximumPrice(true)
 	pct := math.CalculatePercentageGainOrLoss(min, max)
 	status := fmt.Sprintf("Selling %f %v worth of %v will send the price from %v to %v [%.2f%%] and take %v orders.",
-		amount, o.Pair.Base.String(), o.Pair.Quote.String(), max, min,
+		amount, b.Pair.Base.String(), b.Pair.Quote.String(), max, min,
 		pct, len(orders))
 	return &OrderSimulationResult{
 		Orders:               orders,
@@ -138,12 +138,12 @@ func sortOrdersByPrice(o *orderSummary, reverse bool) {
 	}
 }
 
-func (o *Base) findAmount(price float64, buy bool) (float64, orderSummary) {
+func (b *Base) findAmount(price float64, buy bool) (float64, orderSummary) {
 	var orders orderSummary
 	var amt float64
 
 	if buy {
-		asks := o.Asks
+		asks := b.Asks
 		for x := range asks {
 			if asks[x].Price >= price {
 				amt += asks[x].Price * asks[x].Amount
@@ -162,65 +162,65 @@ func (o *Base) findAmount(price float64, buy bool) (float64, orderSummary) {
 		return amt, orders
 	}
 
-	for x := range o.Bids {
-		if o.Bids[x].Price <= price {
-			amt += o.Bids[x].Amount
+	for x := range b.Bids {
+		if b.Bids[x].Price <= price {
+			amt += b.Bids[x].Amount
 			orders = append(orders, Item{
-				Price:  o.Bids[x].Price,
-				Amount: o.Bids[x].Amount,
+				Price:  b.Bids[x].Price,
+				Amount: b.Bids[x].Amount,
 			})
 			break
 		}
 		orders = append(orders, Item{
-			Price:  o.Bids[x].Price,
-			Amount: o.Bids[x].Amount,
+			Price:  b.Bids[x].Price,
+			Amount: b.Bids[x].Amount,
 		})
-		amt += o.Bids[x].Amount
+		amt += b.Bids[x].Amount
 	}
 	return amt, orders
 }
 
-func (o *Base) buy(amount float64) (orders orderSummary, baseAmount float64) {
+func (b *Base) buy(amount float64) (orders orderSummary, baseAmount float64) {
 	var processedAmt float64
-	for x := range o.Asks {
-		subtotal := o.Asks[x].Price * o.Asks[x].Amount
+	for x := range b.Asks {
+		subtotal := b.Asks[x].Price * b.Asks[x].Amount
 		if processedAmt+subtotal >= amount {
 			diff := amount - processedAmt
-			subAmt := diff / o.Asks[x].Price
+			subAmt := diff / b.Asks[x].Price
 			orders = append(orders, Item{
-				Price:  o.Asks[x].Price,
+				Price:  b.Asks[x].Price,
 				Amount: subAmt,
 			})
 			baseAmount += subAmt
 			break
 		}
 		processedAmt += subtotal
-		baseAmount += o.Asks[x].Amount
+		baseAmount += b.Asks[x].Amount
 		orders = append(orders, Item{
-			Price:  o.Asks[x].Price,
-			Amount: o.Asks[x].Amount,
+			Price:  b.Asks[x].Price,
+			Amount: b.Asks[x].Amount,
 		})
 	}
 	return
 }
 
-func (o *Base) sell(amount float64) (orders orderSummary, quoteAmount float64) {
+func (b *Base) sell(amount float64) (orders orderSummary, quoteAmount float64) {
 	var processedAmt float64
-	for x := range o.Bids {
-		if processedAmt+o.Bids[x].Amount >= amount {
+	for x := range b.Bids {
+		if processedAmt+b.Bids[x].Amount >= amount {
 			diff := amount - processedAmt
 			orders = append(orders, Item{
-				Price:  o.Bids[x].Price,
+				Price:  b.Bids[x].Price,
 				Amount: diff,
 			})
-			quoteAmount += diff * o.Bids[x].Price
+			quoteAmount += diff * b.Bids[x].Price
 			break
 		}
-		processedAmt += o.Bids[x].Amount
-		quoteAmount += o.Bids[x].Amount * o.Bids[x].Price
+		processedAmt += b.Bids[x].Amount
+		quoteAmount += b.Bids[x].Amount * b.Bids[x].Price
 		orders = append(orders, Item{
-			Price:  o.Bids[x].Price,
-			Amount: o.Bids[x].Amount,
+			Price:  b.Bids[x].Price,
+			Amount: b.Bids[x].Amount,
 		})
 	}
 	return

--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -262,7 +262,7 @@ type LoanOffer struct {
 	Rate      float64 `json:"rate,string"`
 	Amount    float64 `json:"amount,string"`
 	Duration  int     `json:"duration"`
-	AutoRenew bool    `json:"autoRenew,int"`
+	AutoRenew bool    `json:"autoRenew"`
 	Date      string  `json:"date"`
 }
 

--- a/exchanges/websocket/wsorderbook/wsorderbook_test.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook_test.go
@@ -560,7 +560,6 @@ func TestFlushCache(t *testing.T) {
 	if obl.ob[curr][asset.Spot] != nil {
 		t.Error("expected ob be flushed")
 	}
-
 }
 
 // TestInsertingSnapShots logic test

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -50,7 +50,6 @@ func CloseLogger() error {
 		return err
 	}
 	return nil
-
 }
 
 func validSubLogger(s string) (bool, *subLogger) {

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -366,7 +366,6 @@ func (p *Base) GetPortfolioSummary() Summary {
 				Percentage: getPercentageSpecific(z, y, totalCoins),
 			}
 			coinSummary[y] = coinSum
-
 		}
 		exchangeSummary[exchgName] = coinSummary
 	}

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -108,7 +108,6 @@ func TestExchangeAddressExists(t *testing.T) {
 	if newbase.ExchangeAddressExists("TEST", currency.LTC) {
 		t.Error("Test Failed - portfolio_test.go - ExchangeAddressExists error")
 	}
-
 }
 
 func TestAddExchangeAddress(t *testing.T) {


### PR DESCRIPTION
# Description

This PR bumps GolangCI-Lint from v1.18.0 to v1.19.1

Mainly because of:
![image](https://user-images.githubusercontent.com/1223381/66350185-63d11300-e9a6-11e9-94e1-791077c3661b.png)

But there is also a few other performance improvements & overall 1.13 support improvements

https://github.com/golangci/golangci-lint/compare/v1.18.0...v1.19.1

Fixes #my constant inserting of newlines

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
golangci-lint run -verbose 
go clean -testcache && go test ./... -race -v
```
both run locally and pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules