### PR TITLE
Backtester: Add buy and sell limit for strategies 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 10m0s
+  timeout: 2m0s
   issues-exit-code: 1
   tests: true
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 2m0s
+  timeout: 10m0s
   issues-exit-code: 1
   tests: true
   skip-dirs:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ get:
 linter:
 	GO111MODULE=on go get $(GCTPKG)
 	GO111MODULE=on go get $(LINTPKG)
-	test -z "$$($(LINTBIN) run --timeout=10m --verbose | tee /dev/stderr)"
+	test -z "$$($(LINTBIN) run --verbose | tee /dev/stderr)"
 
 check: linter test
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ get:
 linter:
 	GO111MODULE=on go get $(GCTPKG)
 	GO111MODULE=on go get $(LINTPKG)
-	test -z "$$($(LINTBIN) run --verbose | tee /dev/stderr)"
+	test -z "$$($(LINTBIN) run --timeout=10m --verbose | tee /dev/stderr)"
 
 check: linter test
 

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -15,7 +15,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	gctorder "github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // Reset returns the exchange to initial settings
@@ -105,7 +104,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 		limitReducedAmount = reducedAmount
 	}
 
-	log.Infof(log.BackTester, "limitReducedAmount %v, direction %v,  buyside %+v, sell size %+v", limitReducedAmount, f.GetDirection(), cs.BuySide, cs.SellSide)
+	// log.Infof(log.BackTester, "limitReducedAmount %v, direction %v,  buyside %+v, sell size %+v", limitReducedAmount, f.GetDirection(), cs.BuySide, cs.SellSide)
 	// Conforms the amount to fall into the minimum size and maximum size limit after reduced
 	switch f.GetDirection() {
 	case gctorder.Buy:

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -112,6 +112,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
 			f.AppendReason(e)
 			return f, fmt.Errorf(e)
+
 		}
 
 	case gctorder.Sell:

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -103,11 +103,10 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	} else {
 		limitReducedAmount = reducedAmount
 	}
-
 	// Conforms the amount to fall into the minimum size and maximum size limit after reduced
 	switch f.GetDirection() {
 	case gctorder.Buy:
-		if limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize {
+		if (limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize) && (cs.BuySide.MinimumSize > 0 && cs.BuySide.MaximumSize > 0) {
 			f.SetDirection(common.CouldNotBuy)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
 			f.AppendReason(e)
@@ -115,7 +114,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 		}
 
 	case gctorder.Sell:
-		if limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize {
+		if (limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize) && (cs.SellSide.MinimumSize > 0 && cs.SellSide.MaximumSize > 0) {
 			f.SetDirection(common.CouldNotSell)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.SellSide.MinimumSize, cs.SellSide.MaximumSize)
 			f.AppendReason(e)

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -103,12 +103,10 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	} else {
 		limitReducedAmount = reducedAmount
 	}
-
-	// log.Infof(log.BackTester, "limitReducedAmount %v, direction %v,  buyside %+v, sell size %+v", limitReducedAmount, f.GetDirection(), cs.BuySide, cs.SellSide)
 	// Conforms the amount to fall into the minimum size and maximum size limit after reduced
 	switch f.GetDirection() {
 	case gctorder.Buy:
-		if (limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize) && cs.BuySide.MaximumSize > 0 {
+		if ((limitReducedAmount < cs.BuySide.MinimumSize && cs.BuySide.MinimumSize > 0) || (limitReducedAmount > cs.BuySide.MaximumSize && cs.BuySide.MaximumSize > 0)) && (cs.BuySide.MaximumSize > 0 || cs.BuySide.MinimumSize > 0) {
 			f.SetDirection(common.CouldNotBuy)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
 			f.AppendReason(e)
@@ -116,7 +114,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 		}
 
 	case gctorder.Sell:
-		if (limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize) && cs.SellSide.MaximumSize > 0 {
+		if ((limitReducedAmount < cs.SellSide.MinimumSize && cs.SellSide.MinimumSize > 0) || (limitReducedAmount > cs.SellSide.MaximumSize && cs.SellSide.MaximumSize > 0)) && (cs.SellSide.MaximumSize > 0 || cs.SellSide.MinimumSize > 0) {
 			f.SetDirection(common.CouldNotSell)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.SellSide.MinimumSize, cs.SellSide.MaximumSize)
 			f.AppendReason(e)

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -112,7 +112,6 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
 			f.AppendReason(e)
 			return f, fmt.Errorf(e)
-
 		}
 
 	case gctorder.Sell:

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -118,7 +118,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	case gctorder.Sell:
 		if limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize {
 			f.SetDirection(common.CouldNotSell)
-			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
+			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.SellSide.MinimumSize, cs.SellSide.MaximumSize)
 			f.AppendReason(e)
 			return f, fmt.Errorf(e)
 		}

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -45,7 +45,6 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	if err != nil {
 		return f, err
 	}
-
 	f.ExchangeFee = cs.ExchangeFee // defaulting to just using taker fee right now without orderbook
 	f.Direction = o.GetDirection()
 	if o.GetDirection() != gctorder.Buy && o.GetDirection() != gctorder.Sell {
@@ -60,6 +59,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	volStr := data.StreamVol()
 	volume := volStr[len(volStr)-1]
 	var adjustedPrice, amount float64
+
 	if cs.UseRealOrders {
 		// get current orderbook
 		var ob *orderbook.Base
@@ -102,6 +102,26 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 		}
 	} else {
 		limitReducedAmount = reducedAmount
+	}
+
+	// Conforms the amount to fall into the minimum size and maximum size limit after reduced
+	switch f.GetDirection() {
+	case gctorder.Buy:
+		if limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize {
+			f.SetDirection(common.CouldNotBuy)
+			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
+			f.AppendReason(e)
+			return f, fmt.Errorf(e)
+
+		}
+
+	case gctorder.Sell:
+		if limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize {
+			f.SetDirection(common.CouldNotSell)
+			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
+			f.AppendReason(e)
+			return f, fmt.Errorf(e)
+		}
 	}
 
 	orderID, err := e.placeOrder(adjustedPrice, limitReducedAmount, cs.UseRealOrders, cs.CanUseExchangeLimits, f, bot)

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	gctorder "github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
+	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // Reset returns the exchange to initial settings
@@ -103,10 +104,12 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 	} else {
 		limitReducedAmount = reducedAmount
 	}
+
+	log.Infof(log.BackTester, "limitReducedAmount %v, direction %v,  buyside %+v, sell size %+v", limitReducedAmount, f.GetDirection(), cs.BuySide, cs.SellSide)
 	// Conforms the amount to fall into the minimum size and maximum size limit after reduced
 	switch f.GetDirection() {
 	case gctorder.Buy:
-		if (limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize) && (cs.BuySide.MinimumSize > 0 && cs.BuySide.MaximumSize > 0) {
+		if (limitReducedAmount < cs.BuySide.MinimumSize || limitReducedAmount > cs.BuySide.MaximumSize) && cs.BuySide.MaximumSize > 0 {
 			f.SetDirection(common.CouldNotBuy)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.BuySide.MinimumSize, cs.BuySide.MaximumSize)
 			f.AppendReason(e)
@@ -114,7 +117,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, bot *engine.En
 		}
 
 	case gctorder.Sell:
-		if (limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize) && (cs.SellSide.MinimumSize > 0 && cs.SellSide.MaximumSize > 0) {
+		if (limitReducedAmount < cs.SellSide.MinimumSize || limitReducedAmount > cs.SellSide.MaximumSize) && cs.SellSide.MaximumSize > 0 {
 			f.SetDirection(common.CouldNotSell)
 			e := fmt.Sprintf("Order size  %.8f exceed minimum size %.8f or maximum size %.8f ", limitReducedAmount, cs.SellSide.MinimumSize, cs.SellSide.MaximumSize)
 			f.AppendReason(e)

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -371,7 +371,6 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	}
 	d.Next()
 	_, err = e.ExecuteOrder(o, d, bot)
-	t.Logf("err %v", err)
 	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
 		t.Error(err)
 	}

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -278,6 +278,152 @@ func TestExecuteOrder(t *testing.T) {
 	}
 }
 
+func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
+	t.Parallel()
+	bot, err := engine.NewFromSettings(&engine.Settings{
+		ConfigFile:   filepath.Join("..", "..", "..", "testdata", "configtest.json"),
+		EnableDryRun: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = bot.OrderManager.Start(bot)
+	if err != nil {
+		t.Error(err)
+	}
+	err = bot.LoadExchange(testExchange, false, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	b := bot.GetExchangeByName(testExchange)
+
+	p := currency.NewPair(currency.BTC, currency.USDT)
+	a := asset.Spot
+	_, err = b.FetchOrderbook(p, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	limits, err := b.GetOrderExecutionLimits(a, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cs := Settings{
+		ExchangeName:  testExchange,
+		UseRealOrders: false,
+		InitialFunds:  1337,
+		CurrencyPair:  p,
+		AssetType:     a,
+		ExchangeFee:   0.01,
+		MakerFee:      0.01,
+		TakerFee:      0.01,
+		BuySide: config.MinMax{
+			MaximumSize: 0.01,
+			MinimumSize: 0,
+		},
+		SellSide: config.MinMax{
+			MaximumSize: 0.1,
+			MinimumSize: 0,
+		},
+		Leverage:            config.Leverage{},
+		MinimumSlippageRate: 0,
+		MaximumSlippageRate: 1,
+		Limits:              limits,
+	}
+	e := Exchange{
+		CurrencySettings: []Settings{cs},
+	}
+	ev := event.Base{
+		Exchange:     testExchange,
+		Time:         time.Now(),
+		Interval:     gctkline.FifteenMin,
+		CurrencyPair: p,
+		AssetType:    a,
+	}
+	o := &order.Order{
+		Base:      ev,
+		Direction: gctorder.Buy,
+		Amount:    10,
+		Funds:     1337,
+	}
+
+	d := &kline.DataFromKline{
+		Item: gctkline.Item{
+			Exchange: "",
+			Pair:     currency.Pair{},
+			Asset:    "",
+			Interval: 0,
+			Candles: []gctkline.Candle{
+				{
+					Close:  1,
+					High:   1,
+					Low:    1,
+					Volume: 1,
+				},
+			},
+		},
+	}
+	err = d.Load()
+	if err != nil {
+		t.Error(err)
+	}
+	d.Next()
+	_, err = e.ExecuteOrder(o, d, bot)
+	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
+		t.Error(err)
+	}
+
+	o = &order.Order{
+		Base:      ev,
+		Direction: gctorder.Buy,
+		Amount:    10,
+		Funds:     1337,
+	}
+	cs.BuySide.MaximumSize = 1
+	cs.BuySide.MinimumSize = 0.01
+	_, err = e.ExecuteOrder(o, d, bot)
+	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
+		t.Error(err)
+	}
+
+	o = &order.Order{
+		Base:      ev,
+		Direction: gctorder.Buy,
+		Amount:    10,
+		Funds:     1337,
+	}
+	cs.BuySide.MaximumSize = 0
+	cs.BuySide.MinimumSize = 0.01
+	_, err = e.ExecuteOrder(o, d, bot)
+	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
+		t.Error(err)
+	}
+
+	o = &order.Order{
+		Base:      ev,
+		Direction: gctorder.Sell,
+		Amount:    10,
+		Funds:     1337,
+	}
+	cs.SellSide.MaximumSize = 0
+	cs.SellSide.MinimumSize = 0.01
+	_, err = e.ExecuteOrder(o, d, bot)
+	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
+		t.Error(err)
+	}
+
+	cs.UseRealOrders = true
+	cs.CanUseExchangeLimits = true
+	o.Direction = gctorder.Sell
+	e.CurrencySettings = []Settings{cs}
+	_, err = e.ExecuteOrder(o, d, bot)
+	if err != nil && !strings.Contains(err.Error(), "unset/default API keys") {
+		t.Error(err)
+	}
+}
+
 func TestApplySlippageToPrice(t *testing.T) {
 	t.Parallel()
 	resp := applySlippageToPrice(gctorder.Buy, 1, 0.9)

--- a/backtester/eventhandlers/portfolio/size/size.go
+++ b/backtester/eventhandlers/portfolio/size/size.go
@@ -75,7 +75,7 @@ func (s *Size) calculateBuySize(price, availableFunds, feeRate, buyLimit float64
 		return 0, nil
 	}
 	amount := availableFunds * (1 - feeRate) / price
-	if buyLimit > minMaxSettings.MinimumSize && buyLimit <= minMaxSettings.MaximumSize && buyLimit <= amount {
+	if buyLimit >= minMaxSettings.MinimumSize && buyLimit <= minMaxSettings.MaximumSize && buyLimit <= amount {
 		amount = buyLimit
 	}
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {
@@ -104,7 +104,7 @@ func (s *Size) calculateSellSize(price, baseAmount, feeRate, sellLimit float64, 
 		return 0, nil
 	}
 	amount := baseAmount * (1 - feeRate)
-	if sellLimit > minMaxSettings.MinimumSize && sellLimit <= minMaxSettings.MaximumSize && sellLimit <= amount {
+	if sellLimit >= minMaxSettings.MinimumSize && sellLimit <= minMaxSettings.MaximumSize && sellLimit <= amount {
 		amount = sellLimit
 	}
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {

--- a/backtester/eventhandlers/portfolio/size/size.go
+++ b/backtester/eventhandlers/portfolio/size/size.go
@@ -104,7 +104,7 @@ func (s *Size) calculateSellSize(price, baseAmount, feeRate, sellLimit float64, 
 		return 0, nil
 	}
 	amount := baseAmount * (1 - feeRate)
-	if sellLimit != 0 && sellLimit >= minMaxSettings.MinimumSize && sellLimit <= minMaxSettings.MaximumSize && sellLimit <= amount {
+	if sellLimit != 0 && sellLimit >= minMaxSettings.MinimumSize && (sellLimit <= minMaxSettings.MaximumSize || minMaxSettings.MaximumSize == 0) && sellLimit <= amount {
 		amount = sellLimit
 	}
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {

--- a/backtester/eventhandlers/portfolio/size/size.go
+++ b/backtester/eventhandlers/portfolio/size/size.go
@@ -75,9 +75,10 @@ func (s *Size) calculateBuySize(price, availableFunds, feeRate, buyLimit float64
 		return 0, nil
 	}
 	amount := availableFunds * (1 - feeRate) / price
-	if buyLimit >= minMaxSettings.MinimumSize && buyLimit <= minMaxSettings.MaximumSize && buyLimit <= amount {
+	if buyLimit != 0 && buyLimit >= minMaxSettings.MinimumSize && buyLimit <= minMaxSettings.MaximumSize && buyLimit <= amount {
 		amount = buyLimit
 	}
+
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {
 		amount = minMaxSettings.MaximumSize * (1 - feeRate)
 	}
@@ -104,7 +105,7 @@ func (s *Size) calculateSellSize(price, baseAmount, feeRate, sellLimit float64, 
 		return 0, nil
 	}
 	amount := baseAmount * (1 - feeRate)
-	if sellLimit >= minMaxSettings.MinimumSize && sellLimit <= minMaxSettings.MaximumSize && sellLimit <= amount {
+	if sellLimit != 0 && sellLimit >= minMaxSettings.MinimumSize && sellLimit <= minMaxSettings.MaximumSize && sellLimit <= amount {
 		amount = sellLimit
 	}
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {

--- a/backtester/eventhandlers/portfolio/size/size.go
+++ b/backtester/eventhandlers/portfolio/size/size.go
@@ -75,10 +75,9 @@ func (s *Size) calculateBuySize(price, availableFunds, feeRate, buyLimit float64
 		return 0, nil
 	}
 	amount := availableFunds * (1 - feeRate) / price
-	if buyLimit != 0 && buyLimit >= minMaxSettings.MinimumSize && buyLimit <= minMaxSettings.MaximumSize && buyLimit <= amount {
+	if buyLimit != 0 && buyLimit >= minMaxSettings.MinimumSize && (buyLimit <= minMaxSettings.MaximumSize || minMaxSettings.MaximumSize == 0) && buyLimit <= amount {
 		amount = buyLimit
 	}
-
 	if minMaxSettings.MaximumSize > 0 && amount > minMaxSettings.MaximumSize {
 		amount = minMaxSettings.MaximumSize * (1 - feeRate)
 	}

--- a/backtester/eventhandlers/portfolio/size/size_test.go
+++ b/backtester/eventhandlers/portfolio/size/size_test.go
@@ -81,6 +81,27 @@ func TestSizingUnderMinSize(t *testing.T) {
 	}
 }
 
+func TestMaximumBuySizeEqualZero(t *testing.T) {
+	t.Parallel()
+	globalMinMax := config.MinMax{
+		MinimumSize:  1,
+		MaximumSize:  0,
+		MaximumTotal: 1437,
+	}
+	sizer := Size{
+		BuySide:  globalMinMax,
+		SellSide: globalMinMax,
+	}
+	price := 1338.0
+	availableFunds := 13380.0
+	feeRate := 0.02
+	var buylimit float64 = 1
+	amount, err := sizer.calculateBuySize(price, availableFunds, feeRate, buylimit, globalMinMax)
+	if amount != buylimit || err != nil {
+		t.Errorf("expected: %v, received %v, err: %+v", buylimit, amount, err)
+	}
+}
+
 func TestSizingErrors(t *testing.T) {
 	t.Parallel()
 	globalMinMax := config.MinMax{

--- a/backtester/eventhandlers/portfolio/size/size_test.go
+++ b/backtester/eventhandlers/portfolio/size/size_test.go
@@ -101,6 +101,26 @@ func TestMaximumBuySizeEqualZero(t *testing.T) {
 		t.Errorf("expected: %v, received %v, err: %+v", buylimit, amount, err)
 	}
 }
+func TestMaximumSellSizeEqualZero(t *testing.T) {
+	t.Parallel()
+	globalMinMax := config.MinMax{
+		MinimumSize:  1,
+		MaximumSize:  0,
+		MaximumTotal: 1437,
+	}
+	sizer := Size{
+		BuySide:  globalMinMax,
+		SellSide: globalMinMax,
+	}
+	price := 1338.0
+	availableFunds := 13380.0
+	feeRate := 0.02
+	var selllimit float64 = 1
+	amount, err := sizer.calculateSellSize(price, availableFunds, feeRate, selllimit, globalMinMax)
+	if amount != selllimit || err != nil {
+		t.Errorf("expected: %v, received %v, err: %+v", selllimit, amount, err)
+	}
+}
 
 func TestSizingErrors(t *testing.T) {
 	t.Parallel()

--- a/backtester/eventtypes/signal/signal.go
+++ b/backtester/eventtypes/signal/signal.go
@@ -20,6 +20,21 @@ func (s *Signal) GetDirection() order.Side {
 	return s.Direction
 }
 
+// SetBuyLimit sets the buy limit
+func (s *Signal) SetBuyLimit(f float64) {
+	s.BuyLimit = f
+}
+
+// SetSellLimit sets the buy limit
+func (s *Signal) SetSellLimit(f float64) {
+	s.SellLimit = f
+}
+
+// GetSellLimit returns the sell limit
+func (s *Signal) GetSellLimit(f float64) float64 {
+	return s.SellLimit
+}
+
 // Pair returns the currency pair
 func (s *Signal) Pair() currency.Pair {
 	return s.CurrencyPair

--- a/backtester/eventtypes/signal/signal.go
+++ b/backtester/eventtypes/signal/signal.go
@@ -30,7 +30,7 @@ func (s *Signal) GetBuyLimit() float64 {
 	return s.BuyLimit
 }
 
-// SetSellLimit sets the buy limit
+// SetSellLimit sets the sell limit
 func (s *Signal) SetSellLimit(f float64) {
 	s.SellLimit = f
 }

--- a/backtester/eventtypes/signal/signal_test.go
+++ b/backtester/eventtypes/signal/signal_test.go
@@ -37,7 +37,7 @@ func TestSetBuyLimit(t *testing.T) {
 	}
 	s.SetBuyLimit(20)
 	if s.GetBuyLimit() != 20 {
-		t.Error("expected 20")
+		t.Errorf("expected 20, received %v", s.GetBuyLimit())
 	}
 }
 
@@ -47,6 +47,6 @@ func TestSetSellLimit(t *testing.T) {
 	}
 	s.SetSellLimit(20)
 	if s.GetSellLimit() != 20 {
-		t.Error("expected 20")
+		t.Errorf("expected 20, received %v", s.GetSellLimit())
 	}
 }

--- a/backtester/eventtypes/signal/signal_types.go
+++ b/backtester/eventtypes/signal/signal_types.go
@@ -24,5 +24,7 @@ type Signal struct {
 	LowPrice   float64
 	ClosePrice float64
 	Volume     float64
+	BuyLimit   float64
+	SellLimit  float64
 	Direction  order.Side
 }


### PR DESCRIPTION
# PR Description

add buy and sell limit to backtest strategy to buy and sell a specific amount of asset


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
