### PR TITLE
shunt engine setup to different routine - suggestion

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -462,6 +462,10 @@ func (e *Engine) Start() error {
 
 // Stop correctly shuts down engine saving configuration files
 func (e *Engine) Stop() {
+	if e == nil {
+		return
+	}
+
 	gctlog.Debugln(gctlog.Global, "Engine shutting down..")
 
 	if len(portfolio.Portfolio.Addresses) != 0 {

--- a/main.go
+++ b/main.go
@@ -107,20 +107,22 @@ func main() {
 	fmt.Println(core.Banner)
 	fmt.Println(core.Version(false))
 
-	var err error
-	settings.CheckParamInteraction = true
-	engine.Bot, err = engine.NewFromSettings(&settings)
-	if engine.Bot == nil || err != nil {
-		log.Fatalf("Unable to initialise bot engine. Error: %s\n", err)
-	}
+	go func() {
+		var err error
+		settings.CheckParamInteraction = true
+		engine.Bot, err = engine.NewFromSettings(&settings)
+		if engine.Bot == nil || err != nil {
+			log.Fatalf("Unable to initialise bot engine. Error: %s\n", err)
+		}
 
-	gctscript.Setup()
+		gctscript.Setup()
 
-	engine.PrintSettings(&engine.Bot.Settings)
-	if err = engine.Bot.Start(); err != nil {
-		gctlog.Errorf(gctlog.Global, "Unable to start bot engine. Error: %s\n", err)
-		os.Exit(1)
-	}
+		engine.PrintSettings(&engine.Bot.Settings)
+		if err = engine.Bot.Start(); err != nil {
+			gctlog.Errorf(gctlog.Global, "Unable to start bot engine. Error: %s\n", err)
+			os.Exit(1)
+		}
+	}()
 
 	interrupt := signaler.WaitForInterrupt()
 	gctlog.Infof(gctlog.Global, "Captured %v, shutdown requested.\n", interrupt)


### PR DESCRIPTION
# PR Description

Shunts engine into different routine so in the event of any initial slow down due to net connection or low spec machine, we can close program faster, if we need to change config or we did a whoopsie.  

Fixes # (issue)

nothing

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

ctrl-x

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
