### PR TITLE
(CLI) fix getorders command currency pair filtering 

### DIFF
--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -621,7 +621,12 @@ func (s *RPCServer) GetOrders(ctx context.Context, r *gctrpc.GetOrdersRequest) (
 		return nil, errors.New("exchange is not loaded/doesn't exist")
 	}
 
-	resp, err := exch.GetActiveOrders(&order.GetOrdersRequest{})
+	resp, err := exch.GetActiveOrders(&order.GetOrdersRequest{
+		Currencies: []currency.Pair{
+			currency.NewPairWithDelimiter(r.Pair.Base,
+				r.Pair.Quote, r.Pair.Delimiter),
+		},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# PR Description

The CLI command "getorders" currently returns all currency pairs instead of the currency pair passed in by --pair this PR correctly passes the selected currencyPair to GetActiveOrders

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
