### PR TITLE
CoinbasePro: GetOrderHistory pair handling improvements

### DIFF
--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -425,6 +425,22 @@ func TestGetOrderHistory(t *testing.T) {
 	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
+
+	getOrdersRequest.Pairs = []currency.Pair{}
+	_, err = c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Could not get order history: %s", err)
+	} else if !areTestAPIKeysSet() && err == nil {
+		t.Error("Expecting an error when no keys are set")
+	}
+
+	getOrdersRequest.Pairs = nil
+	_, err = c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Could not get order history: %s", err)
+	} else if !areTestAPIKeysSet() && err == nil {
+		t.Error("Expecting an error when no keys are set")
+	}
 }
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -798,7 +798,7 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 			return nil, err
 		}
 		resp, err := c.GetOrders(ctx,
-			[]string{"done", "settled"},
+			[]string{"done"},
 			fpair.String())
 		if err != nil {
 			return nil, err

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -792,18 +792,28 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 		return nil, err
 	}
 	var respOrders []GeneralizedOrderResponse
-	for i := range req.Pairs {
-		fpair, err := c.FormatExchangeCurrency(req.Pairs[i], asset.Spot)
-		if err != nil {
-			return nil, err
+	if len(req.Pairs) > 0 {
+		for i := range req.Pairs {
+			fpair, err := c.FormatExchangeCurrency(req.Pairs[i], asset.Spot)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := c.GetOrders(ctx,
+				[]string{"done"},
+				fpair.String())
+			if err != nil {
+				return nil, err
+			}
+			respOrders = append(respOrders, resp...)
 		}
+	} else {
 		resp, err := c.GetOrders(ctx,
 			[]string{"done"},
-			fpair.String())
+			"")
 		if err != nil {
 			return nil, err
 		}
-		respOrders = append(respOrders, resp...)
+		respOrders = resp
 	}
 
 	format, err := c.GetPairFormat(asset.Spot, false)
@@ -829,6 +839,7 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 			Date:           respOrders[i].CreatedAt,
 			Side:           orderSide,
 			Pair:           curr,
+			Price:          respOrders[i].Price,
 			Exchange:       c.Name,
 		})
 	}

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -837,6 +837,8 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 			ExecutedAmount: respOrders[i].FilledSize,
 			Type:           orderType,
 			Date:           respOrders[i].CreatedAt,
+			Fee:            respOrders[i].FillFees,
+			FeeAsset:       curr.Quote,
 			Side:           orderSide,
 			Pair:           curr,
 			Price:          respOrders[i].Price,


### PR DESCRIPTION
# PR Description

Allow getting order history without restricting to a currency pair as supported by Coinbase Pro: https://docs.pro.coinbase.com/#list-orders

"product_id: optional"

Also added Price in order to be returned.

Fixes # N/A

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Tested locally by retrieving order with my credentials to Coinbase Pro.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
