### PR TITLE
(BTC Markets) Ticker batching support

### DIFF
--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -375,7 +375,7 @@ func (b *BTCMarkets) NewOrder(marketID string, price, amount float64, orderType,
 }
 
 // GetOrders returns current order information on the exchange
-func (b *BTCMarkets) GetOrders(marketID string, before, after, limit int64, status string) ([]OrderData, error) {
+func (b *BTCMarkets) GetOrders(marketID string, before, after, limit int64, openOnly bool) ([]OrderData, error) {
 	if (before > 0) && (after >= 0) {
 		return nil, errors.New("BTCMarkets only supports either before or after, not both")
 	}
@@ -393,8 +393,8 @@ func (b *BTCMarkets) GetOrders(marketID string, before, after, limit int64, stat
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if status != "" {
-		params.Set("status", status)
+	if openOnly {
+		params.Set("status", "open")
 	}
 	return resp, b.SendAuthenticatedRequest(http.MethodGet,
 		common.EncodeURLValues(btcMarketsOrders, params), nil, &resp)

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -29,7 +29,7 @@ const (
 	btcMarketsGetTrades          = "/trades?"
 	btcMarketOrderBooks          = "/orderbook?"
 	btcMarketsCandles            = "/candles?"
-	btcMarketsTickers            = "/tickers?"
+	btcMarketsTickers            = "tickers?"
 	btcMarketsMultipleOrderbooks = "/orderbooks?"
 	btcMarketsGetTime            = "/time"
 	btcMarketsWithdrawalFees     = "/withdrawal-fees"
@@ -227,11 +227,11 @@ func (b *BTCMarkets) GetMarketCandles(marketID, timeWindow, from, to string, bef
 }
 
 // GetTickers gets multiple tickers
-func (b *BTCMarkets) GetTickers(marketIDs []string) ([]Ticker, error) {
+func (b *BTCMarkets) GetTickers(marketIDs []currency.Pair) ([]Ticker, error) {
 	var tickers []Ticker
 	params := url.Values{}
 	for x := range marketIDs {
-		params.Add("marketId", marketIDs[x])
+		params.Add("marketId", marketIDs[x].String())
 	}
 	return tickers, b.SendHTTPRequest(btcMarketsUnauthPath+btcMarketsTickers+params.Encode(),
 		&tickers)

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -17,7 +17,7 @@ var b BTCMarkets
 const (
 	apiKey                  = ""
 	apiSecret               = ""
-	canManipulateRealOrders = true
+	canManipulateRealOrders = false
 	BTCAUD                  = "BTC-AUD"
 	LTCAUD                  = "LTC-AUD"
 	ETHAUD                  = "ETH-AUD"

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -94,7 +94,6 @@ func TestGetMarketCandles(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	b.Verbose = true
 	temp := currency.NewPairsFromStrings([]string{LTCAUD, BTCAUD})
 	_, err := b.GetTickers(temp)
 	if err != nil {
@@ -455,9 +454,10 @@ func TestGetOrderHistory(t *testing.T) {
 	if !areTestAPIKeysSet() {
 		t.Skip("API keys required but not set, skipping test")
 	}
-	var input order.GetOrdersRequest
-	input.OrderSide = order.Buy
-	_, err := b.GetOrderHistory(&input)
+
+	_, err := b.GetOrderHistory(&order.GetOrdersRequest{
+		OrderSide: order.Buy,
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -487,9 +487,8 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Skip("API keys required but not set, skipping test")
 	}
 
-	tx, err := b.GetActiveOrders(&order.GetOrdersRequest{})
+	_, err := b.GetActiveOrders(&order.GetOrdersRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("%+v", tx)
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -17,7 +17,7 @@ var b BTCMarkets
 const (
 	apiKey                  = ""
 	apiSecret               = ""
-	canManipulateRealOrders = false
+	canManipulateRealOrders = true
 	BTCAUD                  = "BTC-AUD"
 	LTCAUD                  = "LTC-AUD"
 	ETHAUD                  = "ETH-AUD"
@@ -195,11 +195,11 @@ func TestGetOrders(t *testing.T) {
 	if !areTestAPIKeysSet() {
 		t.Skip("API keys required but not set, skipping test")
 	}
-	_, err := b.GetOrders("", -1, -1, 2, "")
+	_, err := b.GetOrders("", -1, -1, 2, false)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrders(LTCAUD, -1, -1, -1, "open")
+	_, err = b.GetOrders(LTCAUD, -1, -1, -1, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -479,4 +479,17 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestGetActiveOrders(t *testing.T) {
+	t.Parallel()
+	if !areTestAPIKeysSet() {
+		t.Skip("API keys required but not set, skipping test")
+	}
+
+	tx, err := b.GetActiveOrders(&order.GetOrdersRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%+v", tx)
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -95,7 +95,7 @@ func TestGetMarketCandles(t *testing.T) {
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
 	b.Verbose = true
-	temp := currency.NewPairsFromStrings([]string{"BTC-AUD", "LTC-AUD"})
+	temp := currency.NewPairsFromStrings([]string{LTCAUD, BTCAUD})
 	_, err := b.GetTickers(temp)
 	if err != nil {
 		t.Error(err)

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -94,7 +94,8 @@ func TestGetMarketCandles(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	temp := []string{BTCAUD, LTCAUD, ETHAUD}
+	b.Verbose = true
+	temp := currency.NewPairsFromStrings([]string{"BTC-AUD", "LTC-AUD"})
 	_, err := b.GetTickers(temp)
 	if err != nil {
 		t.Error(err)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -245,20 +245,20 @@ func (b *BTCMarkets) UpdateTradablePairs(forceUpdate bool) error {
 
 // UpdateTicker updates and returns the ticker for a currency pair
 func (b *BTCMarkets) UpdateTicker(p currency.Pair, assetType asset.Item) (ticker.Price, error) {
-	var resp ticker.Price
 	allPairs := b.GetEnabledPairs(assetType)
-	for x := range allPairs {
-		tick, err := b.GetTicker(b.FormatExchangeCurrency(allPairs[x], assetType).String())
-		if err != nil {
-			return resp, err
-		}
-		resp.Pair = allPairs[x]
-		resp.Last = tick.LastPrice
-		resp.High = tick.High24h
-		resp.Low = tick.Low24h
-		resp.Bid = tick.BestBID
-		resp.Ask = tick.BestAsk
-		resp.Volume = tick.Volume
+	tickers, err := b.GetTickers(allPairs.Slice())
+	if err != nil {
+		return ticker.Price{}, err
+	}
+	for x := range tickers {
+		var resp ticker.Price
+		resp.Pair = currency.NewPairFromString(tickers[x].MarketID)
+		resp.Last = tickers[x].LastPrice
+		resp.High = tickers[x].High24h
+		resp.Low = tickers[x].Low24h
+		resp.Bid = tickers[x].BestBID
+		resp.Ask = tickers[x].BestAsk
+		resp.Volume = tickers[x].Volume
 		resp.LastUpdated = time.Now()
 		err = ticker.ProcessTicker(b.Name, &resp, assetType)
 		if err != nil {
@@ -546,7 +546,7 @@ func (b *BTCMarkets) GetActiveOrders(req *order.GetOrdersRequest) ([]order.Detai
 	}
 	var err error
 	for x := range req.Currencies {
-		tempData, err = b.GetOrders(b.FormatExchangeCurrency(req.Currencies[x], asset.Spot).String(), -1, -1, -1, "")
+		tempData, err = b.GetOrders(b.FormatExchangeCurrency(req.Currencies[x], asset.Spot).String(), -1, -1, -1, "open")
 		if err != nil {
 			return resp, err
 		}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -76,6 +76,7 @@ func (b *BTCMarkets) SetDefaults() {
 			REST:      true,
 			Websocket: true,
 			RESTCapabilities: protocol.Features{
+				TickerBatching:      true,
 				TickerFetching:      true,
 				TradeFetching:       true,
 				OrderbookFetching:   true,

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -397,7 +397,7 @@ func (b *BTCMarkets) CancelAllOrders(_ *order.Cancel) (order.CancelAllResponse, 
 	var resp order.CancelAllResponse
 	tempMap := make(map[string]string)
 	var orderIDs []string
-	orders, err := b.GetOrders("", -1, -1, -1, "open")
+	orders, err := b.GetOrders("", -1, -1, -1, true)
 	if err != nil {
 		return resp, err
 	}
@@ -547,7 +547,7 @@ func (b *BTCMarkets) GetActiveOrders(req *order.GetOrdersRequest) ([]order.Detai
 	}
 	var err error
 	for x := range req.Currencies {
-		tempData, err = b.GetOrders(b.FormatExchangeCurrency(req.Currencies[x], asset.Spot).String(), -1, -1, -1, "open")
+		tempData, err = b.GetOrders(b.FormatExchangeCurrency(req.Currencies[x], asset.Spot).String(), -1, -1, -1, true)
 		if err != nil {
 			return resp, err
 		}
@@ -595,7 +595,7 @@ func (b *BTCMarkets) GetOrderHistory(req *order.GetOrdersRequest) ([]order.Detai
 	var tempResp order.Detail
 	var tempArray []string
 	if len(req.Currencies) == 0 {
-		orders, err := b.GetOrders("", -1, -1, -1, "")
+		orders, err := b.GetOrders("", -1, -1, -1, false)
 		if err != nil {
 			return resp, err
 		}
@@ -604,7 +604,7 @@ func (b *BTCMarkets) GetOrderHistory(req *order.GetOrdersRequest) ([]order.Detai
 		}
 	}
 	for y := range req.Currencies {
-		orders, err := b.GetOrders(b.FormatExchangeCurrency(req.Currencies[y], asset.Spot).String(), -1, -1, -1, "")
+		orders, err := b.GetOrders(b.FormatExchangeCurrency(req.Currencies[y], asset.Spot).String(), -1, -1, -1, false)
 		if err != nil {
 			return resp, err
 		}


### PR DESCRIPTION
# PR Description

Enables ticker batching support for BTC Markets using the [Get Multiple Tickers](https://api.btcmarkets.net/doc/v3#tag/Market-data-APIs/paths/~1v3~1markets~1tickers/get) endpoint

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
