### PR TITLE
engine/order manager: Initial REST managed order updating (resolves #772)

### DIFF
--- a/engine/apiserver.go
+++ b/engine/apiserver.go
@@ -305,7 +305,7 @@ func getAllActiveOrderbooks(m iExchangeManager) []EnabledExchangeOrderbooks {
 	var orderbookData []EnabledExchangeOrderbooks
 	exchanges, err := m.GetExchanges()
 	if err != nil {
-		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
 	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
@@ -345,7 +345,7 @@ func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
 	var tickers []EnabledExchangeCurrencies
 	exchanges, err := m.GetExchanges()
 	if err != nil {
-		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
 	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
@@ -385,7 +385,7 @@ func getAllActiveAccounts(m iExchangeManager) []AllEnabledExchangeAccounts {
 	var accounts []AllEnabledExchangeAccounts
 	exchanges, err := m.GetExchanges()
 	if err != nil {
-		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
 	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)

--- a/engine/apiserver.go
+++ b/engine/apiserver.go
@@ -303,7 +303,10 @@ func (m *apiServerManager) getIndex(w http.ResponseWriter, _ *http.Request) {
 // getAllActiveOrderbooks returns all enabled exchanges orderbooks
 func getAllActiveOrderbooks(m iExchangeManager) []EnabledExchangeOrderbooks {
 	var orderbookData []EnabledExchangeOrderbooks
-	exchanges := m.GetExchanges()
+	exchanges, err := m.GetExchanges()
+	if err != nil {
+		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()
@@ -340,7 +343,10 @@ func getAllActiveOrderbooks(m iExchangeManager) []EnabledExchangeOrderbooks {
 // getAllActiveTickers returns all enabled exchanges tickers
 func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
 	var tickers []EnabledExchangeCurrencies
-	exchanges := m.GetExchanges()
+	exchanges, err := m.GetExchanges()
+	if err != nil {
+		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()
@@ -377,7 +383,10 @@ func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
 // getAllActiveAccounts returns all enabled exchanges accounts
 func getAllActiveAccounts(m iExchangeManager) []AllEnabledExchangeAccounts {
 	var accounts []AllEnabledExchangeAccounts
-	exchanges := m.GetExchanges()
+	exchanges, err := m.GetExchanges()
+	if err != nil {
+		log.Errorf(log.OrderMgr, "Cannot get exchanges: %v", err)
+	}
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -716,7 +716,12 @@ func (bot *Engine) UnloadExchange(exchName string) error {
 
 // GetExchanges retrieves the loaded exchanges
 func (bot *Engine) GetExchanges() []exchange.IBotExchange {
-	return bot.ExchangeManager.GetExchanges()
+	exch, err := bot.ExchangeManager.GetExchanges()
+	if err != nil {
+		gctlog.Warnf(gctlog.ExchangeSys, "Cannot get exchanges: %v", err)
+		return []exchange.IBotExchange{}
+	}
+	return exch
 }
 
 // LoadExchange loads an exchange by name. Optional wait group can be added for
@@ -917,7 +922,7 @@ func (bot *Engine) SetupExchanges() error {
 		}(configs[x])
 	}
 	wg.Wait()
-	if len(bot.ExchangeManager.GetExchanges()) == 0 {
+	if len(bot.GetExchanges()) == 0 {
 		return ErrNoExchangesLoaded
 	}
 	return nil

--- a/engine/exchange_manager.go
+++ b/engine/exchange_manager.go
@@ -61,7 +61,6 @@ type ExchangeManager struct {
 
 // SetupExchangeManager creates a new exchange manager
 func SetupExchangeManager() *ExchangeManager {
-	log.Warnf(log.ExchangeSys, "exchange manager setup")
 	return &ExchangeManager{
 		exchanges: make(map[string]exchange.IBotExchange),
 	}

--- a/engine/exchange_manager.go
+++ b/engine/exchange_manager.go
@@ -78,9 +78,9 @@ func (m *ExchangeManager) Add(exch exchange.IBotExchange) {
 }
 
 // GetExchanges returns all stored exchanges
-func (m *ExchangeManager) GetExchanges() []exchange.IBotExchange {
+func (m *ExchangeManager) GetExchanges() ([]exchange.IBotExchange, error) {
 	if m == nil {
-		log.Errorf(log.ExchangeSys, "exchange manager: %v", ErrNilSubsystem)
+		return nil, fmt.Errorf("exchange manager: %w", ErrNilSubsystem)
 	}
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -88,7 +88,7 @@ func (m *ExchangeManager) GetExchanges() []exchange.IBotExchange {
 	for _, x := range m.exchanges {
 		exchs = append(exchs, x)
 	}
-	return exchs
+	return exchs, nil
 }
 
 // RemoveExchange removes an exchange from the manager

--- a/engine/exchange_manager.go
+++ b/engine/exchange_manager.go
@@ -61,6 +61,7 @@ type ExchangeManager struct {
 
 // SetupExchangeManager creates a new exchange manager
 func SetupExchangeManager() *ExchangeManager {
+	log.Warnf(log.ExchangeSys, "exchange manager setup")
 	return &ExchangeManager{
 		exchanges: make(map[string]exchange.IBotExchange),
 	}
@@ -78,6 +79,9 @@ func (m *ExchangeManager) Add(exch exchange.IBotExchange) {
 
 // GetExchanges returns all stored exchanges
 func (m *ExchangeManager) GetExchanges() []exchange.IBotExchange {
+	if m == nil {
+		log.Errorf(log.ExchangeSys, "exchange manager: %v", ErrNilSubsystem)
+	}
 	m.m.Lock()
 	defer m.m.Unlock()
 	var exchs []exchange.IBotExchange

--- a/engine/exchange_manager_test.go
+++ b/engine/exchange_manager_test.go
@@ -28,7 +28,11 @@ func TestExchangeManagerAdd(t *testing.T) {
 	b := new(bitfinex.Bitfinex)
 	b.SetDefaults()
 	m.Add(b)
-	if exch := m.GetExchanges(); exch[0].GetName() != "Bitfinex" {
+	exchanges, err := m.GetExchanges()
+	if err != nil {
+		t.Error("no exchange manager found")
+	}
+	if exchanges[0].GetName() != "Bitfinex" {
 		t.Error("unexpected exchange name")
 	}
 }
@@ -36,13 +40,21 @@ func TestExchangeManagerAdd(t *testing.T) {
 func TestExchangeManagerGetExchanges(t *testing.T) {
 	t.Parallel()
 	m := SetupExchangeManager()
-	if exchanges := m.GetExchanges(); exchanges != nil {
+	exchanges, err := m.GetExchanges()
+	if err != nil {
+		t.Error("no exchange manager found")
+	}
+	if exchanges != nil {
 		t.Error("unexpected value")
 	}
 	b := new(bitfinex.Bitfinex)
 	b.SetDefaults()
 	m.Add(b)
-	if exch := m.GetExchanges(); exch[0].GetName() != "Bitfinex" {
+	exchanges, err = m.GetExchanges()
+	if err != nil {
+		t.Error("no exchange manager found")
+	}
+	if exchanges[0].GetName() != "Bitfinex" {
 		t.Error("unexpected exchange name")
 	}
 }

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -719,7 +719,7 @@ func (bot *Engine) GetExchangeCryptocurrencyDepositAddresses() map[string]map[st
 
 // GetExchangeNames returns a list of enabled or disabled exchanges
 func (bot *Engine) GetExchangeNames(enabledOnly bool) []string {
-	exchanges := bot.ExchangeManager.GetExchanges()
+	exchanges := bot.GetExchanges()
 	var response []string
 	for i := range exchanges {
 		if !enabledOnly || (enabledOnly && exchanges[i].IsEnabled()) {

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -570,10 +570,6 @@ func (m *OrderManager) processSubmittedOrder(newOrder *order.Submit, result orde
 // processOrders iterates over all exchange orders via API
 // and adds them to the internal order store
 func (m *OrderManager) processOrders() {
-	if m.orderStore.exchangeManager == nil {
-		log.Errorf(log.OrderMgr, "order manager: %v", ErrNilSubsystem)
-	}
-	log.Warnf(log.OrderMgr, "order manager: getting exchanges")
 	exchanges, err := m.orderStore.exchangeManager.GetExchanges()
 	if err != nil {
 		log.Errorf(log.OrderMgr, "Order manager cannot get exchanges: %v", err)

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -658,7 +658,11 @@ func (m *OrderManager) processOrders() {
 }
 
 func (m *OrderManager) processMatchingOrders(exch exchange.IBotExchange, orders []order.Detail, requiresProcessing map[string]bool, wg *sync.WaitGroup) {
-	defer wg.Done()
+	defer func() {
+		if wg != nil {
+			wg.Done()
+		}
+	}()
 	for x := range orders {
 		if time.Since(orders[x].LastUpdated) < time.Minute {
 			continue

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -601,6 +601,14 @@ func (m *OrderManager) processOrders() {
 				Exchange: exchanges[i].GetName(),
 			}
 			orders, err := m.orderStore.getActiveOrders(filter)
+			if err != nil {
+				log.Errorf(log.OrderMgr,
+					"Order manager: Unable to get active orders for %s and asset type %s: %s",
+					exchanges[i].GetName(),
+					supportedAssets[y],
+					err)
+				continue
+			}
 			order.FilterOrdersByCurrencies(&orders, pairs)
 			requiresProcessing := make(map[string]bool, len(orders))
 			for x := range orders {

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -567,6 +567,10 @@ func (m *OrderManager) processSubmittedOrder(newOrder *order.Submit, result orde
 // processOrders iterates over all exchange orders via API
 // and adds them to the internal order store
 func (m *OrderManager) processOrders() {
+	if m.orderStore.exchangeManager == nil {
+		log.Errorf(log.OrderMgr, "order manager: %v", ErrNilSubsystem)
+	}
+	log.Warnf(log.OrderMgr, "order manager: getting exchanges")
 	exchanges := m.orderStore.exchangeManager.GetExchanges()
 	for i := range exchanges {
 		if !exchanges[i].GetAuthenticatedAPISupport(exchange.RestAuthentication) {

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -666,6 +666,9 @@ func (m *OrderManager) processMatchingOrders(exch exchange.IBotExchange, orders 
 
 // FetchAndUpdateExchangeOrder calls the exchange to upsert an order to the order store
 func (m *OrderManager) FetchAndUpdateExchangeOrder(exch exchange.IBotExchange, ord *order.Detail, assetType asset.Item) error {
+	if ord == nil {
+		return errors.New("order manager: Order is nil")
+	}
 	fetchedOrder, err := exch.GetOrderInfo(ord.ID, ord.Pair, assetType)
 	if err != nil {
 		ord.Status = order.UnknownStatus

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -90,6 +90,7 @@ func (m *OrderManager) gracefulShutdown() {
 		exchanges, err := m.orderStore.exchangeManager.GetExchanges()
 		if err != nil {
 			log.Errorf(log.OrderMgr, "Order manager cannot get exchanges: %v", err)
+			return
 		}
 		m.CancelAllOrders(context.TODO(), exchanges)
 	}
@@ -579,6 +580,7 @@ func (m *OrderManager) processOrders() {
 	exchanges, err := m.orderStore.exchangeManager.GetExchanges()
 	if err != nil {
 		log.Errorf(log.OrderMgr, "Order manager cannot get exchanges: %v", err)
+		return
 	}
 	var wg sync.WaitGroup
 	for i := range exchanges {

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -836,12 +836,12 @@ func (s *store) modifyExisting(id string, mod *order.Modify) error {
 // order exists and updates/creates it.
 func (s *store) upsert(od *order.Detail) (resp *OrderUpsertResponse, err error) {
 	if od == nil {
-		return &OrderUpsertResponse{}, errNilOrder
+		return nil, errNilOrder
 	}
 	lName := strings.ToLower(od.Exchange)
 	_, err = s.exchangeManager.GetExchangeByName(lName)
 	if err != nil {
-		return &OrderUpsertResponse{}, err
+		return nil, err
 	}
 	s.m.Lock()
 	defer s.m.Unlock()
@@ -978,9 +978,6 @@ func (s *store) getFilteredOrders(f *order.Filter) ([]order.Detail, error) {
 
 // getActiveOrders returns copy of the orders that are active
 func (s *store) getActiveOrders(f *order.Filter) ([]order.Detail, error) {
-	if f == nil {
-		return nil, errors.New("filter is nil")
-	}
 	s.m.RLock()
 	defer s.m.RUnlock()
 

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -775,10 +775,10 @@ func (m *OrderManager) UpsertOrder(od *order.Detail) error {
 		upsertResponse.OrderDetails.Pair, upsertResponse.OrderDetails.Price, upsertResponse.OrderDetails.Amount,
 		upsertResponse.OrderDetails.Side, upsertResponse.OrderDetails.Type)
 	if upsertResponse.IsNewOrder {
-		log.Infof(log.OrderMgr, "%s", msg)
+		log.Info(log.OrderMgr, msg)
 		return nil
 	}
-	log.Debugf(log.OrderMgr, "%s", msg)
+	log.Debug(log.OrderMgr, msg)
 	return nil
 }
 

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -95,6 +95,7 @@ func (m *OrderManager) gracefulShutdown() {
 // run will periodically process orders
 func (m *OrderManager) run() {
 	log.Debugln(log.OrderMgr, "Order manager started.")
+	m.processOrders()
 	tick := time.NewTicker(orderManagerDelay)
 	m.orderStore.wg.Add(1)
 	defer func() {

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -767,8 +767,11 @@ func (m *OrderManager) UpsertOrder(od *order.Detail) error {
 		upsertResponse.OrderDetails.Exchange, status, upsertResponse.OrderDetails.ID, upsertResponse.OrderDetails.InternalOrderID,
 		upsertResponse.OrderDetails.Pair, upsertResponse.OrderDetails.Price, upsertResponse.OrderDetails.Amount,
 		upsertResponse.OrderDetails.Side, upsertResponse.OrderDetails.Type)
-	log.Infof(log.OrderMgr, "%s", msg)
-
+	if upsertResponse.IsNewOrder {
+		log.Infof(log.OrderMgr, "%s", msg)
+		return nil
+	}
+	log.Debugf(log.OrderMgr, "%s", msg)
 	return nil
 }
 

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -737,12 +737,16 @@ func (m *OrderManager) UpsertOrder(od *order.Detail) error {
 		return errNilOrder
 	}
 	var msg string
-	defer func(message string) {
+	defer func(message *string) {
+		if message == nil {
+			log.Errorf(log.OrderMgr, "UpsertOrder: produced nil order event message\n")
+			return
+		}
 		m.orderStore.commsManager.PushEvent(base.Event{
 			Type:    "order",
-			Message: message,
+			Message: *message,
 		})
-	}(msg)
+	}(&msg)
 
 	updatedOrder, err := m.orderStore.upsert(od)
 	if err != nil {

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -11,6 +11,7 @@ import (
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // omfExchange aka ordermanager fake exchange overrides exchange functions
@@ -157,6 +158,7 @@ func OrdersSetup(t *testing.T) *OrderManager {
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
+	log.Warnf(log.OrderMgr, "OrdersSetup - setup ordermanager with fake exchange")
 	err = m.Start()
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -871,7 +871,6 @@ func Test_processMatchingOrders(t *testing.T) {
 	if res[0].ID != "Test4" {
 		t.Error("Order Test4 should have been fetched and updated")
 	}
-
 }
 
 func TestFetchAndUpdateExchangeOrder(t *testing.T) {

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -158,10 +158,6 @@ func OrdersSetup(t *testing.T) *OrderManager {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
 	m.started = 1
-	if !errors.Is(err, nil) {
-		t.Errorf("error '%v', expected '%v'", err, nil)
-	}
-
 	return m
 }
 

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // omfExchange aka ordermanager fake exchange overrides exchange functions
@@ -748,7 +747,6 @@ func TestOrderManager_Modify(t *testing.T) {
 }
 
 func TestProcessOrders(t *testing.T) {
-	log.Warnf(log.OrderMgr, "TestProcessOrders - set up orders starting")
 	var wg sync.WaitGroup
 	em := SetupExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
@@ -1048,7 +1046,7 @@ func Test_processMatchingOrders(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go m.processMatchingOrders(exch, orders, requiresProcessing, &wg)
+	m.processMatchingOrders(exch, orders, requiresProcessing, &wg)
 	wg.Wait()
 	res, err := m.GetOrdersFiltered(&order.Filter{Exchange: testExchange})
 	if err != nil {

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -942,24 +942,15 @@ func Test_getActiveOrders(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	res, err := m.orderStore.getActiveOrders(nil)
-	if err != nil {
-		t.Error(err)
-	}
+	res := m.orderStore.getActiveOrders(nil)
 	if len(res) != 1 {
 		t.Errorf("Test_getActiveOrders - Expected 1 result, got: %d", len(res))
 	}
-	res, err = m.orderStore.getActiveOrders(&order.Filter{Side: order.Sell})
-	if err != nil {
-		t.Error(err)
-	}
+	res = m.orderStore.getActiveOrders(&order.Filter{Side: order.Sell})
 	if len(res) != 1 {
 		t.Errorf("Test_getActiveOrders - Expected 1 result, got: %d", len(res))
 	}
-	res, err = m.orderStore.getActiveOrders(&order.Filter{Side: order.Buy})
-	if err != nil {
-		t.Error(err)
-	}
+	res = m.orderStore.getActiveOrders(&order.Filter{Side: order.Buy})
 	if len(res) != 0 {
 		t.Errorf("Test_getActiveOrders - Expected 0 results, got: %d", len(res))
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -157,6 +157,7 @@ func OrdersSetup(t *testing.T) *OrderManager {
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
+	m.started = 1
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -11,7 +11,6 @@ import (
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // omfExchange aka ordermanager fake exchange overrides exchange functions
@@ -158,8 +157,6 @@ func OrdersSetup(t *testing.T) *OrderManager {
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
-	log.Warnf(log.OrderMgr, "OrdersSetup - setup ordermanager with fake exchange")
-	err = m.Start()
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -856,7 +856,10 @@ func Test_processMatchingOrders(t *testing.T) {
 			requiresProcessing[orders[i].InternalOrderID] = true
 		}
 	}
-	m.processMatchingOrders(exch, orders, requiresProcessing)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go m.processMatchingOrders(exch, orders, requiresProcessing, &wg)
+	wg.Wait()
 	res, err := m.GetOrdersFiltered(&order.Filter{Exchange: testExchange})
 	if err != nil {
 		t.Error(err)

--- a/engine/order_manager_types.go
+++ b/engine/order_manager_types.go
@@ -22,6 +22,7 @@ var (
 	errNilCommunicationsManager = errors.New("cannot start with nil communications manager")
 	// ErrOrderIDCannotBeEmpty occurs when an order does not have an ID
 	ErrOrderIDCannotBeEmpty = errors.New("orderID cannot be empty")
+	errNilOrder             = errors.New("nil order received")
 )
 
 type orderManagerConfig struct {

--- a/engine/order_manager_types.go
+++ b/engine/order_manager_types.go
@@ -46,11 +46,12 @@ type store struct {
 
 // OrderManager processes and stores orders across enabled exchanges
 type OrderManager struct {
-	started    int32
-	shutdown   chan struct{}
-	orderStore store
-	cfg        orderManagerConfig
-	verbose    bool
+	started          int32
+	processingOrders int32
+	shutdown         chan struct{}
+	orderStore       store
+	cfg              orderManagerConfig
+	verbose          bool
 }
 
 // OrderSubmitResponse contains the order response along with an internal order ID

--- a/engine/order_manager_types.go
+++ b/engine/order_manager_types.go
@@ -58,3 +58,10 @@ type OrderSubmitResponse struct {
 	order.SubmitResponse
 	InternalOrderID string
 }
+
+// OrderUpsertResponse contains a copy of the resulting order details and a bool
+// indicating if the order details were inserted (true) or updated (false)
+type OrderUpsertResponse struct {
+	OrderDetails order.Detail
+	IsNewOrder   bool
+}

--- a/engine/portfolio_manager.go
+++ b/engine/portfolio_manager.go
@@ -145,7 +145,7 @@ func (m *portfolioManager) processPortfolio() {
 
 	exchanges, err := m.exchangeManager.GetExchanges()
 	if err != nil {
-		log.Errorf(log.OrderMgr, "Portfolio manager cannot get exchanges: %v", err)
+		log.Errorf(log.PortfolioMgr, "Portfolio manager cannot get exchanges: %v", err)
 	}
 	d := m.getExchangeAccountInfo(exchanges)
 	m.seedExchangeAccountInfo(d)

--- a/engine/portfolio_manager.go
+++ b/engine/portfolio_manager.go
@@ -143,7 +143,11 @@ func (m *portfolioManager) processPortfolio() {
 			value)
 	}
 
-	d := m.getExchangeAccountInfo(m.exchangeManager.GetExchanges())
+	exchanges, err := m.exchangeManager.GetExchanges()
+	if err != nil {
+		log.Errorf(log.OrderMgr, "Portfolio manager cannot get exchanges: %v", err)
+	}
+	d := m.getExchangeAccountInfo(exchanges)
 	m.seedExchangeAccountInfo(d)
 	atomic.CompareAndSwapInt32(&m.processing, 1, 0)
 }

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -482,7 +482,10 @@ func (s *RPCServer) GetOrderbook(ctx context.Context, r *gctrpc.GetOrderbookRequ
 // GetOrderbooks returns a list of orderbooks for all enabled exchanges and all
 // enabled currency pairs
 func (s *RPCServer) GetOrderbooks(ctx context.Context, _ *gctrpc.GetOrderbooksRequest) (*gctrpc.GetOrderbooksResponse, error) {
-	exchanges := s.ExchangeManager.GetExchanges()
+	exchanges, err := s.ExchangeManager.GetExchanges()
+	if err != nil {
+		return nil, err
+	}
 	var obResponse []*gctrpc.Orderbooks
 	var obs []*gctrpc.OrderbookResponse
 	for x := range exchanges {

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1015,10 +1015,7 @@ func TestGetOrders(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
-	err = om.Start()
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v', expected '%v'", err, nil)
-	}
+	om.started = 1
 	s := RPCServer{Engine: &Engine{ExchangeManager: em, OrderManager: om}}
 
 	p := &gctrpc.CurrencyPair{
@@ -1126,7 +1123,7 @@ func TestGetOrder(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
-	err = om.Start()
+	om.started = 1
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -1656,10 +1653,7 @@ func TestGetManagedOrders(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
-	err = om.Start()
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v', expected '%v'", err, nil)
-	}
+	om.started = 1
 	s := RPCServer{Engine: &Engine{ExchangeManager: em, OrderManager: om}}
 
 	p := &gctrpc.CurrencyPair{

--- a/engine/subsystem_types.go
+++ b/engine/subsystem_types.go
@@ -42,7 +42,7 @@ var (
 // iExchangeManager limits exposure of accessible functions to exchange manager
 // so that subsystems can use some functionality
 type iExchangeManager interface {
-	GetExchanges() []exchange.IBotExchange
+	GetExchanges() ([]exchange.IBotExchange, error)
 	GetExchangeByName(string) (exchange.IBotExchange, error)
 }
 

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -104,7 +104,10 @@ func (m *syncManager) Start() error {
 	m.initSyncWG.Add(1)
 	m.inService.Done()
 	log.Debugln(log.SyncMgr, "Exchange CurrencyPairSyncer started.")
-	exchanges := m.exchangeManager.GetExchanges()
+	exchanges, err := m.exchangeManager.GetExchanges()
+	if err != nil {
+		return err
+	}
 	for x := range exchanges {
 		exchangeName := exchanges[x].GetName()
 		supportsWebsocket := exchanges[x].SupportsWebsocket()
@@ -454,7 +457,10 @@ func (m *syncManager) worker() {
 	defer cleanup()
 
 	for atomic.LoadInt32(&m.started) != 0 {
-		exchanges := m.exchangeManager.GetExchanges()
+		exchanges, err := m.exchangeManager.GetExchanges()
+		if err != nil {
+			log.Errorf(log.OrderMgr, "Sync manager cannot get exchanges: %v", err)
+		}
 		for x := range exchanges {
 			exchangeName := exchanges[x].GetName()
 			supportsREST := exchanges[x].SupportsREST()

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -459,7 +459,7 @@ func (m *syncManager) worker() {
 	for atomic.LoadInt32(&m.started) != 0 {
 		exchanges, err := m.exchangeManager.GetExchanges()
 		if err != nil {
-			log.Errorf(log.OrderMgr, "Sync manager cannot get exchanges: %v", err)
+			log.Errorf(log.SyncMgr, "Sync manager cannot get exchanges: %v", err)
 		}
 		for x := range exchanges {
 			exchangeName := exchanges[x].GetName()

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -81,7 +81,10 @@ func (m *websocketRoutineManager) websocketRoutine() {
 	if m.verbose {
 		log.Debugln(log.WebsocketMgr, "Connecting exchange websocket services...")
 	}
-	exchanges := m.exchangeManager.GetExchanges()
+	exchanges, err := m.exchangeManager.GetExchanges()
+	if err != nil {
+		log.Errorf(log.OrderMgr, "websocket routine manager cannot get exchanges: %v", err)
+	}
 	for i := range exchanges {
 		go func(i int) {
 			if exchanges[i].SupportsWebsocket() {

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -83,7 +83,7 @@ func (m *websocketRoutineManager) websocketRoutine() {
 	}
 	exchanges, err := m.exchangeManager.GetExchanges()
 	if err != nil {
-		log.Errorf(log.OrderMgr, "websocket routine manager cannot get exchanges: %v", err)
+		log.Errorf(log.WebsocketMgr, "websocket routine manager cannot get exchanges: %v", err)
 	}
 	for i := range exchanges {
 		go func(i int) {

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -84,6 +84,7 @@ func (b *Bittrex) SetDefaults() {
 				TradeFetching:       true,
 				OrderbookFetching:   true,
 				AutoPairUpdates:     true,
+				GetOrder:            true,
 				GetOrders:           true,
 				CancelOrder:         true,
 				CancelOrders:        true,

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -815,7 +815,7 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 		RemainingAmount:   0,
 		Fee:               0,
 		Exchange:          "test",
-		ID:                "1",
+		ID:                "",
 		AccountID:         "",
 		ClientID:          "",
 		WalletAddress:     "",
@@ -866,8 +866,8 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 	}
 
 	od.UpdateOrderFromDetail(&om)
-	if od.InternalOrderID == "1" {
-		t.Error("Should not be able to update the internal order ID")
+	if od.InternalOrderID != "1" {
+		t.Error("Failed to initialize the internal order ID")
 	}
 	if !od.ImmediateOrCancel {
 		t.Error("Failed to update")
@@ -986,6 +986,15 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 	}
 	if od.Trades[0].Amount != 1337 {
 		t.Error("Failed to update trades")
+	}
+
+	om = Detail{
+		InternalOrderID: "2",
+	}
+
+	od.UpdateOrderFromDetail(&om)
+	if od.InternalOrderID == "2" {
+		t.Error("Should not be able to update the internal order ID after initialization")
 	}
 }
 

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/validate"
@@ -1215,6 +1216,136 @@ func TestMatchFilter(t *testing.T) {
 		if tt.o.MatchFilter(&tt.f) != tt.expRes {
 			t.Errorf("tests[%v] failed", num)
 		}
+	}
+}
+
+func TestIsActive(t *testing.T) {
+	orders := map[int]Detail{
+		0: {Amount: 0.0, Status: Active},
+		1: {Amount: 1.0, ExecutedAmount: 0.9, Status: Active},
+		2: {Amount: 1.0, ExecutedAmount: 1.0, Status: Active},
+		3: {Amount: 1.0, ExecutedAmount: 1.1, Status: Active},
+	}
+
+	amountTests := map[int]struct {
+		o      Detail
+		expRes bool
+	}{
+		0: {orders[0], false},
+		1: {orders[1], true},
+		2: {orders[2], false},
+		3: {orders[3], false},
+	}
+	// specific tests
+	for num, tt := range amountTests {
+		if tt.o.IsActive() != tt.expRes {
+			t.Errorf("amountTests[%v] failed", num)
+		}
+	}
+
+	statusTests := map[int]struct {
+		o      Detail
+		expRes bool
+	}{
+		0:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: AnyStatus}, true},
+		1:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: New}, true},
+		2:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Active}, true},
+		3:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PartiallyCancelled}, false},
+		4:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PartiallyFilled}, true},
+		5:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Filled}, false},
+		6:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Cancelled}, false},
+		7:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PendingCancel}, true},
+		8:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: InsufficientBalance}, false},
+		9:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: MarketUnavailable}, false},
+		10: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Rejected}, false},
+		11: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Expired}, false},
+		12: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Hidden}, true},
+		13: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: UnknownStatus}, true},
+		14: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Open}, true},
+		15: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: AutoDeleverage}, true},
+		16: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Closed}, false},
+		17: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Pending}, true},
+	}
+	// specific tests
+	for num, tt := range statusTests {
+		if tt.o.IsActive() != tt.expRes {
+			t.Errorf("statusTests[%v] failed", num)
+		}
+	}
+}
+
+func TestIsInctive(t *testing.T) {
+	orders := map[int]Detail{
+		0: {Amount: 0.0, Status: Active},
+		1: {Amount: 1.0, ExecutedAmount: 0.9, Status: Active},
+		2: {Amount: 1.0, ExecutedAmount: 1.0, Status: Active},
+		3: {Amount: 1.0, ExecutedAmount: 1.1, Status: Active},
+	}
+
+	amountTests := map[int]struct {
+		o      Detail
+		expRes bool
+	}{
+		0: {orders[0], true},
+		1: {orders[1], false},
+		2: {orders[2], true},
+		3: {orders[3], true},
+	}
+	// specific tests
+	for num, tt := range amountTests {
+		if tt.o.IsInactive() != tt.expRes {
+			t.Errorf("amountTests[%v] failed", num)
+		}
+	}
+
+	statusTests := map[int]struct {
+		o      Detail
+		expRes bool
+	}{
+		0:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: AnyStatus}, false},
+		1:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: New}, false},
+		2:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Active}, false},
+		3:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PartiallyCancelled}, true},
+		4:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PartiallyFilled}, false},
+		5:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Filled}, true},
+		6:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Cancelled}, true},
+		7:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: PendingCancel}, false},
+		8:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: InsufficientBalance}, true},
+		9:  {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: MarketUnavailable}, true},
+		10: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Rejected}, true},
+		11: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Expired}, true},
+		12: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Hidden}, false},
+		13: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: UnknownStatus}, false},
+		14: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Open}, false},
+		15: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: AutoDeleverage}, false},
+		16: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Closed}, true},
+		17: {Detail{Amount: 1.0, ExecutedAmount: 0.0, Status: Pending}, false},
+	}
+	// specific tests
+	for num, tt := range statusTests {
+		if tt.o.IsInactive() != tt.expRes {
+			t.Errorf("statusTests[%v] failed", num)
+		}
+	}
+}
+
+func TestGenerateInternalOrderID(t *testing.T) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Errorf("unable to create uuid: %s", err)
+	}
+	od := Detail{
+		InternalOrderID: id.String(),
+	}
+	od.GenerateInternalOrderID()
+	if od.InternalOrderID != id.String() {
+		t.Error("Should not be able to generate a new internal order ID")
+	}
+
+	od = Detail{}
+	od.GenerateInternalOrderID()
+	if od.InternalOrderID == "" {
+		t.Error("unable to generate internal order ID")
 	}
 }
 

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -412,7 +412,7 @@ func (d *Detail) MatchFilter(f *Filter) bool {
 // IsActive returns true if an order has a status that indicates it is
 // currently available on the exchange
 func (d *Detail) IsActive() bool {
-	if d.Amount > 0 && d.Amount <= d.ExecutedAmount {
+	if d.Amount <= 0 || d.Amount <= d.ExecutedAmount {
 		return false
 	}
 	return d.Status == Active || d.Status == Open || d.Status == PartiallyFilled || d.Status == New ||
@@ -423,7 +423,7 @@ func (d *Detail) IsActive() bool {
 // IsInactive returns true if an order has a status that indicates it is
 // currently not available on the exchange
 func (d *Detail) IsInactive() bool {
-	if d.Amount > 0 && d.Amount == d.ExecutedAmount {
+	if d.Amount <= 0 || d.Amount <= d.ExecutedAmount {
 		return true
 	}
 	return d.Status == Filled || d.Status == Cancelled || d.Status == InsufficientBalance || d.Status == MarketUnavailable ||

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -419,9 +419,9 @@ func (d *Detail) IsActive() bool {
 		d.Status == AutoDeleverage || d.Status == Pending
 }
 
-// IsActive returns true if an order has a status that indicates it is
+// IsInactive returns true if an order has a status that indicates it is
 // currently not available on the exchange
-func (d *Detail) IsInActive() bool {
+func (d *Detail) IsInactive() bool {
 	if d.Amount > 0 && d.Amount == d.ExecutedAmount {
 		return true
 	}

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -208,6 +208,9 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) {
 	if d.ID == "" {
 		d.ID = m.ID
 	}
+	if d.InternalOrderID == "" {
+		d.InternalOrderID = m.InternalOrderID
+	}
 }
 
 // UpdateOrderFromModify Will update an order detail (used in order management)
@@ -403,6 +406,27 @@ func (d *Detail) MatchFilter(f *Filter) bool {
 		return false
 	}
 	return true
+}
+
+// IsActive returns true if an order has a status that indicates it is
+// currently available on the exchange
+func (d *Detail) IsActive() bool {
+	if d.Amount > 0 && d.Amount <= d.ExecutedAmount {
+		return false
+	}
+	return d.Status == Active || d.Status == Open || d.Status == PartiallyFilled || d.Status == New ||
+		d.Status == AnyStatus || d.Status == PendingCancel || d.Status == Hidden || d.Status == UnknownStatus ||
+		d.Status == AutoDeleverage || d.Status == Pending
+}
+
+// IsActive returns true if an order has a status that indicates it is
+// currently not available on the exchange
+func (d *Detail) IsInActive() bool {
+	if d.Amount > 0 && d.Amount == d.ExecutedAmount {
+		return true
+	}
+	return d.Status == Filled || d.Status == Cancelled || d.Status == InsufficientBalance || d.Status == MarketUnavailable ||
+		d.Status == Rejected || d.Status == PartiallyCancelled || d.Status == Expired || d.Status == Closed
 }
 
 // Copy will return a copy of Detail

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -441,7 +441,6 @@ func (d *Detail) GenerateInternalOrderID() {
 		}
 		d.InternalOrderID = id.String()
 	}
-
 }
 
 // Copy will return a copy of Detail

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/validate"
@@ -427,6 +428,20 @@ func (d *Detail) IsInactive() bool {
 	}
 	return d.Status == Filled || d.Status == Cancelled || d.Status == InsufficientBalance || d.Status == MarketUnavailable ||
 		d.Status == Rejected || d.Status == PartiallyCancelled || d.Status == Expired || d.Status == Closed
+}
+
+// GenerateInternalOrderID sets a new V4 order ID or a V5 order ID if
+// the V4 function returns an error
+func (d *Detail) GenerateInternalOrderID() {
+	if d.InternalOrderID == "" {
+		var id uuid.UUID
+		id, err := uuid.NewV4()
+		if err != nil {
+			id = uuid.NewV5(uuid.UUID{}, d.ID)
+		}
+		d.InternalOrderID = id.String()
+	}
+
 }
 
 // Copy will return a copy of Detail


### PR DESCRIPTION
# PR Description

When a placed order is filled or partially filled, the orderStore is expected to update the order status accordingly, both in WS and in REST mode. Currently, for exchanges where no websocket stream is available/active, active orders will never get updated: they'll never turn into filled or partially filled orders.
This PR addresses that issue by tracking missing orders and performing REST calls to verify and update their status.

Fixes #772 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] I tested this by placing an order on an exchange and cancelling it (after adding some additional debugging output).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
