### PR TITLE
Bump golangci-lint and AppVeyor versions now that Go 1.13.x is supported

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ environment:
   NODEJS_VER: 10.15.3
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
-stack: go 1.12.3
+stack: go 1.13.x
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%
@@ -28,7 +28,7 @@ before_test:
 
 test_script:
   # test back-end
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.20.1
   - '%GOPATH%\bin\golangci-lint.exe run --verbose'
   - ps: >-
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'true') {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 1m0s
+  timeout: 1m0s
   issues-exit-code: 1
   tests: true
   skip-dirs:
@@ -11,41 +11,46 @@ linters:
   disable-all: true
   enable:
 # defaults
-    - govet
-#   - errcheck
-    - staticcheck
-#   - unused
-    - gosimple
-    - structcheck
-#   - varcheck
-    - ineffassign
 #   - deadcode
+#   - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
     - typecheck
+#   - unused
+#   - varcheck
 
 # disabled by default linters
 #   - bodyclose
-    - golint
-    - stylecheck
-    - gosec
-#   - interfacer
-    - unconvert
+    - depguard
+    - dogsled
 #   - dupl
+#   - funlen
+#   - gochecknoglobals
+#   - gochecknoinits
+#   - gocognit
     - goconst
+    - gocritic
 #   - gocyclo
+#   - godox
     - gofmt
     - goimports
-#   - maligned
-    - depguard
-    - misspell
+    - golint
+    - gosec
+#   - interfacer
 #   - lll
-    - unparam
+#   - maligned
+    - misspell
     - nakedret
 #   - prealloc
     - scopelint
-    - gocritic
-#   - gochecknoinits
-#   - gochecknoglobals
-#   - funlen
+    - stylecheck
+    - unconvert
+    - unparam
+    - whitespace
+#   - wsl
 
 linters-settings:
   govet:
@@ -77,6 +82,3 @@ issues:
     - text: "weak cryptographic primitive"
       linters:
         - gosec
-
-service:
-  golangci-lint-version: 1.16.x 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.20.1
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -111,7 +111,6 @@ func TestGetMD5(t *testing.T) {
 		t.Errorf("Test failed. Expected '%s'. Actual '%s'",
 			expectedOutput, []byte(actualStr))
 	}
-
 }
 
 func TestGetSHA512(t *testing.T) {
@@ -197,7 +196,6 @@ func TestGetHMAC(t *testing.T) {
 			expectedmd5, md5,
 		)
 	}
-
 }
 
 func TestSha1Tohex(t *testing.T) {
@@ -838,7 +836,6 @@ func TestGetOSPathSlash(t *testing.T) {
 	if output != "/" && output != "\\" {
 		t.Errorf("Test failed. Common GetOSPathSlash. Returned '%s'", output)
 	}
-
 }
 
 func TestUnixMillis(t *testing.T) {

--- a/communications/slack/slack.go
+++ b/communications/slack/slack.go
@@ -209,34 +209,28 @@ func (s *Slack) WebsocketReader() {
 		}
 
 		switch data.Type {
-
 		case "error":
 			err = s.handleErrorResponse(data)
 			if err != nil {
 				continue
 			}
-
 		case "hello":
 			s.handleHelloResponse()
-
 		case "reconnect_url":
 			err = s.handleReconnectResponse(resp)
 			if err != nil {
 				continue
 			}
-
 		case "presence_change":
 			err = s.handlePresenceChange(resp)
 			if err != nil {
 				continue
 			}
-
 		case "message":
 			err = s.handleMessageResponse(resp, data)
 			if err != nil {
 				continue
 			}
-
 		case "pong":
 			if s.Verbose {
 				log.Debugf("Pong received from server")

--- a/communications/slack/slack_test.go
+++ b/communications/slack/slack_test.go
@@ -140,7 +140,6 @@ func TestGetUsernameByID(t *testing.T) {
 	if username != "cranktakular" {
 		t.Error("test failed - slack GetUsernameByID() error")
 	}
-
 }
 
 func TestGetIDByName(t *testing.T) {
@@ -175,7 +174,6 @@ func TestGetGroupIDByName(t *testing.T) {
 		t.Errorf("test failed - slack GetGroupIDByName() Expected '11223344' Actual '%s' Error: %s",
 			id, err)
 	}
-
 }
 
 func TestGetChannelIDByName(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -338,7 +338,6 @@ func (c *Config) GetClientBankAccounts(exchangeName, targetCurrency string) (Ban
 			c.BankAccounts[x].SupportedExchanges == "ALL") &&
 			common.StringContains(c.BankAccounts[x].SupportedCurrencies, targetCurrency) {
 			return c.BankAccounts[x], nil
-
 		}
 	}
 	return BankAccount{}, fmt.Errorf("client banking details not found for %s and currency %s",
@@ -496,7 +495,6 @@ func (c *Config) CheckCommunicationsConfig() {
 				},
 			}
 		}
-
 	} else {
 		if c.SMS != nil {
 			// flush old SMS config

--- a/currency/code.go
+++ b/currency/code.go
@@ -803,9 +803,9 @@ var (
 	STQ        = NewCode("STQ")
 	INK        = NewCode("INK")
 	HBZ        = NewCode("HBZ")
-	USDT_ETH   = NewCode("USDT_ETH") // nolint: golint
-	QTUM_ETH   = NewCode("QTUM_ETH") // nolint: golint
-	BTM_ETH    = NewCode("BTM_ETH")  // nolint: golint
+	USDT_ETH   = NewCode("USDT_ETH") // nolint: stylecheck, golint
+	QTUM_ETH   = NewCode("QTUM_ETH") // nolint: stylecheck
+	BTM_ETH    = NewCode("BTM_ETH")  // nolint: stylecheck, golint
 	FIL        = NewCode("FIL")
 	STX        = NewCode("STX")
 	BOT        = NewCode("BOT")
@@ -818,7 +818,7 @@ var (
 	GOD        = NewCode("GOD")
 	SMT        = NewCode("SMT")
 	BTF        = NewCode("BTF")
-	NAS_ETH    = NewCode("NAS_ETH") // nolint: golint
+	NAS_ETH    = NewCode("NAS_ETH") // nolint: stylecheck, golint
 	TSL        = NewCode("TSL")
 	BIFI       = NewCode("BIFI")
 	BNTY       = NewCode("BNTY")
@@ -844,21 +844,21 @@ var (
 	MOBI       = NewCode("MOBI")
 	LEDU       = NewCode("LEDU")
 	DBC        = NewCode("DBC")
-	MKR_OLD    = NewCode("MKR_OLD") // nolint: golint
+	MKR_OLD    = NewCode("MKR_OLD") // nolint: stylecheck, golint
 	DPY        = NewCode("DPY")
 	BCDN       = NewCode("BCDN")
-	EOSDAC     = NewCode("EOSDAC") // nolint: golint
+	EOSDAC     = NewCode("EOSDAC") // nolint: stylecheck
 	TIPS       = NewCode("TIPS")
 	XMC        = NewCode("XMC")
 	PPS        = NewCode("PPS")
 	BOE        = NewCode("BOE")
 	MEDX       = NewCode("MEDX")
-	SMT_ETH    = NewCode("SMT_ETH") // nolint: golint
+	SMT_ETH    = NewCode("SMT_ETH") // nolint: stylecheck, golint
 	CS         = NewCode("CS")
 	MAN        = NewCode("MAN")
 	REM        = NewCode("REM")
 	LYM        = NewCode("LYM")
-	INSTAR     = NewCode("INSTAR") // nolint: golint
+	INSTAR     = NewCode("INSTAR") // nolint: stylecheck
 	BFT        = NewCode("BFT")
 	IHT        = NewCode("IHT")
 	SENC       = NewCode("SENC")
@@ -873,7 +873,7 @@ var (
 	SWTH       = NewCode("SWTH")
 	NKN        = NewCode("NKN")
 	SOUL       = NewCode("SOUL")
-	GALA_NEO   = NewCode("GALA_NEO") // nolint: golint
+	GALA_NEO   = NewCode("GALA_NEO") // nolint: stylecheck, golint
 	LRN        = NewCode("LRN")
 	GSE        = NewCode("GSE")
 	RATING     = NewCode("RATING")
@@ -2098,5 +2098,5 @@ var (
 	YER        = NewCode("YER")
 	ZWD        = NewCode("ZWD")
 	XETH       = NewCode("XETH")
-	FX_BTC     = NewCode("FX_BTC") // nolint: golint
+	FX_BTC     = NewCode("FX_BTC") // nolint: stylecheck, golint
 )

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -377,7 +377,6 @@ func (s *Storage) WriteCurrencyDataToFile(path string, mainUpdate bool) error {
 
 // LoadFileCurrencyData loads currencies into the currency codes
 func (s *Storage) LoadFileCurrencyData(f *File) error {
-
 	for i := range f.Contracts {
 		err := s.currencyCodes.LoadItem(&f.Contracts[i])
 		if err != nil {

--- a/currency/symbol_test.go
+++ b/currency/symbol_test.go
@@ -17,5 +17,4 @@ func TestGetSymbolByCurrencyName(t *testing.T) {
 	if err == nil {
 		t.Errorf("Test failed. TestGetSymbolByCurrencyNam returned nil on non-existent currency")
 	}
-
 }

--- a/exchange.go
+++ b/exchange.go
@@ -239,7 +239,6 @@ func SetupExchanges() {
 				continue
 			}
 			return
-
 		}
 		if !exch.Enabled {
 			log.Debugf("%s: Exchange support: Disabled", exch.Name)

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -204,7 +204,6 @@ func (a *ANX) GetDataToken() (string, error) {
 // NewOrder sends a new order request to the exchange.
 func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, tradedCurrencyAmount float64, settlementCurrency string, settlementCurrencyAmount, limitPriceSettlement float64,
 	replace bool, replaceUUID string, replaceIfActive bool) (string, error) {
-
 	req := make(map[string]interface{})
 	var order Order
 	order.OrderType = orderType

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -243,7 +243,6 @@ func TestGetFee(t *testing.T) {
 			t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0), resp)
 			t.Error(err)
 		}
-
 	}
 
 	// CryptocurrencyWithdrawalFee Basic

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -222,7 +222,6 @@ func TestGetSymbols(t *testing.T) {
 		"rrtusd",
 	}
 	if len(expectedCurrencies) <= len(symbols) {
-
 		for _, explicitSymbol := range expectedCurrencies {
 			if common.StringDataCompare(expectedCurrencies, explicitSymbol) {
 				break

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -201,7 +201,6 @@ func (b *Bitfinex) WsDataHandler() {
 						if status == "OK" {
 							b.Websocket.DataHandler <- eventData
 							b.WsAddSubscriptionChannel(0, "account", "N/A")
-
 						} else if status == "fail" {
 							b.Websocket.DataHandler <- fmt.Errorf("bitfinex.go error - Websocket unable to AUTH. Error code: %s",
 								eventData["code"].(string))

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -183,7 +183,6 @@ func (b *Bitmex) wsHandleIncomingData() {
 
 				b.Websocket.DataHandler <- fmt.Errorf("%s websocket error: Unable to subscribe %s",
 					b.Name, decodedResp.Subscribe)
-
 			} else if _, ok := quickCapture["table"]; ok {
 				var decodedResp WebsocketMainResponse
 				err := common.JSONDecode(resp.Raw, &decodedResp)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -36,7 +36,6 @@ func (b *Bitmex) Run() {
 	marketInfo, err := b.GetActiveInstruments(&GenericRequestParams{})
 	if err != nil {
 		log.Errorf("%s Failed to get available symbols.\n", b.GetName())
-
 	} else {
 		var exchangeProducts []string
 		for i := range marketInfo {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -66,7 +66,6 @@ func (b *Bitstamp) UpdateTicker(p currency.Pair, assetType string) (ticker.Price
 	tick, err := b.GetTicker(p.String(), false)
 	if err != nil {
 		return tickerPrice, err
-
 	}
 	tickerPrice.Pair = p
 	tickerPrice.Ask = tick.Ask
@@ -100,7 +99,6 @@ func (b *Bitstamp) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)
-
 }
 
 // GetOrderbookEx returns the orderbook for a currency pair

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -575,5 +575,4 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 // calculateTradingFee returns the fee for trading any currency on Bittrex
 func calculateTradingFee(price, amount float64) float64 {
 	return 0.0025 * price * amount
-
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -306,7 +306,6 @@ func (b *Bittrex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error)
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)
-
 }
 
 // GetActiveOrders retrieves any orders that are active/open

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -166,7 +166,6 @@ func (b *BTSE) GetTrades(symbol string) ([]Trade, error) {
 	var t []Trade
 	endpoint := fmt.Sprintf("%s/%s", btseTrades, symbol)
 	return t, b.SendHTTPRequest(http.MethodGet, endpoint, &t)
-
 }
 
 // GetTicker returns the ticker for a specified symbol

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -120,7 +120,6 @@ func TestGetFills(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 }
 
 func TestCreateOrder(t *testing.T) {

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -66,7 +66,6 @@ func (b *BTSE) UpdateTicker(p currency.Pair, assetType string) (ticker.Price, er
 	s, err := b.GetMarketStatistics(exchange.FormatExchangeCurrency(b.Name, p).String())
 	if err != nil {
 		return tickerPrice, err
-
 	}
 
 	tickerPrice.Pair = p

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -361,7 +361,6 @@ func TestCalculateTradingFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	c.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
 
@@ -440,7 +439,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 
@@ -467,7 +465,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -447,7 +447,7 @@ type WebsocketTicker struct {
 	BestBid   float64   `json:"best_bid,string"`
 	BestAsk   float64   `json:"best_ask,string"`
 	Side      string    `json:"side"`
-	Time      time.Time `json:"time,string"`
+	Time      time.Time `json:"time"`
 	TradeID   int64     `json:"trade_id"`
 	LastSize  float64   `json:"last_size,string"`
 }

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -234,7 +234,6 @@ func TestGetFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	c.SetDefaults()
 	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 
@@ -306,7 +305,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 
@@ -333,7 +331,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	c.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -102,7 +102,6 @@ func (c *COINUT) WsHandleData() {
 					}
 					c.wsProcessResponse(individualJSON)
 				}
-
 			} else {
 				var incoming wsResponse
 				err = common.JSONDecode(resp.Raw, &incoming)
@@ -113,7 +112,6 @@ func (c *COINUT) WsHandleData() {
 
 				c.wsProcessResponse(resp.Raw)
 			}
-
 		}
 	}
 }

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -154,7 +154,6 @@ func (c *COINUT) UpdateTicker(p currency.Pair, assetType string) (ticker.Price, 
 	}
 
 	return ticker.GetTicker(c.Name, p, assetType)
-
 }
 
 // GetTickerPrice returns the ticker for a currency pair
@@ -313,12 +312,10 @@ func (c *COINUT) CancelAllOrders(_ *exchange.OrderCancellation) (exchange.Cancel
 	var allTheOrders []OrderResponse
 	for _, allInstrumentData := range instruments.Instruments {
 		for _, instrumentData := range allInstrumentData {
-
 			openOrders, err := c.GetOpenOrders(instrumentData.InstID)
 			if err != nil {
 				return cancelAllOrdersResponse, err
 			}
-
 			allTheOrders = append(allTheOrders, openOrders.Orders...)
 		}
 	}

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -250,7 +250,6 @@ func TestGetFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
-
 	e.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.NoFiatWithdrawalsText
 
@@ -327,7 +326,6 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
-
 	e.SetDefaults()
 	TestSetup(t)
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
@@ -353,7 +351,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
-
 	e.SetDefaults()
 	TestSetup(t)
 

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -175,7 +175,6 @@ func (g *Gemini) GetSymbols() ([]string, error) {
 
 // GetTicker returns information about recent trading activity for the symbol
 func (g *Gemini) GetTicker(currencyPair string) (Ticker, error) {
-
 	type TickerResponse struct {
 		Ask     float64 `json:"ask,string"`
 		Bid     float64 `json:"bid,string"`

--- a/exchanges/hitbtc/hitbtc_types.go
+++ b/exchanges/hitbtc/hitbtc_types.go
@@ -22,12 +22,12 @@ type Ticker struct {
 
 // TickerResponse is the response type
 type TickerResponse struct {
-	Last        string    `json:"last"`             // Last trade price
-	Ask         string    `json:"ask"`              // Best ask price
-	Bid         string    `json:"bid"`              // Best bid price
-	Timestamp   time.Time `json:"timestamp,string"` // Last update or refresh ticker timestamp
-	Volume      string    `json:"volume"`           // Total trading amount within 24 hours in base currency
-	VolumeQuote string    `json:"volumeQuote"`      // Total trading amount within 24 hours in quote currency
+	Last        string    `json:"last"`        // Last trade price
+	Ask         string    `json:"ask"`         // Best ask price
+	Bid         string    `json:"bid"`         // Best bid price
+	Timestamp   time.Time `json:"timestamp"`   // Last update or refresh ticker timestamp
+	Volume      string    `json:"volume"`      // Total trading amount within 24 hours in base currency
+	VolumeQuote string    `json:"volumeQuote"` // Total trading amount within 24 hours in quote currency
 	Symbol      string    `json:"symbol"`
 	High        string    `json:"high"` // Highest trade price within 24 hours
 	Low         string    `json:"low"`  // Lowest trade price within 24 hours
@@ -75,7 +75,7 @@ type TradeHistory struct {
 
 // ChartData contains chart data
 type ChartData struct {
-	Timestamp   time.Time `json:"timestamp,string"`
+	Timestamp   time.Time `json:"timestamp"`
 	Max         float64   `json:"max,string"`         // Max price
 	Min         float64   `json:"min,string"`         // Min price
 	Open        float64   `json:"open,string"`        // Open price
@@ -88,7 +88,7 @@ type ChartData struct {
 type Currencies struct {
 	ID                 string `json:"id"`                 // Currency identifier.
 	FullName           string `json:"fullName"`           // Currency full name
-	Crypto             bool   `json:"crypto,boolean"`     // Is currency belongs to blockchain (false for ICO and fiat, like EUR)
+	Crypto             bool   `json:"crypto"`             // Is currency belongs to blockchain (false for ICO and fiat, like EUR)
 	PayinEnabled       bool   `json:"payinEnabled"`       // Is allowed for deposit (false for ICO)
 	PayinPaymentID     bool   `json:"payinPaymentId"`     // Is required to provide additional information other than the address for deposit
 	PayinConfirmations int64  `json:"payinConfirmations"` // Blocks confirmations count for deposit
@@ -148,10 +148,10 @@ type Order struct {
 	Quantity    float64   `json:"quantity,string"`    // Order quantity
 	Price       float64   `json:"price,string"`       // Order price
 	CumQuantity float64   `json:"cumQuantity,string"` // Cumulative executed quantity
-	CreatedAt   time.Time `json:"createdAt,string"`
-	UpdatedAt   time.Time `json:"updatedAt,string"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 	StopPrice   float64   `json:"stopPrice,string"`
-	ExpireTime  time.Time `json:"expireTime,string"`
+	ExpireTime  time.Time `json:"expireTime"`
 }
 
 // OpenOrdersResponseAll holds the full open order response
@@ -274,7 +274,7 @@ type LoanOffer struct {
 	Rate      float64 `json:"rate,string"`
 	Amount    float64 `json:"amount,string"`
 	Duration  int     `json:"duration"`
-	AutoRenew bool    `json:"autoRenew,int"`
+	AutoRenew bool    `json:"autoRenew"`
 	Date      string  `json:"date"`
 }
 

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -567,7 +567,6 @@ func (k *Kraken) GetTradeBalance(args ...TradeBalanceOptions) (TradeBalanceInfo,
 		if len(args[0].Asset) > 0 {
 			params.Set("asset", args[0].Asset)
 		}
-
 	}
 
 	var response struct {

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -215,7 +215,6 @@ func (l *LakeBTC) CancelAllOrders(_ *exchange.OrderCancellation) (exchange.Cance
 	}
 
 	return cancelAllOrdersResponse, l.CancelExistingOrders(ordersToCancel)
-
 }
 
 // GetOrderInfo returns information on a current open order

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -230,7 +230,6 @@ func (l *Lbank) GetKlines(symbol, size, klineType, time string) ([]KlineResponse
 				} else {
 					tempResp.TradingVolume = resp2[x].(float64)
 				}
-
 			}
 		}
 		k = append(k, tempResp)

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -510,7 +510,6 @@ func (l *Lbank) getAllOpenOrderID() (map[string][]string, error) {
 
 			for c := 0; c < tempData; c++ {
 				resp[exchange.FormatExchangeCurrency(l.Name, p).String()] = append(resp[exchange.FormatExchangeCurrency(l.Name, p).String()], tempResp.Orders[c].OrderID)
-
 			}
 			tempData = len(tempResp.Orders)
 			b++

--- a/exchanges/localbitcoins/localbitcoins_types.go
+++ b/exchanges/localbitcoins/localbitcoins_types.go
@@ -106,7 +106,7 @@ type AdEdit struct {
 	MaxAmount          int      `json:"max_amount"`
 	OpeningHours       []string `json:"opening_hours"`
 	LimitToFiatAmounts string   `json:"limit_to_fiat_amounts"`
-	Visible            bool     `json:"visible,int"`
+	Visible            bool     `json:"visible"`
 
 	// Optional Arguments ONLINE_SELL ads
 	RequireTradeVolume   int    `json:"require_trade_volume"`
@@ -114,13 +114,13 @@ type AdEdit struct {
 	FirstTimeLimitBTC    int    `json:"first_time_limit_btc"`
 	VolumeCoefficientBTC int    `json:"volume_coefficient_btc"`
 	ReferenceType        string `json:"reference_type"`
-	DisplayReference     bool   `json:"display_reference,int"`
+	DisplayReference     bool   `json:"display_reference"`
 
 	// Optional Arguments ONLINE_BUY
 	PaymentWindowMinutes int `json:"payment_window_minutes"`
 
 	// Optional Arguments LOCAL_SELL
-	Floating bool `json:"floating,int"`
+	Floating bool `json:"floating"`
 }
 
 // AdCreate references an outgoing paramater type for CreateAd() method
@@ -148,7 +148,7 @@ type AdCreate struct {
 	MaxAmount          int      `json:"max_amount"`
 	OpeningHours       []string `json:"opening_hours"`
 	LimitToFiatAmounts string   `json:"limit_to_fiat_amounts"`
-	Visible            bool     `json:"visible,int"`
+	Visible            bool     `json:"visible"`
 
 	// Optional Arguments ONLINE_SELL ads
 	RequireTradeVolume   int    `json:"require_trade_volume"`
@@ -156,13 +156,13 @@ type AdCreate struct {
 	FirstTimeLimitBTC    int    `json:"first_time_limit_btc"`
 	VolumeCoefficientBTC int    `json:"volume_coefficient_btc"`
 	ReferenceType        string `json:"reference_type"`
-	DisplayReference     bool   `json:"display_reference,int"`
+	DisplayReference     bool   `json:"display_reference"`
 
 	// Optional Arguments ONLINE_BUY
 	PaymentWindowMinutes int `json:"payment_window_minutes"`
 
 	// Optional Arguments LOCAL_SELL
-	Floating bool `json:"floating,int"`
+	Floating bool `json:"floating"`
 }
 
 // Message holds the returned message data from a contact

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -55,7 +55,6 @@ func (l *LocalBitcoins) Run() {
 	if err != nil {
 		log.Errorf("%s failed to update available currencies. Err %s", l.Name, err)
 	}
-
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -419,7 +419,6 @@ func GetExcludedItems() (Exclusion, error) {
 			if mErr != nil {
 				return excludedList, mErr
 			}
-
 		} else {
 			err = json.Unmarshal(file, &excludedList)
 			if err != nil {

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1077,7 +1077,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	err := o.CancelOrder(&orderCancellation)
 	testStandardErrorHandling(t, err)
-
 }
 
 // TestCancelAllExchangeOrders Wrapper test

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -88,7 +88,6 @@ func (o *OKEX) SetDefaults() {
 	o.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	o.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	o.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit
-
 }
 
 // GetFuturesPostions Get the information of all holding positions in futures trading.

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1846,7 +1846,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	err := o.CancelOrder(&orderCancellation)
 	testStandardErrorHandling(t, err)
-
 }
 
 // TestCancelAllExchangeOrders Wrapper test

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -668,7 +668,6 @@ func (o *OKGroup) SendHTTPRequest(httpMethod, requestType, requestPath string, d
 		if !errCap.Result {
 			return errors.New("unspecified error occurred")
 		}
-
 	}
 
 	return common.JSONDecode(intermediary, result)

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -313,7 +313,6 @@ func (o *OKGroup) GetAssetTypeFromTableName(table string) string {
 // WsHandleDataResponse classifies the WS response and sends to appropriate handler
 func (o *OKGroup) WsHandleDataResponse(response *WebsocketDataResponse) {
 	switch o.GetWsChannelWithoutOrderType(response.Table) {
-
 	case okGroupWsCandle60s, okGroupWsCandle180s, okGroupWsCandle300s, okGroupWsCandle900s,
 		okGroupWsCandle1800s, okGroupWsCandle3600s, okGroupWsCandle7200s, okGroupWsCandle14400s,
 		okGroupWsCandle21600s, okGroupWsCandle43200s, okGroupWsCandle86400s, okGroupWsCandle604900s:
@@ -502,7 +501,6 @@ func (o *OKGroup) WsProcessUpdateOrderbook(wsEventData *WebsocketDataWrapper, in
 			Asset:    o.GetAssetTypeFromTableName(tableName),
 			Pair:     instrument,
 		}
-
 	} else {
 		if o.Verbose {
 			log.Debug("Orderbook invalid")
@@ -527,7 +525,6 @@ func (o *OKGroup) CalculatePartialOrderbookChecksum(orderbookData *WebsocketData
 		}
 		if len(orderbookData.Asks)-1 >= i {
 			askMessage = fmt.Sprintf("%v:%v:", orderbookData.Asks[i][0], orderbookData.Asks[i][1])
-
 		}
 		if checksum == "" {
 			checksum = fmt.Sprintf("%v%v", bidsMessage, askMessage)

--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -261,7 +261,7 @@ type LoanOffer struct {
 	Rate      float64 `json:"rate,string"`
 	Amount    float64 `json:"amount,string"`
 	Duration  int     `json:"duration"`
-	AutoRenew bool    `json:"autoRenew,int"`
+	AutoRenew bool    `json:"autoRenew"`
 	Date      string  `json:"date"`
 }
 

--- a/exchanges/ticker/ticker_test.go
+++ b/exchanges/ticker/ticker_test.go
@@ -389,5 +389,4 @@ func TestProcessTicker(t *testing.T) { // non-appending function to tickers
 		}
 	}
 	wg.Wait()
-
 }

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -40,7 +40,6 @@ func (w *Websocket) Setup(connector func() error,
 	defaultURL,
 	runningURL string,
 	authenticatedWebsocketAPISupport bool) error {
-
 	w.DataHandler = make(chan interface{}, 1)
 	w.Connected = make(chan struct{}, 1)
 	w.Disconnected = make(chan struct{}, 1)

--- a/exchanges/websocket/wsorderbook/wsorderbook_test.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook_test.go
@@ -434,7 +434,6 @@ func TestFlushCache(t *testing.T) {
 	if obl.ob[curr][spot] != nil {
 		t.Error("expected ob be flushed")
 	}
-
 }
 
 // TestInsertingSnapShots logic test

--- a/exchanges/zb/zb_websocket_types.go
+++ b/exchanges/zb/zb_websocket_types.go
@@ -77,7 +77,7 @@ type WsAddSubUserRequest struct {
 	Memo        string `json:"memo"`
 	Password    string `json:"password"`
 	SubUserName string `json:"subUserName"`
-	No          int64  `json:"no,string,omtempty"`
+	No          int64  `json:"no,string,omitempty"`
 	Sign        string `json:"sign,omitempty"`
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -345,7 +345,6 @@ func SeedExchangeAccountInfo(data []exchange.AccountInfo) {
 		var currencies []exchange.AccountCurrencyInfo
 		for _, account := range exchangeData.Accounts {
 			for _, info := range account.Currencies {
-
 				var update bool
 				for i := range currencies {
 					if info.CurrencyName == currencies[i].CurrencyName {
@@ -388,7 +387,6 @@ func SeedExchangeAccountInfo(data []exchange.AccountInfo) {
 						CoinType:    currencyName,
 						Balance:     total,
 						Description: portfolio.PortfolioAddressExchange})
-
 			} else {
 				if total <= 0 {
 					log.Debugf("Portfolio: Removing %s %s entry.\n",

--- a/main.go
+++ b/main.go
@@ -157,7 +157,6 @@ func main() {
 		*verbosity)
 	if err != nil {
 		log.Fatalf("currency updater system failed to start %v", err)
-
 	}
 
 	bot.portfolio = &portfolio.Portfolio

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -347,7 +347,6 @@ func (p *Base) GetPortfolioSummary() Summary {
 				Percentage: getPercentageSpecific(z, y, totalCoins),
 			}
 			coinSummary[y] = coinSum
-
 		}
 		exchangeSummary[exchgName] = coinSummary
 	}

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -108,7 +108,6 @@ func TestExchangeAddressExists(t *testing.T) {
 	if newbase.ExchangeAddressExists("TEST", currency.LTC) {
 		t.Error("Test Failed - portfolio_test.go - ExchangeAddressExists error")
 	}
-
 }
 
 func TestAddExchangeAddress(t *testing.T) {

--- a/restful_router.go
+++ b/restful_router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/common"
 	log "github.com/thrasher-corp/gocryptotrader/logger"
 
-	_ "net/http/pprof"
+	_ "net/http/pprof" // nolint: gosec
 )
 
 // RESTLogger logs the requests internally

--- a/restful_server.go
+++ b/restful_server.go
@@ -159,7 +159,6 @@ func GetAllActiveOrderbooks() []EnabledExchangeOrderbooks {
 			)
 		}
 		orderbookData = append(orderbookData, individualExchange)
-
 	}
 	return orderbookData
 }

--- a/tools/huobi_auth/main.go
+++ b/tools/huobi_auth/main.go
@@ -96,7 +96,6 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-
 	} else {
 		var pubKeyData []byte
 		pubKeyData, err = common.ReadFile("publickey.pem")


### PR DESCRIPTION
# Description

Go version 1.13.x is now supported on AppVeyor (https://www.appveyor.com/docs/windows-images-software/#golang). As a result, we can now take advantage of Go's 1.13 features plus bump the golangci-lint version. Several new linters have also been enabled. Sadly, this automates RyanLinter ("rm newline") 🕯. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

golangci-lint run --verbose && go test ./... -race

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules