### PR TITLE
Bugfix: Syncer & websocket circular dependency

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -513,7 +513,6 @@ func (bot *Engine) Start() error {
 		bot.currencyPairSyncer, err = setupSyncManager(
 			exchangeSyncCfg,
 			bot.ExchangeManager,
-			bot.websocketRoutineManager,
 			&bot.Config.RemoteControl)
 		if err != nil {
 			gctlog.Errorf(gctlog.Global, "Unable to initialise exchange currency pair syncer. Err: %s", err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -513,7 +513,8 @@ func (bot *Engine) Start() error {
 		bot.currencyPairSyncer, err = setupSyncManager(
 			exchangeSyncCfg,
 			bot.ExchangeManager,
-			&bot.Config.RemoteControl)
+			&bot.Config.RemoteControl,
+			bot.Settings.EnableWebsocketRoutine)
 		if err != nil {
 			gctlog.Errorf(gctlog.Global, "Unable to initialise exchange currency pair syncer. Err: %s", err)
 		} else {

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -180,7 +180,8 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 				bot.currencyPairSyncer, err = setupSyncManager(
 					exchangeSyncCfg,
 					bot.ExchangeManager,
-					&bot.Config.RemoteControl)
+					&bot.Config.RemoteControl,
+					bot.Settings.EnableWebsocketRoutine)
 				if err != nil {
 					return err
 				}

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -177,9 +177,9 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 					SyncTimeoutREST:      bot.Settings.SyncTimeoutREST,
 					SyncTimeoutWebsocket: bot.Settings.SyncTimeoutWebsocket,
 				}
-				bot.currencyPairSyncer, err = setupSyncManager(exchangeSyncCfg,
+				bot.currencyPairSyncer, err = setupSyncManager(
+					exchangeSyncCfg,
 					bot.ExchangeManager,
-					bot.websocketRoutineManager,
 					&bot.Config.RemoteControl)
 				if err != nil {
 					return err

--- a/engine/sync_manager_test.go
+++ b/engine/sync_manager_test.go
@@ -14,22 +14,22 @@ import (
 
 func TestSetupSyncManager(t *testing.T) {
 	t.Parallel()
-	_, err := setupSyncManager(&Config{}, nil, nil)
+	_, err := setupSyncManager(&Config{}, nil, nil, false)
 	if !errors.Is(err, errNoSyncItemsEnabled) {
 		t.Errorf("error '%v', expected '%v'", err, errNoSyncItemsEnabled)
 	}
 
-	_, err = setupSyncManager(&Config{SyncTrades: true}, nil, nil)
+	_, err = setupSyncManager(&Config{SyncTrades: true}, nil, nil, false)
 	if !errors.Is(err, errNilExchangeManager) {
 		t.Errorf("error '%v', expected '%v'", err, errNilExchangeManager)
 	}
 
-	_, err = setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil)
+	_, err = setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil, false)
 	if !errors.Is(err, errNilConfig) {
 		t.Errorf("error '%v', expected '%v'", err, errNilConfig)
 	}
 
-	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{})
+	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -40,7 +40,7 @@ func TestSetupSyncManager(t *testing.T) {
 
 func TestSyncManagerStart(t *testing.T) {
 	t.Parallel()
-	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{})
+	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -85,7 +85,7 @@ func TestSyncManagerStop(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -133,7 +133,7 @@ func TestPrintTickerSummary(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -172,7 +172,7 @@ func TestPrintOrderbookSummary(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}

--- a/engine/sync_manager_test.go
+++ b/engine/sync_manager_test.go
@@ -14,22 +14,22 @@ import (
 
 func TestSetupSyncManager(t *testing.T) {
 	t.Parallel()
-	_, err := setupSyncManager(&Config{}, nil, nil, nil)
+	_, err := setupSyncManager(&Config{}, nil, nil)
 	if !errors.Is(err, errNoSyncItemsEnabled) {
 		t.Errorf("error '%v', expected '%v'", err, errNoSyncItemsEnabled)
 	}
 
-	_, err = setupSyncManager(&Config{SyncTrades: true}, nil, nil, nil)
+	_, err = setupSyncManager(&Config{SyncTrades: true}, nil, nil)
 	if !errors.Is(err, errNilExchangeManager) {
 		t.Errorf("error '%v', expected '%v'", err, errNilExchangeManager)
 	}
 
-	_, err = setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil, nil)
+	_, err = setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil)
 	if !errors.Is(err, errNilConfig) {
 		t.Errorf("error '%v', expected '%v'", err, errNilConfig)
 	}
 
-	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil, &config.RemoteControlConfig{})
+	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -40,7 +40,7 @@ func TestSetupSyncManager(t *testing.T) {
 
 func TestSyncManagerStart(t *testing.T) {
 	t.Parallel()
-	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, nil, &config.RemoteControlConfig{})
+	m, err := setupSyncManager(&Config{SyncTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -85,7 +85,7 @@ func TestSyncManagerStop(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, nil, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -133,7 +133,7 @@ func TestPrintTickerSummary(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, nil, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -172,7 +172,7 @@ func TestPrintOrderbookSummary(t *testing.T) {
 	}
 	exch.SetDefaults()
 	em.Add(exch)
-	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, nil, &config.RemoteControlConfig{})
+	m, err = setupSyncManager(&Config{SyncTrades: true, SyncContinuously: true}, em, &config.RemoteControlConfig{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}

--- a/engine/sync_manager_types.go
+++ b/engine/sync_manager_types.go
@@ -44,16 +44,17 @@ type Config struct {
 
 // syncManager stores the exchange currency pair syncer object
 type syncManager struct {
-	initSyncCompleted   int32
-	initSyncStarted     int32
-	started             int32
-	delimiter           string
-	uppercase           bool
-	initSyncStartTime   time.Time
-	fiatDisplayCurrency currency.Code
-	mux                 sync.Mutex
-	initSyncWG          sync.WaitGroup
-	inService           sync.WaitGroup
+	initSyncCompleted              int32
+	initSyncStarted                int32
+	started                        int32
+	delimiter                      string
+	uppercase                      bool
+	initSyncStartTime              time.Time
+	fiatDisplayCurrency            currency.Code
+	websocketRoutineManagerEnabled bool
+	mux                            sync.Mutex
+	initSyncWG                     sync.WaitGroup
+	inService                      sync.WaitGroup
 
 	currencyPairs            []currencyPairSyncAgent
 	tickerBatchLastRequested map[string]time.Time

--- a/engine/sync_manager_types.go
+++ b/engine/sync_manager_types.go
@@ -58,8 +58,7 @@ type syncManager struct {
 	currencyPairs            []currencyPairSyncAgent
 	tickerBatchLastRequested map[string]time.Time
 
-	remoteConfig          *config.RemoteControlConfig
-	config                Config
-	exchangeManager       iExchangeManager
-	websocketDataReceiver iWebsocketDataReceiver
+	remoteConfig    *config.RemoteControlConfig
+	config          Config
+	exchangeManager iExchangeManager
 }

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"github.com/thrasher-corp/gocryptotrader/common"

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -51,7 +52,7 @@ func (m *websocketRoutineManager) Start() error {
 		return ErrSubSystemAlreadyStarted
 	}
 	m.shutdown = make(chan struct{})
-	go m.websocketRoutine()
+	m.websocketRoutine()
 	return nil
 }
 
@@ -87,7 +88,7 @@ func (m *websocketRoutineManager) websocketRoutine() {
 			if exchanges[i].SupportsWebsocket() {
 				if m.verbose {
 					log.Debugf(log.WebsocketMgr,
-						"Exchange %s websocket support: Yes Enabled: %v\n",
+						"Exchange %s websocket support: Yes Enabled: %v",
 						exchanges[i].GetName(),
 						common.IsEnabled(exchanges[i].IsWebsocketEnabled()),
 					)
@@ -97,35 +98,27 @@ func (m *websocketRoutineManager) websocketRoutine() {
 				if err != nil {
 					log.Errorf(
 						log.WebsocketMgr,
-						"Exchange %s GetWebsocket error: %s\n",
+						"Exchange %s GetWebsocket error: %s",
 						exchanges[i].GetName(),
 						err,
 					)
 					return
 				}
 
-				// Exchange sync manager might have already started ws
-				// service or is in the process of connecting, so check
-				if ws.IsConnected() || ws.IsConnecting() {
-					return
-				}
-
-				// Data handler routine
-				go m.WebsocketDataReceiver(ws)
-
 				if ws.IsEnabled() {
 					err = ws.Connect()
 					if err != nil {
-						log.Errorf(log.WebsocketMgr, "%v\n", err)
+						log.Errorf(log.WebsocketMgr, "%v", err)
 					}
+					go m.WebsocketDataReceiver(ws)
 					err = ws.FlushChannels()
 					if err != nil {
-						log.Errorf(log.WebsocketMgr, "Failed to subscribe: %v\n", err)
+						log.Errorf(log.WebsocketMgr, "Failed to subscribe: %v", err)
 					}
 				}
 			} else if m.verbose {
 				log.Debugf(log.WebsocketMgr,
-					"Exchange %s websocket support: No\n",
+					"Exchange %s websocket support: No",
 					exchanges[i].GetName(),
 				)
 			}

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -75,19 +75,16 @@ type IBotExchange interface {
 	GetHistoricCandlesExtended(p currency.Pair, a asset.Item, timeStart, timeEnd time.Time, interval kline.Interval) (kline.Item, error)
 	DisableRateLimiter() error
 	EnableRateLimiter() error
-	// Websocket specific wrapper functionality
-	// GetWebsocket returns a pointer to the websocket
+
 	GetWebsocket() (*stream.Websocket, error)
 	IsWebsocketEnabled() bool
 	SupportsWebsocket() bool
 	SubscribeToWebsocketChannels(channels []stream.ChannelSubscription) error
 	UnsubscribeToWebsocketChannels(channels []stream.ChannelSubscription) error
 	IsAssetWebsocketSupported(aType asset.Item) bool
-	// FlushWebsocketChannels checks and flushes subscriptions if there is a
-	// pair,asset, url/proxy or subscription change
 	FlushWebsocketChannels() error
 	AuthenticateWebsocket() error
-	// Exchange order related execution limits
+
 	GetOrderExecutionLimits(a asset.Item, cp currency.Pair) (*order.Limits, error)
 	CheckOrderExecutionLimits(a asset.Item, cp currency.Pair, price, amount float64, orderType order.Type) error
 	UpdateOrderExecutionLimits(a asset.Item) error


### PR DESCRIPTION
# PR Description

One of our wonderful Slack members: Przemysław Skiba, highlighted an issue:
> 1. SyncManager is created and needs WebsocketRoutineManager as dependency. In my case, during SyncManager startup, WebsocketRoutineManager is nil.
> 2. SyncManager tries set WebsocketDataReceiver to nil object and transforms WS to "connecting" state
> 3. During WebsocketRoutineManager startup, it checks WS state. State is "connecting", so WebsocketRoutineManager returns from start function and not set WebsocketDataReceiver.
> 
> The result is no updates from WS routine

We have the `CurrencyPairSyncer` depending on the `WebsocketRoutineManager` and the `WebsocketRoutineManager` wants the  `CurrencyPairSyncer`. The `CurrencyPairSyncer` was given the ability to control the websocket connections, but its not necessary. It is not the responsibility of the `CurrencyPairSyncer` to manage websocket connections. Without this ability, the `CurrencyPairSyncer` is fine as the  `WebsocketRoutineManager` maintains connections and if there were an issue, the `CurrencyPairSyncer` reverts to REST.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Running the application to ensure that the currency pair syncer utilises websocket updates without controlling the websocket connection.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
