### PR TITLE
Fixed issues that led to incorrect partially-cancelled status

### DIFF
--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -357,8 +357,8 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			orderVars, err = f.compatibleOrderVars(resultData.OrderData.Side,
 				resultData.OrderData.Status,
 				resultData.OrderData.OrderType,
-				resultData.OrderData.FilledSize,
 				resultData.OrderData.Size,
+				resultData.OrderData.FilledSize,
 				resultData.OrderData.AvgFillPrice)
 			if err != nil {
 				return err


### PR DESCRIPTION
# PR Description

After canceling an order on FTX the internal state of the ordermanager showed partially-cancelled.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Repro via gctcli:
```
gctcli submitorder --exchange="ftx" --asset="spot" --pair="ETH-BTC" --side="SELL" --type="LIMIT" --amount=0.001 --price=0.2
gctcli cancelorder --exchange="ftx" --asset="spot" --pair="ETH-BTC" --order_id=<ORDER_ID_FROM_LAST_RESULT>
gctcli getmanagedorders --exchange="ftx" --asset="spot" --pair="ETH-BTC"
```
Before the fix this resulted in a wrong status:
```
"orders": [
  {
   "exchange": "ftx",
   "id": "67082287779",
   "base_currency": "ETH",
   "quote_currency": "BTC",
   "asset_type": "spot",
   "order_side": "SELL",
   "order_type": "LIMIT",
   "creation_time": 1627556048268559600,
   "update_time": 1627556132748455400,
   "status": "PARTIALLY_CANCELLED",
   "price": 0.2,
   "amount": 0.001,
   "open_volume": 0.001
  }
```

- [x] go test ./... -race
- [x] golangci-lint run

Unfortunately I don't have time right now to add additional tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
