### PR TITLE
GateIO: Update websocket endpoint because of certificate failure

### DIFF
--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	gateioWebsocketEndpoint  = "wss://ws.gate.io/v3/"
+	gateioWebsocketEndpoint  = "wss://ws.gateio.ws/v3/"
 	gatioWsMethodPing        = "ping"
 	gateioWebsocketRateLimit = 120
 )


### PR DESCRIPTION
# Description

Updates the GateIO websocket endpoint to their other reccomended (https://www.gate.io/docs/websocket/index.html#server-url) one due to a certificate failure.

Fixes # (issue).

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Enabling websocket on GateIO and running tests

```
[DEBUG]: 2019/10/31 11:37:04 GateIO Websocket message received: {"method": "ticker.update", "params": ["BTC_USDT", {"period": 86400, "open": "9400", "close": "9175.6", "high": "9400", "low": "9000.22", "last": "9175.6", "change": "-2.38", "quoteVolume": "1759.1883544226", "baseVolume": "16124505.306686951488755921"}], "id": null}
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules