### PR TITLE
huobi: don't overwrite account balances when request spot asset

### DIFF
--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -662,6 +662,9 @@ func (h *HUOBI) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (ac
 				return info, err
 			}
 			for i := range accounts {
+				if accounts[i].Type != "spot" {
+					continue
+				}
 				acc.ID = strconv.FormatInt(accounts[i].ID, 10)
 				balances, err := h.GetAccountBalance(ctx, acc.ID)
 				if err != nil {
@@ -746,7 +749,7 @@ func (h *HUOBI) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (ac
 		}
 		acc.Currencies = currencyDetails
 	}
-	acc.AssetType = asset.Futures
+	acc.AssetType = assetType
 	info.Accounts = append(info.Accounts, acc)
 	err := account.Process(&info)
 	if err != nil {


### PR DESCRIPTION
Fix spot asset account info retrieval on Huobi

- [X] Bug fix (non-breaking change which fixes an issue)

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
