### PR TITLE
FTX: order cancellation improvement

### DIFF
--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -129,6 +129,7 @@ const (
 )
 
 var (
+	errInvalidOrderID                                    = errors.New("invalid order ID")
 	errStartTimeCannotBeAfterEndTime                     = errors.New("start timestamp cannot be after end timestamp")
 	errSubaccountNameMustBeSpecified                     = errors.New("a subaccount name must be specified")
 	errSubaccountUpdateNameInvalid                       = errors.New("invalid subaccount old/new name")
@@ -791,16 +792,25 @@ func (f *FTX) deleteOrderByPath(path string) (string, error) {
 
 // DeleteOrder deletes an order
 func (f *FTX) DeleteOrder(orderID string) (string, error) {
+	if orderID == "" {
+		return "", errInvalidOrderID
+	}
 	return f.deleteOrderByPath(deleteOrder + orderID)
 }
 
 // DeleteOrderByClientID deletes an order
 func (f *FTX) DeleteOrderByClientID(clientID string) (string, error) {
+	if clientID == "" {
+		return "", errInvalidOrderID
+	}
 	return f.deleteOrderByPath(deleteOrderByClientID + clientID)
 }
 
 // DeleteTriggerOrder deletes an order
 func (f *FTX) DeleteTriggerOrder(orderID string) (string, error) {
+	if orderID == "" {
+		return "", errInvalidOrderID
+	}
 	return f.deleteOrderByPath(cancelTriggerOrder + orderID)
 }
 

--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -795,15 +795,15 @@ func (f *FTX) DeleteOrderByClientID(clientID string) (string, error) {
 	resp := struct {
 		Result  string `json:"result"`
 		Success bool   `json:"success"`
+		Error   string `json:"error"`
 	}{}
-
-	if err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, deleteOrderByClientID+clientID, nil, &resp); err != nil {
-		return "", err
+	err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, deleteOrderByClientID+clientID, nil, &resp)
+	// If there is an error reported, but the resp struct reports one of a very few
+	// specific error causes, we still consider this a successful cancellation.
+	if err != nil && !resp.Success && (resp.Error == "Order already closed" || resp.Error == "Order already queued for cancellation") {
+		return resp.Error, nil
 	}
-	if !resp.Success {
-		return resp.Result, errors.New("delete order request by client ID unsuccessful")
-	}
-	return resp.Result, nil
+	return resp.Result, err
 }
 
 // DeleteTriggerOrder deletes an order

--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -774,52 +774,34 @@ func (f *FTX) GetOrderStatusByClientID(clientOrderID string) (OrderData, error) 
 	return resp.Data, f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodGet, getOrderStatusByClientID+clientOrderID, nil, &resp)
 }
 
-// DeleteOrder deletes an order
-func (f *FTX) DeleteOrder(orderID string) (string, error) {
+func (f *FTX) deleteOrderByPath(path string) (string, error) {
 	resp := struct {
 		Result  string `json:"result"`
 		Success bool   `json:"success"`
 		Error   string `json:"error"`
 	}{}
-	err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, deleteOrder+orderID, nil, &resp)
+	err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, path, nil, &resp)
 	// If there is an error reported, but the resp struct reports one of a very few
 	// specific error causes, we still consider this a successful cancellation.
 	if err != nil && !resp.Success && (resp.Error == "Order already closed" || resp.Error == "Order already queued for cancellation") {
 		return resp.Error, nil
 	}
 	return resp.Result, err
+}
+
+// DeleteOrder deletes an order
+func (f *FTX) DeleteOrder(orderID string) (string, error) {
+	return f.deleteOrderByPath(deleteOrder + orderID)
 }
 
 // DeleteOrderByClientID deletes an order
 func (f *FTX) DeleteOrderByClientID(clientID string) (string, error) {
-	resp := struct {
-		Result  string `json:"result"`
-		Success bool   `json:"success"`
-		Error   string `json:"error"`
-	}{}
-	err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, deleteOrderByClientID+clientID, nil, &resp)
-	// If there is an error reported, but the resp struct reports one of a very few
-	// specific error causes, we still consider this a successful cancellation.
-	if err != nil && !resp.Success && (resp.Error == "Order already closed" || resp.Error == "Order already queued for cancellation") {
-		return resp.Error, nil
-	}
-	return resp.Result, err
+	return f.deleteOrderByPath(deleteOrderByClientID + clientID)
 }
 
 // DeleteTriggerOrder deletes an order
 func (f *FTX) DeleteTriggerOrder(orderID string) (string, error) {
-	resp := struct {
-		Result  string `json:"result"`
-		Success bool   `json:"success"`
-	}{}
-
-	if err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, cancelTriggerOrder+orderID, nil, &resp); err != nil {
-		return "", err
-	}
-	if !resp.Success {
-		return resp.Result, errors.New("delete trigger order request unsuccessful")
-	}
-	return resp.Result, nil
+	return f.deleteOrderByPath(cancelTriggerOrder + orderID)
 }
 
 // GetFills gets fills' data

--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -782,8 +782,8 @@ func (f *FTX) DeleteOrder(orderID string) (string, error) {
 		Error   string `json:"error"`
 	}{}
 	err := f.SendAuthHTTPRequest(exchange.RestSpot, http.MethodDelete, deleteOrder+orderID, nil, &resp)
-	// If there is an error reported, but the resp struct repots one of a very few
-	// specific causes, we still consider this a successful cancellation.
+	// If there is an error reported, but the resp struct reports one of a very few
+	// specific error causes, we still consider this a successful cancellation.
 	if err != nil && !resp.Success && (resp.Error == "Order already closed" || resp.Error == "Order already queued for cancellation") {
 		return resp.Error, nil
 	}

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -200,7 +200,7 @@ func (r *Requester) doRequest(req *http.Request, p *Item) error {
 		// Even in the case of an erroneous condition below, yield the parsed
 		// response to caller.
 		var unmarshallError error
-		if p.Result != nil && len(contents) > 0 {
+		if p.Result != nil {
 			unmarshallError = json.Unmarshal(contents, p.Result)
 		}
 

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -197,6 +197,12 @@ func (r *Requester) doRequest(req *http.Request, p *Item) error {
 		if err != nil {
 			return err
 		}
+		// Even in the case of an erroneous condition below, yield the parsed
+		// response to caller.
+		var unmarshallError error
+		if p.Result != nil && len(contents) > 0 {
+			unmarshallError = json.Unmarshal(contents, p.Result)
+		}
 
 		if p.HTTPRecording {
 			// This dumps http responses for future mocking implementations
@@ -242,10 +248,7 @@ func (r *Requester) doRequest(req *http.Request, p *Item) error {
 					string(contents))
 			}
 		}
-		if p.Result != nil {
-			return json.Unmarshal(contents, p.Result)
-		}
-		return nil
+		return unmarshallError
 	}
 }
 


### PR DESCRIPTION
# PR Description

This PR fixes an odd desynchronization that may occur if (1) an order is already "managed", (2) order is already canceled and (3) we try to cancel it from the bot side. What it does basically is it now considers a cancellation successful if the exchange returns one of the following two errors:
* `"Order already closed"`
* `"Order already queued for cancellation"`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
