### PR TITLE
Binance: GetOrderInfo method issue. Kraken - add Cost param to GetOrderInfo output

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -710,10 +710,6 @@ func (b *Binance) GetOrderInfo(orderID string, pair currency.Pair, assetType ass
 	}
 
 	orderSide := order.Side(resp.Side)
-	orderDate, err := convert.TimeFromUnixTimestampFloat(resp.Time)
-	if err != nil {
-		return
-	}
 
 	status, err := order.StringToOrderStatus(resp.Status)
 	if err != nil {
@@ -727,7 +723,7 @@ func (b *Binance) GetOrderInfo(orderID string, pair currency.Pair, assetType ass
 
 	return order.Detail{
 		Amount:         resp.OrigQty,
-		Date:           orderDate,
+		Date:           resp.Time,
 		Exchange:       b.Name,
 		ID:             strconv.FormatInt(resp.OrderID, 10),
 		Side:           orderSide,

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -775,7 +775,7 @@ func (k *Kraken) GetOrderInfo(orderID string, pair currency.Pair, assetType asse
 		RemainingAmount: orderInfo.Volume - orderInfo.VolumeExecuted,
 		Fee:             orderInfo.Fee,
 		Trades:          trades,
-		Cost:			 orderInfo.Cost,
+		Cost:            orderInfo.Cost,
 	}
 
 	return orderDetail, nil

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -775,6 +775,7 @@ func (k *Kraken) GetOrderInfo(orderID string, pair currency.Pair, assetType asse
 		RemainingAmount: orderInfo.Volume - orderInfo.VolumeExecuted,
 		Fee:             orderInfo.Fee,
 		Trades:          trades,
+		Cost:			 orderInfo.Cost,
 	}
 
 	return orderDetail, nil


### PR DESCRIPTION
# PR Description

Fixed faulty resp.Time handling in Binance GetOrderInfo method
Kraken always return Cost param on closed orders on QueryOrders request, so It will be useful to use it

Fixes # (issue)
- [x]  Bug fix (non-breaking change which fixes an issue)

API method GetOrder  always returned an error in case of Binance

Added Cost param in Kraken GetOrderInfo method

## How has this been tested

- [x] go test ./... -race

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

