### PR TITLE
gctrpc: generate protobuf files with latest versions of tools

### DIFF
--- a/gctrpc/README.md
+++ b/gctrpc/README.md
@@ -51,15 +51,6 @@ This will place the following binaries in your `$GOBIN`;
 
 Make sure that your `$GOBIN` is in your `$PATH`.
 
-There was a name change we need to address: `protoc-gen-swagger` is
-renamed to `protoc-gen-openapiv2`.  Somewhere in your $PATH add a
-file, named `protoc-gen-swagger`, with the following contents:
-
-```bash
-#!/bin/bash
-/home/d/go/bin/protoc-gen-openapiv2 $@
-```
-
 ## Usage
 
 After the above dependencies are required, make necessary changes to the `rpc.proto`

--- a/gctrpc/README.md
+++ b/gctrpc/README.md
@@ -37,19 +37,28 @@ Then use `go get` to download the following packages:
 
 ```bash
 go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
 go get google.golang.org/protobuf/cmd/protoc-gen-go
 go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ```
 
-This will place three binaries in your `$GOBIN`;
+This will place the following binaries in your `$GOBIN`;
 
 * `protoc-gen-grpc-gateway`
-* `protoc-gen-swagger`
+* `protoc-gen-openapiv2`
 * `protoc-gen-go`
 * `protoc-gen-go-grpc`
 
 Make sure that your `$GOBIN` is in your `$PATH`.
+
+There was a name change we need to address: `protoc-gen-swagger` is
+renamed to `protoc-gen-openapiv2`.  Somewhere in your $PATH add a
+file, named `protoc-gen-swagger`, with the following contents:
+
+```bash
+#!/bin/bash
+/home/d/go/bin/protoc-gen-openapiv2 $@
+```
 
 ## Usage
 

--- a/gctrpc/gen_pb_linux.sh
+++ b/gctrpc/gen_pb_linux.sh
@@ -6,4 +6,4 @@ export GOPATH=$(go env GOPATH)
 protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --go_out=. rpc.proto
 protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --go-grpc_out=. rpc.proto
 protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. rpc.proto
-protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --swagger_out=logtostderr=true:. rpc.proto
+protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --openapiv2_out=logtostderr=true:. rpc.proto

--- a/gctrpc/gen_pb_win.bat
+++ b/gctrpc/gen_pb_win.bat
@@ -6,4 +6,4 @@ REM %GOPATH%\pkg\mod\github.com\grpc-ecosystem\grpc-gateway\v2@v2.0.1\third_part
 protoc -I=. -I=%GOPATH%\src -I=%GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go_out=. rpc.proto
 protoc -I=. -I=%GOPATH%\src -I=%GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go-grpc_out=. rpc.proto
 protoc -I=. -I=%GOPATH%\src -I=%GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --grpc-gateway_out=logtostderr=true:. rpc.proto
-protoc -I=. -I=%GOPATH%\src -I=%GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --swagger_out=logtostderr=true:. rpc.proto
+protoc -I=. -I=%GOPATH%\src -I=%GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --openapiv2_out=logtostderr=true:. rpc.proto

--- a/gctrpc/rpc.swagger.json
+++ b/gctrpc/rpc.swagger.json
@@ -4,6 +4,11 @@
     "title": "rpc.proto",
     "version": "version not set"
   },
+  "tags": [
+    {
+      "name": "GoCryptoTrader"
+    }
+  ],
   "consumes": [
     "application/json"
   ],
@@ -24,7 +29,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -56,7 +61,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -88,7 +93,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -120,7 +125,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -152,7 +157,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -184,7 +189,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -214,7 +219,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -232,7 +237,7 @@
             "type": "string"
           },
           {
-            "name": "time_interval",
+            "name": "timeInterval",
             "in": "query",
             "required": false,
             "type": "string",
@@ -269,7 +274,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -311,7 +316,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -343,7 +348,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -373,7 +378,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -405,7 +410,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -435,19 +440,19 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
-            "name": "exchange_name",
+            "name": "exchangeName",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -508,19 +513,19 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
-            "name": "exchange_name",
+            "name": "exchangeName",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -574,7 +579,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -606,7 +611,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -630,7 +635,7 @@
             "type": "string"
           },
           {
-            "name": "script.next_run",
+            "name": "script.nextRun",
             "in": "query",
             "required": false,
             "type": "string"
@@ -654,7 +659,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -678,7 +683,7 @@
             "type": "string"
           },
           {
-            "name": "script.next_run",
+            "name": "script.nextRun",
             "in": "query",
             "required": false,
             "type": "string"
@@ -702,7 +707,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -734,7 +739,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -756,7 +761,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -788,7 +793,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -820,7 +825,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -832,7 +837,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -856,7 +861,7 @@
                   "$ref": "#/definitions/gctrpcGetAccountInfoResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
+                  "$ref": "#/definitions/rpcStatus"
                 }
               },
               "title": "Stream result of gctrpcGetAccountInfoResponse"
@@ -865,7 +870,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -877,7 +882,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -901,7 +906,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -923,25 +928,25 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
-            "name": "start_date",
+            "name": "startDate",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "end_date",
+            "name": "endDate",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "order_by",
+            "name": "orderBy",
             "in": "query",
             "required": false,
             "type": "string"
@@ -979,7 +984,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1001,7 +1006,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1023,7 +1028,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1055,7 +1060,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1087,7 +1092,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1129,19 +1134,19 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
         "parameters": [
           {
-            "name": "start_date",
+            "name": "startDate",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "end_date",
+            "name": "endDate",
             "in": "query",
             "required": false,
             "type": "string"
@@ -1165,7 +1170,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1207,7 +1212,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1229,7 +1234,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1259,7 +1264,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1289,7 +1294,7 @@
                   "$ref": "#/definitions/gctrpcOrderbookResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
+                  "$ref": "#/definitions/rpcStatus"
                 }
               },
               "title": "Stream result of gctrpcOrderbookResponse"
@@ -1298,7 +1303,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1328,7 +1333,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1358,7 +1363,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1380,7 +1385,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1412,7 +1417,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1442,7 +1447,7 @@
                   "$ref": "#/definitions/gctrpcTickerResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
+                  "$ref": "#/definitions/rpcStatus"
                 }
               },
               "title": "Stream result of gctrpcTickerResponse"
@@ -1451,7 +1456,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1481,7 +1486,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1503,7 +1508,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1525,7 +1530,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1555,7 +1560,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -1573,14 +1578,14 @@
             "type": "string"
           },
           {
-            "name": "time_interval",
+            "name": "timeInterval",
             "in": "query",
             "required": false,
             "type": "string",
             "format": "int64"
           },
           {
-            "name": "ex_request",
+            "name": "exRequest",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -1592,13 +1597,13 @@
             "type": "boolean"
           },
           {
-            "name": "use_db",
+            "name": "useDb",
             "in": "query",
             "required": false,
             "type": "boolean"
           },
           {
-            "name": "fill_missing_with_trades",
+            "name": "fillMissingWithTrades",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -1628,7 +1633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1650,7 +1655,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1680,7 +1685,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1712,7 +1717,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1744,7 +1749,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1776,7 +1781,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1798,7 +1803,7 @@
                   "$ref": "#/definitions/gctrpcOrderbookResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
+                  "$ref": "#/definitions/rpcStatus"
                 }
               },
               "title": "Stream result of gctrpcOrderbookResponse"
@@ -1807,7 +1812,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1837,7 +1842,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -1861,7 +1866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1893,7 +1898,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1915,7 +1920,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1937,7 +1942,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1959,7 +1964,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -1989,7 +1994,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -2025,7 +2030,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2047,7 +2052,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2079,7 +2084,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2101,7 +2106,7 @@
                   "$ref": "#/definitions/gctrpcTickerResponse"
                 },
                 "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
+                  "$ref": "#/definitions/rpcStatus"
                 }
               },
               "title": "Stream result of gctrpcTickerResponse"
@@ -2110,7 +2115,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2140,7 +2145,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -2164,7 +2169,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2196,7 +2201,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2228,7 +2233,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2264,7 +2269,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2306,7 +2311,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2338,7 +2343,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2374,7 +2379,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2406,7 +2411,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2438,7 +2443,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2470,7 +2475,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2482,7 +2487,7 @@
             "type": "string"
           },
           {
-            "name": "asset_type",
+            "name": "assetType",
             "in": "query",
             "required": false,
             "type": "string"
@@ -2506,7 +2511,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2536,7 +2541,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2568,7 +2573,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2598,7 +2603,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2628,7 +2633,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2664,7 +2669,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2700,7 +2705,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2736,7 +2741,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2768,7 +2773,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2800,7 +2805,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2832,7 +2837,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2864,7 +2869,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -2905,7 +2910,7 @@
         "currency": {
           "type": "string"
         },
-        "total_value": {
+        "totalValue": {
           "type": "number",
           "format": "double"
         },
@@ -2924,13 +2929,13 @@
         "item": {
           "type": "string"
         },
-        "condition_params": {
+        "conditionParams": {
           "$ref": "#/definitions/gctrpcConditionParams"
         },
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
         "action": {
@@ -2953,7 +2958,7 @@
         "address": {
           "type": "string"
         },
-        "coin_type": {
+        "coinType": {
           "type": "string"
         },
         "description": {
@@ -2963,10 +2968,10 @@
           "type": "number",
           "format": "double"
         },
-        "supported_exchanges": {
+        "supportedExchanges": {
           "type": "string"
         },
-        "cold_storage": {
+        "coldStorage": {
           "type": "boolean"
         }
       }
@@ -3017,7 +3022,7 @@
         "exchange": {
           "type": "string"
         },
-        "order_status": {
+        "orderStatus": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -3031,19 +3036,19 @@
         "exchange": {
           "type": "string"
         },
-        "account_id": {
+        "accountId": {
           "type": "string"
         },
-        "orders_id": {
+        "ordersId": {
           "type": "string"
         },
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
-        "wallet_address": {
+        "walletAddress": {
           "type": "string"
         },
         "side": {
@@ -3065,7 +3070,7 @@
     "gctrpcCancelBatchOrdersResponseOrders": {
       "type": "object",
       "properties": {
-        "order_status": {
+        "orderStatus": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -3079,19 +3084,19 @@
         "exchange": {
           "type": "string"
         },
-        "account_id": {
+        "accountId": {
           "type": "string"
         },
-        "order_id": {
+        "orderId": {
           "type": "string"
         },
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
-        "wallet_address": {
+        "walletAddress": {
           "type": "string"
         },
         "side": {
@@ -3167,13 +3172,13 @@
           "type": "number",
           "format": "double"
         },
-        "check_bids": {
+        "checkBids": {
           "type": "boolean"
         },
-        "check_asks": {
+        "checkAsks": {
           "type": "boolean"
         },
-        "orderbook_amount": {
+        "orderbookAmount": {
           "type": "number",
           "format": "double"
         }
@@ -3185,14 +3190,14 @@
         "address": {
           "type": "string"
         },
-        "address_tag": {
+        "addressTag": {
           "type": "string"
         },
         "fee": {
           "type": "number",
           "format": "double"
         },
-        "tx_id": {
+        "txId": {
           "type": "string"
         }
       }
@@ -3229,41 +3234,41 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "start_date": {
+        "startDate": {
           "type": "string"
         },
-        "end_date": {
+        "endDate": {
           "type": "string"
         },
         "interval": {
           "type": "string",
           "format": "int64"
         },
-        "request_size_limit": {
+        "requestSizeLimit": {
           "type": "string",
           "format": "int64"
         },
-        "max_retry_attempts": {
+        "maxRetryAttempts": {
           "type": "string",
           "format": "int64"
         },
-        "batch_size": {
+        "batchSize": {
           "type": "string",
           "format": "int64"
         },
         "status": {
           "type": "string"
         },
-        "data_type": {
+        "dataType": {
           "type": "string"
         },
-        "job_results": {
+        "jobResults": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcDataHistoryJobResult"
           }
         },
-        "result_summaries": {
+        "resultSummaries": {
           "type": "array",
           "items": {
             "type": "string"
@@ -3274,19 +3279,19 @@
     "gctrpcDataHistoryJobResult": {
       "type": "object",
       "properties": {
-        "start_date": {
+        "startDate": {
           "type": "string"
         },
-        "end_date": {
+        "endDate": {
           "type": "string"
         },
-        "has_data": {
+        "hasData": {
           "type": "boolean"
         },
         "message": {
           "type": "string"
         },
-        "run_date": {
+        "runDate": {
           "type": "string"
         }
       }
@@ -3305,13 +3310,13 @@
     "gctrpcFiatWithdrawalEvent": {
       "type": "object",
       "properties": {
-        "bank_name": {
+        "bankName": {
           "type": "string"
         },
-        "account_name": {
+        "accountName": {
           "type": "string"
         },
-        "account_number": {
+        "accountNumber": {
           "type": "string"
         },
         "bsb": {
@@ -3328,16 +3333,16 @@
     "gctrpcFindMissingIntervalsResponse": {
       "type": "object",
       "properties": {
-        "exchange_name": {
+        "exchangeName": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "missing_periods": {
+        "missingPeriods": {
           "type": "array",
           "items": {
             "type": "string"
@@ -3360,17 +3365,17 @@
         "verbose": {
           "type": "boolean"
         },
-        "rest_polling_delay": {
+        "restPollingDelay": {
           "type": "string"
         },
-        "api_key": {
+        "apiKey": {
           "type": "string"
         },
-        "api_key_level": {
+        "apiKeyLevel": {
           "type": "string",
           "format": "int64"
         },
-        "primary_provider": {
+        "primaryProvider": {
           "type": "boolean"
         }
       }
@@ -3388,7 +3393,7 @@
           "type": "number",
           "format": "double"
         },
-        "inverse_rate": {
+        "inverseRate": {
           "type": "number",
           "format": "double"
         }
@@ -3406,7 +3411,7 @@
         "path": {
           "type": "string"
         },
-        "next_run": {
+        "nextRun": {
           "type": "string"
         }
       }
@@ -3475,10 +3480,10 @@
     "gctrpcGCTScriptUploadRequest": {
       "type": "object",
       "properties": {
-        "script_name": {
+        "scriptName": {
           "type": "string"
         },
-        "script_data": {
+        "scriptData": {
           "type": "string"
         },
         "data": {
@@ -3540,7 +3545,7 @@
     "gctrpcGetCommunicationRelayersResponse": {
       "type": "object",
       "properties": {
-        "communication_relayers": {
+        "communicationRelayers": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcCommunicationRelayer"
@@ -3608,7 +3613,7 @@
         "item": {
           "type": "string"
         },
-        "condition_params": {
+        "conditionParams": {
           "$ref": "#/definitions/gctrpcConditionParams"
         },
         "pair": {
@@ -3642,28 +3647,28 @@
         "verbose": {
           "type": "boolean"
         },
-        "using_sandbox": {
+        "usingSandbox": {
           "type": "boolean"
         },
-        "http_timeout": {
+        "httpTimeout": {
           "type": "string"
         },
-        "http_useragent": {
+        "httpUseragent": {
           "type": "string"
         },
-        "http_proxy": {
+        "httpProxy": {
           "type": "string"
         },
-        "base_currencies": {
+        "baseCurrencies": {
           "type": "string"
         },
-        "supported_assets": {
+        "supportedAssets": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcPairsSupported"
           }
         },
-        "authenticated_api": {
+        "authenticatedApi": {
           "type": "boolean"
         }
       }
@@ -3671,7 +3676,7 @@
     "gctrpcGetExchangeOTPReponse": {
       "type": "object",
       "properties": {
-        "otp_code": {
+        "otpCode": {
           "type": "string"
         }
       }
@@ -3679,7 +3684,7 @@
     "gctrpcGetExchangeOTPsResponse": {
       "type": "object",
       "properties": {
-        "otp_codes": {
+        "otpCodes": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -3701,7 +3706,7 @@
     "gctrpcGetExchangePairsResponse": {
       "type": "object",
       "properties": {
-        "supported_assets": {
+        "supportedAssets": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcPairsSupported"
@@ -3720,7 +3725,7 @@
     "gctrpcGetForexProvidersResponse": {
       "type": "object",
       "properties": {
-        "forex_providers": {
+        "forexProviders": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcForexProvider"
@@ -3731,7 +3736,7 @@
     "gctrpcGetForexRatesResponse": {
       "type": "object",
       "properties": {
-        "forex_rates": {
+        "forexRates": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcForexRatesConversion"
@@ -3771,27 +3776,27 @@
         "uptime": {
           "type": "string"
         },
-        "available_exchanges": {
+        "availableExchanges": {
           "type": "string",
           "format": "int64"
         },
-        "enabled_exchanges": {
+        "enabledExchanges": {
           "type": "string",
           "format": "int64"
         },
-        "default_forex_provider": {
+        "defaultForexProvider": {
           "type": "string"
         },
-        "default_fiat_currency": {
+        "defaultFiatCurrency": {
           "type": "string"
         },
-        "subsystem_status": {
+        "subsystemStatus": {
           "type": "object",
           "additionalProperties": {
             "type": "boolean"
           }
         },
-        "rpc_endpoints": {
+        "rpcEndpoints": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcRPCEndpoint"
@@ -3822,7 +3827,7 @@
         "exchange": {
           "type": "string"
         },
-        "order_id": {
+        "orderId": {
           "type": "string"
         },
         "pair": {
@@ -3842,7 +3847,7 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         }
       }
@@ -3864,16 +3869,16 @@
         "exchange": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "start_date": {
+        "startDate": {
           "type": "string"
         },
-        "end_date": {
+        "endDate": {
           "type": "string"
         }
       }
@@ -3903,31 +3908,31 @@
     "gctrpcGetPortfolioSummaryResponse": {
       "type": "object",
       "properties": {
-        "coin_totals": {
+        "coinTotals": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcCoin"
           }
         },
-        "coins_offline": {
+        "coinsOffline": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcCoin"
           }
         },
-        "coins_offline_summary": {
+        "coinsOfflineSummary": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcOfflineCoins"
           }
         },
-        "coins_online": {
+        "coinsOnline": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/gctrpcCoin"
           }
         },
-        "coins_online_summary": {
+        "coinsOnlineSummary": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/gctrpcOnlineCoins"
@@ -3949,7 +3954,7 @@
     "gctrpcGetSusbsytemsResponse": {
       "type": "object",
       "properties": {
-        "subsystems_status": {
+        "subsystemsStatus": {
           "type": "object",
           "additionalProperties": {
             "type": "boolean"
@@ -3966,7 +3971,7 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         }
       }
@@ -4042,29 +4047,29 @@
         "id": {
           "type": "string"
         },
-        "client_order_id": {
+        "clientOrderId": {
           "type": "string"
         },
-        "base_currency": {
+        "baseCurrency": {
           "type": "string"
         },
-        "quote_currency": {
+        "quoteCurrency": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
-        "order_side": {
+        "orderSide": {
           "type": "string"
         },
-        "order_type": {
+        "orderType": {
           "type": "string"
         },
-        "creation_time": {
+        "creationTime": {
           "type": "string",
           "format": "int64"
         },
-        "update_time": {
+        "updateTime": {
           "type": "string",
           "format": "int64"
         },
@@ -4079,7 +4084,7 @@
           "type": "number",
           "format": "double"
         },
-        "open_volume": {
+        "openVolume": {
           "type": "number",
           "format": "double"
         },
@@ -4122,7 +4127,7 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "currency_pair": {
+        "currencyPair": {
           "type": "string"
         },
         "bids": {
@@ -4137,11 +4142,11 @@
             "$ref": "#/definitions/gctrpcOrderbookItem"
           }
         },
-        "last_updated": {
+        "lastUpdated": {
           "type": "string",
           "format": "int64"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         }
       }
@@ -4163,10 +4168,10 @@
     "gctrpcPairsSupported": {
       "type": "object",
       "properties": {
-        "available_pairs": {
+        "availablePairs": {
           "type": "string"
         },
-        "enabled_pairs": {
+        "enabledPairs": {
           "type": "string"
         }
       }
@@ -4177,7 +4182,7 @@
         "address": {
           "type": "string"
         },
-        "coin_type": {
+        "coinType": {
           "type": "string"
         },
         "description": {
@@ -4195,7 +4200,7 @@
         "started": {
           "type": "boolean"
         },
-        "listen_address": {
+        "listenAddress": {
           "type": "string"
         }
       }
@@ -4215,7 +4220,7 @@
         "address": {
           "type": "string"
         },
-        "coin_type": {
+        "coinType": {
           "type": "string"
         },
         "description": {
@@ -4240,7 +4245,7 @@
         "timestamp": {
           "type": "string"
         },
-        "trade_id": {
+        "tradeId": {
           "type": "string"
         }
       }
@@ -4248,7 +4253,7 @@
     "gctrpcSavedTradesResponse": {
       "type": "object",
       "properties": {
-        "exchange_name": {
+        "exchangeName": {
           "type": "string"
         },
         "asset": {
@@ -4271,7 +4276,7 @@
         "exchange": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
         "pairs": {
@@ -4327,15 +4332,15 @@
           "type": "number",
           "format": "double"
         },
-        "minimum_price": {
+        "minimumPrice": {
           "type": "number",
           "format": "double"
         },
-        "maximum_price": {
+        "maximumPrice": {
           "type": "number",
           "format": "double"
         },
-        "percentage_gain_loss": {
+        "percentageGainLoss": {
           "type": "number",
           "format": "double"
         },
@@ -4356,7 +4361,7 @@
         "side": {
           "type": "string"
         },
-        "order_type": {
+        "orderType": {
           "type": "string"
         },
         "amount": {
@@ -4367,10 +4372,10 @@
           "type": "number",
           "format": "double"
         },
-        "client_id": {
+        "clientId": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         }
       }
@@ -4378,10 +4383,10 @@
     "gctrpcSubmitOrderResponse": {
       "type": "object",
       "properties": {
-        "order_placed": {
+        "orderPlaced": {
           "type": "boolean"
         },
-        "order_id": {
+        "orderId": {
           "type": "string"
         },
         "trades": {
@@ -4398,11 +4403,11 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "last_updated": {
+        "lastUpdated": {
           "type": "string",
           "format": "int64"
         },
-        "currency_pair": {
+        "currencyPair": {
           "type": "string"
         },
         "last": {
@@ -4429,7 +4434,7 @@
           "type": "number",
           "format": "double"
         },
-        "price_ath": {
+        "priceAth": {
           "type": "number",
           "format": "double"
         }
@@ -4452,7 +4457,7 @@
     "gctrpcTradeHistory": {
       "type": "object",
       "properties": {
-        "creation_time": {
+        "creationTime": {
           "type": "string",
           "format": "int64"
         },
@@ -4470,10 +4475,10 @@
         "exchange": {
           "type": "string"
         },
-        "asset_type": {
+        "assetType": {
           "type": "string"
         },
-        "order_side": {
+        "orderSide": {
           "type": "string"
         },
         "fee": {
@@ -4501,7 +4506,7 @@
           "type": "number",
           "format": "double"
         },
-        "fee_asset": {
+        "feeAsset": {
           "type": "string"
         }
       }
@@ -4521,33 +4526,33 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "start_date": {
+        "startDate": {
           "type": "string"
         },
-        "end_date": {
+        "endDate": {
           "type": "string"
         },
         "interval": {
           "type": "string",
           "format": "int64"
         },
-        "request_size_limit": {
+        "requestSizeLimit": {
           "type": "string",
           "format": "int64"
         },
-        "data_type": {
+        "dataType": {
           "type": "string",
           "format": "int64"
         },
-        "max_retry_attempts": {
+        "maxRetryAttempts": {
           "type": "string",
           "format": "int64"
         },
-        "batch_size": {
+        "batchSize": {
           "type": "string",
           "format": "int64"
         },
-        "insert_only": {
+        "insertOnly": {
           "type": "boolean"
         }
       }
@@ -4558,7 +4563,7 @@
         "message": {
           "type": "string"
         },
-        "job_id": {
+        "jobId": {
           "type": "string"
         }
       }
@@ -4575,16 +4580,16 @@
         "enabled": {
           "type": "boolean"
         },
-        "authenticated_supported": {
+        "authenticatedSupported": {
           "type": "boolean"
         },
         "authenticated": {
           "type": "boolean"
         },
-        "running_url": {
+        "runningUrl": {
           "type": "string"
         },
-        "proxy_address": {
+        "proxyAddress": {
           "type": "string"
         }
       }
@@ -4629,7 +4634,7 @@
         "pair": {
           "$ref": "#/definitions/gctrpcCurrencyPair"
         },
-        "price_target": {
+        "priceTarget": {
           "type": "number",
           "format": "double"
         },
@@ -4647,7 +4652,7 @@
         "address": {
           "type": "string"
         },
-        "address_tag": {
+        "addressTag": {
           "type": "string"
         },
         "currency": {
@@ -4682,7 +4687,7 @@
         "description": {
           "type": "string"
         },
-        "bank_account_id": {
+        "bankAccountId": {
           "type": "string"
         }
       }
@@ -4726,11 +4731,11 @@
         "request": {
           "$ref": "#/definitions/gctrpcWithdrawalRequestEvent"
         },
-        "created_at": {
+        "createdAt": {
           "type": "string",
           "format": "date-time"
         },
-        "updated_at": {
+        "updatedAt": {
           "type": "string",
           "format": "date-time"
         }
@@ -4825,7 +4830,7 @@
     "protobufAny": {
       "type": "object",
       "properties": {
-        "type_url": {
+        "typeUrl": {
           "type": "string"
         },
         "value": {
@@ -4834,42 +4839,14 @@
         }
       }
     },
-    "runtimeError": {
+    "rpcStatus": {
       "type": "object",
       "properties": {
-        "error": {
-          "type": "string"
-        },
         "code": {
           "type": "integer",
           "format": "int32"
         },
         "message": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
           "type": "string"
         },
         "details": {


### PR DESCRIPTION
# PR Description

To ease future addition of gRPC calls, it would be great to use latest versions of generating tools.

This commit updates the corresponding README and generates anew following `gocryptotrader/gctrpc` files:
* `rpc.swagger.json`
* `rpc_grpc.pb.go` [NO CHANGES AFTER NEW GENERATION]
* `rpc.pb.go` [NO CHANGES AFTER NEW GENERATION]
* `rpc.pb.gw.go` [NO CHANGES AFTER NEW GENERATION]

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [*] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
