### PR TITLE
FTX: Fixed typos in ftx_types

### DIFF
--- a/exchanges/ftx/ftx_types.go
+++ b/exchanges/ftx/ftx_types.go
@@ -186,6 +186,8 @@ type PositionData struct {
 	Side                         string  `json:"side"`
 	Size                         float64 `json:"size"`
 	UnrealizedPnL                float64 `json:"unrealizedPnL"`
+	CollateralUsed               float64 `json:"collateralUsed"`
+	EstimatedLiquidationPrice    float64 `json:"estimatedLiquidationPrice"`
 }
 
 // AccountInfoData stores account data
@@ -377,7 +379,7 @@ type LTBalanceData struct {
 
 // LTCreationData stores token creation requests' data
 type LTCreationData struct {
-	ID            string    `json:"id"`
+	ID            int64     `json:"id"`
 	Token         string    `json:"token"`
 	RequestedSize float64   `json:"requestedSize"`
 	Pending       bool      `json:"pending"`
@@ -391,7 +393,7 @@ type LTCreationData struct {
 
 // RequestTokenCreationData stores data of the token creation requested
 type RequestTokenCreationData struct {
-	ID            string    `json:"id"`
+	ID            int64     `json:"id"`
 	Token         string    `json:"token"`
 	RequestedSize float64   `json:"requestedSize"`
 	Cost          float64   `json:"cost"`
@@ -414,7 +416,7 @@ type LTRedemptionData struct {
 
 // LTRedemptionRequestData stores redemption request data for a leveraged token
 type LTRedemptionRequestData struct {
-	ID                string    `json:"id"`
+	ID                int64     `json:"id"`
 	Token             string    `json:"token"`
 	Size              float64   `json:"size"`
 	ProjectedProceeds float64   `json:"projectedProceeds"`

--- a/exchanges/ftx/ftx_types.go
+++ b/exchanges/ftx/ftx_types.go
@@ -181,11 +181,11 @@ type PositionData struct {
 	MaintenanceMarginRequirement float64 `json:"maintenanceMarginRequirement"`
 	NetSize                      float64 `json:"netSize"`
 	OpenSize                     float64 `json:"openSize"`
-	RealisedPnL                  float64 `json:"realisedPnL"`
-	ShortOrderSide               float64 `json:"shortOrderSide"`
+	RealizedPnL                  float64 `json:"realizedPnL"`
+	ShortOrderSize               float64 `json:"shortOrderSize"`
 	Side                         string  `json:"side"`
 	Size                         float64 `json:"size"`
-	UnrealisedPnL                float64 `json:"unrealisedPnL"`
+	UnrealizedPnL                float64 `json:"unrealizedPnL"`
 }
 
 // AccountInfoData stores account data
@@ -195,7 +195,7 @@ type AccountInfoData struct {
 	Collateral                   float64        `json:"collateral"`
 	FreeCollateral               float64        `json:"freeCollateral"`
 	InitialMarginRequirement     float64        `json:"initialMarginRequirement"`
-	Leverage                     float64        `json:"float64"`
+	Leverage                     float64        `json:"leverage"`
 	Liquidating                  bool           `json:"liquidating"`
 	MaintenanceMarginRequirement float64        `json:"maintenanceMarginRequirement"`
 	MakerFee                     float64        `json:"makerFee"`
@@ -381,7 +381,7 @@ type LTCreationData struct {
 	Token         string    `json:"token"`
 	RequestedSize float64   `json:"requestedSize"`
 	Pending       bool      `json:"pending"`
-	CreatedSize   float64   `json:"createdize"`
+	CreatedSize   float64   `json:"createdSize"`
 	Price         float64   `json:"price"`
 	Cost          float64   `json:"cost"`
 	Fee           float64   `json:"fee"`


### PR DESCRIPTION
# PR Description

I found some typo in ftx_types.go. Those changes enable fetching some fields in private data again. These kind of method is generally supposed not to be tested by CI.

Correct name of fields are here
https://docs.ftx.com/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

These fields referred via private methods have to be manually tested, I suppose. To test the fields, I made some order on the web and rewrote my local ```ftx_test.go``` as follows set with my private key;

<img width="1278" alt="Screen Shot 2021-06-13 at 12 35 56" src="https://user-images.githubusercontent.com/8386849/121795106-71916e00-cc48-11eb-9aa9-aa328f58adf1.png">
<img width="412" alt="Screen Shot 2021-06-13 at 12 53 07" src="https://user-images.githubusercontent.com/8386849/121795110-73f3c800-cc48-11eb-9d8d-5ed8235443c2.png">


- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
