### PR TITLE
FTX: Fix incorrect partially-cancelled order assignment

### DIFF
--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -52,11 +51,14 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	exchCfg.API.AuthenticatedSupport = true
-	exchCfg.API.AuthenticatedWebsocketSupport = true
 	exchCfg.API.Credentials.Key = apiKey
 	exchCfg.API.Credentials.Secret = apiSecret
 	exchCfg.API.Credentials.Subaccount = subaccount
+	if areTestAPIKeysSet() {
+		// Only set auth to true when keys present as fee online calculation requires authentication
+		exchCfg.API.AuthenticatedSupport = true
+		exchCfg.API.AuthenticatedWebsocketSupport = true
+	}
 	f.Websocket = sharedtestvalues.NewTestWebsocket()
 	err = f.Setup(exchCfg)
 	if err != nil {
@@ -987,36 +989,43 @@ func TestFetchAccountInfo(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var x exchange.FeeBuilder
-	x.PurchasePrice = 10
-	x.Amount = 1
-	x.IsMaker = true
-	var a float64
-	var err error
-	if areTestAPIKeysSet() {
-		a, err = f.GetFee(&x)
-		if err != nil {
-			t.Error(err)
-		}
-		if a != 0.0039 {
-			t.Errorf("incorrect maker fee value")
-		}
+	feeBuilder := &exchange.FeeBuilder{
+		PurchasePrice: 10,
+		Amount:        1,
+		IsMaker:       true,
 	}
-	x.IsMaker = false
-	if areTestAPIKeysSet() {
-		if _, err = f.GetFee(&x); err != nil {
-			t.Error(err)
-		}
-	}
-	x.FeeType = exchange.OfflineTradeFee
-	_, err = f.GetFee(&x)
+	fee, err := f.GetFee(feeBuilder)
 	if err != nil {
 		t.Error(err)
 	}
-	x.IsMaker = true
-	_, err = f.GetFee(&x)
+	if fee <= 0 {
+		t.Errorf("incorrect maker fee value")
+	}
+
+	feeBuilder.IsMaker = false
+	if fee, err = f.GetFee(feeBuilder); err != nil {
+		t.Error(err)
+	}
+	if fee <= 0 {
+		t.Errorf("incorrect maker fee value")
+	}
+
+	feeBuilder.FeeType = exchange.OfflineTradeFee
+	fee, err = f.GetFee(feeBuilder)
 	if err != nil {
 		t.Error(err)
+	}
+	if fee <= 0 {
+		t.Errorf("incorrect maker fee value")
+	}
+
+	feeBuilder.IsMaker = true
+	fee, err = f.GetFee(feeBuilder)
+	if err != nil {
+		t.Error(err)
+	}
+	if fee <= 0 {
+		t.Errorf("incorrect maker fee value")
 	}
 }
 
@@ -1241,9 +1250,6 @@ func TestParsingWSTickerData(t *testing.T) {
 
 func TestParsingWSOrdersData(t *testing.T) {
 	t.Parallel()
-	if !areTestAPIKeysSet() {
-		t.Skip("API keys required but not set, skipping test")
-	}
 	data := []byte(`{
 		"channel": "orders",
 		"data": {
@@ -1272,9 +1278,6 @@ func TestParsingWSOrdersData(t *testing.T) {
 
 func TestParsingMarketsData(t *testing.T) {
 	t.Parallel()
-	if !areTestAPIKeysSet() {
-		t.Skip("API keys required but not set, skipping test")
-	}
 	data := []byte(`{"channel": "markets",
 	 	"type": "partial",
 		"data": {
@@ -1401,20 +1404,116 @@ func TestTimestampFromFloat64(t *testing.T) {
 
 func TestCompatibleOrderVars(t *testing.T) {
 	t.Parallel()
-	if !areTestAPIKeysSet() {
-		t.Skip("API keys required but not set, skipping test")
-	}
-	a, err := f.compatibleOrderVars("buy", "closed", "limit", 0.5, 0.5, 9500)
+	orderVars, err := f.compatibleOrderVars(
+		"buy",
+		"closed",
+		"limit",
+		0.5,
+		0.5,
+		9500)
 	if err != nil {
 		t.Error(err)
 	}
-	var b OrderVars
-	b.Side = order.Buy
-	b.OrderType = order.Limit
-	b.Status = order.Filled
-	b.Fee = a.Fee // having a preset value will fail because fees are calculated live with getaccount
-	if !reflect.DeepEqual(a, b) {
-		t.Errorf("incorrect compatible vars")
+	if orderVars.Side != order.Buy {
+		t.Errorf("received %v expected %v", orderVars.Side, order.Buy)
+	}
+	if orderVars.OrderType != order.Limit {
+		t.Errorf("received %v expected %v", orderVars.OrderType, order.Limit)
+	}
+	if orderVars.Status != order.Filled {
+		t.Errorf("received %v expected %v", orderVars.Status, order.Filled)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"closed",
+		"limit",
+		0,
+		0,
+		9500)
+	if !errors.Is(err, nil) {
+		t.Errorf("received %v expected %v", err, nil)
+	}
+	if orderVars.Status != order.Cancelled {
+		t.Errorf("received %v expected %v", orderVars.Status, order.Cancelled)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"closed",
+		"limit",
+		0.5,
+		0.2,
+		9500)
+	if !errors.Is(err, nil) {
+		t.Errorf("received %v expected %v", err, nil)
+	}
+	if orderVars.Status != order.PartiallyCancelled {
+		t.Errorf("received %v expected %v", orderVars.Status, order.PartiallyCancelled)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"sell",
+		"closed",
+		"limit",
+		1337,
+		1337,
+		9500)
+	if !errors.Is(err, nil) {
+		t.Errorf("received %v expected %v", err, nil)
+	}
+	if orderVars.Status != order.Filled {
+		t.Errorf("received %v expected %v", orderVars.Status, order.Filled)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"closed",
+		"limit",
+		0.1,
+		0.2,
+		9500)
+	if !errors.Is(err, errInvalidOrderAmounts) {
+		t.Errorf("received %v expected %v", err, errInvalidOrderAmounts)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"fake",
+		"limit",
+		0.3,
+		0.2,
+		9500)
+	if !errors.Is(err, errUnrecognisedOrderStatus) {
+		t.Errorf("received %v expected %v", err, errUnrecognisedOrderStatus)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"new",
+		"limit",
+		0.3,
+		0.2,
+		9500)
+	if !errors.Is(err, nil) {
+		t.Errorf("received %v expected %v", err, nil)
+	}
+	if orderVars.Status != order.New {
+		t.Errorf("received %v expected %v", orderVars.Status, order.New)
+	}
+
+	orderVars, err = f.compatibleOrderVars(
+		"buy",
+		"open",
+		"limit",
+		0.3,
+		0.2,
+		9500)
+	if !errors.Is(err, nil) {
+		t.Errorf("received %v expected %v", err, nil)
+	}
+	if orderVars.Status != order.Open {
+		t.Errorf("received %v expected %v", orderVars.Status, order.Open)
 	}
 }
 

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -357,8 +357,8 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			orderVars, err = f.compatibleOrderVars(resultData.OrderData.Side,
 				resultData.OrderData.Status,
 				resultData.OrderData.OrderType,
-				resultData.OrderData.FilledSize,
 				resultData.OrderData.Size,
+				resultData.OrderData.FilledSize,
 				resultData.OrderData.AvgFillPrice)
 			if err != nil {
 				return err

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -354,7 +354,8 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			resp.Pair = pair
 			resp.RemainingAmount = resultData.OrderData.Size - resultData.OrderData.FilledSize
 			var orderVars OrderVars
-			orderVars, err = f.compatibleOrderVars(resultData.OrderData.Side,
+			orderVars, err = f.compatibleOrderVars(
+				resultData.OrderData.Side,
 				resultData.OrderData.Status,
 				resultData.OrderData.OrderType,
 				resultData.OrderData.Size,

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -847,11 +847,12 @@ func (f *FTX) GetActiveOrders(getOrdersRequest *order.GetOrdersRequest) ([]order
 			tempResp.Price = orderData[y].Price
 			tempResp.RemainingAmount = orderData[y].RemainingSize
 			var orderVars OrderVars
-			orderVars, err = f.compatibleOrderVars(orderData[y].Side,
+			orderVars, err = f.compatibleOrderVars(
+				orderData[y].Side,
 				orderData[y].Status,
 				orderData[y].OrderType,
-				orderData[y].FilledSize,
 				orderData[y].Size,
+				orderData[y].FilledSize,
 				orderData[y].AvgFillPrice)
 			if err != nil {
 				return resp, err
@@ -884,11 +885,12 @@ func (f *FTX) GetActiveOrders(getOrdersRequest *order.GetOrdersRequest) ([]order
 			tempResp.Price = triggerOrderData[z].AvgFillPrice
 			tempResp.RemainingAmount = triggerOrderData[z].Size - triggerOrderData[z].FilledSize
 			tempResp.TriggerPrice = triggerOrderData[z].TriggerPrice
-			orderVars, err := f.compatibleOrderVars(triggerOrderData[z].Side,
+			orderVars, err := f.compatibleOrderVars(
+				triggerOrderData[z].Side,
 				triggerOrderData[z].Status,
 				triggerOrderData[z].OrderType,
-				triggerOrderData[z].FilledSize,
 				triggerOrderData[z].Size,
+				triggerOrderData[z].FilledSize,
 				triggerOrderData[z].AvgFillPrice)
 			if err != nil {
 				return resp, err
@@ -945,11 +947,12 @@ func (f *FTX) GetOrderHistory(getOrdersRequest *order.GetOrdersRequest) ([]order
 			tempResp.Price = orderData[y].Price
 			tempResp.RemainingAmount = orderData[y].RemainingSize
 			var orderVars OrderVars
-			orderVars, err = f.compatibleOrderVars(orderData[y].Side,
+			orderVars, err = f.compatibleOrderVars(
+				orderData[y].Side,
 				orderData[y].Status,
 				orderData[y].OrderType,
-				orderData[y].FilledSize,
 				orderData[y].Size,
+				orderData[y].FilledSize,
 				orderData[y].AvgFillPrice)
 			if err != nil {
 				return resp, err
@@ -985,11 +988,12 @@ func (f *FTX) GetOrderHistory(getOrdersRequest *order.GetOrdersRequest) ([]order
 			tempResp.Price = triggerOrderData[z].AvgFillPrice
 			tempResp.RemainingAmount = triggerOrderData[z].Size - triggerOrderData[z].FilledSize
 			tempResp.TriggerPrice = triggerOrderData[z].TriggerPrice
-			orderVars, err := f.compatibleOrderVars(triggerOrderData[z].Side,
+			orderVars, err := f.compatibleOrderVars(
+				triggerOrderData[z].Side,
 				triggerOrderData[z].Status,
 				triggerOrderData[z].OrderType,
-				triggerOrderData[z].FilledSize,
 				triggerOrderData[z].Size,
+				triggerOrderData[z].FilledSize,
 				triggerOrderData[z].AvgFillPrice)
 			if err != nil {
 				return resp, err

--- a/exchanges/orderbook/unsafe_test.go
+++ b/exchanges/orderbook/unsafe_test.go
@@ -22,7 +22,7 @@ func TestUnsafe(t *testing.T) {
 
 	ob2 := &externalBook{}
 	ob.Lock()
-	ob.Unlock() // nolint:go-staticcheck // Not needed in test
+	ob.Unlock() // nolint:staticcheck // Not needed in test
 	ob.LockWith(ob2)
 	ob.UnlockWith(ob2)
 }


### PR DESCRIPTION
# PR Description

This is based on https://github.com/thrasher-corp/gocryptotrader/pull/729 but with some additional testing and fixes. Thank you to @MarkDzulko for the intial highlighting of the error
It also fixes all other instances which were incorrect 👀 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestCompatibleOrderVars has been expanded to cover all scenarios and added some additional errors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
