### PR TITLE
Engine: Use atomic.LoadInt32/AddInt32 for starting/stopping the database subsystem

### DIFF
--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -30,13 +30,13 @@ func openDbConnection(driver string) (err error) {
 	if driver == database.DBPostgreSQL {
 		dbConn, err = dbPSQL.Connect()
 		if err != nil {
-			return fmt.Errorf("database failed to connect: %v Some features that utilise a database will be unavailable", err)
+			return fmt.Errorf("database failed to connect: %v, some features that utilise a database will be unavailable", err)
 		}
 		return nil
 	} else if driver == database.DBSQLite || driver == database.DBSQLite3 {
 		dbConn, err = dbsqlite3.Connect()
 		if err != nil {
-			return fmt.Errorf("database failed to connect: %v Some features that utilise a database will be unavailable", err)
+			return fmt.Errorf("database failed to connect: %v, some features that utilise a database will be unavailable", err)
 		}
 		return nil
 	}

--- a/engine/database.go
+++ b/engine/database.go
@@ -18,18 +18,25 @@ var (
 )
 
 type databaseManager struct {
-	running  atomic.Value
+	started  int32
+	stopped  int32
 	shutdown chan struct{}
 }
 
 func (a *databaseManager) Started() bool {
-	return a.running.Load() == true
+	return atomic.LoadInt32(&a.started) == 1
 }
 
 func (a *databaseManager) Start() (err error) {
-	if a.Started() {
+	if atomic.AddInt32(&a.started, 1) != 1 {
 		return errors.New("database manager already started")
 	}
+
+	defer func() {
+		if err != nil {
+			atomic.CompareAndSwapInt32(&a.started, 1, 0)
+		}
+	}()
 
 	log.Debugln(log.DatabaseMgr, "Database manager starting...")
 
@@ -70,11 +77,13 @@ func (a *databaseManager) Start() (err error) {
 }
 
 func (a *databaseManager) Stop() error {
-	if !a.Started() {
-		return errors.New("database manager already stopped")
+	if atomic.LoadInt32(&a.started) == 0 {
+		return errors.New("database manager not started")
 	}
 
-	log.Debugln(log.DatabaseMgr, "Database manager shutting down...")
+	if atomic.AddInt32(&a.stopped, 1) != 1 {
+		return errors.New("database manager is already stopping")
+	}
 
 	err := dbConn.SQL.Close()
 	if err != nil {
@@ -91,11 +100,10 @@ func (a *databaseManager) run() {
 
 	t := time.NewTicker(time.Second * 2)
 
-	a.running.Store(true)
-
 	defer func() {
 		t.Stop()
-		a.running.Store(false)
+		atomic.CompareAndSwapInt32(&a.stopped, 1, 0)
+		atomic.CompareAndSwapInt32(&a.started, 1, 0)
 
 		Bot.ServicesWG.Done()
 


### PR DESCRIPTION
# PR Description

Originally it was possible to crash the bot by sending two subsequent stop requests to the database subsystem (via the cli or an app) due to attempting to close and already closed channel. This method protects the bot when stopping the database subsystem (sets the state to stopping, preventing further stop requests) until the state is finally reset when it does actually shutdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- Send 2 subsequent stops and you'll get a panic on attempt to close an already closed channel

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
