### PR TITLE
Exchange template tool: Fix exchange_template missing import

### DIFF
--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -16,6 +16,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/websocket/wshandler"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/withdraw"
 	log "github.com/thrasher-corp/gocryptotrader/logger"
 )
 


### PR DESCRIPTION
# PR Description

Adds missing withdraw import to the exchange_template tool

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Running the tool with dummy params

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules
