### PR TITLE
Exchanges: Add config variable to set bypassing of orderbook verification by exchange

### DIFF
--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -272,7 +272,13 @@ func ({{.Variable}} *{{.CapitalName}}) FetchOrderbook(currency currency.Pair, as
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func ({{.Variable}} *{{.CapitalName}}) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: {{.Variable}}.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName: {{.Variable}}.Name, 
+		Pair: p, 
+		AssetType: assetType,
+		VerificationBypass: {{.Variable}}.OrderbookVerificationBypass,
+	}
+	
 	// NOTE: UPDATE ORDERBOOK EXAMPLE
 	/* 
 	orderbookNew, err := {{.Variable}}.GetOrderBook(exchange.FormatExchangeCurrency({{.Variable}}.Name, p).String(), 1000)

--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -161,7 +161,7 @@ func ({{.Variable}} *{{.CapitalName}}) Setup(exch *config.ExchangeConfig) error 
 
 	// NOTE: PLEASE ENSURE YOU SET THE ORDERBOOK BUFFER SETTINGS CORRECTLY
 	{{.Variable}}.Websocket.Orderbook.Setup(
-		exch.WebsocketOrderbookBufferLimit,
+		exch.OrderbookConfig.WebsocketBufferLimit,
 		true,
 		true,
 		false,

--- a/config/config.go
+++ b/config/config.go
@@ -1041,12 +1041,12 @@ func (c *Config) CheckExchangeConfigValues() error {
 					defaultWebsocketTrafficTimeout)
 				c.Exchanges[i].WebsocketTrafficTimeout = defaultWebsocketTrafficTimeout
 			}
-			if c.Exchanges[i].WebsocketOrderbookBufferLimit <= 0 {
+			if c.Exchanges[i].OrderbookConfig.WebsocketBufferLimit <= 0 {
 				log.Warnf(log.ConfigMgr,
 					"Exchange %s Websocket orderbook buffer limit value not set, defaulting to %v.",
 					c.Exchanges[i].Name,
 					defaultWebsocketOrderbookBufferLimit)
-				c.Exchanges[i].WebsocketOrderbookBufferLimit = defaultWebsocketOrderbookBufferLimit
+				c.Exchanges[i].OrderbookConfig.WebsocketBufferLimit = defaultWebsocketOrderbookBufferLimit
 			}
 			err := c.CheckPairConsistency(c.Exchanges[i].Name)
 			if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1459,7 +1459,7 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 	// Test websocket and HTTP timeout values
 	cfg.Exchanges[0].WebsocketResponseMaxLimit = 0
 	cfg.Exchanges[0].WebsocketResponseCheckTimeout = 0
-	cfg.Exchanges[0].WebsocketOrderbookBufferLimit = 0
+	cfg.Exchanges[0].OrderbookConfig.WebsocketBufferLimit = 0
 	cfg.Exchanges[0].WebsocketTrafficTimeout = 0
 	cfg.Exchanges[0].HTTPTimeout = 0
 	err = cfg.CheckExchangeConfigValues()
@@ -1471,7 +1471,7 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 		t.Errorf("expected exchange %s to have updated WebsocketResponseMaxLimit value",
 			cfg.Exchanges[0].Name)
 	}
-	if cfg.Exchanges[0].WebsocketOrderbookBufferLimit == 0 {
+	if cfg.Exchanges[0].OrderbookConfig.WebsocketBufferLimit == 0 {
 		t.Errorf("expected exchange %s to have updated WebsocketOrderbookBufferLimit value",
 			cfg.Exchanges[0].Name)
 	}

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -131,6 +131,7 @@ type ExchangeConfig struct {
 	API                             APIConfig              `json:"api"`
 	Features                        *FeaturesConfig        `json:"features"`
 	BankAccounts                    []banking.Account      `json:"bankAccounts,omitempty"`
+	OrderbookVerificationBypass     bool                   `json:"orderbookVerificationBypass"`
 
 	// Deprecated settings which will be removed in a future update
 	AvailablePairs                   *currency.Pairs      `json:"availablePairs,omitempty"`

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -113,25 +113,23 @@ type ConnectionMonitorConfig struct {
 
 // ExchangeConfig holds all the information needed for each enabled Exchange.
 type ExchangeConfig struct {
-	Name                            string                 `json:"name"`
-	Enabled                         bool                   `json:"enabled"`
-	Verbose                         bool                   `json:"verbose"`
-	UseSandbox                      bool                   `json:"useSandbox,omitempty"`
-	HTTPTimeout                     time.Duration          `json:"httpTimeout"`
-	HTTPUserAgent                   string                 `json:"httpUserAgent,omitempty"`
-	HTTPDebugging                   bool                   `json:"httpDebugging,omitempty"`
-	WebsocketResponseCheckTimeout   time.Duration          `json:"websocketResponseCheckTimeout"`
-	WebsocketResponseMaxLimit       time.Duration          `json:"websocketResponseMaxLimit"`
-	WebsocketTrafficTimeout         time.Duration          `json:"websocketTrafficTimeout"`
-	WebsocketOrderbookBufferLimit   int                    `json:"websocketOrderbookBufferLimit"`
-	WebsocketOrderbookBufferEnabled bool                   `json:"websocketOrderbookBufferEnabled"`
-	ProxyAddress                    string                 `json:"proxyAddress,omitempty"`
-	BaseCurrencies                  currency.Currencies    `json:"baseCurrencies"`
-	CurrencyPairs                   *currency.PairsManager `json:"currencyPairs"`
-	API                             APIConfig              `json:"api"`
-	Features                        *FeaturesConfig        `json:"features"`
-	BankAccounts                    []banking.Account      `json:"bankAccounts,omitempty"`
-	OrderbookVerificationBypass     bool                   `json:"orderbookVerificationBypass"`
+	Name                          string                 `json:"name"`
+	Enabled                       bool                   `json:"enabled"`
+	Verbose                       bool                   `json:"verbose"`
+	UseSandbox                    bool                   `json:"useSandbox,omitempty"`
+	HTTPTimeout                   time.Duration          `json:"httpTimeout"`
+	HTTPUserAgent                 string                 `json:"httpUserAgent,omitempty"`
+	HTTPDebugging                 bool                   `json:"httpDebugging,omitempty"`
+	WebsocketResponseCheckTimeout time.Duration          `json:"websocketResponseCheckTimeout"`
+	WebsocketResponseMaxLimit     time.Duration          `json:"websocketResponseMaxLimit"`
+	WebsocketTrafficTimeout       time.Duration          `json:"websocketTrafficTimeout"`
+	ProxyAddress                  string                 `json:"proxyAddress,omitempty"`
+	BaseCurrencies                currency.Currencies    `json:"baseCurrencies"`
+	CurrencyPairs                 *currency.PairsManager `json:"currencyPairs"`
+	API                           APIConfig              `json:"api"`
+	Features                      *FeaturesConfig        `json:"features"`
+	BankAccounts                  []banking.Account      `json:"bankAccounts,omitempty"`
+	OrderbookConfig               `json:"orderbook"`
 
 	// Deprecated settings which will be removed in a future update
 	AvailablePairs                   *currency.Pairs      `json:"availablePairs,omitempty"`
@@ -380,4 +378,11 @@ type APIConfig struct {
 	Endpoints            APIEndpointsConfig             `json:"endpoints"`
 	Credentials          APICredentialsConfig           `json:"credentials"`
 	CredentialsValidator *APICredentialsValidatorConfig `json:"credentialsValidator,omitempty"`
+}
+
+// OrderbookConfig stores the orderbook configuration variables
+type OrderbookConfig struct {
+	VerificationBypass     bool `json:"verificationBypass"`
+	WebsocketBufferLimit   int  `json:"websocketBufferLimit"`
+	WebsocketBufferEnabled bool `json:"websocketBufferEnabled"`
 }

--- a/docs/ADD_NEW_EXCHANGE.md
+++ b/docs/ADD_NEW_EXCHANGE.md
@@ -1095,7 +1095,7 @@ func (f *FTX) Setup(exch *config.ExchangeConfig) error {
 		Features:                         &f.Features.Supports.WebsocketCapabilities, // Defines the capabilities of the websocket outlined in supported features struct. This allows the websocket connection to be flushed appropriately if we have a pair/asset enable/disable change. This is outlined below.
 
 		// Orderbook buffer specific variables for processing orderbook updates via websocket feed. 
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
 		// Other orderbook buffer vars:
 		// BufferEnabled         bool 
 		// SortBuffer            bool 

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -459,6 +459,7 @@ func (b *Binance) SeedLocalCacheWithBook(p currency.Pair, orderbookNew *OrderBoo
 	newOrderBook.AssetType = asset.Spot
 	newOrderBook.ExchangeName = b.Name
 	newOrderBook.LastUpdateID = orderbookNew.LastUpdateID
+	newOrderBook.VerificationBypass = b.OrderbookVerificationBypass
 
 	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -401,7 +401,12 @@ func (b *Binance) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderb
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Binance) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 	orderbookNew, err := b.GetOrderBook(OrderBookDataRequestParams{
 		Symbol: p,
 		Limit:  1000})

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -182,8 +182,8 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     b.Unsubscribe,
 		GenerateSubscriptions:            b.GenerateSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 		SortBufferByUpdateIDs:            true,
 	})

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -968,6 +968,7 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 	book.NotAggregated = true
 	book.HasChecksumValidation = true
 	book.IsFundingRate = fundingRate
+	book.VerificationBypass = b.OrderbookVerificationBypass
 	return b.Websocket.Orderbook.LoadSnapshot(&book)
 }
 

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -387,10 +387,12 @@ func (b *Bitfinex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*order
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bitfinex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	o := &orderbook.Base{
-		ExchangeName:  b.Name,
-		Pair:          p,
-		AssetType:     assetType,
-		NotAggregated: true}
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		NotAggregated:      true,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 
 	fPair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -198,8 +198,8 @@ func (b *Bitfinex) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     b.Unsubscribe,
 		GenerateSubscriptions:            b.GenerateDefaultSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		UpdateEntriesByID:                true,
 	})
 	if err != nil {

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -250,7 +250,12 @@ func (b *Bitflyer) FetchOrderbook(p currency.Pair, assetType asset.Item) (*order
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bitflyer) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 
 	fPair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -242,7 +242,12 @@ func (b *Bithumb) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderb
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bithumb) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 	curr := p.Base.String()
 
 	orderbookNew, err := b.GetOrderBook(curr)

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -512,6 +512,7 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, p currency.
 		book.AssetType = a
 		book.Pair = p
 		book.ExchangeName = b.Name
+		book.VerificationBypass = b.OrderbookVerificationBypass
 
 		err := b.Websocket.Orderbook.LoadSnapshot(&book)
 		if err != nil {

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -154,8 +154,8 @@ func (b *Bitmex) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     b.Unsubscribe,
 		GenerateSubscriptions:            b.GenerateDefaultSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		UpdateEntriesByID:                true,
 	})
 	if err != nil {

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -334,9 +334,10 @@ func (b *Bitmex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bitmex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	book := &orderbook.Base{
-		ExchangeName: b.Name,
-		Pair:         p,
-		AssetType:    assetType,
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
 	}
 
 	if assetType == asset.Index {

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -239,12 +239,13 @@ func (b *Bitstamp) wsUpdateOrderbook(update websocketOrderBook, p currency.Pair,
 		bids = append(bids, orderbook.Item{Price: target, Amount: amount})
 	}
 	return b.Websocket.Orderbook.LoadSnapshot(&orderbook.Base{
-		Bids:         bids,
-		Asks:         asks,
-		Pair:         p,
-		LastUpdated:  time.Unix(update.Timestamp, 0),
-		AssetType:    assetType,
-		ExchangeName: b.Name,
+		Bids:               bids,
+		Asks:               asks,
+		Pair:               p,
+		LastUpdated:        time.Unix(update.Timestamp, 0),
+		AssetType:          assetType,
+		ExchangeName:       b.Name,
+		VerificationBypass: b.OrderbookVerificationBypass,
 	})
 }
 

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -277,6 +277,7 @@ func (b *Bitstamp) seedOrderBook() error {
 		newOrderBook.Pair = p[x]
 		newOrderBook.AssetType = asset.Spot
 		newOrderBook.ExchangeName = b.Name
+		newOrderBook.VerificationBypass = b.OrderbookVerificationBypass
 
 		err = b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 		if err != nil {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -316,7 +316,12 @@ func (b *Bitstamp) FetchOrderbook(p currency.Pair, assetType asset.Item) (*order
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bitstamp) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 	fPair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -164,8 +164,8 @@ func (b *Bitstamp) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     b.Unsubscribe,
 		GenerateSubscriptions:            b.generateDefaultSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -328,7 +328,12 @@ func (b *Bittrex) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderb
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *Bittrex) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 	fpair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -118,12 +118,13 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 		}
 		if ob.Snapshot {
 			err = b.Websocket.Orderbook.LoadSnapshot(&orderbook.Base{
-				Pair:         p,
-				Bids:         orderbook.SortBids(bids), // Alignment completely out sort is needed
-				Asks:         asks,
-				LastUpdated:  ob.Timestamp,
-				AssetType:    asset.Spot,
-				ExchangeName: b.Name,
+				Pair:               p,
+				Bids:               orderbook.SortBids(bids), // Alignment completely out sort is needed
+				Asks:               asks,
+				LastUpdated:        ob.Timestamp,
+				AssetType:          asset.Spot,
+				ExchangeName:       b.Name,
+				VerificationBypass: b.OrderbookVerificationBypass,
 			})
 		} else {
 			err = b.Websocket.Orderbook.Update(&buffer.Update{

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -155,8 +155,8 @@ func (b *BTCMarkets) Setup(exch *config.ExchangeConfig) error {
 		Subscriber:                       b.Subscribe,
 		GenerateSubscriptions:            b.generateDefaultSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 	})
 	if err != nil {

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -352,9 +352,12 @@ func (b *BTCMarkets) FetchOrderbook(p currency.Pair, assetType asset.Item) (*ord
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *BTCMarkets) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
 	book := &orderbook.Base{
-		ExchangeName: b.Name,
-		Pair:         p,
-		AssetType:    assetType, NotAggregated: true}
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		NotAggregated:      true,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 
 	fpair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -282,6 +282,7 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 		newOB.AssetType = a
 		newOB.ExchangeName = b.Name
 		orderbook.Reverse(newOB.Asks) // Reverse asks for correct alignment
+		newOB.VerificationBypass = b.OrderbookVerificationBypass
 		err = b.Websocket.Orderbook.LoadSnapshot(&newOB)
 		if err != nil {
 			return err

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -184,8 +184,8 @@ func (b *BTSE) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     b.Unsubscribe,
 		GenerateSubscriptions:            b.GenerateDefaultSubscriptions,
 		Features:                         &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -319,7 +319,12 @@ func (b *BTSE) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (b *BTSE) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: b.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       b.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: b.OrderbookVerificationBypass,
+	}
 	fPair, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -312,6 +312,7 @@ func (c *CoinbasePro) ProcessSnapshot(snapshot *WebsocketOrderbookSnapshot) erro
 	base.AssetType = asset.Spot
 	base.Pair = pair
 	base.ExchangeName = c.Name
+	base.VerificationBypass = c.OrderbookVerificationBypass
 
 	return c.Websocket.Orderbook.LoadSnapshot(&base)
 }

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -400,7 +400,12 @@ func (c *CoinbasePro) FetchOrderbook(p currency.Pair, assetType asset.Item) (*or
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (c *CoinbasePro) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: c.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       c.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: c.OrderbookVerificationBypass,
+	}
 	fpair, err := c.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -166,8 +166,8 @@ func (c *CoinbasePro) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     c.Unsubscribe,
 		GenerateSubscriptions:            c.GenerateDefaultSubscriptions,
 		Features:                         &c.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 	})
 	if err != nil {

--- a/exchanges/coinbene/coinbene_websocket.go
+++ b/exchanges/coinbene/coinbene_websocket.go
@@ -289,6 +289,7 @@ func (c *Coinbene) wsHandleData(respRaw []byte) error {
 			newOB.Pair = newPair
 			newOB.ExchangeName = c.Name
 			newOB.LastUpdated = time.Unix(orderBook.Data[0].Timestamp, 0)
+			newOB.VerificationBypass = c.OrderbookVerificationBypass
 			err = c.Websocket.Orderbook.LoadSnapshot(&newOB)
 			if err != nil {
 				return err

--- a/exchanges/coinbene/coinbene_wrapper.go
+++ b/exchanges/coinbene/coinbene_wrapper.go
@@ -181,8 +181,8 @@ func (c *Coinbene) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     c.Unsubscribe,
 		GenerateSubscriptions:            c.GenerateDefaultSubscriptions,
 		Features:                         &c.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 	})
 	if err != nil {

--- a/exchanges/coinbene/coinbene_wrapper.go
+++ b/exchanges/coinbene/coinbene_wrapper.go
@@ -405,7 +405,12 @@ func (c *Coinbene) FetchOrderbook(p currency.Pair, assetType asset.Item) (*order
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (c *Coinbene) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: c.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       c.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: c.OrderbookVerificationBypass,
+	}
 	if !c.SupportsAsset(assetType) {
 		return book,
 			fmt.Errorf("%s does not support asset type %s", c.Name, assetType)

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -530,6 +530,7 @@ func (c *COINUT) WsProcessOrderbookSnapshot(ob *WsOrderbookSnapshot) error {
 	var newOrderBook orderbook.Base
 	newOrderBook.Asks = asks
 	newOrderBook.Bids = bids
+	newOrderBook.VerificationBypass = c.OrderbookVerificationBypass
 
 	pairs, err := c.GetEnabledPairs(asset.Spot)
 	if err != nil {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -149,8 +149,8 @@ func (c *COINUT) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     c.Unsubscribe,
 		GenerateSubscriptions:            c.GenerateDefaultSubscriptions,
 		Features:                         &c.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 		SortBufferByUpdateIDs:            true,
 	})

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -453,7 +453,12 @@ func (c *COINUT) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (c *COINUT) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: c.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       c.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: c.OrderbookVerificationBypass,
+	}
 	err := c.loadInstrumentsIfNotLoaded()
 	if err != nil {
 		return book, err

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -590,7 +590,7 @@ func (e *Base) SetupDefaults(exch *config.ExchangeConfig) error {
 		return err
 	}
 	e.BaseCurrencies = exch.BaseCurrencies
-	e.OrderbookVerificationBypass = exch.OrderbookVerificationBypass
+	e.OrderbookVerificationBypass = exch.OrderbookConfig.VerificationBypass
 	return nil
 }
 

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -590,6 +590,7 @@ func (e *Base) SetupDefaults(exch *config.ExchangeConfig) error {
 		return err
 	}
 	e.BaseCurrencies = exch.BaseCurrencies
+	e.OrderbookVerificationBypass = exch.OrderbookVerificationBypass
 	return nil
 }
 

--- a/exchanges/exchange_types.go
+++ b/exchanges/exchange_types.go
@@ -218,6 +218,7 @@ type Base struct {
 	WebsocketOrderbookBufferLimit int64
 	Websocket                     *stream.Websocket
 	*request.Requester
-	Config        *config.ExchangeConfig
-	settingsMutex sync.RWMutex
+	Config                      *config.ExchangeConfig
+	settingsMutex               sync.RWMutex
+	OrderbookVerificationBypass bool
 }

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -235,7 +235,12 @@ func (e *EXMO) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (e *EXMO) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	callingBook := &orderbook.Base{ExchangeName: e.Name, Pair: p, AssetType: assetType}
+	callingBook := &orderbook.Base{
+		ExchangeName:       e.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: e.OrderbookVerificationBypass,
+	}
 	enabledPairs, err := e.GetEnabledPairs(assetType)
 	if err != nil {
 		return callingBook, err
@@ -253,9 +258,11 @@ func (e *EXMO) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderboo
 
 	for i := range enabledPairs {
 		book := &orderbook.Base{
-			ExchangeName: e.Name,
-			Pair:         enabledPairs[i],
-			AssetType:    assetType}
+			ExchangeName:       e.Name,
+			Pair:               enabledPairs[i],
+			AssetType:          assetType,
+			VerificationBypass: e.OrderbookVerificationBypass,
+		}
 
 		curr, err := e.FormatExchangeCurrency(enabledPairs[i], assetType)
 		if err != nil {

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -506,12 +506,13 @@ func (f *FTX) WsProcessPartialOB(data *WsOrderbookData, p currency.Pair, a asset
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:         asks,
-		Bids:         bids,
-		AssetType:    a,
-		LastUpdated:  timestampFromFloat64(data.Time),
-		Pair:         p,
-		ExchangeName: f.Name,
+		Asks:               asks,
+		Bids:               bids,
+		AssetType:          a,
+		LastUpdated:        timestampFromFloat64(data.Time),
+		Pair:               p,
+		ExchangeName:       f.Name,
+		VerificationBypass: f.OrderbookVerificationBypass,
 	}
 	return f.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -333,7 +333,12 @@ func (f *FTX) FetchOrderbook(currency currency.Pair, assetType asset.Item) (*ord
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (f *FTX) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: f.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       f.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: f.OrderbookVerificationBypass,
+	}
 	formattedPair, err := f.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -176,8 +176,8 @@ func (f *FTX) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     f.Unsubscribe,
 		GenerateSubscriptions:            f.GenerateDefaultSubscriptions,
 		Features:                         &f.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -353,6 +353,7 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 			newOrderBook.AssetType = asset.Spot
 			newOrderBook.Pair = p
 			newOrderBook.ExchangeName = g.Name
+			newOrderBook.VerificationBypass = g.OrderbookVerificationBypass
 
 			err = g.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 			if err != nil {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -163,8 +163,8 @@ func (g *Gateio) Setup(exch *config.ExchangeConfig) error {
 		Subscriber:                       g.Subscribe,
 		GenerateSubscriptions:            g.GenerateDefaultSubscriptions,
 		Features:                         &g.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -278,7 +278,12 @@ func (g *Gateio) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (g *Gateio) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: g.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       g.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: g.OrderbookVerificationBypass,
+	}
 	curr, err := g.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -397,6 +397,7 @@ func (g *Gemini) wsProcessUpdate(result WsMarketUpdateResponse, pair currency.Pa
 		newOrderBook.AssetType = asset.Spot
 		newOrderBook.Pair = pair
 		newOrderBook.ExchangeName = g.Name
+		newOrderBook.VerificationBypass = g.OrderbookVerificationBypass
 		err := g.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 		if err != nil {
 			g.Websocket.DataHandler <- err

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -294,7 +294,12 @@ func (g *Gemini) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (g *Gemini) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: g.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       g.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: g.OrderbookVerificationBypass,
+	}
 	fPair, err := g.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -142,8 +142,8 @@ func (g *Gemini) Setup(exch *config.ExchangeConfig) error {
 		RunningURL:                       exch.API.Endpoints.WebsocketURL,
 		Connector:                        g.WsConnect,
 		Features:                         &g.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 	})
 }

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -330,6 +330,7 @@ func (h *HitBTC) WsProcessOrderbookSnapshot(ob WsOrderbook) error {
 	newOrderBook.AssetType = asset.Spot
 	newOrderBook.Pair = p
 	newOrderBook.ExchangeName = h.Name
+	newOrderBook.VerificationBypass = h.OrderbookVerificationBypass
 
 	return h.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -165,8 +165,8 @@ func (h *HitBTC) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     h.Unsubscribe,
 		GenerateSubscriptions:            h.GenerateDefaultSubscriptions,
 		Features:                         &h.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 		SortBufferByUpdateIDs:            true,
 	})

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -366,7 +366,12 @@ func (h *HitBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (h *HitBTC) UpdateOrderbook(c currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: h.Name, Pair: c, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       h.Name,
+		Pair:               c,
+		AssetType:          assetType,
+		VerificationBypass: h.OrderbookVerificationBypass,
+	}
 	fpair, err := h.FormatExchangeCurrency(c, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -465,6 +465,7 @@ func (h *HUOBI) WsProcessOrderbook(update *WsDepth, symbol string) error {
 	newOrderBook.Pair = p
 	newOrderBook.AssetType = asset.Spot
 	newOrderBook.ExchangeName = h.Name
+	newOrderBook.VerificationBypass = h.OrderbookVerificationBypass
 
 	return h.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -163,8 +163,8 @@ func (h *HUOBI) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     h.Unsubscribe,
 		GenerateSubscriptions:            h.GenerateDefaultSubscriptions,
 		Features:                         &h.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -386,7 +386,12 @@ func (h *HUOBI) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderboo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (h *HUOBI) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: h.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       h.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: h.OrderbookVerificationBypass,
+	}
 	fpair, err := h.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -186,7 +186,13 @@ func (i *ItBit) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderboo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (i *ItBit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: i.Name, Pair: p, AssetType: assetType, NotAggregated: true}
+	book := &orderbook.Base{
+		ExchangeName:       i.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		NotAggregated:      true,
+		VerificationBypass: i.OrderbookVerificationBypass,
+	}
 	fpair, err := i.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -791,8 +791,9 @@ func (k *Kraken) wsProcessOrderBook(channelData *WebsocketChannelData, data map[
 // wsProcessOrderBookPartial creates a new orderbook entry for a given currency pair
 func (k *Kraken) wsProcessOrderBookPartial(channelData *WebsocketChannelData, askData, bidData []interface{}) error {
 	base := orderbook.Base{
-		Pair:      channelData.Pair,
-		AssetType: asset.Spot,
+		Pair:               channelData.Pair,
+		AssetType:          asset.Spot,
+		VerificationBypass: k.OrderbookVerificationBypass,
 	}
 	// Kraken ob data is timestamped per price, GCT orderbook data is
 	// timestamped per entry using the highest last update time, we can attempt

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -186,8 +186,8 @@ func (k *Kraken) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     k.Unsubscribe,
 		GenerateSubscriptions:            k.GenerateDefaultSubscriptions,
 		Features:                         &k.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 	})
 	if err != nil {

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -425,7 +425,12 @@ func (k *Kraken) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (k *Kraken) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: k.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       k.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: k.OrderbookVerificationBypass,
+	}
 	fpair, err := k.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/lakebtc/lakebtc_websocket.go
+++ b/exchanges/lakebtc/lakebtc_websocket.go
@@ -174,10 +174,11 @@ func (l *LakeBTC) processOrderbook(obUpdate, channel string) error {
 	}
 
 	book := orderbook.Base{
-		Pair:         p,
-		LastUpdated:  time.Now(),
-		AssetType:    asset.Spot,
-		ExchangeName: l.Name,
+		Pair:               p,
+		LastUpdated:        time.Now(),
+		AssetType:          asset.Spot,
+		ExchangeName:       l.Name,
+		VerificationBypass: l.OrderbookVerificationBypass,
 	}
 
 	for i := range update.Asks {

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -137,8 +137,8 @@ func (l *LakeBTC) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     l.Unsubscribe,
 		GenerateSubscriptions:            l.GenerateDefaultSubscriptions,
 		Features:                         &l.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 }
 

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -269,7 +269,12 @@ func (l *LakeBTC) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderb
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (l *LakeBTC) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: l.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       l.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: l.OrderbookVerificationBypass,
+	}
 	fPair, err := l.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -243,7 +243,12 @@ func (l *Lbank) FetchOrderbook(currency currency.Pair, assetType asset.Item) (*o
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (l *Lbank) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: l.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       l.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: l.OrderbookVerificationBypass,
+	}
 	fpair, err := l.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -214,7 +214,12 @@ func (l *LocalBitcoins) FetchOrderbook(p currency.Pair, assetType asset.Item) (*
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (l *LocalBitcoins) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: l.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       l.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: l.OrderbookVerificationBypass,
+	}
 	orderbookNew, err := l.GetOrderbook(p.Quote.String())
 	if err != nil {
 		return book, err

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -700,7 +700,7 @@ func (o *OKEX) GetWithdrawalsHistory(c currency.Code) (resp []exchange.Withdrawa
 	return nil, common.ErrNotYetImplemented
 }
 
-// GetHistoricTrades returns historic trade data within the timeframe provided
+// GetRecentTrades returns recent trade data
 func (o *OKEX) GetRecentTrades(p currency.Pair, assetType asset.Item) ([]trade.Data, error) {
 	var err error
 	p, err = o.FormatExchangeCurrency(p, assetType)

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -678,12 +678,13 @@ func (o *OKGroup) WsProcessPartialOrderBook(wsEventData *WebsocketOrderBook, ins
 	}
 
 	newOrderBook := orderbook.Base{
-		Asks:         asks,
-		Bids:         bids,
-		AssetType:    a,
-		LastUpdated:  wsEventData.Timestamp,
-		Pair:         instrument,
-		ExchangeName: o.Name,
+		Asks:               asks,
+		Bids:               bids,
+		AssetType:          a,
+		LastUpdated:        wsEventData.Timestamp,
+		Pair:               instrument,
+		ExchangeName:       o.Name,
+		VerificationBypass: o.OrderbookVerificationBypass,
 	}
 	return o.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -49,8 +49,8 @@ func (o *OKGroup) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     o.Unsubscribe,
 		GenerateSubscriptions:            o.GenerateDefaultSubscriptions,
 		Features:                         &o.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -79,9 +79,10 @@ func (o *OKGroup) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderb
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (o *OKGroup) UpdateOrderbook(p currency.Pair, a asset.Item) (*orderbook.Base, error) {
 	book := &orderbook.Base{
-		ExchangeName: o.Name,
-		Pair:         p,
-		AssetType:    a,
+		ExchangeName:       o.Name,
+		Pair:               p,
+		AssetType:          a,
+		VerificationBypass: o.OrderbookVerificationBypass,
 	}
 
 	if a == asset.Index {

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -275,11 +275,12 @@ func (b *Base) Process() error {
 		b.LastUpdated = time.Now()
 	}
 
-	err := b.Verify()
-	if err != nil {
-		return err
+	if !b.VerificationBypass {
+		err := b.Verify()
+		if err != nil {
+			return err
+		}
 	}
-
 	return service.Update(b)
 }
 

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -83,6 +83,10 @@ type Base struct {
 	// in a payload
 	NotAggregated bool `json:"-"`
 	IsFundingRate bool `json:"fundingRate"`
+
+	// VerificationBypass is a complete orderbook verification bypass set by
+	// user configuration
+	VerificationBypass bool `json:"-"`
 }
 
 type byOBPrice []Item

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -506,6 +506,7 @@ func (p *Poloniex) WsProcessOrderbookSnapshot(ob []interface{}, symbol string) e
 	book.Asks = orderbook.SortAsks(book.Asks)
 	book.Bids = orderbook.SortBids(book.Bids)
 	book.AssetType = asset.Spot
+	book.VerificationBypass = p.OrderbookVerificationBypass
 
 	var err error
 	book.Pair, err = currency.NewPairFromString(symbol)

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -166,8 +166,8 @@ func (p *Poloniex) Setup(exch *config.ExchangeConfig) error {
 		UnSubscriber:                     p.Unsubscribe,
 		GenerateSubscriptions:            p.GenerateDefaultSubscriptions,
 		Features:                         &p.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 		SortBuffer:                       true,
 		SortBufferByUpdateIDs:            true,
 	})

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -320,7 +320,12 @@ func (p *Poloniex) FetchOrderbook(currencyPair currency.Pair, assetType asset.It
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (p *Poloniex) UpdateOrderbook(c currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	callingBook := &orderbook.Base{ExchangeName: p.Name, Pair: c, AssetType: assetType}
+	callingBook := &orderbook.Base{
+		ExchangeName:       p.Name,
+		Pair:               c,
+		AssetType:          assetType,
+		VerificationBypass: p.OrderbookVerificationBypass,
+	}
 	orderbookNew, err := p.GetOrderbook("", poloniexMaxOrderbookDepth)
 	if err != nil {
 		return callingBook, err
@@ -332,9 +337,11 @@ func (p *Poloniex) UpdateOrderbook(c currency.Pair, assetType asset.Item) (*orde
 	}
 	for i := range enabledPairs {
 		book := &orderbook.Base{
-			ExchangeName: p.Name,
-			Pair:         enabledPairs[i],
-			AssetType:    assetType}
+			ExchangeName:       p.Name,
+			Pair:               enabledPairs[i],
+			AssetType:          assetType,
+			VerificationBypass: p.OrderbookVerificationBypass,
+		}
 
 		fpair, err := p.FormatExchangeCurrency(enabledPairs[i], assetType)
 		if err != nil {

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -236,7 +236,12 @@ func (y *Yobit) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderboo
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (y *Yobit) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: y.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       y.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: y.OrderbookVerificationBypass,
+	}
 	fpair, err := y.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -147,6 +147,7 @@ func (z *ZB) wsHandleData(respRaw []byte) error {
 		book.AssetType = asset.Spot
 		book.Pair = cPair
 		book.ExchangeName = z.Name
+		book.VerificationBypass = z.OrderbookVerificationBypass
 
 		err = z.Websocket.Orderbook.LoadSnapshot(&book)
 		if err != nil {

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -166,8 +166,8 @@ func (z *ZB) Setup(exch *config.ExchangeConfig) error {
 		GenerateSubscriptions:            z.GenerateDefaultSubscriptions,
 		Subscriber:                       z.Subscribe,
 		Features:                         &z.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferLimit:             exch.WebsocketOrderbookBufferLimit,
-		BufferEnabled:                    exch.WebsocketOrderbookBufferEnabled,
+		OrderbookBufferLimit:             exch.OrderbookConfig.WebsocketBufferLimit,
+		BufferEnabled:                    exch.OrderbookConfig.WebsocketBufferEnabled,
 	})
 	if err != nil {
 		return err

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -292,7 +292,12 @@ func (z *ZB) FetchOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.B
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
 func (z *ZB) UpdateOrderbook(p currency.Pair, assetType asset.Item) (*orderbook.Base, error) {
-	book := &orderbook.Base{ExchangeName: z.Name, Pair: p, AssetType: assetType}
+	book := &orderbook.Base{
+		ExchangeName:       z.Name,
+		Pair:               p,
+		AssetType:          assetType,
+		VerificationBypass: z.OrderbookVerificationBypass,
+	}
 	currFormat, err := z.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return book, err

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
-github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v3.4.0+incompatible h1:d3y9DuA2LnGr8hiQ+1dPQrNsydLvutmRq9cjULPWYZQ=
 github.com/gofrs/uuid v3.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=


### PR DESCRIPTION
# PR Description

Allow user to set orderbook verification bypass by the configuration file for an individual exchange. This assumes the user has deemed the exchange to have correct bid-ask alignment and stable data. This affects all exchanges and all protocols. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
