### PR TITLE
FTX: allow authenticated tests to run

### DIFF
--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 	exchCfg.API.Credentials.Key = apiKey
 	exchCfg.API.Credentials.Secret = apiSecret
 	exchCfg.API.Credentials.Subaccount = subaccount
-	if areTestAPIKeysSet() {
+	if apiKey != "" && apiSecret != "" {
 		// Only set auth to true when keys present as fee online calculation requires authentication
 		exchCfg.API.AuthenticatedSupport = true
 		exchCfg.API.AuthenticatedWebsocketSupport = true


### PR DESCRIPTION
# PR Description
I made a mistake in a previous PR which allowed test fee calculation to work without API keys present. Problem is, when API keys are present, authenticated tests don't run as `areTestAPIKeysSet()` requires `exchCfg.API.AuthenticatedSupport = true` be set before setting API keys, which then makes `GetFee` require API keys... 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
I tested with keys and then authenticated tests could run.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
