### PR TITLE
Bittrex: Enable ws orderbook sync recovery (resolves #746)

### DIFF
--- a/exchanges/bittrex/bittrex_types.go
+++ b/exchanges/bittrex/bittrex_types.go
@@ -284,9 +284,10 @@ type orderbookManager struct {
 }
 
 type update struct {
-	buffer       chan *OrderbookUpdateMessage
-	fetchingBook bool
-	initialSync  bool
+	buffer            chan *OrderbookUpdateMessage
+	fetchingBook      bool
+	initialSync       bool
+	needsFetchingBook bool
 }
 
 // job defines a synchonisation job that tells a go routine to fetch an

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -130,16 +130,7 @@ func (b *Bittrex) SeedLocalCacheWithOrderBook(p currency.Pair, sequence int64, o
 	newOrderBook.LastUpdateID = sequence
 	newOrderBook.VerifyOrderbook = b.CanVerifyOrderbook
 
-	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
-	if err != nil {
-		return err
-	}
-	depth, err := orderbook.GetDepth(b.Name, p, asset.Spot)
-	if err != nil {
-		return err
-	}
-	depth.AssignOptions(&newOrderBook)
-	return nil
+	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }
 
 // applyBufferUpdate applies the buffer to the orderbook or initiates a new
@@ -154,7 +145,7 @@ func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
 	}
 
 	recent, err := b.Websocket.Orderbook.GetOrderbook(pair, asset.Spot)
-	if err != nil || (recent.Asks == nil && recent.Bids == nil) || (len(recent.Asks) == 0 && len(recent.Bids) == 0) {
+	if err != nil || (len(recent.Asks) == 0 && len(recent.Bids) == 0) {
 		if b.Verbose {
 			log.Debugf(log.WebsocketMgr, "Orderbook: Fetching via REST\n")
 		}

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -130,7 +130,16 @@ func (b *Bittrex) SeedLocalCacheWithOrderBook(p currency.Pair, sequence int64, o
 	newOrderBook.LastUpdateID = sequence
 	newOrderBook.VerifyOrderbook = b.CanVerifyOrderbook
 
-	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
+	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
+	if err != nil {
+		return err
+	}
+	depth, err := orderbook.GetDepth(b.Name, p, asset.Spot)
+	if err != nil {
+		return err
+	}
+	depth.AssignOptions(&newOrderBook)
+	return nil
 }
 
 // applyBufferUpdate applies the buffer to the orderbook or initiates a new
@@ -145,7 +154,7 @@ func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
 	}
 
 	recent, err := b.Websocket.Orderbook.GetOrderbook(pair, asset.Spot)
-	if err != nil || (recent.Asks == nil && recent.Bids == nil) {
+	if err != nil || (recent.Asks == nil && recent.Bids == nil) || (len(recent.Asks) == 0 && len(recent.Bids) == 0) {
 		if b.Verbose {
 			log.Debugf(log.WebsocketMgr, "Orderbook: Fetching via REST\n")
 		}

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -93,9 +93,7 @@ func (b *Bittrex) UpdateLocalOBBuffer(update *OrderbookUpdateMessage) (bool, err
 
 	err = b.applyBufferUpdate(currencyPair)
 	if err != nil {
-		if b.Verbose {
-			log.Debugf(log.WebsocketMgr, "UpdateLocalOBBuffer: Could not apply buffer update\n")
-		}
+		log.Errorf(log.WebsocketMgr, "%s websocket UpdateLocalOBBuffer: Could not apply buffer update\n", b.Name)
 	}
 
 	return false, err
@@ -147,7 +145,7 @@ func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
 	}
 	if needsFetching {
 		if b.Verbose {
-			log.Debugf(log.WebsocketMgr, "Orderbook: Fetching via REST\n")
+			log.Debugf(log.WebsocketMgr, "%s Orderbook: Fetching via REST\n", b.Name)
 		}
 		return b.obm.fetchBookViaREST(pair)
 	}
@@ -155,7 +153,8 @@ func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
 	if err != nil {
 		log.Errorf(
 			log.WebsocketMgr,
-			"Could not fetch recent orderbook when applying updates: %s\n",
+			"%s error fetching recent orderbook when applying updates: %s\n",
+			b.Name,
 			err)
 	}
 
@@ -164,7 +163,8 @@ func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
 		if err != nil {
 			log.Errorf(
 				log.WebsocketMgr,
-				"Unable to process update - initiating new orderbook sync via REST: %s\n",
+				"%s error processing update - initiating new orderbook sync via REST: %s\n",
+				b.Name,
 				err)
 			b.obm.setNeedsFetchingBook(pair)
 		}

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -93,7 +93,9 @@ func (b *Bittrex) UpdateLocalOBBuffer(update *OrderbookUpdateMessage) (bool, err
 
 	err = b.applyBufferUpdate(currencyPair)
 	if err != nil {
-		b.flushAndCleanup(currencyPair)
+		if b.Verbose {
+			log.Debugf(log.WebsocketMgr, "UpdateLocalOBBuffer: Could not apply buffer update\n")
+		}
 	}
 
 	return false, err
@@ -136,23 +138,31 @@ func (b *Bittrex) SeedLocalCacheWithOrderBook(p currency.Pair, sequence int64, o
 // applyBufferUpdate applies the buffer to the orderbook or initiates a new
 // orderbook sync by the REST protocol which is off handed to go routine.
 func (b *Bittrex) applyBufferUpdate(pair currency.Pair) error {
-	fetching, err := b.obm.checkIsFetchingBook(pair)
+	fetching, needsFetching, err := b.obm.handleFetchingBook(pair)
 	if err != nil {
 		return err
 	}
 	if fetching {
 		return nil
 	}
-
-	recent, err := b.Websocket.Orderbook.GetOrderbook(pair, asset.Spot)
-	if err != nil || (len(recent.Asks) == 0 && len(recent.Bids) == 0) {
+	if needsFetching {
 		if b.Verbose {
 			log.Debugf(log.WebsocketMgr, "Orderbook: Fetching via REST\n")
 		}
 		return b.obm.fetchBookViaREST(pair)
 	}
+	recent, err := b.Websocket.Orderbook.GetOrderbook(pair, asset.Spot)
+	if err != nil {
+		log.Debugf(log.WebsocketMgr, "Orderbook: Could not get recent book\n")
+	}
 
-	return b.obm.checkAndProcessUpdate(b.ProcessUpdateOB, pair, recent)
+	if recent != nil {
+		err = b.obm.checkAndProcessUpdate(b.ProcessUpdateOB, pair, recent)
+		if err != nil {
+			b.obm.setNeedsFetchingBook(pair)
+		}
+	}
+	return nil
 }
 
 // SynchroniseWebsocketOrderbook synchronises full orderbook for currency pair
@@ -192,12 +202,7 @@ func (b *Bittrex) processJob(p currency.Pair) error {
 
 	// Immediately apply the buffer updates so we don't wait for a
 	// new update to initiate this.
-	err = b.applyBufferUpdate(p)
-	if err != nil {
-		b.flushAndCleanup(p)
-		return err
-	}
-	return nil
+	return b.applyBufferUpdate(p)
 }
 
 // flushAndCleanup flushes orderbook and clean local cache
@@ -239,9 +244,10 @@ func (o *orderbookManager) stageWsUpdate(u *OrderbookUpdateMessage, pair currenc
 		state = &update{
 			// 100ms update assuming we might have up to a 10 second delay.
 			// There could be a potential 100 updates for the currency.
-			buffer:       make(chan *OrderbookUpdateMessage, maxWSUpdateBuffer),
-			fetchingBook: false,
-			initialSync:  true,
+			buffer:            make(chan *OrderbookUpdateMessage, maxWSUpdateBuffer),
+			fetchingBook:      false,
+			initialSync:       true,
+			needsFetchingBook: true,
 		}
 		m2[a] = state
 	}
@@ -256,21 +262,6 @@ func (o *orderbookManager) stageWsUpdate(u *OrderbookUpdateMessage, pair currenc
 		return fmt.Errorf("channel blockage for %s, asset %s and connection",
 			pair, a)
 	}
-}
-
-// checkIsFetchingBook checks status if the book is currently being via the REST
-// protocol.
-func (o *orderbookManager) checkIsFetchingBook(pair currency.Pair) (bool, error) {
-	o.Lock()
-	defer o.Unlock()
-	state, ok := o.state[pair.Base][pair.Quote][asset.Spot]
-	if !ok {
-		return false,
-			fmt.Errorf("check is fetching book cannot match currency pair %s asset type %s",
-				pair,
-				asset.Spot)
-	}
-	return state.fetchingBook, nil
 }
 
 // stopFetchingBook completes the book fetching.
@@ -290,6 +281,64 @@ func (o *orderbookManager) stopFetchingBook(pair currency.Pair) error {
 	}
 	state.fetchingBook = false
 	return nil
+}
+
+// stopNeedsFetchingBook completes the book fetching initiation.
+func (o *orderbookManager) stopNeedsFetchingBook(pair currency.Pair) error {
+	o.Lock()
+	defer o.Unlock()
+	state, ok := o.state[pair.Base][pair.Quote][asset.Spot]
+	if !ok {
+		return fmt.Errorf("could not match pair %s and asset type %s in hash table",
+			pair,
+			asset.Spot)
+	}
+	if !state.needsFetchingBook {
+		return fmt.Errorf("needs fetching book already set to false for %s %s",
+			pair,
+			asset.Spot)
+	}
+	state.needsFetchingBook = false
+	return nil
+}
+
+// setNeedsFetchingBook completes the book fetching initiation.
+func (o *orderbookManager) setNeedsFetchingBook(pair currency.Pair) error {
+	o.Lock()
+	defer o.Unlock()
+	state, ok := o.state[pair.Base][pair.Quote][asset.Spot]
+	if !ok {
+		return fmt.Errorf("could not match pair %s and asset type %s in hash table",
+			pair,
+			asset.Spot)
+	}
+	state.needsFetchingBook = true
+	return nil
+}
+
+// handleFetchingBook checks if a full book is beeing fetched or needs being
+// fetched
+func (o *orderbookManager) handleFetchingBook(pair currency.Pair) (fetching bool, needsFetching bool, err error) {
+	o.Lock()
+	defer o.Unlock()
+	state, ok := o.state[pair.Base][pair.Quote][asset.Spot]
+	if !ok {
+		return false, false,
+			fmt.Errorf("check is fetching book cannot match currency pair %s asset type %s",
+				pair,
+				asset.Spot)
+	}
+
+	if state.fetchingBook {
+		return true, false, nil
+	}
+
+	if state.needsFetchingBook {
+		state.needsFetchingBook = false
+		state.fetchingBook = true
+		return false, true, nil
+	}
+	return false, false, nil
 }
 
 // completeInitialSync sets if an asset type has completed its initial sync
@@ -437,5 +486,6 @@ bufferEmpty:
 	// disable rest orderbook synchronisation
 	_ = o.stopFetchingBook(pair)
 	_ = o.completeInitialSync(pair)
+	_ = o.stopNeedsFetchingBook(pair)
 	return nil
 }

--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -142,7 +142,6 @@ func (d *Depth) UpdateBidAskByID(bidUpdts, askUpdts Items, lastUpdateID int64, l
 		return nil
 	}
 	d.m.Lock()
-
 	defer d.m.Unlock()
 	if len(bidUpdts) != 0 {
 		err := d.bids.updateByID(bidUpdts)
@@ -168,7 +167,6 @@ func (d *Depth) DeleteBidAskByID(bidUpdts, askUpdts Items, bypassErr bool, lastU
 		return nil
 	}
 	d.m.Lock()
-
 	defer d.m.Unlock()
 	if len(bidUpdts) != 0 {
 		err := d.bids.deleteByID(bidUpdts, d.stack, bypassErr)

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -121,7 +121,7 @@ func TestTotalAmounts(t *testing.T) {
 
 func TestLoadSnapshot(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}}, 0, time.Time{}, false)
 	if d.Retrieve().Asks[0].Price != 1337 || d.Retrieve().Bids[0].Price != 1337 {
 		t.Fatal("not set")
 	}
@@ -129,12 +129,12 @@ func TestLoadSnapshot(t *testing.T) {
 
 func TestFlush(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}}, 0, time.Time{}, false)
 	d.Flush()
 	if len(d.Retrieve().Asks) != 0 || len(d.Retrieve().Bids) != 0 {
 		t.Fatal("not flushed")
 	}
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1}}, Items{{Price: 1337, Amount: 10}}, 0, time.Time{}, false)
 	d.Flush()
 	if len(d.Retrieve().Asks) != 0 || len(d.Retrieve().Bids) != 0 {
 		t.Fatal("not flushed")
@@ -143,12 +143,12 @@ func TestFlush(t *testing.T) {
 
 func TestUpdateBidAskByPrice(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}})
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0)
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 0, time.Time{})
 	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0)
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 0, time.Time{})
 	if d.GetAskLength() != 0 || d.GetBidLength() != 0 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
@@ -156,8 +156,8 @@ func TestUpdateBidAskByPrice(t *testing.T) {
 
 func TestDeleteBidAskByID(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}})
-	err := d.DeleteBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, false)
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
+	err := d.DeleteBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, false, 0, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,17 +165,17 @@ func TestDeleteBidAskByID(t *testing.T) {
 		t.Fatal("items not deleted")
 	}
 
-	err = d.DeleteBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, nil, false)
+	err = d.DeleteBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, nil, false, 0, time.Time{})
 	if !errors.Is(err, errIDCannotBeMatched) {
 		t.Fatalf("error expected %v received %v", errIDCannotBeMatched, err)
 	}
 
-	err = d.DeleteBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 2}}, false)
+	err = d.DeleteBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 2}}, false, 0, time.Time{})
 	if !errors.Is(err, errIDCannotBeMatched) {
 		t.Fatalf("error expected %v received %v", errIDCannotBeMatched, err)
 	}
 
-	err = d.DeleteBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 2}}, true)
+	err = d.DeleteBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 2}}, true, 0, time.Time{})
 	if !errors.Is(err, nil) {
 		t.Fatalf("error expected %v received %v", nil, err)
 	}
@@ -183,8 +183,8 @@ func TestDeleteBidAskByID(t *testing.T) {
 
 func TestUpdateBidAskByID(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}})
-	err := d.UpdateBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
+	err := d.UpdateBidAskByID(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,12 +193,12 @@ func TestUpdateBidAskByID(t *testing.T) {
 	}
 
 	// random unmatching IDs
-	err = d.UpdateBidAskByID(Items{{Price: 1337, Amount: 2, ID: 666}}, nil)
+	err = d.UpdateBidAskByID(Items{{Price: 1337, Amount: 2, ID: 666}}, nil, 0, time.Time{})
 	if !errors.Is(err, errIDCannotBeMatched) {
 		t.Fatalf("error expected %v received %v", errIDCannotBeMatched, err)
 	}
 
-	err = d.UpdateBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 69}})
+	err = d.UpdateBidAskByID(nil, Items{{Price: 1337, Amount: 2, ID: 69}}, 0, time.Time{})
 	if !errors.Is(err, errIDCannotBeMatched) {
 		t.Fatalf("error expected %v received %v", errIDCannotBeMatched, err)
 	}
@@ -206,8 +206,8 @@ func TestUpdateBidAskByID(t *testing.T) {
 
 func TestInsertBidAskByID(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}})
-	err := d.InsertBidAskByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
+	err := d.InsertBidAskByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}}, 0, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,19 +218,19 @@ func TestInsertBidAskByID(t *testing.T) {
 
 func TestUpdateInsertByID(t *testing.T) {
 	d := newDepth(id)
-	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}})
+	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
 
-	err := d.UpdateInsertByID(Items{{Price: 1338, Amount: 0, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}})
+	err := d.UpdateInsertByID(Items{{Price: 1338, Amount: 0, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}}, 0, time.Time{})
 	if !errors.Is(err, errAmountCannotBeLessOrEqualToZero) {
 		t.Fatalf("expected: %v but received: %v", errAmountCannotBeLessOrEqualToZero, err)
 	}
 
-	err = d.UpdateInsertByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 0, ID: 4}})
+	err = d.UpdateInsertByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 0, ID: 4}}, 0, time.Time{})
 	if !errors.Is(err, errAmountCannotBeLessOrEqualToZero) {
 		t.Fatalf("expected: %v but received: %v", errAmountCannotBeLessOrEqualToZero, err)
 	}
 
-	err = d.UpdateInsertByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}})
+	err = d.UpdateInsertByID(Items{{Price: 1338, Amount: 2, ID: 3}}, Items{{Price: 1336, Amount: 2, ID: 4}}, 0, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,17 +267,6 @@ func TestAssignOptions(t *testing.T) {
 		!d.VerifyOrderbook ||
 		!d.restSnapshot ||
 		!d.idAligned {
-		t.Fatal("failed to set correctly")
-	}
-}
-
-func TestSetLastUpdate(t *testing.T) {
-	d := Depth{}
-	tn := time.Now()
-	d.SetLastUpdate(tn, 1337, true)
-	if d.lastUpdated != tn ||
-		d.lastUpdateID != 1337 ||
-		!d.restSnapshot {
 		t.Fatal("failed to set correctly")
 	}
 }

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -79,8 +79,7 @@ func (s *Service) Update(b *Base) error {
 		book.AssignOptions(b)
 		m3[b.Pair.Quote.Item] = book
 	}
-	book.SetLastUpdate(b.LastUpdated, b.LastUpdateID, true)
-	book.LoadSnapshot(b.Bids, b.Asks)
+	book.LoadSnapshot(b.Bids, b.Asks, b.LastUpdateID, b.LastUpdated, true)
 	s.Unlock()
 	return s.Mux.Publish([]uuid.UUID{m1.ID}, book.Retrieve())
 }

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -802,7 +802,7 @@ func TestUpdateByIDAndAction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	book.LoadSnapshot(append(bids[:0:0], bids...), append(asks[:0:0], asks...))
+	book.LoadSnapshot(append(bids[:0:0], bids...), append(asks[:0:0], asks...), 0, time.Time{}, true)
 
 	err = book.Retrieve().Verify()
 	if err != nil {
@@ -924,7 +924,7 @@ func TestUpdateByIDAndAction(t *testing.T) {
 		t.Fatal("did not adjust ask item placement and details")
 	}
 
-	book.LoadSnapshot(append(bids[:0:0], bids...), append(bids[:0:0], bids...)) // nolint:gocritic
+	book.LoadSnapshot(append(bids[:0:0], bids...), append(bids[:0:0], bids...), 0, time.Time{}, true) // nolint:gocritic
 
 	// Delete - not found
 	err = holder.updateByIDAndAction(&Update{


### PR DESCRIPTION
# PR Description

Bittrex fails to recover after a failed websocket orderbook update. This PR addresses this by
- Testing if books have been cleared
- Assigning options when loading snapshot

Fixes #746 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

The PR has been tested by dropping ws orderbook updates on-demand.

- [x] go test ./... -race
- [ ] golangci-lint run
- [x] Test 'dropping ws orderbook updates on-demand.'

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
