### PR TITLE
Config: Race fix (draft)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,8 +36,8 @@ func (c *Config) GetCurrencyConfig() CurrencyConfig {
 // GetExchangeBankAccounts returns banking details associated with an exchange
 // for depositing funds
 func (c *Config) GetExchangeBankAccounts(exchangeName, id, depositingCurrency string) (*banking.Account, error) {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	for x := range c.Exchanges {
 		if strings.EqualFold(c.Exchanges[x].Name, exchangeName) {
@@ -60,8 +60,8 @@ func (c *Config) GetExchangeBankAccounts(exchangeName, id, depositingCurrency st
 // UpdateExchangeBankAccounts updates the configuration for the associated
 // exchange bank
 func (c *Config) UpdateExchangeBankAccounts(exchangeName string, bankCfg []banking.Account) error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	for i := range c.Exchanges {
 		if strings.EqualFold(c.Exchanges[i].Name, exchangeName) {
@@ -76,8 +76,8 @@ func (c *Config) UpdateExchangeBankAccounts(exchangeName string, bankCfg []banki
 // GetClientBankAccounts returns banking details used for a given exchange
 // and currency
 func (c *Config) GetClientBankAccounts(exchangeName, targetCurrency string) (*banking.Account, error) {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	for x := range c.BankAccounts {
 		if (strings.Contains(c.BankAccounts[x].SupportedExchanges, exchangeName) ||
@@ -93,8 +93,8 @@ func (c *Config) GetClientBankAccounts(exchangeName, targetCurrency string) (*ba
 
 // UpdateClientBankAccounts updates the configuration for a bank
 func (c *Config) UpdateClientBankAccounts(bankCfg *banking.Account) error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	for i := range c.BankAccounts {
 		if c.BankAccounts[i].BankName == bankCfg.BankName && c.BankAccounts[i].AccountNumber == bankCfg.AccountNumber {
@@ -108,8 +108,8 @@ func (c *Config) UpdateClientBankAccounts(bankCfg *banking.Account) error {
 
 // CheckClientBankAccounts checks client bank details
 func (c *Config) CheckClientBankAccounts() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if len(c.BankAccounts) == 0 {
 		c.BankAccounts = append(c.BankAccounts,
@@ -144,8 +144,8 @@ func (c *Config) CheckClientBankAccounts() {
 
 // PurgeExchangeAPICredentials purges the stored API credentials
 func (c *Config) PurgeExchangeAPICredentials() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for x := range c.Exchanges {
 		if !c.Exchanges[x].API.AuthenticatedSupport && !c.Exchanges[x].API.AuthenticatedWebsocketSupport {
 			continue
@@ -172,40 +172,40 @@ func (c *Config) PurgeExchangeAPICredentials() {
 
 // GetCommunicationsConfig returns the communications configuration
 func (c *Config) GetCommunicationsConfig() CommunicationsConfig {
-	m.Lock()
+	c.Lock()
 	comms := c.Communications
-	m.Unlock()
+	c.Unlock()
 	return comms
 }
 
 // UpdateCommunicationsConfig sets a new updated version of a Communications
 // configuration
 func (c *Config) UpdateCommunicationsConfig(config *CommunicationsConfig) {
-	m.Lock()
+	c.Lock()
 	c.Communications = *config
-	m.Unlock()
+	c.Unlock()
 }
 
 // GetCryptocurrencyProviderConfig returns the communications configuration
 func (c *Config) GetCryptocurrencyProviderConfig() CryptocurrencyProvider {
-	m.Lock()
+	c.Lock()
 	provider := c.Currency.CryptocurrencyProvider
-	m.Unlock()
+	c.Unlock()
 	return provider
 }
 
 // UpdateCryptocurrencyProviderConfig returns the communications configuration
 func (c *Config) UpdateCryptocurrencyProviderConfig(config CryptocurrencyProvider) {
-	m.Lock()
+	c.Lock()
 	c.Currency.CryptocurrencyProvider = config
-	m.Unlock()
+	c.Unlock()
 }
 
 // CheckCommunicationsConfig checks to see if the variables are set correctly
 // from config.json
 func (c *Config) CheckCommunicationsConfig() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	// If the communications config hasn't been populated, populate
 	// with example settings
@@ -734,16 +734,16 @@ func (c *Config) GetCurrencyPairDisplayConfig() *CurrencyPairFormatConfig {
 
 // GetAllExchangeConfigs returns all exchange configurations
 func (c *Config) GetAllExchangeConfigs() []ExchangeConfig {
-	m.Lock()
+	c.Lock()
 	configs := c.Exchanges
-	m.Unlock()
+	c.Unlock()
 	return configs
 }
 
 // GetExchangeConfig returns exchange configurations by its indivdual name
 func (c *Config) GetExchangeConfig(name string) (*ExchangeConfig, error) {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for i := range c.Exchanges {
 		if strings.EqualFold(c.Exchanges[i].Name, name) {
 			return &c.Exchanges[i], nil
@@ -754,8 +754,8 @@ func (c *Config) GetExchangeConfig(name string) (*ExchangeConfig, error) {
 
 // GetForexProvider returns a forex provider configuration by its name
 func (c *Config) GetForexProvider(name string) (currency.FXSettings, error) {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for i := range c.Currency.ForexProviders {
 		if strings.EqualFold(c.Currency.ForexProviders[i].Name, name) {
 			return c.Currency.ForexProviders[i], nil
@@ -766,16 +766,16 @@ func (c *Config) GetForexProvider(name string) (currency.FXSettings, error) {
 
 // GetForexProviders returns a list of available forex providers
 func (c *Config) GetForexProviders() []currency.FXSettings {
-	m.Lock()
+	c.Lock()
 	fxProviders := c.Currency.ForexProviders
-	m.Unlock()
+	c.Unlock()
 	return fxProviders
 }
 
 // GetPrimaryForexProvider returns the primary forex provider
 func (c *Config) GetPrimaryForexProvider() string {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for i := range c.Currency.ForexProviders {
 		if c.Currency.ForexProviders[i].PrimaryProvider {
 			return c.Currency.ForexProviders[i].Name
@@ -786,8 +786,8 @@ func (c *Config) GetPrimaryForexProvider() string {
 
 // UpdateExchangeConfig updates exchange configurations
 func (c *Config) UpdateExchangeConfig(e *ExchangeConfig) error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for i := range c.Exchanges {
 		if strings.EqualFold(c.Exchanges[i].Name, e.Name) {
 			c.Exchanges[i] = *e
@@ -1276,8 +1276,8 @@ func (c *Config) RetrieveConfigCurrencyPairs(enabledOnly bool, assetType asset.I
 // CheckLoggerConfig checks to see logger values are present and valid in config
 // if not creates a default instance of the logger
 func (c *Config) CheckLoggerConfig() error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if c.Logging.Enabled == nil || c.Logging.Output == "" {
 		c.Logging = log.GenDefaultSettings()
@@ -1315,8 +1315,8 @@ func (c *Config) CheckLoggerConfig() error {
 }
 
 func (c *Config) checkGCTScriptConfig() error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if c.GCTScript.ScriptTimeout <= 0 {
 		c.GCTScript.ScriptTimeout = gctscript.DefaultTimeoutValue
@@ -1344,8 +1344,8 @@ func (c *Config) checkGCTScriptConfig() error {
 }
 
 func (c *Config) checkDatabaseConfig() error {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if (c.Database == database.Config{}) {
 		c.Database.Driver = database.DBSQLite3
@@ -1377,8 +1377,8 @@ func (c *Config) checkDatabaseConfig() error {
 
 // CheckNTPConfig checks for missing or incorrectly configured NTPClient and recreates with known safe defaults
 func (c *Config) CheckNTPConfig() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if c.NTPClient.AllowedDifference == nil || *c.NTPClient.AllowedDifference == 0 {
 		c.NTPClient.AllowedDifference = new(time.Duration)
@@ -1398,8 +1398,8 @@ func (c *Config) CheckNTPConfig() {
 
 // DisableNTPCheck allows the user to change how they are prompted for timesync alerts
 func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	reader := bufio.NewReader(input)
 	log.Warnln(log.ConfigMgr, "Your system time is out of sync, this may cause issues with trading")
@@ -1437,8 +1437,8 @@ func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 
 // CheckConnectionMonitorConfig checks and if zero value assigns default values
 func (c *Config) CheckConnectionMonitorConfig() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if c.ConnectionMonitor.CheckInterval == 0 {
 		c.ConnectionMonitor.CheckInterval = connchecker.DefaultCheckInterval
@@ -1560,12 +1560,10 @@ func (c *Config) ReadConfigFromFile(configPath string, dryrun bool) error {
 		return err
 	}
 	defer confFile.Close()
-	result, wasEncrypted, err := ReadConfig(confFile, func() ([]byte, error) { return PromptForConfigKey(false) })
+	wasEncrypted, err := c.ReadConfig(confFile, func() ([]byte, error) { return PromptForConfigKey(false) })
 	if err != nil {
 		return fmt.Errorf("error reading config %w", err)
 	}
-	// Override values in the current config
-	*c = *result
 
 	if dryrun || wasEncrypted || c.EncryptConfig == fileEncryptionDisabled {
 		return nil
@@ -1594,31 +1592,29 @@ func (c *Config) ReadConfigFromFile(configPath string, dryrun bool) error {
 // ReadConfig verifies and checks for encryption and loads the config from a JSON object.
 // Prompts for decryption key, if target data is encrypted.
 // Returns the loaded configuration and whether it was encrypted.
-func ReadConfig(configReader io.Reader, keyProvider func() ([]byte, error)) (*Config, bool, error) {
+func (c *Config) ReadConfig(configReader io.Reader, keyProvider func() ([]byte, error)) (bool, error) {
 	reader := bufio.NewReader(configReader)
-
 	pref, err := reader.Peek(len(EncryptConfirmString))
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 
 	if !ConfirmECS(pref) {
 		// Read unencrypted configuration
 		decoder := json.NewDecoder(reader)
-		c := &Config{}
 		err = decoder.Decode(c)
-		return c, false, err
+		return false, err
 	}
 
-	conf, err := readEncryptedConfWithKey(reader, keyProvider)
-	return conf, true, err
+	err = c.readEncryptedConfWithKey(reader, keyProvider)
+	return true, err
 }
 
 // readEncryptedConf reads encrypted configuration and requests key from provider
-func readEncryptedConfWithKey(reader *bufio.Reader, keyProvider func() ([]byte, error)) (*Config, error) {
+func (c *Config) readEncryptedConfWithKey(reader *bufio.Reader, keyProvider func() ([]byte, error)) error {
 	fileData, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for errCounter := 0; errCounter < maxAuthFailures; errCounter++ {
 		key, err := keyProvider()
@@ -1627,26 +1623,22 @@ func readEncryptedConfWithKey(reader *bufio.Reader, keyProvider func() ([]byte, 
 			continue
 		}
 
-		var c *Config
-		c, err = readEncryptedConf(bytes.NewReader(fileData), key)
+		err = c.readEncryptedConf(bytes.NewReader(fileData), key)
 		if err != nil {
 			log.Error(log.ConfigMgr, "Could not decrypt and deserialise data with given key. Invalid password?", err)
 			continue
 		}
-		return c, nil
+		return nil
 	}
-	return nil, errors.New("failed to decrypt config after 3 attempts")
+	return errors.New("failed to decrypt config after 3 attempts")
 }
 
-func readEncryptedConf(reader io.Reader, key []byte) (*Config, error) {
-	c := &Config{}
+func (c *Config) readEncryptedConf(reader io.Reader, key []byte) error {
 	data, err := c.decryptConfigData(reader, key)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	err = json.Unmarshal(data, c)
-	return c, err
+	return json.Unmarshal(data, c)
 }
 
 // SaveConfigToFile saves your configuration to your desired path as a JSON object.
@@ -1709,8 +1701,8 @@ func (c *Config) Save(writerProvider func() (io.Writer, error), keyProvider func
 // CheckRemoteControlConfig checks to see if the old c.Webserver field is used
 // and migrates the existing settings to the new RemoteControl struct
 func (c *Config) CheckRemoteControlConfig() {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	if c.Webserver != nil {
 		port := common.ExtractPort(c.Webserver.ListenAddress)
@@ -1840,13 +1832,13 @@ func (c *Config) UpdateConfig(configPath string, newCfg *Config, dryrun bool) er
 
 // GetConfig returns a pointer to a configuration object
 func GetConfig() *Config {
-	return &Cfg
+	return config
 }
 
 // RemoveExchange removes an exchange config
 func (c *Config) RemoveExchange(exchName string) bool {
-	m.Lock()
-	defer m.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	for x := range c.Exchanges {
 		if strings.EqualFold(c.Exchanges[x].Name, exchName) {
 			c.Exchanges = append(c.Exchanges[:x], c.Exchanges[x+1:]...)

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -94,8 +94,10 @@ func EncryptConfigFile(configData, key []byte) ([]byte, error) {
 		return nil, err
 	}
 	c := &Config{
-		sessionDK:  sessionDK,
-		storedSalt: salt,
+		d: Details{
+			sessionDK:  sessionDK,
+			storedSalt: salt,
+		},
 	}
 	return c.encryptConfigFile(configData)
 }
@@ -103,7 +105,7 @@ func EncryptConfigFile(configData, key []byte) ([]byte, error) {
 // encryptConfigFile encrypts configuration data that is parsed in with a key
 // and returns it as a byte array with an error
 func (c *Config) encryptConfigFile(configData []byte) ([]byte, error) {
-	block, err := aes.NewCipher(c.sessionDK)
+	block, err := aes.NewCipher(c.d.sessionDK)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func (c *Config) encryptConfigFile(configData []byte) ([]byte, error) {
 	stream.XORKeyStream(ciphertext[aes.BlockSize:], configData)
 
 	appendedFile := []byte(EncryptConfirmString)
-	appendedFile = append(appendedFile, c.storedSalt...)
+	appendedFile = append(appendedFile, c.d.storedSalt...)
 	appendedFile = append(appendedFile, ciphertext...)
 	return appendedFile, nil
 }
@@ -175,7 +177,7 @@ func (c *Config) decryptConfigData(configReader io.Reader, key []byte) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	c.sessionDK, c.storedSalt = sessionDK, storedSalt
+	c.d.sessionDK, c.d.storedSalt = sessionDK, storedSalt
 
 	return result, nil
 }

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -44,7 +44,7 @@ func TestEncryptConfigFile(t *testing.T) {
 	}
 
 	c := &Config{
-		sessionDK: []byte("a"),
+		d: Details{sessionDK: []byte("a")},
 	}
 	_, err = c.encryptConfigFile([]byte("test"))
 	if err == nil {
@@ -57,8 +57,10 @@ func TestEncryptConfigFile(t *testing.T) {
 	}
 
 	c = &Config{
-		sessionDK:  sessDk,
-		storedSalt: salt,
+		d: Details{
+			sessionDK:  sessDk,
+			storedSalt: salt,
+		},
 	}
 	_, err = c.encryptConfigFile([]byte("test"))
 	if err != nil {
@@ -136,7 +138,7 @@ func TestMakeNewSessionDK(t *testing.T) {
 
 func TestEncryptTwiceReusesSaltButNewCipher(t *testing.T) {
 	c := &Config{}
-	c.EncryptConfig = 1
+	c.d.EncryptConfig = 1
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
@@ -193,8 +195,8 @@ func TestEncryptTwiceReusesSaltButNewCipher(t *testing.T) {
 
 func TestSaveAndReopenEncryptedConfig(t *testing.T) {
 	c := &Config{}
-	c.Name = "myCustomName"
-	c.EncryptConfig = 1
+	c.d.Name = "myCustomName"
+	c.d.EncryptConfig = 1
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
@@ -221,7 +223,7 @@ func TestSaveAndReopenEncryptedConfig(t *testing.T) {
 		t.Fatalf("Problem reading config in file %s: %s\n", enc, err)
 	}
 
-	if c.Name != readConf.Name || c.EncryptConfig != readConf.EncryptConfig {
+	if c.d.Name != readConf.d.Name || c.d.EncryptConfig != readConf.d.EncryptConfig {
 		t.Error("Loaded conf not the same as original")
 	}
 }
@@ -252,7 +254,7 @@ func TestReadConfigWithPrompt(t *testing.T) {
 
 	// Ensure we'll get the prompt when loading
 	c := &Config{
-		EncryptConfig: 0,
+		d: Details{EncryptConfig: 0},
 	}
 
 	// Save config
@@ -276,7 +278,7 @@ func TestReadConfigWithPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Problem reading saved file at %s: %s\n", testConfigFile, err)
 	}
-	if c.EncryptConfig != fileEncryptionEnabled {
+	if c.d.EncryptConfig != fileEncryptionEnabled {
 		t.Error("Config encryption flag should be set after prompts")
 	}
 	if !ConfirmECS(data) {
@@ -296,7 +298,7 @@ func TestReadEncryptedConfigFromReader(t *testing.T) {
 	if !encrypted {
 		t.Errorf("Expected encrypted config %s", err)
 	}
-	if conf.Name != "test" {
+	if conf.d.Name != "test" {
 		t.Errorf("Conf not properly loaded %s", err)
 	}
 
@@ -311,8 +313,10 @@ func TestReadEncryptedConfigFromReader(t *testing.T) {
 // TestSaveConfigToFileWithErrorInPasswordPrompt should preserve the original file
 func TestSaveConfigToFileWithErrorInPasswordPrompt(t *testing.T) {
 	c := &Config{
-		Name:          "test",
-		EncryptConfig: fileEncryptionEnabled,
+		d: Details{
+			Name:          "test",
+			EncryptConfig: fileEncryptionEnabled,
+		},
 	}
 	testData := []byte("testdata")
 	f, err := ioutil.TempFile("", "")

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -285,10 +285,11 @@ func TestReadConfigWithPrompt(t *testing.T) {
 }
 
 func TestReadEncryptedConfigFromReader(t *testing.T) {
+	conf := &Config{}
 	keyProvider := func() ([]byte, error) { return []byte("pass"), nil }
 	// Encrypted conf for: `{"name":"test"}` with key `pass`
 	confBytes := []byte{84, 72, 79, 82, 83, 45, 72, 65, 77, 77, 69, 82, 126, 71, 67, 84, 126, 83, 79, 126, 83, 65, 76, 84, 89, 126, 246, 110, 128, 3, 30, 168, 172, 160, 198, 176, 136, 62, 152, 155, 253, 176, 16, 48, 52, 246, 44, 29, 151, 47, 217, 226, 178, 12, 218, 113, 248, 172, 195, 232, 136, 104, 9, 199, 20, 4, 71, 4, 253, 249}
-	conf, encrypted, err := ReadConfig(bytes.NewReader(confBytes), keyProvider)
+	encrypted, err := conf.ReadConfig(bytes.NewReader(confBytes), keyProvider)
 	if err != nil {
 		t.Errorf("TestReadConfig %s", err)
 	}
@@ -301,7 +302,7 @@ func TestReadEncryptedConfigFromReader(t *testing.T) {
 
 	// Change the salt
 	confBytes[20] = 0
-	conf, _, err = ReadConfig(bytes.NewReader(confBytes), keyProvider)
+	_, err = conf.ReadConfig(bytes.NewReader(confBytes), keyProvider)
 	if err == nil {
 		t.Errorf("Expected unable to decrypt, but got %+v", conf)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,7 @@ func TestCheckBankAccountConfig(t *testing.T) {
 		t.Error("GetExchangeBankAccounts LoadConfig error", err)
 	}
 
-	cfg.BankAccounts[0].Enabled = true
+	cfg.d.BankAccounts[0].Enabled = true
 	cfg.CheckBankAccountConfig()
 }
 
@@ -106,7 +106,7 @@ func TestUpdateExchangeBankAccounts(t *testing.T) {
 		t.Error("UpdateExchangeBankAccounts error", err)
 	}
 	var count int
-	for _, exch := range cfg.Exchanges {
+	for _, exch := range cfg.d.Exchanges {
 		if exch.Name == "Bitfinex" {
 			if !exch.BankAccounts[0].Enabled {
 				count++
@@ -141,7 +141,7 @@ func TestUpdateClientBankAccounts(t *testing.T) {
 	}
 
 	var count int
-	for _, bank := range cfg.BankAccounts {
+	for _, bank := range cfg.d.BankAccounts {
 		if bank.BankName == b.BankName {
 			if !bank.Enabled {
 				count++
@@ -160,21 +160,21 @@ func TestCheckClientBankAccounts(t *testing.T) {
 		t.Error("CheckClientBankAccounts LoadConfig error", err)
 	}
 
-	cfg.BankAccounts = nil
+	cfg.d.BankAccounts = nil
 	cfg.CheckClientBankAccounts()
-	if len(cfg.BankAccounts) == 0 {
+	if len(cfg.d.BankAccounts) == 0 {
 		t.Error("CheckClientBankAccounts error:", err)
 	}
 
-	cfg.BankAccounts = nil
-	cfg.BankAccounts = []banking.Account{
+	cfg.d.BankAccounts = nil
+	cfg.d.BankAccounts = []banking.Account{
 		{
 			Enabled: true,
 		},
 	}
 
 	cfg.CheckClientBankAccounts()
-	if cfg.BankAccounts[0].Enabled {
+	if cfg.d.BankAccounts[0].Enabled {
 		t.Error("unexpected result")
 	}
 
@@ -189,10 +189,10 @@ func TestCheckClientBankAccounts(t *testing.T) {
 		AccountNumber:       "1231006505",
 		SupportedCurrencies: "USD",
 	}
-	cfg.BankAccounts = []banking.Account{b}
+	cfg.d.BankAccounts = []banking.Account{b}
 	cfg.CheckClientBankAccounts()
-	if cfg.BankAccounts[0].Enabled ||
-		cfg.BankAccounts[0].SupportedExchanges != "ALL" {
+	if cfg.d.BankAccounts[0].Enabled ||
+		cfg.d.BankAccounts[0].SupportedExchanges != "ALL" {
 		t.Error("unexpected result")
 	}
 
@@ -200,17 +200,17 @@ func TestCheckClientBankAccounts(t *testing.T) {
 	// transfers)
 	b.SupportedCurrencies = "AUD"
 	b.SWIFTCode = "BACXSI22"
-	cfg.BankAccounts = []banking.Account{b}
+	cfg.d.BankAccounts = []banking.Account{b}
 	cfg.CheckClientBankAccounts()
-	if cfg.BankAccounts[0].Enabled {
+	if cfg.d.BankAccounts[0].Enabled {
 		t.Error("unexpected result")
 	}
 
 	// Valid AU bank
 	b.BSBNumber = "061337"
-	cfg.BankAccounts = []banking.Account{b}
+	cfg.d.BankAccounts = []banking.Account{b}
 	cfg.CheckClientBankAccounts()
-	if !cfg.BankAccounts[0].Enabled {
+	if !cfg.d.BankAccounts[0].Enabled {
 		t.Error("unexpected result")
 	}
 
@@ -218,9 +218,9 @@ func TestCheckClientBankAccounts(t *testing.T) {
 	b.Enabled = true
 	b.IBAN = "SI56290000170073837"
 	b.SWIFTCode = "BACXSI22"
-	cfg.BankAccounts = []banking.Account{b}
+	cfg.d.BankAccounts = []banking.Account{b}
 	cfg.CheckClientBankAccounts()
-	if !cfg.BankAccounts[0].Enabled {
+	if !cfg.d.BankAccounts[0].Enabled {
 		t.Error("unexpected result")
 	}
 }
@@ -228,7 +228,7 @@ func TestCheckClientBankAccounts(t *testing.T) {
 func TestPurgeExchangeCredentials(t *testing.T) {
 	t.Parallel()
 	var c Config
-	c.Exchanges = []ExchangeConfig{
+	c.d.Exchanges = []ExchangeConfig{
 		{
 			Name: testString,
 			API: APIConfig{
@@ -303,7 +303,7 @@ func TestUpdateCommunicationsConfig(t *testing.T) {
 		t.Error("UpdateCommunicationsConfig LoadConfig error", err)
 	}
 	cfg.UpdateCommunicationsConfig(&CommunicationsConfig{SlackConfig: SlackConfig{Name: testString}})
-	if cfg.Communications.SlackConfig.Name != testString {
+	if cfg.d.Communications.SlackConfig.Name != testString {
 		t.Error("UpdateCommunicationsConfig LoadConfig error")
 	}
 }
@@ -326,7 +326,7 @@ func TestUpdateCryptocurrencyProviderConfig(t *testing.T) {
 
 	orig := cfg.GetCryptocurrencyProviderConfig()
 	cfg.UpdateCryptocurrencyProviderConfig(CryptocurrencyProvider{Name: "SERIOUS TESTING PROCEDURE!"})
-	if cfg.Currency.CryptocurrencyProvider.Name != "SERIOUS TESTING PROCEDURE!" {
+	if cfg.d.Currency.CryptocurrencyProvider.Name != "SERIOUS TESTING PROCEDURE!" {
 		t.Error("UpdateCurrencyProviderConfig LoadConfig error")
 	}
 
@@ -340,84 +340,84 @@ func TestCheckCommunicationsConfig(t *testing.T) {
 		t.Error("CheckCommunicationsConfig LoadConfig error", err)
 	}
 
-	cfg.Communications = CommunicationsConfig{}
+	cfg.d.Communications = CommunicationsConfig{}
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SlackConfig.Name != "Slack" ||
-		cfg.Communications.SMSGlobalConfig.Name != "SMSGlobal" ||
-		cfg.Communications.SMTPConfig.Name != "SMTP" ||
-		cfg.Communications.TelegramConfig.Name != "Telegram" {
+	if cfg.d.Communications.SlackConfig.Name != "Slack" ||
+		cfg.d.Communications.SMSGlobalConfig.Name != "SMSGlobal" ||
+		cfg.d.Communications.SMTPConfig.Name != "SMTP" ||
+		cfg.d.Communications.TelegramConfig.Name != "Telegram" {
 		t.Error("CheckCommunicationsConfig unexpected data:",
-			cfg.Communications)
+			cfg.d.Communications)
 	}
 
-	cfg.SMS = &SMSGlobalConfig{}
-	cfg.Communications.SMSGlobalConfig.Name = ""
+	cfg.d.SMS = &SMSGlobalConfig{}
+	cfg.d.Communications.SMSGlobalConfig.Name = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SMSGlobalConfig.Password != testString {
+	if cfg.d.Communications.SMSGlobalConfig.Password != testString {
 		t.Error("CheckCommunicationsConfig error:", err)
 	}
 
-	cfg.SMS.Contacts = append(cfg.SMS.Contacts, SMSContact{
+	cfg.d.SMS.Contacts = append(cfg.d.SMS.Contacts, SMSContact{
 		Name:    "Bobby",
 		Number:  "4321",
 		Enabled: false,
 	})
-	cfg.Communications.SMSGlobalConfig.Name = ""
+	cfg.d.Communications.SMSGlobalConfig.Name = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SMSGlobalConfig.Contacts[0].Name != "Bobby" {
+	if cfg.d.Communications.SMSGlobalConfig.Contacts[0].Name != "Bobby" {
 		t.Error("CheckCommunicationsConfig error:", err)
 	}
 
-	cfg.Communications.SMSGlobalConfig.From = ""
+	cfg.d.Communications.SMSGlobalConfig.From = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SMSGlobalConfig.From != cfg.Name {
+	if cfg.d.Communications.SMSGlobalConfig.From != cfg.d.Name {
 		t.Error("CheckCommunicationsConfig From value should have been set to the config name")
 	}
 
-	cfg.Communications.SMSGlobalConfig.From = "aaaaaaaaaaaaaaaaaaa"
+	cfg.d.Communications.SMSGlobalConfig.From = "aaaaaaaaaaaaaaaaaaa"
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SMSGlobalConfig.From != "aaaaaaaaaaa" {
+	if cfg.d.Communications.SMSGlobalConfig.From != "aaaaaaaaaaa" {
 		t.Error("CheckCommunicationsConfig From value should have been trimmed to 11 characters")
 	}
 
-	cfg.SMS = &SMSGlobalConfig{}
+	cfg.d.SMS = &SMSGlobalConfig{}
 	cfg.CheckCommunicationsConfig()
-	if cfg.SMS != nil {
+	if cfg.d.SMS != nil {
 		t.Error("CheckCommunicationsConfig unexpected data:",
-			cfg.SMS)
+			cfg.d.SMS)
 	}
 
-	cfg.Communications.SlackConfig.Name = "NOT Slack"
+	cfg.d.Communications.SlackConfig.Name = "NOT Slack"
 	cfg.CheckCommunicationsConfig()
 
-	cfg.Communications.SlackConfig.Name = "Slack"
-	cfg.Communications.SlackConfig.Enabled = true
+	cfg.d.Communications.SlackConfig.Name = "Slack"
+	cfg.d.Communications.SlackConfig.Enabled = true
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SlackConfig.Enabled {
+	if cfg.d.Communications.SlackConfig.Enabled {
 		t.Error("CheckCommunicationsConfig Slack is enabled when it shouldn't be.")
 	}
 
-	cfg.Communications.SlackConfig.Enabled = false
-	cfg.Communications.SMSGlobalConfig.Enabled = true
-	cfg.Communications.SMSGlobalConfig.Password = ""
+	cfg.d.Communications.SlackConfig.Enabled = false
+	cfg.d.Communications.SMSGlobalConfig.Enabled = true
+	cfg.d.Communications.SMSGlobalConfig.Password = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SlackConfig.Enabled {
+	if cfg.d.Communications.SlackConfig.Enabled {
 		t.Error("CheckCommunicationsConfig SMSGlobal is enabled when it shouldn't be.")
 	}
 
-	cfg.Communications.SMSGlobalConfig.Enabled = false
-	cfg.Communications.SMTPConfig.Enabled = true
-	cfg.Communications.SMTPConfig.AccountPassword = ""
+	cfg.d.Communications.SMSGlobalConfig.Enabled = false
+	cfg.d.Communications.SMTPConfig.Enabled = true
+	cfg.d.Communications.SMTPConfig.AccountPassword = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.SlackConfig.Enabled {
+	if cfg.d.Communications.SlackConfig.Enabled {
 		t.Error("CheckCommunicationsConfig SMTPConfig is enabled when it shouldn't be.")
 	}
 
-	cfg.Communications.SMTPConfig.Enabled = false
-	cfg.Communications.TelegramConfig.Enabled = true
-	cfg.Communications.TelegramConfig.VerificationToken = ""
+	cfg.d.Communications.SMTPConfig.Enabled = false
+	cfg.d.Communications.TelegramConfig.Enabled = true
+	cfg.d.Communications.TelegramConfig.VerificationToken = ""
 	cfg.CheckCommunicationsConfig()
-	if cfg.Communications.TelegramConfig.Enabled {
+	if cfg.d.Communications.TelegramConfig.Enabled {
 		t.Error("CheckCommunicationsConfig TelegramConfig is enabled when it shouldn't be.")
 	}
 }
@@ -430,7 +430,7 @@ func TestGetExchangeAssetTypes(t *testing.T) {
 		t.Error("err should have been thrown on a non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 			CurrencyPairs: &currency.PairsManager{
@@ -452,7 +452,7 @@ func TestGetExchangeAssetTypes(t *testing.T) {
 		t.Error("unexpected results")
 	}
 
-	c.Exchanges[0].CurrencyPairs = nil
+	c.d.Exchanges[0].CurrencyPairs = nil
 	_, err = c.GetExchangeAssetTypes(testFakeExchangeName)
 	if err == nil {
 		t.Error("Expected error from nil currency pair")
@@ -467,7 +467,7 @@ func TestSupportsExchangeAssetType(t *testing.T) {
 		t.Error("Expected error for non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 			CurrencyPairs: &currency.PairsManager{
@@ -488,7 +488,7 @@ func TestSupportsExchangeAssetType(t *testing.T) {
 		t.Error("Expected error from invalid asset item")
 	}
 
-	c.Exchanges[0].CurrencyPairs = nil
+	c.d.Exchanges[0].CurrencyPairs = nil
 	err = c.SupportsExchangeAssetType(testFakeExchangeName, asset.Spot)
 	if err == nil {
 		t.Error("Expected error from nil pair manager")
@@ -514,7 +514,7 @@ func TestSetPairs(t *testing.T) {
 		t.Error("Expected error from non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 		},
@@ -525,7 +525,7 @@ func TestSetPairs(t *testing.T) {
 		t.Error("Expected error from non initialised pair manager")
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		Pairs: map[asset.Item]*currency.PairStore{
 			asset.Spot: new(currency.PairStore),
 		},
@@ -551,7 +551,7 @@ func TestGetCurrencyPairConfig(t *testing.T) {
 		t.Error("Expected error with non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 		},
@@ -577,7 +577,7 @@ func TestGetCurrencyPairConfig(t *testing.T) {
 		},
 	}
 
-	c.Exchanges[0].CurrencyPairs = pm
+	c.d.Exchanges[0].CurrencyPairs = pm
 	_, err = c.GetCurrencyPairConfig(testFakeExchangeName, asset.Index)
 	if err == nil {
 		t.Error("Expected error with unsupported asset")
@@ -604,7 +604,7 @@ func TestCheckPairConfigFormats(t *testing.T) {
 	}
 
 	// Test nil pair store
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 		},
@@ -614,7 +614,7 @@ func TestCheckPairConfigFormats(t *testing.T) {
 		t.Error("nil pair store should return an error")
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		Pairs: map[asset.Item]*currency.PairStore{
 			asset.Spot:    {},
 			asset.Futures: {},
@@ -624,7 +624,7 @@ func TestCheckPairConfigFormats(t *testing.T) {
 		t.Error("error cannot be nil")
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		Pairs: map[asset.Item]*currency.PairStore{
 			asset.Spot: {
 				RequestFormat: &currency.PairFormat{},
@@ -648,7 +648,7 @@ func TestCheckPairConfigFormats(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test having a pair index and delimiter set at the same time throws an error
-	c.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
+	c.d.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
 		asset.Spot: {
 			RequestFormat: &currency.PairFormat{
 				Uppercase: false,
@@ -673,21 +673,21 @@ func TestCheckPairConfigFormats(t *testing.T) {
 	}
 
 	// Test wrong pair delimiter throws an error
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].ConfigFormat.Index = ""
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].ConfigFormat.Index = ""
 	if err := c.CheckPairConfigFormats(testFakeExchangeName); err == nil {
 		t.Error("invalid pair delimiter should throw an error")
 	}
 
 	// Test wrong pair index in the enabled pairs throw an error
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
 		ConfigFormat: &currency.PairFormat{
 			Index: currency.AUD.String(),
 		},
 	}
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
 		currency.NewPair(currency.BTC, currency.AUD),
 	}
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
 		currency.NewPair(currency.BTC, currency.KRW),
 	}
 
@@ -704,7 +704,7 @@ func TestCheckPairConsistency(t *testing.T) {
 		t.Error("non-existent exchange should return an error")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 		},
@@ -720,7 +720,7 @@ func TestCheckPairConsistency(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		Pairs: map[asset.Item]*currency.PairStore{
 			asset.Spot: {
 				RequestFormat: &currency.PairFormat{
@@ -750,7 +750,7 @@ func TestCheckPairConsistency(t *testing.T) {
 	}
 
 	// Test that enabled pair is not found in the available pairs
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
 		p1,
 	}
 
@@ -761,7 +761,7 @@ func TestCheckPairConsistency(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, item := range c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled {
+	for _, item := range c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled {
 		if !item.Equal(p1) {
 			t.Fatal("LTC_USD should be contained in the enabled pairs list")
 		}
@@ -773,7 +773,7 @@ func TestCheckPairConsistency(t *testing.T) {
 	}
 
 	// Add the BTC_USD pair and see result
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
 		p1,
 		p2,
 	}
@@ -783,17 +783,17 @@ func TestCheckPairConsistency(t *testing.T) {
 	}
 
 	// Test that an empty enabled pair is populated with an available pair
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = nil
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = nil
 	if err := c.CheckPairConsistency(testFakeExchangeName); err != nil {
 		t.Error("unexpected result")
 	}
 
-	if len(c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled) != 1 {
+	if len(c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled) != 1 {
 		t.Fatal("should be populated with atleast one currency pair")
 	}
 
 	// Test that an invalid enabled pair is removed from the list
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
 		p1,
 		p2,
 	}
@@ -807,31 +807,31 @@ func TestCheckPairConsistency(t *testing.T) {
 		t.Error("unexpected result")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(true)
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{}
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(true)
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{}
 
 	// Test no conflict and atleast one on enabled asset type
 	if err := c.CheckPairConsistency(testFakeExchangeName); err != nil {
 		t.Error("unexpected result")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(true)
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{currency.NewPair(currency.DASH, currency.USD)}
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(true)
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{currency.NewPair(currency.DASH, currency.USD)}
 
 	// Test with conflict and atleast one on enabled asset type
 	if err := c.CheckPairConsistency(testFakeExchangeName); err != nil {
 		t.Error("unexpected result")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(false)
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{}
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(false)
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{}
 
 	// Test no conflict and atleast one on disabled asset type
 	if err := c.CheckPairConsistency(testFakeExchangeName); err != nil {
 		t.Error("unexpected result")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
 		currency.NewPair(currency.DASH, currency.USD),
 		p1,
 		p2,
@@ -842,7 +842,7 @@ func TestCheckPairConsistency(t *testing.T) {
 		t.Error("unexpected result")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = nil
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = nil
 
 	// assetType enabled failure check
 	if err := c.CheckPairConsistency(testFakeExchangeName); err != nil {
@@ -884,7 +884,7 @@ func TestGetPairFormat(t *testing.T) {
 		t.Error("Expected error from non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name: testFakeExchangeName,
 		},
@@ -894,7 +894,7 @@ func TestGetPairFormat(t *testing.T) {
 		t.Error("Expected error from nil pair manager")
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		UseGlobalFormat: false,
 		RequestFormat: &currency.PairFormat{
 			Uppercase: false,
@@ -914,7 +914,7 @@ func TestGetPairFormat(t *testing.T) {
 		t.Error("Expected error from nil pair manager")
 	}
 
-	c.Exchanges[0].CurrencyPairs = &currency.PairsManager{
+	c.d.Exchanges[0].CurrencyPairs = &currency.PairsManager{
 		UseGlobalFormat: true,
 		RequestFormat: &currency.PairFormat{
 			Uppercase: false,
@@ -949,13 +949,13 @@ func TestGetPairFormat(t *testing.T) {
 	}
 
 	// Test nil pair store
-	c.Exchanges[0].CurrencyPairs.UseGlobalFormat = false
+	c.d.Exchanges[0].CurrencyPairs.UseGlobalFormat = false
 	_, err = c.GetPairFormat(testFakeExchangeName, asset.Spot)
 	if err == nil {
 		t.Error("Expected error")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
+	c.d.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
 		asset.Spot: {
 			ConfigFormat: &currency.PairFormat{
 				Uppercase: true,
@@ -982,7 +982,7 @@ func TestGetAvailablePairs(t *testing.T) {
 		t.Error("Expected error from non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name:          testFakeExchangeName,
 			CurrencyPairs: &currency.PairsManager{},
@@ -994,7 +994,7 @@ func TestGetAvailablePairs(t *testing.T) {
 		t.Error("Expected error from nil pair manager")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
+	c.d.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
 		asset.Spot: {
 			ConfigFormat: &currency.PairFormat{
 				Delimiter: "-",
@@ -1007,7 +1007,7 @@ func TestGetAvailablePairs(t *testing.T) {
 		t.Error("Expected error from nil pairs")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
 		currency.NewPair(currency.BTC, currency.USD),
 	}
 	_, err = c.GetAvailablePairs(testFakeExchangeName, asset.Spot)
@@ -1025,7 +1025,7 @@ func TestGetEnabledPairs(t *testing.T) {
 		t.Error("Expected error from non-existent exchange")
 	}
 
-	c.Exchanges = append(c.Exchanges,
+	c.d.Exchanges = append(c.d.Exchanges,
 		ExchangeConfig{
 			Name:          testFakeExchangeName,
 			CurrencyPairs: &currency.PairsManager{},
@@ -1037,7 +1037,7 @@ func TestGetEnabledPairs(t *testing.T) {
 		t.Error("Expected error from nil pair manager")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
+	c.d.Exchanges[0].CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
 		asset.Spot: {
 			ConfigFormat: &currency.PairFormat{
 				Delimiter: "-",
@@ -1050,11 +1050,11 @@ func TestGetEnabledPairs(t *testing.T) {
 		t.Error("nil pairs should return a nil error")
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = currency.Pairs{
 		currency.NewPair(currency.BTC, currency.USD),
 	}
 
-	c.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
+	c.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Available = currency.Pairs{
 		currency.NewPair(currency.BTC, currency.USD),
 	}
 
@@ -1225,8 +1225,8 @@ func TestGetPrimaryForexProvider(t *testing.T) {
 		t.Error("GetPrimaryForexProvider error")
 	}
 
-	for i := range cfg.Currency.ForexProviders {
-		cfg.Currency.ForexProviders[i].PrimaryProvider = false
+	for i := range cfg.d.Currency.ForexProviders {
+		cfg.d.Currency.ForexProviders[i].PrimaryProvider = false
 	}
 	primary = cfg.GetPrimaryForexProvider()
 	if primary != "" {
@@ -1277,12 +1277,12 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg.Exchanges[0].Name = "GDAX"
+	cfg.d.Exchanges[0].Name = "GDAX"
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
-	if cfg.Exchanges[0].Name != "CoinbasePro" {
+	if cfg.d.Exchanges[0].Name != "CoinbasePro" {
 		t.Error("exchange name should have been updated from GDAX to CoinbasePRo")
 	}
 
@@ -1290,70 +1290,70 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 	sptr := func(s string) *string { return &s }
 	int64ptr := func(i int64) *int64 { return &i }
 
-	cfg.Exchanges[0].APIKey = sptr("awesomeKey")
-	cfg.Exchanges[0].APISecret = sptr("meowSecret")
-	cfg.Exchanges[0].ClientID = sptr("clientIDerino")
-	cfg.Exchanges[0].APIAuthPEMKey = sptr("-----BEGIN EC PRIVATE KEY-----\nASDF\n-----END EC PRIVATE KEY-----\n")
-	cfg.Exchanges[0].APIAuthPEMKeySupport = convert.BoolPtr(true)
-	cfg.Exchanges[0].AuthenticatedAPISupport = convert.BoolPtr(true)
-	cfg.Exchanges[0].AuthenticatedWebsocketAPISupport = convert.BoolPtr(true)
-	cfg.Exchanges[0].WebsocketURL = sptr("wss://1337")
-	cfg.Exchanges[0].APIURL = sptr(APIURLNonDefaultMessage)
-	cfg.Exchanges[0].APIURLSecondary = sptr(APIURLNonDefaultMessage)
+	cfg.d.Exchanges[0].APIKey = sptr("awesomeKey")
+	cfg.d.Exchanges[0].APISecret = sptr("meowSecret")
+	cfg.d.Exchanges[0].ClientID = sptr("clientIDerino")
+	cfg.d.Exchanges[0].APIAuthPEMKey = sptr("-----BEGIN EC PRIVATE KEY-----\nASDF\n-----END EC PRIVATE KEY-----\n")
+	cfg.d.Exchanges[0].APIAuthPEMKeySupport = convert.BoolPtr(true)
+	cfg.d.Exchanges[0].AuthenticatedAPISupport = convert.BoolPtr(true)
+	cfg.d.Exchanges[0].AuthenticatedWebsocketAPISupport = convert.BoolPtr(true)
+	cfg.d.Exchanges[0].WebsocketURL = sptr("wss://1337")
+	cfg.d.Exchanges[0].APIURL = sptr(APIURLNonDefaultMessage)
+	cfg.d.Exchanges[0].APIURLSecondary = sptr(APIURLNonDefaultMessage)
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Ensure that all of our previous settings are migrated
-	if cfg.Exchanges[0].API.Credentials.Key != "awesomeKey" ||
-		cfg.Exchanges[0].API.Credentials.Secret != "meowSecret" ||
-		cfg.Exchanges[0].API.Credentials.ClientID != "clientIDerino" ||
-		!strings.Contains(cfg.Exchanges[0].API.Credentials.PEMKey, "ASDF") ||
-		!cfg.Exchanges[0].API.PEMKeySupport ||
-		!cfg.Exchanges[0].API.AuthenticatedSupport ||
-		!cfg.Exchanges[0].API.AuthenticatedWebsocketSupport ||
-		cfg.Exchanges[0].API.Endpoints.WebsocketURL != "wss://1337" ||
-		cfg.Exchanges[0].API.Endpoints.URL != APIURLNonDefaultMessage ||
-		cfg.Exchanges[0].API.Endpoints.URLSecondary != APIURLNonDefaultMessage {
+	if cfg.d.Exchanges[0].API.Credentials.Key != "awesomeKey" ||
+		cfg.d.Exchanges[0].API.Credentials.Secret != "meowSecret" ||
+		cfg.d.Exchanges[0].API.Credentials.ClientID != "clientIDerino" ||
+		!strings.Contains(cfg.d.Exchanges[0].API.Credentials.PEMKey, "ASDF") ||
+		!cfg.d.Exchanges[0].API.PEMKeySupport ||
+		!cfg.d.Exchanges[0].API.AuthenticatedSupport ||
+		!cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport ||
+		cfg.d.Exchanges[0].API.Endpoints.WebsocketURL != "wss://1337" ||
+		cfg.d.Exchanges[0].API.Endpoints.URL != APIURLNonDefaultMessage ||
+		cfg.d.Exchanges[0].API.Endpoints.URLSecondary != APIURLNonDefaultMessage {
 		t.Error("unexpected values")
 	}
 
-	if cfg.Exchanges[0].APIKey != nil ||
-		cfg.Exchanges[0].APISecret != nil ||
-		cfg.Exchanges[0].ClientID != nil ||
-		cfg.Exchanges[0].APIAuthPEMKey != nil ||
-		cfg.Exchanges[0].APIAuthPEMKeySupport != nil ||
-		cfg.Exchanges[0].AuthenticatedAPISupport != nil ||
-		cfg.Exchanges[0].AuthenticatedWebsocketAPISupport != nil ||
-		cfg.Exchanges[0].WebsocketURL != nil ||
-		cfg.Exchanges[0].APIURL != nil ||
-		cfg.Exchanges[0].APIURLSecondary != nil {
+	if cfg.d.Exchanges[0].APIKey != nil ||
+		cfg.d.Exchanges[0].APISecret != nil ||
+		cfg.d.Exchanges[0].ClientID != nil ||
+		cfg.d.Exchanges[0].APIAuthPEMKey != nil ||
+		cfg.d.Exchanges[0].APIAuthPEMKeySupport != nil ||
+		cfg.d.Exchanges[0].AuthenticatedAPISupport != nil ||
+		cfg.d.Exchanges[0].AuthenticatedWebsocketAPISupport != nil ||
+		cfg.d.Exchanges[0].WebsocketURL != nil ||
+		cfg.d.Exchanges[0].APIURL != nil ||
+		cfg.d.Exchanges[0].APIURLSecondary != nil {
 		t.Error("unexpected values")
 	}
 
 	// Test feature and endpoint migrations migrations
-	cfg.Exchanges[0].Features = nil
-	cfg.Exchanges[0].SupportsAutoPairUpdates = convert.BoolPtr(true)
-	cfg.Exchanges[0].Websocket = convert.BoolPtr(true)
-	cfg.Exchanges[0].API.Endpoints.URL = ""
-	cfg.Exchanges[0].API.Endpoints.URLSecondary = ""
-	cfg.Exchanges[0].API.Endpoints.WebsocketURL = ""
+	cfg.d.Exchanges[0].Features = nil
+	cfg.d.Exchanges[0].SupportsAutoPairUpdates = convert.BoolPtr(true)
+	cfg.d.Exchanges[0].Websocket = convert.BoolPtr(true)
+	cfg.d.Exchanges[0].API.Endpoints.URL = ""
+	cfg.d.Exchanges[0].API.Endpoints.URLSecondary = ""
+	cfg.d.Exchanges[0].API.Endpoints.WebsocketURL = ""
 
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !cfg.Exchanges[0].Features.Enabled.AutoPairUpdates ||
-		!cfg.Exchanges[0].Features.Enabled.Websocket ||
-		!cfg.Exchanges[0].Features.Supports.RESTCapabilities.AutoPairUpdates {
+	if !cfg.d.Exchanges[0].Features.Enabled.AutoPairUpdates ||
+		!cfg.d.Exchanges[0].Features.Enabled.Websocket ||
+		!cfg.d.Exchanges[0].Features.Supports.RESTCapabilities.AutoPairUpdates {
 		t.Error("unexpected values")
 	}
 
-	if cfg.Exchanges[0].API.Endpoints.URL != APIURLNonDefaultMessage ||
-		cfg.Exchanges[0].API.Endpoints.URLSecondary != APIURLNonDefaultMessage ||
-		cfg.Exchanges[0].API.Endpoints.WebsocketURL != WebsocketURLNonDefaultMessage {
+	if cfg.d.Exchanges[0].API.Endpoints.URL != APIURLNonDefaultMessage ||
+		cfg.d.Exchanges[0].API.Endpoints.URLSecondary != APIURLNonDefaultMessage ||
+		cfg.d.Exchanges[0].API.Endpoints.WebsocketURL != WebsocketURLNonDefaultMessage {
 		t.Error("unexpected values")
 	}
 
@@ -1364,23 +1364,23 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 
 	// Test currency pair migration
 	setupPairs := func(emptyAssets bool) {
-		cfg.Exchanges[0].CurrencyPairs = nil
+		cfg.d.Exchanges[0].CurrencyPairs = nil
 		p := currency.Pairs{
 			p1,
 		}
-		cfg.Exchanges[0].PairsLastUpdated = int64ptr(1234567)
+		cfg.d.Exchanges[0].PairsLastUpdated = int64ptr(1234567)
 
 		if !emptyAssets {
-			cfg.Exchanges[0].AssetTypes = sptr("spot")
+			cfg.d.Exchanges[0].AssetTypes = sptr("spot")
 		}
 
-		cfg.Exchanges[0].AvailablePairs = &p
-		cfg.Exchanges[0].EnabledPairs = &p
-		cfg.Exchanges[0].ConfigCurrencyPairFormat = &currency.PairFormat{
+		cfg.d.Exchanges[0].AvailablePairs = &p
+		cfg.d.Exchanges[0].EnabledPairs = &p
+		cfg.d.Exchanges[0].ConfigCurrencyPairFormat = &currency.PairFormat{
 			Uppercase: true,
 			Delimiter: "-",
 		}
-		cfg.Exchanges[0].RequestCurrencyPairFormat = &currency.PairFormat{
+		cfg.d.Exchanges[0].RequestCurrencyPairFormat = &currency.PairFormat{
 			Uppercase: false,
 			Delimiter: "~",
 		}
@@ -1398,28 +1398,28 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 		t.Error(err)
 	}
 
-	if cfg.Exchanges[0].CurrencyPairs.LastUpdated != 1234567 {
+	if cfg.d.Exchanges[0].CurrencyPairs.LastUpdated != 1234567 {
 		t.Error("last updated has wrong value")
 	}
 
-	pFmt := cfg.Exchanges[0].CurrencyPairs.ConfigFormat
+	pFmt := cfg.d.Exchanges[0].CurrencyPairs.ConfigFormat
 	if pFmt.Delimiter != "-" ||
 		!pFmt.Uppercase {
 		t.Error("unexpected config format values")
 	}
 
-	pFmt = cfg.Exchanges[0].CurrencyPairs.RequestFormat
+	pFmt = cfg.d.Exchanges[0].CurrencyPairs.RequestFormat
 	if pFmt.Delimiter != "~" ||
 		pFmt.Uppercase {
 		t.Error("unexpected request format values")
 	}
 
-	if !cfg.Exchanges[0].CurrencyPairs.GetAssetTypes().Contains(asset.Spot) ||
-		!cfg.Exchanges[0].CurrencyPairs.UseGlobalFormat {
+	if !cfg.d.Exchanges[0].CurrencyPairs.GetAssetTypes().Contains(asset.Spot) ||
+		!cfg.d.Exchanges[0].CurrencyPairs.UseGlobalFormat {
 		t.Error("unexpected results")
 	}
 
-	pairs, err := cfg.Exchanges[0].CurrencyPairs.GetPairs(asset.Spot, true)
+	pairs, err := cfg.d.Exchanges[0].CurrencyPairs.GetPairs(asset.Spot, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1428,7 +1428,7 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 		t.Error("pairs not set properly")
 	}
 
-	pairs, err = cfg.Exchanges[0].CurrencyPairs.GetPairs(asset.Spot, false)
+	pairs, err = cfg.d.Exchanges[0].CurrencyPairs.GetPairs(asset.Spot, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1438,115 +1438,115 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 	}
 
 	// Ensure that all old settings are flushed
-	if cfg.Exchanges[0].PairsLastUpdated != nil ||
-		cfg.Exchanges[0].ConfigCurrencyPairFormat != nil ||
-		cfg.Exchanges[0].RequestCurrencyPairFormat != nil ||
-		cfg.Exchanges[0].AssetTypes != nil ||
-		cfg.Exchanges[0].AvailablePairs != nil ||
-		cfg.Exchanges[0].EnabledPairs != nil {
+	if cfg.d.Exchanges[0].PairsLastUpdated != nil ||
+		cfg.d.Exchanges[0].ConfigCurrencyPairFormat != nil ||
+		cfg.d.Exchanges[0].RequestCurrencyPairFormat != nil ||
+		cfg.d.Exchanges[0].AssetTypes != nil ||
+		cfg.d.Exchanges[0].AvailablePairs != nil ||
+		cfg.d.Exchanges[0].EnabledPairs != nil {
 		t.Error("unexpected results")
 	}
 
 	// Test AutoPairUpdates
-	cfg.Exchanges[0].Features.Supports.RESTCapabilities.AutoPairUpdates = false
-	cfg.Exchanges[0].Features.Supports.WebsocketCapabilities.AutoPairUpdates = false
-	cfg.Exchanges[0].CurrencyPairs.LastUpdated = 0
+	cfg.d.Exchanges[0].Features.Supports.RESTCapabilities.AutoPairUpdates = false
+	cfg.d.Exchanges[0].Features.Supports.WebsocketCapabilities.AutoPairUpdates = false
+	cfg.d.Exchanges[0].CurrencyPairs.LastUpdated = 0
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Test websocket and HTTP timeout values
-	cfg.Exchanges[0].WebsocketResponseMaxLimit = 0
-	cfg.Exchanges[0].WebsocketResponseCheckTimeout = 0
-	cfg.Exchanges[0].OrderbookConfig.WebsocketBufferLimit = 0
-	cfg.Exchanges[0].WebsocketTrafficTimeout = 0
-	cfg.Exchanges[0].HTTPTimeout = 0
+	cfg.d.Exchanges[0].WebsocketResponseMaxLimit = 0
+	cfg.d.Exchanges[0].WebsocketResponseCheckTimeout = 0
+	cfg.d.Exchanges[0].OrderbookConfig.WebsocketBufferLimit = 0
+	cfg.d.Exchanges[0].WebsocketTrafficTimeout = 0
+	cfg.d.Exchanges[0].HTTPTimeout = 0
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if cfg.Exchanges[0].WebsocketResponseMaxLimit == 0 {
+	if cfg.d.Exchanges[0].WebsocketResponseMaxLimit == 0 {
 		t.Errorf("expected exchange %s to have updated WebsocketResponseMaxLimit value",
-			cfg.Exchanges[0].Name)
+			cfg.d.Exchanges[0].Name)
 	}
-	if cfg.Exchanges[0].OrderbookConfig.WebsocketBufferLimit == 0 {
+	if cfg.d.Exchanges[0].OrderbookConfig.WebsocketBufferLimit == 0 {
 		t.Errorf("expected exchange %s to have updated WebsocketOrderbookBufferLimit value",
-			cfg.Exchanges[0].Name)
+			cfg.d.Exchanges[0].Name)
 	}
-	if cfg.Exchanges[0].WebsocketTrafficTimeout == 0 {
+	if cfg.d.Exchanges[0].WebsocketTrafficTimeout == 0 {
 		t.Errorf("expected exchange %s to have updated WebsocketTrafficTimeout value",
-			cfg.Exchanges[0].Name)
+			cfg.d.Exchanges[0].Name)
 	}
-	if cfg.Exchanges[0].HTTPTimeout == 0 {
+	if cfg.d.Exchanges[0].HTTPTimeout == 0 {
 		t.Errorf("expected exchange %s to have updated HTTPTimeout value",
-			cfg.Exchanges[0].Name)
+			cfg.d.Exchanges[0].Name)
 	}
 
 	v := &APICredentialsValidatorConfig{
 		RequiresKey:    true,
 		RequiresSecret: true,
 	}
-	cfg.Exchanges[0].API.CredentialsValidator = v
-	cfg.Exchanges[0].API.Credentials.Key = "Key"
-	cfg.Exchanges[0].API.Credentials.Secret = "Secret"
-	cfg.Exchanges[0].API.AuthenticatedSupport = true
-	cfg.Exchanges[0].API.AuthenticatedWebsocketSupport = true
+	cfg.d.Exchanges[0].API.CredentialsValidator = v
+	cfg.d.Exchanges[0].API.Credentials.Key = "Key"
+	cfg.d.Exchanges[0].API.Credentials.Secret = "Secret"
+	cfg.d.Exchanges[0].API.AuthenticatedSupport = true
+	cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport = true
 	cfg.CheckExchangeConfigValues()
-	if cfg.Exchanges[0].API.AuthenticatedSupport ||
-		cfg.Exchanges[0].API.AuthenticatedWebsocketSupport {
+	if cfg.d.Exchanges[0].API.AuthenticatedSupport ||
+		cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport {
 		t.Error("Expected authenticated endpoints to be false from invalid API keys")
 	}
 
 	v.RequiresKey = false
 	v.RequiresClientID = true
-	cfg.Exchanges[0].API.AuthenticatedSupport = true
-	cfg.Exchanges[0].API.AuthenticatedWebsocketSupport = true
-	cfg.Exchanges[0].API.Credentials.ClientID = DefaultAPIClientID
-	cfg.Exchanges[0].API.Credentials.Secret = "TESTYTEST"
+	cfg.d.Exchanges[0].API.AuthenticatedSupport = true
+	cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport = true
+	cfg.d.Exchanges[0].API.Credentials.ClientID = DefaultAPIClientID
+	cfg.d.Exchanges[0].API.Credentials.Secret = "TESTYTEST"
 	cfg.CheckExchangeConfigValues()
-	if cfg.Exchanges[0].API.AuthenticatedSupport ||
-		cfg.Exchanges[0].API.AuthenticatedWebsocketSupport {
+	if cfg.d.Exchanges[0].API.AuthenticatedSupport ||
+		cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport {
 		t.Error("Expected AuthenticatedAPISupport to be false from invalid API keys")
 	}
 
 	v.RequiresKey = true
-	cfg.Exchanges[0].API.AuthenticatedSupport = true
-	cfg.Exchanges[0].API.AuthenticatedWebsocketSupport = true
-	cfg.Exchanges[0].API.Credentials.Key = "meow"
-	cfg.Exchanges[0].API.Credentials.Secret = "test123"
-	cfg.Exchanges[0].API.Credentials.ClientID = "clientIDerino"
+	cfg.d.Exchanges[0].API.AuthenticatedSupport = true
+	cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport = true
+	cfg.d.Exchanges[0].API.Credentials.Key = "meow"
+	cfg.d.Exchanges[0].API.Credentials.Secret = "test123"
+	cfg.d.Exchanges[0].API.Credentials.ClientID = "clientIDerino"
 	cfg.CheckExchangeConfigValues()
-	if !cfg.Exchanges[0].API.AuthenticatedSupport ||
-		!cfg.Exchanges[0].API.AuthenticatedWebsocketSupport {
+	if !cfg.d.Exchanges[0].API.AuthenticatedSupport ||
+		!cfg.d.Exchanges[0].API.AuthenticatedWebsocketSupport {
 		t.Error("Expected AuthenticatedAPISupport and AuthenticatedWebsocketAPISupport to be false from invalid API keys")
 	}
 
 	// Make a sneaky copy for bank account testing
-	cpy := append(cfg.Exchanges[:0:0], cfg.Exchanges...)
+	cpy := append(cfg.d.Exchanges[:0:0], cfg.d.Exchanges...)
 
 	// Test empty exchange name for an enabled exchange
-	cfg.Exchanges[0].Enabled = true
-	cfg.Exchanges[0].Name = ""
+	cfg.d.Exchanges[0].Enabled = true
+	cfg.d.Exchanges[0].Name = ""
 	cfg.CheckExchangeConfigValues()
-	if cfg.Exchanges[0].Enabled {
+	if cfg.d.Exchanges[0].Enabled {
 		t.Errorf(
 			"Exchange with no name should be empty",
 		)
 	}
 
 	// Test no enabled exchanges
-	cfg.Exchanges = cfg.Exchanges[:1]
-	cfg.Exchanges[0].Enabled = false
+	cfg.d.Exchanges = cfg.d.Exchanges[:1]
+	cfg.d.Exchanges[0].Enabled = false
 	err = cfg.CheckExchangeConfigValues()
 	if err == nil {
 		t.Error("Expected error from no enabled exchanges")
 	}
 
-	cfg.Exchanges = cpy
+	cfg.d.Exchanges = cpy
 	// Check bank account validation for exchange
-	cfg.Exchanges[0].BankAccounts = []banking.Account{
+	cfg.d.Exchanges[0].BankAccounts = []banking.Account{
 		{
 			Enabled: true,
 		},
@@ -1557,64 +1557,64 @@ func TestCheckExchangeConfigValues(t *testing.T) {
 		t.Error(err)
 	}
 
-	if cfg.Exchanges[0].BankAccounts[0].Enabled {
+	if cfg.d.Exchanges[0].BankAccounts[0].Enabled {
 		t.Fatal("bank aaccount details not provided this should disable")
 	}
 
 	// Test international bank
-	cfg.Exchanges[0].BankAccounts[0].Enabled = true
-	cfg.Exchanges[0].BankAccounts[0].BankName = testString
-	cfg.Exchanges[0].BankAccounts[0].BankAddress = testString
-	cfg.Exchanges[0].BankAccounts[0].BankPostalCode = testString
-	cfg.Exchanges[0].BankAccounts[0].BankPostalCity = testString
-	cfg.Exchanges[0].BankAccounts[0].BankCountry = testString
-	cfg.Exchanges[0].BankAccounts[0].AccountName = testString
-	cfg.Exchanges[0].BankAccounts[0].SupportedCurrencies = "monopoly moneys"
-	cfg.Exchanges[0].BankAccounts[0].IBAN = "some iban"
-	cfg.Exchanges[0].BankAccounts[0].SWIFTCode = "some swifty"
+	cfg.d.Exchanges[0].BankAccounts[0].Enabled = true
+	cfg.d.Exchanges[0].BankAccounts[0].BankName = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankAddress = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankPostalCode = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankPostalCity = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankCountry = testString
+	cfg.d.Exchanges[0].BankAccounts[0].AccountName = testString
+	cfg.d.Exchanges[0].BankAccounts[0].SupportedCurrencies = "monopoly moneys"
+	cfg.d.Exchanges[0].BankAccounts[0].IBAN = "some iban"
+	cfg.d.Exchanges[0].BankAccounts[0].SWIFTCode = "some swifty"
 
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !cfg.Exchanges[0].BankAccounts[0].Enabled {
+	if !cfg.d.Exchanges[0].BankAccounts[0].Enabled {
 		t.Fatal("bank aaccount details provided this should not disable")
 	}
 
 	// Test aussie bank
-	cfg.Exchanges[0].BankAccounts[0].Enabled = true
-	cfg.Exchanges[0].BankAccounts[0].BankName = testString
-	cfg.Exchanges[0].BankAccounts[0].BankAddress = testString
-	cfg.Exchanges[0].BankAccounts[0].BankPostalCode = testString
-	cfg.Exchanges[0].BankAccounts[0].BankPostalCity = testString
-	cfg.Exchanges[0].BankAccounts[0].BankCountry = testString
-	cfg.Exchanges[0].BankAccounts[0].AccountName = testString
-	cfg.Exchanges[0].BankAccounts[0].SupportedCurrencies = "AUD"
-	cfg.Exchanges[0].BankAccounts[0].BSBNumber = "some BSB nonsense"
-	cfg.Exchanges[0].BankAccounts[0].IBAN = ""
-	cfg.Exchanges[0].BankAccounts[0].SWIFTCode = ""
+	cfg.d.Exchanges[0].BankAccounts[0].Enabled = true
+	cfg.d.Exchanges[0].BankAccounts[0].BankName = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankAddress = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankPostalCode = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankPostalCity = testString
+	cfg.d.Exchanges[0].BankAccounts[0].BankCountry = testString
+	cfg.d.Exchanges[0].BankAccounts[0].AccountName = testString
+	cfg.d.Exchanges[0].BankAccounts[0].SupportedCurrencies = "AUD"
+	cfg.d.Exchanges[0].BankAccounts[0].BSBNumber = "some BSB nonsense"
+	cfg.d.Exchanges[0].BankAccounts[0].IBAN = ""
+	cfg.d.Exchanges[0].BankAccounts[0].SWIFTCode = ""
 
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !cfg.Exchanges[0].BankAccounts[0].Enabled {
+	if !cfg.d.Exchanges[0].BankAccounts[0].Enabled {
 		t.Fatal("bank account details provided this should not disable")
 	}
 
-	cfg.Exchanges = nil
-	cfg.Exchanges = append(cfg.Exchanges, cpy[0])
+	cfg.d.Exchanges = nil
+	cfg.d.Exchanges = append(cfg.d.Exchanges, cpy[0])
 
-	cfg.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = nil
-	cfg.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(false)
+	cfg.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].Enabled = nil
+	cfg.d.Exchanges[0].CurrencyPairs.Pairs[asset.Spot].AssetEnabled = convert.BoolPtr(false)
 	err = cfg.CheckExchangeConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
 
-	cfg.Exchanges[0].CurrencyPairs.Pairs = make(map[asset.Item]*currency.PairStore)
+	cfg.d.Exchanges[0].CurrencyPairs.Pairs = make(map[asset.Item]*currency.PairStore)
 	err = cfg.CheckExchangeConfigValues()
 	if err == nil {
 		t.Error("err cannot be nil")
@@ -1669,7 +1669,7 @@ func TestReadConfigFromReader(t *testing.T) {
 	if encrypted {
 		t.Errorf("Expected unencrypted config %s", err)
 	}
-	if conf.Name != "test" {
+	if conf.d.Name != "test" {
 		t.Errorf("Conf not properly loaded %s", err)
 	}
 	_, err = conf.ReadConfig(strings.NewReader("{}"), Unencrypted)
@@ -1713,16 +1713,16 @@ func TestCheckConnectionMonitorConfig(t *testing.T) {
 	t.Parallel()
 
 	var c Config
-	c.ConnectionMonitor.CheckInterval = 0
-	c.ConnectionMonitor.DNSList = nil
-	c.ConnectionMonitor.PublicDomainList = nil
+	c.d.ConnectionMonitor.CheckInterval = 0
+	c.d.ConnectionMonitor.DNSList = nil
+	c.d.ConnectionMonitor.PublicDomainList = nil
 	c.CheckConnectionMonitorConfig()
 
-	if c.ConnectionMonitor.CheckInterval != connchecker.DefaultCheckInterval ||
+	if c.d.ConnectionMonitor.CheckInterval != connchecker.DefaultCheckInterval ||
 		len(common.StringSliceDifference(
-			c.ConnectionMonitor.DNSList, connchecker.DefaultDNSList)) != 0 ||
+			c.d.ConnectionMonitor.DNSList, connchecker.DefaultDNSList)) != 0 ||
 		len(common.StringSliceDifference(
-			c.ConnectionMonitor.PublicDomainList, connchecker.DefaultDomainList)) != 0 {
+			c.d.ConnectionMonitor.PublicDomainList, connchecker.DefaultDomainList)) != 0 {
 		t.Error("unexpected values")
 	}
 }
@@ -1769,7 +1769,7 @@ func TestCheckRemoteControlConfig(t *testing.T) {
 	t.Parallel()
 
 	var c Config
-	c.Webserver = &WebserverConfig{
+	c.d.Webserver = &WebserverConfig{
 		Enabled:                      true,
 		AdminUsername:                "satoshi",
 		AdminPassword:                "ultrasecurepassword",
@@ -1781,24 +1781,24 @@ func TestCheckRemoteControlConfig(t *testing.T) {
 
 	c.CheckRemoteControlConfig()
 
-	if c.RemoteControl.Username != "satoshi" ||
-		c.RemoteControl.Password != "ultrasecurepassword" ||
-		!c.RemoteControl.GRPC.Enabled ||
-		c.RemoteControl.GRPC.ListenAddress != "localhost:9052" ||
-		!c.RemoteControl.GRPC.GRPCProxyEnabled ||
-		c.RemoteControl.GRPC.GRPCProxyListenAddress != "localhost:9053" ||
-		!c.RemoteControl.DeprecatedRPC.Enabled ||
-		c.RemoteControl.DeprecatedRPC.ListenAddress != "localhost:9050" ||
-		!c.RemoteControl.WebsocketRPC.Enabled ||
-		c.RemoteControl.WebsocketRPC.ListenAddress != "localhost:9051" ||
-		!c.RemoteControl.WebsocketRPC.AllowInsecureOrigin ||
-		c.RemoteControl.WebsocketRPC.ConnectionLimit != 5 ||
-		c.RemoteControl.WebsocketRPC.MaxAuthFailures != 10 {
+	if c.d.RemoteControl.Username != "satoshi" ||
+		c.d.RemoteControl.Password != "ultrasecurepassword" ||
+		!c.d.RemoteControl.GRPC.Enabled ||
+		c.d.RemoteControl.GRPC.ListenAddress != "localhost:9052" ||
+		!c.d.RemoteControl.GRPC.GRPCProxyEnabled ||
+		c.d.RemoteControl.GRPC.GRPCProxyListenAddress != "localhost:9053" ||
+		!c.d.RemoteControl.DeprecatedRPC.Enabled ||
+		c.d.RemoteControl.DeprecatedRPC.ListenAddress != "localhost:9050" ||
+		!c.d.RemoteControl.WebsocketRPC.Enabled ||
+		c.d.RemoteControl.WebsocketRPC.ListenAddress != "localhost:9051" ||
+		!c.d.RemoteControl.WebsocketRPC.AllowInsecureOrigin ||
+		c.d.RemoteControl.WebsocketRPC.ConnectionLimit != 5 ||
+		c.d.RemoteControl.WebsocketRPC.MaxAuthFailures != 10 {
 		t.Error("unexpected results")
 	}
 
 	// Now test to ensure the previous settings are flushed
-	if c.Webserver != nil {
+	if c.d.Webserver != nil {
 		t.Error("old webserver settings should be nil")
 	}
 }
@@ -1833,12 +1833,12 @@ func TestUpdateConfig(t *testing.T) {
 		t.Fatalf("Error should have been thrown for invalid path")
 	}
 
-	c.Currency.Cryptocurrencies = currency.NewCurrenciesFromStringArray([]string{""})
+	c.d.Currency.Cryptocurrencies = currency.NewCurrenciesFromStringArray([]string{""})
 	err = c.UpdateConfig(TestFile, &c, true)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
-	if c.Currency.Cryptocurrencies.Join() == "" {
+	if c.d.Currency.Cryptocurrencies.Join() == "" {
 		t.Fatalf("Cryptocurrencies should have been repopulated")
 	}
 }
@@ -1859,31 +1859,31 @@ func TestCheckLoggerConfig(t *testing.T) {
 	t.Parallel()
 
 	var c Config
-	c.Logging = log.Config{}
+	c.d.Logging = log.Config{}
 	err := c.CheckLoggerConfig()
 	if err != nil {
 		t.Errorf("Failed to create default logger. Error: %s", err)
 	}
 
-	if !*c.Logging.Enabled {
+	if !*c.d.Logging.Enabled {
 		t.Error("unexpected result")
 	}
 
-	c.Logging.LoggerFileConfig.FileName = ""
-	c.Logging.LoggerFileConfig.Rotate = nil
-	c.Logging.LoggerFileConfig.MaxSize = -1
-	c.Logging.AdvancedSettings.ShowLogSystemName = nil
+	c.d.Logging.LoggerFileConfig.FileName = ""
+	c.d.Logging.LoggerFileConfig.Rotate = nil
+	c.d.Logging.LoggerFileConfig.MaxSize = -1
+	c.d.Logging.AdvancedSettings.ShowLogSystemName = nil
 
 	err = c.CheckLoggerConfig()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if c.Logging.LoggerFileConfig.FileName != "log.txt" ||
-		c.Logging.LoggerFileConfig.Rotate == nil ||
-		c.Logging.LoggerFileConfig.MaxSize != 100 ||
-		c.Logging.AdvancedSettings.ShowLogSystemName == nil ||
-		*c.Logging.AdvancedSettings.ShowLogSystemName {
+	if c.d.Logging.LoggerFileConfig.FileName != "log.txt" ||
+		c.d.Logging.LoggerFileConfig.Rotate == nil ||
+		c.d.Logging.LoggerFileConfig.MaxSize != 100 ||
+		c.d.Logging.AdvancedSettings.ShowLogSystemName == nil ||
+		*c.d.Logging.AdvancedSettings.ShowLogSystemName {
 		t.Error("unexpected result")
 	}
 }
@@ -1925,11 +1925,11 @@ func TestCheckGCTScriptConfig(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c.GCTScript.ScriptTimeout != gctscript.DefaultTimeoutValue {
+	if c.d.GCTScript.ScriptTimeout != gctscript.DefaultTimeoutValue {
 		t.Fatal("unexpected value return")
 	}
 
-	if c.GCTScript.MaxVirtualMachines != gctscript.DefaultMaxVirtualMachines {
+	if c.d.GCTScript.MaxVirtualMachines != gctscript.DefaultMaxVirtualMachines {
 		t.Fatal("unexpected value return")
 	}
 }
@@ -1942,20 +1942,20 @@ func TestCheckDatabaseConfig(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c.Database.Driver != database.DBSQLite3 ||
-		c.Database.Database != database.DefaultSQLiteDatabase ||
-		c.Database.Enabled {
+	if c.d.Database.Driver != database.DBSQLite3 ||
+		c.d.Database.Database != database.DefaultSQLiteDatabase ||
+		c.d.Database.Enabled {
 		t.Error("unexpected results")
 	}
 
-	c.Database.Enabled = true
-	c.Database.Driver = "mssqlisthebest"
+	c.d.Database.Enabled = true
+	c.d.Database.Driver = "mssqlisthebest"
 	if err := c.checkDatabaseConfig(); err == nil {
 		t.Error("unexpected result")
 	}
 
-	c.Database.Driver = database.DBSQLite3
-	c.Database.Enabled = true
+	c.d.Database.Driver = database.DBSQLite3
+	c.d.Database.Enabled = true
 	if err := c.checkDatabaseConfig(); err != nil {
 		t.Error(err)
 	}
@@ -1964,86 +1964,86 @@ func TestCheckDatabaseConfig(t *testing.T) {
 func TestCheckNTPConfig(t *testing.T) {
 	c := GetConfig()
 
-	c.NTPClient.Level = 0
-	c.NTPClient.Pool = nil
-	c.NTPClient.AllowedNegativeDifference = nil
-	c.NTPClient.AllowedDifference = nil
+	c.d.NTPClient.Level = 0
+	c.d.NTPClient.Pool = nil
+	c.d.NTPClient.AllowedNegativeDifference = nil
+	c.d.NTPClient.AllowedDifference = nil
 
 	c.CheckNTPConfig()
-	_ = ntpclient.NTPClient(c.NTPClient.Pool)
+	_ = ntpclient.NTPClient(c.d.NTPClient.Pool)
 
-	if c.NTPClient.Pool[0] != "pool.ntp.org:123" {
+	if c.d.NTPClient.Pool[0] != "pool.ntp.org:123" {
 		t.Error("ntpclient with no valid pool should default to pool.ntp.org")
 	}
 
-	if c.NTPClient.AllowedDifference == nil {
+	if c.d.NTPClient.AllowedDifference == nil {
 		t.Error("ntpclient with nil alloweddifference should default to sane value")
 	}
 
-	if c.NTPClient.AllowedNegativeDifference == nil {
+	if c.d.NTPClient.AllowedNegativeDifference == nil {
 		t.Error("ntpclient with nil allowednegativedifference should default to sane value")
 	}
 }
 
 func TestCheckCurrencyConfigValues(t *testing.T) {
 	c := GetConfig()
-	c.Currency.ForexProviders = nil
-	c.Currency.CryptocurrencyProvider = CryptocurrencyProvider{}
+	c.d.Currency.ForexProviders = nil
+	c.d.Currency.CryptocurrencyProvider = CryptocurrencyProvider{}
 	err := c.CheckCurrencyConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
-	if c.Currency.ForexProviders == nil {
-		t.Error("Failed to populate c.Currency.ForexProviders")
+	if c.d.Currency.ForexProviders == nil {
+		t.Error("Failed to populate c.d.Currency.ForexProviders")
 	}
-	if c.Currency.CryptocurrencyProvider.APIkey != DefaultUnsetAPIKey {
+	if c.d.Currency.CryptocurrencyProvider.APIkey != DefaultUnsetAPIKey {
 		t.Error("Failed to set the api key to the default key")
 	}
-	if c.Currency.CryptocurrencyProvider.Name != "CoinMarketCap" {
-		t.Error("Failed to set the  c.Currency.CryptocurrencyProvider.Name")
+	if c.d.Currency.CryptocurrencyProvider.Name != "CoinMarketCap" {
+		t.Error("Failed to set the  c.d.Currency.CryptocurrencyProvider.Name")
 	}
 
-	c.Currency.ForexProviders[0].Enabled = true
-	c.Currency.ForexProviders[0].Name = "CurrencyConverter"
-	c.Currency.ForexProviders[0].PrimaryProvider = true
-	c.Currency.Cryptocurrencies = nil
-	c.Cryptocurrencies = nil
-	c.Currency.CurrencyPairFormat = nil
-	c.CurrencyPairFormat = &CurrencyPairFormatConfig{
+	c.d.Currency.ForexProviders[0].Enabled = true
+	c.d.Currency.ForexProviders[0].Name = "CurrencyConverter"
+	c.d.Currency.ForexProviders[0].PrimaryProvider = true
+	c.d.Currency.Cryptocurrencies = nil
+	c.d.Cryptocurrencies = nil
+	c.d.Currency.CurrencyPairFormat = nil
+	c.d.CurrencyPairFormat = &CurrencyPairFormatConfig{
 		Uppercase: true,
 	}
-	c.Currency.FiatDisplayCurrency = currency.Code{}
-	c.FiatDisplayCurrency = &currency.BTC
-	c.Currency.CryptocurrencyProvider.Enabled = true
+	c.d.Currency.FiatDisplayCurrency = currency.Code{}
+	c.d.FiatDisplayCurrency = &currency.BTC
+	c.d.Currency.CryptocurrencyProvider.Enabled = true
 	err = c.CheckCurrencyConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
-	if c.Currency.ForexProviders[0].Enabled {
+	if c.d.Currency.ForexProviders[0].Enabled {
 		t.Error("Failed to disable invalid forex provider")
 	}
-	if !c.Currency.CurrencyPairFormat.Uppercase {
-		t.Error("Failed to apply c.CurrencyPairFormat format to c.Currency.CurrencyPairFormat")
+	if !c.d.Currency.CurrencyPairFormat.Uppercase {
+		t.Error("Failed to apply c.d.CurrencyPairFormat format to c.d.Currency.CurrencyPairFormat")
 	}
 
-	c.Currency.CryptocurrencyProvider.Enabled = false
-	c.Currency.CryptocurrencyProvider.APIkey = ""
-	c.Currency.CryptocurrencyProvider.AccountPlan = ""
-	c.FiatDisplayCurrency = &currency.BTC
-	c.Currency.ForexProviders[0].Enabled = true
-	c.Currency.ForexProviders[0].Name = "Name"
-	c.Currency.ForexProviders[0].PrimaryProvider = true
-	c.Currency.Cryptocurrencies = currency.Currencies{}
-	c.Cryptocurrencies = &currency.Currencies{}
+	c.d.Currency.CryptocurrencyProvider.Enabled = false
+	c.d.Currency.CryptocurrencyProvider.APIkey = ""
+	c.d.Currency.CryptocurrencyProvider.AccountPlan = ""
+	c.d.FiatDisplayCurrency = &currency.BTC
+	c.d.Currency.ForexProviders[0].Enabled = true
+	c.d.Currency.ForexProviders[0].Name = "Name"
+	c.d.Currency.ForexProviders[0].PrimaryProvider = true
+	c.d.Currency.Cryptocurrencies = currency.Currencies{}
+	c.d.Cryptocurrencies = &currency.Currencies{}
 	err = c.CheckCurrencyConfigValues()
 	if err != nil {
 		t.Error(err)
 	}
-	if c.FiatDisplayCurrency != nil {
+	if c.d.FiatDisplayCurrency != nil {
 		t.Error("Failed to clear c.FiatDisplayCurrency")
 	}
-	if c.Currency.CryptocurrencyProvider.APIkey != DefaultUnsetAPIKey ||
-		c.Currency.CryptocurrencyProvider.AccountPlan != DefaultUnsetAccountPlan {
+	if c.d.Currency.CryptocurrencyProvider.APIkey != DefaultUnsetAPIKey ||
+		c.d.Currency.CryptocurrencyProvider.AccountPlan != DefaultUnsetAccountPlan {
 		t.Error("Failed to set CryptocurrencyProvider.APIkey and AccountPlan")
 	}
 }
@@ -2059,7 +2059,7 @@ func TestRemoveExchange(t *testing.T) {
 	t.Parallel()
 	var c Config
 	const testExchangeName = "0xBAAAAAAD"
-	c.Exchanges = append(c.Exchanges, ExchangeConfig{
+	c.d.Exchanges = append(c.d.Exchanges, ExchangeConfig{
 		Name: testExchangeName,
 	})
 	_, err := c.GetExchangeConfig(testExchangeName)
@@ -2109,7 +2109,7 @@ func TestGetDataPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &Config{
-				DataDirectory: tt.dir,
+				d: Details{DataDirectory: tt.dir},
 			}
 			if got := c.GetDataPath(tt.elem...); got != tt.want {
 				t.Errorf("Config.GetDataPath() = %v, want %v", got, tt.want)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1660,8 +1660,9 @@ func TestReadConfigFromFile(t *testing.T) {
 }
 
 func TestReadConfigFromReader(t *testing.T) {
+	conf := GetConfig()
 	confString := `{"name":"test"}`
-	conf, encrypted, err := ReadConfig(strings.NewReader(confString), Unencrypted)
+	encrypted, err := conf.ReadConfig(strings.NewReader(confString), Unencrypted)
 	if err != nil {
 		t.Errorf("TestReadConfig %s", err)
 	}
@@ -1671,8 +1672,7 @@ func TestReadConfigFromReader(t *testing.T) {
 	if conf.Name != "test" {
 		t.Errorf("Conf not properly loaded %s", err)
 	}
-
-	_, _, err = ReadConfig(strings.NewReader("{}"), Unencrypted)
+	_, err = conf.ReadConfig(strings.NewReader("{}"), Unencrypted)
 	if err == nil {
 		t.Error("TestReadConfig error cannot be nil")
 	}
@@ -1823,19 +1823,18 @@ func TestUpdateConfig(t *testing.T) {
 		t.Errorf("%s", err)
 	}
 
-	newCfg := c
-	err = c.UpdateConfig(TestFile, &newCfg, true)
+	err = c.UpdateConfig(TestFile, &c, true)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
 
-	err = c.UpdateConfig("//non-existantpath\\", &newCfg, false)
+	err = c.UpdateConfig("//non-existantpath\\", &c, false)
 	if err == nil {
 		t.Fatalf("Error should have been thrown for invalid path")
 	}
 
-	newCfg.Currency.Cryptocurrencies = currency.NewCurrenciesFromStringArray([]string{""})
-	err = c.UpdateConfig(TestFile, &newCfg, true)
+	c.Currency.Cryptocurrencies = currency.NewCurrenciesFromStringArray([]string{""})
+	err = c.UpdateConfig(TestFile, &c, true)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -1851,9 +1850,8 @@ func BenchmarkUpdateConfig(b *testing.B) {
 		b.Errorf("Unable to benchmark UpdateConfig(): %s", err)
 	}
 
-	newCfg := c
 	for i := 0; i < b.N; i++ {
-		_ = c.UpdateConfig(TestFile, &newCfg, true)
+		_ = c.UpdateConfig(TestFile, &c, true)
 	}
 }
 

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -67,8 +67,7 @@ const (
 
 // Variables here are used for configuration
 var (
-	Cfg Config
-	m   sync.Mutex
+	config = new(Config)
 )
 
 // Config is the overarching object that holds all the information for
@@ -101,6 +100,7 @@ type Config struct {
 	// encryption session values
 	storedSalt []byte
 	sessionDK  []byte
+	sync.Mutex
 }
 
 // ConnectionMonitorConfig defines the connection monitor variables to ensure

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -70,10 +70,15 @@ var (
 	config = new(Config)
 )
 
-// Config is the overarching object that holds all the information for
-// prestart management of Portfolio, Communications, Webserver and Enabled
-// Exchanges
+// Config defines the exported protected object of configuration details
 type Config struct {
+	d Details
+	sync.Mutex
+}
+
+// Details define configuration parameters for prestart management of portfolio,
+// communications, webserver and enabled exchanges
+type Details struct {
 	Name              string                  `json:"name"`
 	DataDirectory     string                  `json:"dataDirectory"`
 	EncryptConfig     int                     `json:"encryptConfig"`
@@ -100,7 +105,6 @@ type Config struct {
 	// encryption session values
 	storedSalt []byte
 	sessionDK  []byte
-	sync.Mutex
 }
 
 // ConnectionMonitorConfig defines the connection monitor variables to ensure

--- a/engine/connection.go
+++ b/engine/connection.go
@@ -22,7 +22,7 @@ func (c *connectionManager) Started() bool {
 }
 
 // Start starts an instance of the connection manager
-func (c *connectionManager) Start(conf *config.ConnectionMonitorConfig) error {
+func (c *connectionManager) Start(conf config.ConnectionMonitorConfig) error {
 	if atomic.AddInt32(&c.started, 1) != 1 {
 		return errors.New("connection manager already started")
 	}

--- a/engine/database.go
+++ b/engine/database.go
@@ -42,20 +42,21 @@ func (a *databaseManager) Start(bot *Engine) (err error) {
 
 	a.shutdown = make(chan struct{})
 
-	if bot.Config.Database.Enabled {
-		if bot.Config.Database.Driver == database.DBPostgreSQL {
+	confDB := bot.Config.GetDatabase()
+	if confDB.Enabled {
+		if confDB.Driver == database.DBPostgreSQL {
 			log.Debugf(log.DatabaseMgr,
 				"Attempting to establish database connection to host %s/%s utilising %s driver\n",
-				bot.Config.Database.Host,
-				bot.Config.Database.Database,
-				bot.Config.Database.Driver)
+				confDB.Host,
+				confDB.Database,
+				confDB.Driver)
 			dbConn, err = dbpsql.Connect()
-		} else if bot.Config.Database.Driver == database.DBSQLite ||
-			bot.Config.Database.Driver == database.DBSQLite3 {
+		} else if confDB.Driver == database.DBSQLite ||
+			confDB.Driver == database.DBSQLite3 {
 			log.Debugf(log.DatabaseMgr,
 				"Attempting to establish database connection to %s utilising %s driver\n",
-				bot.Config.Database.Database,
-				bot.Config.Database.Driver)
+				confDB.Database,
+				confDB.Driver)
 			dbConn, err = dbsqlite3.Connect()
 		}
 		if err != nil {
@@ -64,7 +65,7 @@ func (a *databaseManager) Start(bot *Engine) (err error) {
 		dbConn.Connected = true
 
 		DBLogger := database.Logger{}
-		if bot.Config.Database.Verbose {
+		if confDB.Verbose {
 			boil.DebugMode = true
 			boil.DebugWriter = DBLogger
 		}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -52,7 +52,7 @@ var (
 // New starts a new engine
 func New() (*Engine, error) {
 	var b Engine
-	b.Config = &config.Cfg
+	b.Config = config.GetConfig()
 
 	err := b.Config.LoadConfig("", false)
 	if err != nil {
@@ -113,7 +113,7 @@ func loadConfigWithSettings(settings *Settings, flagSet map[string]bool) (*confi
 	}
 	log.Printf("Loading config file %s..\n", filePath)
 
-	conf := &config.Cfg
+	conf := config.GetConfig()
 	err = conf.ReadConfigFromFile(filePath, settings.EnableDryRun)
 	if err != nil {
 		return nil, fmt.Errorf(config.ErrFailureOpeningConfig, filePath, err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -64,8 +64,8 @@ func TestLoadConfigWithSettings(t *testing.T) {
 			if got != nil || tt.want != nil {
 				if (got == nil && tt.want != nil) || (got != nil && tt.want == nil) {
 					t.Errorf("loadConfigWithSettings() = is nil %v, want nil %v", got == nil, tt.want == nil)
-				} else if got.DataDirectory != *tt.want {
-					t.Errorf("loadConfigWithSettings() = %v, want %v", got.DataDirectory, *tt.want)
+				} else if got.GetDataDirectory() != *tt.want {
+					t.Errorf("loadConfigWithSettings() = %v, want %v", got.GetDataDirectory(), *tt.want)
 				}
 			}
 		})

--- a/engine/events.go
+++ b/engine/events.go
@@ -308,10 +308,10 @@ func EventManger() {
 
 // IsValidExchange validates the exchange
 func IsValidExchange(exchangeName string) bool {
-	cfg := config.GetConfig()
-	for x := range cfg.Exchanges {
-		if strings.EqualFold(cfg.Exchanges[x].Name, exchangeName) && cfg.Exchanges[x].Enabled {
-			return true
+	exchanges := config.GetConfig().GetAllExchangeConfigs()
+	for x := range exchanges {
+		if strings.EqualFold(exchanges[x].Name, exchangeName) {
+			return exchanges[x].Enabled
 		}
 	}
 	return false

--- a/engine/fake_exchange_test.go
+++ b/engine/fake_exchange_test.go
@@ -36,12 +36,11 @@ func addPassingFakeExchange(baseExchangeName string) error {
 		return ErrExchangeNotFound
 	}
 	base := testExch.GetBase()
-	Bot.Config.Exchanges = append(Bot.Config.Exchanges, config.ExchangeConfig{
+	Bot.Config.AddExchangeConfig(config.ExchangeConfig{
 		Name:    fakePassExchange,
 		Enabled: true,
 		Verbose: false,
 	})
-
 	Bot.exchangeManager.add(&FakePassingExchange{
 		Base: exchange.Base{
 			Name:                          fakePassExchange,

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -34,7 +34,7 @@ func SetupTestHelpers(t *testing.T) *Engine {
 		if Bot == nil {
 			Bot = new(Engine)
 		}
-		Bot.Config = &config.Cfg
+		Bot.Config = config.GetConfig()
 		err := Bot.Config.LoadConfig(config.TestFile, true)
 		if err != nil {
 			t.Fatalf("SetupTest: Failed to load config: %s", err)

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -139,7 +139,7 @@ func TestIsOnline(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 
-	if err := e.ConnectionManager.Start(&e.Config.ConnectionMonitor); err != nil {
+	if err := e.ConnectionManager.Start(e.Config.GetConnectionMonitor()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -763,8 +763,8 @@ func TestGetExchangeNames(t *testing.T) {
 	if e := bot.GetExchangeNames(true); common.StringDataCompare(e, testExchange) {
 		t.Error("Bitstamp should be missing")
 	}
-	if e := bot.GetExchangeNames(false); len(e) != len(bot.Config.Exchanges) {
-		t.Errorf("Expected %v Received %v", len(e), len(bot.Config.Exchanges))
+	if e := bot.GetExchangeNames(false); len(e) != len(bot.Config.GetAllExchangeConfigs()) {
+		t.Errorf("Expected %v Received %v", len(e), len(bot.Config.GetAllExchangeConfigs()))
 	}
 }
 

--- a/engine/portfolio.go
+++ b/engine/portfolio.go
@@ -31,7 +31,7 @@ func (p *portfolioManager) Start() error {
 
 	log.Debugln(log.PortfolioMgr, "Portfolio manager starting...")
 	Bot.Portfolio = &portfolio.Portfolio
-	Bot.Portfolio.Seed(Bot.Config.Portfolio)
+	Bot.Portfolio.Seed(Bot.Config.GetPortfolio())
 	p.shutdown = make(chan struct{})
 	portfolio.Verbose = Bot.Settings.Verbose
 

--- a/engine/restful_router.go
+++ b/engine/restful_router.go
@@ -32,10 +32,12 @@ func RESTLogger(inner http.Handler, name string) http.Handler {
 
 // StartRESTServer starts a REST server
 func StartRESTServer(bot *Engine) {
-	listenAddr := bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
+	confRC := bot.Config.GetRemoteControl()
+	listenAddr := confRC.DeprecatedRPC.ListenAddress
 	log.Debugf(log.RESTSys,
 		"Deprecated RPC server support enabled. Listen URL: http://%s:%d\n",
-		common.ExtractHost(listenAddr), common.ExtractPort(listenAddr))
+		common.ExtractHost(listenAddr),
+		common.ExtractPort(listenAddr))
 	err := http.ListenAndServe(listenAddr, newRouter(bot, true))
 	if err != nil {
 		log.Errorf(log.RESTSys, "Failed to start deprecated RPC server. Err: %s", err)
@@ -44,10 +46,12 @@ func StartRESTServer(bot *Engine) {
 
 // StartWebsocketServer starts a Websocket server
 func StartWebsocketServer(bot *Engine) {
-	listenAddr := bot.Config.RemoteControl.WebsocketRPC.ListenAddress
+	confRC := bot.Config.GetRemoteControl()
+	listenAddr := confRC.WebsocketRPC.ListenAddress
 	log.Debugf(log.RESTSys,
 		"Websocket RPC support enabled. Listen URL: ws://%s:%d/ws\n",
-		common.ExtractHost(listenAddr), common.ExtractPort(listenAddr))
+		common.ExtractHost(listenAddr),
+		common.ExtractPort(listenAddr))
 	err := http.ListenAndServe(listenAddr, newRouter(bot, false))
 	if err != nil {
 		log.Errorf(log.RESTSys, "Failed to start websocket RPC server. Err: %s", err)
@@ -60,11 +64,11 @@ func newRouter(bot *Engine, isREST bool) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	var routes []Route
 	var listenAddr string
-
+	confRC := bot.Config.GetRemoteControl()
 	if isREST {
-		listenAddr = bot.Config.RemoteControl.DeprecatedRPC.ListenAddress
+		listenAddr = confRC.DeprecatedRPC.ListenAddress
 	} else {
-		listenAddr = bot.Config.RemoteControl.WebsocketRPC.ListenAddress
+		listenAddr = confRC.WebsocketRPC.ListenAddress
 	}
 
 	if common.ExtractPort(listenAddr) == 80 {
@@ -84,10 +88,10 @@ func newRouter(bot *Engine, isREST bool) *mux.Router {
 			{"GetPortfolio", http.MethodGet, "/portfolio/all", RESTGetPortfolio},
 			{"AllActiveExchangesAndOrderbooks", http.MethodGet, "/exchanges/orderbook/latest/all", RESTGetAllActiveOrderbooks},
 		}
-
-		if bot.Config.Profiler.Enabled {
-			if bot.Config.Profiler.MutexProfileFraction > 0 {
-				runtime.SetMutexProfileFraction(bot.Config.Profiler.MutexProfileFraction)
+		confProf := bot.Config.GetProfiler()
+		if confProf.Enabled {
+			if confProf.MutexProfileFraction > 0 {
+				runtime.SetMutexProfileFraction(confProf.MutexProfileFraction)
 			}
 			log.Debugf(log.RESTSys,
 				"HTTP Go performance profiler (pprof) endpoint enabled: http://%s:%d/debug/pprof/\n",

--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -89,8 +89,7 @@ func TestProfilerEnabledShouldEnableProfileEndPoint(t *testing.T) {
 		t.Errorf("Response returned wrong status code expected %v got %v", http.StatusNotFound, status)
 	}
 
-	Bot.Config.Profiler.Enabled = true
-	Bot.Config.Profiler.MutexProfileFraction = 5
+	Bot.Config.SetProfiler(config.Profiler{Enabled: true, MutexProfileFraction: 5})
 	req, err = http.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -38,7 +38,7 @@ func TestConfigAllJsonResponse(t *testing.T) {
 		t.Error("Response not parseable as json", err)
 	}
 
-	if reflect.DeepEqual(responseConfig, Bot.Config) {
+	if reflect.DeepEqual(&responseConfig, Bot.Config) {
 		t.Error("Json not equal to config")
 	}
 }

--- a/engine/routines.go
+++ b/engine/routines.go
@@ -18,7 +18,7 @@ import (
 )
 
 func printCurrencyFormat(price float64) string {
-	displaySymbol, err := currency.GetSymbolByCurrencyName(Bot.Config.Currency.FiatDisplayCurrency)
+	displaySymbol, err := currency.GetSymbolByCurrencyName(Bot.Config.GetCurrency().FiatDisplayCurrency)
 	if err != nil {
 		log.Errorf(log.Global, "Failed to get display symbol: %s\n", err)
 	}
@@ -27,7 +27,7 @@ func printCurrencyFormat(price float64) string {
 }
 
 func printConvertCurrencyFormat(origCurrency currency.Code, origPrice float64) string {
-	displayCurrency := Bot.Config.Currency.FiatDisplayCurrency
+	displayCurrency := Bot.Config.GetCurrency().FiatDisplayCurrency
 	conv, err := currency.ConvertCurrency(origPrice,
 		origCurrency,
 		displayCurrency)
@@ -72,8 +72,9 @@ func printTickerSummary(result *ticker.Price, protocol string, err error) {
 	}
 
 	stats.Add(result.ExchangeName, result.Pair, result.AssetType, result.Last, result.Volume)
+	displayCurrency := Bot.Config.GetCurrency().FiatDisplayCurrency
 	if result.Pair.Quote.IsFiatCurrency() &&
-		result.Pair.Quote != Bot.Config.Currency.FiatDisplayCurrency {
+		result.Pair.Quote != displayCurrency {
 		origCurrency := result.Pair.Quote.Upper()
 		log.Infof(log.Ticker, "%s %s %s %s: TICKER: Last %s Ask %s Bid %s High %s Low %s Volume %.8f\n",
 			result.ExchangeName,
@@ -88,7 +89,7 @@ func printTickerSummary(result *ticker.Price, protocol string, err error) {
 			result.Volume)
 	} else {
 		if result.Pair.Quote.IsFiatCurrency() &&
-			result.Pair.Quote == Bot.Config.Currency.FiatDisplayCurrency {
+			result.Pair.Quote == displayCurrency {
 			log.Infof(log.Ticker, "%s %s %s %s: TICKER: Last %s Ask %s Bid %s High %s Low %s Volume %.8f\n",
 				result.ExchangeName,
 				protocol,
@@ -149,13 +150,14 @@ func printOrderbookSummary(result *orderbook.Base, protocol string, err error) {
 	bidsAmount, bidsValue := result.TotalBidsAmount()
 	asksAmount, asksValue := result.TotalAsksAmount()
 
+	displayCurrency := Bot.Config.GetCurrency().FiatDisplayCurrency
 	var bidValueResult, askValueResult string
 	switch {
-	case result.Pair.Quote.IsFiatCurrency() && result.Pair.Quote != Bot.Config.Currency.FiatDisplayCurrency:
+	case result.Pair.Quote.IsFiatCurrency() && result.Pair.Quote != displayCurrency:
 		origCurrency := result.Pair.Quote.Upper()
 		bidValueResult = printConvertCurrencyFormat(origCurrency, bidsValue)
 		askValueResult = printConvertCurrencyFormat(origCurrency, asksValue)
-	case result.Pair.Quote.IsFiatCurrency() && result.Pair.Quote == Bot.Config.Currency.FiatDisplayCurrency:
+	case result.Pair.Quote.IsFiatCurrency() && result.Pair.Quote == displayCurrency:
 		bidValueResult = printCurrencyFormat(bidsValue)
 		askValueResult = printCurrencyFormat(asksValue)
 	default:

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -58,7 +58,7 @@ func RPCTestSetup(t *testing.T) *Engine {
 			t.Fatalf("SetupTest: Failed to load exchange: %s", err)
 		}
 	}
-	engerino.Config.Database = dbConf
+	engerino.Config.SetDatabase(dbConf)
 	err = engerino.DatabaseManager.Start(engerino)
 	if err != nil {
 		log.Fatal(err)

--- a/engine/syncer.go
+++ b/engine/syncer.go
@@ -436,7 +436,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 									}
 									printTickerSummary(result, "REST", err)
 									if err == nil {
-										if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
+										if Bot.Config.GetRemoteControl().WebsocketRPC.Enabled {
 											relayWebsocketEvent(result, "ticker_update", c.AssetType.String(), exchangeName)
 										}
 									}
@@ -475,7 +475,7 @@ func (e *ExchangeCurrencyPairSyncer) worker() {
 								result, err := exchanges[x].UpdateOrderbook(c.Pair, c.AssetType)
 								printOrderbookSummary(result, "REST", err)
 								if err == nil {
-									if Bot.Config.RemoteControl.WebsocketRPC.Enabled {
+									if Bot.Config.GetRemoteControl().WebsocketRPC.Enabled {
 										relayWebsocketEvent(result, "orderbook_update", c.AssetType.String(), exchangeName)
 									}
 								}

--- a/engine/syncer_test.go
+++ b/engine/syncer_test.go
@@ -13,7 +13,7 @@ func TestNewCurrencyPairSyncer(t *testing.T) {
 	if Bot == nil {
 		Bot = new(Engine)
 	}
-	Bot.Config = &config.Cfg
+	Bot.Config = config.GetConfig()
 	err := Bot.Config.LoadConfig("", true)
 	if err != nil {
 		t.Fatalf("TestNewExchangeSyncer: Failed to load config: %s", err)


### PR DESCRIPTION
# PR Description

This includes a hotfix for a potential race condition when the engine starts and stops a global service and multiple services are interacting with the configuration system. 

Moves config fields to a subtype to be protected by a mutex and not accessible out of the package. Not idiomatic but added getter and setter methods ad hoc. 

Open as a draft to gauge feedback and to get a better direction. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
