### PR TITLE
Bugfix: Submit/Cancel order scripting errors + Ordermanager GetOrder & CancelOrder improvements

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -233,9 +233,9 @@ func TestSendHTTPGetRequest(t *testing.T) {
 	type test struct {
 		Address string `json:"address"`
 		ETH     struct {
-			Balance  int `json:"balance"`
-			TotalIn  int `json:"totalIn"`
-			TotalOut int `json:"totalOut"`
+			Balance  float64 `json:"balance"`
+			TotalIn  float64 `json:"totalIn"`
+			TotalOut float64 `json:"totalOut"`
 		} `json:"ETH"`
 	}
 	ethURL := `https://api.ethplorer.io/getAddressInfo/0xff71cb760666ab06aa73f34995b42dd4b85ea07b?apiKey=freekey`

--- a/engine/comms_relayer.go
+++ b/engine/comms_relayer.go
@@ -90,7 +90,7 @@ func (c *commsManager) run() {
 	for {
 		select {
 		case msg := <-c.relayMsg:
-			go c.comms.PushEvent(msg)
+			c.comms.PushEvent(msg)
 		case <-c.shutdown:
 			return
 		}

--- a/engine/comms_relayer.go
+++ b/engine/comms_relayer.go
@@ -72,7 +72,11 @@ func (c *commsManager) PushEvent(evt base.Event) {
 	if !c.Started() {
 		return
 	}
-	c.relayMsg <- evt
+	select {
+	case c.relayMsg <- evt:
+	default:
+		log.Errorf(log.CommunicationMgr, "Failed to send, no receiver when pushing event [%v]", evt)
+	}
 }
 
 func (c *commsManager) run() {
@@ -86,7 +90,7 @@ func (c *commsManager) run() {
 	for {
 		select {
 		case msg := <-c.relayMsg:
-			c.comms.PushEvent(msg)
+			go c.comms.PushEvent(msg)
 		case <-c.shutdown:
 			return
 		}

--- a/engine/fake_exchange_test.go
+++ b/engine/fake_exchange_test.go
@@ -133,7 +133,10 @@ func (h *FakePassingExchange) CancelAllOrders(_ *order.Cancel) (order.CancelAllR
 	return order.CancelAllResponse{}, nil
 }
 func (h *FakePassingExchange) GetOrderInfo(_ string, _ currency.Pair, _ asset.Item) (order.Detail, error) {
-	return order.Detail{}, nil
+	return order.Detail{
+		Exchange: fakePassExchange,
+		ID:       "fakeOrder",
+	}, nil
 }
 func (h *FakePassingExchange) GetDepositAddress(_ currency.Code, _ string) (string, error) {
 	return "", nil

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -381,7 +381,8 @@ func (o *orderManager) Submit(newOrder *order.Submit) (*orderSubmitResponse, err
 
 	return &orderSubmitResponse{
 		SubmitResponse: order.SubmitResponse{
-			OrderID: result.OrderID,
+			IsOrderPlaced: result.IsOrderPlaced,
+			OrderID:       result.OrderID,
 		},
 		InternalOrderID: id.String(),
 	}, nil

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -278,29 +278,26 @@ func (o *orderManager) Cancel(cancel *order.Cancel) error {
 
 // GetOrderInfo calls the exchange's wrapper GetOrderInfo function
 // and stores the result in the order manager
-func (o *orderManager) GetOrderInfo(exchangeName, orderID string, cp currency.Pair, a asset.Item) (*order.Detail, error) {
+func (o *orderManager) GetOrderInfo(exchangeName, orderID string, cp currency.Pair, a asset.Item) (order.Detail, error) {
 	if orderID == "" {
-		return nil, errors.New("order cannot be empty")
+		return order.Detail{}, errors.New("order cannot be empty")
 	}
 
 	exch := Bot.GetExchangeByName(exchangeName)
 	if exch == nil {
-		return nil, ErrExchangeNotFound
+		return order.Detail{}, ErrExchangeNotFound
 	}
 	result, err := exch.GetOrderInfo(orderID, cp, a)
 	if err != nil {
-		return nil, err
+		return order.Detail{}, err
 	}
 
 	err = o.orderStore.Add(&result)
-	if err != nil {
-		if err == ErrOrdersAlreadyExists {
-			return &result, nil
-		}
-		return nil, err
+	if err != nil && err != ErrOrdersAlreadyExists {
+		return order.Detail{}, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // Submit will take in an order struct, send it to the exchange and

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -262,7 +262,7 @@ func (o *orderManager) Cancel(cancel *order.Cancel) error {
 		return err
 	}
 
-	log.Debugf(log.OrderMgr, "Order manager: Cancelling order ID %v [%v]",
+	log.Debugf(log.OrderMgr, "Order manager: Cancelling order ID %v [%+v]",
 		cancel.ID, cancel)
 
 	err = exch.CancelOrder(cancel)

--- a/engine/orders.go
+++ b/engine/orders.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -35,7 +36,7 @@ func (o *orderStore) get() map[string][]*order.Detail {
 func (o *orderStore) GetByExchangeAndID(exchange, id string) (*order.Detail, error) {
 	o.m.RLock()
 	defer o.m.RUnlock()
-	r, ok := o.Orders[exchange]
+	r, ok := o.Orders[strings.ToLower(exchange)]
 	if !ok {
 		return nil, ErrExchangeNotFound
 	}
@@ -52,7 +53,7 @@ func (o *orderStore) GetByExchangeAndID(exchange, id string) (*order.Detail, err
 func (o *orderStore) GetByExchange(exchange string) ([]*order.Detail, error) {
 	o.m.RLock()
 	defer o.m.RUnlock()
-	r, ok := o.Orders[exchange]
+	r, ok := o.Orders[strings.ToLower(exchange)]
 	if !ok {
 		return nil, ErrExchangeNotFound
 	}
@@ -80,7 +81,7 @@ func (o *orderStore) exists(det *order.Detail) bool {
 	}
 	o.m.RLock()
 	defer o.m.RUnlock()
-	r, ok := o.Orders[det.Exchange]
+	r, ok := o.Orders[strings.ToLower(det.Exchange)]
 	if !ok {
 		return false
 	}
@@ -118,9 +119,9 @@ func (o *orderStore) Add(det *order.Detail) error {
 	}
 	o.m.Lock()
 	defer o.m.Unlock()
-	orders := o.Orders[det.Exchange]
+	orders := o.Orders[strings.ToLower(det.Exchange)]
 	orders = append(orders, det)
-	o.Orders[det.Exchange] = orders
+	o.Orders[strings.ToLower(det.Exchange)] = orders
 
 	return nil
 }

--- a/engine/orders_test.go
+++ b/engine/orders_test.go
@@ -278,6 +278,31 @@ func TestCancelOrder(t *testing.T) {
 	}
 }
 
+func TestGetOrderInfo(t *testing.T) {
+	OrdersSetup(t)
+	_, err := Bot.OrderManager.GetOrderInfo("", "", currency.Pair{}, "")
+	if err == nil {
+		t.Error("Expected error due to empty order")
+	}
+
+	var result *order.Detail
+	result, err = Bot.OrderManager.GetOrderInfo(fakePassExchange, "1234", currency.Pair{}, "")
+	if err != nil {
+		t.Error(err)
+	}
+	if result.ID != "fakeOrder" {
+		t.Error("unexpected order returned")
+	}
+
+	result, err = Bot.OrderManager.GetOrderInfo(fakePassExchange, "1234", currency.Pair{}, "")
+	if err != nil {
+		t.Error(err)
+	}
+	if result.ID != "fakeOrder" {
+		t.Error("unexpected order returned")
+	}
+}
+
 func TestCancelAllOrders(t *testing.T) {
 	OrdersSetup(t)
 	o := &order.Detail{

--- a/engine/orders_test.go
+++ b/engine/orders_test.go
@@ -285,7 +285,7 @@ func TestGetOrderInfo(t *testing.T) {
 		t.Error("Expected error due to empty order")
 	}
 
-	var result *order.Detail
+	var result order.Detail
 	result, err = Bot.OrderManager.GetOrderInfo(fakePassExchange, "1234", currency.Pair{}, "")
 	if err != nil {
 		t.Error(err)

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -811,7 +811,7 @@ func (s *RPCServer) GetOrder(_ context.Context, r *gctrpc.GetOrderRequest) (*gct
 		Quote:     currency.NewCode(r.Pair.Quote),
 	}
 
-	result, err := exch.GetOrderInfo(r.OrderId, pair, "") // assetType will be implemented in the future
+	result, err := s.OrderManager.GetOrderInfo(r.Exchange, r.OrderId, pair, "") // assetType will be implemented in the future
 	if err != nil {
 		return nil, fmt.Errorf("error whilst trying to retrieve info for order %s: %s", r.OrderId, err)
 	}

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -377,12 +377,9 @@ func TestGetFeeByType(t *testing.T) {
 	input.Amount = 2
 	input.FeeType = exchange.CryptocurrencyWithdrawalFee
 	input.Pair = cp
-	a, err := l.GetFeeByType(&input)
+	_, err := l.GetFeeByType(&input)
 	if err != nil {
 		t.Error(err)
-	}
-	if a != 0.0005 {
-		t.Errorf("expected: 0.0005, received: %v", a)
 	}
 }
 

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -707,16 +707,17 @@ func (l *Lbank) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		if err != nil {
 			return resp, err
 		}
-		var tempFee string
-		temp := strings.Split(withdrawalFee[0].Fee, ":\"")
-		if len(temp) > 1 {
-			tempFee = strings.TrimRight(temp[1], ",\"type")
-		} else {
-			tempFee = temp[0]
-		}
-		resp, err = strconv.ParseFloat(tempFee, 64)
-		if err != nil {
-			return resp, err
+		for i := range withdrawalFee {
+			if !strings.EqualFold(withdrawalFee[i].AssetCode, feeBuilder.Pair.Base.String()) {
+				continue
+			}
+			if withdrawalFee[i].Fee == "" {
+				return 0, nil
+			}
+			resp, err = strconv.ParseFloat(withdrawalFee[i].Fee, 64)
+			if err != nil {
+				return resp, err
+			}
 		}
 	}
 	return resp, nil

--- a/gctscript/examples/exchange/cancel_order.gct
+++ b/gctscript/examples/exchange/cancel_order.gct
@@ -1,0 +1,9 @@
+fmt := import("fmt")
+exch := import("exchange")
+
+load := func() {
+  info := exch.ordercancel("binance","13371337", "btc-usdt", "spot")
+  fmt.println(info)
+}
+
+load()

--- a/gctscript/examples/exchange/submit_order.gct
+++ b/gctscript/examples/exchange/submit_order.gct
@@ -2,7 +2,7 @@ fmt := import("fmt")
 exch := import("exchange")
 
 load := func() {
-  info := exch.ordersubmit("BTC Markets","BTC-AUD","-","LIMIT","SELL",1000000, 1,"", SPOT)
+  info := exch.ordersubmit("BTC Markets","BTC-AUD","-","LIMIT","SELL",1000000, 1,"", "spot")
   fmt.println(info)
 }
 

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -330,7 +330,7 @@ func ExchangeOrderQuery(args ...objects.Object) (objects.Object, error) {
 
 // ExchangeOrderCancel cancels order on requested exchange
 func ExchangeOrderCancel(args ...objects.Object) (objects.Object, error) {
-	if len(args) != 4 {
+	if len(args) < 2 || len(args) > 4 {
 		return nil, objects.ErrWrongNumArguments
 	}
 
@@ -349,23 +349,30 @@ func ExchangeOrderCancel(args ...objects.Object) (objects.Object, error) {
 	if orderID == "" {
 		return nil, fmt.Errorf(ErrEmptyParameter, "orderID")
 	}
-	var currencyPair string
-	currencyPair, ok = objects.ToString(args[2])
-	if !ok {
-		return nil, fmt.Errorf(ErrParameterConvertFailed, currencyPair)
-	}
-	cp, err := currency.NewPairFromString(currencyPair)
-	if err != nil {
-		return nil, err
-	}
-	assetType, ok := objects.ToString(args[3])
-	if !ok {
-		return nil, fmt.Errorf(ErrParameterConvertFailed, assetType)
+	var err error
+	var cp currency.Pair
+	if len(args) >= 2 {
+		var currencyPair string
+		currencyPair, ok = objects.ToString(args[2])
+		if !ok {
+			return nil, fmt.Errorf(ErrParameterConvertFailed, currencyPair)
+		}
+		cp, err = currency.NewPairFromString(currencyPair)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var a asset.Item
-	a, err = asset.New(assetType)
-	if err != nil {
-		return nil, err
+	if len(args) >= 3 {
+		var assetType string
+		assetType, ok = objects.ToString(args[3])
+		if !ok {
+			return nil, fmt.Errorf(ErrParameterConvertFailed, assetType)
+		}
+		a, err = asset.New(assetType)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var isCancelled bool

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -338,10 +338,16 @@ func ExchangeOrderCancel(args ...objects.Object) (objects.Object, error) {
 	if !ok {
 		return nil, fmt.Errorf(ErrParameterConvertFailed, exchangeName)
 	}
+	if exchangeName == "" {
+		return nil, fmt.Errorf(ErrEmptyParameter, "exchange name")
+	}
 	var orderID string
 	orderID, ok = objects.ToString(args[1])
 	if !ok {
 		return nil, fmt.Errorf(ErrParameterConvertFailed, orderID)
+	}
+	if orderID == "" {
+		return nil, fmt.Errorf(ErrEmptyParameter, "orderID")
 	}
 	var currencyPair string
 	currencyPair, ok = objects.ToString(args[2])

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -351,7 +351,7 @@ func ExchangeOrderCancel(args ...objects.Object) (objects.Object, error) {
 	}
 	var err error
 	var cp currency.Pair
-	if len(args) >= 2 {
+	if len(args) > 2 {
 		var currencyPair string
 		currencyPair, ok = objects.ToString(args[2])
 		if !ok {
@@ -363,7 +363,7 @@ func ExchangeOrderCancel(args ...objects.Object) (objects.Object, error) {
 		}
 	}
 	var a asset.Item
-	if len(args) >= 3 {
+	if len(args) > 3 {
 		var assetType string
 		assetType, ok = objects.ToString(args[3])
 		if !ok {

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -413,6 +413,7 @@ func ExchangeOrderSubmit(args ...objects.Object) (objects.Object, error) {
 		Amount:    orderAmount,
 		ClientID:  orderClientID,
 		AssetType: a,
+		Exchange:  exchangeName,
 	}
 
 	rtn, err := wrappers.GetWrapper().SubmitOrder(tempSubmit)

--- a/gctscript/modules/gct/gct_test.go
+++ b/gctscript/modules/gct/gct_test.go
@@ -32,6 +32,9 @@ var (
 	orderID = &objects.String{
 		Value: "1235",
 	}
+	blank = &objects.String{
+		Value: "",
+	}
 
 	tv            = objects.TrueValue
 	fv            = objects.FalseValue
@@ -167,17 +170,22 @@ func TestExchangeOrderCancel(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = ExchangeOrderCancel(exch, objects.FalseValue, currencyPair, assetType)
-	if err != nil {
+	_, err = ExchangeOrderCancel(blank, orderID, currencyPair, assetType)
+	if err == nil {
 		t.Error("expecting error")
 	}
 
-	_, err = ExchangeOrderCancel(exch, orderID, objects.FalseValue, assetType)
-	if err != nil {
+	_, err = ExchangeOrderCancel(exch, blank, currencyPair, assetType)
+	if err == nil {
 		t.Error("expecting error")
 	}
 
-	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, objects.FalseValue)
+	_, err = ExchangeOrderCancel(exch, orderID, blank, assetType)
+	if err == nil {
+		t.Error("expecting error")
+	}
+
+	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, blank)
 	if err == nil {
 		t.Error("expecting error")
 	}

--- a/gctscript/modules/gct/gct_test.go
+++ b/gctscript/modules/gct/gct_test.go
@@ -180,14 +180,14 @@ func TestExchangeOrderCancel(t *testing.T) {
 		t.Error("expecting error")
 	}
 
-	_, err = ExchangeOrderCancel(exch, orderID, blank, assetType)
-	if err == nil {
-		t.Error("expecting error")
+	_, err = ExchangeOrderCancel(exch, orderID)
+	if err != nil {
+		t.Error(err)
 	}
 
-	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, blank)
-	if err == nil {
-		t.Error("expecting error")
+	_, err = ExchangeOrderCancel(exch, orderID, currencyPair)
+	if err != nil {
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, assetType)

--- a/gctscript/modules/gct/gct_test.go
+++ b/gctscript/modules/gct/gct_test.go
@@ -47,17 +47,17 @@ func TestExchangeOrderbook(t *testing.T) {
 	t.Parallel()
 	_, err := ExchangeOrderbook(exch, currencyPair, delimiter, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderbook(exchError, currencyPair, delimiter, assetType)
 	if err != nil && errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderbook()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -65,17 +65,17 @@ func TestExchangeTicker(t *testing.T) {
 	t.Parallel()
 	_, err := ExchangeTicker(exch, currencyPair, delimiter, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeTicker(exchError, currencyPair, delimiter, assetType)
 	if err != nil && errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeTicker()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -84,22 +84,22 @@ func TestExchangeExchanges(t *testing.T) {
 
 	_, err := ExchangeExchanges(tv)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeExchanges(exch)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeExchanges(fv)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeExchanges()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -108,17 +108,17 @@ func TestExchangePairs(t *testing.T) {
 
 	_, err := ExchangePairs(exch, tv, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangePairs(exchError, tv, assetType)
 	if err != nil && errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangePairs()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -127,17 +127,17 @@ func TestAccountInfo(t *testing.T) {
 
 	_, err := ExchangeAccountInfo()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeAccountInfo(exch)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeAccountInfo(exchError)
 	if err != nil && !errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -146,46 +146,53 @@ func TestExchangeOrderQuery(t *testing.T) {
 
 	_, err := ExchangeOrderQuery()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderQuery(exch, orderID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderQuery(exchError, orderID)
 	if err != nil && !errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestExchangeOrderCancel(t *testing.T) {
+	t.Parallel()
 	_, err := ExchangeOrderCancel()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
-	_, err = ExchangeOrderCancel(exch, orderID)
+	_, err = ExchangeOrderCancel(exch, objects.FalseValue, currencyPair, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error("expecting error")
 	}
 
-	_, err = ExchangeOrderCancel(exch, objects.FalseValue)
+	_, err = ExchangeOrderCancel(exch, orderID, objects.FalseValue, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error("expecting error")
 	}
 
-	_, err = ExchangeOrderCancel(exchError, orderID)
-	if err != nil && !errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, objects.FalseValue)
+	if err == nil {
+		t.Error("expecting error")
+	}
+
+	_, err = ExchangeOrderCancel(exch, orderID, currencyPair, assetType)
+	if err != nil {
+		t.Error(err)
 	}
 }
 
 func TestExchangeOrderSubmit(t *testing.T) {
+	t.Parallel()
 	_, err := ExchangeOrderSubmit()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	orderSide := &objects.String{Value: "ASK"}
@@ -203,46 +210,49 @@ func TestExchangeOrderSubmit(t *testing.T) {
 	_, err = ExchangeOrderSubmit(exch, currencyPair, delimiter,
 		orderType, orderSide, orderPrice, orderAmount, orderID, orderAsset)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderSubmit(objects.TrueValue, currencyPair, delimiter,
 		orderType, orderSide, orderPrice, orderAmount, orderID, orderAsset)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestAllModuleNames(t *testing.T) {
+	t.Parallel()
 	x := AllModuleNames()
 	xType := reflect.TypeOf(x).Kind()
 	if xType != reflect.Slice {
-		t.Fatalf("AllModuleNames() should return slice instead received: %v", x)
+		t.Errorf("AllModuleNames() should return slice instead received: %v", x)
 	}
 }
 
 func TestExchangeDepositAddress(t *testing.T) {
+	t.Parallel()
 	_, err := ExchangeDepositAddress()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	currCode := &objects.String{Value: "BTC"}
 	_, err = ExchangeDepositAddress(exch, currCode)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeDepositAddress(exchError, currCode)
 	if err != nil && !errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestExchangeWithdrawCrypto(t *testing.T) {
+	t.Parallel()
 	_, err := ExchangeWithdrawCrypto()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	currCode := &objects.String{Value: "BTC"}
@@ -252,14 +262,15 @@ func TestExchangeWithdrawCrypto(t *testing.T) {
 
 	_, err = ExchangeWithdrawCrypto(exch, currCode, address, address, amount, amount, desc)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestExchangeWithdrawFiat(t *testing.T) {
+	t.Parallel()
 	_, err := ExchangeWithdrawFiat()
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	currCode := &objects.String{Value: "AUD"}
@@ -268,14 +279,15 @@ func TestExchangeWithdrawFiat(t *testing.T) {
 	bankID := &objects.String{Value: "test-bank-01"}
 	_, err = ExchangeWithdrawFiat(exch, currCode, desc, amount, bankID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestParseInterval(t *testing.T) {
+	t.Parallel()
 	v, err := parseInterval("1h")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if v != time.Hour {
 		t.Fatalf("unexpected value return expected %v received %v", time.Hour, v)
@@ -283,32 +295,32 @@ func TestParseInterval(t *testing.T) {
 
 	v, err = parseInterval("1d")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if v != time.Hour*24 {
-		t.Fatalf("unexpected value return expected %v received %v", time.Hour*24, v)
+		t.Errorf("unexpected value return expected %v received %v", time.Hour*24, v)
 	}
 
 	v, err = parseInterval("3d")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if v != time.Hour*72 {
-		t.Fatalf("unexpected value return expected %v received %v", time.Hour*72, v)
+		t.Errorf("unexpected value return expected %v received %v", time.Hour*72, v)
 	}
 
 	v, err = parseInterval("1w")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if v != time.Hour*168 {
-		t.Fatalf("unexpected value return expected %v received %v", time.Hour*168, v)
+		t.Errorf("unexpected value return expected %v received %v", time.Hour*168, v)
 	}
 
 	_, err = parseInterval("6m")
 	if err != nil {
 		if !errors.Is(err, errInvalidInterval) {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 }

--- a/gctscript/modules/gct/gct_test.go
+++ b/gctscript/modules/gct/gct_test.go
@@ -197,7 +197,7 @@ func TestExchangeOrderSubmit(t *testing.T) {
 	_, err = ExchangeOrderSubmit(exch, currencyPair, delimiter,
 		orderType, orderSide, orderPrice, orderAmount, orderID, orderAsset)
 	if err != nil && !errors.Is(err, errTestFailed) {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = ExchangeOrderSubmit(exch, currencyPair, delimiter,

--- a/gctscript/modules/gct/gct_types.go
+++ b/gctscript/modules/gct/gct_types.go
@@ -9,6 +9,7 @@ import (
 const (
 	// ErrParameterConvertFailed error to return when type conversion fails
 	ErrParameterConvertFailed = "%v failed conversion"
+	ErrEmptyParameter         = "received empty parameter for %v"
 )
 
 var errInvalidInterval = errors.New("invalid interval")

--- a/gctscript/modules/wrapper_types.go
+++ b/gctscript/modules/wrapper_types.go
@@ -37,7 +37,7 @@ type Exchange interface {
 	Pairs(exch string, enabledOnly bool, item asset.Item) (*currency.Pairs, error)
 	QueryOrder(exch, orderid string, pair currency.Pair, assetType asset.Item) (*order.Detail, error)
 	SubmitOrder(submit *order.Submit) (*order.SubmitResponse, error)
-	CancelOrder(exch, orderid string) (bool, error)
+	CancelOrder(exch, orderid string, pair currency.Pair, item asset.Item) (bool, error)
 	AccountInformation(exch string) (account.Holdings, error)
 	DepositAddress(exch string, currencyCode currency.Code) (string, error)
 	WithdrawalFiatFunds(bankAccountID string, request *withdraw.Request) (out string, err error)

--- a/gctscript/wrappers/gct/exchange/exchange.go
+++ b/gctscript/wrappers/gct/exchange/exchange.go
@@ -83,17 +83,12 @@ func (e Exchange) Pairs(exch string, enabledOnly bool, item asset.Item) (*curren
 
 // QueryOrder returns details of a valid exchange order
 func (e Exchange) QueryOrder(exch, orderID string, pair currency.Pair, assetType asset.Item) (*order.Detail, error) {
-	ex, err := e.GetExchange(exch)
+	o, err := engine.Bot.OrderManager.GetOrderInfo(exch, orderID, pair, assetType)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := ex.GetOrderInfo(orderID, pair, assetType)
-	if err != nil {
-		return nil, err
-	}
-
-	return &r, nil
+	return o, nil
 }
 
 // SubmitOrder submit new order on exchange

--- a/gctscript/wrappers/gct/exchange/exchange.go
+++ b/gctscript/wrappers/gct/exchange/exchange.go
@@ -107,8 +107,8 @@ func (e Exchange) SubmitOrder(submit *order.Submit) (*order.SubmitResponse, erro
 }
 
 // CancelOrder wrapper to cancel order on exchange
-func (e Exchange) CancelOrder(exch, orderID string) (bool, error) {
-	orderDetails, err := e.QueryOrder(exch, orderID, currency.Pair{}, "")
+func (e Exchange) CancelOrder(exch, orderID string, cp currency.Pair, a asset.Item) (bool, error) {
+	orderDetails, err := e.QueryOrder(exch, orderID, cp, a)
 	if err != nil {
 		return false, err
 	}

--- a/gctscript/wrappers/gct/exchange/exchange.go
+++ b/gctscript/wrappers/gct/exchange/exchange.go
@@ -88,7 +88,7 @@ func (e Exchange) QueryOrder(exch, orderID string, pair currency.Pair, assetType
 		return nil, err
 	}
 
-	return o, nil
+	return &o, nil
 }
 
 // SubmitOrder submit new order on exchange

--- a/gctscript/wrappers/gct/exchange/exchange.go
+++ b/gctscript/wrappers/gct/exchange/exchange.go
@@ -119,6 +119,7 @@ func (e Exchange) CancelOrder(exch, orderID string) (bool, error) {
 		Pair:      orderDetails.Pair,
 		Side:      orderDetails.Side,
 		AssetType: orderDetails.AssetType,
+		Exchange:  exch,
 	}
 
 	err = engine.Bot.OrderManager.Cancel(cancel)

--- a/gctscript/wrappers/gct/exchange/exchange_test.go
+++ b/gctscript/wrappers/gct/exchange/exchange_test.go
@@ -139,6 +139,7 @@ func TestExchange_QueryOrder(t *testing.T) {
 	if !configureExchangeKeys() {
 		t.Skip("no exchange configured test skipped")
 	}
+	t.Parallel()
 	_, err := exchangeTest.QueryOrder(exchName, orderID, currency.Pair{}, assetType)
 	if err != nil {
 		t.Fatal(err)
@@ -150,6 +151,7 @@ func TestExchange_SubmitOrder(t *testing.T) {
 		t.Skip("no exchange configured test skipped")
 	}
 
+	t.Parallel()
 	c, err := currency.NewPairDelimiter(pairs, delimiter)
 	if err != nil {
 		t.Fatal(err)
@@ -176,13 +178,17 @@ func TestExchange_CancelOrder(t *testing.T) {
 	if !configureExchangeKeys() {
 		t.Skip("no exchange configured test skipped")
 	}
-	_, err := exchangeTest.CancelOrder(exchName, orderID)
+	t.Parallel()
+	cp := currency.NewPair(currency.BTC, currency.USD)
+	a := asset.Spot
+	_, err := exchangeTest.CancelOrder(exchName, orderID, cp, a)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestOHLCV(t *testing.T) {
+	t.Parallel()
 	cp := currency.NewPair(currency.BTC, currency.AUD)
 	cp.Delimiter = currency.DashDelimiter
 	calvinKline, err := exchangeTest.OHLCV(exchName, cp, assetType, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.OneHour)
@@ -199,7 +205,8 @@ func setupEngine() (err error) {
 	if err != nil {
 		return err
 	}
-	return engine.Bot.Start()
+
+	return engine.Bot.LoadExchange(exchName, false, nil)
 }
 
 func cleanup() {

--- a/gctscript/wrappers/gct/exchange/exchange_test.go
+++ b/gctscript/wrappers/gct/exchange/exchange_test.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/engine"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 )
 
@@ -177,6 +179,18 @@ func TestExchange_CancelOrder(t *testing.T) {
 	_, err := exchangeTest.CancelOrder(exchName, orderID)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestOHLCV(t *testing.T) {
+	cp := currency.NewPair(currency.BTC, currency.AUD)
+	cp.Delimiter = currency.DashDelimiter
+	calvinKline, err := exchangeTest.OHLCV(exchName, cp, assetType, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.OneHour)
+	if err != nil {
+		t.Error(err)
+	}
+	if calvinKline.Exchange != exchName {
+		t.Error("unexpected response")
 	}
 }
 

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -1,14 +1,299 @@
 package gct
 
 import (
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	objects "github.com/d5/tengo/v2"
+	"github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/thrasher-corp/gocryptotrader/engine"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/gctscript/modules"
+	"github.com/thrasher-corp/gocryptotrader/gctscript/modules/gct"
 )
+
+var (
+	bitstampAPIKey     = ""
+	bitstampAPISecret  = ""
+	bitstampCustomerID = ""
+)
+
+func apiKeysSet() bool {
+	return bitstampAPIKey != "" &&
+		bitstampAPISecret != "" &&
+		bitstampCustomerID != ""
+}
 
 func TestSetup(t *testing.T) {
 	x := Setup()
 	xType := reflect.TypeOf(x).String()
 	if xType != "*gct.Wrapper" {
 		t.Fatalf("Setup() should return pointer to Wrapper instead received: %v", x)
+	}
+}
+
+var (
+	exch = &objects.String{
+		Value: "Bitstamp",
+	}
+	exchError = &objects.String{
+		Value: "error",
+	}
+	currencyPair = &objects.String{
+		Value: "BTCUSD",
+	}
+	delimiter = &objects.String{
+		Value: "",
+	}
+	assetType = &objects.String{
+		Value: "SPOT",
+	}
+	orderID = &objects.String{
+		Value: "1235",
+	}
+
+	tv            = objects.TrueValue
+	fv            = objects.FalseValue
+	errTestFailed = errors.New("test failed")
+)
+
+func TestMain(m *testing.M) {
+	settings := engine.Settings{
+		ConfigFile:                  filepath.Join("..", "..", "..", "testdata", "configtest.json"),
+		EnableDryRun:                true,
+		DataDir:                     filepath.Join("..", "..", "..", "testdata", "gocryptotrader"),
+		EnableDepositAddressManager: true,
+	}
+	var err error
+	engine.Bot, err = engine.NewFromSettings(&settings, nil)
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+	err = engine.Bot.Start()
+	bs := engine.Bot.GetExchangeByName(exch.Value)
+	base := bs.GetBase()
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+	if apiKeysSet() {
+		base.API.Credentials.Key = bitstampAPIKey
+		base.API.Credentials.Secret = bitstampAPISecret
+		base.API.Credentials.ClientID = bitstampCustomerID
+		base.API.AuthenticatedSupport = true
+		base.Verbose = true
+	}
+	modules.SetModuleWrapper(Setup())
+	os.Exit(m.Run())
+}
+
+func TestExchangeOrderbook(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeOrderbook(exch, currencyPair, delimiter, assetType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeOrderbook(exchError, currencyPair, delimiter, assetType)
+	if err != nil && errors.Is(err, errTestFailed) {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeOrderbook()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeTicker(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeTicker(exch, currencyPair, delimiter, assetType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeTicker(exchError, currencyPair, delimiter, assetType)
+	if err != nil && errors.Is(err, errTestFailed) {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeTicker()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeExchanges(t *testing.T) {
+	t.Parallel()
+
+	_, err := gct.ExchangeExchanges(tv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeExchanges(exch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeExchanges(fv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeExchanges()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangePairs(t *testing.T) {
+	t.Parallel()
+
+	_, err := gct.ExchangePairs(exch, tv, assetType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangePairs(exchError, tv, assetType)
+	if err != nil && errors.Is(err, errTestFailed) {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangePairs()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+}
+
+func TestAccountInfo(t *testing.T) {
+	t.Parallel()
+
+	_, err := gct.ExchangeAccountInfo()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+	set := apiKeysSet()
+	_, err = gct.ExchangeAccountInfo(exch)
+	if set && err != nil {
+		t.Fatal(err)
+	} else if !set && err != nil &&
+		!strings.Contains(err.Error(), "unset/default API keys") {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeOrderQuery(t *testing.T) {
+	t.Parallel()
+
+	_, err := gct.ExchangeOrderQuery()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeOrderQuery(exch, orderID)
+	if err != nil && err != common.ErrNotYetImplemented {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeOrderCancel(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeOrderCancel()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	_, err = gct.ExchangeOrderCancel(exch, orderID)
+	if err != nil && err != common.ErrNotYetImplemented {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeOrderSubmit(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeOrderSubmit()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	orderSide := &objects.String{Value: "ASK"}
+	orderType := &objects.String{Value: "LIMIT"}
+	orderPrice := &objects.Float{Value: 1}
+	orderAmount := &objects.Float{Value: 1}
+	orderAsset := &objects.String{Value: asset.Spot.String()}
+
+	set := apiKeysSet()
+	_, err = gct.ExchangeOrderSubmit(exch, currencyPair, delimiter,
+		orderType, orderSide, orderPrice, orderAmount, orderID, orderAsset)
+	if set && err != nil {
+		t.Error(err)
+	} else if !set && err != nil &&
+		!strings.Contains(err.Error(), "unset/default API keys") {
+		t.Error(err)
+	}
+}
+
+func TestAllModuleNames(t *testing.T) {
+	t.Parallel()
+	x := gct.AllModuleNames()
+	xType := reflect.TypeOf(x).Kind()
+	if xType != reflect.Slice {
+		t.Fatalf("AllModuleNames() should return slice instead received: %v", x)
+	}
+}
+
+func TestExchangeDepositAddress(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeDepositAddress()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	currCode := &objects.String{Value: "BTC"}
+	_, err = gct.ExchangeDepositAddress(exch, currCode)
+	if err != nil && err.Error() != "deposit address store is nil" {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeWithdrawCrypto(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeWithdrawCrypto()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	currCode := &objects.String{Value: "BTC"}
+	desc := &objects.String{Value: "HELLO"}
+	address := &objects.String{Value: "0xTHISISALEGITBTCADDRESSS"}
+	amount := &objects.Float{Value: 1.0}
+
+	_, err = gct.ExchangeWithdrawCrypto(exch, currCode, address, address, amount, amount, desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExchangeWithdrawFiat(t *testing.T) {
+	t.Parallel()
+	_, err := gct.ExchangeWithdrawFiat()
+	if !errors.Is(err, objects.ErrWrongNumArguments) {
+		t.Fatal(err)
+	}
+
+	currCode := &objects.String{Value: "TEST"}
+	amount := &objects.Float{Value: 1.0}
+	desc := &objects.String{Value: "2"}
+	bankID := &objects.String{Value: "3!"}
+	_, err = gct.ExchangeWithdrawFiat(exch, currCode, desc, amount, bankID)
+	if err != nil && err.Error() != "exchange Bitstamp bank details not found for TEST" {
+		t.Fatal(err)
 	}
 }

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -59,7 +59,7 @@ var (
 		Value: "",
 	}
 	assetType = &objects.String{
-		Value: "SPOT",
+		Value: "spot",
 	}
 	orderID = &objects.String{
 		Value: "1235",
@@ -180,8 +180,7 @@ func TestExchangeOrderCancel(t *testing.T) {
 	if !errors.Is(err, objects.ErrWrongNumArguments) {
 		t.Fatal(err)
 	}
-
-	_, err = gct.ExchangeOrderCancel(exch, orderID)
+	_, err = gct.ExchangeOrderCancel(exch, orderID, currencyPair, assetType)
 	if err != nil && err != common.ErrNotYetImplemented {
 		t.Error(err)
 	}

--- a/gctscript/wrappers/validator/validator.go
+++ b/gctscript/wrappers/validator/validator.go
@@ -174,10 +174,10 @@ func (w Wrapper) CancelOrder(exch, orderid string, cp currency.Pair, a asset.Ite
 	if orderid == "" {
 		return false, errTestFailed
 	}
-	if cp.IsInvalid() {
+	if !cp.IsEmpty() && cp.IsInvalid() {
 		return false, errTestFailed
 	}
-	if !a.IsValid() {
+	if a != "" && !a.IsValid() {
 		return false, errTestFailed
 	}
 	return true, nil

--- a/gctscript/wrappers/validator/validator.go
+++ b/gctscript/wrappers/validator/validator.go
@@ -167,11 +167,20 @@ func (w Wrapper) SubmitOrder(o *order.Submit) (*order.SubmitResponse, error) {
 }
 
 // CancelOrder validator for test execution/scripts
-func (w Wrapper) CancelOrder(exch, orderid string) (bool, error) {
+func (w Wrapper) CancelOrder(exch, orderid string, cp currency.Pair, a asset.Item) (bool, error) {
 	if exch == exchError.String() {
 		return false, errTestFailed
 	}
-	return orderid != "false", nil
+	if orderid == "" {
+		return false, errTestFailed
+	}
+	if cp.IsInvalid() {
+		return false, errTestFailed
+	}
+	if !a.IsValid() {
+		return false, errTestFailed
+	}
+	return true, nil
 }
 
 // AccountInformation validator for test execution/scripts

--- a/gctscript/wrappers/validator/validator_test.go
+++ b/gctscript/wrappers/validator/validator_test.go
@@ -79,27 +79,27 @@ func TestWrapper_CancelOrder(t *testing.T) {
 	cp := currency.NewPair(currency.BTC, currency.USD)
 	_, err := testWrapper.CancelOrder(exchName, orderID, cp, assetType)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	_, err = testWrapper.CancelOrder(exchError.String(), orderID, cp, assetType)
 	if err == nil {
-		t.Fatal("expected CancelOrder to return error on invalid name")
+		t.Error("expected CancelOrder to return error on invalid name")
 	}
 
 	_, err = testWrapper.CancelOrder(exchName, "", cp, assetType)
 	if err == nil {
-		t.Fatal("expected CancelOrder to return error on invalid name")
+		t.Error("expected CancelOrder to return error on invalid name")
 	}
 
 	_, err = testWrapper.CancelOrder(exchName, orderID, currency.Pair{}, assetType)
-	if err == nil {
-		t.Fatal("expected CancelOrder to return error on invalid name")
+	if err != nil {
+		t.Error(err)
 	}
 
 	_, err = testWrapper.CancelOrder(exchName, orderID, cp, "")
-	if err == nil {
-		t.Fatal("expected CancelOrder to return error on invalid name")
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/gctscript/wrappers/validator/validator_test.go
+++ b/gctscript/wrappers/validator/validator_test.go
@@ -76,13 +76,28 @@ func TestWrapper_AccountInformation(t *testing.T) {
 
 func TestWrapper_CancelOrder(t *testing.T) {
 	t.Parallel()
-
-	_, err := testWrapper.CancelOrder(exchName, orderID)
+	cp := currency.NewPair(currency.BTC, currency.USD)
+	_, err := testWrapper.CancelOrder(exchName, orderID, cp, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.CancelOrder(exchError.String(), "")
+	_, err = testWrapper.CancelOrder(exchError.String(), orderID, cp, assetType)
+	if err == nil {
+		t.Fatal("expected CancelOrder to return error on invalid name")
+	}
+
+	_, err = testWrapper.CancelOrder(exchName, "", cp, assetType)
+	if err == nil {
+		t.Fatal("expected CancelOrder to return error on invalid name")
+	}
+
+	_, err = testWrapper.CancelOrder(exchName, orderID, currency.Pair{}, assetType)
+	if err == nil {
+		t.Fatal("expected CancelOrder to return error on invalid name")
+	}
+
+	_, err = testWrapper.CancelOrder(exchName, orderID, cp, "")
 	if err == nil {
 		t.Fatal("expected CancelOrder to return error on invalid name")
 	}

--- a/gctscript/wrappers/validator/validator_types.go
+++ b/gctscript/wrappers/validator/validator_types.go
@@ -12,7 +12,7 @@ var (
 	IsTestExecution atomic.Value
 
 	exchError = &objects.String{
-		Value: "error",
+		Value: "",
 	}
 	errTestFailed = errors.New("test failed")
 )


### PR DESCRIPTION
# PR Description
Our Slack community member "ed" discovered a bug when attempting to execute scripted trading:
![image](https://user-images.githubusercontent.com/9261323/97123364-9dc2b200-177f-11eb-88b7-e998527dd35c.png)

When attempting to submit or cancel orders via scripting, gctscript would error out because the exchange name was unset. This PR sets it. 

Since this area of code was untested against a real interface, I've added tests to ensure that these kind of errors would surface Just double checking this part. Fixed a few other things I noticed too.

Update: This PR also updates the script implementation of cancel order to include currency pair and asset type. It also adds the ability for the bot ordermanager to retrieve orders on an exchange's behalf. This will allow us to store any order retrieved via command so that we will not get any order not founds when cancelling orders via script

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested
Added new tests in `gctwrapper_test.go`, and `exchange_test.go` to expand coverage and test our logic without immediately passing.

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
