### PR TITLE
Config/Engine: Add data directory to config.json

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1849,8 +1849,8 @@ func (c *Config) AssetTypeEnabled(a asset.Item, exch string) (bool, error) {
 // GetDataPath gets the data path for the given subpath
 func (c *Config) GetDataPath(elem ...string) string {
 	var baseDir string
-	if c.DataDir != "" {
-		baseDir = c.DataDir
+	if c.DataDirectory != "" {
+		baseDir = c.DataDirectory
 	} else {
 		baseDir = common.GetDefaultDataDir(runtime.GOOS)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1303,7 +1303,7 @@ func (c *Config) CheckLoggerConfig() error {
 	log.GlobalLogConfig = &c.Logging
 	log.RWM.Unlock()
 
-	logPath := filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "logs")
+	logPath := c.GetDataPath("logs")
 	err := common.CreateDir(logPath)
 	if err != nil {
 		return err
@@ -1325,7 +1325,7 @@ func (c *Config) checkGCTScriptConfig() error {
 		c.GCTScript.MaxVirtualMachines = gctscript.DefaultMaxVirtualMachines
 	}
 
-	scriptPath := filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "scripts")
+	scriptPath := c.GetDataPath("scripts")
 	err := common.CreateDir(scriptPath)
 	if err != nil {
 		return err
@@ -1362,7 +1362,7 @@ func (c *Config) checkDatabaseConfig() error {
 	}
 
 	if c.Database.Driver == database.DBSQLite || c.Database.Driver == database.DBSQLite3 {
-		databaseDir := filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "database")
+		databaseDir := c.GetDataPath("database")
 		err := common.CreateDir(databaseDir)
 		if err != nil {
 			return err
@@ -1844,4 +1844,15 @@ func (c *Config) AssetTypeEnabled(a asset.Item, exch string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// GetDataPath gets the data path for the given subpath
+func (c *Config) GetDataPath(elem ...string) string {
+	var baseDir string
+	if c.DataDir != "" {
+		baseDir = c.DataDir
+	} else {
+		baseDir = common.GetDefaultDataDir(runtime.GOOS)
+	}
+	return filepath.Join(append([]string{baseDir}, elem...)...)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2037,7 +2037,7 @@ func TestRemoveExchange(t *testing.T) {
 	}
 }
 
-func TestConfig_GetDataPath(t *testing.T) {
+func TestGetDataPath(t *testing.T) {
 	tests := []struct {
 		name string
 		dir  string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2064,6 +2064,7 @@ func TestConfig_GetDataPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Config{
 				DataDir: tt.dir,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -2032,5 +2034,43 @@ func TestRemoveExchange(t *testing.T) {
 	}
 	if success := c.RemoveExchange("1D10TH0RS3"); success {
 		t.Fatal("exchange shouldn't exist")
+	}
+}
+
+func TestConfig_GetDataPath(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		elem []string
+		want string
+	}{
+		{
+			name: "empty",
+			dir:  "",
+			elem: []string{},
+			want: common.GetDefaultDataDir(runtime.GOOS),
+		},
+		{
+			name: "empty a b",
+			dir:  "",
+			elem: []string{"a", "b"},
+			want: filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "a", "b"),
+		},
+		{
+			name: "target",
+			dir:  "target",
+			elem: []string{"a", "b"},
+			want: filepath.Join("target", "a", "b"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				DataDir: tt.dir,
+			}
+			if got := c.GetDataPath(tt.elem...); got != tt.want {
+				t.Errorf("Config.GetDataPath() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2067,7 +2067,7 @@ func TestConfig_GetDataPath(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Config{
-				DataDir: tt.dir,
+				DataDirectory: tt.dir,
 			}
 			if got := c.GetDataPath(tt.elem...); got != tt.want {
 				t.Errorf("Config.GetDataPath() = %v, want %v", got, tt.want)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2066,6 +2066,7 @@ func TestConfig_GetDataPath(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Config{
 				DataDirectory: tt.dir,
 			}

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -78,7 +78,7 @@ var (
 // Exchanges
 type Config struct {
 	Name              string                  `json:"name"`
-	DataDir           string                  `json:"datadir,omitempty"`
+	DataDirectory     string                  `json:"dataDirectory"`
 	EncryptConfig     int                     `json:"encryptConfig"`
 	GlobalHTTPTimeout time.Duration           `json:"globalHTTPTimeout"`
 	Database          database.Config         `json:"database"`

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -78,6 +78,7 @@ var (
 // Exchanges
 type Config struct {
 	Name              string                  `json:"name"`
+	DataDir           string                  `json:"datadir,omitempty"`
 	EncryptConfig     int                     `json:"encryptConfig"`
 	GlobalHTTPTimeout time.Duration           `json:"globalHTTPTimeout"`
 	Database          database.Config         `json:"database"`

--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,6 @@
 {
  "name": "Skynet",
- "dataDirectory":"data",
+ "dataDirectory": "",
  "encryptConfig": 0,
  "globalHTTPTimeout": 15000000000,
  "database": {

--- a/config_example.json
+++ b/config_example.json
@@ -1,5 +1,6 @@
 {
  "name": "Skynet",
+ "dataDirectory":"data",
  "encryptConfig": 0,
  "globalHTTPTimeout": 15000000000,
  "database": {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -120,6 +120,11 @@ func loadConfigWithSettings(settings *Settings) (*config.Config, error) {
 	}
 	// Apply overrides from settings
 	if flagSet["datadir"] {
+		// warn if dryrun isn't  enabled
+		if !settings.EnableDryRun {
+			log.Println("Command line argument '-datadir' induces dry run mode.")
+		}
+		settings.EnableDryRun = true
 		conf.DataDirectory = settings.DataDir
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -113,7 +113,7 @@ func loadConfigWithSettings(settings *Settings) (*config.Config, error) {
 	}
 	log.Printf("Loading config file %s..\n", filePath)
 
-	conf := &config.Config{}
+	conf := &config.Cfg
 	err = conf.ReadConfig(filePath, settings.EnableDryRun)
 	if err != nil {
 		return nil, fmt.Errorf(config.ErrFailureOpeningConfig, filePath, err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -116,7 +116,7 @@ func loadConfigWithSettings(settings *Settings) (*config.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf(config.ErrFailureOpeningConfig, filePath, err)
 	}
-	//Apply overrides from settings
+	// Apply overrides from settings
 	conf.DataDir = settings.DataDir
 
 	return conf, conf.CheckConfig()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -120,7 +120,7 @@ func loadConfigWithSettings(settings *Settings) (*config.Config, error) {
 	}
 	// Apply overrides from settings
 	if flagSet["datadir"] {
-		conf.DataDir = settings.DataDir
+		conf.DataDirectory = settings.DataDir
 	}
 
 	return conf, conf.CheckConfig()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -113,14 +113,14 @@ func loadConfigWithSettings(settings *Settings) (*config.Config, error) {
 	}
 	log.Printf("Loading config file %s..\n", filePath)
 
-	conf := &config.Cfg
+	conf := &config.Config{}
 	err = conf.ReadConfig(filePath, settings.EnableDryRun)
 	if err != nil {
 		return nil, fmt.Errorf(config.ErrFailureOpeningConfig, filePath, err)
 	}
 	// Apply overrides from settings
 	if flagSet["datadir"] {
-		// warn if dryrun isn't  enabled
+		// warn if dryrun isn't enabled
 		if !settings.EnableDryRun {
 			log.Println("Command line argument '-datadir' induces dry run mode.")
 		}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -49,6 +49,7 @@ func Test_loadConfigWithSettings(t *testing.T) {
 	}
 	config.TestBypass = true
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := loadConfigWithSettings(tt.settings)
 			if (err != nil) != tt.wantErr {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -53,7 +53,6 @@ func Test_loadConfigWithSettings(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			// prepare the 'flags'
 			flagSet = make(map[string]bool)
 			for _, v := range tt.flags {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -67,8 +67,8 @@ func Test_loadConfigWithSettings(t *testing.T) {
 			if got != nil || tt.want != nil {
 				if (got == nil && tt.want != nil) || (got != nil && tt.want == nil) {
 					t.Errorf("loadConfigWithSettings() = is nil %v, want nil %v", got == nil, tt.want == nil)
-				} else if got.DataDir != *tt.want {
-					t.Errorf("loadConfigWithSettings() = %v, want %v", got.DataDir, *tt.want)
+				} else if got.DataDirectory != *tt.want {
+					t.Errorf("loadConfigWithSettings() = %v, want %v", got.DataDirectory, *tt.want)
 				}
 			}
 		})

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"os"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
@@ -9,6 +10,8 @@ import (
 func TestLoadConfigWithSettings(t *testing.T) {
 	empty := ""
 	somePath := "somePath"
+	// Clean up after the tests
+	defer os.RemoveAll(somePath)
 	tests := []struct {
 		name     string
 		flags    []string
@@ -44,7 +47,6 @@ func TestLoadConfigWithSettings(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	config.TestBypass = true
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/thrasher-corp/gocryptotrader/config"
+)
+
+func Test_loadConfigWithSettings(t *testing.T) {
+	empty := ""
+	somePath := "somePath"
+	tests := []struct {
+		name     string
+		settings *Settings
+		want     *string
+		wantErr  bool
+	}{
+		{
+			name:     "empty",
+			settings: &Settings{},
+			wantErr:  true,
+		},
+		{
+			name: "invalid file",
+			settings: &Settings{
+				ConfigFile: "nonExistent.json",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test file",
+			settings: &Settings{
+				ConfigFile:   config.TestFile,
+				EnableDryRun: true,
+			},
+			want:    &empty,
+			wantErr: false,
+		},
+		{
+			name: "data dir in settings overrides config data dir",
+			settings: &Settings{
+				ConfigFile:   config.TestFile,
+				DataDir:      somePath,
+				EnableDryRun: true,
+			},
+			want:    &somePath,
+			wantErr: false,
+		},
+	}
+	config.TestBypass = true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadConfigWithSettings(tt.settings)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadConfigWithSettings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil || tt.want != nil {
+				if (got == nil && tt.want != nil) || (got != nil && tt.want == nil) {
+					t.Errorf("loadConfigWithSettings() = is nil %v, want nil %v", got == nil, tt.want == nil)
+				} else if got.DataDir != *tt.want {
+					t.Errorf("loadConfigWithSettings() = %v, want %v", got.DataDir, *tt.want)
+				}
+			}
+		})
+	}
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -53,6 +53,7 @@ func Test_loadConfigWithSettings(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// prepare the 'flags'
 			flagSet = make(map[string]bool)
 			for _, v := range tt.flags {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/config"
 )
 
-func Test_loadConfigWithSettings(t *testing.T) {
+func TestLoadConfigWithSettings(t *testing.T) {
 	empty := ""
 	somePath := "somePath"
 	tests := []struct {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -17,11 +17,6 @@ func Test_loadConfigWithSettings(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "empty",
-			settings: &Settings{},
-			wantErr:  true,
-		},
-		{
 			name: "invalid file",
 			settings: &Settings{
 				ConfigFile: "nonExistent.json",

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -11,6 +11,7 @@ func Test_loadConfigWithSettings(t *testing.T) {
 	somePath := "somePath"
 	tests := []struct {
 		name     string
+		flags    []string
 		settings *Settings
 		want     *string
 		wantErr  bool
@@ -37,7 +38,8 @@ func Test_loadConfigWithSettings(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "data dir in settings overrides config data dir",
+			name:  "data dir in settings overrides config data dir",
+			flags: []string{"datadir"},
 			settings: &Settings{
 				ConfigFile:   config.TestFile,
 				DataDir:      somePath,
@@ -51,6 +53,12 @@ func Test_loadConfigWithSettings(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			// prepare the 'flags'
+			flagSet = make(map[string]bool)
+			for _, v := range tt.flags {
+				flagSet[v] = true
+			}
+			// Run the test
 			got, err := loadConfigWithSettings(tt.settings)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadConfigWithSettings() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
# PR Description

The provided data directory is not honored by the engine in some cases, instead a default path is used.
This change makes the data directory configuration part of config.json and enables the override using command line flag. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./config ./engine -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
