### PR TITLE
gctcli: remove all exchange name client-side validation

### DIFF
--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -291,10 +291,6 @@ func enableExchange(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -341,10 +337,6 @@ func disableExchange(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -389,10 +381,6 @@ func getExchangeOTPCode(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()
@@ -466,10 +454,6 @@ func getExchangeInfo(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -525,10 +509,6 @@ func getTicker(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -643,10 +623,6 @@ func getOrderbook(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
 	} else {
@@ -758,10 +734,6 @@ func getAccountInfo(c *cli.Context) error {
 		assetType = c.Args().Get(1)
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if !validAsset(assetType) {
 		return errInvalidAsset
 	}
@@ -822,10 +794,6 @@ func getAccountInfoStream(c *cli.Context) error {
 		assetType = c.String("asset")
 	} else {
 		assetType = c.Args().Get(1)
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if !validAsset(assetType) {
@@ -896,10 +864,6 @@ func updateAccountInfo(c *cli.Context) error {
 		assetType = c.String("asset")
 	} else {
 		assetType = c.Args().Get(1)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if !validAsset(assetType) {
@@ -1274,10 +1238,6 @@ func getOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1392,10 +1352,6 @@ func getManagedOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1487,10 +1443,6 @@ func getOrder(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		assetType = c.String("asset")
 	} else {
@@ -1605,10 +1557,6 @@ func submitOrder(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -1758,10 +1706,6 @@ func simulateOrder(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
 	} else {
@@ -1865,10 +1809,6 @@ func whaleBomb(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -1985,10 +1925,6 @@ func cancelOrder(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("account_id") {
@@ -2133,10 +2069,6 @@ func cancelBatchOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("account_id") {
 		accountID = c.String("account_id")
 	} else {
@@ -2277,13 +2209,6 @@ func cancelAllOrders(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	// exchange name is an optional param
-	if exchangeName != "" {
-		if !validExchange(exchangeName) {
-			return errInvalidExchange
-		}
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -2317,9 +2242,6 @@ func modifyOrder(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("asset") {
@@ -2488,10 +2410,6 @@ func addEvent(c *cli.Context) error {
 		return fmt.Errorf("exchange name is required")
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("item") {
 		item = c.String("item")
 	} else {
@@ -2658,10 +2576,6 @@ func getCryptocurrencyDepositAddresses(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -2708,10 +2622,6 @@ func getCryptocurrencyDepositAddress(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("cryptocurrency") {
@@ -2794,10 +2704,6 @@ func withdrawCryptocurrencyFunds(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else if c.Args().Get(0) != "" {
 		exchange = c.Args().Get(0)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("currency") {
@@ -2909,10 +2815,6 @@ func withdrawFiatFunds(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else if c.Args().Get(0) != "" {
 		exchange = c.Args().Get(0)
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("currency") {
@@ -3380,10 +3282,6 @@ func getOrderbookStream(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pair") {
 		pair = c.String("pair")
 	} else {
@@ -3516,10 +3414,6 @@ func getExchangeOrderbookStream(c *cli.Context) error {
 		exchangeName = c.Args().First()
 	}
 
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -3587,10 +3481,6 @@ func getTickerStream(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("pair") {
@@ -3693,10 +3583,6 @@ func getExchangeTickerStream(c *cli.Context) error {
 		exchangeName = c.String("exchange")
 	} else {
 		exchangeName = c.Args().First()
-	}
-
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()
@@ -4330,10 +4216,6 @@ func getHistoricCandles(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -4489,10 +4371,6 @@ func getHistoricCandlesExtended(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -4668,10 +4546,6 @@ func findMissingSavedCandleIntervals(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")

--- a/cmd/gctcli/data_history.go
+++ b/cmd/gctcli/data_history.go
@@ -382,9 +382,6 @@ func upsertDataHistoryJob(c *cli.Context) error {
 	if c.IsSet("exchange") {
 		exchange = c.String("exchange")
 	}
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
 
 	if c.IsSet("asset") {
 		assetType = c.String("asset")

--- a/cmd/gctcli/pair_management.go
+++ b/cmd/gctcli/pair_management.go
@@ -180,10 +180,6 @@ func enableDisableExchangePair(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("pairs") {
 		pairs = c.String("pairs")
 	} else {
@@ -259,10 +255,6 @@ func getExchangePairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	if c.IsSet("asset") {
 		asset = c.String("asset")
 	} else {
@@ -310,10 +302,6 @@ func enableDisableExchangeAsset(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	if c.IsSet("asset") {
@@ -364,10 +352,6 @@ func enableDisableAllExchangePairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -400,10 +384,6 @@ func updateExchangeSupportedPairs(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return errInvalidExchange
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -433,10 +413,6 @@ func getExchangeAssets(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return errInvalidExchange
 	}
 
 	conn, err := setupClient()

--- a/cmd/gctcli/trades.go
+++ b/cmd/gctcli/trades.go
@@ -229,10 +229,6 @@ func findMissingSavedTradeIntervals(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -324,10 +320,6 @@ func setExchangeTradeProcessing(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var status bool
 	if c.IsSet("status") {
 		status = c.Bool("status")
@@ -376,10 +368,6 @@ func getSavedTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -475,10 +463,6 @@ func getRecentTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -546,10 +530,6 @@ func getHistoricTrades(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
@@ -668,10 +648,6 @@ func convertSavedTradesToCandles(c *cli.Context) error {
 	} else {
 		exchangeName = c.Args().First()
 	}
-	if !validExchange(exchangeName) {
-		return errInvalidExchange
-	}
-
 	var currencyPair string
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")

--- a/cmd/gctcli/validation.go
+++ b/cmd/gctcli/validation.go
@@ -4,22 +4,16 @@ import (
 	"errors"
 	"strings"
 
-	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
 var (
-	errInvalidPair     = errors.New("invalid currency pair supplied")
-	errInvalidExchange = errors.New("invalid exchange supplied")
-	errInvalidAsset    = errors.New("invalid asset supplied")
+	errInvalidPair  = errors.New("invalid currency pair supplied")
+	errInvalidAsset = errors.New("invalid asset supplied")
 )
 
 func validPair(pair string) bool {
 	return strings.Contains(pair, pairDelimiter)
-}
-
-func validExchange(exch string) bool {
-	return exchange.IsSupported(exch)
 }
 
 func validAsset(i string) bool {

--- a/cmd/gctcli/websocket_management.go
+++ b/cmd/gctcli/websocket_management.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"
 	"github.com/urfave/cli/v2"
@@ -107,10 +106,6 @@ func getwebsocketInfo(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -138,10 +133,6 @@ func enableDisableWebsocket(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	conn, err := setupClient()
@@ -172,10 +163,6 @@ func getSubscriptions(c *cli.Context) error {
 		exchange = c.Args().First()
 	}
 
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
-	}
-
 	conn, err := setupClient()
 	if err != nil {
 		return err
@@ -202,10 +189,6 @@ func setProxy(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	var proxy string
@@ -241,10 +224,6 @@ func setURL(c *cli.Context) error {
 		exchange = c.String("exchange")
 	} else {
 		exchange = c.Args().First()
-	}
-
-	if !validExchange(exchange) {
-		return fmt.Errorf("[%s] is not a valid exchange", exchange)
 	}
 
 	var url string

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -286,6 +286,9 @@ func (s *RPCServer) EnableExchange(_ context.Context, r *gctrpc.GenericExchangeN
 
 // GetExchangeOTPCode retrieves an exchanges OTP code
 func (s *RPCServer) GetExchangeOTPCode(_ context.Context, r *gctrpc.GenericExchangeNameRequest) (*gctrpc.GetExchangeOTPResponse, error) {
+	if exch := s.GetExchangeByName(r.Exchange); exch == nil {
+		return nil, ErrExchangeNotFound
+	}
 	result, err := s.GetExchangeOTPByName(r.Exchange)
 	return &gctrpc.GetExchangeOTPResponse{OtpCode: result}, err
 }
@@ -1864,6 +1867,10 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 		return errExchangeNameUnset
 	}
 
+	if exch := s.GetExchangeByName(r.Exchange); exch == nil {
+		return ErrExchangeNotFound
+	}
+
 	pipe, err := orderbook.SubscribeToExchangeOrderbooks(r.Exchange)
 	if err != nil {
 		return err
@@ -1914,6 +1921,10 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gctrpc.GoCryptoTrader_GetTickerStreamServer) error {
 	if r.Exchange == "" {
 		return errExchangeNameUnset
+	}
+
+	if exch := s.GetExchangeByName(r.Exchange); exch == nil {
+		return ErrExchangeNotFound
 	}
 
 	a, err := asset.New(r.AssetType)
@@ -1977,6 +1988,10 @@ func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gct
 func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamRequest, stream gctrpc.GoCryptoTrader_GetExchangeTickerStreamServer) error {
 	if r.Exchange == "" {
 		return errExchangeNameUnset
+	}
+
+	if exch := s.GetExchangeByName(r.Exchange); exch == nil {
+		return ErrExchangeNotFound
 	}
 
 	pipe, err := ticker.SubscribeToExchangeTickers(r.Exchange)


### PR DESCRIPTION
Since now exchange names can be user-assigned we can no longer have
client-side validation, all exchange name validation must now occur
on the server (it was already doing that).

- [X] New feature (non-breaking change which adds functionality)

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
