### PR TITLE
Add in types for order fields

### DIFF
--- a/exchanges/order/order_types.go
+++ b/exchanges/order/order_types.go
@@ -106,14 +106,14 @@ const (
 
 // Detail holds order detail data
 type Detail struct {
-	Exchange     string
-	AccountID    string
-	ID           string
-	CurrencyPair currency.Pair
-	OrderSide    Side
-	OrderType    Type
-	OrderDate    time.Time
-	Status
+	Exchange        string
+	AccountID       string
+	ID              string
+	CurrencyPair    currency.Pair
+	OrderSide       Side
+	OrderType       Type
+	OrderDate       time.Time
+	Status          Status
 	Price           float64
 	Amount          float64
 	ExecutedAmount  float64
@@ -124,13 +124,13 @@ type Detail struct {
 
 // TradeHistory holds exchange history data
 type TradeHistory struct {
-	Timestamp time.Time
-	TID       int64
-	Price     float64
-	Amount    float64
-	Exchange  string
-	Type
-	Side
+	Timestamp   time.Time
+	TID         int64
+	Price       float64
+	Amount      float64
+	Exchange    string
+	Type        Type
+	Side        Side
 	Fee         float64
 	Description string
 }
@@ -142,7 +142,7 @@ type Cancel struct {
 	CurrencyPair  currency.Pair
 	AssetType     asset.Item
 	WalletAddress string
-	Side
+	Side          Side
 }
 
 // GetOrdersRequest used for GetOrderHistory and GetOpenOrders wrapper functions


### PR DESCRIPTION
# Description

When testing some code on my engine qa branch, I noticed that append wasn't working as expected when using exchange wrapper order funcs. After investigating it a bit more, it turns out that using anonymous fields breaks it.

```
func TestAppendage(t *testing.T) {
	var orders []order.Detail

	orders = append(orders, order.Detail{
		Price: 1337,
	})

	t.Log(orders)
}
```

Output: bitstamp_test.go:263: []

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually testing order wrapper funcs and go test ./... -race (though isn't helpful for runtime)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules