### PR TITLE
[Config] Add "ID" field to BankAccount struct & GetBankAccountByID method

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ func (c *Config) CheckClientBankAccounts() {
 	if len(c.BankAccounts) == 0 {
 		c.BankAccounts = append(c.BankAccounts,
 			BankAccount{
+				ID:                  "test-bank-01",
 				BankName:            "Test Bank",
 				BankAddress:         "42 Bank Street",
 				BankPostalCode:      "13337",
@@ -135,6 +136,19 @@ func (c *Config) CheckClientBankAccounts() {
 			}
 		}
 	}
+}
+
+// GetBankAccountByID Returns a bank account based on its ID
+func (c *Config) GetBankAccountByID(id string) (*BankAccount, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	for x := range c.BankAccounts {
+		if strings.EqualFold(c.BankAccounts[x].ID, id) {
+			return &c.BankAccounts[x], nil
+		}
+	}
+	return nil, fmt.Errorf(ErrBankAccountNotFound, id)
 }
 
 // PurgeExchangeAPICredentials purges the stored API credentials

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -211,6 +211,7 @@ func TestGetBankAccountByID(t *testing.T) {
 	if len(cfg.BankAccounts) == 0 {
 		t.Error("CheckClientBankAccounts error:", err)
 	}
+
 	_, err = cfg.GetBankAccountByID("test-bank-01")
 	if err != nil {
 		t.Error(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -198,6 +198,30 @@ func TestCheckClientBankAccounts(t *testing.T) {
 	}
 }
 
+func TestGetBankAccountByID(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig()
+	err := cfg.LoadConfig(TestFile, true)
+	if err != nil {
+		t.Error("CheckClientBankAccounts LoadConfig error", err)
+	}
+
+	cfg.BankAccounts = nil
+	cfg.CheckClientBankAccounts()
+	if len(cfg.BankAccounts) == 0 {
+		t.Error("CheckClientBankAccounts error:", err)
+	}
+	_, err = cfg.GetBankAccountByID("test-bank-01")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = cfg.GetBankAccountByID("invalid-test-bank-01")
+	if err == nil {
+		t.Error("error expected for invalid account received nil")
+	}
+}
+
 func TestPurgeExchangeCredentials(t *testing.T) {
 	t.Parallel()
 	var c Config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -199,7 +199,6 @@ func TestCheckClientBankAccounts(t *testing.T) {
 }
 
 func TestGetBankAccountByID(t *testing.T) {
-	t.Parallel()
 	cfg := GetConfig()
 	err := cfg.LoadConfig(TestFile, true)
 	if err != nil {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -49,6 +49,7 @@ const (
 	ErrFailureOpeningConfig                    = "fatal error opening %s file. Error: %s"
 	ErrCheckingConfigValues                    = "fatal error checking config values. Error: %s"
 	ErrSavingConfigBytesMismatch               = "config file %q bytes comparison doesn't match, read %s expected %s"
+	ErrBankAccountNotFound                     = "Bank Account ID: %v not found"
 	WarningWebserverCredentialValuesEmpty      = "webserver support disabled due to empty Username/Password values"
 	WarningWebserverListenAddressInvalid       = "webserver support disabled due to invalid listen address"
 	WarningExchangeAuthAPIDefaultOrEmptyValues = "exchange %s authenticated API support disabled due to default/empty APIKey/Secret/ClientID values"
@@ -226,6 +227,7 @@ type CurrencyPairFormatConfig struct {
 // currency
 type BankAccount struct {
 	Enabled             bool   `json:"enabled"`
+	ID                  string `json:"id,omitempty"`
 	BankName            string `json:"bankName"`
 	BankAddress         string `json:"bankAddress"`
 	BankPostalCode      string `json:"bankPostalCode"`

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -49,7 +49,7 @@ const (
 	ErrFailureOpeningConfig                    = "fatal error opening %s file. Error: %s"
 	ErrCheckingConfigValues                    = "fatal error checking config values. Error: %s"
 	ErrSavingConfigBytesMismatch               = "config file %q bytes comparison doesn't match, read %s expected %s"
-	ErrBankAccountNotFound                     = "Bank Account ID: %v not found"
+	ErrBankAccountNotFound                     = "bank account ID: %v not found"
 	WarningWebserverCredentialValuesEmpty      = "webserver support disabled due to empty Username/Password values"
 	WarningWebserverListenAddressInvalid       = "webserver support disabled due to invalid listen address"
 	WarningExchangeAuthAPIDefaultOrEmptyValues = "exchange %s authenticated API support disabled due to default/empty APIKey/Secret/ClientID values"


### PR DESCRIPTION
# PR Description

Another small PR this adds a field "ID" to the BankAccount struct along with a method GetBankAccountByID to return pointer to BankAccount

adding this as an easy way to pass bank details when withdrawing fiat funds as part of #383 so users dont need to pass and have validation doesn't need to happen on 30 parameters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
