### PR TITLE
(FIX) Update ZB API URLs

### DIFF
--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	zbTradeURL   = "http://api.zb.cn/data"
-	zbMarketURL  = "https://trade.zb.cn/api"
+	zbTradeURL   = "http://api.zb.live/data"
+	zbMarketURL  = "https://trade.zb.live/api"
 	zbAPIVersion = "v1"
 
 	zbAccountInfo                     = "getAccountInfo"

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -511,20 +511,6 @@ func TestWsTransferFunds(t *testing.T) {
 	}
 }
 
-// TestWsCreateSuUserKey ws test
-func TestWsCreateSuUserKey(t *testing.T) {
-	setupWsAuth(t)
-	subUsers, err := z.wsGetSubUserList()
-	if err != nil {
-		t.Fatal(err)
-	}
-	userID := subUsers.Message[0].UserID
-	_, err = z.wsCreateSubUserKey(true, true, true, true, "subu", strconv.FormatInt(userID, 10))
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestGetSubUserList ws test
 func TestGetSubUserList(t *testing.T) {
 	setupWsAuth(t)
@@ -538,6 +524,23 @@ func TestGetSubUserList(t *testing.T) {
 func TestAddSubUser(t *testing.T) {
 	setupWsAuth(t)
 	_, err := z.wsAddSubUser("1", "123456789101112aA!")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWsCreateSuUserKey ws test
+func TestWsCreateSuUserKey(t *testing.T) {
+	setupWsAuth(t)
+	subUsers, err := z.wsGetSubUserList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subUsers.Message) == 0 {
+		t.Skip("User ID required for test to continue. Create a subuser first")
+	}
+	userID := subUsers.Message[0].UserID
+	_, err = z.wsCreateSubUserKey(true, true, true, true, "subu", strconv.FormatInt(userID, 10))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -52,7 +52,6 @@ func TestMain(m *testing.M) {
 	}
 	z.Websocket.DataHandler = sharedtestvalues.GetWebsocketInterfaceChannelOverride()
 	z.Websocket.TrafficAlert = sharedtestvalues.GetWebsocketStructChannelOverride()
-	z.Verbose = true
 	os.Exit(m.Run())
 }
 

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -81,7 +81,7 @@ func (z *ZB) wsHandleData(respRaw []byte) error {
 	}
 	if result.No > 0 {
 		if z.WebsocketConn.IsIDWaitingForResponse(result.No) {
-			z.WebsocketConn.SetResponseIDAndData(result.No, respRaw)
+			z.WebsocketConn.SetResponseIDAndData(result.No, fixedJSON)
 			return nil
 		}
 	}

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	zbWebsocketAPI       = "wss://api.zb.cn:9999/websocket"
+	zbWebsocketAPI       = "wss://api.zb.live/websocket"
 	zWebsocketAddChannel = "addChannel"
 	zbWebsocketRateLimit = 20
 )


### PR DESCRIPTION
# PR Description
ZB has changed its websocket URL, I've changed it. See: https://www.zb.com/api#WebSocket%20API
Its also changed its Trading and Data API urls, however, they appear to be redirecting. I've updated those now too

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
- Comparing results of old URL to current URL. The new one can connect, the old one can't
- go test ./... race
- Testing with API credentials

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
