### PR TITLE
Binance: Websocket order update fixes

### DIFF
--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2517,9 +2517,8 @@ func TestWsOrderExecutionReport(t *testing.T) {
 		t.Fatal(err)
 	}
 	res := <-b.Websocket.DataHandler
-	switch res.(type) {
+	switch r := res.(type) {
 	case *order.Detail:
-		r := res.(*order.Detail)
 		// ignore the date
 		r.Date = time.Time{}
 		if diff := cmp.Diff(expRes, *r); diff != "" {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2491,8 +2491,8 @@ func TestSetExchangeOrderExecutionLimits(t *testing.T) {
 }
 
 func TestWsOrderExecutionReport(t *testing.T) {
-	//	cannot run in parallel due to inspecting the DataHandler result
-	t.Parallel()
+	// cannot run in parallel due to inspecting the DataHandler result
+	// t.Parallel()
 	payload := []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616627567900,"s":"BTCUSDT","c":"c4wyKsIhoAaittTYlIVLqk","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028400","p":"52789.10000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"NEW","X":"NEW","r":"NONE","i":5340845958,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":null,"T":1616627567900,"t":-1,"I":11388173160,"w":true,"m":false,"M":false,"O":1616627567900,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000"}}`)
 	expRes := order.Detail{
 		Price:           52789.1,

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"sync"
 	"testing"
 	"time"
@@ -2269,7 +2270,7 @@ func TestExecutionTypeToOrderStatus(t *testing.T) {
 	}
 	testCases := []TestCases{
 		{Case: "NEW", Result: order.New},
-		{Case: "CANCELLED", Result: order.Cancelled},
+		{Case: "CANCELED", Result: order.Cancelled},
 		{Case: "REJECTED", Result: order.Rejected},
 		{Case: "TRADE", Result: order.PartiallyFilled},
 		{Case: "EXPIRED", Result: order.Expired},
@@ -2490,11 +2491,41 @@ func TestSetExchangeOrderExecutionLimits(t *testing.T) {
 }
 
 func TestWsOrderExecutionReport(t *testing.T) {
+	//	cannot run in parallel due to inspecting the DataHandler result
 	t.Parallel()
 	payload := []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616627567900,"s":"BTCUSDT","c":"c4wyKsIhoAaittTYlIVLqk","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028400","p":"52789.10000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"NEW","X":"NEW","r":"NONE","i":5340845958,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":null,"T":1616627567900,"t":-1,"I":11388173160,"w":true,"m":false,"M":false,"O":1616627567900,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000"}}`)
+	expRes := order.Detail{
+		Price:           52789.1,
+		Amount:          0.00028400,
+		Exchange:        "Binance",
+		ID:              "5340845958",
+		ClientID:        "c4wyKsIhoAaittTYlIVLqk",
+		Side:            order.Buy,
+		Type:            order.Limit,
+		Status:          order.New,
+		AssetType:       asset.Spot,
+		Pair:            currency.NewPair(currency.BTC, currency.USDT),
+		RemainingAmount: 0.000284,
+	}
+	//empty the channel. otherwise mock_test will fail
+	for len(b.Websocket.DataHandler) > 0 {
+		<-b.Websocket.DataHandler
+	}
+
 	err := b.wsHandleData(payload)
 	if err != nil {
 		t.Fatal(err)
+	}
+	res := <-b.Websocket.DataHandler
+	switch res.(type) {
+	case *order.Detail:
+		r := res.(*order.Detail)
+		r.Date = time.Time{} //ignore the date
+		if diff := cmp.Diff(expRes, *r); diff != "" {
+			t.Error(diff)
+		}
+	default:
+		t.Fatalf("expected type order.Detail, found %T", res)
 	}
 
 	payload = []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616633041556,"s":"BTCUSDT","c":"YeULctvPAnHj5HXCQo9Mob","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028600","p":"52436.85000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"TRADE","X":"FILLED","r":"NONE","i":5341783271,"l":"0.00028600","z":"0.00028600","L":"52436.85000000","n":"0.00000029","N":"BTC","T":1616633041555,"t":726946523,"I":11390206312,"w":false,"m":false,"M":true,"O":1616633041555,"Z":"14.99693910","Y":"14.99693910","Q":"0.00000000"}}`)

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2507,7 +2507,7 @@ func TestWsOrderExecutionReport(t *testing.T) {
 		Pair:            currency.NewPair(currency.BTC, currency.USDT),
 		RemainingAmount: 0.000284,
 	}
-	//empty the channel. otherwise mock_test will fail
+	// empty the channel. otherwise mock_test will fail
 	for len(b.Websocket.DataHandler) > 0 {
 		<-b.Websocket.DataHandler
 	}
@@ -2520,7 +2520,8 @@ func TestWsOrderExecutionReport(t *testing.T) {
 	switch res.(type) {
 	case *order.Detail:
 		r := res.(*order.Detail)
-		r.Date = time.Time{} //ignore the date
+		// ignore the date
+		r.Date = time.Time{}
 		if diff := cmp.Diff(expRes, *r); diff != "" {
 			t.Error(diff)
 		}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -763,7 +763,7 @@ type WsOrderUpdateData struct {
 	RejectionReason                   string    `json:"r"`
 	Symbol                            string    `json:"s"`
 	TradeID                           int64     `json:"t"`
-	Ignored                           int64     `json:"I"` //must be ignored explicitly, otherwise it overwrites 'i'
+	Ignored                           int64     `json:"I"` // must be ignored explicitly, otherwise it overwrites 'i'
 	IsOnOrderBook                     bool      `json:"w"`
 	CurrentExecutionType              string    `json:"x"`
 	CumulativeFilledQuantity          float64   `json:"z,string"`

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -736,7 +736,7 @@ type wsOrderUpdate struct {
 
 // WsOrderUpdateData defines websocket account order update data
 type WsOrderUpdateData struct {
-	ClientOrderID                     string    `json:"C"`
+	ClientOrderID                     string    `json:"c"`
 	EventTime                         time.Time `json:"E"`
 	IcebergQuantity                   float64   `json:"F,string"`
 	LastExecutedPrice                 float64   `json:"L,string"`
@@ -749,7 +749,7 @@ type WsOrderUpdateData struct {
 	OrderStatus                       string    `json:"X"`
 	LastQuoteAssetTransactedQuantity  float64   `json:"Y,string"`
 	CumulativeQuoteTransactedQuantity float64   `json:"Z,string"`
-	CancelledClientOrderID            string    `json:"c"`
+	CancelledClientOrderID            string    `json:"C"`
 	EventType                         string    `json:"e"`
 	TimeInForce                       string    `json:"f"`
 	OrderListID                       int64     `json:"g"`
@@ -763,6 +763,7 @@ type WsOrderUpdateData struct {
 	RejectionReason                   string    `json:"r"`
 	Symbol                            string    `json:"s"`
 	TradeID                           int64     `json:"t"`
+	Ignored                           int64     `json:"I"` //must be ignored explicitly, otherwise it overwrites 'i'
 	IsOnOrderBook                     bool      `json:"w"`
 	CurrentExecutionType              string    `json:"x"`
 	CumulativeFilledQuantity          float64   `json:"z,string"`

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -253,6 +253,7 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					AssetType:       a,
 					Date:            data.Data.OrderCreationTime,
 					Pair:            p,
+					ClientID:        data.Data.ClientOrderID,
 				}
 				return nil
 			case "listStatus":
@@ -421,7 +422,7 @@ func stringToOrderStatus(status string) (order.Status, error) {
 	switch status {
 	case "NEW":
 		return order.New, nil
-	case "CANCELLED":
+	case "CANCELED":
 		return order.Cancelled, nil
 	case "REJECTED":
 		return order.Rejected, nil

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/d5/tengo/v2 v2.7.0
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/gorilla/mux v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/d5/tengo/v2 v2.7.0
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible
-	github.com/google/go-cmp v0.5.6	
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/d5/tengo/v2 v2.7.0
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible
-	github.com/golang/protobuf v1.5.2
+	github.com/google/go-cmp v0.5.6	
 	github.com/google/go-querystring v1.1.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2


### PR DESCRIPTION
# PR Description

While looking into the Orderbook manager, I discovered some issues with Binance websockets which led to 3 orders ending up as active orders in the order manager with invalid ids after an order was created and then canceled.

Example message from the execution report highlighting the areas that were wrongly interpreted:

> {"e":"executionReport","E":1625512039095,"s":"BTCUSDT",**"c":"A4kplXxxIvEDqoAKq6xlIf"**,"S":"SELL","o":"LIMIT","f":"GTC","q":"0.00020000","p":"68121.64000000","P":"0.00000000","F":"0.00000000","g":-1,**"C":"QJyBvorya02T3MeyNLc9HT"**,"x":"CANCELED",**"X":"CANCELED"**,"r":"NONE",_"i":6745981401_,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":null,"T":1625512039095,"t":-1,**"I":14416574986**,"w":false,"m":false,"M":false,"O":1625512033495,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000"}

I found the following issues:

- CANCELED was spelled CANCELLED
- ClientOrderID was using 'C' instead of 'c'
- in WsOrderUpdateData: 'I' needs to be explicitly captured (I used Ignored), otherwise the JSON unmarshalling is overwriting the OrderID ('i')

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

I modified test TestWsOrderExecutionReport, but this needs to be checked, because I was unsure how to best test the returning data through the Websocket.DataHandler and I did not find another test doing an inspection like this.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] revive

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
