### PR TITLE
Bump golangci-lint to v1.24.0, linter fixes and general code improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
   PSQL_SSLMODE: disable
   PSQL_SKIPSQLCMD: true
   PSQL_TESTDBNAME: gct_dev_ci
-stack: go 1.13.x
+stack: go 1.14.x
 
 services:
   - postgresql96
@@ -49,7 +49,7 @@ before_test:
 
 test_script:
   # test back-end
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.20.1
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
   - '%GOPATH%\bin\golangci-lint.exe run --verbose'
   - ps: >-
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'true') {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ linters:
 #   - varcheck
 
 # disabled by default linters
-#   - bodyclose
+    - bodyclose
     - depguard
     - dogsled
 #   - dupl
@@ -38,6 +38,8 @@ linters:
     - gofmt
     - goimports
     - golint
+#   - gomnd
+    - goprintffuncname
     - gosec
 #   - interfacer
 #   - lll
@@ -45,6 +47,7 @@ linters:
     - misspell
     - nakedret
 #   - prealloc
+    - rowserrcheck
     - scopelint
     - stylecheck
     - unconvert
@@ -80,5 +83,8 @@ issues:
 
   exclude-rules:
     - text: "weak cryptographic primitive"
+      linters:
+        - gosec
+    - text: "Expect WriteFile permissions to be 0600 or less"
       linters:
         - gosec

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       dist: xenial
       name: 'GoCryptoTrader [back-end] [linux] [64-bit]'
       go:
-        - 1.13.x
+        - 1.14.x
       env:
         - GO111MODULE=on
         - PSQL_USER=postgres
@@ -43,7 +43,7 @@ matrix:
       dist: xenial
       name: 'GoCryptoTrader [back-end] [linux] [32-bit]'
       go:
-        - 1.13.x
+        - 1.14.x
       env:
         - GO111MODULE=on
         - NO_RACE_TEST=1
@@ -72,7 +72,7 @@ matrix:
       os: osx
       name: 'GoCryptoTrader [back-end] [darwin]'
       go:
-        - 1.13.x
+        - 1.14.x
       env:
         - GO111MODULE=on
         - PSQL_USER=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as build
+FROM golang:1.14 as build
 WORKDIR /go/src/github.com/thrasher-corp/gocryptotrader
 COPY . .
 RUN GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.20.1
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -313,16 +313,11 @@ func checkMissingExchanges() []string {
 // readFileData reads the file data from the given json file
 func readFileData(fileName string) (Config, error) {
 	var c Config
-	file, err := os.Open(fileName)
+	data, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return c, err
 	}
-	defer file.Close()
-	byteValue, err := ioutil.ReadAll(file)
-	if err != nil {
-		return c, err
-	}
-	err = json.Unmarshal(byteValue, &c)
+	err = json.Unmarshal(data, &c)
 	if err != nil {
 		return c, err
 	}
@@ -609,6 +604,7 @@ func htmlScrapeDefault(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -664,6 +660,7 @@ func htmlScrapeBTSE(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -694,6 +691,7 @@ func htmlScrapeBitfinex(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
@@ -727,6 +725,7 @@ func htmlScrapeBitmex(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -764,6 +763,7 @@ func htmlScrapeHitBTC(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
@@ -798,6 +798,7 @@ func htmlScrapeBTCMarkets(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tempData, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return resp, err
@@ -819,6 +820,7 @@ func htmlScrapeBitflyer(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -870,6 +872,7 @@ func htmlScrapeOk(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -923,6 +926,7 @@ func htmlScrapeANX(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
@@ -962,6 +966,7 @@ func htmlScrapeExmo(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer httpResp.Body.Close()
 	a, err := ioutil.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, err
@@ -982,6 +987,7 @@ func htmlScrapePoloniex(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -1034,6 +1040,7 @@ func htmlScrapeItBit(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -1067,6 +1074,7 @@ func htmlScrapeLakeBTC(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
@@ -1088,6 +1096,7 @@ func htmlScrapeBitstamp(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
@@ -1108,6 +1117,7 @@ func htmlScrapeKraken(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -1163,6 +1173,7 @@ func htmlScrapeAlphaPoint(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 loop:
 	for {
@@ -1217,6 +1228,7 @@ func htmlScrapeYobit(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return resp, err
 	}
+	defer temp.Body.Close()
 	tokenizer := html.NewTokenizer(temp.Body)
 	var case1, case2, case3 bool
 loop:
@@ -1274,6 +1286,7 @@ func htmlScrapeLocalBitcoins(htmlData *HTMLScrapingData) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer temp.Body.Close()
 	a, err := ioutil.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err

--- a/cmd/apichecker/apicheck_test.go
+++ b/cmd/apichecker/apicheck_test.go
@@ -43,14 +43,13 @@ func TestMain(m *testing.M) {
 	}
 	usageData = testConfigData
 	setTestVars()
-	defer os.Exit(m.Run())
-	defer func() {
-		err := removeTestFileVars()
-		if err != nil {
-			log.Error(log.Global, err)
-			os.Exit(1)
-		}
-	}()
+	testExitCode := m.Run()
+	err = removeTestFileVars()
+	if err != nil {
+		log.Error(log.Global, err)
+		os.Exit(1)
+	}
+	os.Exit(testExitCode)
 }
 
 func areTestAPIKeysSet() bool {

--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	dbConn         *database.Db
+	dbConn         *database.Instance
 	configFile     string
 	defaultDataDir string
 	migrationDir   string
@@ -26,7 +26,7 @@ var (
 	args           string
 )
 
-func openDbConnection(driver string) (err error) {
+func openDBConnection(driver string) (err error) {
 	if driver == database.DBPostgreSQL {
 		dbConn, err = dbPSQL.Connect()
 		if err != nil {
@@ -68,7 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = openDbConnection(conf.Database.Driver)
+	err = openDBConnection(conf.Database.Driver)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/core"
 )
 
@@ -267,48 +268,42 @@ func main() {
 // GetConfiguration retrieves the documentation configuration
 func GetConfiguration() (Config, error) {
 	var c Config
-	configFilePath := filepath.Join([]string{toolDir, "config.json"}...)
-	file, err := os.OpenFile(configFilePath, os.O_RDWR, os.ModePerm)
-	if err != nil {
-		fmt.Println("Creating configuration file, please check to add a different github repository path and change preferences")
+	configFilePath := filepath.Join(toolDir, "config.json")
 
-		file, err = os.Create(configFilePath)
+	if file.Exists(configFilePath) {
+		config, err := ioutil.ReadFile(configFilePath)
 		if err != nil {
 			return c, err
 		}
 
-		// Set default params for configuration
-		c.GithubRepo = DefaultRepo
-		c.ContributorFile = true
-		c.LicenseFile = true
-		c.RootReadme = true
-		c.Exclusions.Directories = DefaultExcludedDirectories
-
-		data, mErr := json.MarshalIndent(c, "", " ")
-		if mErr != nil {
-			return c, mErr
-		}
-
-		_, err = file.WriteAt(data, 0)
+		err = json.Unmarshal(config, &c)
 		if err != nil {
 			return c, err
 		}
+
+		if c.GithubRepo == "" {
+			return c, errors.New("repository not set in config.json file, please change")
+		}
+
+		return c, nil
 	}
 
-	defer file.Close()
+	fmt.Println("Creating configuration file, please check to add a different github repository path and change preferences")
 
-	config, err := ioutil.ReadAll(file)
+	// Set default params for configuration
+	c.GithubRepo = DefaultRepo
+	c.ContributorFile = true
+	c.LicenseFile = true
+	c.RootReadme = true
+	c.Exclusions.Directories = DefaultExcludedDirectories
+
+	data, err := json.MarshalIndent(c, "", " ")
 	if err != nil {
 		return c, err
 	}
 
-	err = json.Unmarshal(config, &c)
-	if err != nil {
+	if err := ioutil.WriteFile(configFilePath, data, 0770); err != nil {
 		return c, err
-	}
-
-	if c.GithubRepo == "" {
-		return c, errors.New("repository not set in config.json file, please change")
 	}
 
 	return c, nil

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -735,12 +735,7 @@ func jsonifyInterface(params []interface{}) json.RawMessage {
 
 func loadConfig() (Config, error) {
 	var config Config
-	file, err := os.OpenFile("wrapperconfig.json", os.O_RDONLY, os.ModePerm)
-	if err != nil {
-		return config, err
-	}
-	defer file.Close()
-	keys, err := ioutil.ReadAll(file)
+	keys, err := ioutil.ReadFile("wrapperconfig.json")
 	if err != nil {
 		return config, err
 	}
@@ -812,12 +807,11 @@ func outputToHTML(exchangeResponses []ExchangeResponses) {
 		return
 	}
 
-	defer file.Close()
 	err = tmpl.Execute(file, exchangeResponses)
 	if err != nil {
 		log.Print(err)
-		return
 	}
+	file.Close()
 }
 
 func outputToConsole(exchangeResponses []ExchangeResponses) {

--- a/cmd/websocket_client/main.go
+++ b/cmd/websocket_client/main.go
@@ -88,11 +88,13 @@ func main() {
 	log.Printf("Connecting to websocket host: %s", wsHost)
 
 	var dialer websocket.Dialer
-	WSConn, _, err = dialer.Dial(wsHost, http.Header{})
+	var resp *http.Response
+	WSConn, resp, err = dialer.Dial(wsHost, http.Header{})
 	if err != nil {
 		log.Println("Unable to connect to websocket server")
 		return
 	}
+	resp.Body.Close()
 	log.Println("Connected to websocket!")
 
 	log.Println("Authenticating..")

--- a/common/common.go
+++ b/common/common.go
@@ -264,22 +264,19 @@ func ExtractPort(host string) int {
 
 // OutputCSV dumps data into a file as comma-separated values
 func OutputCSV(filePath string, data [][]string) error {
-	_, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		errTwo := ioutil.WriteFile(filePath, nil, 0770)
-		if errTwo != nil {
-			return errTwo
-		}
-	}
-
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	writer := csv.NewWriter(file)
-	return writer.WriteAll(data)
+	if err = writer.WriteAll(data); err != nil {
+		file.Close()
+		return err
+	}
+
+	file.Close()
+	return nil
 }
 
 // GetURIPath returns the path of a URL given a URI

--- a/common/crypto/crypto.go
+++ b/common/crypto/crypto.go
@@ -2,9 +2,9 @@ package crypto
 
 import (
 	"crypto/hmac"
-	"crypto/md5" // nolint:gosec
+	"crypto/md5" // nolint // Used by some exchanges
 	"crypto/rand"
-	"crypto/sha1" // nolint:gosec
+	"crypto/sha1" // nolint // Used by some exchanges
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
@@ -62,7 +62,7 @@ func GetRandomSalt(input []byte, saltLen int) ([]byte, error) {
 
 // GetMD5 returns a MD5 hash of a byte array
 func GetMD5(input []byte) []byte {
-	m := md5.New() // nolint:gosec
+	m := md5.New() // nolint // Used by some exchanges
 	m.Write(input)
 	return m.Sum(nil)
 }
@@ -107,7 +107,7 @@ func GetHMAC(hashType int, input, key []byte) []byte {
 // Sha1ToHex takes a string, sha1 hashes it and return a hex string of the
 // result
 func Sha1ToHex(data string) string {
-	h := sha1.New() // nolint:gosec
+	h := sha1.New() // nolint // Used by some exchanges
 	h.Write([]byte(data))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/common/file/archive/zip.go
+++ b/common/file/archive/zip.go
@@ -32,8 +32,9 @@ func UnZip(src, dest string) (fileList []string, err error) {
 	}
 
 	for x := range z.File {
-		fPath := filepath.Join(dest, z.File[x].Name) // nolint:gosec
-		// We ignore gosec linter above because the code below files the file traversal bug when extracting archives
+		fPath := filepath.Join(dest, z.File[x].Name) // nolint // We ignore
+		// gosec linter above because the code below files the file traversal
+		// bug when extracting archives
 		if !strings.HasPrefix(fPath, filepath.Clean(dest)+string(os.PathSeparator)) {
 			err = z.Close()
 			if err != nil {
@@ -116,8 +117,6 @@ func Zip(src, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
 	z := zip.NewWriter(f)
 	defer z.Close()
 
@@ -134,6 +133,7 @@ func Zip(src, dest string) error {
 		}
 		return err
 	}
+	f.Close()
 	return nil
 }
 

--- a/common/file/archive/zip.go
+++ b/common/file/archive/zip.go
@@ -117,11 +117,12 @@ func Zip(src, dest string) error {
 	if err != nil {
 		return err
 	}
+
 	z := zip.NewWriter(f)
-	defer z.Close()
 
 	err = addFilesToZip(z, src, i.IsDir())
 	if err != nil {
+		z.Close()
 		errCls := f.Close()
 		if errCls != nil {
 			log.Errorf(log.Global, "Failed to close file handle, manual deletion required: %v", errCls)
@@ -133,6 +134,8 @@ func Zip(src, dest string) error {
 		}
 		return err
 	}
+
+	z.Close()
 	f.Close()
 	return nil
 }

--- a/common/timedmutex/timed_mutex.go
+++ b/common/timedmutex/timed_mutex.go
@@ -61,8 +61,9 @@ func (t *TimedMutex) stopTimer() bool {
 // isTimerNil safely read locks to detect nil
 func (t *TimedMutex) isTimerNil() bool {
 	t.timerLock.RLock()
-	defer t.timerLock.RUnlock()
-	return t.timer == nil
+	isNil := t.timer == nil
+	t.timerLock.RUnlock()
+	return isNil
 }
 
 // setTimer safely locks and sets a timer

--- a/communications/slack/slack.go
+++ b/communications/slack/slack.go
@@ -194,10 +194,12 @@ func (s *Slack) WebsocketConnect() error {
 		websocketURL = s.ReconnectURL
 	}
 
-	s.WebsocketConn, _, err = dialer.Dial(websocketURL, http.Header{})
+	var resp *http.Response
+	s.WebsocketConn, resp, err = dialer.Dial(websocketURL, http.Header{})
 	if err != nil {
 		return err
 	}
+	resp.Body.Close()
 
 	go s.WebsocketReader()
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -172,8 +172,9 @@ func (c *Config) PurgeExchangeAPICredentials() {
 // GetCommunicationsConfig returns the communications configuration
 func (c *Config) GetCommunicationsConfig() CommunicationsConfig {
 	m.Lock()
-	defer m.Unlock()
-	return c.Communications
+	comms := c.Communications
+	m.Unlock()
+	return comms
 }
 
 // UpdateCommunicationsConfig sets a new updated version of a Communications
@@ -187,8 +188,9 @@ func (c *Config) UpdateCommunicationsConfig(config *CommunicationsConfig) {
 // GetCryptocurrencyProviderConfig returns the communications configuration
 func (c *Config) GetCryptocurrencyProviderConfig() CryptocurrencyProvider {
 	m.Lock()
-	defer m.Unlock()
-	return c.Currency.CryptocurrencyProvider
+	provider := c.Currency.CryptocurrencyProvider
+	m.Unlock()
+	return provider
 }
 
 // UpdateCryptocurrencyProviderConfig returns the communications configuration
@@ -677,8 +679,9 @@ func (c *Config) GetCurrencyPairDisplayConfig() *CurrencyPairFormatConfig {
 // GetAllExchangeConfigs returns all exchange configurations
 func (c *Config) GetAllExchangeConfigs() []ExchangeConfig {
 	m.Lock()
-	defer m.Unlock()
-	return c.Exchanges
+	configs := c.Exchanges
+	m.Unlock()
+	return configs
 }
 
 // GetExchangeConfig returns exchange configurations by its indivdual name
@@ -708,8 +711,9 @@ func (c *Config) GetForexProvider(name string) (currency.FXSettings, error) {
 // GetForexProviders returns a list of available forex providers
 func (c *Config) GetForexProviders() []currency.FXSettings {
 	m.Lock()
-	defer m.Unlock()
-	return c.Currency.ForexProviders
+	fxProviders := c.Currency.ForexProviders
+	m.Unlock()
+	return fxProviders
 }
 
 // GetPrimaryForexProvider returns the primary forex provider

--- a/connchecker/connchecker.go
+++ b/connchecker/connchecker.go
@@ -181,6 +181,7 @@ func (c *Checker) CheckHost(host string) error {
 // IsConnected returns if there is internet connectivity
 func (c *Checker) IsConnected() bool {
 	c.Lock()
-	defer c.Unlock()
-	return c.connected
+	isConnected := c.connected
+	c.Unlock()
+	return isConnected
 }

--- a/currency/code_types.go
+++ b/currency/code_types.go
@@ -99,7 +99,7 @@ var (
 	BAT        = NewCode("BAT")
 	ETP        = NewCode("ETP")
 	HOT        = NewCode("HOT")
-	STRAT      = NewCode("STRAT") // nolint: misspell
+	STRAT      = NewCode("STRAT") // nolint // Cryptocurrency code
 	GNT        = NewCode("GNT")
 	REP        = NewCode("REP")
 	SNT        = NewCode("SNT")
@@ -356,9 +356,9 @@ var (
 	STQ        = NewCode("STQ")
 	INK        = NewCode("INK")
 	HBZ        = NewCode("HBZ")
-	USDT_ETH   = NewCode("USDT_ETH") // nolint: golint,stylecheck
-	QTUM_ETH   = NewCode("QTUM_ETH") // nolint: golint
-	BTM_ETH    = NewCode("BTM_ETH")  // nolint: golint,stylecheck
+	USDT_ETH   = NewCode("USDT_ETH") // nolint // Cryptocurrency code
+	QTUM_ETH   = NewCode("QTUM_ETH") // nolint // Cryptocurrency code
+	BTM_ETH    = NewCode("BTM_ETH")  // nolint // Cryptocurrency code
 	FIL        = NewCode("FIL")
 	STX        = NewCode("STX")
 	BOT        = NewCode("BOT")
@@ -371,7 +371,7 @@ var (
 	GOD        = NewCode("GOD")
 	SMT        = NewCode("SMT")
 	BTF        = NewCode("BTF")
-	NAS_ETH    = NewCode("NAS_ETH") // nolint: golint,stylecheck
+	NAS_ETH    = NewCode("NAS_ETH") // nolint // Cryptocurrency code
 	TSL        = NewCode("TSL")
 	BIFI       = NewCode("BIFI")
 	BNTY       = NewCode("BNTY")
@@ -397,21 +397,21 @@ var (
 	MOBI       = NewCode("MOBI")
 	LEDU       = NewCode("LEDU")
 	DBC        = NewCode("DBC")
-	MKR_OLD    = NewCode("MKR_OLD") // nolint: golint,stylecheck
+	MKR_OLD    = NewCode("MKR_OLD") // nolint // Cryptocurrency code
 	DPY        = NewCode("DPY")
 	BCDN       = NewCode("BCDN")
-	EOSDAC     = NewCode("EOSDAC") // nolint: golint
+	EOSDAC     = NewCode("EOSDAC")
 	TIPS       = NewCode("TIPS")
 	XMC        = NewCode("XMC")
 	PPS        = NewCode("PPS")
 	BOE        = NewCode("BOE")
 	MEDX       = NewCode("MEDX")
-	SMT_ETH    = NewCode("SMT_ETH") // nolint: golint,stylecheck
+	SMT_ETH    = NewCode("SMT_ETH") // nolint // Cryptocurrency code
 	CS         = NewCode("CS")
 	MAN        = NewCode("MAN")
 	REM        = NewCode("REM")
 	LYM        = NewCode("LYM")
-	INSTAR     = NewCode("INSTAR") // nolint: golint
+	INSTAR     = NewCode("INSTAR")
 	BFT        = NewCode("BFT")
 	IHT        = NewCode("IHT")
 	SENC       = NewCode("SENC")
@@ -426,7 +426,7 @@ var (
 	SWTH       = NewCode("SWTH")
 	NKN        = NewCode("NKN")
 	SOUL       = NewCode("SOUL")
-	GALA_NEO   = NewCode("GALA_NEO") // nolint: golint,stylecheck
+	GALA_NEO   = NewCode("GALA_NEO") // nolint // Cryptocurrency code
 	LRN        = NewCode("LRN")
 	GSE        = NewCode("GSE")
 	RATING     = NewCode("RATING")
@@ -1651,5 +1651,5 @@ var (
 	YER        = NewCode("YER")
 	ZWD        = NewCode("ZWD")
 	XETH       = NewCode("XETH")
-	FX_BTC     = NewCode("FX_BTC") // nolint: golint,stylecheck
+	FX_BTC     = NewCode("FX_BTC") // nolint // Cryptocurrency code
 )

--- a/database/database_types.go
+++ b/database/database_types.go
@@ -9,12 +9,11 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/database/drivers"
 )
 
-// Db holds all information for a database instance
-type Db struct {
-	SQL      *sql.DB
-	DataPath string
-	Config   *Config
-
+// Instance holds all information for a database instance
+type Instance struct {
+	SQL       *sql.DB
+	DataPath  string
+	Config    *Config
 	Connected bool
 	Mu        sync.RWMutex
 }
@@ -29,7 +28,7 @@ type Config struct {
 
 var (
 	// DB Global Database Connection
-	DB = &Db{}
+	DB = &Instance{}
 
 	// MigrationDir which folder to look in for current migrations
 	MigrationDir = filepath.Join("..", "..", "database", "migrations")

--- a/database/drivers/postgres/postgres.go
+++ b/database/drivers/postgres/postgres.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Connect opens a connection to Postgres database and returns a pointer to database.DB
-func Connect() (*database.Db, error) {
+func Connect() (*database.Instance, error) {
 	if database.DB.Config.SSLMode == "" {
 		database.DB.Config.SSLMode = "disable"
 	}

--- a/database/drivers/sqlite3/sqlite3.go
+++ b/database/drivers/sqlite3/sqlite3.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Connect opens a connection to sqlite database and returns a pointer to database.DB
-func Connect() (*database.Db, error) {
+func Connect() (*database.Instance, error) {
 	if database.DB.Config.Database == "" {
 		return nil, database.ErrNoDatabaseProvided
 	}

--- a/database/repository/audit/audit_test.go
+++ b/database/repository/audit/audit_test.go
@@ -40,7 +40,7 @@ func TestAudit(t *testing.T) {
 		name   string
 		config *database.Config
 		runner func(t *testing.T)
-		closer func(dbConn *database.Db) error
+		closer func(dbConn *database.Instance) error
 		output interface{}
 	}{
 		{

--- a/database/repository/script/script_test.go
+++ b/database/repository/script/script_test.go
@@ -41,7 +41,7 @@ func TestScript(t *testing.T) {
 		name   string
 		config *database.Config
 		runner func()
-		closer func(dbConn *database.Db) error
+		closer func(dbConn *database.Instance) error
 		output interface{}
 	}{
 		{

--- a/database/repository/withdraw/withdraw.go
+++ b/database/repository/withdraw/withdraw.go
@@ -20,6 +20,7 @@ import (
 )
 
 var (
+	// ErrNoResults is the error returned if no results are found
 	ErrNoResults = errors.New("no results found")
 )
 

--- a/database/repository/withdraw/withdraw_test.go
+++ b/database/repository/withdraw/withdraw_test.go
@@ -45,7 +45,7 @@ func TestWithdraw(t *testing.T) {
 		name   string
 		config *database.Config
 		runner func(t *testing.T)
-		closer func(dbConn *database.Db) error
+		closer func(dbConn *database.Instance) error
 		output interface{}
 	}{
 		{

--- a/database/testhelpers/test_helpers.go
+++ b/database/testhelpers/test_helpers.go
@@ -66,7 +66,7 @@ func GetConnectionDetails() *database.Config {
 }
 
 // ConnectToDatabase opens connection to database and returns pointer to instance of database.DB
-func ConnectToDatabase(conn *database.Config) (dbConn *database.Db, err error) {
+func ConnectToDatabase(conn *database.Config) (dbConn *database.Instance, err error) {
 	database.DB.Config = conn
 
 	if conn.Driver == database.DBPostgreSQL {
@@ -87,7 +87,7 @@ func ConnectToDatabase(conn *database.Config) (dbConn *database.Db, err error) {
 }
 
 // CloseDatabase closes database connection
-func CloseDatabase(conn *database.Db) (err error) {
+func CloseDatabase(conn *database.Instance) (err error) {
 	if conn != nil {
 		return conn.SQL.Close()
 	}

--- a/database/testhelpers/test_helpers_test.go
+++ b/database/testhelpers/test_helpers_test.go
@@ -33,7 +33,7 @@ func TestDatabaseConnect(t *testing.T) {
 	testCases := []struct {
 		name   string
 		config *database.Config
-		closer func(dbConn *database.Db) error
+		closer func(dbConn *database.Instance) error
 		output interface{}
 	}{
 		{

--- a/engine/database.go
+++ b/engine/database.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	dbConn *database.Db
+	dbConn *database.Instance
 )
 
 type databaseManager struct {

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -24,8 +24,9 @@ var (
 // should not be exported as it can have large impact if used improperly
 func (o *orderStore) get() map[string][]*order.Detail {
 	o.m.RLock()
-	defer o.m.RUnlock()
-	return o.Orders
+	orders := o.Orders
+	o.m.RUnlock()
+	return orders
 }
 
 // GetByExchangeAndID returns a specific order by exchange and id

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"fmt"
 	"net/http"
-	_ "net/http/pprof" // nolint: gosec
+	"net/http/pprof"
 	"runtime"
 	"strconv"
 	"strings"
@@ -93,7 +93,7 @@ func newRouter(isREST bool) *mux.Router {
 				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof\n",
 				common.ExtractHost(listenAddr),
 				common.ExtractPort(listenAddr))
-			router.PathPrefix("/debug").Handler(http.DefaultServeMux)
+			router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 		}
 	} else {
 		routes = []Route{

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -90,7 +90,7 @@ func newRouter(isREST bool) *mux.Router {
 				runtime.SetMutexProfileFraction(Bot.Config.Profiler.MutexProfileFraction)
 			}
 			log.Debugf(log.RESTSys,
-				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof\n",
+				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof/\n",
 				common.ExtractHost(listenAddr),
 				common.ExtractPort(listenAddr))
 			router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -412,7 +412,6 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 									}
 									printTickerSummary(result, c.Pair, c.AssetType, exchangeName, "REST", err)
 									if err == nil {
-										//nolint:gocritic Bot.CommsRelayer.StageTickerData(exchangeName, c.AssetType, result)
 										if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
 											relayWebsocketEvent(result, "ticker_update", c.AssetType.String(), exchangeName)
 										}
@@ -452,7 +451,6 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 								result, err := exchanges[x].UpdateOrderbook(c.Pair, c.AssetType)
 								printOrderbookSummary(result, c.Pair, c.AssetType, exchangeName, "REST", err)
 								if err == nil {
-									//nolint:gocritic Bot.CommsRelayer.StageOrderbookData(exchangeName, c.AssetType, result)
 									if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
 										relayWebsocketEvent(result, "orderbook_update", c.AssetType.String(), exchangeName)
 									}

--- a/engine/websocket.go
+++ b/engine/websocket.go
@@ -151,7 +151,7 @@ func (c *WebsocketClient) write() {
 	defer func() {
 		c.Conn.Close()
 	}()
-	for { // nolint: gosimple
+	for { // nolint // ws client write routine loop
 		select {
 		case message, ok := <-c.Send:
 			if !ok {

--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -53,12 +53,11 @@ func GetHoldings(exch string) (Holdings, error) {
 	exch = strings.ToLower(exch)
 
 	service.Lock()
+	defer service.Unlock()
 	h, ok := service.accounts[exch]
 	if !ok {
-		service.Unlock()
 		return Holdings{}, errors.New("exchange account holdings not found")
 	}
-	defer service.Unlock()
 	return *h.h, nil
 }
 

--- a/exchanges/alphapoint/alphapoint_websocket.go
+++ b/exchanges/alphapoint/alphapoint_websocket.go
@@ -17,7 +17,9 @@ func (a *Alphapoint) WebsocketClient() {
 	for a.Enabled {
 		var dialer websocket.Dialer
 		var err error
-		a.WebsocketConn, _, err = dialer.Dial(a.API.Endpoints.WebsocketURL, http.Header{})
+		var httpResp *http.Response
+		a.WebsocketConn, httpResp, err = dialer.Dial(a.API.Endpoints.WebsocketURL, http.Header{})
+		httpResp.Body.Close() // not used, so safely free the body
 
 		if err != nil {
 			log.Errorf(log.ExchangeSys, "%s Unable to connect to Websocket. Error: %s\n", a.Name, err)

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -467,7 +467,7 @@ func (b *Bitmex) wsHandleData(respRaw []byte) error {
 }
 
 // ProcessOrderbook processes orderbook updates
-func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPair currency.Pair, assetType asset.Item) error { // nolint: unparam
+func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPair currency.Pair, assetType asset.Item) error {
 	if len(data) < 1 {
 		return errors.New("bitmex_websocket.go error - no orderbook data")
 	}

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -419,8 +419,9 @@ func getInternationalBankDepositFee(c currency.Code, amount float64) float64 {
 // IsLoaded returns whether or not the instrument map has been seeded
 func (i *instrumentMap) IsLoaded() bool {
 	i.m.Lock()
-	defer i.m.Unlock()
-	return i.Loaded
+	isLoaded := i.Loaded
+	i.m.Unlock()
+	return isLoaded
 }
 
 // Seed seeds the instrument map

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	warningBase64DecryptSecretKeyFailed = "exchange %s unable to base64 decode secret key.. Disabling Authenticated API support" // nolint:gosec
+	warningBase64DecryptSecretKeyFailed = "exchange %s unable to base64 decode secret key.. Disabling Authenticated API support" // nolint // False positive (G101: Potential hardcoded credentials)
 	// WarningAuthenticatedRequestWithoutCredentialsSet error message for authenticated request without credentials set
 	WarningAuthenticatedRequestWithoutCredentialsSet = "exchange %s authenticated HTTP request called but not supported due to unset/default API keys"
 	// DefaultHTTPTimeout is the default HTTP/HTTPS Timeout for exchange requests

--- a/exchanges/lakebtc/lakebtc_types.go
+++ b/exchanges/lakebtc/lakebtc_types.go
@@ -50,7 +50,7 @@ type AccountInfo struct {
 	Profile struct {
 		Email             string `json:"email"`
 		UID               string `json:"uid"`
-		BTCDepositAddress string `json:"btc_deposit_addres"` // nolint: misspell
+		BTCDepositAddress string `json:"btc_deposit_addres"` // nolint // API misspelling
 	} `json:"profile"`
 }
 

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -257,8 +257,9 @@ func (w *Websocket) setConnectedStatus(b bool) {
 // IsConnected returns status of connection
 func (w *Websocket) IsConnected() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.connected
+	isConnected := w.connected
+	w.connectionMutex.RUnlock()
+	return isConnected
 }
 
 func (w *Websocket) setConnectingStatus(b bool) {
@@ -270,8 +271,9 @@ func (w *Websocket) setConnectingStatus(b bool) {
 // IsConnecting returns status of connecting
 func (w *Websocket) IsConnecting() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.connecting
+	isConnecting := w.connecting
+	w.connectionMutex.RUnlock()
+	return isConnecting
 }
 
 func (w *Websocket) setEnabled(b bool) {
@@ -283,8 +285,9 @@ func (w *Websocket) setEnabled(b bool) {
 // IsEnabled returns status of enabled
 func (w *Websocket) IsEnabled() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.enabled
+	isEnabled := w.enabled
+	w.connectionMutex.RUnlock()
+	return isEnabled
 }
 
 func (w *Websocket) setInit(b bool) {
@@ -296,8 +299,9 @@ func (w *Websocket) setInit(b bool) {
 // IsInit returns status of init
 func (w *Websocket) IsInit() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.init
+	isInit := w.init
+	w.connectionMutex.RUnlock()
+	return isInit
 }
 
 func (w *Websocket) setTrafficMonitorRunning(b bool) {
@@ -309,8 +313,9 @@ func (w *Websocket) setTrafficMonitorRunning(b bool) {
 // IsTrafficMonitorRunning returns status of the traffic monitor
 func (w *Websocket) IsTrafficMonitorRunning() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.trafficMonitorRunning
+	trafficMonRunning := w.trafficMonitorRunning
+	w.connectionMutex.RUnlock()
+	return trafficMonRunning
 }
 
 func (w *Websocket) setConnectionMonitorRunning(b bool) {
@@ -322,8 +327,9 @@ func (w *Websocket) setConnectionMonitorRunning(b bool) {
 // IsConnectionMonitorRunning returns status of connection monitor
 func (w *Websocket) IsConnectionMonitorRunning() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.connectionMonitorRunning
+	isConnMonRunning := w.connectionMonitorRunning
+	w.connectionMutex.RUnlock()
+	return isConnMonRunning
 }
 
 // CanUseAuthenticatedWebsocketForWrapper Handles a common check to
@@ -616,8 +622,9 @@ func (w *Websocket) SetCanUseAuthenticatedEndpoints(val bool) {
 // a thread safe manner
 func (w *Websocket) CanUseAuthenticatedEndpoints() bool {
 	w.subscriptionMutex.Lock()
-	defer w.subscriptionMutex.Unlock()
-	return w.canUseAuthenticatedEndpoints
+	canUseAuthEndpoints := w.canUseAuthenticatedEndpoints
+	w.subscriptionMutex.Unlock()
+	return canUseAuthEndpoints
 }
 
 // SetResponseIDAndData adds data to IDResponses with locks and a nil check
@@ -642,6 +649,7 @@ func (w *WebsocketConnection) Dial(dialer *websocket.Dialer, headers http.Header
 	var err error
 	var conStatus *http.Response
 	w.Connection, conStatus, err = dialer.Dial(w.URL, headers)
+	defer conStatus.Body.Close()
 	if err != nil {
 		if conStatus != nil {
 			return fmt.Errorf("%v %v %v Error: %v", w.URL, conStatus, conStatus.StatusCode, err)
@@ -801,8 +809,9 @@ func (w *WebsocketConnection) setConnectedStatus(b bool) {
 // IsConnected exposes websocket connection status
 func (w *WebsocketConnection) IsConnected() bool {
 	w.connectionMutex.RLock()
-	defer w.connectionMutex.RUnlock()
-	return w.connected
+	isConnected := w.connected
+	w.connectionMutex.RUnlock()
+	return isConnected
 }
 
 // ReadMessage reads messages, can handle text, gzip and binary

--- a/exchanges/websocket/wshandler/wshandler.go
+++ b/exchanges/websocket/wshandler/wshandler.go
@@ -649,7 +649,9 @@ func (w *WebsocketConnection) Dial(dialer *websocket.Dialer, headers http.Header
 	var err error
 	var conStatus *http.Response
 	w.Connection, conStatus, err = dialer.Dial(w.URL, headers)
-	defer conStatus.Body.Close()
+	if conStatus != nil {
+		conStatus.Body.Close()
+	}
 	if err != nil {
 		if conStatus != nil {
 			return fmt.Errorf("%v %v %v Error: %v", w.URL, conStatus, conStatus.StatusCode, err)

--- a/exchanges/websocket/wshandler/wshandler_types.go
+++ b/exchanges/websocket/wshandler/wshandler_types.go
@@ -177,6 +177,7 @@ type WebsocketPingHandler struct {
 	Delay             time.Duration
 }
 
+// UnhandledMessageWarning is used for unhandled websocket messages
 type UnhandledMessageWarning struct {
 	Message string
 }

--- a/exchanges/websocket/wsorderbook/wsorderbook.go
+++ b/exchanges/websocket/wsorderbook/wsorderbook.go
@@ -259,8 +259,9 @@ func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook *orderbook.Base) err
 // calculation and cause problems
 func (w *WebsocketOrderbookLocal) GetOrderbook(p currency.Pair, a asset.Item) *orderbook.Base {
 	w.m.Lock()
-	defer w.m.Unlock()
-	return w.ob[p][a]
+	ob := w.ob[p][a]
+	w.m.Unlock()
+	return ob
 }
 
 // FlushCache flushes w.ob data to be garbage collected and refreshed when a

--- a/gctscript/vm/vm.go
+++ b/gctscript/vm/vm.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/hex"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -64,20 +63,10 @@ func (vm *VM) Load(file string) error {
 		log.Debugf(log.GCTScriptMgr, "Loading script: %s ID: %v", vm.ShortName(), vm.ID)
 	}
 
-	f, err := os.Open(file)
+	code, err := ioutil.ReadFile(file)
 	if err != nil {
 		return &Error{
-			Action: "Load: Open",
-			Script: file,
-			Cause:  err,
-		}
-	}
-
-	defer f.Close()
-	code, err := ioutil.ReadAll(f)
-	if err != nil {
-		return &Error{
-			Action: "Load: Read",
+			Action: "Load: ReadFile",
 			Script: file,
 			Cause:  err,
 		}

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
@@ -208,8 +206,6 @@ github.com/toorop/go-pusher v0.0.0-20180521062818-4521e2eb39fb h1:9kcmLvQdiIecpg
 github.com/toorop/go-pusher v0.0.0-20180521062818-4521e2eb39fb/go.mod h1:VTLqNCX1tXrur6pdIRCl8Q90FR7nw/mEBdyMkWMcsb0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/urfave/cli v1.22.3 h1:FpNT6zq26xNpHZy08emi755QwzLPs6Pukqjlc7RfOMU=
-github.com/urfave/cli v1.22.3/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/volatiletech/inflect v0.0.0-20170731032912-e7201282ae8d h1:gI4/tqP6lCY5k6Sg+4k9qSoBXmPwG+xXgMpK7jivD4M=
@@ -289,8 +285,6 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
-google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
 google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/log/sublogger_types.go
+++ b/log/sublogger_types.go
@@ -1,6 +1,6 @@
 package log
 
-//nolint
+// Global vars related to the logger package
 var (
 	subLoggers = map[string]*subLogger{}
 

--- a/portfolio/banking/banking_types.go
+++ b/portfolio/banking/banking_types.go
@@ -17,7 +17,8 @@ const (
 	ErrBSBRequiredforAUD = "BSB must be set for AUD values"
 	// ErrIBANSwiftNotSet message to return when no iban or swift value set
 	ErrIBANSwiftNotSet = "IBAN/SWIFT values not set"
-	// ErrCurrencyNotSupportedByAccount
+	// ErrCurrencyNotSupportedByAccount message to return when the requested
+	// currency is not supported by the bank account
 	ErrCurrencyNotSupportedByAccount = "requested currency is not supported by account"
 )
 

--- a/portfolio/portfolio_types.go
+++ b/portfolio/portfolio_types.go
@@ -62,10 +62,10 @@ type EthplorerResponse struct {
 		Image          string `json:"image"`
 		Description    string `json:"description"`
 		Price          struct {
-			Rate     int    `json:"rate"`
-			Diff     int    `json:"diff"`
-			Ts       int    `json:"ts"`
-			Currency string `json:"currency"`
+			Rate      int    `json:"rate"`
+			Diff      int    `json:"diff"`
+			Timestamp int64  `json:"ts"`
+			Currency  string `json:"currency"`
 		} `json:"price"`
 	} `json:"tokenInfo"`
 	Error struct {


### PR DESCRIPTION
# PR Description

This PR updates golangci-lint to `v1.24.0` and thus has a bunch of linter and general code improvements. One of the more notable changes was not using defer close to a return and in our usage, this is most often used with sync.Mutex Get methods. After bench marking the change, it's quite significant:

Code: https://play.golang.org/p/HVG5-ZRrKs5
```
BenchmarkName
BenchmarkName-8        	100000000	        12.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeferName
BenchmarkDeferName-8   	66841940	        18.0 ns/op	       0 B/op	       0 allocs/op
```

Representing a **36% gain** in ns/op performance without the defer overhead. Extremely beneficial for code which needs to be as quick as possible!

Other changes include removing redundant code (ioutil.ReadFile usage instead of os.Open/OpenFile, followed by ioutil.ReadAll as ioutil.ReadFile) does the same thing behind the scene, but much neater.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
