### PR TITLE
Bugfix: Orderbook locks

### DIFF
--- a/engine/routines_test.go
+++ b/engine/routines_test.go
@@ -81,16 +81,6 @@ func TestHandleData(t *testing.T) {
 		t.Error("Expected order to be modified to Active")
 	}
 
-	err = b.WebsocketDataHandler(exchName, &order.Cancel{
-		Exchange: fakePassExchange,
-		ID:       orderID,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-	if origOrder.Status != order.Cancelled {
-		t.Error("Expected order status to be cancelled")
-	}
 	// Send some gibberish
 	err = b.WebsocketDataHandler(exchName, order.Stop)
 	if err != nil {

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -544,6 +544,7 @@ func (b *Binance) Subscribe(channelsToSubscribe []stream.ChannelSubscription) er
 	for i := range channelsToSubscribe {
 		payload.Params = append(payload.Params, channelsToSubscribe[i].Channel)
 	}
+
 	err := b.Websocket.Conn.SendJSONMessage(payload)
 	if err != nil {
 		return err

--- a/exchanges/orderbook/calculator_test.go
+++ b/exchanges/orderbook/calculator_test.go
@@ -1,6 +1,7 @@
 package orderbook
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -32,14 +33,26 @@ func TestWhaleBomb(t *testing.T) {
 	}
 
 	// valid
-	b.WhaleBomb(7001, true)
+	_, err = b.WhaleBomb(7001, true)
+	if !errors.Is(err, nil) {
+		t.Errorf("received '%v', expected '%v'", err, nil)
+	}
 	// invalid
-	b.WhaleBomb(7002, true)
+	_, err = b.WhaleBomb(7002, true)
+	if err == nil {
+		t.Error("unexpected result")
+	}
 
 	// valid
-	b.WhaleBomb(6998, false)
+	_, err = b.WhaleBomb(6998, false)
+	if !errors.Is(err, nil) {
+		t.Errorf("received '%v', expected '%v'", err, nil)
+	}
 	// invalid
-	b.WhaleBomb(6997, false)
+	_, err = b.WhaleBomb(6997, false)
+	if err == nil {
+		t.Error("unexpected result")
+	}
 }
 
 func TestSimulateOrder(t *testing.T) {

--- a/exchanges/orderbook/node_test.go
+++ b/exchanges/orderbook/node_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestPushPop(t *testing.T) {
 	s := newStack()
-	var nSlice []*node
+	var nSlice [100]*node
 	for i := 0; i < 100; i++ {
-		nSlice = append(nSlice, s.Pop())
+		nSlice[i] = s.Pop()
 	}
 
 	if s.getCount() != 0 {
@@ -29,9 +29,9 @@ func TestPushPop(t *testing.T) {
 
 func TestCleaner(t *testing.T) {
 	s := newStack()
-	var nSlice []*node
+	var nSlice [100]*node
 	for i := 0; i < 100; i++ {
-		nSlice = append(nSlice, s.Pop())
+		nSlice[i] = s.Pop()
 	}
 
 	tn := getNow()
@@ -39,16 +39,16 @@ func TestCleaner(t *testing.T) {
 		s.Push(nSlice[i], tn)
 	}
 	// Makes all the 50 pushed nodes invalid
-	time.Sleep(time.Millisecond * 550)
+	time.Sleep(time.Millisecond * 260)
 	tn = getNow()
 	for i := 50; i < 100; i++ {
 		s.Push(nSlice[i], tn)
 	}
-	time.Sleep(time.Millisecond * 550)
+	time.Sleep(time.Millisecond * 50)
 	if s.getCount() != 50 {
 		t.Fatalf("incorrect stack count expected %v but received %v", 50, s.getCount())
 	}
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 350)
 	if s.getCount() != 0 {
 		t.Fatalf("incorrect stack count expected %v but received %v", 0, s.getCount())
 	}

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -98,6 +98,7 @@ func (s *Service) DeployDepth(exchange string, p currency.Pair, a asset.Item) (*
 		return nil, errAssetTypeNotSet
 	}
 	s.Lock()
+	defer s.Unlock()
 	m1, ok := s.books[strings.ToLower(exchange)]
 	if !ok {
 		id, err := s.Mux.GetID()
@@ -125,7 +126,6 @@ func (s *Service) DeployDepth(exchange string, p currency.Pair, a asset.Item) (*
 		book = newDepth(m1.ID)
 		m3[p.Quote.Item] = book
 	}
-	s.Unlock()
 	return book, nil
 }
 


### PR DESCRIPTION

![gct666](https://user-images.githubusercontent.com/9261323/116331923-1b8d7600-a814-11eb-961c-81dc3e089d23.png)


# PR Description
Shazbert and I debugged an orderbook test as a result of this lovely appveyor output: https://ci.appveyor.com/project/thrasher-/gocryptotrader-g5pk0/builds/38887028?fullLog=true

I've changed a few minor things as well.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

