### PR TITLE
Bitstamp: Fix currency pair handling

### DIFF
--- a/exchanges/bitstamp/bitstamp_live_test.go
+++ b/exchanges/bitstamp/bitstamp_live_test.go
@@ -1,4 +1,5 @@
-//+build mock_test_off
+//go:build mock_test_off
+// +build mock_test_off
 
 // This will build if build tag mock_test_off is parsed and will do live testing
 // using all tests in (exchange)_test.go

--- a/exchanges/bitstamp/bitstamp_mock_test.go
+++ b/exchanges/bitstamp/bitstamp_mock_test.go
@@ -1,4 +1,5 @@
-//+build !mock_test_off
+//go:build !mock_test_off
+// +build !mock_test_off
 
 // This will build if build tag mock_test_off is not parsed and will try to mock
 // all tests in _test.go

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -173,6 +173,27 @@ func TestGetTradingPairs(t *testing.T) {
 	}
 }
 
+func TestFetchTradablePairs(t *testing.T) {
+	t.Parallel()
+	r, err := b.FetchTradablePairs(asset.Spot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pairs, err := currency.NewPairsFromStrings(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pairs.Contains(currency.NewPair(currency.COMP, currency.USD), false) {
+		t.Error("expected pair COMP/USD")
+	}
+	if !pairs.Contains(currency.NewPair(currency.BTC, currency.USD), false) {
+		t.Error("expected pair BTC/USD")
+	}
+	if !pairs.Contains(currency.NewPair(currency.USDC, currency.USDT), false) {
+		t.Error("expected pair USDC/USDT")
+	}
+}
+
 func TestGetTransactions(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetTransactions(currency.BTC.String()+currency.USD.String(), "hour")

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -56,8 +56,11 @@ func (b *Bitstamp) SetDefaults() {
 	b.API.CredentialsValidator.RequiresKey = true
 	b.API.CredentialsValidator.RequiresSecret = true
 	b.API.CredentialsValidator.RequiresClientID = true
-	requestFmt := &currency.PairFormat{Uppercase: true}
-	configFmt := &currency.PairFormat{Uppercase: true}
+	requestFmt := &currency.PairFormat{}
+	configFmt := &currency.PairFormat{
+		Uppercase: true,
+		Delimiter: currency.ForwardSlashDelimiter,
+	}
 	err := b.SetGlobalPairsManager(requestFmt, configFmt, asset.Spot)
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
@@ -204,11 +207,61 @@ func (b *Bitstamp) Run() {
 		b.PrintEnabledPairs()
 	}
 
-	if !b.GetEnabledFeatures().AutoPairUpdates {
+	forceUpdate := false
+	format, err := b.GetPairFormat(asset.Spot, false)
+	if err != nil {
+		log.Errorf(log.ExchangeSys, "%s failed to get enabled currencies. Err %s\n",
+			b.Name,
+			err)
 		return
 	}
 
-	err := b.UpdateTradablePairs(false)
+	enabled, err := b.CurrencyPairs.GetPairs(asset.Spot, true)
+	if err != nil {
+		log.Errorf(log.ExchangeSys, "%s failed to get enabled currencies. Err %s\n",
+			b.Name,
+			err)
+		return
+	}
+
+	avail, err := b.CurrencyPairs.GetPairs(asset.Spot, false)
+	if err != nil {
+		log.Errorf(log.ExchangeSys, "%s failed to get available currencies. Err %s\n",
+			b.Name,
+			err)
+		return
+	}
+
+	if !common.StringDataContains(enabled.Strings(), format.Delimiter) ||
+		!common.StringDataContains(avail.Strings(), format.Delimiter) {
+		var enabledPairs currency.Pairs
+		enabledPairs, err = currency.NewPairsFromStrings([]string{
+			currency.BTC.String() + format.Delimiter + currency.USD.String(),
+		})
+		if err != nil {
+			log.Errorf(log.ExchangeSys, "%s failed to update currencies. Err %s\n",
+				b.Name,
+				err)
+		} else {
+			log.Warn(log.ExchangeSys,
+				"Bitstamp: Enabled and available pairs reset due to config upgrade, please enable the ones you would like to use again")
+			forceUpdate = true
+
+			err = b.UpdatePairs(enabledPairs, asset.Spot, true, true)
+			if err != nil {
+				log.Errorf(log.ExchangeSys,
+					"%s failed to update currencies. Err: %s\n",
+					b.Name,
+					err)
+			}
+		}
+	}
+
+	if !b.GetEnabledFeatures().AutoPairUpdates && !forceUpdate {
+		return
+	}
+
+	err = b.UpdateTradablePairs(forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",
@@ -229,9 +282,7 @@ func (b *Bitstamp) FetchTradablePairs(asset asset.Item) ([]string, error) {
 		if pairs[x].Trading != "Enabled" {
 			continue
 		}
-
-		pair := strings.Split(pairs[x].Name, "/")
-		products = append(products, pair[0]+pair[1])
+		products = append(products, pairs[x].Name)
 	}
 
 	return products, nil
@@ -672,9 +723,16 @@ func (b *Bitstamp) GetActiveOrders(req *order.GetOrdersRequest) ([]order.Detail,
 				"%s GetActiveOrders unable to parse time: %s\n", b.Name, err)
 		}
 
-		pair, err := currency.NewPairFromString(resp[i].Currency)
-		if err != nil {
-			return nil, err
+		var p currency.Pair
+		if currPair == "all" {
+			// Currency pairs are returned as format "currency_pair": "BTC/USD"
+			// only when all is specifed
+			p, err = currency.NewPairFromString(resp[i].Currency)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			p = req.Pairs[0]
 		}
 
 		orders = append(orders, order.Detail{
@@ -684,7 +742,7 @@ func (b *Bitstamp) GetActiveOrders(req *order.GetOrdersRequest) ([]order.Detail,
 			Type:     order.Limit,
 			Side:     orderSide,
 			Date:     tm,
-			Pair:     pair,
+			Pair:     p,
 			Exchange: b.Name,
 		})
 	}

--- a/testdata/http_mock/bitstamp/bitstamp.json
+++ b/testdata/http_mock/bitstamp/bitstamp.json
@@ -63740,142 +63740,934 @@
      "data": [
       {
        "base_decimals": 8,
-       "minimum_order": "5.0 USD",
-       "name": "LTC/USD",
        "counter_decimals": 2,
+       "description": "Bitcoin / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "ltcusd",
-       "description": "Litecoin / U.S. dollar"
+       "url_symbol": "btcusd"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "5.0 USD",
-       "name": "ETH/USD",
        "counter_decimals": 2,
+       "description": "Bitcoin / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "ethusd",
-       "description": "Ether / U.S. dollar"
+       "url_symbol": "btceur"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "5.0 EUR",
-       "name": "XRP/EUR",
-       "counter_decimals": 5,
-       "trading": "Enabled",
-       "url_symbol": "xrpeur",
-       "description": "XRP / Euro"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "5.0 USD",
-       "name": "BCH/USD",
        "counter_decimals": 2,
+       "description": "Bitcoin / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "bchusd",
-       "description": "Bitcoin Cash / U.S. dollar"
+       "url_symbol": "btcgbp"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "5.0 EUR",
-       "name": "BCH/EUR",
        "counter_decimals": 2,
+       "description": "Bitcoin / Paxos Standard",
+       "minimum_order": "20.0 PAX",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "bcheur",
-       "description": "Bitcoin Cash / Euro"
+       "url_symbol": "btcpax"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "5.0 EUR",
-       "name": "BTC/EUR",
        "counter_decimals": 2,
+       "description": "Bitcoin / Tether",
+       "minimum_order": "20.0 USDT",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "btceur",
-       "description": "Bitcoin / Euro"
+       "url_symbol": "btcusdt"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "0.001 BTC",
-       "name": "XRP/BTC",
-       "counter_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Bitcoin / USD Coin",
+       "minimum_order": "20.0 USDC",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "xrpbtc",
-       "description": "XRP / Bitcoin"
+       "url_symbol": "btcusdc"
       },
       {
        "base_decimals": 5,
-       "minimum_order": "5.0 USD",
-       "name": "EUR/USD",
        "counter_decimals": 5,
+       "description": "British Pound / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "eurusd",
-       "description": "Euro / U.S. dollar"
+       "url_symbol": "gbpusd"
       },
       {
-       "base_decimals": 8,
-       "minimum_order": "0.001 BTC",
-       "name": "BCH/BTC",
-       "counter_decimals": 8,
-       "trading": "Enabled",
-       "url_symbol": "bchbtc",
-       "description": "Bitcoin Cash / Bitcoin"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "5.0 EUR",
-       "name": "LTC/EUR",
-       "counter_decimals": 2,
-       "trading": "Enabled",
-       "url_symbol": "ltceur",
-       "description": "Litecoin / Euro"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "5.0 USD",
-       "name": "BTC/USD",
-       "counter_decimals": 2,
-       "trading": "Enabled",
-       "url_symbol": "btcusd",
-       "description": "Bitcoin / U.S. dollar"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "0.001 BTC",
-       "name": "LTC/BTC",
-       "counter_decimals": 8,
-       "trading": "Enabled",
-       "url_symbol": "ltcbtc",
-       "description": "Litecoin / Bitcoin"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "5.0 USD",
-       "name": "XRP/USD",
+       "base_decimals": 5,
        "counter_decimals": 5,
+       "description": "British Pound / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "xrpusd",
-       "description": "XRP / U.S. dollar"
+       "url_symbol": "gbpeur"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Euro / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "eurusd"
       },
       {
        "base_decimals": 8,
-       "minimum_order": "0.001 BTC",
-       "name": "ETH/BTC",
-       "counter_decimals": 8,
-       "trading": "Enabled",
-       "url_symbol": "ethbtc",
-       "description": "Ether / Bitcoin"
-      },
-      {
-       "base_decimals": 8,
-       "minimum_order": "5.0 EUR",
-       "name": "ETH/EUR",
        "counter_decimals": 2,
+       "description": "Ether / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
        "trading": "Enabled",
-       "url_symbol": "etheur",
-       "description": "Ether / Euro"
+       "url_symbol": "ethusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Ether / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "etheur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Ether / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ethbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Ether / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ethgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Ether / Paxos Standard",
+       "minimum_order": "20.0 PAX",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ethpax"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Ether / Tether",
+       "minimum_order": "20.0 USDT",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ethusdt"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Ether / USD Coin",
+       "minimum_order": "20.0 USDC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ethusdc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "XRP / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrpusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "XRP / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrpeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "XRP / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrpbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "XRP / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrpgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "XRP / Paxos Standard",
+       "minimum_order": "20.0 PAX",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrppax"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "XRP / Tether",
+       "minimum_order": "20.0 USDT",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xrpusdt"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Uniswap / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "uniusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Uniswap / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "unieur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Uniswap / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "unibtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Litecoin / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ltcusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Litecoin / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ltceur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Litecoin / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ltcbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Litecoin / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "ltcgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Chainlink / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "linkusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Chainlink / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "linkeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Chainlink / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "linkbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Chainlink / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "linkgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Chainlink / Ether",
+       "minimum_order": "0.005 ETH",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "linketh"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Polygon / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "maticusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Polygon / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "maticeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Stellar Lumens / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xlmusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Stellar Lumens / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xlmeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Stellar Lumens / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xlmbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Stellar Lumens / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "xlmgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Bitcoin Cash / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "bchusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Bitcoin Cash / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "bcheur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Bitcoin Cash / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "bchbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Bitcoin Cash / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "bchgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "AAVE / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "aaveusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "AAVE / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "aaveeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "AAVE / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "aavebtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Algorand / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "algousd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Algorand / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "algoeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Algorand / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "algobtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Compound / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "compusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Compound / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "compeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Compound / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "compbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Synthetix / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "snxusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Synthetix / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "snxeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Synthetix / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "snxbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Enjin Coin / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "enjusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Enjin Coin / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "enjeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Basic Attention Token / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "batusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Basic Attention Token / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "bateur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Basic Attention Token / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "batbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Maker / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "mkrusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "Maker / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "mkreur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Maker / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "mkrbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "0x / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "zrxusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "0x / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "zrxeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "0x / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "zrxbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "yearn.finance / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "yfiusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "yearn.finance / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "yfieur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "yearn.finance / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "yfibtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "SushiSwap / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "sushiusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "SushiSwap / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "sushieur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "The Graph / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "grtusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "The Graph / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "grteur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "UMA / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "umausd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "UMA / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "umaeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "UMA / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "umabtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "OMG Network / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "omgusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "OMG Network / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "omgeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "OMG Network / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "omgbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 2,
+       "description": "OMG Network / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "omggbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Kyber Network / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "kncusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Kyber Network / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "knceur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Kyber Network / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "kncbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Curve / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "crvusd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Curve / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "crveur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Curve / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "crvbtc"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Audius / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "audiousd"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 5,
+       "description": "Audius / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "audioeur"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Audius / Bitcoin",
+       "minimum_order": "0.0002 BTC",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "audiobtc"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Tether / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "usdtusd"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Tether / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "usdteur"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "USD Coin / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "usdcusd"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "USD Coin / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "usdceur"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "USD Coin / Tether",
+       "minimum_order": "20.0 USDT",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "usdcusdt"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Euro Tether / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "eurtusd"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Euro Tether / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "eurteur"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "DAI / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "daiusd"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Paxos Standard / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "paxusd"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Paxos Standard / Euro",
+       "minimum_order": "20.0 EUR",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "paxeur"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Paxos Standard / British Pound",
+       "minimum_order": "20.0 GBP",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "paxgbp"
+      },
+      {
+       "base_decimals": 8,
+       "counter_decimals": 8,
+       "description": "Ethereum 2.0 / Ether",
+       "minimum_order": "0.005 ETH",
+       "name": "",
+       "trading": "Disabled",
+       "url_symbol": "eth2eth"
+      },
+      {
+       "base_decimals": 5,
+       "counter_decimals": 5,
+       "description": "Gemini Dollar / U.S. dollar",
+       "minimum_order": "20.0 USD",
+       "name": "",
+       "trading": "Enabled",
+       "url_symbol": "gusdusd"
       }
      ],
      "queryString": "",
-     "bodyParams": "\u003cnil\u003e",
+     "bodyParams": "",
      "headers": {
       "Referer": [
        "https://www.bitstamp.net/api/v2/trading-pairs-info"


### PR DESCRIPTION
# PR Description

Przemysław Skiba from Slack reported an issue with pair handling for Bitstamp. Previously, Bitstamp only had pairs which had 6 characters in length: "BTCUSD" whereas now it supports "USDT/USDC". This PR introduces a delimiter to handle the pairs correctly. Note: Their REST endpoints return currency pairs as "BTC/USDT" whereas their websocket endpoint returns currency pair as "btcusdt"

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
