### PR TITLE
Bugfix: Hold values for BTSE and Gemini

### DIFF
--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -392,7 +392,7 @@ func (b *BTSE) UpdateAccountInfo(assetType asset.Item) (account.Holdings, error)
 			account.Balance{
 				CurrencyName: currency.NewCode(balance[b].Currency),
 				TotalValue:   balance[b].Total,
-				Hold:         balance[b].Available,
+				Hold:         balance[b].Total - balance[b].Available,
 			},
 		)
 	}

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -317,7 +317,7 @@ func (g *Gemini) UpdateAccountInfo(assetType asset.Item) (account.Holdings, erro
 		var exchangeCurrency account.Balance
 		exchangeCurrency.CurrencyName = currency.NewCode(accountBalance[i].Currency)
 		exchangeCurrency.TotalValue = accountBalance[i].Amount
-		exchangeCurrency.Hold = accountBalance[i].Available
+		exchangeCurrency.Hold = accountBalance[i].Amount - accountBalance[i].Available
 		currencies = append(currencies, exchangeCurrency)
 	}
 


### PR DESCRIPTION
# PR Description
# 🕵️ 
Thanks to @ydm for highlighting this issue in https://github.com/thrasher-corp/gocryptotrader/pull/736. This PR fixes up Gemini and BTSE misrepresenting account info for `Hold` amounts

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested
I read the documentation [here](https://docs.gemini.com/rest-api/#get-available-balances) for Gemini and [here](https://www.btse.com/apiexplorer/spot/#getwallets) for BTSE

## Checklist

- [x] I have performed a self-review of my own code

