### PR TITLE
Binance: Fix Balance.Hold for spot

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -607,7 +607,7 @@ func (b *Binance) UpdateAccountInfo(assetType asset.Item) (account.Holdings, err
 			currencyBalance = append(currencyBalance, account.Balance{
 				CurrencyName: currency.NewCode(raw.Balances[i].Asset),
 				TotalValue:   freeCurrency + lockedCurrency,
-				Hold:         freeCurrency,
+				Hold:         lockedCurrency,
 			})
 		}
 


### PR DESCRIPTION
# PR Description

Balance.Hold for Binance spot seems wrong as it is set to freeCurrency and not to lockedCurrency.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Using real Binance and other exchange accounts. :)

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
