### PR TITLE
connchecker: initialCheck() now also respects CheckInterval

### DIFF
--- a/connchecker/connchecker.go
+++ b/connchecker/connchecker.go
@@ -1,6 +1,7 @@
 package connchecker
 
 import (
+	"context"
 	"net"
 	"strings"
 	"sync"
@@ -169,13 +170,17 @@ func (c *Checker) connectionTest() {
 
 // CheckDNS checks current dns for connectivity
 func (c *Checker) CheckDNS(dns string) error {
-	_, err := net.LookupAddr(dns)
+	ctx, cancel := context.WithTimeout(context.Background(), c.CheckInterval)
+	defer cancel()
+	_, err := net.DefaultResolver.LookupAddr(ctx, dns)
 	return err
 }
 
 // CheckHost checks current host name for connectivity
 func (c *Checker) CheckHost(host string) error {
-	_, err := net.LookupHost(host)
+	ctx, cancel := context.WithTimeout(context.Background(), c.CheckInterval)
+	defer cancel()
+	_, err := net.DefaultResolver.LookupHost(ctx, host)
 	return err
 }
 

--- a/connchecker/connchecker_test.go
+++ b/connchecker/connchecker_test.go
@@ -2,22 +2,23 @@ package connchecker
 
 import (
 	"testing"
+	"time"
 )
 
 func TestConnection(t *testing.T) {
 	faultyDomain := []string{"faultyIP"}
 	faultyHost := []string{"faultyHost"}
-	_, err := New(faultyDomain, nil, 100000)
+	_, err := New(faultyDomain, nil, 1*time.Second)
 	if err == nil {
 		t.Fatal("New error cannot be nil")
 	}
 
-	_, err = New(DefaultDNSList, nil, 100000)
+	_, err = New(DefaultDNSList, nil, 1*time.Second)
 	if err != nil {
 		t.Fatal("New error", err)
 	}
 
-	_, err = New(nil, faultyHost, 100000)
+	_, err = New(nil, faultyHost, 1*time.Second)
 	if err != nil {
 		t.Fatal("New error cannot be nil", err)
 	}


### PR DESCRIPTION
# PR Description

In the case of a connection problem, Checker.initialCheck() has to wait for a connection timeout. This fix makes it aware of the CheckInterval setting.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Initially the connchecker tests were blocking locally because of timeouts to "faultyIP" and "faultyHost".

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
