### PR TITLE
Always set go.mod/go.sum file line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod text eol=lf
+go.sum text eol=lf


### PR DESCRIPTION
# Description

Introduces a .gitattributes file which sets go.mod/go.sum line endings to LF based off the discussion in: https://github.com/golang/go/issues/31870

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules