### PR TITLE
gctcli: Add flag var for TLS cert path

### DIFF
--- a/cmd/gctcli/main.go
+++ b/cmd/gctcli/main.go
@@ -21,6 +21,7 @@ var (
 	username      string
 	password      string
 	pairDelimiter string
+	certPath      string
 )
 
 func jsonOutput(in interface{}) {
@@ -32,8 +33,7 @@ func jsonOutput(in interface{}) {
 }
 
 func setupClient() (*grpc.ClientConn, error) {
-	targetPath := filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "tls", "cert.pem")
-	creds, err := credentials.NewClientTLSFromFile(targetPath, "")
+	creds, err := credentials.NewClientTLSFromFile(certPath, "")
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +82,12 @@ func main() {
 			Value:       "-",
 			Usage:       "the default currency pair delimiter used to standardise currency pair input",
 			Destination: &pairDelimiter,
+		},
+		cli.StringFlag{
+			Name:        "cert",
+			Value:       filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "tls", "cert.pem"),
+			Usage:       "the path to TLS cert of the gRPC server",
+			Destination: &certPath,
 		},
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
# PR Description

GCT cli can only read cert from default dir. Fix this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
