### PR TITLE
engine/gRPC: Add update account info to grpc interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ CRON = $(TRAVIS_EVENT_TYPE)
 DRIVER ?= psql
 RACE_FLAG := $(if $(NO_RACE_TEST),,-race)
 
+.PHONY: get linter check test build install update_deps
+
+all: check build
+
 get:
 	GO111MODULE=on go get $(GCTPKG)
 

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -831,6 +831,55 @@ func getAccountInfoStream(c *cli.Context) error {
 	}
 }
 
+var updateAccountInfoCommand = cli.Command{
+	Name:      "updateaccountinfo",
+	Usage:     "updates the exchange account balance info",
+	ArgsUsage: "<exchange>",
+	Action:    updateAccountInfo,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "exchange",
+			Usage: "the exchange to get the account info for",
+		},
+	},
+}
+
+func updateAccountInfo(c *cli.Context) error {
+	if c.NArg() == 0 && c.NumFlags() == 0 {
+		return cli.ShowCommandHelp(c, "updateaccountinfo")
+	}
+
+	var exchange string
+	if c.IsSet("exchange") {
+		exchange = c.String("exchange")
+	} else {
+		exchange = c.Args().First()
+	}
+
+	if !validExchange(exchange) {
+		return errInvalidExchange
+	}
+
+	conn, err := setupClient()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := gctrpc.NewGoCryptoTraderClient(conn)
+	result, err := client.UpdateAccountInfo(context.Background(),
+		&gctrpc.GetAccountInfoRequest{
+			Exchange: exchange,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	jsonOutput(result)
+	return nil
+}
+
 var getConfigCommand = cli.Command{
 	Name:   "getconfig",
 	Usage:  "gets the config",

--- a/cmd/gctcli/main.go
+++ b/cmd/gctcli/main.go
@@ -109,6 +109,7 @@ func main() {
 		getOrderbooksCommand,
 		getAccountInfoCommand,
 		getAccountInfoStreamCommand,
+		updateAccountInfoCommand,
 		getConfigCommand,
 		getPortfolioCommand,
 		getPortfolioSummaryCommand,

--- a/engine/fake_exchange_test.go
+++ b/engine/fake_exchange_test.go
@@ -27,6 +27,8 @@ const (
 // the engine package
 type FakePassingExchange struct {
 	exchange.Base
+
+	Holdings account.Holdings
 }
 
 // addPassingFakeExchange adds an exchange to engine tests where all funcs return a positive result
@@ -60,6 +62,10 @@ func addPassingFakeExchange(baseExchangeName string) error {
 			Websocket:                     base.Websocket,
 			Requester:                     base.Requester,
 			Config:                        base.Config,
+		},
+		Holdings: account.Holdings{
+			Exchange: fakePassExchange,
+			Accounts: []account.SubAccount{},
 		},
 	})
 	return nil
@@ -96,13 +102,23 @@ func (h *FakePassingExchange) GetEnabledPairs(_ asset.Item) (currency.Pairs, err
 func (h *FakePassingExchange) GetAvailablePairs(_ asset.Item) (currency.Pairs, error) {
 	return currency.Pairs{}, nil
 }
+
 func (h *FakePassingExchange) FetchAccountInfo() (account.Holdings, error) {
-	return account.Holdings{}, nil
+	acc, err := account.GetHoldings(h.Name)
+	if err != nil {
+		return h.UpdateAccountInfo()
+	}
+
+	return acc, nil
 }
 
 func (h *FakePassingExchange) UpdateAccountInfo() (account.Holdings, error) {
-	return account.Holdings{}, nil
+	if err := account.Process(&h.Holdings); err != nil {
+		return account.Holdings{}, err
+	}
+	return h.Holdings, nil
 }
+
 func (h *FakePassingExchange) GetAuthenticatedAPISupport(_ uint8) bool { return true }
 func (h *FakePassingExchange) SetPairs(_ currency.Pairs, _ asset.Item, _ bool) error {
 	return nil

--- a/engine/fake_exchange_test.go
+++ b/engine/fake_exchange_test.go
@@ -27,8 +27,6 @@ const (
 // the engine package
 type FakePassingExchange struct {
 	exchange.Base
-
-	Holdings account.Holdings
 }
 
 // addPassingFakeExchange adds an exchange to engine tests where all funcs return a positive result
@@ -62,10 +60,6 @@ func addPassingFakeExchange(baseExchangeName string) error {
 			Websocket:                     base.Websocket,
 			Requester:                     base.Requester,
 			Config:                        base.Config,
-		},
-		Holdings: account.Holdings{
-			Exchange: fakePassExchange,
-			Accounts: []account.SubAccount{},
 		},
 	})
 	return nil
@@ -104,19 +98,37 @@ func (h *FakePassingExchange) GetAvailablePairs(_ asset.Item) (currency.Pairs, e
 }
 
 func (h *FakePassingExchange) FetchAccountInfo() (account.Holdings, error) {
-	acc, err := account.GetHoldings(h.Name)
-	if err != nil {
-		return h.UpdateAccountInfo()
-	}
-
-	return acc, nil
+	return account.Holdings{
+		Exchange: h.Name,
+		Accounts: []account.SubAccount{
+			{
+				Currencies: []account.Balance{
+					{
+						CurrencyName: currency.BTC,
+						TotalValue:   10.,
+						Hold:         0,
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 func (h *FakePassingExchange) UpdateAccountInfo() (account.Holdings, error) {
-	if err := account.Process(&h.Holdings); err != nil {
-		return account.Holdings{}, err
-	}
-	return h.Holdings, nil
+	return account.Holdings{
+		Exchange: h.Name,
+		Accounts: []account.SubAccount{
+			{
+				Currencies: []account.Balance{
+					{
+						CurrencyName: currency.BTC,
+						TotalValue:   20.,
+						Hold:         0,
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 func (h *FakePassingExchange) GetAuthenticatedAPISupport(_ uint8) bool { return true }

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -524,6 +524,21 @@ func (s *RPCServer) GetAccountInfo(_ context.Context, r *gctrpc.GetAccountInfoRe
 	return &gctrpc.GetAccountInfoResponse{Exchange: r.Exchange, Accounts: accounts}, nil
 }
 
+// UpdateAccountInfo forces an update of the account info
+func (s *RPCServer) UpdateAccountInfo(ctx context.Context, r *gctrpc.GetAccountInfoRequest) (*gctrpc.GetAccountInfoResponse, error) {
+	exch := s.GetExchangeByName(r.Exchange)
+	if exch == nil {
+		return nil, errExchangeNotLoaded
+	}
+
+	_, err := exch.UpdateAccountInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetAccountInfo(ctx, r)
+}
+
 // GetAccountInfoStream streams an account balance for a specific exchange
 func (s *RPCServer) GetAccountInfoStream(r *gctrpc.GetAccountInfoRequest, stream gctrpc.GoCryptoTrader_GetAccountInfoStreamServer) error {
 	if r.Exchange == "" {
@@ -2843,7 +2858,6 @@ func (s *RPCServer) GetHistoricTrades(r *gctrpc.GetSavedTradesRequest, stream gc
 	if err != nil {
 		return err
 	}
-
 	resp := &gctrpc.SavedTradesResponse{
 		ExchangeName: r.Exchange,
 		Asset:        r.AssetType,

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -795,8 +795,7 @@ func TestGetAccountInfo(t *testing.T) {
 
 	r, err := s.GetAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakePassExchange})
 	if err != nil {
-		t.Errorf("TestGetAccountInfo: Failed to get account info: %w", err)
-		return
+		t.Fatalf("TestGetAccountInfo: Failed to get account info: %s", err)
 	}
 
 	validateAccountInfoResponse(t, r, accounts)
@@ -811,8 +810,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		r, err := s.GetAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakePassExchange})
 		if err != nil {
-			t.Errorf("TestGetAccountInfo: Failed to get account info: %w", err)
-			return
+			t.Fatalf("TestGetAccountInfo: Failed to get account info: %s", err)
 		}
 		validateAccountInfoResponse(t, r, accounts)
 	}
@@ -831,8 +829,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 
 	testExchange, ok := bot.GetExchangeByName(fakePassExchange).(*FakePassingExchange)
 	if testExchange == nil || !ok {
-		t.Errorf("TestGetAccountInfo: Failed to get test exchange: %s", fakePassExchange)
-		return
+		t.Fatalf("TestGetAccountInfo: Failed to get test exchange: %s", fakePassExchange)
 	}
 
 	testExchange.Holdings = account.Holdings{
@@ -842,14 +839,12 @@ func TestUpdateAccountInfo(t *testing.T) {
 
 	_, err := s.UpdateAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakePassExchange})
 	if err != nil {
-		t.Errorf("TestGetAccountInfo: Failed to update account info: %w", err)
-		return
+		t.Fatalf("TestGetAccountInfo: Failed to update account info: %s", err)
 	}
 
 	r, err := s.GetAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakePassExchange})
 	if err != nil {
-		t.Errorf("TestGetAccountInfo: Failed to get account info: %w", err)
-		return
+		t.Fatalf("TestGetAccountInfo: Failed to get account info: %s", err)
 	}
 
 	validateAccountInfoResponse(t, r, newAccounts)
@@ -872,21 +867,18 @@ func refreshAccounts(t *testing.T) []account.SubAccount {
 		Accounts: accounts,
 	})
 	if err != nil {
-		t.Errorf("TestGetAccountInfo: Failed to process account with holdings: %w", err)
-		return nil
+		t.Fatalf("TestGetAccountInfo: Failed to process account with holdings: %s", err)
 	}
 	return accounts
 }
 
 func validateAccountInfoResponse(t *testing.T, r *gctrpc.GetAccountInfoResponse, accounts []account.SubAccount) {
 	if r.Exchange != fakePassExchange {
-		t.Errorf("TestGetAccountInfo: Unexpected exchange in the response: exp=%s, act=%s", fakePassExchange, r.Exchange)
-		return
+		t.Fatalf("TestGetAccountInfo: Unexpected exchange in the response: exp=%s, act=%s", fakePassExchange, r.Exchange)
 	}
 
 	if len(r.Accounts) != len(accounts) {
-		t.Errorf("TestGetAccountInfo: Unexpected size of accounts in the response: exp=%v, act=%v", len(accounts), len(r.Accounts))
-		return
+		t.Fatalf("TestGetAccountInfo: Unexpected size of accounts in the response: exp=%v, act=%v", len(accounts), len(r.Accounts))
 	}
 
 	cmpAccounts(t, accounts, r.Accounts)
@@ -894,25 +886,22 @@ func validateAccountInfoResponse(t *testing.T, r *gctrpc.GetAccountInfoResponse,
 
 func cmpAccounts(t *testing.T, exp []account.SubAccount, act []*gctrpc.Account) {
 	if len(act) != len(exp) {
-		t.Errorf("TestGetAccountInfo: Unexpected number of accouns in the response: exp=%d, act=%d", len(exp), len(act))
-		return
+		t.Fatalf("TestGetAccountInfo: Unexpected number of accouns in the response: exp=%d, act=%d", len(exp), len(act))
 	}
 	if act[0].Currencies[0].Currency != exp[0].Currencies[0].CurrencyName.String() {
-		t.Errorf("TestGetAccountInfo: Unexpected value of the 'CurrencyName': exp=%v, act=%v",
+		t.Fatalf("TestGetAccountInfo: Unexpected value of the 'CurrencyName': exp=%v, act=%v",
 			exp[0].Currencies[0].CurrencyName.String(),
 			act[0].Currencies[0].Currency,
 		)
-		return
 	}
 	if act[0].Currencies[0].TotalValue != exp[0].Currencies[0].TotalValue {
-		t.Errorf("TestGetAccountInfo: Unexpected value of the 'TotalValue': exp=%v, act=%v",
+		t.Fatalf("TestGetAccountInfo: Unexpected value of the 'TotalValue': exp=%v, act=%v",
 			exp[0].Currencies[0].TotalValue,
 			act[0].Currencies[0].TotalValue,
 		)
-		return
 	}
 	if act[0].Currencies[0].Hold != exp[0].Currencies[0].Hold {
-		t.Errorf("TestGetAccountInfo: Unexpected value of the 'Hold': exp=%v, act=%v",
+		t.Fatalf("TestGetAccountInfo: Unexpected value of the 'Hold': exp=%v, act=%v",
 			exp[0].Currencies[0].Hold,
 			act[0].Currencies[0].Hold,
 		)

--- a/exchanges/lbank/lbank_types.go
+++ b/exchanges/lbank/lbank_types.go
@@ -26,9 +26,9 @@ type TickerResponse struct {
 // MarketDepthResponse stores arrays for asks, bids and a timestamp for a currecy pair
 type MarketDepthResponse struct {
 	ErrCapture `json:",omitempty"`
-	Asks       [][]float64 `json:"asks"`
-	Bids       [][]float64 `json:"bids"`
-	Timestamp  int64       `json:"timestamp"`
+	Asks       [][]string `json:"asks"`
+	Bids       [][]string `json:"bids"`
+	Timestamp  int64      `json:"timestamp"`
 }
 
 // TradeResponse stores date_ms, amount, price, type, tid for a currency pair

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -248,19 +248,38 @@ func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 	if err != nil {
 		return nil, err
 	}
+
 	a, err := l.GetMarketDepths(fpair.String(), "60", "1")
 	if err != nil {
 		return orderBook, err
 	}
 	for i := range a.Asks {
+		price, err := strconv.ParseFloat(a.Asks[i][0], 64)
+		if err != nil {
+			return orderBook, err
+		}
+		amount, err := strconv.ParseFloat(a.Asks[i][1], 64)
+		if err != nil {
+			return orderBook, err
+		}
 		orderBook.Asks = append(orderBook.Asks, orderbook.Item{
-			Price:  a.Asks[i][0],
-			Amount: a.Asks[i][1]})
+			Price:  price,
+			Amount: amount,
+		})
 	}
 	for i := range a.Bids {
+		price, err := strconv.ParseFloat(a.Bids[i][0], 64)
+		if err != nil {
+			return orderBook, err
+		}
+		amount, err := strconv.ParseFloat(a.Bids[i][1], 64)
+		if err != nil {
+			return orderBook, err
+		}
 		orderBook.Bids = append(orderBook.Bids, orderbook.Item{
-			Price:  a.Bids[i][0],
-			Amount: a.Bids[i][1]})
+			Price:  price,
+			Amount: amount,
+		})
 	}
 	orderBook.Pair = p
 	orderBook.ExchangeName = l.Name

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -254,13 +254,13 @@ func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 		return orderBook, err
 	}
 	for i := range a.Asks {
-		price, err := strconv.ParseFloat(a.Asks[i][0], 64)
-		if err != nil {
-			return orderBook, err
+		price, convErr := strconv.ParseFloat(a.Asks[i][0], 64)
+		if convErr != nil {
+			return orderBook, convErr
 		}
-		amount, err := strconv.ParseFloat(a.Asks[i][1], 64)
-		if err != nil {
-			return orderBook, err
+		amount, convErr := strconv.ParseFloat(a.Asks[i][1], 64)
+		if convErr != nil {
+			return orderBook, convErr
 		}
 		orderBook.Asks = append(orderBook.Asks, orderbook.Item{
 			Price:  price,
@@ -268,13 +268,13 @@ func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 		})
 	}
 	for i := range a.Bids {
-		price, err := strconv.ParseFloat(a.Bids[i][0], 64)
-		if err != nil {
-			return orderBook, err
+		price, convErr := strconv.ParseFloat(a.Bids[i][0], 64)
+		if convErr != nil {
+			return orderBook, convErr
 		}
-		amount, err := strconv.ParseFloat(a.Bids[i][1], 64)
-		if err != nil {
-			return orderBook, err
+		amount, convErr := strconv.ParseFloat(a.Bids[i][1], 64)
+		if convErr != nil {
+			return orderBook, convErr
 		}
 		orderBook.Bids = append(orderBook.Bids, orderbook.Item{
 			Price:  price,

--- a/gctrpc/rpc.pb.go
+++ b/gctrpc/rpc.pb.go
@@ -10268,7 +10268,7 @@ var file_rpc_proto_rawDesc = []byte{
 	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x63, 0x68, 0x61,
 	0x6e, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x63, 0x68, 0x61,
 	0x6e, 0x67, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x08, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x32, 0x9d, 0x47, 0x0a, 0x0e,
+	0x01, 0x28, 0x08, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x32, 0x90, 0x48, 0x0a, 0x0e,
 	0x47, 0x6f, 0x43, 0x72, 0x79, 0x70, 0x74, 0x6f, 0x54, 0x72, 0x61, 0x64, 0x65, 0x72, 0x12, 0x4f,
 	0x0a, 0x07, 0x47, 0x65, 0x74, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x16, 0x2e, 0x67, 0x63, 0x74, 0x72,
 	0x70, 0x63, 0x2e, 0x47, 0x65, 0x74, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
@@ -10838,11 +10838,18 @@ var file_rpc_proto_rawDesc = []byte{
 	0x72, 0x70, 0x63, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x52, 0x65, 0x73, 0x70, 0x6f,
 	0x6e, 0x73, 0x65, 0x22, 0x26, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x20, 0x12, 0x1e, 0x2f, 0x76, 0x31,
 	0x2f, 0x73, 0x65, 0x74, 0x65, 0x78, 0x63, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x74, 0x72, 0x61, 0x64,
-	0x65, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x69, 0x6e, 0x67, 0x42, 0x30, 0x5a, 0x2e, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x68, 0x72, 0x61, 0x73, 0x68,
-	0x65, 0x72, 0x2d, 0x63, 0x6f, 0x72, 0x70, 0x2f, 0x67, 0x6f, 0x63, 0x72, 0x79, 0x70, 0x74, 0x6f,
-	0x74, 0x72, 0x61, 0x64, 0x65, 0x72, 0x2f, 0x67, 0x63, 0x74, 0x72, 0x70, 0x63, 0x62, 0x06, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x65, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x69, 0x6e, 0x67, 0x12, 0x71, 0x0a, 0x11, 0x55,
+	0x70, 0x64, 0x61, 0x74, 0x65, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x49, 0x6e, 0x66, 0x6f,
+	0x12, 0x1d, 0x2e, 0x67, 0x63, 0x74, 0x72, 0x70, 0x63, 0x2e, 0x47, 0x65, 0x74, 0x41, 0x63, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
+	0x1e, 0x2e, 0x67, 0x63, 0x74, 0x72, 0x70, 0x63, 0x2e, 0x47, 0x65, 0x74, 0x41, 0x63, 0x63, 0x6f,
+	0x75, 0x6e, 0x74, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x1d, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x17, 0x12, 0x15, 0x2f, 0x76, 0x31, 0x2f, 0x75, 0x70, 0x64,
+	0x61, 0x74, 0x65, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x69, 0x6e, 0x66, 0x6f, 0x42, 0x30,
+	0x5a, 0x2e, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x68, 0x72,
+	0x61, 0x73, 0x68, 0x65, 0x72, 0x2d, 0x63, 0x6f, 0x72, 0x70, 0x2f, 0x67, 0x6f, 0x63, 0x72, 0x79,
+	0x70, 0x74, 0x6f, 0x74, 0x72, 0x61, 0x64, 0x65, 0x72, 0x2f, 0x67, 0x63, 0x74, 0x72, 0x70, 0x63,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -11188,86 +11195,88 @@ var file_rpc_proto_depIdxs = []int32{
 	141, // 162: gctrpc.GoCryptoTrader.FindMissingSavedCandleIntervals:input_type -> gctrpc.FindMissingCandlePeriodsRequest
 	142, // 163: gctrpc.GoCryptoTrader.FindMissingSavedTradeIntervals:input_type -> gctrpc.FindMissingTradePeriodsRequest
 	144, // 164: gctrpc.GoCryptoTrader.SetExchangeTradeProcessing:input_type -> gctrpc.SetExchangeTradeProcessingRequest
-	1,   // 165: gctrpc.GoCryptoTrader.GetInfo:output_type -> gctrpc.GetInfoResponse
-	7,   // 166: gctrpc.GoCryptoTrader.GetSubsystems:output_type -> gctrpc.GetSusbsytemsResponse
-	127, // 167: gctrpc.GoCryptoTrader.EnableSubsystem:output_type -> gctrpc.GenericResponse
-	127, // 168: gctrpc.GoCryptoTrader.DisableSubsystem:output_type -> gctrpc.GenericResponse
-	10,  // 169: gctrpc.GoCryptoTrader.GetRPCEndpoints:output_type -> gctrpc.GetRPCEndpointsResponse
-	4,   // 170: gctrpc.GoCryptoTrader.GetCommunicationRelayers:output_type -> gctrpc.GetCommunicationRelayersResponse
-	13,  // 171: gctrpc.GoCryptoTrader.GetExchanges:output_type -> gctrpc.GetExchangesResponse
-	127, // 172: gctrpc.GoCryptoTrader.DisableExchange:output_type -> gctrpc.GenericResponse
-	19,  // 173: gctrpc.GoCryptoTrader.GetExchangeInfo:output_type -> gctrpc.GetExchangeInfoResponse
-	14,  // 174: gctrpc.GoCryptoTrader.GetExchangeOTPCode:output_type -> gctrpc.GetExchangeOTPReponse
-	16,  // 175: gctrpc.GoCryptoTrader.GetExchangeOTPCodes:output_type -> gctrpc.GetExchangeOTPsResponse
-	127, // 176: gctrpc.GoCryptoTrader.EnableExchange:output_type -> gctrpc.GenericResponse
-	22,  // 177: gctrpc.GoCryptoTrader.GetTicker:output_type -> gctrpc.TickerResponse
-	25,  // 178: gctrpc.GoCryptoTrader.GetTickers:output_type -> gctrpc.GetTickersResponse
-	28,  // 179: gctrpc.GoCryptoTrader.GetOrderbook:output_type -> gctrpc.OrderbookResponse
-	31,  // 180: gctrpc.GoCryptoTrader.GetOrderbooks:output_type -> gctrpc.GetOrderbooksResponse
-	35,  // 181: gctrpc.GoCryptoTrader.GetAccountInfo:output_type -> gctrpc.GetAccountInfoResponse
-	35,  // 182: gctrpc.GoCryptoTrader.GetAccountInfoStream:output_type -> gctrpc.GetAccountInfoResponse
-	37,  // 183: gctrpc.GoCryptoTrader.GetConfig:output_type -> gctrpc.GetConfigResponse
-	40,  // 184: gctrpc.GoCryptoTrader.GetPortfolio:output_type -> gctrpc.GetPortfolioResponse
-	47,  // 185: gctrpc.GoCryptoTrader.GetPortfolioSummary:output_type -> gctrpc.GetPortfolioSummaryResponse
-	127, // 186: gctrpc.GoCryptoTrader.AddPortfolioAddress:output_type -> gctrpc.GenericResponse
-	127, // 187: gctrpc.GoCryptoTrader.RemovePortfolioAddress:output_type -> gctrpc.GenericResponse
-	52,  // 188: gctrpc.GoCryptoTrader.GetForexProviders:output_type -> gctrpc.GetForexProvidersResponse
-	55,  // 189: gctrpc.GoCryptoTrader.GetForexRates:output_type -> gctrpc.GetForexRatesResponse
-	59,  // 190: gctrpc.GoCryptoTrader.GetOrders:output_type -> gctrpc.GetOrdersResponse
-	56,  // 191: gctrpc.GoCryptoTrader.GetOrder:output_type -> gctrpc.OrderDetails
-	63,  // 192: gctrpc.GoCryptoTrader.SubmitOrder:output_type -> gctrpc.SubmitOrderResponse
-	65,  // 193: gctrpc.GoCryptoTrader.SimulateOrder:output_type -> gctrpc.SimulateOrderResponse
-	65,  // 194: gctrpc.GoCryptoTrader.WhaleBomb:output_type -> gctrpc.SimulateOrderResponse
-	127, // 195: gctrpc.GoCryptoTrader.CancelOrder:output_type -> gctrpc.GenericResponse
-	69,  // 196: gctrpc.GoCryptoTrader.CancelBatchOrders:output_type -> gctrpc.CancelBatchOrdersResponse
-	71,  // 197: gctrpc.GoCryptoTrader.CancelAllOrders:output_type -> gctrpc.CancelAllOrdersResponse
-	74,  // 198: gctrpc.GoCryptoTrader.GetEvents:output_type -> gctrpc.GetEventsResponse
-	76,  // 199: gctrpc.GoCryptoTrader.AddEvent:output_type -> gctrpc.AddEventResponse
-	127, // 200: gctrpc.GoCryptoTrader.RemoveEvent:output_type -> gctrpc.GenericResponse
-	79,  // 201: gctrpc.GoCryptoTrader.GetCryptocurrencyDepositAddresses:output_type -> gctrpc.GetCryptocurrencyDepositAddressesResponse
-	81,  // 202: gctrpc.GoCryptoTrader.GetCryptocurrencyDepositAddress:output_type -> gctrpc.GetCryptocurrencyDepositAddressResponse
-	84,  // 203: gctrpc.GoCryptoTrader.WithdrawFiatFunds:output_type -> gctrpc.WithdrawResponse
-	84,  // 204: gctrpc.GoCryptoTrader.WithdrawCryptocurrencyFunds:output_type -> gctrpc.WithdrawResponse
-	86,  // 205: gctrpc.GoCryptoTrader.WithdrawalEventByID:output_type -> gctrpc.WithdrawalEventByIDResponse
-	89,  // 206: gctrpc.GoCryptoTrader.WithdrawalEventsByExchange:output_type -> gctrpc.WithdrawalEventsByExchangeResponse
-	89,  // 207: gctrpc.GoCryptoTrader.WithdrawalEventsByDate:output_type -> gctrpc.WithdrawalEventsByExchangeResponse
-	96,  // 208: gctrpc.GoCryptoTrader.GetLoggerDetails:output_type -> gctrpc.GetLoggerDetailsResponse
-	96,  // 209: gctrpc.GoCryptoTrader.SetLoggerDetails:output_type -> gctrpc.GetLoggerDetailsResponse
-	99,  // 210: gctrpc.GoCryptoTrader.GetExchangePairs:output_type -> gctrpc.GetExchangePairsResponse
-	127, // 211: gctrpc.GoCryptoTrader.SetExchangePair:output_type -> gctrpc.GenericResponse
-	28,  // 212: gctrpc.GoCryptoTrader.GetOrderbookStream:output_type -> gctrpc.OrderbookResponse
-	28,  // 213: gctrpc.GoCryptoTrader.GetExchangeOrderbookStream:output_type -> gctrpc.OrderbookResponse
-	22,  // 214: gctrpc.GoCryptoTrader.GetTickerStream:output_type -> gctrpc.TickerResponse
-	22,  // 215: gctrpc.GoCryptoTrader.GetExchangeTickerStream:output_type -> gctrpc.TickerResponse
-	106, // 216: gctrpc.GoCryptoTrader.GetAuditEvent:output_type -> gctrpc.GetAuditEventResponse
-	127, // 217: gctrpc.GoCryptoTrader.GCTScriptExecute:output_type -> gctrpc.GenericResponse
-	127, // 218: gctrpc.GoCryptoTrader.GCTScriptUpload:output_type -> gctrpc.GenericResponse
-	126, // 219: gctrpc.GoCryptoTrader.GCTScriptReadScript:output_type -> gctrpc.GCTScriptQueryResponse
-	125, // 220: gctrpc.GoCryptoTrader.GCTScriptStatus:output_type -> gctrpc.GCTScriptStatusResponse
-	126, // 221: gctrpc.GoCryptoTrader.GCTScriptQuery:output_type -> gctrpc.GCTScriptQueryResponse
-	127, // 222: gctrpc.GoCryptoTrader.GCTScriptStop:output_type -> gctrpc.GenericResponse
-	127, // 223: gctrpc.GoCryptoTrader.GCTScriptStopAll:output_type -> gctrpc.GenericResponse
-	125, // 224: gctrpc.GoCryptoTrader.GCTScriptListAll:output_type -> gctrpc.GCTScriptStatusResponse
-	127, // 225: gctrpc.GoCryptoTrader.GCTScriptAutoLoadToggle:output_type -> gctrpc.GenericResponse
-	112, // 226: gctrpc.GoCryptoTrader.GetHistoricCandles:output_type -> gctrpc.GetHistoricCandlesResponse
-	127, // 227: gctrpc.GoCryptoTrader.SetExchangeAsset:output_type -> gctrpc.GenericResponse
-	127, // 228: gctrpc.GoCryptoTrader.SetAllExchangePairs:output_type -> gctrpc.GenericResponse
-	127, // 229: gctrpc.GoCryptoTrader.UpdateExchangeSupportedPairs:output_type -> gctrpc.GenericResponse
-	132, // 230: gctrpc.GoCryptoTrader.GetExchangeAssets:output_type -> gctrpc.GetExchangeAssetsResponse
-	134, // 231: gctrpc.GoCryptoTrader.WebsocketGetInfo:output_type -> gctrpc.WebsocketGetInfoResponse
-	127, // 232: gctrpc.GoCryptoTrader.WebsocketSetEnabled:output_type -> gctrpc.GenericResponse
-	138, // 233: gctrpc.GoCryptoTrader.WebsocketGetSubscriptions:output_type -> gctrpc.WebsocketGetSubscriptionsResponse
-	127, // 234: gctrpc.GoCryptoTrader.WebsocketSetProxy:output_type -> gctrpc.GenericResponse
-	127, // 235: gctrpc.GoCryptoTrader.WebsocketSetURL:output_type -> gctrpc.GenericResponse
-	109, // 236: gctrpc.GoCryptoTrader.GetRecentTrades:output_type -> gctrpc.SavedTradesResponse
-	109, // 237: gctrpc.GoCryptoTrader.GetHistoricTrades:output_type -> gctrpc.SavedTradesResponse
-	109, // 238: gctrpc.GoCryptoTrader.GetSavedTrades:output_type -> gctrpc.SavedTradesResponse
-	112, // 239: gctrpc.GoCryptoTrader.ConvertTradesToCandles:output_type -> gctrpc.GetHistoricCandlesResponse
-	143, // 240: gctrpc.GoCryptoTrader.FindMissingSavedCandleIntervals:output_type -> gctrpc.FindMissingIntervalsResponse
-	143, // 241: gctrpc.GoCryptoTrader.FindMissingSavedTradeIntervals:output_type -> gctrpc.FindMissingIntervalsResponse
-	127, // 242: gctrpc.GoCryptoTrader.SetExchangeTradeProcessing:output_type -> gctrpc.GenericResponse
-	165, // [165:243] is the sub-list for method output_type
-	87,  // [87:165] is the sub-list for method input_type
+	32,  // 165: gctrpc.GoCryptoTrader.UpdateAccountInfo:input_type -> gctrpc.GetAccountInfoRequest
+	1,   // 166: gctrpc.GoCryptoTrader.GetInfo:output_type -> gctrpc.GetInfoResponse
+	7,   // 167: gctrpc.GoCryptoTrader.GetSubsystems:output_type -> gctrpc.GetSusbsytemsResponse
+	127, // 168: gctrpc.GoCryptoTrader.EnableSubsystem:output_type -> gctrpc.GenericResponse
+	127, // 169: gctrpc.GoCryptoTrader.DisableSubsystem:output_type -> gctrpc.GenericResponse
+	10,  // 170: gctrpc.GoCryptoTrader.GetRPCEndpoints:output_type -> gctrpc.GetRPCEndpointsResponse
+	4,   // 171: gctrpc.GoCryptoTrader.GetCommunicationRelayers:output_type -> gctrpc.GetCommunicationRelayersResponse
+	13,  // 172: gctrpc.GoCryptoTrader.GetExchanges:output_type -> gctrpc.GetExchangesResponse
+	127, // 173: gctrpc.GoCryptoTrader.DisableExchange:output_type -> gctrpc.GenericResponse
+	19,  // 174: gctrpc.GoCryptoTrader.GetExchangeInfo:output_type -> gctrpc.GetExchangeInfoResponse
+	14,  // 175: gctrpc.GoCryptoTrader.GetExchangeOTPCode:output_type -> gctrpc.GetExchangeOTPReponse
+	16,  // 176: gctrpc.GoCryptoTrader.GetExchangeOTPCodes:output_type -> gctrpc.GetExchangeOTPsResponse
+	127, // 177: gctrpc.GoCryptoTrader.EnableExchange:output_type -> gctrpc.GenericResponse
+	22,  // 178: gctrpc.GoCryptoTrader.GetTicker:output_type -> gctrpc.TickerResponse
+	25,  // 179: gctrpc.GoCryptoTrader.GetTickers:output_type -> gctrpc.GetTickersResponse
+	28,  // 180: gctrpc.GoCryptoTrader.GetOrderbook:output_type -> gctrpc.OrderbookResponse
+	31,  // 181: gctrpc.GoCryptoTrader.GetOrderbooks:output_type -> gctrpc.GetOrderbooksResponse
+	35,  // 182: gctrpc.GoCryptoTrader.GetAccountInfo:output_type -> gctrpc.GetAccountInfoResponse
+	35,  // 183: gctrpc.GoCryptoTrader.GetAccountInfoStream:output_type -> gctrpc.GetAccountInfoResponse
+	37,  // 184: gctrpc.GoCryptoTrader.GetConfig:output_type -> gctrpc.GetConfigResponse
+	40,  // 185: gctrpc.GoCryptoTrader.GetPortfolio:output_type -> gctrpc.GetPortfolioResponse
+	47,  // 186: gctrpc.GoCryptoTrader.GetPortfolioSummary:output_type -> gctrpc.GetPortfolioSummaryResponse
+	127, // 187: gctrpc.GoCryptoTrader.AddPortfolioAddress:output_type -> gctrpc.GenericResponse
+	127, // 188: gctrpc.GoCryptoTrader.RemovePortfolioAddress:output_type -> gctrpc.GenericResponse
+	52,  // 189: gctrpc.GoCryptoTrader.GetForexProviders:output_type -> gctrpc.GetForexProvidersResponse
+	55,  // 190: gctrpc.GoCryptoTrader.GetForexRates:output_type -> gctrpc.GetForexRatesResponse
+	59,  // 191: gctrpc.GoCryptoTrader.GetOrders:output_type -> gctrpc.GetOrdersResponse
+	56,  // 192: gctrpc.GoCryptoTrader.GetOrder:output_type -> gctrpc.OrderDetails
+	63,  // 193: gctrpc.GoCryptoTrader.SubmitOrder:output_type -> gctrpc.SubmitOrderResponse
+	65,  // 194: gctrpc.GoCryptoTrader.SimulateOrder:output_type -> gctrpc.SimulateOrderResponse
+	65,  // 195: gctrpc.GoCryptoTrader.WhaleBomb:output_type -> gctrpc.SimulateOrderResponse
+	127, // 196: gctrpc.GoCryptoTrader.CancelOrder:output_type -> gctrpc.GenericResponse
+	69,  // 197: gctrpc.GoCryptoTrader.CancelBatchOrders:output_type -> gctrpc.CancelBatchOrdersResponse
+	71,  // 198: gctrpc.GoCryptoTrader.CancelAllOrders:output_type -> gctrpc.CancelAllOrdersResponse
+	74,  // 199: gctrpc.GoCryptoTrader.GetEvents:output_type -> gctrpc.GetEventsResponse
+	76,  // 200: gctrpc.GoCryptoTrader.AddEvent:output_type -> gctrpc.AddEventResponse
+	127, // 201: gctrpc.GoCryptoTrader.RemoveEvent:output_type -> gctrpc.GenericResponse
+	79,  // 202: gctrpc.GoCryptoTrader.GetCryptocurrencyDepositAddresses:output_type -> gctrpc.GetCryptocurrencyDepositAddressesResponse
+	81,  // 203: gctrpc.GoCryptoTrader.GetCryptocurrencyDepositAddress:output_type -> gctrpc.GetCryptocurrencyDepositAddressResponse
+	84,  // 204: gctrpc.GoCryptoTrader.WithdrawFiatFunds:output_type -> gctrpc.WithdrawResponse
+	84,  // 205: gctrpc.GoCryptoTrader.WithdrawCryptocurrencyFunds:output_type -> gctrpc.WithdrawResponse
+	86,  // 206: gctrpc.GoCryptoTrader.WithdrawalEventByID:output_type -> gctrpc.WithdrawalEventByIDResponse
+	89,  // 207: gctrpc.GoCryptoTrader.WithdrawalEventsByExchange:output_type -> gctrpc.WithdrawalEventsByExchangeResponse
+	89,  // 208: gctrpc.GoCryptoTrader.WithdrawalEventsByDate:output_type -> gctrpc.WithdrawalEventsByExchangeResponse
+	96,  // 209: gctrpc.GoCryptoTrader.GetLoggerDetails:output_type -> gctrpc.GetLoggerDetailsResponse
+	96,  // 210: gctrpc.GoCryptoTrader.SetLoggerDetails:output_type -> gctrpc.GetLoggerDetailsResponse
+	99,  // 211: gctrpc.GoCryptoTrader.GetExchangePairs:output_type -> gctrpc.GetExchangePairsResponse
+	127, // 212: gctrpc.GoCryptoTrader.SetExchangePair:output_type -> gctrpc.GenericResponse
+	28,  // 213: gctrpc.GoCryptoTrader.GetOrderbookStream:output_type -> gctrpc.OrderbookResponse
+	28,  // 214: gctrpc.GoCryptoTrader.GetExchangeOrderbookStream:output_type -> gctrpc.OrderbookResponse
+	22,  // 215: gctrpc.GoCryptoTrader.GetTickerStream:output_type -> gctrpc.TickerResponse
+	22,  // 216: gctrpc.GoCryptoTrader.GetExchangeTickerStream:output_type -> gctrpc.TickerResponse
+	106, // 217: gctrpc.GoCryptoTrader.GetAuditEvent:output_type -> gctrpc.GetAuditEventResponse
+	127, // 218: gctrpc.GoCryptoTrader.GCTScriptExecute:output_type -> gctrpc.GenericResponse
+	127, // 219: gctrpc.GoCryptoTrader.GCTScriptUpload:output_type -> gctrpc.GenericResponse
+	126, // 220: gctrpc.GoCryptoTrader.GCTScriptReadScript:output_type -> gctrpc.GCTScriptQueryResponse
+	125, // 221: gctrpc.GoCryptoTrader.GCTScriptStatus:output_type -> gctrpc.GCTScriptStatusResponse
+	126, // 222: gctrpc.GoCryptoTrader.GCTScriptQuery:output_type -> gctrpc.GCTScriptQueryResponse
+	127, // 223: gctrpc.GoCryptoTrader.GCTScriptStop:output_type -> gctrpc.GenericResponse
+	127, // 224: gctrpc.GoCryptoTrader.GCTScriptStopAll:output_type -> gctrpc.GenericResponse
+	125, // 225: gctrpc.GoCryptoTrader.GCTScriptListAll:output_type -> gctrpc.GCTScriptStatusResponse
+	127, // 226: gctrpc.GoCryptoTrader.GCTScriptAutoLoadToggle:output_type -> gctrpc.GenericResponse
+	112, // 227: gctrpc.GoCryptoTrader.GetHistoricCandles:output_type -> gctrpc.GetHistoricCandlesResponse
+	127, // 228: gctrpc.GoCryptoTrader.SetExchangeAsset:output_type -> gctrpc.GenericResponse
+	127, // 229: gctrpc.GoCryptoTrader.SetAllExchangePairs:output_type -> gctrpc.GenericResponse
+	127, // 230: gctrpc.GoCryptoTrader.UpdateExchangeSupportedPairs:output_type -> gctrpc.GenericResponse
+	132, // 231: gctrpc.GoCryptoTrader.GetExchangeAssets:output_type -> gctrpc.GetExchangeAssetsResponse
+	134, // 232: gctrpc.GoCryptoTrader.WebsocketGetInfo:output_type -> gctrpc.WebsocketGetInfoResponse
+	127, // 233: gctrpc.GoCryptoTrader.WebsocketSetEnabled:output_type -> gctrpc.GenericResponse
+	138, // 234: gctrpc.GoCryptoTrader.WebsocketGetSubscriptions:output_type -> gctrpc.WebsocketGetSubscriptionsResponse
+	127, // 235: gctrpc.GoCryptoTrader.WebsocketSetProxy:output_type -> gctrpc.GenericResponse
+	127, // 236: gctrpc.GoCryptoTrader.WebsocketSetURL:output_type -> gctrpc.GenericResponse
+	109, // 237: gctrpc.GoCryptoTrader.GetRecentTrades:output_type -> gctrpc.SavedTradesResponse
+	109, // 238: gctrpc.GoCryptoTrader.GetHistoricTrades:output_type -> gctrpc.SavedTradesResponse
+	109, // 239: gctrpc.GoCryptoTrader.GetSavedTrades:output_type -> gctrpc.SavedTradesResponse
+	112, // 240: gctrpc.GoCryptoTrader.ConvertTradesToCandles:output_type -> gctrpc.GetHistoricCandlesResponse
+	143, // 241: gctrpc.GoCryptoTrader.FindMissingSavedCandleIntervals:output_type -> gctrpc.FindMissingIntervalsResponse
+	143, // 242: gctrpc.GoCryptoTrader.FindMissingSavedTradeIntervals:output_type -> gctrpc.FindMissingIntervalsResponse
+	127, // 243: gctrpc.GoCryptoTrader.SetExchangeTradeProcessing:output_type -> gctrpc.GenericResponse
+	35,  // 244: gctrpc.GoCryptoTrader.UpdateAccountInfo:output_type -> gctrpc.GetAccountInfoResponse
+	166, // [166:245] is the sub-list for method output_type
+	87,  // [87:166] is the sub-list for method input_type
 	87,  // [87:87] is the sub-list for extension type_name
 	87,  // [87:87] is the sub-list for extension extendee
 	0,   // [0:87] is the sub-list for field type_name

--- a/gctrpc/rpc.pb.gw.go
+++ b/gctrpc/rpc.pb.gw.go
@@ -2475,6 +2475,42 @@ func local_request_GoCryptoTrader_SetExchangeTradeProcessing_0(ctx context.Conte
 
 }
 
+var (
+	filter_GoCryptoTrader_UpdateAccountInfo_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_GoCryptoTrader_UpdateAccountInfo_0(ctx context.Context, marshaler runtime.Marshaler, client GoCryptoTraderClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetAccountInfoRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GoCryptoTrader_UpdateAccountInfo_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.UpdateAccountInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_GoCryptoTrader_UpdateAccountInfo_0(ctx context.Context, marshaler runtime.Marshaler, server GoCryptoTraderServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetAccountInfoRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GoCryptoTrader_UpdateAccountInfo_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.UpdateAccountInfo(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterGoCryptoTraderHandlerServer registers the http handlers for service GoCryptoTrader to "mux".
 // UnaryRPC     :call GoCryptoTraderServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -4179,6 +4215,29 @@ func RegisterGoCryptoTraderHandlerServer(ctx context.Context, mux *runtime.Serve
 
 	})
 
+	mux.Handle("GET", pattern_GoCryptoTrader_UpdateAccountInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/gctrpc.GoCryptoTrader/UpdateAccountInfo")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_GoCryptoTrader_UpdateAccountInfo_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_GoCryptoTrader_UpdateAccountInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -5780,6 +5839,26 @@ func RegisterGoCryptoTraderHandlerClient(ctx context.Context, mux *runtime.Serve
 
 	})
 
+	mux.Handle("GET", pattern_GoCryptoTrader_UpdateAccountInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/gctrpc.GoCryptoTrader/UpdateAccountInfo")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_GoCryptoTrader_UpdateAccountInfo_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_GoCryptoTrader_UpdateAccountInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -5939,6 +6018,8 @@ var (
 	pattern_GoCryptoTrader_FindMissingSavedTradeIntervals_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "findmissingsavedtradeintervals"}, ""))
 
 	pattern_GoCryptoTrader_SetExchangeTradeProcessing_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "setexchangetradeprocessing"}, ""))
+
+	pattern_GoCryptoTrader_UpdateAccountInfo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "updateaccountinfo"}, ""))
 )
 
 var (
@@ -6097,4 +6178,6 @@ var (
 	forward_GoCryptoTrader_FindMissingSavedTradeIntervals_0 = runtime.ForwardResponseMessage
 
 	forward_GoCryptoTrader_SetExchangeTradeProcessing_0 = runtime.ForwardResponseMessage
+
+	forward_GoCryptoTrader_UpdateAccountInfo_0 = runtime.ForwardResponseMessage
 )

--- a/gctrpc/rpc.proto
+++ b/gctrpc/rpc.proto
@@ -953,6 +953,12 @@ service GoCryptoTrader {
         };
     }
 
+    rpc UpdateAccountInfo (GetAccountInfoRequest) returns (GetAccountInfoResponse) {
+        option (google.api.http) = {
+            get: "/v1/updateaccountinfo"
+        };
+    }
+
     rpc GetAccountInfoStream (GetAccountInfoRequest) returns (stream GetAccountInfoResponse) {
         option (google.api.http) = {
             get: "/v1/getaccountinfostream"

--- a/gctrpc/rpc.swagger.json
+++ b/gctrpc/rpc.swagger.json
@@ -2229,6 +2229,36 @@
         ]
       }
     },
+    "/v1/updateaccountinfo": {
+      "get": {
+        "operationId": "GoCryptoTrader_UpdateAccountInfo",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/gctrpcGetAccountInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "GoCryptoTrader"
+        ]
+      }
+    },
     "/v1/updateexchangesupportedpairs": {
       "get": {
         "operationId": "GoCryptoTrader_UpdateExchangeSupportedPairs",

--- a/gctrpc/rpc_grpc.pb.go
+++ b/gctrpc/rpc_grpc.pb.go
@@ -95,6 +95,7 @@ type GoCryptoTraderClient interface {
 	FindMissingSavedCandleIntervals(ctx context.Context, in *FindMissingCandlePeriodsRequest, opts ...grpc.CallOption) (*FindMissingIntervalsResponse, error)
 	FindMissingSavedTradeIntervals(ctx context.Context, in *FindMissingTradePeriodsRequest, opts ...grpc.CallOption) (*FindMissingIntervalsResponse, error)
 	SetExchangeTradeProcessing(ctx context.Context, in *SetExchangeTradeProcessingRequest, opts ...grpc.CallOption) (*GenericResponse, error)
+	UpdateAccountInfo(ctx context.Context, in *GetAccountInfoRequest, opts ...grpc.CallOption) (*GetAccountInfoResponse, error)
 }
 
 type goCryptoTraderClient struct {
@@ -945,6 +946,15 @@ func (c *goCryptoTraderClient) SetExchangeTradeProcessing(ctx context.Context, i
 	return out, nil
 }
 
+func (c *goCryptoTraderClient) UpdateAccountInfo(ctx context.Context, in *GetAccountInfoRequest, opts ...grpc.CallOption) (*GetAccountInfoResponse, error) {
+	out := new(GetAccountInfoResponse)
+	err := c.cc.Invoke(ctx, "/gctrpc.GoCryptoTrader/UpdateAccountInfo", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GoCryptoTraderServer is the server API for GoCryptoTrader service.
 // All implementations must embed UnimplementedGoCryptoTraderServer
 // for forward compatibility
@@ -1027,6 +1037,7 @@ type GoCryptoTraderServer interface {
 	FindMissingSavedCandleIntervals(context.Context, *FindMissingCandlePeriodsRequest) (*FindMissingIntervalsResponse, error)
 	FindMissingSavedTradeIntervals(context.Context, *FindMissingTradePeriodsRequest) (*FindMissingIntervalsResponse, error)
 	SetExchangeTradeProcessing(context.Context, *SetExchangeTradeProcessingRequest) (*GenericResponse, error)
+	UpdateAccountInfo(context.Context, *GetAccountInfoRequest) (*GetAccountInfoResponse, error)
 	mustEmbedUnimplementedGoCryptoTraderServer()
 }
 
@@ -1267,6 +1278,9 @@ func (UnimplementedGoCryptoTraderServer) FindMissingSavedTradeIntervals(context.
 }
 func (UnimplementedGoCryptoTraderServer) SetExchangeTradeProcessing(context.Context, *SetExchangeTradeProcessingRequest) (*GenericResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetExchangeTradeProcessing not implemented")
+}
+func (UnimplementedGoCryptoTraderServer) UpdateAccountInfo(context.Context, *GetAccountInfoRequest) (*GetAccountInfoResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateAccountInfo not implemented")
 }
 func (UnimplementedGoCryptoTraderServer) mustEmbedUnimplementedGoCryptoTraderServer() {}
 
@@ -2703,6 +2717,24 @@ func _GoCryptoTrader_SetExchangeTradeProcessing_Handler(srv interface{}, ctx con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GoCryptoTrader_UpdateAccountInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetAccountInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoCryptoTraderServer).UpdateAccountInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gctrpc.GoCryptoTrader/UpdateAccountInfo",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoCryptoTraderServer).UpdateAccountInfo(ctx, req.(*GetAccountInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _GoCryptoTrader_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "gctrpc.GoCryptoTrader",
 	HandlerType: (*GoCryptoTraderServer)(nil),
@@ -2994,6 +3026,10 @@ var _GoCryptoTrader_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetExchangeTradeProcessing",
 			Handler:    _GoCryptoTrader_SetExchangeTradeProcessing_Handler,
+		},
+		{
+			MethodName: "UpdateAccountInfo",
+			Handler:    _GoCryptoTrader_UpdateAccountInfo_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
# PR Description

This patch add support of UpdateAccountInfo to the GRPC server. 
It is useful to have actual account state for the preliminary validation of the bid request. 
Without such possibility we have to send requests to the exchange and either use completed orders for keeping account up to date or handle error messages from the exchange.  

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## How has this been tested

Added tests to the engine/rpcserver_test.go

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ x] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally and on Travis with my changes (there are couple of broken tests in the upstream/master)
- [ ] Any dependent changes have been merged and published in downstream modules
