### PR TITLE
Coinut: Fix nonce issue based on new API change

### DIFF
--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -640,3 +640,12 @@ func TestCurrencyMapInstrumentIDs(t *testing.T) {
 		t.Error("unexpected result")
 	}
 }
+
+func TestGetNonce(t *testing.T) {
+	result := getNonce()
+	for x := 0; x < 100000; x++ {
+		if result <= 0 || result > coinutMaxNonce {
+			t.Fatal("invalid nonce value")
+		}
+	}
+}

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -3,6 +3,7 @@ package coinut
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -125,6 +126,7 @@ func (c *COINUT) SetDefaults() {
 	c.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	c.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	c.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit
+	rand.Seed(time.Now().UnixNano())
 }
 
 // Setup sets the current exchange configuration


### PR DESCRIPTION
# PR Description

Our tests were failing due to an invalid nonce issue, this PR introduces a simple getNonce func to generate a number between 1 and 16777215 as per https://github.com/coinut/api/wiki/Websocket-API#nonce

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] websocket test

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
