### PR TITLE
Backtester: Update flag typo

### DIFF
--- a/backtester/config/configbuilder/README.md
+++ b/backtester/config/configbuilder/README.md
@@ -22,7 +22,7 @@ Join our slack to discuss all things related to GoCryptoTrader! [GoCryptoTrader 
 
 ### What does the config builder do?
 The config builder runs you through the process of creating a strategy config (`.strat`) file. Configs can also be generated via test code under `config_test.go`.
-Once the config is created, when running the backtester, you can reference it via `go run . -configPath=(path-to-strat-file)`
+Once the config is created, when running the backtester, you can reference it via `go run . -configpath=(path-to-strat-file)`
 
 ### How do I run it?
 `go run .`

--- a/cmd/documentation/backtester_templates/backtester_config_configbuilder_readme.tmpl
+++ b/cmd/documentation/backtester_templates/backtester_config_configbuilder_readme.tmpl
@@ -4,7 +4,7 @@
 
 ### What does the config builder do?
 The config builder runs you through the process of creating a strategy config (`.strat`) file. Configs can also be generated via test code under `config_test.go`.
-Once the config is created, when running the backtester, you can reference it via `go run . -configPath=(path-to-strat-file)`
+Once the config is created, when running the backtester, you can reference it via `go run . -configpath=(path-to-strat-file)`
 
 ### How do I run it?
 `go run .`


### PR DESCRIPTION
# PR Description

The typo in flag -config**P**ath breaks running backtest.


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

