### PR TITLE
Engine: Use int32 for dispatcher atomic operations

### DIFF
--- a/dispatch/dispatch_types.go
+++ b/dispatch/dispatch_types.go
@@ -46,11 +46,11 @@ type Dispatcher struct {
 	outbound sync.Pool
 
 	// MaxWorkers defines max worker ceiling
-	maxWorkers int64
+	maxWorkers int32
 
 	// Atomic values -----------------------
 	// Worker counter
-	count int64
+	count int32
 	// Dispatch status
 	running uint32
 

--- a/engine/engine_types.go
+++ b/engine/engine_types.go
@@ -64,5 +64,5 @@ type Settings struct {
 
 	// Dispatch system settings
 	EnableDispatcher        bool
-	DispatchMaxWorkerAmount int64
+	DispatchMaxWorkerAmount int
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.DurationVar(&settings.EventManagerDelay, "eventmanagerdelay", time.Duration(0), "sets the event managers sleep delay between event checking")
 	flag.BoolVar(&settings.EnableNTPClient, "ntpclient", true, "enables the NTP client to check system clock drift")
 	flag.BoolVar(&settings.EnableDispatcher, "dispatch", true, "enables the dispatch system")
-	flag.Int64Var(&settings.DispatchMaxWorkerAmount, "dispatchworkers", dispatch.DefaultMaxWorkers, "sets the dispatch package max worker generation limit")
+	flag.IntVar(&settings.DispatchMaxWorkerAmount, "dispatchworkers", dispatch.DefaultMaxWorkers, "sets the dispatch package max worker generation limit")
 
 	// Forex provider settings
 	flag.BoolVar(&settings.EnableCurrencyConverter, "currencyconverter", false, "overrides config and sets up foreign exchange Currency Converter")


### PR DESCRIPTION
# Description

Uses int32 for dispatcher atomic variables, in line with the rest of the engine changes. 

Fixes # (issue)

Fixes a crash bug when running GCT on ARM.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI and by running the binary

![image](https://user-images.githubusercontent.com/4685270/67343107-f9140000-f57f-11e9-9885-a39869149d73.png)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules