### PR TITLE
CoinbasePro: Remove settled from order history status

### DIFF
--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -798,7 +798,7 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 			return nil, err
 		}
 		resp, err := c.GetOrders(ctx,
-			[]string{"done", "settled"},
+			[]string{"done"},
 			fpair.String())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# PR Description

Remove "settled" from status when querying from Coinbase Pro for orders. As from Coinbase Pro's documentation: "Valid statuses: 'open', 'pending', 'rejected', 'done', 'active'."

Doc: https://docs.pro.coinbase.com/#list-orders

Fixes # Error when querying for order history from Coinbase Pro "CoinbasePro unsuccessful HTTP status code: 400 raw response: {"message":"settled is not a valid status"}"

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Submitted order on Coinbase Pro, then tested by calling function "GetOrderHistory()" with Coinbase Pro config setup with my exchange credentials and successfully got filled orders.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
