### PR TITLE
Kraken: Authenticated websocket bugfix

### DIFF
--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -1141,10 +1141,8 @@ func (k *Kraken) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, e
 	}
 	if k.Websocket.CanUseAuthenticatedEndpoints() {
 		for i := range authenticatedChannels {
-			params := make(map[string]interface{})
 			subscriptions = append(subscriptions, stream.ChannelSubscription{
 				Channel: authenticatedChannels[i],
-				Params:  params,
 			})
 		}
 	}
@@ -1187,7 +1185,7 @@ channels:
 		if !channelsToSubscribe[i].Currency.IsEmpty() {
 			outbound.Pairs = []string{channelsToSubscribe[i].Currency.String()}
 		}
-		if channelsToSubscribe[i].Params != nil {
+		if common.StringDataContains(authenticatedChannels, channelsToSubscribe[i].Channel) {
 			outbound.Subscription.Token = authToken
 		}
 
@@ -1262,6 +1260,9 @@ channels:
 				Depth: depth,
 			},
 			RequestID: id,
+		}
+		if common.StringDataContains(authenticatedChannels, channelsToUnsubscribe[x].Channel) {
+			unsub.Subscription.Token = authToken
 		}
 		unsub.Channels = append(unsub.Channels, channelsToUnsubscribe[x])
 		unsubs = append(unsubs, unsub)


### PR DESCRIPTION
# PR Description

This PR is based off of Vazha's lovely PR: #650 . For context, if you have both `authenticatedSupport` and `authenticatedWebsocketApiSupport` set to `true` in your config, along with having API keys, the websocket will not work, instead, returning "already subscribed" errors.

I thought I would just fix the area that prevented Authenticated Kraken websocket from working without any of the other contended changes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
I tested that the authenticated websocket actually connects and can subscribe to authenticated endpoints successfully.

- [x] go test ./... -race
- [x] golangci-lint run


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
