### PR TITLE
Config: Remove TestBypass flag

### DIFF
--- a/cmd/dbseed/dbseed_test.go
+++ b/cmd/dbseed/dbseed_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/urfave/cli/v2"
 )
@@ -36,7 +35,6 @@ var (
 )
 
 func TestLoad(t *testing.T) {
-	config.TestBypass = true
 	fs := &flag.FlagSet{}
 	fs.String("config", testConfig, "")
 	newCtx := cli.NewContext(testApp, fs, &cli.Context{})

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1482,10 +1481,6 @@ func DefaultFilePath() string {
 func GetFilePath(configfile string) (string, error) {
 	if configfile != "" {
 		return configfile, nil
-	}
-
-	if flag.Lookup("test.v") != nil && !TestBypass {
-		return TestFile, nil
 	}
 
 	exePath, err := common.GetExecutablePath()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/connchecker"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/database"
@@ -1643,11 +1644,6 @@ func TestReadConfig(t *testing.T) {
 	if err == nil {
 		t.Error("TestReadConfig error cannot be nil")
 	}
-
-	err = readConfig.ReadConfig("", true)
-	if err != nil {
-		t.Error("TestReadConfig error")
-	}
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -1714,12 +1710,17 @@ func TestGetFilePath(t *testing.T) {
 		t.Errorf("TestGetFilePath: expected %s got %s", expected, result)
 	}
 
-	expected = TestFile
-	result, _ = GetFilePath("")
-	if result != expected {
-		t.Errorf("TestGetFilePath: expected %s got %s", expected, result)
+	expected = DefaultFilePath()
+	result, err := GetFilePath("")
+	if file.Exists(expected) {
+		if err != nil || result != expected {
+			t.Errorf("TestGetFilePath: expected %s got %s", expected, result)
+		}
+	} else {
+		if err == nil {
+			t.Error("Expected error when default config file does not exist")
+		}
 	}
-	TestBypass = true
 }
 
 func TestCheckRemoteControlConfig(t *testing.T) {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -69,7 +69,6 @@ const (
 var (
 	Cfg            Config
 	IsInitialSetup bool
-	TestBypass     bool
 	m              sync.Mutex
 )
 


### PR DESCRIPTION
Tests should explicitly state their target configuration file, so no need
to use fallback default override flag

## Type of change

- [x] Cleanup - unnecessary code

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestGetFilePath

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
I don't think there would be any