### PR TITLE
BUGFIX: GateIO candle retrieval, backtester formatting

### DIFF
--- a/backtester/backtest/backtest.go
+++ b/backtester/backtest/backtest.go
@@ -137,7 +137,8 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, bot *engine.
 		}
 		exch := bot.ExchangeManager.GetExchangeByName(cfg.CurrencySettings[i].ExchangeName)
 		b := exch.GetBase()
-		pFmt, err := b.GetPairFormat(a, true)
+		var pFmt currency.PairFormat
+		pFmt, err = b.GetPairFormat(a, true)
 		if err != nil {
 			return nil, fmt.Errorf("could not fotmat currency %v, %w", curr, err)
 		}

--- a/backtester/backtest/backtest.go
+++ b/backtester/backtest/backtest.go
@@ -135,6 +135,14 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, bot *engine.
 				cfg.CurrencySettings[i].Base+cfg.CurrencySettings[i].Quote,
 				err)
 		}
+		exch := bot.ExchangeManager.GetExchangeByName(cfg.CurrencySettings[i].ExchangeName)
+		b := exch.GetBase()
+		if b.CurrencyPairs.RequestFormat != nil {
+			curr = curr.Format(b.CurrencyPairs.RequestFormat.Delimiter, b.CurrencyPairs.RequestFormat.Uppercase)
+		} else if b.CurrencyPairs.Pairs[a].RequestFormat != nil {
+			curr = curr.Format(b.CurrencyPairs.Pairs[a].RequestFormat.Delimiter, b.CurrencyPairs.Pairs[a].RequestFormat.Uppercase)
+		}
+
 		portfolioRisk.CurrencySettings[cfg.CurrencySettings[i].ExchangeName][a][curr] = &risk.CurrencySettings{
 			MaximumOrdersWithLeverageRatio: cfg.CurrencySettings[i].Leverage.MaximumOrdersWithLeverageRatio,
 			MaxLeverageRate:                cfg.CurrencySettings[i].Leverage.MaximumLeverageRate,

--- a/backtester/backtest/backtest.go
+++ b/backtester/backtest/backtest.go
@@ -140,7 +140,7 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, bot *engine.
 		var pFmt currency.PairFormat
 		pFmt, err = b.GetPairFormat(a, true)
 		if err != nil {
-			return nil, fmt.Errorf("could not fotmat currency %v, %w", curr, err)
+			return nil, fmt.Errorf("could not format currency %v, %w", curr, err)
 		}
 		curr = curr.Format(pFmt.Delimiter, pFmt.Uppercase)
 

--- a/backtester/backtest/backtest.go
+++ b/backtester/backtest/backtest.go
@@ -137,11 +137,11 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, bot *engine.
 		}
 		exch := bot.ExchangeManager.GetExchangeByName(cfg.CurrencySettings[i].ExchangeName)
 		b := exch.GetBase()
-		if b.CurrencyPairs.RequestFormat != nil {
-			curr = curr.Format(b.CurrencyPairs.RequestFormat.Delimiter, b.CurrencyPairs.RequestFormat.Uppercase)
-		} else if b.CurrencyPairs.Pairs[a].RequestFormat != nil {
-			curr = curr.Format(b.CurrencyPairs.Pairs[a].RequestFormat.Delimiter, b.CurrencyPairs.Pairs[a].RequestFormat.Uppercase)
+		pFmt, err := b.GetPairFormat(a, true)
+		if err != nil {
+			return nil, fmt.Errorf("could not fotmat currency %v, %w", curr, err)
 		}
+		curr = curr.Format(pFmt.Delimiter, pFmt.Uppercase)
 
 		portfolioRisk.CurrencySettings[cfg.CurrencySettings[i].ExchangeName][a][curr] = &risk.CurrencySettings{
 			MaximumOrdersWithLeverageRatio: cfg.CurrencySettings[i].Leverage.MaximumOrdersWithLeverageRatio,

--- a/backtester/config/config.go
+++ b/backtester/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	gctcommon "github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/file"
@@ -179,6 +180,7 @@ func (c *Config) ValidateCurrencySettings() error {
 			c.CurrencySettings[i].MinimumSlippagePercent > c.CurrencySettings[i].MaximumSlippagePercent {
 			return ErrBadSlippageRates
 		}
+		c.CurrencySettings[i].ExchangeName = strings.ToLower(c.CurrencySettings[i].ExchangeName)
 	}
 	return nil
 }

--- a/backtester/config/examples/dca-api-candles.strat
+++ b/backtester/config/examples/dca-api-candles.strat
@@ -8,10 +8,10 @@
  },
  "currency-settings": [
   {
-   "exchange-name": "binance",
+   "exchange-name": "poloniex",
    "asset": "spot",
    "base": "BTC",
-   "quote": "USDT",
+   "quote": "XRP",
    "initial-funds": 100000,
    "leverage": {
     "can-use-leverage": false,

--- a/backtester/config/examples/dca-api-candles.strat
+++ b/backtester/config/examples/dca-api-candles.strat
@@ -8,10 +8,10 @@
  },
  "currency-settings": [
   {
-   "exchange-name": "poloniex",
+   "exchange-name": "binance",
    "asset": "spot",
    "base": "BTC",
-   "quote": "XRP",
+   "quote": "USDT",
    "initial-funds": 100000,
    "leverage": {
     "can-use-leverage": false,

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -265,7 +265,7 @@ func (e *Exchange) SetExchangeAssetCurrencySettings(exch string, a asset.Item, c
 // GetCurrencySettings returns the settings for an exchange, asset currency
 func (e *Exchange) GetCurrencySettings(exch string, a asset.Item, cp currency.Pair) (Settings, error) {
 	for i := range e.CurrencySettings {
-		if e.CurrencySettings[i].CurrencyPair == cp {
+		if e.CurrencySettings[i].CurrencyPair.Equal(cp) {
 			if e.CurrencySettings[i].AssetType == a {
 				if exch == e.CurrencySettings[i].ExchangeName {
 					return e.CurrencySettings[i], nil

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -826,7 +826,7 @@ func (g *Gateio) GetHistoricCandles(pair currency.Pair, a asset.Item, start, end
 		return kline.Item{}, err
 	}
 
-	hours := end.Sub(start).Hours()
+	hours := time.Since(start).Hours()
 	formattedPair, err := g.FormatExchangeCurrency(pair, a)
 	if err != nil {
 		return kline.Item{}, err
@@ -847,6 +847,7 @@ func (g *Gateio) GetHistoricCandles(pair currency.Pair, a asset.Item, start, end
 	klineData.Asset = a
 
 	klineData.SortCandlesByTimestamp(false)
+	klineData.RemoveOutsideRange(start, end)
 	return klineData, nil
 }
 


### PR DESCRIPTION
# PR Description
A Slack user name Dave highlighted that there was an issue with the backtester regarding GateIO data retreival. I found the following issues:

- GateIO was unable to retrieve candle data if the end date wasn't the current date due to the API not having start/end support and so we were providing the wrong time. The backtester would yell MISSING DATA
- The backtester was having issues with GateIO and currency lookups due to formatting differences between default and request format, so I format currencies in the backtester to match their request format.
- I noticed that CaPiTaLiSaTiOn was impacting backtester settings lookup for exchanges such as "OKCOIN International", so its now loaded lowercase

## Something to consider
GateIO's API [has been updated to v4 which has better candle retrieval support](https://api.gateio.io/docs/apiv4/en/index.html#retrieve-market-trades). The v2 API [does not have start and end support](https://www.gate.io/api2#kline) and is limited to 1001 results. So you cannot get 2019 candle data for 1m intervals as an example. This PR is a small fix, but a move to v4 will be good later 🤙 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
- Tested with existing exchanges and the problem exchanges in the backtester to ensure that the backtester still works.
- Tested candle retrieval on GateIO to ensure that data is being retrieved properly
- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
