### PR TITLE
LBANK: Fix undocumented kline limit adjustment

### DIFF
--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -102,7 +102,7 @@ func (l *Lbank) SetDefaults() {
 					kline.OneDay.Word():     true,
 					kline.OneWeek.Word():    true,
 				},
-				ResultLimit: 2880,
+				ResultLimit: 2000,
 			},
 		},
 	}


### PR DESCRIPTION
# PR Description

Our LBANK tests reported an error for kline retrieval. After testing the endpoint, it appears that the limit has changed from 2880 to 2000. This PR amends the enabled limit to reflect this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules
