### PR TITLE
 kraken futures: fix account info currency pairs

### DIFF
--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -604,7 +604,7 @@ func (k *Kraken) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		for name := range bal.Accounts {
 			for code := range bal.Accounts[name].Balances {
 				balances = append(balances, account.Balance{
-					CurrencyName: currency.NewCode(name),
+					CurrencyName: currency.NewCode(code),
 					TotalValue:   bal.Accounts[name].Balances[code],
 				})
 			}


### PR DESCRIPTION
Fixes issue on UpdateAccountInfo of Kraken futures, it was returning the symbol instead of the actual currency code

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
