### PR TITLE
gen_sqlboiler: fix incorrect database path for non-default sqlite location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ sqlboiler.json
 # GCT API Check
 backup.json
 .DS_STORE
+
+# Designated generated files dir
+target/

--- a/cmd/gen_sqlboiler_config/main.go
+++ b/cmd/gen_sqlboiler_config/main.go
@@ -7,9 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/database"
@@ -17,9 +15,8 @@ import (
 )
 
 var (
-	configFile     string
-	defaultDataDir string
-	outputFolder   string
+	configFile   string
+	outputFolder string
 )
 
 var sqlboilerConfig map[string]driverConfig
@@ -41,7 +38,6 @@ func main() {
 	fmt.Println()
 
 	flag.StringVar(&configFile, "config", config.DefaultFilePath(), "config file to load")
-	flag.StringVar(&defaultDataDir, "datadir", common.GetDefaultDataDir(runtime.GOOS), "default data directory for GoCryptoTrader files")
 	flag.StringVar(&outputFolder, "outdir", "", "overwrite default output folder")
 	flag.Parse()
 
@@ -82,7 +78,7 @@ func convertGCTtoSQLBoilerConfig(c *database.Config) {
 		dbType = "psql"
 	}
 	if dbType == database.DBSQLite || dbType == database.DBSQLite3 {
-		tempConfig.DBName = convertDBName(c.Database)
+		tempConfig.DBName = getLoadedDBPath()
 	} else {
 		tempConfig.User = c.Username
 		tempConfig.Pass = c.Password
@@ -95,6 +91,7 @@ func convertGCTtoSQLBoilerConfig(c *database.Config) {
 	sqlboilerConfig[dbType] = tempConfig
 }
 
-func convertDBName(in string) string {
-	return filepath.Join(common.GetDefaultDataDir(runtime.GOOS), "database", in)
+// getLoadedDBPath gets the path loaded by 'database/drivers/sqlite3'
+func getLoadedDBPath() string {
+	return filepath.Join(database.DB.DataPath, database.DB.Config.Database)
 }


### PR DESCRIPTION
* the generator should use the same path as the database/drivers/sqlite3
* remove unused data directory
* auto-generate sqlboiler.json for model generation
* ignore target folder

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] manual test

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
