### PR TITLE
Engine: Refactor use of global Bot

### DIFF
--- a/cmd/config_builder/builder.go
+++ b/cmd/config_builder/builder.go
@@ -21,7 +21,7 @@ func main() {
 	var wg sync.WaitGroup
 	for x := range exchange.Exchanges {
 		name := exchange.Exchanges[x]
-		err = engine.LoadExchange(name, true, &wg)
+		err = engine.Bot.LoadExchange(name, true, &wg)
 		if err != nil {
 			log.Printf("Failed to load exchange %s. Err: %s", name, err)
 			continue
@@ -31,7 +31,7 @@ func main() {
 	log.Println("Done.")
 
 	var cfgs []config.ExchangeConfig
-	exchanges := engine.GetExchanges()
+	exchanges := engine.Bot.GetExchanges()
 	for x := range exchanges {
 		var cfg *config.ExchangeConfig
 		cfg, err = exchanges[x].GetDefaultConfig()

--- a/cmd/exchange_wrapper_coverage/main.go
+++ b/cmd/exchange_wrapper_coverage/main.go
@@ -34,7 +34,7 @@ func main() {
 	var wg sync.WaitGroup
 	for x := range exchange.Exchanges {
 		name := exchange.Exchanges[x]
-		err := engine.LoadExchange(name, true, &wg)
+		err := engine.Bot.LoadExchange(name, true, &wg)
 		if err != nil {
 			log.Printf("Failed to load exchange %s. Err: %s", name, err)
 			continue
@@ -46,7 +46,7 @@ func main() {
 	log.Printf("Testing exchange wrappers..")
 	results := make(map[string][]string)
 	wg = sync.WaitGroup{}
-	exchanges := engine.GetExchanges()
+	exchanges := engine.Bot.GetExchanges()
 	for x := range exchanges {
 		wg.Add(1)
 		go func(num int) {

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -32,14 +32,14 @@ import (
 func main() {
 	log.Println("Loading flags...")
 	parseCLFlags()
-	var err error
 	log.Println("Loading engine...")
-	engine.Bot, err = engine.New()
+	bot, err := engine.New()
 	if err != nil {
 		log.Fatalf("Failed to initialise engine. Err: %s", err)
 	}
+	engine.Bot = bot
 
-	engine.Bot.Settings = engine.Settings{
+	bot.Settings = engine.Settings{
 		DisableExchangeAutoPairUpdates: true,
 		Verbose:                        verboseOverride,
 		EnableExchangeHTTPRateLimiter:  true,
@@ -63,7 +63,7 @@ func main() {
 			wrapperConfig.Exchanges[strings.ToLower(name)] = &config.APICredentialsConfig{}
 		}
 		if shouldLoadExchange(name) {
-			err = engine.LoadExchange(name, true, &wg)
+			err = bot.LoadExchange(name, true, &wg)
 			if err != nil {
 				log.Printf("Failed to load exchange %s. Err: %s", name, err)
 				continue
@@ -92,7 +92,7 @@ func main() {
 	log.Println("Testing exchange wrappers..")
 	var exchangeResponses []ExchangeResponses
 
-	exchs := engine.GetExchanges()
+	exchs := bot.GetExchanges()
 	for x := range exchs {
 		base := exchs[x].GetBase()
 		if !base.Config.Enabled {

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -743,6 +743,8 @@ func (s *Storage) IsVerbose() bool {
 
 // Shutdown shuts down the currency storage system and saves to currency.json
 func (s *Storage) Shutdown() error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	close(s.shutdown)
 	s.wg.Wait()
 	return s.WriteCurrencyDataToFile(s.path, true)

--- a/engine/addr_helpers.go
+++ b/engine/addr_helpers.go
@@ -95,6 +95,6 @@ func (d *DepositAddressManager) GetDepositAddressesByExchange(exchName string) (
 
 // Sync synchronises all deposit addresses
 func (d *DepositAddressManager) Sync() {
-	result := GetExchangeCryptocurrencyDepositAddresses()
+	result := Bot.GetExchangeCryptocurrencyDepositAddresses()
 	d.Store.Seed(result)
 }

--- a/engine/connection.go
+++ b/engine/connection.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync/atomic"
 
+	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/connchecker"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
@@ -21,16 +22,16 @@ func (c *connectionManager) Started() bool {
 }
 
 // Start starts an instance of the connection manager
-func (c *connectionManager) Start() error {
+func (c *connectionManager) Start(conf *config.ConnectionMonitorConfig) error {
 	if atomic.AddInt32(&c.started, 1) != 1 {
 		return errors.New("connection manager already started")
 	}
 
 	log.Debugln(log.ConnectionMgr, "Connection manager starting...")
 	var err error
-	c.conn, err = connchecker.New(Bot.Config.ConnectionMonitor.DNSList,
-		Bot.Config.ConnectionMonitor.PublicDomainList,
-		Bot.Config.ConnectionMonitor.CheckInterval)
+	c.conn, err = connchecker.New(conf.DNSList,
+		conf.PublicDomainList,
+		conf.CheckInterval)
 	if err != nil {
 		atomic.CompareAndSwapInt32(&c.started, 1, 0)
 		return err

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -411,11 +411,11 @@ func (bot *Engine) Start() error {
 	}
 
 	if bot.Settings.EnableDeprecatedRPC {
-		go StartRESTServer()
+		go StartRESTServer(bot)
 	}
 
 	if bot.Settings.EnableWebsocketRPC {
-		go StartWebsocketServer()
+		go StartWebsocketServer(bot)
 		StartWebsocketHandler()
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -319,153 +319,153 @@ func PrintSettings(s *Settings) {
 }
 
 // Start starts the engine
-func (e *Engine) Start() error {
-	if e == nil {
+func (bot *Engine) Start() error {
+	if bot == nil {
 		return errors.New("engine instance is nil")
 	}
 
-	if e.Settings.EnableDatabaseManager {
-		if err := e.DatabaseManager.Start(); err != nil {
+	if bot.Settings.EnableDatabaseManager {
+		if err := bot.DatabaseManager.Start(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Database manager unable to start: %v", err)
 		}
 	}
 
-	if e.Settings.EnableDispatcher {
-		if err := dispatch.Start(e.Settings.DispatchMaxWorkerAmount, e.Settings.DispatchJobsLimit); err != nil {
+	if bot.Settings.EnableDispatcher {
+		if err := dispatch.Start(bot.Settings.DispatchMaxWorkerAmount, bot.Settings.DispatchJobsLimit); err != nil {
 			gctlog.Errorf(gctlog.DispatchMgr, "Dispatcher unable to start: %v", err)
 		}
 	}
 
 	// Sets up internet connectivity monitor
-	if e.Settings.EnableConnectivityMonitor {
-		if err := e.ConnectionManager.Start(); err != nil {
+	if bot.Settings.EnableConnectivityMonitor {
+		if err := bot.ConnectionManager.Start(&bot.Config.ConnectionMonitor); err != nil {
 			gctlog.Errorf(gctlog.Global, "Connection manager unable to start: %v", err)
 		}
 	}
 
-	if e.Settings.EnableNTPClient {
-		if err := e.NTPManager.Start(); err != nil {
+	if bot.Settings.EnableNTPClient {
+		if err := bot.NTPManager.Start(); err != nil {
 			gctlog.Errorf(gctlog.Global, "NTP manager unable to start: %v", err)
 		}
 	}
 
-	e.Uptime = time.Now()
-	gctlog.Debugf(gctlog.Global, "Bot '%s' started.\n", e.Config.Name)
-	gctlog.Debugf(gctlog.Global, "Using data dir: %s\n", e.Settings.DataDir)
-	if *e.Config.Logging.Enabled && strings.Contains(e.Config.Logging.Output, "file") {
+	bot.Uptime = time.Now()
+	gctlog.Debugf(gctlog.Global, "Bot '%s' started.\n", bot.Config.Name)
+	gctlog.Debugf(gctlog.Global, "Using data dir: %s\n", bot.Settings.DataDir)
+	if *bot.Config.Logging.Enabled && strings.Contains(bot.Config.Logging.Output, "file") {
 		gctlog.Debugf(gctlog.Global, "Using log file: %s\n",
-			filepath.Join(gctlog.LogPath, e.Config.Logging.LoggerFileConfig.FileName))
+			filepath.Join(gctlog.LogPath, bot.Config.Logging.LoggerFileConfig.FileName))
 	}
 	gctlog.Debugf(gctlog.Global,
 		"Using %d out of %d logical processors for runtime performance\n",
 		runtime.GOMAXPROCS(-1), runtime.NumCPU())
 
-	enabledExchanges := e.Config.CountEnabledExchanges()
-	if e.Settings.EnableAllExchanges {
-		enabledExchanges = len(e.Config.Exchanges)
+	enabledExchanges := bot.Config.CountEnabledExchanges()
+	if bot.Settings.EnableAllExchanges {
+		enabledExchanges = len(bot.Config.Exchanges)
 	}
 
 	gctlog.Debugln(gctlog.Global, "EXCHANGE COVERAGE")
 	gctlog.Debugf(gctlog.Global, "\t Available Exchanges: %d. Enabled Exchanges: %d.\n",
-		len(e.Config.Exchanges), enabledExchanges)
+		len(bot.Config.Exchanges), enabledExchanges)
 
-	if e.Settings.ExchangePurgeCredentials {
+	if bot.Settings.ExchangePurgeCredentials {
 		gctlog.Debugln(gctlog.Global, "Purging exchange API credentials.")
-		e.Config.PurgeExchangeAPICredentials()
+		bot.Config.PurgeExchangeAPICredentials()
 	}
 
 	gctlog.Debugln(gctlog.Global, "Setting up exchanges..")
-	SetupExchanges()
-	if Bot.exchangeManager.Len() == 0 {
+	bot.SetupExchanges()
+	if bot.exchangeManager.Len() == 0 {
 		return errors.New("no exchanges are loaded")
 	}
 
-	if e.Settings.EnableCommsRelayer {
-		if err := e.CommsManager.Start(); err != nil {
+	if bot.Settings.EnableCommsRelayer {
+		if err := bot.CommsManager.Start(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Communications manager unable to start: %v\n", err)
 		}
 	}
 
 	err := currency.RunStorageUpdater(currency.BotOverrides{
-		Coinmarketcap:       e.Settings.EnableCoinmarketcapAnalysis,
-		FxCurrencyConverter: e.Settings.EnableCurrencyConverter,
-		FxCurrencyLayer:     e.Settings.EnableCurrencyLayer,
-		FxFixer:             e.Settings.EnableFixer,
-		FxOpenExchangeRates: e.Settings.EnableOpenExchangeRates,
+		Coinmarketcap:       bot.Settings.EnableCoinmarketcapAnalysis,
+		FxCurrencyConverter: bot.Settings.EnableCurrencyConverter,
+		FxCurrencyLayer:     bot.Settings.EnableCurrencyLayer,
+		FxFixer:             bot.Settings.EnableFixer,
+		FxOpenExchangeRates: bot.Settings.EnableOpenExchangeRates,
 	},
 		&currency.MainConfiguration{
-			ForexProviders:         e.Config.GetForexProviders(),
-			CryptocurrencyProvider: coinmarketcap.Settings(e.Config.Currency.CryptocurrencyProvider),
-			Cryptocurrencies:       e.Config.Currency.Cryptocurrencies,
-			FiatDisplayCurrency:    e.Config.Currency.FiatDisplayCurrency,
-			CurrencyDelay:          e.Config.Currency.CurrencyFileUpdateDuration,
-			FxRateDelay:            e.Config.Currency.ForeignExchangeUpdateDuration,
+			ForexProviders:         bot.Config.GetForexProviders(),
+			CryptocurrencyProvider: coinmarketcap.Settings(bot.Config.Currency.CryptocurrencyProvider),
+			Cryptocurrencies:       bot.Config.Currency.Cryptocurrencies,
+			FiatDisplayCurrency:    bot.Config.Currency.FiatDisplayCurrency,
+			CurrencyDelay:          bot.Config.Currency.CurrencyFileUpdateDuration,
+			FxRateDelay:            bot.Config.Currency.ForeignExchangeUpdateDuration,
 		},
-		e.Settings.DataDir)
+		bot.Settings.DataDir)
 	if err != nil {
 		gctlog.Errorf(gctlog.Global, "Currency updater system failed to start %v", err)
 	}
 
-	if e.Settings.EnableGRPC {
-		go StartRPCServer()
+	if bot.Settings.EnableGRPC {
+		go StartRPCServer(bot)
 	}
 
-	if e.Settings.EnableDeprecatedRPC {
+	if bot.Settings.EnableDeprecatedRPC {
 		go StartRESTServer()
 	}
 
-	if e.Settings.EnableWebsocketRPC {
+	if bot.Settings.EnableWebsocketRPC {
 		go StartWebsocketServer()
 		StartWebsocketHandler()
 	}
 
-	if e.Settings.EnablePortfolioManager {
-		if err = e.PortfolioManager.Start(); err != nil {
+	if bot.Settings.EnablePortfolioManager {
+		if err = bot.PortfolioManager.Start(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Fund manager unable to start: %v", err)
 		}
 	}
 
-	if e.Settings.EnableDepositAddressManager {
-		e.DepositAddressManager = new(DepositAddressManager)
-		go e.DepositAddressManager.Sync()
+	if bot.Settings.EnableDepositAddressManager {
+		bot.DepositAddressManager = new(DepositAddressManager)
+		go bot.DepositAddressManager.Sync()
 	}
 
-	if e.Settings.EnableOrderManager {
-		if err = e.OrderManager.Start(); err != nil {
+	if bot.Settings.EnableOrderManager {
+		if err = bot.OrderManager.Start(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Order manager unable to start: %v", err)
 		}
 	}
 
-	if e.Settings.EnableExchangeSyncManager {
+	if bot.Settings.EnableExchangeSyncManager {
 		exchangeSyncCfg := CurrencyPairSyncerConfig{
-			SyncTicker:       e.Settings.EnableTickerSyncing,
-			SyncOrderbook:    e.Settings.EnableOrderbookSyncing,
-			SyncTrades:       e.Settings.EnableTradeSyncing,
-			SyncContinuously: e.Settings.SyncContinuously,
-			NumWorkers:       e.Settings.SyncWorkers,
-			Verbose:          e.Settings.Verbose,
-			SyncTimeout:      e.Settings.SyncTimeout,
+			SyncTicker:       bot.Settings.EnableTickerSyncing,
+			SyncOrderbook:    bot.Settings.EnableOrderbookSyncing,
+			SyncTrades:       bot.Settings.EnableTradeSyncing,
+			SyncContinuously: bot.Settings.SyncContinuously,
+			NumWorkers:       bot.Settings.SyncWorkers,
+			Verbose:          bot.Settings.Verbose,
+			SyncTimeout:      bot.Settings.SyncTimeout,
 		}
 
-		e.ExchangeCurrencyPairManager, err = NewCurrencyPairSyncer(exchangeSyncCfg)
+		bot.ExchangeCurrencyPairManager, err = NewCurrencyPairSyncer(exchangeSyncCfg)
 		if err != nil {
 			gctlog.Warnf(gctlog.Global, "Unable to initialise exchange currency pair syncer. Err: %s", err)
 		} else {
-			go e.ExchangeCurrencyPairManager.Start()
+			go bot.ExchangeCurrencyPairManager.Start()
 		}
 	}
 
-	if e.Settings.EnableEventManager {
+	if bot.Settings.EnableEventManager {
 		go EventManger()
 	}
 
-	if e.Settings.EnableWebsocketRoutine {
+	if bot.Settings.EnableWebsocketRoutine {
 		go WebsocketRoutine()
 	}
 
-	if e.Settings.EnableGCTScriptManager {
-		if e.Config.GCTScript.Enabled {
-			if err := e.GctScriptManager.Start(); err != nil {
+	if bot.Settings.EnableGCTScriptManager {
+		if bot.Config.GCTScript.Enabled {
+			if err := bot.GctScriptManager.Start(); err != nil {
 				gctlog.Errorf(gctlog.Global, "GCTScript manager unable to start: %v", err)
 			}
 		}
@@ -475,50 +475,50 @@ func (e *Engine) Start() error {
 }
 
 // Stop correctly shuts down engine saving configuration files
-func (e *Engine) Stop() {
+func (bot *Engine) Stop() {
 	gctlog.Debugln(gctlog.Global, "Engine shutting down..")
 
 	if len(portfolio.Portfolio.Addresses) != 0 {
-		e.Config.Portfolio = portfolio.Portfolio
+		bot.Config.Portfolio = portfolio.Portfolio
 	}
 
-	if e.GctScriptManager.Started() {
-		if err := e.GctScriptManager.Stop(); err != nil {
+	if bot.GctScriptManager.Started() {
+		if err := bot.GctScriptManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "GCTScript manager unable to stop. Error: %v", err)
 		}
 	}
-	if e.OrderManager.Started() {
-		if err := e.OrderManager.Stop(); err != nil {
+	if bot.OrderManager.Started() {
+		if err := bot.OrderManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Order manager unable to stop. Error: %v", err)
 		}
 	}
 
-	if e.NTPManager.Started() {
-		if err := e.NTPManager.Stop(); err != nil {
+	if bot.NTPManager.Started() {
+		if err := bot.NTPManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "NTP manager unable to stop. Error: %v", err)
 		}
 	}
 
-	if e.CommsManager.Started() {
-		if err := e.CommsManager.Stop(); err != nil {
+	if bot.CommsManager.Started() {
+		if err := bot.CommsManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Communication manager unable to stop. Error: %v", err)
 		}
 	}
 
-	if e.PortfolioManager.Started() {
-		if err := e.PortfolioManager.Stop(); err != nil {
+	if bot.PortfolioManager.Started() {
+		if err := bot.PortfolioManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Fund manager unable to stop. Error: %v", err)
 		}
 	}
 
-	if e.ConnectionManager.Started() {
-		if err := e.ConnectionManager.Stop(); err != nil {
+	if bot.ConnectionManager.Started() {
+		if err := bot.ConnectionManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Connection manager unable to stop. Error: %v", err)
 		}
 	}
 
-	if e.DatabaseManager.Started() {
-		if err := e.DatabaseManager.Stop(); err != nil {
+	if bot.DatabaseManager.Started() {
+		if err := bot.DatabaseManager.Stop(); err != nil {
 			gctlog.Errorf(gctlog.Global, "Database manager unable to stop. Error: %v", err)
 		}
 	}
@@ -533,8 +533,8 @@ func (e *Engine) Stop() {
 		gctlog.Errorf(gctlog.Global, "Currency storage system. Error: %v", err)
 	}
 
-	if !e.Settings.EnableDryRun {
-		err := e.Config.SaveConfig(e.Settings.ConfigFile, false)
+	if !bot.Settings.EnableDryRun {
+		err := bot.Config.SaveConfig(bot.Settings.ConfigFile, false)
 		if err != nil {
 			gctlog.Errorln(gctlog.Global, "Unable to save config.")
 		} else {
@@ -543,7 +543,7 @@ func (e *Engine) Stop() {
 	}
 
 	// Wait for services to gracefully shutdown
-	e.ServicesWG.Wait()
+	bot.ServicesWG.Wait()
 	err := gctlog.CloseLogger()
 	if err != nil {
 		log.Printf("Failed to close logger. Error: %v\n", err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -72,7 +72,7 @@ func TestLoadConfigWithSettings(t *testing.T) {
 	}
 }
 func TestStartStopDoesNotCausePanic(t *testing.T) {
-	t.Skip("Due to race condition with global config.Cfg being used from multiple tests and RPC server and REST proxy never propoerly stopped when engine.Stop() is called")
+	t.Skip("Due to race condition with global config.Cfg being used from multiple tests and RPC server and REST proxy never properly stopped when engine.Stop() is called")
 	botOne, err := NewFromSettings(&Settings{
 		ConfigFile:   config.TestFile,
 		EnableDryRun: true,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -72,6 +72,7 @@ func TestLoadConfigWithSettings(t *testing.T) {
 	}
 }
 func TestStartStopDoesNotCausePanic(t *testing.T) {
+	t.Skip("Due to race condition with global config.Cfg being used from multiple tests and RPC server and REST proxy never propoerly stopped when engine.Stop() is called")
 	botOne, err := NewFromSettings(&Settings{
 		ConfigFile:   config.TestFile,
 		EnableDryRun: true,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -71,3 +71,18 @@ func TestLoadConfigWithSettings(t *testing.T) {
 		})
 	}
 }
+func TestStartStopDoesNotCausePanic(t *testing.T) {
+	botOne, err := NewFromSettings(&Settings{
+		ConfigFile:   config.TestFile,
+		EnableDryRun: true,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err = botOne.Start(); err != nil {
+		t.Error(err)
+	}
+
+	botOne.Stop()
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -71,6 +71,7 @@ func TestLoadConfigWithSettings(t *testing.T) {
 		})
 	}
 }
+
 func TestStartStopDoesNotCausePanic(t *testing.T) {
 	t.Skip("Due to race condition with global config.Cfg being used from multiple tests and RPC server and REST proxy never properly stopped when engine.Stop() is called")
 	botOne, err := NewFromSettings(&Settings{

--- a/engine/exchange.go
+++ b/engine/exchange.go
@@ -355,7 +355,7 @@ func (bot *Engine) LoadExchange(name string, useWG bool, wg *sync.WaitGroup) err
 	return nil
 }
 
-// SetupExchanges sets up the exchanges used by the e
+// SetupExchanges sets up the exchanges used by the Bot
 func (bot *Engine) SetupExchanges() {
 	var wg sync.WaitGroup
 	configs := bot.Config.GetAllExchangeConfigs()

--- a/engine/exchange_test.go
+++ b/engine/exchange_test.go
@@ -116,7 +116,7 @@ func TestUnloadExchange(t *testing.T) {
 	e := SetupTestHelpers(t)
 
 	err := e.UnloadExchange("asdf")
-	if err.Error() != "exchange asdf not found" {
+	if err == nil || err.Error() != "exchange asdf not found" {
 		t.Errorf("TestUnloadExchange: Incorrect result: %s",
 			err)
 	}

--- a/engine/fake_exchange_test.go
+++ b/engine/fake_exchange_test.go
@@ -30,7 +30,7 @@ type FakePassingExchange struct {
 
 // addPassingFakeExchange adds an exchange to engine tests where all funcs return a positive result
 func addPassingFakeExchange(baseExchangeName string) error {
-	testExch := GetExchangeByName(baseExchangeName)
+	testExch := Bot.GetExchangeByName(baseExchangeName)
 	if testExch == nil {
 		return ErrExchangeNotFound
 	}

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -29,7 +29,7 @@ var (
 	helperTestLoaded = false
 )
 
-func SetupTestHelpers(t *testing.T) {
+func SetupTestHelpers(t *testing.T) *Engine {
 	if !helperTestLoaded {
 		if Bot == nil {
 			Bot = new(Engine)
@@ -46,39 +46,40 @@ func SetupTestHelpers(t *testing.T) {
 		helperTestLoaded = true
 	}
 
-	if GetExchangeByName(testExchange) == nil {
-		err := LoadExchange(testExchange, false, nil)
+	if Bot.GetExchangeByName(testExchange) == nil {
+		err := Bot.LoadExchange(testExchange, false, nil)
 		if err != nil {
 			t.Fatalf("SetupTest: Failed to load exchange: %s", err)
 		}
 	}
-	if GetExchangeByName(fakePassExchange) == nil {
+	if Bot.GetExchangeByName(fakePassExchange) == nil {
 		err := addPassingFakeExchange(testExchange)
 		if err != nil {
 			t.Fatalf("SetupTest: Failed to load exchange: %s", err)
 		}
 	}
+	return Bot
 }
 
 func TestGetExchangeOTPs(t *testing.T) {
-	SetupTestHelpers(t)
-	_, err := GetExchangeOTPs()
+	bot := SetupTestHelpers(t)
+	_, err := bot.GetExchangeOTPs()
 	if err == nil {
 		t.Fatal("Expected err with no exchange OTP secrets set")
 	}
 
-	bfxCfg, err := Bot.Config.GetExchangeConfig("Bitfinex")
+	bfxCfg, err := bot.Config.GetExchangeConfig("Bitfinex")
 	if err != nil {
 		t.Fatal(err)
 	}
-	bCfg, err := Bot.Config.GetExchangeConfig("Bitstamp")
+	bCfg, err := bot.Config.GetExchangeConfig("Bitstamp")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	bfxCfg.API.Credentials.OTPSecret = "JBSWY3DPEHPK3PXP"
 	bCfg.API.Credentials.OTPSecret = "JBSWY3DPEHPK3PXP"
-	result, err := GetExchangeOTPs()
+	result, err := bot.GetExchangeOTPs()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +88,7 @@ func TestGetExchangeOTPs(t *testing.T) {
 	}
 
 	bfxCfg.API.Credentials.OTPSecret = "°"
-	result, err = GetExchangeOTPs()
+	result, err = bot.GetExchangeOTPs()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,19 +102,19 @@ func TestGetExchangeOTPs(t *testing.T) {
 }
 
 func TestGetExchangeoOTPByName(t *testing.T) {
-	SetupTestHelpers(t)
-	_, err := GetExchangeoOTPByName("Bitstamp")
+	bot := SetupTestHelpers(t)
+	_, err := bot.GetExchangeoOTPByName("Bitstamp")
 	if err == nil {
 		t.Fatal("Expected err with no exchange OTP secrets set")
 	}
 
-	bCfg, err := Bot.Config.GetExchangeConfig("Bitstamp")
+	bCfg, err := bot.Config.GetExchangeConfig("Bitstamp")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	bCfg.API.Credentials.OTPSecret = "JBSWY3DPEHPK3PXP"
-	result, err := GetExchangeoOTPByName("Bitstamp")
+	result, err := bot.GetExchangeoOTPByName("Bitstamp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,19 +127,19 @@ func TestGetExchangeoOTPByName(t *testing.T) {
 }
 
 func TestGetAuthAPISupportedExchanges(t *testing.T) {
-	SetupTestHelpers(t)
-	if result := GetAuthAPISupportedExchanges(); len(result) != 1 {
+	e := SetupTestHelpers(t)
+	if result := e.GetAuthAPISupportedExchanges(); len(result) != 1 {
 		t.Fatal("Unexpected result", result)
 	}
 }
 
 func TestIsOnline(t *testing.T) {
-	SetupTestHelpers(t)
-	if r := IsOnline(); r {
+	e := SetupTestHelpers(t)
+	if r := e.IsOnline(); r {
 		t.Fatal("Unexpected result")
 	}
 
-	if err := Bot.ConnectionManager.Start(); err != nil {
+	if err := e.ConnectionManager.Start(&e.Config.ConnectionMonitor); err != nil {
 		t.Fatal(err)
 	}
 
@@ -149,8 +150,8 @@ func TestIsOnline(t *testing.T) {
 		case <-tick.C:
 			t.Fatal("Test timeout")
 		default:
-			if IsOnline() {
-				if err := Bot.ConnectionManager.Stop(); err != nil {
+			if e.IsOnline() {
+				if err := e.ConnectionManager.Stop(); err != nil {
 					t.Fatal("unable to shutdown connection manager")
 				}
 				return
@@ -160,16 +161,16 @@ func TestIsOnline(t *testing.T) {
 }
 
 func TestGetAvailableExchanges(t *testing.T) {
-	SetupTestHelpers(t)
-	if r := len(GetAvailableExchanges()); r == 0 {
+	e := SetupTestHelpers(t)
+	if r := len(e.GetAvailableExchanges()); r == 0 {
 		t.Error("Expected len > 0")
 	}
 }
 
 func TestGetSpecificAvailablePairs(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 	assetType := asset.Spot
-	result := GetSpecificAvailablePairs(true, true, true, false, assetType)
+	result := e.GetSpecificAvailablePairs(true, true, true, false, assetType)
 
 	btsusd, err := currency.NewPairFromStrings("BTC", "USD")
 	if err != nil {
@@ -189,7 +190,7 @@ func TestGetSpecificAvailablePairs(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 
-	result = GetSpecificAvailablePairs(true, true, false, false, assetType)
+	result = e.GetSpecificAvailablePairs(true, true, false, false, assetType)
 
 	if result.Contains(btcusdt, false) {
 		t.Fatal("Unexpected result")
@@ -200,7 +201,7 @@ func TestGetSpecificAvailablePairs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result = GetSpecificAvailablePairs(true, false, false, true, assetType)
+	result = e.GetSpecificAvailablePairs(true, false, false, true, assetType)
 	if !result.Contains(ltcbtc, false) {
 		t.Fatal("Unexpected result")
 	}
@@ -476,14 +477,14 @@ func TestGetRelatableFiatCurrencies(t *testing.T) {
 }
 
 func TestMapCurrenciesByExchange(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 
 	var pairs = []currency.Pair{
 		currency.NewPair(currency.BTC, currency.USD),
 		currency.NewPair(currency.BTC, currency.EUR),
 	}
 
-	result := MapCurrenciesByExchange(pairs, true, asset.Spot)
+	result := e.MapCurrenciesByExchange(pairs, true, asset.Spot)
 	pairs, ok := result["Bitstamp"]
 	if !ok {
 		t.Fatal("Unexpected result")
@@ -495,7 +496,7 @@ func TestMapCurrenciesByExchange(t *testing.T) {
 }
 
 func TestGetExchangeNamesByCurrency(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 	assetType := asset.Spot
 
 	btsusd, err := currency.NewPairFromStrings("BTC", "USD")
@@ -513,21 +514,21 @@ func TestGetExchangeNamesByCurrency(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := GetExchangeNamesByCurrency(btsusd,
+	result := e.GetExchangeNamesByCurrency(btsusd,
 		true,
 		assetType)
 	if !common.StringDataCompare(result, "Bitstamp") {
 		t.Fatal("Unexpected result")
 	}
 
-	result = GetExchangeNamesByCurrency(btcjpy,
+	result = e.GetExchangeNamesByCurrency(btcjpy,
 		true,
 		assetType)
 	if !common.StringDataCompare(result, "Bitflyer") {
 		t.Fatal("Unexpected result")
 	}
 
-	result = GetExchangeNamesByCurrency(blahjpy,
+	result = e.GetExchangeNamesByCurrency(blahjpy,
 		true,
 		assetType)
 	if len(result) > 0 {
@@ -536,9 +537,9 @@ func TestGetExchangeNamesByCurrency(t *testing.T) {
 }
 
 func TestGetSpecificOrderbook(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 
-	LoadExchange("Bitstamp", false, nil)
+	e.LoadExchange("Bitstamp", false, nil)
 
 	var bids []orderbook.Item
 	bids = append(bids, orderbook.Item{Price: 1000, Amount: 1})
@@ -560,7 +561,7 @@ func TestGetSpecificOrderbook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ob, err := GetSpecificOrderbook(btsusd, "Bitstamp", asset.Spot)
+	ob, err := e.GetSpecificOrderbook(btsusd, "Bitstamp", asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -574,18 +575,18 @@ func TestGetSpecificOrderbook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = GetSpecificOrderbook(ethltc, "Bitstamp", asset.Spot)
+	_, err = e.GetSpecificOrderbook(ethltc, "Bitstamp", asset.Spot)
 	if err == nil {
 		t.Fatal("Unexpected result")
 	}
 
-	UnloadExchange("Bitstamp")
+	e.UnloadExchange("Bitstamp")
 }
 
 func TestGetSpecificTicker(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 
-	LoadExchange("Bitstamp", false, nil)
+	e.LoadExchange("Bitstamp", false, nil)
 	p, err := currency.NewPairFromStrings("BTC", "USD")
 	if err != nil {
 		t.Fatal(err)
@@ -600,7 +601,7 @@ func TestGetSpecificTicker(t *testing.T) {
 		t.Fatal("ProcessTicker error", err)
 	}
 
-	tick, err := GetSpecificTicker(p, "Bitstamp", asset.Spot)
+	tick, err := e.GetSpecificTicker(p, "Bitstamp", asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,12 +615,12 @@ func TestGetSpecificTicker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = GetSpecificTicker(ethltc, "Bitstamp", asset.Spot)
+	_, err = e.GetSpecificTicker(ethltc, "Bitstamp", asset.Spot)
 	if err == nil {
 		t.Fatal("Unexpected result")
 	}
 
-	UnloadExchange("Bitstamp")
+	e.UnloadExchange("Bitstamp")
 }
 
 func TestGetCollatedExchangeAccountInfoByCoin(t *testing.T) {
@@ -743,27 +744,27 @@ func TestGetExchangeLowestPriceByCurrencyPair(t *testing.T) {
 }
 
 func TestGetCryptocurrenciesByExchange(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 
-	_, err := GetCryptocurrenciesByExchange("Bitfinex", false, false, asset.Spot)
+	_, err := e.GetCryptocurrenciesByExchange("Bitfinex", false, false, asset.Spot)
 	if err != nil {
 		t.Fatalf("Err %s", err)
 	}
 }
 
 func TestGetExchangeNames(t *testing.T) {
-	SetupTestHelpers(t)
-	if e := GetExchangeNames(true); len(e) == 0 {
+	bot := SetupTestHelpers(t)
+	if e := bot.GetExchangeNames(true); len(e) == 0 {
 		t.Error("exchange names should be populated")
 	}
-	if err := UnloadExchange(testExchange); err != nil {
+	if err := bot.UnloadExchange(testExchange); err != nil {
 		t.Fatal(err)
 	}
-	if e := GetExchangeNames(true); common.StringDataCompare(e, testExchange) {
+	if e := bot.GetExchangeNames(true); common.StringDataCompare(e, testExchange) {
 		t.Error("Bitstamp should be missing")
 	}
-	if e := GetExchangeNames(false); len(e) != len(Bot.Config.Exchanges) {
-		t.Errorf("Expected %v Received %v", len(e), len(Bot.Config.Exchanges))
+	if e := bot.GetExchangeNames(false); len(e) != len(bot.Config.Exchanges) {
+		t.Errorf("Expected %v Received %v", len(e), len(bot.Config.Exchanges))
 	}
 }
 

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -96,7 +96,7 @@ func (o *orderStore) Add(order *order.Detail) error {
 	if order == nil {
 		return errors.New("order store: Order is nil")
 	}
-	exch := GetExchangeByName(order.Exchange)
+	exch := Bot.GetExchangeByName(order.Exchange)
 	if exch == nil {
 		return ErrExchangeNotFound
 	}
@@ -250,7 +250,7 @@ func (o *orderManager) Cancel(cancel *order.Cancel) error {
 		return errors.New("order id is empty")
 	}
 
-	exch := GetExchangeByName(cancel.Exchange)
+	exch := Bot.GetExchangeByName(cancel.Exchange)
 	if exch == nil {
 		return ErrExchangeNotFound
 	}
@@ -307,7 +307,7 @@ func (o *orderManager) Submit(newOrder *order.Submit) (*orderSubmitResponse, err
 		}
 	}
 
-	exch := GetExchangeByName(newOrder.Exchange)
+	exch := Bot.GetExchangeByName(newOrder.Exchange)
 	if exch == nil {
 		return nil, ErrExchangeNotFound
 	}
@@ -387,13 +387,13 @@ func (o *orderManager) Submit(newOrder *order.Submit) (*orderSubmitResponse, err
 }
 
 func (o *orderManager) processOrders() {
-	authExchanges := GetAuthAPISupportedExchanges()
+	authExchanges := Bot.GetAuthAPISupportedExchanges()
 	for x := range authExchanges {
 		log.Debugf(log.OrderMgr,
 			"Order manager: Processing orders for exchange %v.",
 			authExchanges[x])
 
-		exch := GetExchangeByName(authExchanges[x])
+		exch := Bot.GetExchangeByName(authExchanges[x])
 		supportedAssets := exch.GetAssetTypes()
 		for y := range supportedAssets {
 			pairs, err := exch.GetEnabledPairs(supportedAssets[y])

--- a/engine/portfolio.go
+++ b/engine/portfolio.go
@@ -89,5 +89,5 @@ func (p *portfolioManager) processPortfolio() {
 			key,
 			value)
 	}
-	SeedExchangeAccountInfo(GetAllEnabledExchangeAccountInfo().Data)
+	SeedExchangeAccountInfo(Bot.GetAllEnabledExchangeAccountInfo().Data)
 }

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -31,24 +31,24 @@ func RESTLogger(inner http.Handler, name string) http.Handler {
 }
 
 // StartRESTServer starts a REST server
-func StartRESTServer() {
-	listenAddr := Bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
+func StartRESTServer(bot *Engine) {
+	listenAddr := bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
 	log.Debugf(log.RESTSys,
 		"Deprecated RPC server support enabled. Listen URL: http://%s:%d\n",
 		common.ExtractHost(listenAddr), common.ExtractPort(listenAddr))
-	err := http.ListenAndServe(listenAddr, newRouter(true))
+	err := http.ListenAndServe(listenAddr, newRouter(bot, true))
 	if err != nil {
 		log.Errorf(log.RESTSys, "Failed to start deprecated RPC server. Err: %s", err)
 	}
 }
 
 // StartWebsocketServer starts a Websocket server
-func StartWebsocketServer() {
-	listenAddr := Bot.Config.RemoteControl.WebsocketRPC.ListenAddress
+func StartWebsocketServer(bot *Engine) {
+	listenAddr := bot.Config.RemoteControl.WebsocketRPC.ListenAddress
 	log.Debugf(log.RESTSys,
 		"Websocket RPC support enabled. Listen URL: ws://%s:%d/ws\n",
 		common.ExtractHost(listenAddr), common.ExtractPort(listenAddr))
-	err := http.ListenAndServe(listenAddr, newRouter(false))
+	err := http.ListenAndServe(listenAddr, newRouter(bot, false))
 	if err != nil {
 		log.Errorf(log.RESTSys, "Failed to start websocket RPC server. Err: %s", err)
 	}
@@ -56,15 +56,15 @@ func StartWebsocketServer() {
 
 // newRouter takes in the exchange interfaces and returns a new multiplexor
 // router
-func newRouter(isREST bool) *mux.Router {
+func newRouter(bot *Engine, isREST bool) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	var routes []Route
 	var listenAddr string
 
 	if isREST {
-		listenAddr = Bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
+		listenAddr = bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
 	} else {
-		listenAddr = Bot.Config.RemoteControl.WebsocketRPC.ListenAddress
+		listenAddr = bot.Config.RemoteControl.WebsocketRPC.ListenAddress
 	}
 
 	if common.ExtractPort(listenAddr) == 80 {
@@ -85,9 +85,9 @@ func newRouter(isREST bool) *mux.Router {
 			{"AllActiveExchangesAndOrderbooks", http.MethodGet, "/exchanges/orderbook/latest/all", RESTGetAllActiveOrderbooks},
 		}
 
-		if Bot.Config.Profiler.Enabled {
-			if Bot.Config.Profiler.MutexProfileFraction > 0 {
-				runtime.SetMutexProfileFraction(Bot.Config.Profiler.MutexProfileFraction)
+		if bot.Config.Profiler.Enabled {
+			if bot.Config.Profiler.MutexProfileFraction > 0 {
+				runtime.SetMutexProfileFraction(bot.Config.Profiler.MutexProfileFraction)
 			}
 			log.Debugf(log.RESTSys,
 				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof/\n",

--- a/engine/restful_server.go
+++ b/engine/restful_server.go
@@ -52,13 +52,13 @@ func RESTSaveAllSettings(w http.ResponseWriter, r *http.Request) {
 		RESTfulError(r.Method, err)
 	}
 
-	SetupExchanges()
+	Bot.SetupExchanges()
 }
 
 // GetAllActiveOrderbooks returns all enabled exchanges orderbooks
 func GetAllActiveOrderbooks() []EnabledExchangeOrderbooks {
 	var orderbookData []EnabledExchangeOrderbooks
-	exchanges := GetExchanges()
+	exchanges := Bot.GetExchanges()
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes()
 		exchName := exchanges[x].GetName()
@@ -116,7 +116,7 @@ func RESTGetPortfolio(w http.ResponseWriter, r *http.Request) {
 // RESTGetAllActiveTickers returns all active tickers
 func RESTGetAllActiveTickers(w http.ResponseWriter, r *http.Request) {
 	var response AllEnabledExchangeCurrencies
-	response.Data = GetAllActiveTickers()
+	response.Data = Bot.GetAllActiveTickers()
 
 	err := RESTfulJSONResponse(w, response)
 	if err != nil {
@@ -127,7 +127,7 @@ func RESTGetAllActiveTickers(w http.ResponseWriter, r *http.Request) {
 // RESTGetAllEnabledAccountInfo via get request returns JSON response of account
 // info
 func RESTGetAllEnabledAccountInfo(w http.ResponseWriter, r *http.Request) {
-	response := GetAllEnabledExchangeAccountInfo()
+	response := Bot.GetAllEnabledExchangeAccountInfo()
 	err := RESTfulJSONResponse(w, response)
 	if err != nil {
 		RESTfulError(r.Method, err)

--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -44,7 +44,7 @@ func TestConfigAllJsonResponse(t *testing.T) {
 }
 
 func TestInvalidHostRequest(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 	req, err := http.NewRequest(http.MethodGet, "/config/all", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func TestInvalidHostRequest(t *testing.T) {
 	req.Host = "invalidsite.com"
 
 	resp := httptest.NewRecorder()
-	newRouter(true).ServeHTTP(resp, req)
+	newRouter(e, true).ServeHTTP(resp, req)
 
 	if status := resp.Code; status != http.StatusNotFound {
 		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusNotFound, status)
@@ -60,7 +60,7 @@ func TestInvalidHostRequest(t *testing.T) {
 }
 
 func TestValidHostRequest(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 	req, err := http.NewRequest(http.MethodGet, "/config/all", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -68,7 +68,7 @@ func TestValidHostRequest(t *testing.T) {
 	req.Host = "localhost:9050"
 
 	resp := httptest.NewRecorder()
-	newRouter(true).ServeHTTP(resp, req)
+	newRouter(e, true).ServeHTTP(resp, req)
 
 	if status := resp.Code; status != http.StatusOK {
 		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusOK, status)
@@ -76,7 +76,7 @@ func TestValidHostRequest(t *testing.T) {
 }
 
 func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
-	SetupTestHelpers(t)
+	e := SetupTestHelpers(t)
 	req, err := http.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +84,7 @@ func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
 
 	req.Host = "localhost:9050"
 	resp := httptest.NewRecorder()
-	newRouter(true).ServeHTTP(resp, req)
+	newRouter(e, true).ServeHTTP(resp, req)
 	if status := resp.Code; status != http.StatusNotFound {
 		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusNotFound, status)
 	}
@@ -102,7 +102,7 @@ func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
 	}
 
 	resp = httptest.NewRecorder()
-	newRouter(true).ServeHTTP(resp, req)
+	newRouter(e, true).ServeHTTP(resp, req)
 	mutexValue = runtime.SetMutexProfileFraction(10)
 	if mutexValue != 5 {
 		t.Fatalf("SetMutexProfileFraction() should be 5 after setup received: %v", mutexValue)

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -205,7 +205,7 @@ func WebsocketRoutine() {
 		log.Debugln(log.WebsocketMgr, "Connecting exchange websocket services...")
 	}
 
-	exchanges := GetExchanges()
+	exchanges := Bot.GetExchanges()
 	for i := range exchanges {
 		go func(i int) {
 			if exchanges[i].SupportsWebsocket() {

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -293,7 +293,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 	defer cleanup()
 
 	for atomic.LoadInt32(&e.shutdown) != 1 {
-		exchanges := GetExchanges()
+		exchanges := Bot.GetExchanges()
 		for x := range exchanges {
 			exchangeName := exchanges[x].GetName()
 			assetTypes := exchanges[x].GetAssetTypes()
@@ -502,7 +502,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 // Start starts an exchange currency pair syncer
 func (e *ExchangeCurrencyPairSyncer) Start() {
 	log.Debugln(log.SyncMgr, "Exchange CurrencyPairSyncer started.")
-	exchanges := GetExchanges()
+	exchanges := Bot.GetExchanges()
 	for x := range exchanges {
 		exchangeName := exchanges[x].GetName()
 		supportsWebsocket := exchanges[x].SupportsWebsocket()

--- a/engine/syncer_test.go
+++ b/engine/syncer_test.go
@@ -23,7 +23,7 @@ func TestNewCurrencyPairSyncer(t *testing.T) {
 	Bot.Settings.Verbose = true
 	Bot.Settings.EnableExchangeWebsocketSupport = true
 
-	SetupExchanges()
+	Bot.SetupExchanges()
 
 	if err != nil {
 		t.Log("failed to start exchange syncer")

--- a/engine/websocket.go
+++ b/engine/websocket.go
@@ -317,13 +317,13 @@ func wsSaveConfig(client *WebsocketClient, data interface{}) error {
 		return err
 	}
 
-	SetupExchanges()
+	Bot.SetupExchanges()
 	wsResp.Data = WebsocketResponseSuccess
 	return client.SendWebsocketMessage(wsResp)
 }
 
 func wsGetAccountInfo(client *WebsocketClient, data interface{}) error {
-	accountInfo := GetAllEnabledExchangeAccountInfo()
+	accountInfo := Bot.GetAllEnabledExchangeAccountInfo()
 	wsResp := WebsocketEventResponse{
 		Event: "GetAccountInfo",
 		Data:  accountInfo,
@@ -335,7 +335,7 @@ func wsGetTickers(client *WebsocketClient, data interface{}) error {
 	wsResp := WebsocketEventResponse{
 		Event: "GetTickers",
 	}
-	wsResp.Data = GetAllActiveTickers()
+	wsResp.Data = Bot.GetAllActiveTickers()
 	return client.SendWebsocketMessage(wsResp)
 }
 
@@ -356,7 +356,7 @@ func wsGetTicker(client *WebsocketClient, data interface{}) error {
 		return err
 	}
 
-	result, err := GetSpecificTicker(p,
+	result, err := Bot.GetSpecificTicker(p,
 		tickerReq.Exchange,
 		asset.Item(tickerReq.AssetType))
 
@@ -394,7 +394,7 @@ func wsGetOrderbook(client *WebsocketClient, data interface{}) error {
 		return err
 	}
 
-	result, err := GetSpecificOrderbook(p,
+	result, err := Bot.GetSpecificOrderbook(p,
 		orderbookReq.Exchange, asset.Item(orderbookReq.AssetType))
 
 	if err != nil {

--- a/engine/withdraw.go
+++ b/engine/withdraw.go
@@ -38,7 +38,7 @@ func SubmitWithdrawal(exchName string, req *withdraw.Request) (*withdraw.Respons
 		return nil, err
 	}
 
-	exch := GetExchangeByName(exchName)
+	exch := Bot.GetExchangeByName(exchName)
 	if exch == nil {
 		return nil, ErrExchangeNotFound
 	}

--- a/gctscript/wrappers/gct/exchange/exchange.go
+++ b/gctscript/wrappers/gct/exchange/exchange.go
@@ -25,12 +25,12 @@ type Exchange struct{}
 
 // Exchanges returns slice of all current exchanges
 func (e Exchange) Exchanges(enabledOnly bool) []string {
-	return engine.GetExchangeNames(enabledOnly)
+	return engine.Bot.GetExchangeNames(enabledOnly)
 }
 
 // GetExchange returns IBotExchange for exchange or error if exchange is not found
 func (e Exchange) GetExchange(exch string) (exchange.IBotExchange, error) {
-	ex := engine.GetExchangeByName(exch)
+	ex := engine.Bot.GetExchangeByName(exch)
 	if ex == nil {
 		return nil, fmt.Errorf("%v exchange not found", exch)
 	}
@@ -50,7 +50,7 @@ func (e Exchange) IsEnabled(exch string) bool {
 
 // Orderbook returns current orderbook requested exchange, pair and asset
 func (e Exchange) Orderbook(exch string, pair currency.Pair, item asset.Item) (*orderbook.Base, error) {
-	return engine.GetSpecificOrderbook(pair, exch, item)
+	return engine.Bot.GetSpecificOrderbook(pair, exch, item)
 }
 
 // Ticker returns ticker for provided currency pair & asset type
@@ -166,7 +166,7 @@ func (e Exchange) WithdrawalFiatFunds(exch, bankAccountID string, request *withd
 		}
 	}
 
-	otp, err := engine.GetExchangeoOTPByName(exch)
+	otp, err := engine.Bot.GetExchangeoOTPByName(exch)
 	if err == nil {
 		otpValue, errParse := strconv.ParseInt(otp, 10, 64)
 		if errParse != nil {
@@ -200,7 +200,7 @@ func (e Exchange) WithdrawalCryptoFunds(exch string, request *withdraw.Request) 
 		return "", err
 	}
 
-	otp, err := engine.GetExchangeoOTPByName(exch)
+	otp, err := engine.Bot.GetExchangeoOTPByName(exch)
 	if err == nil {
 		v, errParse := strconv.ParseInt(otp, 10, 64)
 		if errParse != nil {

--- a/gctscript/wrappers/gct/exchange/exchange_test.go
+++ b/gctscript/wrappers/gct/exchange/exchange_test.go
@@ -195,7 +195,7 @@ func cleanup() {
 }
 
 func configureExchangeKeys() bool {
-	ex := engine.GetExchangeByName(exchName).GetBase()
+	ex := engine.Bot.GetExchangeByName(exchName).GetBase()
 	ex.SetAPIKeys(exchAPIKEY, exchAPISECRET, exchClientID)
 	ex.SkipAuthCheck = true
 	return ex.ValidateAPICredentials()


### PR DESCRIPTION
* make the dependency on having an existing running Engine more obvious
* use explicit dependency of engine in RPCServer
* reduce static dependencies in rpcserver
* improve helpers

# PR Description

This change should have no functional impact on the code. Just a Refactoring to use less of `engine.Bot` global variable.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
It will break external code that uses static methods, but it's only a small syntactic change, replacing
`engine.GetXXX()` with `engine.Bot.GetXXX()` is the fix (e.g. `engine.Bot.GetExchangeNames(true)`)
but ideally `engine.Bot` should not be used at all, instead your local intance of the bot should be preferred.

## How has this been tested

Ran all the existing tests
- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
Is there a list somewhere?
