### PR TITLE
(BUGFIX) OKCoin websocket port update

### DIFF
--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -13,7 +13,7 @@ const (
 	okCoinAPIURL              = "https://www.okcoin.com/" + okCoinAPIPath
 	okCoinAPIVersion          = "/v3/"
 	okCoinExchangeName        = "OKCOIN International"
-	okCoinWebsocketURL        = "wss://real.okcoin.com:10442/ws/v3"
+	okCoinWebsocketURL        = "wss://real.okcoin.com:8443/ws/v3"
 )
 
 // OKCoin bases all methods off okgroup implementation


### PR DESCRIPTION
![very slow](https://pa1.narvii.com/6240/9aa2cdfca576390de4607c770d6a8945607f8e6a_hq.gif "Very slow")

# PR Description
Another websocket connection issue caught. Embarrassingly, I missed this post from last year: https://support.okcoin.com/hc/en-us/articles/360031164711-Change-in-V3-WebSocket-API-Address-Port-Number
I've also missed that okcoin hasn't been able to connect to the websocket with this:
```
[ERROR] | WEBSOCKET | 31/03/2020 15:14:28 | OKCOIN International Error connecting wss://real.okcoin.com:10442/ws/v3 Error: dial tcp 149.129.81.119:10442: connectex: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
Running with the new URL:
```
[INFO]  | WEBSOCKET | 31/03/2020 15:16:30 | OKCOIN International Websocket connected to wss://real.okcoin.com:8443/ws/v3
```
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

