### PR TITLE
(BTC Markets) Add support for GetHistoricCandles wrapper

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1176,8 +1176,9 @@ func (c *Config) CheckLoggerConfig() error {
 		}
 		log.FileLoggingConfiguredCorrectly = true
 	}
-
+	log.RWM.Lock()
 	log.GlobalLogConfig = &c.Logging
+	log.RWM.Unlock()
 
 	logPath := filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "logs")
 	err := common.CreateDir(logPath)

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -186,10 +186,10 @@ func (b *BTCMarkets) GetMarketCandles(marketID string, timeWindow time.Duration,
 		params.Set("timeWindow", intervalStr)
 	}
 	if !from.IsZero() {
-		params.Set("from", from.Format(time.RFC3339))
+		params.Set("from", from.UTC().Format(time.RFC3339))
 	}
 	if !to.IsZero() {
-		params.Set("to", to.Format(time.RFC3339))
+		params.Set("to", to.UTC().Format(time.RFC3339))
 	}
 	if before > 0 {
 		params.Set("before", strconv.FormatInt(before, 10))

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -16,6 +16,8 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/websocket/wshandler"
 )
@@ -161,21 +163,33 @@ func (b *BTCMarkets) GetOrderbook(marketID string, level int64) (Orderbook, erro
 }
 
 // GetMarketCandles gets candles for specified currency pair
-func (b *BTCMarkets) GetMarketCandles(marketID, timeWindow, from, to string, before, after, limit int64) ([]MarketCandle, error) {
+func (b *BTCMarkets) GetMarketCandles(marketID string, timeWindow time.Duration, from, to time.Time, before, after, limit int64) (kline.Item, error) {
 	if (before > 0) && (after >= 0) {
-		return nil, errors.New("BTCMarkets only supports either before or after, not both")
+		return kline.Item{}, errors.New("BTCMarkets only supports either before or after, not both")
 	}
-	var marketCandles []MarketCandle
 	var temp [][]string
 	params := url.Values{}
-	if timeWindow != "" {
-		params.Set("timeWindow", timeWindow)
+
+	var intervalStr string
+	switch timeWindow {
+	case kline.OneMin:
+		intervalStr = "1m"
+	case kline.OneHour:
+		intervalStr = "1h"
+	case kline.OneDay:
+		intervalStr = "1d"
+	default:
+		return kline.Item{}, errInvalidTimeInterval
 	}
-	if from != "" {
-		params.Set("from", from)
+
+	if timeWindow != 0 {
+		params.Set("timeWindow", intervalStr)
 	}
-	if to != "" {
-		params.Set("to", to)
+	if !from.IsZero() {
+		params.Set("from", from.Format(time.RFC3339))
+	}
+	if !to.IsZero() {
+		params.Set("to", to.Format(time.RFC3339))
 	}
 	if before > 0 {
 		params.Set("before", strconv.FormatInt(before, 10))
@@ -189,39 +203,46 @@ func (b *BTCMarkets) GetMarketCandles(marketID, timeWindow, from, to string, bef
 	err := b.SendHTTPRequest(btcMarketsUnauthPath+marketID+btcMarketsCandles+params.Encode(),
 		&temp)
 	if err != nil {
-		return marketCandles, err
+		return kline.Item{}, err
 	}
-	var tempData MarketCandle
+	ret := kline.Item{
+		Exchange: b.Name,
+		Pair:     currency.NewPairFromString(marketID),
+		Asset:    asset.Spot,
+		Interval: timeWindow,
+	}
+
+	var tempData kline.Candle
 	var tempTime time.Time
 	for x := range temp {
 		tempTime, err = time.Parse(time.RFC3339, temp[x][0])
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
 		tempData.Time = tempTime
 		tempData.Open, err = strconv.ParseFloat(temp[x][1], 64)
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
 		tempData.High, err = strconv.ParseFloat(temp[x][2], 64)
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
 		tempData.Low, err = strconv.ParseFloat(temp[x][3], 64)
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
 		tempData.Close, err = strconv.ParseFloat(temp[x][4], 64)
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
 		tempData.Volume, err = strconv.ParseFloat(temp[x][5], 64)
 		if err != nil {
-			return marketCandles, err
+			return kline.Item{}, err
 		}
-		marketCandles = append(marketCandles, tempData)
+		ret.Candles = append(ret.Candles, tempData)
 	}
-	return marketCandles, nil
+	return ret, nil
 }
 
 // GetTickers gets multiple tickers

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -1,14 +1,17 @@
 package btcmarkets
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 )
@@ -97,7 +100,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetMarketCandles(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarketCandles(BTCAUD, "", "", "", 0, 0, 5)
+	_, err := b.GetMarketCandles(BTCAUD, kline.OneHour, time.Now().UTC().Add(-time.Hour*24), time.Now().UTC(), -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -713,5 +716,19 @@ func TestWsOrders(t *testing.T) {
 	err = b.wsHandleData(pressXToJSON)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestBTCMarkets_GetHistoricCandles(t *testing.T) {
+	p := currency.NewPairFromString(BTCAUD)
+	_, err := b.GetHistoricCandles(p, asset.Spot, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.OneHour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.GetHistoricCandles(p, asset.Spot, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.FifteenMin)
+	if err != nil {
+		if !errors.Is(err, errInvalidTimeInterval) {
+			t.Fatal(err)
+		}
 	}
 }

--- a/exchanges/btcmarkets/btcmarkets_types.go
+++ b/exchanges/btcmarkets/btcmarkets_types.go
@@ -1,6 +1,11 @@
 package btcmarkets
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var errInvalidTimeInterval = errors.New("invalid time interval")
 
 // Market holds a tradable market instrument
 type Market struct {

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -745,5 +745,5 @@ func (b *BTCMarkets) ValidateCredentials() error {
 
 // GetHistoricCandles returns candles between a time period for a set time interval
 func (b *BTCMarkets) GetHistoricCandles(pair currency.Pair, a asset.Item, start, end time.Time, interval time.Duration) (kline.Item, error) {
-	return kline.Item{}, common.ErrNotYetImplemented
+	return b.GetMarketCandles(pair.String(), interval, start, end, -1, -1, 0)
 }

--- a/log/logger_types.go
+++ b/log/logger_types.go
@@ -31,6 +31,9 @@ var (
 
 	// LogPath system path to store log files in
 	LogPath string
+
+	// RWM read/write mutex for logger
+	RWM = &sync.RWMutex{}
 )
 
 // Config holds configuration settings loaded from bot config

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -168,6 +168,8 @@ func displayError(err error) {
 }
 
 func enabled() bool {
+	RWM.RLock()
+	defer RWM.RUnlock()
 	if GlobalLogConfig.Enabled == nil {
 		return false
 	}


### PR DESCRIPTION
# PR Description

Adds support for the updated GetHistoricCandles() wrapper method added in #454 and also reworks GetMarketCandles() method to match requirements of [BTC Markets API](https://api.btcmarkets.net/doc/v3#tag/Market-data-APIs/paths/~1v3~1markets~1{marketId}~1candles/get)


```
✗ go run ./cmd/gctcli gethistoriccandles "BTC Markets" "BTC-AUD" "SPOT" 1 86400
{
 "candle": [
  {
   "time": 1584230400,
   "low": 8355.12,
   "high": 9550,
   "open": 8430.65,
   "close": 8744.37,
   "volume": 383.06940601
  },
  {
   "time": 1584316800,
   "low": 8500,
   "high": 8776.22,
   "open": 8773.25,
   "close": 8598.41,
   "volume": 138.76640452
  }
 ]
}%         
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
