### PR TITLE
gctrpc: endpoints now optionally return timestamps in nanoseconds (configurable)

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -179,6 +179,7 @@ type GRPCConfig struct {
 	ListenAddress          string `json:"listenAddress"`
 	GRPCProxyEnabled       bool   `json:"grpcProxyEnabled"`
 	GRPCProxyListenAddress string `json:"grpcProxyListenAddress"`
+	TimeInNanoSeconds      bool   `json:"timeInNanoSeconds"`
 }
 
 // DepcrecatedRPCConfig stores the deprecatedRPCConfig settings

--- a/config_example.json
+++ b/config_example.json
@@ -183,7 +183,8 @@
    "enabled": true,
    "listenAddress": "localhost:9052",
    "grpcProxyEnabled": false,
-   "grpcProxyListenAddress": "localhost:9053"
+   "grpcProxyListenAddress": "localhost:9053",
+   "timeInNanoSeconds": false
   },
   "deprecatedRPC": {
    "enabled": true,

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -363,7 +363,7 @@ func (s *RPCServer) GetTicker(_ context.Context, r *gctrpc.GetTickerRequest) (*g
 
 	resp := &gctrpc.TickerResponse{
 		Pair:        r.Pair,
-		LastUpdated: t.LastUpdated.Unix(),
+		LastUpdated: s.unixTimestamp(t.LastUpdated),
 		Last:        t.Last,
 		High:        t.High,
 		Low:         t.Low,
@@ -394,7 +394,7 @@ func (s *RPCServer) GetTickers(_ context.Context, _ *gctrpc.GetTickersRequest) (
 					Base:      val.Pair.Base.String(),
 					Quote:     val.Pair.Quote.String(),
 				},
-				LastUpdated: val.LastUpdated.Unix(),
+				LastUpdated: s.unixTimestamp(val.LastUpdated),
 				Last:        val.Last,
 				High:        val.High,
 				Low:         val.Low,
@@ -456,7 +456,7 @@ func (s *RPCServer) GetOrderbook(_ context.Context, r *gctrpc.GetOrderbookReques
 		Pair:        r.Pair,
 		Bids:        bids,
 		Asks:        asks,
-		LastUpdated: ob.LastUpdated.Unix(),
+		LastUpdated: s.unixTimestamp(ob.LastUpdated),
 		AssetType:   r.AssetType,
 	}
 
@@ -500,7 +500,7 @@ func (s *RPCServer) GetOrderbooks(_ context.Context, _ *gctrpc.GetOrderbooksRequ
 						Quote:     currencies[z].Quote.String(),
 					},
 					AssetType:   assets[y].String(),
-					LastUpdated: resp.LastUpdated.Unix(),
+					LastUpdated: s.unixTimestamp(resp.LastUpdated),
 				}
 				for i := range resp.Bids {
 					ob.Bids = append(ob.Bids, &gctrpc.OrderbookItem{
@@ -911,7 +911,7 @@ func (s *RPCServer) GetOrders(_ context.Context, r *gctrpc.GetOrdersRequest) (*g
 				Total:     resp[x].Trades[i].Total,
 			}
 			if !resp[x].Trades[i].Timestamp.IsZero() {
-				t.CreationTime = resp[x].Trades[i].Timestamp.Unix()
+				t.CreationTime = s.unixTimestamp(resp[x].Trades[i].Timestamp)
 			}
 			trades = append(trades, t)
 		}
@@ -933,10 +933,10 @@ func (s *RPCServer) GetOrders(_ context.Context, r *gctrpc.GetOrdersRequest) (*g
 			Trades:        trades,
 		}
 		if !resp[x].Date.IsZero() {
-			o.CreationTime = resp[x].Date.Unix()
+			o.CreationTime = s.unixTimestamp(resp[x].Date)
 		}
 		if !resp[x].LastUpdated.IsZero() {
-			o.UpdateTime = resp[x].LastUpdated.Unix()
+			o.UpdateTime = s.unixTimestamp(resp[x].LastUpdated)
 		}
 		orders = append(orders, o)
 	}
@@ -995,7 +995,7 @@ func (s *RPCServer) GetManagedOrders(_ context.Context, r *gctrpc.GetOrdersReque
 				Total:     resp[x].Trades[i].Total,
 			}
 			if !resp[x].Trades[i].Timestamp.IsZero() {
-				t.CreationTime = resp[x].Trades[i].Timestamp.Unix()
+				t.CreationTime = s.unixTimestamp(resp[x].Trades[i].Timestamp)
 			}
 			trades = append(trades, t)
 		}
@@ -1017,10 +1017,10 @@ func (s *RPCServer) GetManagedOrders(_ context.Context, r *gctrpc.GetOrdersReque
 			Trades:        trades,
 		}
 		if !resp[x].Date.IsZero() {
-			o.CreationTime = resp[x].Date.Unix()
+			o.CreationTime = s.unixTimestamp(resp[x].Date)
 		}
 		if !resp[x].LastUpdated.IsZero() {
-			o.UpdateTime = resp[x].LastUpdated.Unix()
+			o.UpdateTime = s.unixTimestamp(resp[x].LastUpdated)
 		}
 		orders = append(orders, o)
 	}
@@ -1062,7 +1062,7 @@ func (s *RPCServer) GetOrder(_ context.Context, r *gctrpc.GetOrderRequest) (*gct
 	var trades []*gctrpc.TradeHistory
 	for i := range result.Trades {
 		trades = append(trades, &gctrpc.TradeHistory{
-			CreationTime: result.Trades[i].Timestamp.Unix(),
+			CreationTime: s.unixTimestamp(result.Trades[i].Timestamp),
 			Id:           result.Trades[i].TID,
 			Price:        result.Trades[i].Price,
 			Amount:       result.Trades[i].Amount,
@@ -1075,11 +1075,11 @@ func (s *RPCServer) GetOrder(_ context.Context, r *gctrpc.GetOrderRequest) (*gct
 	}
 
 	var creationTime, updateTime int64
-	if result.Date.Unix() > 0 {
-		creationTime = result.Date.Unix()
+	if !result.Date.IsZero() {
+		creationTime = s.unixTimestamp(result.Date)
 	}
-	if result.LastUpdated.Unix() > 0 {
-		updateTime = result.LastUpdated.Unix()
+	if !result.LastUpdated.IsZero() {
+		updateTime = s.unixTimestamp(result.LastUpdated)
 	}
 
 	return &gctrpc.OrderDetails{
@@ -1924,7 +1924,7 @@ func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gct
 				Base:      t.Pair.Base.String(),
 				Quote:     t.Pair.Quote.String(),
 				Delimiter: t.Pair.Delimiter},
-			LastUpdated: t.LastUpdated.Unix(),
+			LastUpdated: s.unixTimestamp(t.LastUpdated),
 			Last:        t.Last,
 			High:        t.High,
 			Low:         t.Low,
@@ -1969,7 +1969,7 @@ func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamReq
 				Base:      t.Pair.Base.String(),
 				Quote:     t.Pair.Quote.String(),
 				Delimiter: t.Pair.Delimiter},
-			LastUpdated: t.LastUpdated.Unix(),
+			LastUpdated: s.unixTimestamp(t.LastUpdated),
 			Last:        t.Last,
 			High:        t.High,
 			Low:         t.Low,
@@ -3655,4 +3655,13 @@ func (s *RPCServer) GetDataHistoryJobSummary(_ context.Context, r *gctrpc.GetDat
 		Status:          job.Status.String(),
 		ResultSummaries: job.ResultRanges,
 	}, nil
+}
+
+// unixTimestamp returns given time in either unix seconds or unix nanoseconds, depending
+// on the remoteControl/gRPC/timeInNanoSeconds boolean configuration.
+func (s *RPCServer) unixTimestamp(x time.Time) int64 {
+	if s.Config.RemoteControl.GRPC.TimeInNanoSeconds {
+		return x.UnixNano()
+	}
+	return x.Unix()
 }

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1688,3 +1688,31 @@ func TestGetManagedOrders(t *testing.T) {
 		t.Errorf("unexpected order result: %v", oo)
 	}
 }
+
+func TestRPCServer_unixTimestamp(t *testing.T) {
+	s := RPCServer{
+		Engine: &Engine{
+			Config: &config.Config{
+				RemoteControl: config.RemoteControlConfig{
+					GRPC: config.GRPCConfig{
+						TimeInNanoSeconds: false,
+					},
+				},
+			},
+		},
+	}
+	const sec = 1618888141
+	const nsec = 2
+	x := time.Unix(sec, nsec)
+
+	timestampSeconds := s.unixTimestamp(x)
+	if timestampSeconds != sec {
+		t.Errorf("have %d, want %d", timestampSeconds, sec)
+	}
+
+	s.Config.RemoteControl.GRPC.TimeInNanoSeconds = true
+	timestampNanos := s.unixTimestamp(x)
+	if want := int64(sec*1_000_000_000 + nsec); timestampNanos != want {
+		t.Errorf("have %d, want %d", timestampSeconds, want)
+	}
+}

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/binance"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/banking"
@@ -1720,34 +1721,64 @@ func TestRPCServer_unixTimestamp(t *testing.T) {
 }
 
 func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
-	server := RPCServer{Engine: RPCTestSetup(t)}
+	// Make a dummy pair we'll be using for this test.
+	pair := currency.NewPairWithDelimiter("XXXXX", "YYYYY", "")
 
+	// Create a mock-up RPCServer and add our newly made pair to its list of available
+	// and enabled pairs.
+	server := RPCServer{Engine: RPCTestSetup(t)}
+	b := server.ExchangeManager.GetExchangeByName(testExchange).GetBase()
+	b.CurrencyPairs.Pairs[asset.Spot].Available = append(
+		b.CurrencyPairs.Pairs[asset.Spot].Available,
+		pair,
+	)
+	b.CurrencyPairs.Pairs[asset.Spot].Enabled = append(
+		b.CurrencyPairs.Pairs[asset.Spot].Enabled,
+		pair,
+	)
+
+	// Push a mock-up ticker.
+	now := time.Now()
+	ticker.ProcessTicker(&ticker.Price{
+		ExchangeName: testExchange,
+		Pair:         pair,
+		AssetType:    asset.Spot,
+		LastUpdated:  now,
+
+		Open:  69,
+		High:  96,
+		Low:   169,
+		Close: 196,
+	})
+
+	// Prepare a ticker request.
 	request := &gctrpc.GetTickerRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
-			Delimiter: currency.DashDelimiter,
-			Base:      currency.BTC.String(),
-			Quote:     currency.USD.String(),
+			Delimiter: pair.Delimiter,
+			Base:      pair.Base.String(),
+			Quote:     pair.Quote.String(),
 		},
 		AssetType: asset.Spot.String(),
 	}
 
+	// Check if timestamp returned is in seconds if !TimeInNanoSeconds.
+	server.Config.RemoteControl.GRPC.TimeInNanoSeconds = false
 	one, err := server.GetTicker(context.Background(), request)
 	if err != nil {
 		t.Error(err)
 	}
+	if want := now.Unix(); one.LastUpdated != want {
+		t.Errorf("have %d, want %d", one.LastUpdated, want)
+	}
 
+	// Check if timestamp returned is in nanoseconds if TimeInNanoSeconds.
 	server.Config.RemoteControl.GRPC.TimeInNanoSeconds = true
 	two, err := server.GetTicker(context.Background(), request)
 	if err != nil {
 		t.Error(err)
 	}
-
-	now := time.Now().Unix()
-	if x := now - one.LastUpdated; x > 300 {
-		t.Errorf("have %d, want %d +- 300s", one.LastUpdated, now)
-	}
-	if x := now - two.LastUpdated/1_000_000_000; x > 300 {
-		t.Errorf("have %d, want %d +- 300s", two.LastUpdated, now*1_000_000_000)
+	if want := now.UnixNano(); two.LastUpdated != want {
+		t.Errorf("have %d, want %d", two.LastUpdated, want)
 	}
 }

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1690,6 +1690,8 @@ func TestGetManagedOrders(t *testing.T) {
 }
 
 func TestRPCServer_unixTimestamp(t *testing.T) {
+	t.Parallel()
+
 	s := RPCServer{
 		Engine: &Engine{
 			Config: &config.Config{
@@ -1742,10 +1744,10 @@ func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
 	}
 
 	now := time.Now().Unix()
-	if x := now - one.LastUpdated; x > 10 {
-		t.Errorf("have %d, want %d +- 10s", one.LastUpdated, now)
+	if x := now - one.LastUpdated; x > 300 {
+		t.Errorf("have %d, want %d +- 300s", one.LastUpdated, now)
 	}
-	if x := now - two.LastUpdated/1_000_000_000; x > 10 {
-		t.Errorf("have %d, want %d +- 10s", two.LastUpdated, now)
+	if x := now - two.LastUpdated/1_000_000_000; x > 300 {
+		t.Errorf("have %d, want %d +- 300s", two.LastUpdated, now*1_000_000_000)
 	}
 }

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1716,3 +1716,36 @@ func TestRPCServer_unixTimestamp(t *testing.T) {
 		t.Errorf("have %d, want %d", timestampSeconds, want)
 	}
 }
+
+func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
+	server := RPCServer{Engine: RPCTestSetup(t)}
+
+	request := &gctrpc.GetTickerRequest{
+		Exchange: testExchange,
+		Pair: &gctrpc.CurrencyPair{
+			Delimiter: currency.DashDelimiter,
+			Base:      currency.BTC.String(),
+			Quote:     currency.USD.String(),
+		},
+		AssetType: asset.Spot.String(),
+	}
+
+	one, err := server.GetTicker(context.Background(), request)
+	if err != nil {
+		t.Error(err)
+	}
+
+	server.Config.RemoteControl.GRPC.TimeInNanoSeconds = true
+	two, err := server.GetTicker(context.Background(), request)
+	if err != nil {
+		t.Error(err)
+	}
+
+	now := time.Now().Unix()
+	if x := now - one.LastUpdated; x > 10 {
+		t.Errorf("have %d, want %d +- 10s", one.LastUpdated, now)
+	}
+	if x := now - two.LastUpdated/1_000_000_000; x > 10 {
+		t.Errorf("have %d, want %d +- 10s", two.LastUpdated, now)
+	}
+}


### PR DESCRIPTION
# PR Description

gRPC endpoints currently set  
* ```TickerResponse.LastUpdated```
* ```OrderbookResponse.LastUpdated```
* ```TradeHistory.CreationTime```
* ```OrderDetails.CreationTime```
* ```OrderDetails.UpdateTime```
to timestamps with a precision of **1 second**.

This PR proposes a new configuration attribute -- ```remoteControl/gRPC/timeInNanoSeconds``` -- that changes the precision to **1 nanosecond**.

Affected endpoints are:  
* ```GetTicker()```
* ```GetTickers()```
* ```GetOrderbook()```
* ```GetOrderbooks()```
* ```GetOrders()```
* ```GetManagedOrders()```
* ```GetOrder()```
* ```GetTickerStream()```
* ```GetExchangeTickerStream()```

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

There are two new tests added in rpcserver_test.go:  
* ```TestRPCServer_unixTimestamp```
* ```TestRPCServer_GetTicker_LastUpdatedNanos```

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules