### PR TITLE
gctcli: remove all exchange name client-side validation

### DIFF
--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -291,10 +291,6 @@ func enableExchange(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -341,10 +337,6 @@ func disableExchange(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -389,10 +381,6 @@ func getExchangeOTPCode(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()
@@ -466,10 +454,6 @@ func getExchangeInfo(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -525,10 +509,6 @@ func getTicker(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -643,10 +623,6 @@ func getOrderbook(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
 	} else {
@@ -758,10 +734,6 @@ func getAccountInfo(c *cli.Context) error {
 		assetType = c.Args().Get(1)
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if !validAsset(assetType) {
 		return errInvalidAsset
 	}
@@ -822,10 +794,6 @@ func getAccountInfoStream(c *cli.Context) error {
 		assetType = c.String("asset")
 	} else {
 		assetType = c.Args().Get(1)
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if !validAsset(assetType) {
@@ -896,10 +864,6 @@ func updateAccountInfo(c *cli.Context) error {
 		assetType = c.String("asset")
 	} else {
 		assetType = c.Args().Get(1)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if !validAsset(assetType) {
@@ -1274,10 +1238,6 @@ func getOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1392,10 +1352,6 @@ func getManagedOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1487,10 +1443,6 @@ func getOrder(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1605,10 +1557,6 @@ func submitOrder(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -1758,10 +1706,6 @@ func simulateOrder(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
 	} else {
@@ -1865,10 +1809,6 @@ func whaleBomb(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -1985,10 +1925,6 @@ func cancelOrder(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("account_id") {
@@ -2133,10 +2069,6 @@ func cancelBatchOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("account_id") {
 		accountID = c.String("account_id")
 	} else {
@@ -2275,13 +2207,6 @@ func cancelAllOrders(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	// exchange name is an optional param
-	if exchangeName != "" {
-		if !validExchange(exchangeName) {
-			return errInvalidExchange
-		}
 	}
 
 	conn, err := setupClient()
@@ -2488,10 +2413,6 @@ func addEvent(c *cli.Context) error {
 		return fmt.Errorf("exchange name is required")
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("item") {
 		item = c.String("item")
 	} else {
@@ -2658,10 +2579,6 @@ func getCryptocurrencyDepositAddresses(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -2708,10 +2625,6 @@ func getCryptocurrencyDepositAddress(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("cryptocurrency") {
@@ -2794,10 +2707,6 @@ func withdrawCryptocurrencyFunds(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else if c.Args().Get(0) != "" {
 		exchange = c.Args().Get(0)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("currency") {
@@ -2909,10 +2818,6 @@ func withdrawFiatFunds(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else if c.Args().Get(0) != "" {
 		exchange = c.Args().Get(0)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("currency") {
@@ -3380,10 +3285,6 @@ func getOrderbookStream(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		pair = c.String("pair")
 	} else {
@@ -3516,10 +3417,6 @@ func getExchangeOrderbookStream(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -3587,10 +3484,6 @@ func getTickerStream(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -3693,10 +3586,6 @@ func getExchangeTickerStream(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()
@@ -4330,10 +4219,6 @@ func getHistoricCandles(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -4489,10 +4374,6 @@ func getHistoricCandlesExtended(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -4668,10 +4549,6 @@ func findMissingSavedCandleIntervals(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")

--- a/cmd/gctcli/data_history.go
+++ b/cmd/gctcli/data_history.go
@@ -382,9 +382,6 @@ func upsertDataHistoryJob(c *cli.Context) error {
 	if c.IsSet("exchange") {
 		exchange = c.String("exchange")
 	}
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
 
 	if c.IsSet("asset") {
 		assetType = c.String("asset")

--- a/cmd/gctcli/pair_management.go
+++ b/cmd/gctcli/pair_management.go
@@ -177,10 +177,6 @@ func enableDisableExchangePair(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pairs") {
 		pairs = c.String("pairs")
 	} else {
@@ -256,10 +252,6 @@ func getExchangePairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		asset = c.String("asset")
 	} else {
@@ -307,10 +299,6 @@ func enableDisableExchangeAsset(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("asset") {
@@ -361,10 +349,6 @@ func enableDisableAllExchangePairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -397,10 +381,6 @@ func updateExchangeSupportedPairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -430,10 +410,6 @@ func getExchangeAssets(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()

--- a/cmd/gctcli/trades.go
+++ b/cmd/gctcli/trades.go
@@ -229,10 +229,6 @@ func findMissingSavedTradeIntervals(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -324,10 +320,6 @@ func setExchangeTradeProcessing(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var status bool
 	if c.IsSet("status") {
 		status = c.Bool("status")
@@ -376,10 +368,6 @@ func getSavedTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -475,10 +463,6 @@ func getRecentTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -546,10 +530,6 @@ func getHistoricTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -668,10 +648,6 @@ func convertSavedTradesToCandles(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")

--- a/cmd/gctcli/validation.go
+++ b/cmd/gctcli/validation.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
@@ -16,10 +15,6 @@ var (
 
 func validPair(pair string) bool {
 	return strings.Contains(pair, pairDelimiter)
-}
-
-func validExchange(exch string) bool {
-	return exchange.IsSupported(exch)
 }
 
 func validAsset(i string) bool {

--- a/cmd/gctcli/websocket_management.go
+++ b/cmd/gctcli/websocket_management.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"
 	"github.com/urfave/cli/v2"
@@ -106,10 +105,6 @@ func getwebsocketInfo(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -137,10 +132,6 @@ func enableDisableWebsocket(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	conn, err := setupClient()
@@ -171,10 +162,6 @@ func getSubscriptions(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -201,10 +188,6 @@ func setProxy(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	var proxy string
@@ -240,10 +223,6 @@ func setURL(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	var url string


### PR DESCRIPTION
Since now exchange names can be user-assigned dynamically we can no longer have
client-side validation, all exchange name validation must now occur
on the server (it was already doing that).

- [X] New feature (non-breaking change which adds functionality)

- [X] go test ./... -race
- [X] golangci-lint run

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
