### PR TITLE
Exchanges: Bypass websocket book validation

### DIFF
--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -966,7 +966,7 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 	book.Pair = p
 	book.ExchangeName = b.Name
 	book.NotAggregated = true
-	book.ChecksumBypass = true
+	book.HasChecksumValidation = true
 	book.IsFundingRate = fundingRate
 	return b.Websocket.Orderbook.LoadSnapshot(&book)
 }

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -966,6 +966,7 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 	book.Pair = p
 	book.ExchangeName = b.Name
 	book.NotAggregated = true
+	book.ChecksumBypass = true
 	book.IsFundingRate = fundingRate
 	return b.Websocket.Orderbook.LoadSnapshot(&book)
 }

--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -25,7 +25,7 @@ const (
 	apiSecret               = ""
 	canManipulateRealOrders = false
 	spotPair                = "FTT/BTC"
-	futuresPair             = "LEO-0327"
+	futuresPair             = "DOGE-PERP"
 	testToken               = "ADAMOON"
 	btcusd                  = "BTC/USD"
 )

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -506,13 +506,13 @@ func (f *FTX) WsProcessPartialOB(data *WsOrderbookData, p currency.Pair, a asset
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:           asks,
-		Bids:           bids,
-		AssetType:      a,
-		LastUpdated:    timestampFromFloat64(data.Time),
-		Pair:           p,
-		ExchangeName:   f.Name,
-		ChecksumBypass: true,
+		Asks:                  asks,
+		Bids:                  bids,
+		AssetType:             a,
+		LastUpdated:           timestampFromFloat64(data.Time),
+		Pair:                  p,
+		ExchangeName:          f.Name,
+		HasChecksumValidation: true,
 	}
 	return f.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -506,12 +506,13 @@ func (f *FTX) WsProcessPartialOB(data *WsOrderbookData, p currency.Pair, a asset
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:         asks,
-		Bids:         bids,
-		AssetType:    a,
-		LastUpdated:  timestampFromFloat64(data.Time),
-		Pair:         p,
-		ExchangeName: f.Name,
+		Asks:           asks,
+		Bids:           bids,
+		AssetType:      a,
+		LastUpdated:    timestampFromFloat64(data.Time),
+		Pair:           p,
+		ExchangeName:   f.Name,
+		ChecksumBypass: true,
 	}
 	return f.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -847,6 +847,7 @@ func (k *Kraken) wsProcessOrderBookPartial(channelData *WebsocketChannelData, as
 	}
 	base.LastUpdated = highestLastUpdate
 	base.ExchangeName = k.Name
+	base.ChecksumBypass = true
 	return k.Websocket.Orderbook.LoadSnapshot(&base)
 }
 

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -847,7 +847,7 @@ func (k *Kraken) wsProcessOrderBookPartial(channelData *WebsocketChannelData, as
 	}
 	base.LastUpdated = highestLastUpdate
 	base.ExchangeName = k.Name
-	base.ChecksumBypass = true
+	base.HasChecksumValidation = true
 	return k.Websocket.Orderbook.LoadSnapshot(&base)
 }
 

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -678,13 +678,13 @@ func (o *OKGroup) WsProcessPartialOrderBook(wsEventData *WebsocketOrderBook, ins
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:           asks,
-		Bids:           bids,
-		AssetType:      a,
-		LastUpdated:    wsEventData.Timestamp,
-		Pair:           instrument,
-		ExchangeName:   o.Name,
-		ChecksumBypass: true,
+		Asks:                  asks,
+		Bids:                  bids,
+		AssetType:             a,
+		LastUpdated:           wsEventData.Timestamp,
+		Pair:                  instrument,
+		ExchangeName:          o.Name,
+		HasChecksumValidation: true,
 	}
 	return o.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -678,12 +678,13 @@ func (o *OKGroup) WsProcessPartialOrderBook(wsEventData *WebsocketOrderBook, ins
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:         asks,
-		Bids:         bids,
-		AssetType:    a,
-		LastUpdated:  wsEventData.Timestamp,
-		Pair:         instrument,
-		ExchangeName: o.Name,
+		Asks:           asks,
+		Bids:           bids,
+		AssetType:      a,
+		LastUpdated:    wsEventData.Timestamp,
+		Pair:           instrument,
+		ExchangeName:   o.Name,
+		ChecksumBypass: true,
 	}
 	return o.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -275,7 +275,7 @@ func (b *Base) Process() error {
 		b.LastUpdated = time.Now()
 	}
 
-	if !b.ChecksumBypass {
+	if !b.HasChecksumValidation {
 		err := b.Verify()
 		if err != nil {
 			return err

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -275,9 +275,11 @@ func (b *Base) Process() error {
 		b.LastUpdated = time.Now()
 	}
 
-	err := b.Verify()
-	if err != nil {
-		return err
+	if !b.ChecksumBypass {
+		err := b.Verify()
+		if err != nil {
+			return err
+		}
 	}
 
 	return service.Update(b)

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -85,9 +85,9 @@ type Base struct {
 	NotAggregated bool `json:"-"`
 	IsFundingRate bool `json:"fundingRate"`
 
-	// ChecksumBypass defines an allowance to bypass internal verification if
-	// the book has been verified by checksum.
-	ChecksumBypass bool `json:"-"`
+	// HasChecksumValidation defines an allowance to bypass internal
+	// verification if the book has been verified by checksum.
+	HasChecksumValidation bool `json:"-"`
 }
 
 type byOBPrice []Item

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -79,10 +79,15 @@ type Base struct {
 	LastUpdateID int64         `json:"lastUpdateId"`
 	AssetType    asset.Item    `json:"assetType"`
 	ExchangeName string        `json:"exchangeName"`
+
 	// NotAggregated defines whether an orderbook can contain duplicate prices
 	// in a payload
 	NotAggregated bool `json:"-"`
 	IsFundingRate bool `json:"fundingRate"`
+
+	// ChecksumBypass defines an allowance to bypass internal verification if
+	// the book has been verified by checksum.
+	ChecksumBypass bool `json:"-"`
 }
 
 type byOBPrice []Item

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
-github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v3.4.0+incompatible h1:d3y9DuA2LnGr8hiQ+1dPQrNsydLvutmRq9cjULPWYZQ=
 github.com/gofrs/uuid v3.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=


### PR DESCRIPTION
# PR Description

Reduces the need to traverse and validate book contents when there is a checksum present from the exchange.

Exchanges affected:
- [x] Bitfinex
- [x] FTX
- [x] Kraken
- [x] Okex
- [x] OkCoin

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
