### PR TITLE
GCTCLI: Destination var/arg check usage fixes

### DIFF
--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -894,7 +894,7 @@ func addPortfolioAddress(c *cli.Context) error {
 	}
 
 	if c.IsSet("description") {
-		description = c.String("asset")
+		description = c.String("description")
 	} else {
 		description = c.Args().Get(2)
 	}
@@ -902,7 +902,13 @@ func addPortfolioAddress(c *cli.Context) error {
 	if c.IsSet("balance") {
 		balance = c.Float64("balance")
 	} else {
-		balance, _ = strconv.ParseFloat(c.Args().Get(3), 64)
+		if c.Args().Get(3) != "" {
+			var err error
+			balance, err = strconv.ParseFloat(c.Args().Get(3), 64)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	client := gctrpc.NewGoCryptoTraderClient(conn)
@@ -973,7 +979,7 @@ func removePortfolioAddress(c *cli.Context) error {
 	}
 
 	if c.IsSet("description") {
-		description = c.String("asset")
+		description = c.String("description")
 	} else {
 		description = c.Args().Get(2)
 	}
@@ -1044,7 +1050,7 @@ func getForexRates(_ *cli.Context) error {
 var getOrdersCommand = cli.Command{
 	Name:      "getorders",
 	Usage:     "gets the open orders",
-	ArgsUsage: "<exchange> <asset_type> <pair>",
+	ArgsUsage: "<exchange> <asset> <pair>",
 	Action:    getOrders,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -1052,7 +1058,7 @@ var getOrdersCommand = cli.Command{
 			Usage: "the exchange to get orders for",
 		},
 		cli.StringFlag{
-			Name:  "asset_type",
+			Name:  "asset",
 			Usage: "the asset type to get orders for",
 		},
 		cli.StringFlag{
@@ -1077,8 +1083,8 @@ func getOrders(c *cli.Context) error {
 		return errInvalidExchange
 	}
 
-	if c.IsSet("asset_type") {
-		assetType = c.String("asset_type")
+	if c.IsSet("asset") {
+		assetType = c.String("asset")
 	} else {
 		assetType = c.Args().Get(1)
 	}
@@ -1270,13 +1276,21 @@ func submitOrder(c *cli.Context) error {
 	if c.IsSet("amount") {
 		amount = c.Float64("amount")
 	} else {
-		amount, _ = strconv.ParseFloat(c.Args().Get(4), 64)
+		var err error
+		amount, err = strconv.ParseFloat(c.Args().Get(4), 64)
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.IsSet("price") {
 		price = c.Float64("price")
 	} else {
-		price, _ = strconv.ParseFloat(c.Args().Get(5), 64)
+		var err error
+		price, err = strconv.ParseFloat(c.Args().Get(5), 64)
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.IsSet("client_id") {
@@ -1375,11 +1389,23 @@ func simulateOrder(c *cli.Context) error {
 	} else {
 		orderSide = c.Args().Get(2)
 	}
+	if orderSide != "" {
+		return errors.New("side must be set")
+	}
 
 	if c.IsSet("amount") {
 		amount = c.Float64("amount")
 	} else {
-		amount, _ = strconv.ParseFloat(c.Args().Get(3), 64)
+		if c.Args().Get(3) != "" {
+			var err error
+			amount, err = strconv.ParseFloat(c.Args().Get(3), 64)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if amount == 0 {
+		return errors.New("amount must be set")
 	}
 
 	conn, err := setupClient()
@@ -1473,7 +1499,13 @@ func whaleBomb(c *cli.Context) error {
 	if c.IsSet("price") {
 		price = c.Float64("price")
 	} else {
-		price, _ = strconv.ParseFloat(c.Args().Get(3), 64)
+		if c.Args().Get(3) != "" {
+			var err error
+			price, err = strconv.ParseFloat(c.Args().Get(3), 64)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	conn, err := setupClient()
@@ -1505,7 +1537,7 @@ func whaleBomb(c *cli.Context) error {
 var cancelOrderCommand = cli.Command{
 	Name:      "cancelorder",
 	Usage:     "cancel order cancels an exchange order",
-	ArgsUsage: "<exchange> <account_id> <order_id> <pair> <asset_type> <wallet_address> <side>",
+	ArgsUsage: "<exchange> <account_id> <order_id> <pair> <asset> <wallet_address> <side>",
 	Action:    cancelOrder,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -1525,7 +1557,7 @@ var cancelOrderCommand = cli.Command{
 			Usage: "the currency pair to cancel the order for",
 		},
 		cli.StringFlag{
-			Name:  "asset_type",
+			Name:  "asset",
 			Usage: "the asset type",
 		},
 		cli.Float64Flag{
@@ -1577,8 +1609,8 @@ func cancelOrder(c *cli.Context) error {
 		currencyPair = c.String("pair")
 	}
 
-	if c.IsSet("asset_type") {
-		assetType = c.String("asset_type")
+	if c.IsSet("asset") {
+		assetType = c.String("asset")
 	}
 
 	assetType = strings.ToLower(assetType)
@@ -1702,7 +1734,7 @@ func getEvents(_ *cli.Context) error {
 var addEventCommand = cli.Command{
 	Name:      "addevent",
 	Usage:     "adds an event",
-	ArgsUsage: "<exchange> <item> <condition> <price> <check_bids> <check_bids_and_asks> <orderbook_amount> <pair> <asset_type> <action>",
+	ArgsUsage: "<exchange> <item> <condition> <price> <check_bids> <check_bids_and_asks> <orderbook_amount> <pair> <asset> <action>",
 	Action:    addEvent,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -1738,7 +1770,7 @@ var addEventCommand = cli.Command{
 			Usage: "the currency pair",
 		},
 		cli.StringFlag{
-			Name:  "asset_type",
+			Name:  "asset",
 			Usage: "the asset type",
 		},
 		cli.StringFlag{
@@ -1805,8 +1837,12 @@ func addEvent(c *cli.Context) error {
 		return fmt.Errorf("currency pair is required")
 	}
 
-	if c.IsSet("asset_type") {
-		assetType = c.String("asset_type")
+	if !validPair(currencyPair) {
+		return errInvalidPair
+	}
+
+	if c.IsSet("asset") {
+		assetType = c.String("asset")
 	}
 
 	assetType = strings.ToLower(assetType)
@@ -1818,10 +1854,6 @@ func addEvent(c *cli.Context) error {
 		action = c.String("action")
 	} else {
 		return fmt.Errorf("action is required")
-	}
-
-	if !validPair(currencyPair) {
-		return errInvalidPair
 	}
 
 	conn, err := setupClient()
@@ -1881,11 +1913,14 @@ func removeEvent(c *cli.Context) error {
 	if c.IsSet("event_id") {
 		eventID = c.Int64("event_id")
 	} else {
-		evtID, err := strconv.Atoi(c.Args().Get(0))
-		if err != nil {
-			return fmt.Errorf("unable to strconv input to int. Err: %s", err)
+		if c.Args().Get(0) != "" {
+			var err error
+			eventID, err = strconv.ParseInt(c.Args().Get(0), 10, 64)
+			if err != nil {
+				return err
+			}
 		}
-		eventID = int64(evtID)
+
 	}
 
 	conn, err := setupClient()
@@ -1991,7 +2026,13 @@ func getCryptocurrencyDepositAddress(c *cli.Context) error {
 	if c.IsSet("cryptocurrency") {
 		cryptocurrency = c.String("cryptocurrency")
 	} else {
-		cryptocurrency = c.Args().Get(1)
+		if c.Args().Get(1) != "" {
+			cryptocurrency = c.Args().Get(1)
+		}
+	}
+
+	if cryptocurrency == "" {
+		return errors.New("cryptocurrency must be set")
 	}
 
 	conn, err := setupClient()
@@ -2868,7 +2909,7 @@ func getAuditEvent(c *cli.Context) error {
 
 	if !c.IsSet("limit") {
 		if c.Args().Get(3) != "" {
-			limitStr, err := strconv.ParseInt(c.Args().Get(3), 10, 32)
+			limitStr, err := strconv.ParseInt(c.Args().Get(3), 10, 64)
 			if err == nil {
 				limit = int(limitStr)
 			}
@@ -3351,6 +3392,7 @@ func gctScriptUpload(c *cli.Context) error {
 	return nil
 }
 
+var candleRangeSize, candleGranularity int64
 var getHistoricCandlesCommand = cli.Command{
 	Name:      "gethistoriccandles",
 	Usage:     "gets historical candles for the specified granularity up to range size time from now.",
@@ -3365,13 +3407,17 @@ var getHistoricCandlesCommand = cli.Command{
 			Name:  "pair",
 			Usage: "the currency pair to get the candles for",
 		},
-		cli.IntFlag{
-			Name:  "rangesize, r",
-			Usage: "the amount of time to go back from now to fetch candles in the given granularity",
+		cli.Int64Flag{
+			Name:        "rangesize, r",
+			Usage:       "the amount of time to go back from now to fetch candles in the given granularity",
+			Value:       10,
+			Destination: &candleRangeSize,
 		},
-		cli.IntFlag{
-			Name:  "granularity, g",
-			Usage: "value is in seconds and can be one of the following {60, 300, 900, 3600, 21600, 86400}",
+		cli.Int64Flag{
+			Name:        "granularity, g",
+			Usage:       "value is in seconds and can be one of the following {60, 300, 900, 3600, 21600, 86400}",
+			Value:       86400,
+			Destination: &candleGranularity,
 		},
 	},
 }
@@ -3403,26 +3449,28 @@ func getHistoricCandles(c *cli.Context) error {
 	}
 	p := currency.NewPairDelimiter(currencyPair, pairDelimiter)
 
-	var rangesize int64
 	if c.IsSet("rangesize") {
-		rangesize = c.Int64("rangesize")
+		candleRangeSize = c.Int64("rangesize")
 	} else {
-		rs, err := strconv.Atoi(c.Args().Get(2))
-		if err != nil {
-			return fmt.Errorf("unable to strconv input to int. Err: %s", err)
+		if c.Args().Get(2) != "" {
+			var err error
+			candleRangeSize, err = strconv.ParseInt(c.Args().Get(2), 10, 64)
+			if err != nil {
+				return err
+			}
 		}
-		rangesize = int64(rs)
 	}
 
-	var granularity int64
 	if c.IsSet("granularity") {
-		granularity = c.Int64("granularity")
+		candleGranularity = c.Int64("granularity")
 	} else {
-		gr, err := strconv.Atoi(c.Args().Get(3))
-		if err != nil {
-			return fmt.Errorf("unable to strconv input to int. Err: %s", err)
+		if c.Args().Get(3) != "" {
+			var err error
+			candleGranularity, err = strconv.ParseInt(c.Args().Get(3), 10, 64)
+			if err != nil {
+				return err
+			}
 		}
-		granularity = int64(gr)
 	}
 
 	conn, err := setupClient()
@@ -3440,8 +3488,8 @@ func getHistoricCandles(c *cli.Context) error {
 				Base:      p.Base.String(),
 				Quote:     p.Quote.String(),
 			},
-			Rangesize:   rangesize,
-			Granularity: granularity,
+			Rangesize:   candleRangeSize,
+			Granularity: candleGranularity,
 		})
 
 	if err != nil {

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -1609,6 +1609,8 @@ func cancelOrder(c *cli.Context) error {
 
 	if c.IsSet("account_id") {
 		accountID = c.String("account_id")
+	} else {
+		accountID = c.Args().Get(1)
 	}
 
 	if c.IsSet("order_id") {
@@ -1623,10 +1625,14 @@ func cancelOrder(c *cli.Context) error {
 
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
+	} else {
+		currencyPair = c.Args().Get(3)
 	}
 
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
+	} else {
+		assetType = c.Args().Get(4)
 	}
 
 	assetType = strings.ToLower(assetType)
@@ -1636,12 +1642,17 @@ func cancelOrder(c *cli.Context) error {
 
 	if c.IsSet("wallet_address") {
 		walletAddress = c.String("wallet_address")
+	} else {
+		walletAddress = c.Args().Get(5)
 	}
 
 	if c.IsSet("side") {
 		orderSide = c.String("side")
+	} else {
+		orderSide = c.Args().Get(6)
 	}
 
+	// pair is optional, but if it's set, do a validity check
 	var p currency.Pair
 	if len(currencyPair) > 0 {
 		if !validPair(currencyPair) {
@@ -1817,6 +1828,10 @@ func addEvent(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		return fmt.Errorf("exchange name is required")
+	}
+
+	if !validExchange(exchangeName) {
+		return errInvalidExchange
 	}
 
 	if c.IsSet("item") {

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -901,13 +901,10 @@ func addPortfolioAddress(c *cli.Context) error {
 
 	if c.IsSet("balance") {
 		balance = c.Float64("balance")
-	} else {
-		if c.Args().Get(3) != "" {
-			var err error
-			balance, err = strconv.ParseFloat(c.Args().Get(3), 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(3) != "" {
+		balance, err = strconv.ParseFloat(c.Args().Get(3), 64)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1395,13 +1392,11 @@ func simulateOrder(c *cli.Context) error {
 
 	if c.IsSet("amount") {
 		amount = c.Float64("amount")
-	} else {
-		if c.Args().Get(3) != "" {
-			var err error
-			amount, err = strconv.ParseFloat(c.Args().Get(3), 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(3) != "" {
+		var err error
+		amount, err = strconv.ParseFloat(c.Args().Get(3), 64)
+		if err != nil {
+			return err
 		}
 	}
 	if amount == 0 {
@@ -1498,13 +1493,11 @@ func whaleBomb(c *cli.Context) error {
 
 	if c.IsSet("price") {
 		price = c.Float64("price")
-	} else {
-		if c.Args().Get(3) != "" {
-			var err error
-			price, err = strconv.ParseFloat(c.Args().Get(3), 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(3) != "" {
+		var err error
+		price, err = strconv.ParseFloat(c.Args().Get(3), 64)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1912,15 +1905,12 @@ func removeEvent(c *cli.Context) error {
 	var eventID int64
 	if c.IsSet("event_id") {
 		eventID = c.Int64("event_id")
-	} else {
-		if c.Args().Get(0) != "" {
-			var err error
-			eventID, err = strconv.ParseInt(c.Args().Get(0), 10, 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(0) != "" {
+		var err error
+		eventID, err = strconv.ParseInt(c.Args().Get(0), 10, 64)
+		if err != nil {
+			return err
 		}
-
 	}
 
 	conn, err := setupClient()
@@ -2025,10 +2015,8 @@ func getCryptocurrencyDepositAddress(c *cli.Context) error {
 
 	if c.IsSet("cryptocurrency") {
 		cryptocurrency = c.String("cryptocurrency")
-	} else {
-		if c.Args().Get(1) != "" {
-			cryptocurrency = c.Args().Get(1)
-		}
+	} else if c.Args().Get(1) != "" {
+		cryptocurrency = c.Args().Get(1)
 	}
 
 	if cryptocurrency == "" {
@@ -3451,25 +3439,21 @@ func getHistoricCandles(c *cli.Context) error {
 
 	if c.IsSet("rangesize") {
 		candleRangeSize = c.Int64("rangesize")
-	} else {
-		if c.Args().Get(2) != "" {
-			var err error
-			candleRangeSize, err = strconv.ParseInt(c.Args().Get(2), 10, 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(2) != "" {
+		var err error
+		candleRangeSize, err = strconv.ParseInt(c.Args().Get(2), 10, 64)
+		if err != nil {
+			return err
 		}
 	}
 
 	if c.IsSet("granularity") {
 		candleGranularity = c.Int64("granularity")
-	} else {
-		if c.Args().Get(3) != "" {
-			var err error
-			candleGranularity, err = strconv.ParseInt(c.Args().Get(3), 10, 64)
-			if err != nil {
-				return err
-			}
+	} else if c.Args().Get(3) != "" {
+		var err error
+		candleGranularity, err = strconv.ParseInt(c.Args().Get(3), 10, 64)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -72,7 +72,7 @@ type Binance struct {
 	validIntervals []TimeInterval
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Binance) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -72,7 +72,7 @@ type Binance struct {
 	validIntervals []TimeInterval
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Binance) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -91,7 +91,7 @@ type Bitfinex struct {
 	WebsocketSubdChannels      map[int]WebsocketChanInfo
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bitfinex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -91,7 +91,7 @@ type Bitfinex struct {
 	WebsocketSubdChannels      map[int]WebsocketChanInfo
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bitfinex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -71,7 +71,7 @@ type Bitflyer struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bitflyer) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -71,7 +71,7 @@ type Bitflyer struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bitflyer) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -56,7 +56,7 @@ type Bithumb struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bithumb) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -56,7 +56,7 @@ type Bithumb struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bithumb) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -910,7 +910,7 @@ func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {
 	return fee * purchasePrice * amount
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bitmex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -910,7 +910,7 @@ func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {
 	return fee * purchasePrice * amount
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bitmex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -64,7 +64,7 @@ type Bitstamp struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bitstamp) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -64,7 +64,7 @@ type Bitstamp struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bitstamp) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -63,7 +63,7 @@ type Bittrex struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *Bittrex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -63,7 +63,7 @@ type Bittrex struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *Bittrex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -82,7 +82,7 @@ type BTCMarkets struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *BTCMarkets) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -82,7 +82,7 @@ type BTCMarkets struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *BTCMarkets) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -326,7 +326,7 @@ func parseOrderTime(timeStr string) (time.Time, error) {
 	return time.Parse(btseTimeLayout, timeStr)
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (b *BTSE) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -326,7 +326,7 @@ func parseOrderTime(timeStr string) (time.Time, error) {
 	return time.Parse(btseTimeLayout, timeStr)
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (b *BTSE) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/coinbene/coinbene.go
+++ b/exchanges/coinbene/coinbene.go
@@ -1074,7 +1074,7 @@ func (c *Coinbene) SendAuthHTTPRequest(method, path, epPath string, isSwap bool,
 	return json.Unmarshal(resp, result)
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (c *Coinbene) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/coinbene/coinbene.go
+++ b/exchanges/coinbene/coinbene.go
@@ -1074,7 +1074,7 @@ func (c *Coinbene) SendAuthHTTPRequest(method, path, epPath string, isSwap bool,
 	return json.Unmarshal(resp, result)
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (c *Coinbene) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -56,7 +56,7 @@ type COINUT struct {
 	instrumentMap instrumentMap
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (c *COINUT) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -56,7 +56,7 @@ type COINUT struct {
 	instrumentMap instrumentMap
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (c *COINUT) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -49,7 +49,7 @@ type EXMO struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (e *EXMO) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -49,7 +49,7 @@ type EXMO struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (e *EXMO) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -48,8 +48,7 @@ type Gateio struct {
 	exchange.Base
 }
 
-// GetHistoriCandles
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (g *Gateio) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -48,7 +48,7 @@ type Gateio struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (g *Gateio) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -446,7 +446,7 @@ func calculateTradingFee(notionVolume *NotionalVolume, purchasePrice, amount flo
 	return volumeFee * amount * purchasePrice
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (g *Gemini) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -446,7 +446,7 @@ func calculateTradingFee(notionVolume *NotionalVolume, purchasePrice, amount flo
 	return volumeFee * amount * purchasePrice
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (g *Gemini) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -51,7 +51,7 @@ type HitBTC struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (h *HitBTC) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -51,7 +51,7 @@ type HitBTC struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (h *HitBTC) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -70,7 +70,7 @@ type HUOBI struct {
 	AuthenticatedWebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (h *HUOBI) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -70,7 +70,7 @@ type HUOBI struct {
 	AuthenticatedWebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (h *HUOBI) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -40,7 +40,7 @@ type ItBit struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (i *ItBit) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -40,7 +40,7 @@ type ItBit struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (i *ItBit) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -64,7 +64,7 @@ type Kraken struct {
 	wsRequestMtx               sync.Mutex
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (k *Kraken) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -64,7 +64,7 @@ type Kraken struct {
 	wsRequestMtx               sync.Mutex
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (k *Kraken) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -41,7 +41,7 @@ type LakeBTC struct {
 	WebsocketConn
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (l *LakeBTC) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -41,7 +41,7 @@ type LakeBTC struct {
 	WebsocketConn
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (l *LakeBTC) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -581,7 +581,7 @@ func (l *Lbank) SendAuthHTTPRequest(method, endpoint string, vals url.Values, re
 		l.HTTPRecording)
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (l *Lbank) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -581,7 +581,7 @@ func (l *Lbank) SendAuthHTTPRequest(method, endpoint string, vals url.Values, re
 		l.HTTPRecording)
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (l *Lbank) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -113,7 +113,7 @@ type LocalBitcoins struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (l *LocalBitcoins) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -113,7 +113,7 @@ type LocalBitcoins struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (l *LocalBitcoins) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -22,7 +22,7 @@ type OKCoin struct {
 	okgroup.OKGroup
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (o *OKCoin) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -22,7 +22,7 @@ type OKCoin struct {
 	okgroup.OKGroup
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (o *OKCoin) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -47,7 +47,7 @@ type OKEX struct {
 	okgroup.OKGroup
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (o *OKEX) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -47,7 +47,7 @@ type OKEX struct {
 	okgroup.OKGroup
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (o *OKEX) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrFunctionNotSupported
 }

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -60,7 +60,7 @@ type Poloniex struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (p *Poloniex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -60,7 +60,7 @@ type Poloniex struct {
 	WebsocketConn *wshandler.WebsocketConnection
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (p *Poloniex) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/withdraw/withdraw_types.go
+++ b/exchanges/withdraw/withdraw_types.go
@@ -11,15 +11,17 @@ const (
 	ErrStrAmountMustBeGreaterThanZero = "amount must be greater than 0"
 	// ErrStrAddressisInvalid message to return when address is invalid for crypto request
 	ErrStrAddressisInvalid = "address is not valid"
-	// ErrStrAddressNotSet message to returh when address is empty
+	// ErrStrAddressNotSet message to return when address is empty
 	ErrStrAddressNotSet = "address cannot be empty"
 	// ErrStrNoCurrencySet message to return when no currency is set
 	ErrStrNoCurrencySet = "currency not set"
 )
 
 var (
+	// ErrRequestCannotBeNil message to return when a request is nil
 	ErrRequestCannotBeNil = errors.New("request cannot be nil")
-	ErrInvalidRequest     = errors.New("invalid request type")
+	// ErrInvalidRequest message to return when a request is invalid
+	ErrInvalidRequest = errors.New("invalid request type")
 )
 
 // GenericInfo stores genric withdraw request info

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -43,7 +43,7 @@ type Yobit struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (y *Yobit) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -43,7 +43,7 @@ type Yobit struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (y *Yobit) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -48,7 +48,7 @@ type ZB struct {
 	exchange.Base
 }
 
-// GetHistoriCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
 func (z *ZB) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -48,7 +48,7 @@ type ZB struct {
 	exchange.Base
 }
 
-// GetHistoricCandles returns _rangesize_ number of candles for the given _granularity_ and _pair_ starting from the latest available
+// GetHistoricCandles returns rangesize number of candles for the given granularity and pair starting from the latest available
 func (z *ZB) GetHistoricCandles(pair currency.Pair, rangesize, granularity int64) ([]exchange.Candle, error) {
 	return nil, common.ErrNotYetImplemented
 }


### PR DESCRIPTION
# PR Description

Basic commit which adds destination vars and arg checks before assignment in GCTCLI
Also fixes linter issues associated with func name comments

```
NAME:
   gctcli gethistoriccandles - gets historical candles for the specified granularity up to range size time from now.

USAGE:
   gctcli gethistoriccandles [command options] <exchange> <pair> <rangesize> <granularity>

OPTIONS:
   --exchange value, -e value     the exchange to get the candles from
   --pair value                   the currency pair to get the candles for
   --rangesize value, -r value    the amount of time to go back from now to fetch candles in the given granularity (default: 10)
   --granularity value, -g value  value is in seconds and can be one of the following {60, 300, 900, 3600, 21600, 86400} (default: 86400)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
