### PR TITLE
gctcli: Fix enable flag for various commands

### DIFF
--- a/cmd/gctcli/pair_management.go
+++ b/cmd/gctcli/pair_management.go
@@ -60,6 +60,7 @@ var exchangePairManagerCommand = &cli.Command{
 				&cli.BoolFlag{
 					Name:   "enable",
 					Hidden: true,
+					Value:  true,
 				},
 			},
 			Action: enableDisableExchangeAsset,
@@ -102,6 +103,7 @@ var exchangePairManagerCommand = &cli.Command{
 				&cli.BoolFlag{
 					Name:   "enable",
 					Hidden: true,
+					Value:  true,
 				},
 			},
 			Action: enableDisableExchangePair,
@@ -117,6 +119,7 @@ var exchangePairManagerCommand = &cli.Command{
 				&cli.BoolFlag{
 					Name:   "enable",
 					Hidden: true,
+					Value:  true,
 				},
 			},
 			Action: enableDisableAllExchangePairs,

--- a/cmd/gctcli/websocket_management.go
+++ b/cmd/gctcli/websocket_management.go
@@ -46,6 +46,7 @@ var websocketManagerCommand = &cli.Command{
 				&cli.BoolFlag{
 					Name:   "enable",
 					Hidden: true,
+					Value:  true,
 				},
 			},
 			Action: enableDisableWebsocket,


### PR DESCRIPTION
# PR Description

Fix enable flag for various gctcli commands

Fixes https://github.com/thrasher-corp/gocryptotrader/issues/751

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] below command
```
$ ./gctcli pair enable --exchange binance --pairs "VITE-BTC" --asset spot
{
 "status": "success"
}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
