### PR TITLE
script: remove rounding from scripting TA

### DIFF
--- a/gctscript/modules/ta/indicators/atr.go
+++ b/gctscript/modules/ta/indicators/atr.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -87,7 +86,7 @@ func atr(args ...objects.Object) (objects.Object, error) {
 	r.Period = inTimePeriod
 	ret := indicators.ATR(ohlcvData[2], ohlcvData[3], ohlcvData[4], inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil

--- a/gctscript/modules/ta/indicators/bbands.go
+++ b/gctscript/modules/ta/indicators/bbands.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -125,12 +124,12 @@ func bbands(args ...objects.Object) (objects.Object, error) {
 	retUpper, retMiddle, retLower := indicators.BBANDS(ohlcvData[selector], inTimePeriod, inNbDevDn, inNbDevDn, MAType)
 	for x := range retMiddle {
 		temp := &objects.Array{}
-		temp.Value = append(temp.Value, &objects.Float{Value: math.Round(retMiddle[x]*100) / 100})
+		temp.Value = append(temp.Value, &objects.Float{Value: retMiddle[x]})
 		if retUpper != nil {
-			temp.Value = append(temp.Value, &objects.Float{Value: math.Round(retUpper[x]*100) / 100})
+			temp.Value = append(temp.Value, &objects.Float{Value: retUpper[x]})
 		}
 		if retLower != nil {
-			temp.Value = append(temp.Value, &objects.Float{Value: math.Round(retLower[x]*100) / 100})
+			temp.Value = append(temp.Value, &objects.Float{Value: retLower[x]})
 		}
 		r.Value = append(r.Value, temp)
 	}

--- a/gctscript/modules/ta/indicators/correlation.go
+++ b/gctscript/modules/ta/indicators/correlation.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -84,7 +83,7 @@ func correlationCoefficient(args ...objects.Object) (objects.Object, error) {
 
 	ret := indicators.CorrelationCoefficient(closures1, closures2, inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil

--- a/gctscript/modules/ta/indicators/ema.go
+++ b/gctscript/modules/ta/indicators/ema.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -72,7 +71,7 @@ func ema(args ...objects.Object) (objects.Object, error) {
 
 	ret := indicators.EMA(ohlcvClose, inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil

--- a/gctscript/modules/ta/indicators/macd.go
+++ b/gctscript/modules/ta/indicators/macd.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -85,12 +84,12 @@ func macd(args ...objects.Object) (objects.Object, error) {
 	macd, macdSignal, macdHist := indicators.MACD(ohlcvClose, inFastPeriod, inSlowPeriod, inTimePeriod)
 	for x := range macdHist {
 		tempMACD := &objects.Array{}
-		tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: math.Round(macdHist[x]*100) / 100})
+		tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: macdHist[x]})
 		if macd != nil {
-			tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: math.Round(macd[x]*100) / 100})
+			tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: macd[x]})
 		}
 		if macdSignal != nil {
-			tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: math.Round(macdSignal[x]*100) / 100})
+			tempMACD.Value = append(tempMACD.Value, &objects.Float{Value: macdSignal[x]})
 		}
 		r.Value = append(r.Value, tempMACD)
 	}

--- a/gctscript/modules/ta/indicators/mfi.go
+++ b/gctscript/modules/ta/indicators/mfi.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -87,7 +86,7 @@ func mfi(args ...objects.Object) (objects.Object, error) {
 
 	ret := indicators.MFI(ohlcvData[2], ohlcvData[3], ohlcvData[4], ohlcvData[5], inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil

--- a/gctscript/modules/ta/indicators/obv.go
+++ b/gctscript/modules/ta/indicators/obv.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -81,7 +80,7 @@ func obv(args ...objects.Object) (objects.Object, error) {
 
 	ret := indicators.OBV(ohlcvData[4], ohlcvData[5])
 	for x := range ret {
-		temp := &objects.Float{Value: math.Round(ret[x]*100) / 100}
+		temp := &objects.Float{Value: ret[x]}
 		r.Value = append(r.Value, temp)
 	}
 	return r, nil

--- a/gctscript/modules/ta/indicators/rsi.go
+++ b/gctscript/modules/ta/indicators/rsi.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -71,7 +70,7 @@ func rsi(args ...objects.Object) (objects.Object, error) {
 	r.Period = inTimePeriod
 	ret := indicators.RSI(ohlcvClose, inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil

--- a/gctscript/modules/ta/indicators/sma.go
+++ b/gctscript/modules/ta/indicators/sma.go
@@ -3,7 +3,6 @@ package indicators
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	objects "github.com/d5/tengo/v2"
@@ -69,7 +68,7 @@ func sma(args ...objects.Object) (objects.Object, error) {
 	r.Period = inTimePeriod
 	ret := indicators.SMA(ohlcvClose, inTimePeriod)
 	for x := range ret {
-		r.Value = append(r.Value, &objects.Float{Value: math.Round(ret[x]*100) / 100})
+		r.Value = append(r.Value, &objects.Float{Value: ret[x]})
 	}
 
 	return r, nil


### PR DESCRIPTION
# PR Description

An issue was brought up by Ed via our Slack. Due to small decimals, we are not getting the correct output when running TA scripts. 
This attempts to address this issue by removing the rounding of outbound float64's inside the script package. 


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules
