### PR TITLE
(PROFILING): Add config support for setting runtime.SetMutexProfileFraction() value

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -86,7 +86,7 @@ type Config struct {
 	Database          database.Config         `json:"database"`
 	Logging           log.Config              `json:"logging"`
 	ConnectionMonitor ConnectionMonitorConfig `json:"connectionMonitor"`
-	Profiler          ProfilerConfig          `json:"profiler"`
+	Profiler          Profiler                `json:"profiler"`
 	NTPClient         NTPClientConfig         `json:"ntpclient"`
 	GCTScript         gctscript.Config        `json:"gctscript"`
 	Currency          CurrencyConfig          `json:"currencyConfig"`
@@ -154,9 +154,10 @@ type ExchangeConfig struct {
 	WebsocketURL                     *string              `json:"websocketUrl,omitempty"`
 }
 
-// ProfilerConfig defines the profiler configuration to enable pprof
-type ProfilerConfig struct {
-	Enabled bool `json:"enabled"`
+// Profiler defines the profiler configuration to enable pprof
+type Profiler struct {
+	Enabled              bool `json:"enabled"`
+	MutexProfileFraction int  `json:"mutex_profile_fraction"`
 }
 
 // NTPClientConfig defines a network time protocol configuration to allow for

--- a/config_example.json
+++ b/config_example.json
@@ -51,7 +51,8 @@
   "checkInterval": 1000000000
  },
  "profiler": {
-  "enabled": false
+  "enabled": false,
+  "mutex_profile_fraction": 0
  },
  "ntpclient": {
   "enabled": 0,

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" // nolint: gosec
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -85,6 +86,9 @@ func newRouter(isREST bool) *mux.Router {
 		}
 
 		if Bot.Config.Profiler.Enabled {
+			if Bot.Config.Profiler.MutexProfileFraction > 0 {
+				runtime.SetMutexProfileFraction(Bot.Config.Profiler.MutexProfileFraction)
+			}
 			log.Debugf(log.RESTSys,
 				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug\n",
 				common.ExtractHost(listenAddr),

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -90,7 +90,7 @@ func newRouter(isREST bool) *mux.Router {
 				runtime.SetMutexProfileFraction(Bot.Config.Profiler.MutexProfileFraction)
 			}
 			log.Debugf(log.RESTSys,
-				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug\n",
+				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof\n",
 				common.ExtractHost(listenAddr),
 				common.ExtractPort(listenAddr))
 			router.PathPrefix("/debug").Handler(http.DefaultServeMux)

--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -92,7 +92,6 @@ func TestValidHostRequest(t *testing.T) {
 }
 
 func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
-	const host = "localhost:9050"
 	Bot = &Engine{
 		Config: loadConfig(t),
 	}
@@ -102,7 +101,7 @@ func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req.Host = host
+	req.Host = "localhost:9050"
 	resp := httptest.NewRecorder()
 	newRouter(true).ServeHTTP(resp, req)
 	if status := resp.Code; status != http.StatusNotFound {
@@ -115,12 +114,12 @@ func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Host = host
 
 	mutexValue := runtime.SetMutexProfileFraction(10)
 	if mutexValue != 0 {
 		t.Fatalf("SetMutexProfileFraction() should be 0 on first set received: %v", mutexValue)
 	}
+
 	resp = httptest.NewRecorder()
 	newRouter(true).ServeHTTP(resp, req)
 	mutexValue = runtime.SetMutexProfileFraction(10)

--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
@@ -53,6 +54,10 @@ func TestConfigAllJsonResponse(t *testing.T) {
 }
 
 func TestInvalidHostRequest(t *testing.T) {
+	Bot = &Engine{
+		Config: loadConfig(t),
+	}
+
 	req, err := http.NewRequest(http.MethodGet, "/config/all", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -68,6 +73,10 @@ func TestInvalidHostRequest(t *testing.T) {
 }
 
 func TestValidHostRequest(t *testing.T) {
+	Bot = &Engine{
+		Config: loadConfig(t),
+	}
+
 	req, err := http.NewRequest(http.MethodGet, "/config/all", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -77,6 +86,47 @@ func TestValidHostRequest(t *testing.T) {
 	resp := httptest.NewRecorder()
 	newRouter(true).ServeHTTP(resp, req)
 
+	if status := resp.Code; status != http.StatusOK {
+		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusOK, status)
+	}
+}
+
+func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
+	const host = "localhost:9050"
+	Bot = &Engine{
+		Config: loadConfig(t),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Host = host
+	resp := httptest.NewRecorder()
+	newRouter(true).ServeHTTP(resp, req)
+	if status := resp.Code; status != http.StatusNotFound {
+		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusNotFound, status)
+	}
+
+	Bot.Config.Profiler.Enabled = true
+	Bot.Config.Profiler.MutexProfileFraction = 5
+	req, err = http.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = host
+
+	mutexValue := runtime.SetMutexProfileFraction(10)
+	if mutexValue != 0 {
+		t.Fatalf("SetMutexProfileFraction() should be 0 on first set received: %v", mutexValue)
+	}
+	resp = httptest.NewRecorder()
+	newRouter(true).ServeHTTP(resp, req)
+	mutexValue = runtime.SetMutexProfileFraction(10)
+	if mutexValue != 5 {
+		t.Fatalf("SetMutexProfileFraction() should be 5 after setup received: %v", mutexValue)
+	}
 	if status := resp.Code; status != http.StatusOK {
 		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusOK, status)
 	}

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -49,7 +49,8 @@
   "checkInterval": 1000000000
  },
  "profiler": {
-  "enabled": false
+  "enabled": false,
+  "mutex_profile_fraction": 0
  },
  "ntpclient": {
   "enabled": 0,


### PR DESCRIPTION
# PR Description

Adds a config entry for setting [SetMutexProfileFraction](https://golang.org/pkg/runtime/#SetMutexProfileFraction) value this allows you to do mutex profiling with pprof

![2020-01-30-114748_1596x662_scrot](https://user-images.githubusercontent.com/1223381/73410903-ba000280-4357-11ea-8e1a-1ef958bdb94d.png)

Also removed the stutter on config struct adds additional test covage to check endpoint responds if its enabled 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Enable profiler and manually visit endpoint ( http://localhost:9050/debug/pprof/mutex?debug=1 ) to confirm data is returned

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
