### PR TITLE
Kraken: wsProcessOrderBook, the method was returning wrong bids data

### DIFF
--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -606,7 +606,7 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 // Then sends to appropriate fun
 func (k *Kraken) wsProcessOrderBook(channelData *WebsocketChannelData, data map[string]interface{}) error {
 	if fullAsk, ok := data["as"].([]interface{}); ok {
-		fullBids := data["as"].([]interface{})
+		fullBids := data["bs"].([]interface{})
 		err := k.wsProcessOrderBookPartial(channelData, fullAsk, fullBids)
 		if err != nil {
 			return err

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -605,9 +605,10 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 // wsProcessOrderBook determines if the orderbook data is partial or update
 // Then sends to appropriate fun
 func (k *Kraken) wsProcessOrderBook(channelData *WebsocketChannelData, data map[string]interface{}) error {
-	if fullAsk, ok := data["as"].([]interface{}); ok {
-		fullBids := data["bs"].([]interface{})
-		err := k.wsProcessOrderBookPartial(channelData, fullAsk, fullBids)
+	askSnapshot, askSnapshotExists := data["as"].([]interface{})
+	bidSnapshot, bidSnapshotExists := data["bs"].([]interface{})
+	if askSnapshotExists || bidSnapshotExists  {
+		err := k.wsProcessOrderBookPartial(channelData, askSnapshot, bidSnapshot)
 		if err != nil {
 			return err
 		}

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -607,7 +607,7 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 func (k *Kraken) wsProcessOrderBook(channelData *WebsocketChannelData, data map[string]interface{}) error {
 	askSnapshot, askSnapshotExists := data["as"].([]interface{})
 	bidSnapshot, bidSnapshotExists := data["bs"].([]interface{})
-	if askSnapshotExists || bidSnapshotExists  {
+	if askSnapshotExists || bidSnapshotExists {
 		err := k.wsProcessOrderBookPartial(channelData, askSnapshot, bidSnapshot)
 		if err != nil {
 			return err


### PR DESCRIPTION
# PR Description

Please include a summary of the change, feature or issue which this pull request addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Probably a mechanical typo in the wsProcessOrderBook method (Kraken). As a result, both variables fullAsk and fullBids got the Ask data.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
