### PR TITLE
(Exchange Interface) Convert Fetch & Update orderbook/ticker methods to return pointers

### DIFF
--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -198,15 +198,15 @@ func ({{.Variable}} *{{.CapitalName}}) UpdateTradablePairs(forceUpdate bool) err
 
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func ({{.Variable}} *{{.CapitalName}}) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func ({{.Variable}} *{{.CapitalName}}) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
   	// NOTE: EXAMPLE FOR GETTING TICKER PRICE
 	/*
-	var tickerPrice ticker.Price
+	tickerPrice := new(ticker.Price)
 	tick, err := {{.Variable}}.GetTicker(p.String())
 	if err != nil {
 		return tickerPrice, err
 	}
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		High:  tick.High,
 		Low:   tick.Low,
 		Bid:   tick.Bid,
@@ -215,7 +215,7 @@ func ({{.Variable}} *{{.CapitalName}}) UpdateTicker(p currency.Pair, assetType a
 		Close: tick.Close,
 		Pair:  p,
 	}
-	err = ticker.ProcessTicker({{.Variable}}.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker({{.Variable}}.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -224,7 +224,7 @@ func ({{.Variable}} *{{.CapitalName}}) UpdateTicker(p currency.Pair, assetType a
 }
 
 // FetchTicker returns the ticker for a currency pair
-func ({{.Variable}} *{{.CapitalName}}) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func ({{.Variable}} *{{.CapitalName}}) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker({{.Variable}}.Name, p, assetType)
 	if err != nil {
 		return {{.Variable}}.UpdateTicker(p, assetType)
@@ -233,7 +233,7 @@ func ({{.Variable}} *{{.CapitalName}}) FetchTicker(p currency.Pair, assetType as
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func ({{.Variable}} *{{.CapitalName}}) FetchOrderbook(currency currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func ({{.Variable}} *{{.CapitalName}}) FetchOrderbook(currency currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get({{.Variable}}.Name, currency, assetType)
 	if err != nil {
 		return {{.Variable}}.UpdateOrderbook(currency, assetType)
@@ -242,8 +242,8 @@ func ({{.Variable}} *{{.CapitalName}}) FetchOrderbook(currency currency.Pair, as
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func ({{.Variable}} *{{.CapitalName}}) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func ({{.Variable}} *{{.CapitalName}}) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
     // NOTE: UPDATE ORDERBOOK EXAMPLE
 	/* 
 	orderbookNew, err := {{.Variable}}.GetOrderBook(exchange.FormatExchangeCurrency({{.Variable}}.Name, p).String(), 1000)

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -314,7 +314,7 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 		log.Printf("Executing wrappers for %v %v %v", base.GetName(), assetTypes[i], p)
 
 		if !authenticatedOnly {
-			var r1 ticker.Price
+			var r1 *ticker.Price
 			r1, err = e.FetchTicker(p, assetTypes[i])
 			msg = ""
 			if err != nil {
@@ -328,7 +328,7 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 				Response:   jsonifyInterface([]interface{}{r1}),
 			})
 
-			var r2 ticker.Price
+			var r2 *ticker.Price
 			r2, err = e.UpdateTicker(p, assetTypes[i])
 			msg = ""
 			if err != nil {
@@ -342,7 +342,7 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 				Response:   jsonifyInterface([]interface{}{r2}),
 			})
 
-			var r3 orderbook.Base
+			var r3 *orderbook.Base
 			r3, err = e.FetchOrderbook(p, assetTypes[i])
 			msg = ""
 			if err != nil {
@@ -356,7 +356,7 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 				Response:   jsonifyInterface([]interface{}{r3}),
 			})
 
-			var r4 orderbook.Base
+			var r4 *orderbook.Base
 			r4, err = e.UpdateOrderbook(p, assetTypes[i])
 			msg = ""
 			if err != nil {

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -416,40 +416,14 @@ func GetRelatableCurrencies(p currency.Pair, incOrig, incUSDT bool) currency.Pai
 
 // GetSpecificOrderbook returns a specific orderbook given the currency,
 // exchangeName and assetType
-func GetSpecificOrderbook(p currency.Pair, exchangeName string, assetType asset.Item) (orderbook.Base, error) {
-	var specificOrderbook orderbook.Base
-	var err error
-	for x := range Bot.Exchanges {
-		if Bot.Exchanges[x] != nil {
-			if Bot.Exchanges[x].GetName() == exchangeName {
-				specificOrderbook, err = Bot.Exchanges[x].FetchOrderbook(
-					p,
-					assetType,
-				)
-				break
-			}
-		}
-	}
-	return specificOrderbook, err
+func GetSpecificOrderbook(p currency.Pair, exchangeName string, assetType asset.Item) (*orderbook.Base, error) {
+	return GetExchangeByName(exchangeName).FetchOrderbook(p, assetType)
 }
 
 // GetSpecificTicker returns a specific ticker given the currency,
 // exchangeName and assetType
-func GetSpecificTicker(p currency.Pair, exchangeName string, assetType asset.Item) (ticker.Price, error) {
-	var specificTicker ticker.Price
-	var err error
-	for x := range Bot.Exchanges {
-		if Bot.Exchanges[x] != nil {
-			if Bot.Exchanges[x].GetName() == exchangeName {
-				specificTicker, err = Bot.Exchanges[x].FetchTicker(
-					p,
-					assetType,
-				)
-				break
-			}
-		}
-	}
-	return specificTicker, err
+func GetSpecificTicker(p currency.Pair, exchangeName string, assetType asset.Item) (*ticker.Price, error) {
+	return GetExchangeByName(exchangeName).FetchTicker(p, assetType)
 }
 
 // GetCollatedExchangeAccountInfoByCoin collates individual exchange account
@@ -757,7 +731,7 @@ func GetAllActiveTickers() []EnabledExchangeCurrencies {
 						err)
 					continue
 				}
-				exchangeTicker.ExchangeValues = append(exchangeTicker.ExchangeValues, tp)
+				exchangeTicker.ExchangeValues = append(exchangeTicker.ExchangeValues, *tp)
 			}
 			tickerData = append(tickerData, exchangeTicker)
 		}

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -409,7 +409,7 @@ func TestGetSpecificOrderbook(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 
-	ob, err = GetSpecificOrderbook(currency.NewPairFromStrings("ETH", "LTC"),
+	_, err = GetSpecificOrderbook(currency.NewPairFromStrings("ETH", "LTC"),
 		"Bitstamp",
 		asset.Spot)
 	if err == nil {
@@ -441,7 +441,7 @@ func TestGetSpecificTicker(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 
-	tick, err = GetSpecificTicker(currency.NewPairFromStrings("ETH", "LTC"), "Bitstamp",
+	_, err = GetSpecificTicker(currency.NewPairFromStrings("ETH", "LTC"), "Bitstamp",
 		asset.Spot)
 	if err == nil {
 		t.Fatal("Unexpected result")

--- a/engine/restful_server.go
+++ b/engine/restful_server.go
@@ -80,7 +80,7 @@ func GetAllActiveOrderbooks() []EnabledExchangeOrderbooks {
 						err)
 					continue
 				}
-				exchangeOB.ExchangeValues = append(exchangeOB.ExchangeValues, ob)
+				exchangeOB.ExchangeValues = append(exchangeOB.ExchangeValues, *ob)
 			}
 			orderbookData = append(orderbookData, exchangeOB)
 		}

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -380,7 +380,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 
 								if c.Ticker.IsUsingREST {
 									e.setProcessing(c.Exchange, c.Pair, c.AssetType, SyncItemTicker, true)
-									var result ticker.Price
+									var result *ticker.Price
 									var err error
 
 									if supportsRESTTickerBatching {
@@ -408,7 +408,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 									} else {
 										result, err = Bot.Exchanges[x].UpdateTicker(c.Pair, c.AssetType)
 									}
-									printTickerSummary(&result, c.Pair, c.AssetType, exchangeName, err)
+									printTickerSummary(result, c.Pair, c.AssetType, exchangeName, err)
 									if err == nil {
 										//nolint:gocritic Bot.CommsRelayer.StageTickerData(exchangeName, c.AssetType, result)
 										if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
@@ -444,7 +444,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 
 								e.setProcessing(c.Exchange, c.Pair, c.AssetType, SyncItemOrderbook, true)
 								result, err := Bot.Exchanges[x].UpdateOrderbook(c.Pair, c.AssetType)
-								printOrderbookSummary(&result, c.Pair, c.AssetType, exchangeName, err)
+								printOrderbookSummary(result, c.Pair, c.AssetType, exchangeName, err)
 								if err == nil {
 									//nolint:gocritic Bot.CommsRelayer.StageOrderbookData(exchangeName, c.AssetType, result)
 									if Bot.Config.RemoteControl.WebsocketRPC.Enabled {

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -113,8 +113,8 @@ func (a *Alphapoint) GetAccountInfo() (exchange.AccountInfo, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (a *Alphapoint) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (a *Alphapoint) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := a.GetTicker(p.String())
 	if err != nil {
 		return tickerPrice, err
@@ -128,7 +128,7 @@ func (a *Alphapoint) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker
 	tickerPrice.Volume = tick.Volume
 	tickerPrice.Last = tick.Last
 
-	err = ticker.ProcessTicker(a.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(a.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -137,7 +137,7 @@ func (a *Alphapoint) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (a *Alphapoint) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (a *Alphapoint) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(a.Name, p, assetType)
 	if err != nil {
 		return a.UpdateTicker(p, assetType)
@@ -146,8 +146,8 @@ func (a *Alphapoint) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (a *Alphapoint) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (a *Alphapoint) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := a.GetOrderbook(p.String())
 	if err != nil {
 		return orderBook, err
@@ -180,7 +180,7 @@ func (a *Alphapoint) UpdateOrderbook(p currency.Pair, assetType asset.Item) (ord
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (a *Alphapoint) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (a *Alphapoint) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(a.Name, p, assetType)
 	if err != nil {
 		return a.UpdateOrderbook(p, assetType)

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -202,8 +202,8 @@ func (a *ANX) FetchTradablePairs(asset asset.Item) ([]string, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (a *ANX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (a *ANX) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := a.GetTicker(a.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return tickerPrice, err
@@ -215,7 +215,7 @@ func (a *ANX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price,
 	ask, _ := convert.FloatFromString(tick.Data.Sell.Value)
 	volume, _ := convert.FloatFromString(tick.Data.Volume.Value)
 
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		Last:        last,
 		High:        high,
 		Low:         low,
@@ -226,7 +226,7 @@ func (a *ANX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price,
 		LastUpdated: time.Unix(0, tick.Data.UpdateTime),
 	}
 
-	err = ticker.ProcessTicker(a.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(a.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -235,7 +235,7 @@ func (a *ANX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price,
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (a *ANX) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (a *ANX) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(a.Name, p, assetType)
 	if err != nil {
 		return a.UpdateTicker(p, assetType)
@@ -244,7 +244,7 @@ func (a *ANX) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, 
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (a *ANX) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (a *ANX) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(a.Name, p, assetType)
 	if err != nil {
 		return a.UpdateOrderbook(p, assetType)
@@ -253,8 +253,8 @@ func (a *ANX) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.B
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (a *ANX) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (a *ANX) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := a.GetDepth(a.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -257,11 +257,10 @@ func (b *Binance) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Binance) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Binance) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := b.GetTickers()
 	if err != nil {
-		return tickerPrice, err
+		return nil, err
 	}
 	pairs := b.GetEnabledPairs(assetType)
 	for i := range pairs {
@@ -270,7 +269,7 @@ func (b *Binance) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 			if tick[y].Symbol != pairFmt {
 				continue
 			}
-			tickerPrice := ticker.Price{
+			tickerPrice := &ticker.Price{
 				Last:        tick[y].LastPrice,
 				High:        tick[y].HighPrice,
 				Low:         tick[y].LowPrice,
@@ -282,7 +281,7 @@ func (b *Binance) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 				Close:       tick[y].PrevClosePrice,
 				Pair:        pairs[i],
 			}
-			err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -292,7 +291,7 @@ func (b *Binance) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Binance) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Binance) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -301,7 +300,7 @@ func (b *Binance) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (b *Binance) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Binance) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -310,8 +309,8 @@ func (b *Binance) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Binance) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Binance) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := b.GetOrderBook(OrderBookDataRequestParams{Symbol: b.FormatExchangeCurrency(p,
 		assetType).String(), Limit: 1000})
 	if err != nil {

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -240,8 +240,8 @@ func (b *Bitfinex) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bitfinex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bitfinex) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	enabledPairs := b.GetEnabledPairs(assetType)
 	var pairs []string
 	for x := range enabledPairs {
@@ -274,7 +274,7 @@ func (b *Bitfinex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.P
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bitfinex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bitfinex) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	b.appendOptionalDelimiter(&p)
 	tick, err := ticker.GetTicker(b.Name, p, asset.Spot)
 	if err != nil {
@@ -284,7 +284,7 @@ func (b *Bitfinex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (b *Bitfinex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bitfinex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	b.appendOptionalDelimiter(&p)
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
@@ -294,9 +294,9 @@ func (b *Bitfinex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderb
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bitfinex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bitfinex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	b.appendOptionalDelimiter(&p)
-	var orderBook orderbook.Base
+	orderBook := new(orderbook.Base)
 	urlVals := url.Values{}
 	urlVals.Set("limit_bids", "100")
 	urlVals.Set("limit_asks", "100")

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -176,8 +176,8 @@ func (b *Bitflyer) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bitflyer) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bitflyer) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 
 	p = b.CheckFXString(p)
 
@@ -191,7 +191,7 @@ func (b *Bitflyer) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.P
 	tickerPrice.Bid = tickerNew.BestBid
 	tickerPrice.Last = tickerNew.Last
 	tickerPrice.Volume = tickerNew.Volume
-	err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -200,7 +200,7 @@ func (b *Bitflyer) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.P
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bitflyer) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bitflyer) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -218,7 +218,7 @@ func (b *Bitflyer) CheckFXString(p currency.Pair) currency.Pair {
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (b *Bitflyer) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bitflyer) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -227,8 +227,8 @@ func (b *Bitflyer) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderb
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bitflyer) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Bitflyer) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 
 	p = b.CheckFXString(p)
 

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -172,8 +172,8 @@ func (b *Bithumb) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bithumb) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bithumb) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tickers, err := b.GetAllTickers()
 	if err != nil {
 		return tickerPrice, err
@@ -202,7 +202,7 @@ func (b *Bithumb) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bithumb) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bithumb) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -211,7 +211,7 @@ func (b *Bithumb) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (b *Bithumb) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bithumb) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -220,8 +220,8 @@ func (b *Bithumb) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bithumb) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Bithumb) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	curr := p.Base.String()
 
 	orderbookNew, err := b.GetOrderBook(curr)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -284,8 +284,8 @@ func (b *Bitmex) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bitmex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bitmex) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := b.GetActiveInstruments(&GenericRequestParams{})
 	if err != nil {
 		return tickerPrice, err
@@ -296,7 +296,7 @@ func (b *Bitmex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 			if !pairs[i].Equal(tick[j].Symbol) {
 				continue
 			}
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        tick[j].LastPrice,
 				High:        tick[j].HighPrice,
 				Low:         tick[j].LowPrice,
@@ -307,7 +307,7 @@ func (b *Bitmex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 				Pair:        tick[j].Symbol,
 				LastUpdated: tick[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -317,7 +317,7 @@ func (b *Bitmex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bitmex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bitmex) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -326,7 +326,7 @@ func (b *Bitmex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (b *Bitmex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bitmex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -335,8 +335,8 @@ func (b *Bitmex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bitmex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Bitmex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 
 	orderbookNew, err := b.GetOrderbook(OrderBookGetL2Params{
 		Symbol: b.FormatExchangeCurrency(p, assetType).String(),

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -139,7 +139,7 @@ func (b *Bitstamp) CalculateTradingFee(base, quote currency.Code, purchasePrice,
 }
 
 // GetTicker returns ticker information
-func (b *Bitstamp) GetTicker(currency string, hourly bool) (Ticker, error) {
+func (b *Bitstamp) GetTicker(currency string, hourly bool) (*Ticker, error) {
 	response := Ticker{}
 	tickerEndpoint := bitstampAPITicker
 
@@ -154,7 +154,7 @@ func (b *Bitstamp) GetTicker(currency string, hourly bool) (Ticker, error) {
 		tickerEndpoint,
 		strings.ToLower(currency),
 	)
-	return response, b.SendHTTPRequest(path, &response)
+	return &response, b.SendHTTPRequest(path, &response)
 }
 
 // GetOrderbook Returns a JSON dictionary with "bids" and "asks". Each is a list

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -227,14 +227,14 @@ func (b *Bitstamp) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bitstamp) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bitstamp) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := b.GetTicker(p.String(), false)
 	if err != nil {
 		return tickerPrice, err
 	}
 
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		Last:        tick.Last,
 		High:        tick.High,
 		Low:         tick.Low,
@@ -246,7 +246,7 @@ func (b *Bitstamp) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.P
 		LastUpdated: time.Unix(tick.Timestamp, 0),
 	}
 
-	err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -255,7 +255,7 @@ func (b *Bitstamp) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.P
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bitstamp) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bitstamp) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -273,7 +273,7 @@ func (b *Bitstamp) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (b *Bitstamp) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bitstamp) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -282,8 +282,8 @@ func (b *Bitstamp) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderb
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bitstamp) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Bitstamp) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := b.GetOrderbook(p.String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -222,8 +222,8 @@ func (b *Bittrex) GetAccountInfo() (exchange.AccountInfo, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *Bittrex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *Bittrex) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	ticks, err := b.GetMarketSummaries()
 	if err != nil {
 		return tickerPrice, err
@@ -239,7 +239,7 @@ func (b *Bittrex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 				log.Errorf(log.ExchangeSys,
 					"%s UpdateTicker unable to parse time: %s\n", b.Name, err)
 			}
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        ticks.Result[j].Last,
 				High:        ticks.Result[j].High,
 				Low:         ticks.Result[j].Low,
@@ -251,7 +251,7 @@ func (b *Bittrex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 				Pair:        pairs[i],
 				LastUpdated: tickerTime,
 			}
-			err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -262,7 +262,7 @@ func (b *Bittrex) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *Bittrex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *Bittrex) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -271,7 +271,7 @@ func (b *Bittrex) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (b *Bittrex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *Bittrex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -280,8 +280,8 @@ func (b *Bittrex) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *Bittrex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *Bittrex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := b.GetOrderbook(b.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -244,32 +244,32 @@ func (b *BTCMarkets) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *BTCMarkets) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var resp ticker.Price
+func (b *BTCMarkets) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	allPairs := b.GetEnabledPairs(assetType)
 	for x := range allPairs {
 		tick, err := b.GetTicker(b.FormatExchangeCurrency(allPairs[x], assetType).String())
 		if err != nil {
-			return resp, err
+			return tickerPrice, err
 		}
-		resp.Pair = allPairs[x]
-		resp.Last = tick.LastPrice
-		resp.High = tick.High24h
-		resp.Low = tick.Low24h
-		resp.Bid = tick.BestBID
-		resp.Ask = tick.BestAsk
-		resp.Volume = tick.Volume
-		resp.LastUpdated = time.Now()
-		err = ticker.ProcessTicker(b.Name, &resp, assetType)
+		tickerPrice.Pair = allPairs[x]
+		tickerPrice.Last = tick.LastPrice
+		tickerPrice.High = tick.High24h
+		tickerPrice.Low = tick.Low24h
+		tickerPrice.Bid = tick.BestBID
+		tickerPrice.Ask = tick.BestAsk
+		tickerPrice.Volume = tick.Volume
+		tickerPrice.LastUpdated = time.Now()
+		err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 		if err != nil {
-			return resp, err
+			return tickerPrice, err
 		}
 	}
 	return ticker.GetTicker(b.Name, p, assetType)
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *BTCMarkets) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *BTCMarkets) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -278,7 +278,7 @@ func (b *BTCMarkets) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (b *BTCMarkets) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *BTCMarkets) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -287,8 +287,8 @@ func (b *BTCMarkets) FetchOrderbook(p currency.Pair, assetType asset.Item) (orde
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *BTCMarkets) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (b *BTCMarkets) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	tempResp, err := b.GetOrderbook(b.FormatExchangeCurrency(p, assetType).String(), 2)
 	if err != nil {
 		return orderBook, err

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -222,8 +222,8 @@ func (b *BTSE) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (b *BTSE) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (b *BTSE) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 
 	t, err := b.GetTicker(b.FormatExchangeCurrency(p,
 		assetType).String())
@@ -246,7 +246,7 @@ func (b *BTSE) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 	tickerPrice.High = s.High
 	tickerPrice.LastUpdated = s.Time
 
-	err = ticker.ProcessTicker(b.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(b.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -254,7 +254,7 @@ func (b *BTSE) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (b *BTSE) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (b *BTSE) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateTicker(p, assetType)
@@ -263,7 +263,7 @@ func (b *BTSE) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price,
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (b *BTSE) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (b *BTSE) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(b.Name, p, assetType)
 	if err != nil {
 		return b.UpdateOrderbook(p, assetType)
@@ -272,28 +272,28 @@ func (b *BTSE) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (b *BTSE) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var resp orderbook.Base
+func (b *BTSE) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	a, err := b.FetchOrderBook(b.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
-		return resp, err
+		return orderBook, err
 	}
 	for x := range a.BuyQuote {
-		resp.Bids = append(resp.Bids, orderbook.Item{
+		orderBook.Bids = append(orderBook.Bids, orderbook.Item{
 			Price:  a.BuyQuote[x].Price,
 			Amount: a.BuyQuote[x].Size})
 	}
 	for x := range a.SellQuote {
-		resp.Asks = append(resp.Asks, orderbook.Item{
+		orderBook.Asks = append(orderBook.Asks, orderbook.Item{
 			Price:  a.SellQuote[x].Price,
 			Amount: a.SellQuote[x].Size})
 	}
-	resp.Pair = p
-	resp.ExchangeName = b.Name
-	resp.AssetType = assetType
-	err = resp.Process()
+	orderBook.Pair = p
+	orderBook.ExchangeName = b.Name
+	orderBook.AssetType = assetType
+	err = orderBook.Process()
 	if err != nil {
-		return resp, err
+		return orderBook, err
 	}
 	return orderbook.Get(b.Name, p, assetType)
 }

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -281,18 +281,18 @@ func (c *CoinbasePro) GetAccountInfo() (exchange.AccountInfo, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := c.GetTicker(c.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
-		return ticker.Price{}, err
+		return nil, err
 	}
 	stats, err := c.GetStats(c.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
-		return ticker.Price{}, err
+		return nil, err
 	}
 
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		Last:        tick.Size,
 		High:        stats.High,
 		Low:         stats.Low,
@@ -304,7 +304,7 @@ func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (ticke
 		LastUpdated: tick.Time,
 	}
 
-	err = ticker.ProcessTicker(c.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(c.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -313,7 +313,7 @@ func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (ticke
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (c *CoinbasePro) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (c *CoinbasePro) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(c.Name, p, assetType)
 	if err != nil {
 		return c.UpdateTicker(p, assetType)
@@ -322,7 +322,7 @@ func (c *CoinbasePro) FetchTicker(p currency.Pair, assetType asset.Item) (ticker
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (c *CoinbasePro) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (c *CoinbasePro) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(c.Name, p, assetType)
 	if err != nil {
 		return c.UpdateOrderbook(p, assetType)
@@ -331,8 +331,8 @@ func (c *CoinbasePro) FetchOrderbook(p currency.Pair, assetType asset.Item) (ord
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (c *CoinbasePro) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (c *CoinbasePro) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := c.GetOrderbook(c.FormatExchangeCurrency(p,
 		assetType).String(), 2)
 	if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -282,7 +282,6 @@ func (c *CoinbasePro) GetAccountInfo() (exchange.AccountInfo, error) {
 
 // UpdateTicker updates and returns the ticker for a currency pair
 func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
-	tickerPrice := new(ticker.Price)
 	tick, err := c.GetTicker(c.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return nil, err
@@ -292,7 +291,7 @@ func (c *CoinbasePro) UpdateTicker(p currency.Pair, assetType asset.Item) (*tick
 		return nil, err
 	}
 
-	tickerPrice = &ticker.Price{
+	tickerPrice := &ticker.Price{
 		Last:        tick.Size,
 		High:        stats.High,
 		Low:         stats.Low,

--- a/exchanges/coinbene/coinbene_wrapper.go
+++ b/exchanges/coinbene/coinbene_wrapper.go
@@ -238,33 +238,33 @@ func (c *Coinbene) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (c *Coinbene) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var resp ticker.Price
+func (c *Coinbene) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	allPairs := c.GetEnabledPairs(assetType)
 	for x := range allPairs {
 		tempResp, err := c.GetTicker(c.FormatExchangeCurrency(allPairs[x],
 			assetType).String())
 		if err != nil {
-			return resp, err
+			return tickerPrice, err
 		}
-		resp.Pair = allPairs[x]
-		resp.Last = tempResp.TickerData.LatestPrice
-		resp.High = tempResp.TickerData.DailyHigh
-		resp.Low = tempResp.TickerData.DailyLow
-		resp.Bid = tempResp.TickerData.BestBid
-		resp.Ask = tempResp.TickerData.BestAsk
-		resp.Volume = tempResp.TickerData.DailyVolume
-		resp.LastUpdated = time.Now()
-		err = ticker.ProcessTicker(c.Name, &resp, assetType)
+		tickerPrice.Pair = allPairs[x]
+		tickerPrice.Last = tempResp.TickerData.LatestPrice
+		tickerPrice.High = tempResp.TickerData.DailyHigh
+		tickerPrice.Low = tempResp.TickerData.DailyLow
+		tickerPrice.Bid = tempResp.TickerData.BestBid
+		tickerPrice.Ask = tempResp.TickerData.BestAsk
+		tickerPrice.Volume = tempResp.TickerData.DailyVolume
+		tickerPrice.LastUpdated = time.Now()
+		err = ticker.ProcessTicker(c.Name, tickerPrice, assetType)
 		if err != nil {
-			return resp, err
+			return tickerPrice, err
 		}
 	}
 	return ticker.GetTicker(c.Name, p, assetType)
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (c *Coinbene) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (c *Coinbene) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(c.Name, p, assetType)
 	if err != nil {
 		return c.UpdateTicker(p, assetType)
@@ -273,7 +273,7 @@ func (c *Coinbene) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (c *Coinbene) FetchOrderbook(currency currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (c *Coinbene) FetchOrderbook(currency currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(c.Name, currency, assetType)
 	if err != nil {
 		return c.UpdateOrderbook(currency, assetType)
@@ -282,48 +282,48 @@ func (c *Coinbene) FetchOrderbook(currency currency.Pair, assetType asset.Item) 
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (c *Coinbene) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var resp orderbook.Base
+func (c *Coinbene) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	tempResp, err := c.GetOrderbook(
 		c.FormatExchangeCurrency(p, assetType).String(),
 		100,
 	)
 	if err != nil {
-		return resp, err
+		return orderBook, err
 	}
-	resp.ExchangeName = c.Name
-	resp.Pair = p
-	resp.AssetType = assetType
+	orderBook.ExchangeName = c.Name
+	orderBook.Pair = p
+	orderBook.AssetType = assetType
 	var amount, price float64
 	for i := range tempResp.Orderbook.Asks {
 		amount, err = strconv.ParseFloat(tempResp.Orderbook.Asks[i][1], 64)
 		if err != nil {
-			return resp, err
+			return orderBook, err
 		}
 		price, err = strconv.ParseFloat(tempResp.Orderbook.Asks[i][0], 64)
 		if err != nil {
-			return resp, err
+			return orderBook, err
 		}
-		resp.Asks = append(resp.Asks, orderbook.Item{
+		orderBook.Asks = append(orderBook.Asks, orderbook.Item{
 			Price:  price,
 			Amount: amount})
 	}
 	for j := range tempResp.Orderbook.Bids {
 		amount, err = strconv.ParseFloat(tempResp.Orderbook.Bids[j][1], 64)
 		if err != nil {
-			return resp, err
+			return orderBook, err
 		}
 		price, err = strconv.ParseFloat(tempResp.Orderbook.Bids[j][0], 64)
 		if err != nil {
-			return resp, err
+			return orderBook, err
 		}
-		resp.Bids = append(resp.Bids, orderbook.Item{
+		orderBook.Bids = append(orderBook.Bids, orderbook.Item{
 			Price:  price,
 			Amount: amount})
 	}
-	err = resp.Process()
+	err = orderBook.Process()
 	if err != nil {
-		return resp, err
+		return orderBook, err
 	}
 	return orderbook.Get(c.Name, p, assetType)
 }

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -347,8 +347,8 @@ func (c *COINUT) GetAccountInfo() (exchange.AccountInfo, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	err := c.loadInstrumentsIfNotLoaded()
 	if err != nil {
 		return tickerPrice, err
@@ -364,7 +364,7 @@ func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 	if err != nil {
 		return tickerPrice, err
 	}
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		Last:        tick.Last,
 		High:        tick.High24,
 		Low:         tick.Low24,
@@ -374,7 +374,7 @@ func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 		Pair:        p,
 		LastUpdated: time.Unix(0, tick.Timestamp),
 	}
-	err = ticker.ProcessTicker(c.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(c.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -383,7 +383,7 @@ func (c *COINUT) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (c *COINUT) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (c *COINUT) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(c.Name, p, assetType)
 	if err != nil {
 		return c.UpdateTicker(p, assetType)
@@ -392,7 +392,7 @@ func (c *COINUT) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (c *COINUT) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (c *COINUT) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(c.Name, p, assetType)
 	if err != nil {
 		return c.UpdateOrderbook(p, assetType)
@@ -401,8 +401,8 @@ func (c *COINUT) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (c *COINUT) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (c *COINUT) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	err := c.loadInstrumentsIfNotLoaded()
 	if err != nil {
 		return orderBook, err

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -175,8 +175,8 @@ func (e *EXMO) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (e *EXMO) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (e *EXMO) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	result, err := e.GetTicker()
 	if err != nil {
 		return tickerPrice, err
@@ -190,7 +190,7 @@ func (e *EXMO) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 			if !strings.EqualFold(pairs[i].String(), j) {
 				continue
 			}
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Pair:   pairs[i],
 				Last:   result[j].Last,
 				Ask:    result[j].Sell,
@@ -199,7 +199,7 @@ func (e *EXMO) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 				Low:    result[j].Low,
 				Volume: result[j].Volume,
 			}
-			err = ticker.ProcessTicker(e.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(e.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -209,7 +209,7 @@ func (e *EXMO) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (e *EXMO) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (e *EXMO) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(e.Name, p, assetType)
 	if err != nil {
 		return e.UpdateTicker(p, assetType)
@@ -218,7 +218,7 @@ func (e *EXMO) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price,
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (e *EXMO) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (e *EXMO) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(e.Name, p, assetType)
 	if err != nil {
 		return e.UpdateOrderbook(p, assetType)
@@ -227,8 +227,8 @@ func (e *EXMO) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (e *EXMO) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (e *EXMO) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	pairsCollated, err := e.FormatExchangeCurrencies(e.GetEnabledPairs(assetType),
 		assetType)
 	if err != nil {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -220,8 +220,8 @@ func (g *Gateio) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (g *Gateio) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (g *Gateio) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	result, err := g.GetTickers()
 	if err != nil {
 		return tickerPrice, err
@@ -232,7 +232,7 @@ func (g *Gateio) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 			if !strings.EqualFold(k, pairs[i].String()) {
 				continue
 			}
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        result[k].Last,
 				High:        result[k].High,
 				Low:         result[k].Low,
@@ -242,7 +242,7 @@ func (g *Gateio) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 				Close:       result[k].Close,
 				Pair:        pairs[i],
 			}
-			err = ticker.ProcessTicker(g.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(g.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -253,7 +253,7 @@ func (g *Gateio) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (g *Gateio) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (g *Gateio) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(g.Name, p, assetType)
 	if err != nil {
 		return g.UpdateTicker(p, assetType)
@@ -262,7 +262,7 @@ func (g *Gateio) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (g *Gateio) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (g *Gateio) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(g.Name, p, assetType)
 	if err != nil {
 		return g.UpdateOrderbook(p, assetType)
@@ -271,8 +271,8 @@ func (g *Gateio) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (g *Gateio) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (g *Gateio) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	curr := g.FormatExchangeCurrency(p, assetType).String()
 
 	orderbookNew, err := g.GetOrderbook(curr)

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -236,13 +236,13 @@ func (g *Gemini) GetAccountInfo() (exchange.AccountInfo, error) {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (g *Gemini) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (g *Gemini) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := g.GetTicker(p.String())
 	if err != nil {
 		return tickerPrice, err
 	}
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		High:  tick.High,
 		Low:   tick.Low,
 		Bid:   tick.Bid,
@@ -251,7 +251,7 @@ func (g *Gemini) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 		Close: tick.Close,
 		Pair:  p,
 	}
-	err = ticker.ProcessTicker(g.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(g.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -260,7 +260,7 @@ func (g *Gemini) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (g *Gemini) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (g *Gemini) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(g.Name, p, assetType)
 	if err != nil {
 		return g.UpdateTicker(p, assetType)
@@ -269,7 +269,7 @@ func (g *Gemini) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (g *Gemini) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (g *Gemini) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(g.Name, p, assetType)
 	if err != nil {
 		return g.UpdateOrderbook(p, assetType)
@@ -278,8 +278,8 @@ func (g *Gemini) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (g *Gemini) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (g *Gemini) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := g.GetOrderbook(p.String(), url.Values{})
 	if err != nil {
 		return orderBook, err

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -242,8 +242,8 @@ func (h *HitBTC) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (h *HitBTC) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (h *HitBTC) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := h.GetTickers()
 	if err != nil {
 		return tickerPrice, err
@@ -263,7 +263,7 @@ func (h *HitBTC) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) 
 					continue
 				}
 			}
-			tickerPrice := ticker.Price{
+			tickerPrice := &ticker.Price{
 				Last:        tick[j].Last,
 				High:        tick[j].High,
 				Low:         tick[j].Low,
@@ -275,7 +275,7 @@ func (h *HitBTC) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) 
 				Pair:        pairs[i],
 				LastUpdated: tick[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(h.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(h.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -285,7 +285,7 @@ func (h *HitBTC) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) 
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (h *HitBTC) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (h *HitBTC) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(h.Name, p, assetType)
 	if err != nil {
 		return h.UpdateTicker(p, assetType)
@@ -294,7 +294,7 @@ func (h *HitBTC) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (h *HitBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (h *HitBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(h.Name, p, assetType)
 	if err != nil {
 		return h.UpdateOrderbook(p, assetType)
@@ -303,8 +303,8 @@ func (h *HitBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (h *HitBTC) UpdateOrderbook(currencyPair currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (h *HitBTC) UpdateOrderbook(currencyPair currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := h.GetOrderbook(h.FormatExchangeCurrency(currencyPair, assetType).String(), 1000)
 	if err != nil {
 		return orderBook, err

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -291,8 +291,8 @@ func (h *HUOBI) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (h *HUOBI) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (h *HUOBI) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tickers, err := h.GetTickers()
 	if err != nil {
 		return tickerPrice, err
@@ -304,7 +304,7 @@ func (h *HUOBI) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 			if pairFmt != tickers.Data[j].Symbol {
 				continue
 			}
-			tickerPrice := ticker.Price{
+			tickerPrice := &ticker.Price{
 				High:   tickers.Data[j].High,
 				Low:    tickers.Data[j].Low,
 				Volume: tickers.Data[j].Volume,
@@ -312,7 +312,7 @@ func (h *HUOBI) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 				Close:  tickers.Data[j].Close,
 				Pair:   pairs[i],
 			}
-			err = ticker.ProcessTicker(h.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(h.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -323,7 +323,7 @@ func (h *HUOBI) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (h *HUOBI) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (h *HUOBI) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(h.Name, p, assetType)
 	if err != nil {
 		return h.UpdateTicker(p, assetType)
@@ -332,7 +332,7 @@ func (h *HUOBI) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (h *HUOBI) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (h *HUOBI) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(h.Name, p, assetType)
 	if err != nil {
 		return h.UpdateOrderbook(p, assetType)
@@ -341,8 +341,8 @@ func (h *HUOBI) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (h *HUOBI) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (h *HUOBI) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := h.GetDepth(OrderBookDataRequestParams{
 		Symbol: h.FormatExchangeCurrency(p, assetType).String(),
 		Type:   OrderBookDataRequestParamsTypeStep0,

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -22,10 +22,10 @@ type IBotExchange interface {
 	GetName() string
 	IsEnabled() bool
 	SetEnabled(bool)
-	FetchTicker(currency currency.Pair, assetType asset.Item) (ticker.Price, error)
-	UpdateTicker(currency currency.Pair, assetType asset.Item) (ticker.Price, error)
-	FetchOrderbook(currency currency.Pair, assetType asset.Item) (orderbook.Base, error)
-	UpdateOrderbook(currency currency.Pair, assetType asset.Item) (orderbook.Base, error)
+	FetchTicker(currency currency.Pair, assetType asset.Item) (*ticker.Price, error)
+	UpdateTicker(currency currency.Pair, assetType asset.Item) (*ticker.Price, error)
+	FetchOrderbook(currency currency.Pair, assetType asset.Item) (*orderbook.Base, error)
+	UpdateOrderbook(currency currency.Pair, assetType asset.Item) (*orderbook.Base, error)
 	FetchTradablePairs(assetType asset.Item) ([]string, error)
 	UpdateTradablePairs(forceUpdate bool) error
 	GetEnabledPairs(assetType asset.Item) currency.Pairs

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -142,13 +142,13 @@ func (i *ItBit) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (i *ItBit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (i *ItBit) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := i.GetTicker(i.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return tickerPrice, err
 	}
-	tickerPrice = ticker.Price{
+	tickerPrice = &ticker.Price{
 		Last:        tick.LastPrice,
 		High:        tick.High24h,
 		Low:         tick.Low24h,
@@ -159,7 +159,7 @@ func (i *ItBit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 		Pair:        p,
 		LastUpdated: tick.ServertimeUTC,
 	}
-	err = ticker.ProcessTicker(i.Name, &tickerPrice, assetType)
+	err = ticker.ProcessTicker(i.Name, tickerPrice, assetType)
 	if err != nil {
 		return tickerPrice, err
 	}
@@ -168,7 +168,7 @@ func (i *ItBit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (i *ItBit) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (i *ItBit) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(i.Name, p, assetType)
 	if err != nil {
 		return i.UpdateTicker(p, assetType)
@@ -177,7 +177,7 @@ func (i *ItBit) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (i *ItBit) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (i *ItBit) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(i.Name, p, assetType)
 	if err != nil {
 		return i.UpdateOrderbook(p, assetType)
@@ -186,8 +186,8 @@ func (i *ItBit) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (i *ItBit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (i *ItBit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := i.GetOrderbook(i.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -282,8 +282,8 @@ func (k *Kraken) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (k *Kraken) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (k *Kraken) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	pairs := k.GetEnabledPairs(assetType)
 	pairsCollated, err := k.FormatExchangeCurrencies(pairs, assetType)
 	if err != nil {
@@ -307,7 +307,7 @@ func (k *Kraken) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 				}
 			}
 
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:   t.Last,
 				High:   t.High,
 				Low:    t.Low,
@@ -317,7 +317,7 @@ func (k *Kraken) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 				Open:   t.Open,
 				Pair:   pairs[i],
 			}
-			err = ticker.ProcessTicker(k.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(k.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -327,7 +327,7 @@ func (k *Kraken) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (k *Kraken) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (k *Kraken) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(k.Name, p, assetType)
 	if err != nil {
 		return k.UpdateTicker(p, assetType)
@@ -336,7 +336,7 @@ func (k *Kraken) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (k *Kraken) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (k *Kraken) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(k.Name, p, assetType)
 	if err != nil {
 		return k.UpdateOrderbook(p, assetType)
@@ -345,8 +345,8 @@ func (k *Kraken) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderboo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (k *Kraken) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (k *Kraken) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := k.GetDepth(k.FormatExchangeCurrency(p,
 		assetType).String())
 	if err != nil {

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -207,10 +207,10 @@ func (l *LakeBTC) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (l *LakeBTC) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (l *LakeBTC) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	ticks, err := l.GetTicker()
 	if err != nil {
-		return ticker.Price{}, err
+		return nil, err
 	}
 
 	pairs := l.GetEnabledPairs(assetType)
@@ -220,7 +220,7 @@ func (l *LakeBTC) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 			continue
 		}
 
-		var tickerPrice ticker.Price
+		tickerPrice := new(ticker.Price)
 		tickerPrice.Pair = pairs[i]
 		tickerPrice.Ask = c.Ask
 		tickerPrice.Bid = c.Bid
@@ -229,7 +229,7 @@ func (l *LakeBTC) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 		tickerPrice.Low = c.Low
 		tickerPrice.Last = c.Last
 
-		err = ticker.ProcessTicker(l.Name, &tickerPrice, assetType)
+		err = ticker.ProcessTicker(l.Name, tickerPrice, assetType)
 		if err != nil {
 			log.Error(log.Ticker, err)
 		}
@@ -238,7 +238,7 @@ func (l *LakeBTC) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pr
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (l *LakeBTC) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (l *LakeBTC) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(l.Name, p, assetType)
 	if err != nil {
 		return l.UpdateTicker(p, assetType)
@@ -247,7 +247,7 @@ func (l *LakeBTC) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (l *LakeBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (l *LakeBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(l.Name, p, assetType)
 	if err != nil {
 		return l.UpdateOrderbook(p, assetType)
@@ -256,8 +256,8 @@ func (l *LakeBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbo
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (l *LakeBTC) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (l *LakeBTC) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := l.GetOrderBook(p.String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -173,8 +173,8 @@ func (l *Lbank) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (l *Lbank) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (l *Lbank) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tickerInfo, err := l.GetTickers()
 	if err != nil {
 		return tickerPrice, err
@@ -185,7 +185,7 @@ func (l *Lbank) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 			if !pairs[i].Equal(tickerInfo[j].Symbol) {
 				continue
 			}
-			tickerPrice = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        tickerInfo[j].Ticker.Latest,
 				High:        tickerInfo[j].Ticker.High,
 				Low:         tickerInfo[j].Ticker.Low,
@@ -193,7 +193,7 @@ func (l *Lbank) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 				Pair:        tickerInfo[j].Symbol,
 				LastUpdated: time.Unix(0, tickerInfo[j].Timestamp),
 			}
-			err = ticker.ProcessTicker(l.Name, &tickerPrice, assetType)
+			err = ticker.ProcessTicker(l.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -203,7 +203,7 @@ func (l *Lbank) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (l *Lbank) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (l *Lbank) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(l.Name,
 		l.FormatExchangeCurrency(p, assetType), assetType)
 	if err != nil {
@@ -213,7 +213,7 @@ func (l *Lbank) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (l *Lbank) FetchOrderbook(currency currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (l *Lbank) FetchOrderbook(currency currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(l.Name, currency, assetType)
 	if err != nil {
 		return l.UpdateOrderbook(currency, assetType)
@@ -222,8 +222,8 @@ func (l *Lbank) FetchOrderbook(currency currency.Pair, assetType asset.Item) (or
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	a, err := l.GetMarketDepths(l.FormatExchangeCurrency(p, assetType).String(), "60", "1")
 	if err != nil {
 		return orderBook, err

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -165,8 +165,8 @@ func (l *LocalBitcoins) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (l *LocalBitcoins) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (l *LocalBitcoins) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := l.GetTicker()
 	if err != nil {
 		return tickerPrice, err
@@ -193,7 +193,7 @@ func (l *LocalBitcoins) UpdateTicker(p currency.Pair, assetType asset.Item) (tic
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (l *LocalBitcoins) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (l *LocalBitcoins) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(l.Name, p, assetType)
 	if err != nil {
 		return l.UpdateTicker(p, assetType)
@@ -202,7 +202,7 @@ func (l *LocalBitcoins) FetchTicker(p currency.Pair, assetType asset.Item) (tick
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (l *LocalBitcoins) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (l *LocalBitcoins) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(l.Name, p, assetType)
 	if err != nil {
 		return l.UpdateOrderbook(p, assetType)
@@ -211,8 +211,8 @@ func (l *LocalBitcoins) FetchOrderbook(p currency.Pair, assetType asset.Item) (o
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (l *LocalBitcoins) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (l *LocalBitcoins) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := l.GetOrderbook(p.Quote.String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -214,12 +214,12 @@ func (o *OKCoin) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (o *OKCoin) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (o *OKCoin) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	var tickerData ticker.Price
 	if assetType == asset.Spot {
 		resp, err := o.GetSpotAllTokenPairsInformation()
 		if err != nil {
-			return tickerData, err
+			return nil, err
 		}
 		pairs := o.GetEnabledPairs(assetType)
 		for i := range pairs {
@@ -250,7 +250,7 @@ func (o *OKCoin) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pri
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (o *OKCoin) FetchTicker(p currency.Pair, assetType asset.Item) (tickerData ticker.Price, err error) {
+func (o *OKCoin) FetchTicker(p currency.Pair, assetType asset.Item) (tickerData *ticker.Price, err error) {
 	tickerData, err = ticker.GetTicker(o.Name, p, assetType)
 	if err != nil {
 		return o.UpdateTicker(p, assetType)

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -392,7 +392,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Pric
 				Pair:        nC,
 				LastUpdated: resp[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(o.Name, nil, assetType)
+			err = ticker.ProcessTicker(o.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -308,19 +308,19 @@ func (o *OKEX) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerData ticker.Price
+func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	switch assetType {
 	case asset.Spot:
 		resp, err := o.GetSpotAllTokenPairsInformation()
 		if err != nil {
-			return tickerData, err
+			return tickerPrice, err
 		}
 		for j := range resp {
 			if !o.GetEnabledPairs(assetType).Contains(resp[j].InstrumentID, true) {
 				continue
 			}
-			tickerData = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        resp[j].Last,
 				High:        resp[j].High24h,
 				Low:         resp[j].Low24h,
@@ -332,7 +332,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 				Pair:        resp[j].InstrumentID,
 				LastUpdated: resp[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(o.Name, &tickerData, assetType)
+			err = ticker.ProcessTicker(o.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -341,7 +341,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 	case asset.PerpetualSwap:
 		resp, err := o.GetAllSwapTokensInformation()
 		if err != nil {
-			return tickerData, err
+			return nil, err
 		}
 
 		for j := range resp {
@@ -352,7 +352,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 			if !o.GetEnabledPairs(assetType).Contains(nC, true) {
 				continue
 			}
-			tickerData = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        resp[j].Last,
 				High:        resp[j].High24H,
 				Low:         resp[j].Low24H,
@@ -362,7 +362,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 				Pair:        nC,
 				LastUpdated: resp[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(o.Name, &tickerData, assetType)
+			err = ticker.ProcessTicker(o.Name, tickerPrice, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -371,7 +371,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 	case asset.Futures:
 		resp, err := o.GetAllFuturesTokenInfo()
 		if err != nil {
-			return tickerData, err
+			return nil, err
 		}
 
 		for j := range resp {
@@ -382,7 +382,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 			if !o.GetEnabledPairs(assetType).Contains(nC, true) {
 				continue
 			}
-			tickerData = ticker.Price{
+			tickerPrice = &ticker.Price{
 				Last:        resp[j].Last,
 				High:        resp[j].High24h,
 				Low:         resp[j].Low24h,
@@ -392,7 +392,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 				Pair:        nC,
 				LastUpdated: resp[j].Timestamp,
 			}
-			err = ticker.ProcessTicker(o.Name, &tickerData, assetType)
+			err = ticker.ProcessTicker(o.Name, nil, assetType)
 			if err != nil {
 				log.Error(log.Ticker, err)
 			}
@@ -403,7 +403,7 @@ func (o *OKEX) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (o *OKEX) FetchTicker(p currency.Pair, assetType asset.Item) (tickerData ticker.Price, err error) {
+func (o *OKEX) FetchTicker(p currency.Pair, assetType asset.Item) (tickerData *ticker.Price, err error) {
 	if assetType == asset.Index {
 		return tickerData, errors.New("ticker fetching not supported for index")
 	}

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -18,7 +18,7 @@ import (
 func Get(exchange string, p currency.Pair, a asset.Item) (*Base, error) {
 	o, err := service.Retrieve(exchange, p, a)
 	if err != nil {
-		return &Base{}, err
+		return nil, err
 	}
 	return o, nil
 }

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -15,12 +15,12 @@ import (
 
 // Get checks and returns the orderbook given an exchange name and currency pair
 // if it exists
-func Get(exchange string, p currency.Pair, a asset.Item) (Base, error) {
+func Get(exchange string, p currency.Pair, a asset.Item) (*Base, error) {
 	o, err := service.Retrieve(exchange, p, a)
 	if err != nil {
-		return Base{}, err
+		return &Base{}, err
 	}
-	return *o, nil
+	return o, nil
 }
 
 // SubscribeOrderbook subcribes to an orderbook and returns a communication

--- a/exchanges/orderbook/orderbook_test.go
+++ b/exchanges/orderbook/orderbook_test.go
@@ -395,7 +395,7 @@ func TestProcessOrderbook(t *testing.T) {
 		t.Error("Process() error", err)
 	}
 
-	result, err = Get("Blah", c, "quarterly")
+	_, err = Get("Blah", c, "quarterly")
 	if err != nil {
 		t.Fatal("TestProcessOrderbook failed to create new orderbook")
 	}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -232,8 +232,8 @@ func (p *Poloniex) UpdateTradablePairs(forceUpgrade bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (p *Poloniex) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (p *Poloniex) UpdateTicker(currencyPair currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	tick, err := p.GetTicker()
 	if err != nil {
 		return tickerPrice, err
@@ -264,7 +264,7 @@ func (p *Poloniex) UpdateTicker(currencyPair currency.Pair, assetType asset.Item
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (p *Poloniex) FetchTicker(currencyPair currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (p *Poloniex) FetchTicker(currencyPair currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(p.Name, currencyPair, assetType)
 	if err != nil {
 		return p.UpdateTicker(currencyPair, assetType)
@@ -273,7 +273,7 @@ func (p *Poloniex) FetchTicker(currencyPair currency.Pair, assetType asset.Item)
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (p *Poloniex) FetchOrderbook(currencyPair currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (p *Poloniex) FetchOrderbook(currencyPair currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(p.Name, currencyPair, assetType)
 	if err != nil {
 		return p.UpdateOrderbook(currencyPair, assetType)
@@ -282,8 +282,8 @@ func (p *Poloniex) FetchOrderbook(currencyPair currency.Pair, assetType asset.It
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (p *Poloniex) UpdateOrderbook(currencyPair currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (p *Poloniex) UpdateOrderbook(currencyPair currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := p.GetOrderbook("", 1000)
 	if err != nil {
 		return orderBook, err

--- a/exchanges/ticker/ticker.go
+++ b/exchanges/ticker/ticker.go
@@ -52,30 +52,30 @@ func SubscribeToExchangeTickers(exchange string) (dispatch.Pipe, error) {
 }
 
 // GetTicker checks and returns a requested ticker if it exists
-func GetTicker(exchange string, p currency.Pair, tickerType asset.Item) (Price, error) {
+func GetTicker(exchange string, p currency.Pair, tickerType asset.Item) (*Price, error) {
 	exchange = strings.ToLower(exchange)
 	service.RLock()
 	defer service.RUnlock()
 	if service.Tickers[exchange] == nil {
-		return Price{}, fmt.Errorf("no tickers for %s exchange", exchange)
+		return nil, fmt.Errorf("no tickers for %s exchange", exchange)
 	}
 
 	if service.Tickers[exchange][p.Base.Item] == nil {
-		return Price{}, fmt.Errorf("no tickers associated with base currency %s",
+		return nil, fmt.Errorf("no tickers associated with base currency %s",
 			p.Base)
 	}
 
 	if service.Tickers[exchange][p.Base.Item][p.Quote.Item] == nil {
-		return Price{}, fmt.Errorf("no tickers associated with quote currency %s",
+		return nil, fmt.Errorf("no tickers associated with quote currency %s",
 			p.Quote)
 	}
 
 	if service.Tickers[exchange][p.Base.Item][p.Quote.Item][tickerType] == nil {
-		return Price{}, fmt.Errorf("no tickers associated with asset type %s",
+		return nil, fmt.Errorf("no tickers associated with asset type %s",
 			tickerType)
 	}
 
-	return service.Tickers[exchange][p.Base.Item][p.Quote.Item][tickerType].Price, nil
+	return &service.Tickers[exchange][p.Base.Item][p.Quote.Item][tickerType].Price, nil
 }
 
 // ProcessTicker processes incoming tickers, creating or updating the Tickers

--- a/exchanges/ticker/ticker_test.go
+++ b/exchanges/ticker/ticker_test.go
@@ -219,11 +219,11 @@ func TestProcessTicker(t *testing.T) { // non-appending function to tickers
 	if err != nil {
 		t.Fatal("ProcessTicker error", err)
 	}
-	result, err = GetTicker(exchName, newPair, asset.Spot)
+	_, err = GetTicker(exchName, newPair, asset.Spot)
 	if err != nil {
 		t.Fatal("TestProcessTicker failed to create and return a new ticker")
 	}
-	result, err = GetTicker(exchName, newPair, asset.Spot)
+	_, err = GetTicker(exchName, newPair, asset.Spot)
 	if err != nil {
 		t.Fatal("TestProcessTicker failed to return an existing ticker")
 	}
@@ -235,11 +235,11 @@ func TestProcessTicker(t *testing.T) { // non-appending function to tickers
 	if err != nil {
 		t.Fatal("ProcessTicker error", err)
 	}
-	result, err = GetTicker(exchName, newPair, asset.Spot)
+	_, err = GetTicker(exchName, newPair, asset.Spot)
 	if err != nil {
 		t.Fatal("TestProcessTicker failed to create and return a new ticker")
 	}
-	result, err = GetTicker(exchName, newPair, asset.Spot)
+	_, err = GetTicker(exchName, newPair, asset.Spot)
 	if err != nil {
 		t.Fatal("TestProcessTicker failed to return an existing ticker")
 	}

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -176,8 +176,8 @@ func (y *Yobit) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (y *Yobit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (y *Yobit) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 	pairsCollated, err := y.FormatExchangeCurrencies(y.GetEnabledPairs(assetType), assetType)
 	if err != nil {
 		return tickerPrice, err
@@ -195,7 +195,7 @@ func (y *Yobit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 			continue
 		}
 		resultCurr := result[curr]
-		var tickerPrice ticker.Price
+		tickerPrice := new(ticker.Price)
 		tickerPrice.Pair = enabledPairs[i]
 		tickerPrice.Last = resultCurr.Last
 		tickerPrice.Ask = resultCurr.Sell
@@ -205,7 +205,7 @@ func (y *Yobit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 		tickerPrice.QuoteVolume = resultCurr.VolumeCurrent
 		tickerPrice.Volume = resultCurr.Vol
 
-		err = ticker.ProcessTicker(y.Name, &tickerPrice, assetType)
+		err = ticker.ProcessTicker(y.Name, tickerPrice, assetType)
 		if err != nil {
 			log.Error(log.Ticker, err)
 		}
@@ -214,7 +214,7 @@ func (y *Yobit) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Pric
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (y *Yobit) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (y *Yobit) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tick, err := ticker.GetTicker(y.Name, p, assetType)
 	if err != nil {
 		return y.UpdateTicker(p, assetType)
@@ -223,7 +223,7 @@ func (y *Yobit) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price
 }
 
 // FetchOrderbook returns the orderbook for a currency pair
-func (y *Yobit) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (y *Yobit) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(y.Name, p, assetType)
 	if err != nil {
 		return y.UpdateOrderbook(p, assetType)
@@ -232,8 +232,8 @@ func (y *Yobit) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (y *Yobit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (y *Yobit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	orderbookNew, err := y.GetDepth(y.FormatExchangeCurrency(p, assetType).String())
 	if err != nil {
 		return orderBook, err

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -215,8 +215,8 @@ func (z *ZB) UpdateTradablePairs(forceUpdate bool) error {
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair
-func (z *ZB) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var tickerPrice ticker.Price
+func (z *ZB) UpdateTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
+	tickerPrice := new(ticker.Price)
 
 	result, err := z.GetTickers()
 	if err != nil {
@@ -250,7 +250,7 @@ func (z *ZB) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, 
 }
 
 // FetchTicker returns the ticker for a currency pair
-func (z *ZB) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
+func (z *ZB) FetchTicker(p currency.Pair, assetType asset.Item) (*ticker.Price, error) {
 	tickerNew, err := ticker.GetTicker(z.Name, p, assetType)
 	if err != nil {
 		return z.UpdateTicker(p, assetType)
@@ -259,7 +259,7 @@ func (z *ZB) FetchTicker(p currency.Pair, assetType asset.Item) (ticker.Price, e
 }
 
 // FetchOrderbook returns orderbook base on the currency pair
-func (z *ZB) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
+func (z *ZB) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	ob, err := orderbook.Get(z.Name, p, assetType)
 	if err != nil {
 		return z.UpdateOrderbook(p, assetType)
@@ -268,8 +268,8 @@ func (z *ZB) FetchOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Ba
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
-func (z *ZB) UpdateOrderbook(p currency.Pair, assetType asset.Item) (orderbook.Base, error) {
-	var orderBook orderbook.Base
+func (z *ZB) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
+	orderBook := new(orderbook.Base)
 	curr := z.FormatExchangeCurrency(p, assetType).String()
 
 	orderbookNew, err := z.GetOrderbook(curr)


### PR DESCRIPTION
# PR Description

Another change to address some issues with #383 converts exchange interface Fetch & Update Orderbook/Ticker methods to return pointers instead of copy of the orderbook as orderbooks can be pretty large in size

I tested to confirm there was no race conditions on updates and also any possible slowness with all exchanges enabled but please test again

Also bonus update on GetSpecificOrderbook & GetSpecificTicker helpers as before they ranged over and were case sensitive when we already have these as part of GetExchangeByName()

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
