### PR TITLE
Added MarketType field in MarketInfo of bitflyer

### DIFF
--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -93,9 +93,17 @@ func TestGetAddressInfoCA(t *testing.T) {
 
 func TestGetMarkets(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarkets()
+	markets, err := b.GetMarkets()
 	if err != nil {
 		t.Error("Bitflyer - GetMarkets() error:", err)
+	}
+	for _, market := range markets {
+		if market.ProductCode == "" {
+			t.Error("Bitflyer - ProductCode is empty in GetMarkets()")
+		}
+		if market.MarketType == "" {
+			t.Error("Bitflyer - MarketType is empty in GetMarkets()")
+		}
 	}
 }
 

--- a/exchanges/bitflyer/bitflyer_types.go
+++ b/exchanges/bitflyer/bitflyer_types.go
@@ -52,6 +52,7 @@ type ChainAnalysisAddress struct {
 type MarketInfo struct {
 	ProductCode string `json:"product_code"`
 	Alias       string `json:"alias"`
+	MarketType  string `json:"market_type"`
 }
 
 // Orderbook holds orderbook information


### PR DESCRIPTION
# PR Description

Added MarketType field in MarketInfo of bitflyer.
Before this, struct MarketInfo of bitflyer contained only ProductCode and Alias. But it seems insufficient, see the definition of the endpoint ```/v1/getmarkets```; https://lightning.bitflyer.com/docs?lang=en#market-list

In case that this MarketType field is absent, you can't distinguish futures valid or expired on SQdate.
Here is an response example below on SQdate (I requested on 6, Nov 2020). You can find BTCJPY06NOV2020 expiring futures doesn't have Alias field but MarketType, and the other futures have both yet.
Namely Alias field is not mandatory but MarketType is. So I added.

```
[
    {
        "product_code": "BTC_JPY",
        "market_type": "Spot"
    },
    {
        "product_code": "FX_BTC_JPY",
        "market_type": "FX"
    },
    {
        "product_code": "ETH_BTC",
        "market_type": "Spot"
    },
    {
        "product_code": "BCH_BTC",
        "market_type": "Spot"
    },
    {
        "product_code": "ETH_JPY",
        "market_type": "Spot"
    },
    {
        "product_code": "BTCJPY25DEC2020",
        "alias": "BTCJPY_MAT3M",
        "market_type": "Futures"
    },
    {
        "product_code": "BTCJPY06NOV2020",
        "market_type": "Futures"
    },
    {
        "product_code": "BTCJPY13NOV2020",
        "alias": "BTCJPY_MAT1WK",
        "market_type": "Futures"
    },
    {
        "product_code": "BTCJPY20NOV2020",
        "alias": "BTCJPY_MAT2WK",
        "market_type": "Futures"
    }
]
```

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

ProductCode and MarketType fields in MarketInfo are mandatory. so I added tests in ```TestGetMarkets```

- [x] go test ./... -race

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
