### PR TITLE
Binance: Fix UKlineData func

### DIFF
--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -218,7 +219,7 @@ func (b *Binance) UKlineData(symbol currency.Pair, interval string, limit int64,
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, interval) {
+	if !common.StringDataCompare(validFuturesIntervals, interval) {
 		return resp, errors.New("invalid interval")
 	}
 	params.Set("interval", interval)
@@ -229,8 +230,8 @@ func (b *Binance) UKlineData(symbol currency.Pair, interval string, limit int64,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", timeString(startTime))
+		params.Set("endTime", timeString(endTime))
 	}
 	rateBudget := uFuturesDefaultRate
 	switch {
@@ -256,7 +257,10 @@ func (b *Binance) UKlineData(symbol currency.Pair, interval string, limit int64,
 		if !ok {
 			return resp, errors.New("type assertion failed for opentime")
 		}
-		tempData.OpenTime = time.Unix(int64(floatData), 0)
+		tempData.OpenTime, err = convert.TimeFromUnixTimestampFloat(floatData)
+		if err != nil {
+			return resp, err
+		}
 		strData, ok = data[x][1].(string)
 		if !ok {
 			return resp, errors.New("type assertion failed for open")
@@ -306,7 +310,10 @@ func (b *Binance) UKlineData(symbol currency.Pair, interval string, limit int64,
 		if !ok {
 			return resp, errors.New("type assertion failed for close time")
 		}
-		tempData.CloseTime = time.Unix(int64(floatData), 0)
+		tempData.CloseTime, err = convert.TimeFromUnixTimestampFloat(floatData)
+		if err != nil {
+			return resp, err
+		}
 		strData, ok = data[x][7].(string)
 		if !ok {
 			return resp, errors.New("type assertion failed base asset volume")


### PR DESCRIPTION
# PR Description
Fix some issues for `exchanges/binance/binance_ufutures.go#UKlineData` function
1. `UKlineData` func introduce some wrong parameters which lead to wrong response
start_time -> startTime
end_time -> endTime

2. Incorrect supported interval list
`ufuturesKlineData          = "/fapi/v1/klines?"`
The endpoint for this func can support all intervals the list of `validFuturesIntervals`
uValidPeriods -> validFuturesIntervals

3. Make consistency for time format with others Kline fetching func (ex: GetSpotKline)
time.Unix() --> convert.TimeFromUnixTimestampFloat 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
