### PR TITLE
engine: allow exchange name to be set

### DIFF
--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -340,6 +340,11 @@ func (b *Base) GetName() string {
 	return b.Name
 }
 
+// SetName is a method that overrides the name of the exchange base
+func (b *Base) SetName(name string) {
+	b.Name = name
+}
+
 // GetEnabledFeatures returns the exchanges enabled features
 func (b *Base) GetEnabledFeatures() FeaturesEnabled {
 	return b.Features.Enabled

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -739,6 +739,20 @@ func TestGetName(t *testing.T) {
 	}
 }
 
+func TestSetName(t *testing.T) {
+	t.Parallel()
+
+	b := Base{
+		Name: "TESTNAM3",
+	}
+    b.SetName("TESTNAME")
+
+	name := b.GetName()
+	if name != "TESTNAME" {
+		t.Error("Exchange GetName() returned incorrect name")
+	}
+}
+
 func TestGetFeatures(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -24,6 +24,7 @@ type IBotExchange interface {
 	Start(wg *sync.WaitGroup)
 	SetDefaults()
 	GetName() string
+	SetName(string)
 	IsEnabled() bool
 	SetEnabled(bool)
 	ValidateCredentials(a asset.Item) error


### PR DESCRIPTION
Add a `SetName` to base exchange that allows custom exchange builders to set dynamic names.

- [X] New feature (non-breaking change which adds functionality)

- [X] go test ./... -race
- [X] golangci-lint run

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
