### PR TITLE
Binance/FTX: spot websocket fixes

### DIFF
--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2266,9 +2266,11 @@ func TestExecutionTypeToOrderStatus(t *testing.T) {
 	}
 	testCases := []TestCases{
 		{Case: "NEW", Result: order.New},
+		{Case: "PARTIALLY_FILLED", Result: order.PartiallyFilled},
+		{Case: "FILLED", Result: order.Filled},
 		{Case: "CANCELED", Result: order.Cancelled},
+		{Case: "PENDING_CANCEL", Result: order.PendingCancel},
 		{Case: "REJECTED", Result: order.Rejected},
-		{Case: "TRADE", Result: order.PartiallyFilled},
 		{Case: "EXPIRED", Result: order.Expired},
 		{Case: "LOL", Result: order.UnknownStatus},
 	}
@@ -2491,20 +2493,25 @@ func TestWsOrderExecutionReport(t *testing.T) {
 	payload := []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616627567900,"s":"BTCUSDT","c":"c4wyKsIhoAaittTYlIVLqk","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028400","p":"52789.10000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"NEW","X":"NEW","r":"NONE","i":5340845958,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":"BTC","T":1616627567900,"t":-1,"I":11388173160,"w":true,"m":false,"M":false,"O":1616627567900,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000"}}`)
 	// this is a buy BTC order, normally commission is charged in BTC, vice versa.
 	expRes := order.Detail{
-		Price:           52789.1,
-		Amount:          0.00028400,
-		Exchange:        "Binance",
-		ID:              "5340845958",
-		ClientOrderID:   "c4wyKsIhoAaittTYlIVLqk",
-		Side:            order.Buy,
-		Type:            order.Limit,
-		Status:          order.New,
-		AssetType:       asset.Spot,
-		Pair:            currency.NewPair(currency.BTC, currency.USDT),
-		RemainingAmount: 0.000284,
-		Date:            time.Unix(0, 1616627567900*int64(time.Millisecond)),
-		Cost:            0,
-		CostAsset:       currency.BTC,
+		Price:                52789.1,
+		Amount:               0.00028400,
+		AverageExecutedPrice: 0,
+		TargetAmount:         0.00028400,
+		ExecutedAmount:       0,
+		RemainingAmount:      0.00028400,
+		Cost:                 0,
+		CostAsset:            currency.USDT,
+		Fee:                  0,
+		FeeAsset:             currency.BTC,
+		Exchange:             "Binance",
+		ID:                   "5340845958",
+		ClientOrderID:        "c4wyKsIhoAaittTYlIVLqk",
+		Type:                 order.Limit,
+		Side:                 order.Buy,
+		Status:               order.New,
+		AssetType:            asset.Spot,
+		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
+		Date:                 time.Unix(0, 1616627567900*int64(time.Millisecond)),
 	}
 	// empty the channel. otherwise mock_test will fail
 	for len(b.Websocket.DataHandler) > 0 {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2496,7 +2496,7 @@ func TestWsOrderExecutionReport(t *testing.T) {
 		Price:                52789.1,
 		Amount:               0.00028400,
 		AverageExecutedPrice: 0,
-		TargetAmount:         0.00028400,
+		TargetAmount:         0,
 		ExecutedAmount:       0,
 		RemainingAmount:      0.00028400,
 		Cost:                 0,
@@ -2510,8 +2510,9 @@ func TestWsOrderExecutionReport(t *testing.T) {
 		Side:                 order.Buy,
 		Status:               order.New,
 		AssetType:            asset.Spot,
-		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
 		Date:                 time.Unix(0, 1616627567900*int64(time.Millisecond)),
+		LastUpdated:          time.Unix(0, 1616627567900*int64(time.Millisecond)),
+		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
 	}
 	// empty the channel. otherwise mock_test will fail
 	for len(b.Websocket.DataHandler) > 0 {

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -736,34 +736,34 @@ type wsOrderUpdate struct {
 
 // WsOrderUpdateData defines websocket account order update data
 type WsOrderUpdateData struct {
-	EventType                string    `json:"e"`
-	EventTime                time.Time `json:"E"`
-	Symbol                   string    `json:"s"`
-	ClientOrderID            string    `json:"c"`
-	Side                     string    `json:"S"`
-	OrderType                string    `json:"o"`
-	TimeInForce              string    `json:"f"`
-	Quantity                 float64   `json:"q,string"`
-	Price                    float64   `json:"p,string"`
-	StopPrice                float64   `json:"P,string"`
-	IcebergQuantity          float64   `json:"F,string"`
-	OrderListID              int64     `json:"g"`
-	CancelledClientOrderID   string    `json:"C"`
-	CurrentExecutionType     string    `json:"x"`
-	OrderStatus              string    `json:"X"`
-	RejectionReason          string    `json:"r"`
-	OrderID                  int64     `json:"i"`
-	LastExecutedQuantity     float64   `json:"l,string"`
-	CumulativeFilledQuantity float64   `json:"z,string"`
-	LastExecutedPrice        float64   `json:"L,string"`
-	Commission               float64   `json:"n,string"`
-	CommissionAsset          string    `json:"N"`
-	TransactionTime          time.Time `json:"T"`
-	TradeID                  int64     `json:"t"`
-	Ignored                  int64     `json:"I"` // must be ignored explicitly, otherwise it overwrites 'i'
-	IsOnOrderBook            bool      `json:"w"`
-	IsMaker                  bool      `json:"m"`
-	// TODO: M
+	EventType                         string    `json:"e"`
+	EventTime                         time.Time `json:"E"`
+	Symbol                            string    `json:"s"`
+	ClientOrderID                     string    `json:"c"`
+	Side                              string    `json:"S"`
+	OrderType                         string    `json:"o"`
+	TimeInForce                       string    `json:"f"`
+	Quantity                          float64   `json:"q,string"`
+	Price                             float64   `json:"p,string"`
+	StopPrice                         float64   `json:"P,string"`
+	IcebergQuantity                   float64   `json:"F,string"`
+	OrderListID                       int64     `json:"g"`
+	CancelledClientOrderID            string    `json:"C"`
+	CurrentExecutionType              string    `json:"x"`
+	OrderStatus                       string    `json:"X"`
+	RejectionReason                   string    `json:"r"`
+	OrderID                           int64     `json:"i"`
+	LastExecutedQuantity              float64   `json:"l,string"`
+	CumulativeFilledQuantity          float64   `json:"z,string"`
+	LastExecutedPrice                 float64   `json:"L,string"`
+	Commission                        float64   `json:"n,string"`
+	CommissionAsset                   string    `json:"N"`
+	TransactionTime                   time.Time `json:"T"`
+	TradeID                           int64     `json:"t"`
+	Ignored                           int64     `json:"I"` // Must be ignored explicitly, otherwise it overwrites 'i'.
+	IsOnOrderBook                     bool      `json:"w"`
+	IsMaker                           bool      `json:"m"`
+	Ignored2                          bool      `json:"M"` // See the comment for "I".
 	OrderCreationTime                 time.Time `json:"O"`
 	CumulativeQuoteTransactedQuantity float64   `json:"Z,string"`
 	LastQuoteAssetTransactedQuantity  float64   `json:"Y,string"`

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -736,37 +736,38 @@ type wsOrderUpdate struct {
 
 // WsOrderUpdateData defines websocket account order update data
 type WsOrderUpdateData struct {
-	ClientOrderID                     string    `json:"c"`
-	EventTime                         time.Time `json:"E"`
-	IcebergQuantity                   float64   `json:"F,string"`
-	LastExecutedPrice                 float64   `json:"L,string"`
-	CommissionAsset                   string    `json:"N"`
+	EventType                string    `json:"e"`
+	EventTime                time.Time `json:"E"`
+	Symbol                   string    `json:"s"`
+	ClientOrderID            string    `json:"c"`
+	Side                     string    `json:"S"`
+	OrderType                string    `json:"o"`
+	TimeInForce              string    `json:"f"`
+	Quantity                 float64   `json:"q,string"`
+	Price                    float64   `json:"p,string"`
+	StopPrice                float64   `json:"P,string"`
+	IcebergQuantity          float64   `json:"F,string"`
+	OrderListID              int64     `json:"g"`
+	CancelledClientOrderID   string    `json:"C"`
+	CurrentExecutionType     string    `json:"x"`
+	OrderStatus              string    `json:"X"`
+	RejectionReason          string    `json:"r"`
+	OrderID                  int64     `json:"i"`
+	LastExecutedQuantity     float64   `json:"l,string"`
+	CumulativeFilledQuantity float64   `json:"z,string"`
+	LastExecutedPrice        float64   `json:"L,string"`
+	Commission               float64   `json:"n,string"`
+	CommissionAsset          string    `json:"N"`
+	TransactionTime          time.Time `json:"T"`
+	TradeID                  int64     `json:"t"`
+	Ignored                  int64     `json:"I"` // must be ignored explicitly, otherwise it overwrites 'i'
+	IsOnOrderBook            bool      `json:"w"`
+	IsMaker                  bool      `json:"m"`
+	// TODO: M
 	OrderCreationTime                 time.Time `json:"O"`
-	StopPrice                         float64   `json:"P,string"`
-	QuoteOrderQuantity                float64   `json:"Q,string"`
-	Side                              string    `json:"S"`
-	TransactionTime                   time.Time `json:"T"`
-	OrderStatus                       string    `json:"X"`
-	LastQuoteAssetTransactedQuantity  float64   `json:"Y,string"`
 	CumulativeQuoteTransactedQuantity float64   `json:"Z,string"`
-	CancelledClientOrderID            string    `json:"C"`
-	EventType                         string    `json:"e"`
-	TimeInForce                       string    `json:"f"`
-	OrderListID                       int64     `json:"g"`
-	OrderID                           int64     `json:"i"`
-	LastExecutedQuantity              float64   `json:"l,string"`
-	IsMaker                           bool      `json:"m"`
-	Commission                        float64   `json:"n,string"`
-	OrderType                         string    `json:"o"`
-	Price                             float64   `json:"p,string"`
-	Quantity                          float64   `json:"q,string"`
-	RejectionReason                   string    `json:"r"`
-	Symbol                            string    `json:"s"`
-	TradeID                           int64     `json:"t"`
-	Ignored                           int64     `json:"I"` // must be ignored explicitly, otherwise it overwrites 'i'
-	IsOnOrderBook                     bool      `json:"w"`
-	CurrentExecutionType              string    `json:"x"`
-	CumulativeFilledQuantity          float64   `json:"z,string"`
+	LastQuoteAssetTransactedQuantity  float64   `json:"Y,string"`
+	QuoteOrderQuantity                float64   `json:"Q,string"`
 }
 
 type wsListStatus struct {

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -207,7 +207,11 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 						b.Name,
 						err)
 				}
-				var averagePrice = data.Data.CumulativeQuoteTransactedQuantity / data.Data.CumulativeFilledQuantity
+				averagePrice := data.Data.CumulativeQuoteTransactedQuantity / data.Data.CumulativeFilledQuantity
+				remainingAmount := data.Data.Quantity - data.Data.CumulativeFilledQuantity
+				cost := averagePrice * data.Data.Quantity
+				feeAsset := currency.NewCode(data.Data.CommissionAsset)
+
 				var orderID = strconv.FormatInt(data.Data.OrderID, 10)
 				oType, err := order.StringToOrderType(data.Data.OrderType)
 				if err != nil {
@@ -249,12 +253,13 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					Price:                data.Data.Price,
 					Amount:               data.Data.Quantity,
 					AverageExecutedPrice: averagePrice,
+					TargetAmount:         data.Data.Quantity,
 					ExecutedAmount:       data.Data.CumulativeFilledQuantity,
-					RemainingAmount:      data.Data.Quantity - data.Data.CumulativeFilledQuantity,
-					Cost:                 averagePrice * data.Data.Quantity,
+					RemainingAmount:      remainingAmount,
+					Cost:                 cost,
 					CostAsset:            p.Quote,
 					Fee:                  data.Data.Commission,
-					FeeAsset:             currency.NewCode(data.Data.CommissionAsset),
+					FeeAsset:             feeAsset,
 					Exchange:             b.Name,
 					ID:                   orderID,
 					ClientOrderID:        clientOrderID,
@@ -262,7 +267,7 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					Side:                 oSide,
 					Status:               oStatus,
 					AssetType:            a,
-					Date:                 data.Data.EventTime,
+					Date:                 data.Data.TransactionTime,
 					Pair:                 p,
 				}
 				return nil

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -254,6 +254,7 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					Cost:                 averagePrice * data.Data.Quantity,
 					CostAsset:            p.Quote,
 					Fee:                  data.Data.Commission,
+					FeeAsset:             currency.NewCode(data.Data.CommissionAsset),
 					Exchange:             b.Name,
 					ID:                   orderID,
 					ClientOrderID:        clientOrderID,

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -250,7 +250,6 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					Price:                data.Data.Price,
 					Amount:               data.Data.Quantity,
 					AverageExecutedPrice: averagePrice,
-					TargetAmount:         data.Data.Quantity,
 					ExecutedAmount:       data.Data.CumulativeFilledQuantity,
 					RemainingAmount:      remainingAmount,
 					Cost:                 data.Data.CumulativeQuoteTransactedQuantity,

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -216,7 +216,10 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 				if err != nil {
 					return err
 				}
-				feeAsset := currency.NewCode(data.Data.CommissionAsset)
+				var feeAsset currency.Code
+				if data.Data.CommissionAsset != "" {
+					feeAsset = currency.NewCode(data.Data.CommissionAsset)
+				}
 				orderID := strconv.FormatInt(data.Data.OrderID, 10)
 				orderStatus, err := stringToOrderStatus(data.Data.OrderStatus)
 				if err != nil {

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -207,7 +207,10 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 						b.Name,
 						err)
 				}
-				averagePrice := data.Data.CumulativeQuoteTransactedQuantity / data.Data.CumulativeFilledQuantity
+				averagePrice := 0.0
+				if data.Data.CumulativeFilledQuantity != 0 {
+					averagePrice = data.Data.CumulativeQuoteTransactedQuantity / data.Data.CumulativeFilledQuantity
+				}
 				remainingAmount := data.Data.Quantity - data.Data.CumulativeFilledQuantity
 				cost := averagePrice * data.Data.Quantity
 				pair, assetType, err := b.GetRequestFormattedPairAndAssetType(data.Data.Symbol)

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -263,7 +263,8 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					Side:                 orderSide,
 					Status:               orderStatus,
 					AssetType:            assetType,
-					Date:                 data.Data.TransactionTime,
+					Date:                 data.Data.OrderCreationTime,
+					LastUpdated:          data.Data.TransactionTime,
 					Pair:                 pair,
 				}
 				return nil

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -212,7 +212,6 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					averagePrice = data.Data.CumulativeQuoteTransactedQuantity / data.Data.CumulativeFilledQuantity
 				}
 				remainingAmount := data.Data.Quantity - data.Data.CumulativeFilledQuantity
-				cost := averagePrice * data.Data.Quantity
 				pair, assetType, err := b.GetRequestFormattedPairAndAssetType(data.Data.Symbol)
 				if err != nil {
 					return err
@@ -254,7 +253,7 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 					TargetAmount:         data.Data.Quantity,
 					ExecutedAmount:       data.Data.CumulativeFilledQuantity,
 					RemainingAmount:      remainingAmount,
-					Cost:                 cost,
+					Cost:                 data.Data.CumulativeQuoteTransactedQuantity,
 					CostAsset:            pair.Quote,
 					Fee:                  data.Data.Commission,
 					FeeAsset:             feeAsset,

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -353,7 +353,7 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			resp.AverageExecutedPrice = resultData.OrderData.AvgFillPrice
 			resp.ExecutedAmount = resultData.OrderData.FilledSize
 			resp.RemainingAmount = resultData.OrderData.Size - resultData.OrderData.FilledSize
-			resp.Cost = resp.AverageExecutedPrice * resp.Amount
+			resp.Cost = resp.AverageExecutedPrice * resultData.OrderData.FilledSize
 			// Fee: orderVars.Fee is incorrect.
 			resp.Exchange = f.Name
 			resp.ID = strconv.FormatInt(resultData.OrderData.ID, 10)

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -363,6 +363,8 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			resp.Status = orderVars.Status
 			resp.AssetType = assetType
 			resp.Date = resultData.OrderData.CreatedAt
+			// There's no current timestamp, so this is the best we can get.
+			resp.LastUpdated = resultData.OrderData.CreatedAt
 			resp.Pair = pair
 			f.Websocket.DataHandler <- &resp
 		case wsFills:

--- a/exchanges/order/order_types.go
+++ b/exchanges/order/order_types.go
@@ -135,6 +135,7 @@ type Detail struct {
 	Cost                 float64
 	CostAsset            currency.Code
 	Fee                  float64
+	FeeAsset             currency.Code
 	Exchange             string
 	InternalOrderID      string
 	ID                   string


### PR DESCRIPTION
# PR Description
With c38757a68990858aa989557d2cdfb8be1e7f932f a number of issues were introduced. Some of them are:
1. instead of reading the order status, which is pushed through the websocket, floating point numbers were compared for equality :)
2. there was no average price populated
3. incorrectly fee was assigned to cost
4. "m" was being overridden by "M" 

This PR fixes all of them and, on top of that:
1. orders fields of WsOrderUpdateData the way they are described in the latest version of Binance docs + that's the same order when they come out of the websocket
2. adds and populates order.Detail.FeeAsset
3. sorts out mixed := and var declarations
4. orders temporary variables by the order they are used

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
