### PR TITLE
Engine: Remove incorrect creation of data directory

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -81,11 +81,6 @@ func NewFromSettings(settings *Settings) (*Engine, error) {
 		return nil, fmt.Errorf("failed to load config. Err: %s", err)
 	}
 
-	err = common.CreateDir(settings.DataDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open/create data directory: %s. Err: %s", settings.DataDir, err)
-	}
-
 	if *b.Config.Logging.Enabled {
 		gctlog.SetupGlobalLogger()
 		gctlog.SetupSubLoggers(b.Config.Logging.SubLoggers)


### PR DESCRIPTION
* the data directory can be loaded from config file and not from settings
* the correct data directory will be created later when subdirs are created

# PR Description

The default data dir is created even if other directory is specified in config file and no flag is set.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
