### PR TITLE
Exchanges: enrich order history with avg executed price, cost, and more

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1408,15 +1408,21 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 					return nil, err
 				}
 				orders = append(orders, order.Detail{
-					Amount:   resp[i].OrigQty,
-					Date:     resp[i].Time,
-					Exchange: b.Name,
-					ID:       strconv.FormatInt(resp[i].OrderID, 10),
-					Side:     orderSide,
-					Type:     orderType,
-					Price:    resp[i].Price,
-					Pair:     pair,
-					Status:   order.Status(resp[i].Status),
+					Amount:               resp[i].OrigQty,
+					ExecutedAmount:       resp[i].ExecutedQty,
+					RemainingAmount:      resp[i].OrigQty - resp[i].ExecutedQty,
+					Cost:                 resp[i].CummulativeQuoteQty,
+					CostAsset:            pair.Quote,
+					Date:                 resp[i].Time,
+					LastUpdated:          resp[i].UpdateTime,
+					Exchange:             b.Name,
+					ID:                   strconv.FormatInt(resp[i].OrderID, 10),
+					Side:                 orderSide,
+					Type:                 orderType,
+					Price:                resp[i].Price,
+					AverageExecutedPrice: resp[i].ExecutedQty / resp[i].CummulativeQuoteQty,
+					Pair:                 pair,
+					Status:               order.Status(resp[i].Status),
 				})
 			}
 		}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -913,15 +913,18 @@ func (b *Bitfinex) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 		}
 
 		orderDetail := order.Detail{
-			Amount:          resp[i].OriginalAmount,
-			Date:            orderDate,
-			Exchange:        b.Name,
-			ID:              strconv.FormatInt(resp[i].ID, 10),
-			Side:            orderSide,
-			Price:           resp[i].Price,
-			RemainingAmount: resp[i].RemainingAmount,
-			ExecutedAmount:  resp[i].ExecutedAmount,
-			Pair:            pair,
+			Amount:               resp[i].OriginalAmount,
+			Date:                 orderDate,
+			Exchange:             b.Name,
+			ID:                   strconv.FormatInt(resp[i].ID, 10),
+			Side:                 orderSide,
+			Price:                resp[i].Price,
+			AverageExecutedPrice: resp[i].AverageExecutionPrice,
+			RemainingAmount:      resp[i].RemainingAmount,
+			ExecutedAmount:       resp[i].ExecutedAmount,
+			Cost:                 resp[i].ExecutedAmount * resp[i].AverageExecutionPrice,
+			CostAsset:            pair.Quote,
+			Pair:                 pair,
 		}
 
 		switch {

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -754,13 +754,16 @@ func (b *Bithumb) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 			}
 
 			orderDate := time.Unix(resp.Data[i].OrderDate, 0)
+			dateCompleted := time.Unix(resp.Data[i].DateCompleted, 0)
 			orderDetail := order.Detail{
 				Amount:          resp.Data[i].Units,
+				ExecutedAmount:  resp.Data[i].Units - resp.Data[i].UnitsRemaining,
+				RemainingAmount: resp.Data[i].UnitsRemaining,
 				Exchange:        b.Name,
 				ID:              resp.Data[i].OrderID,
 				Date:            orderDate,
+				CloseTime:       dateCompleted,
 				Price:           resp.Data[i].Price,
-				RemainingAmount: resp.Data[i].UnitsRemaining,
 				Pair: currency.NewPairWithDelimiter(resp.Data[i].OrderCurrency,
 					resp.Data[i].PaymentCurrency,
 					format.Delimiter),

--- a/exchanges/bitmex/bitmex_types.go
+++ b/exchanges/bitmex/bitmex_types.go
@@ -291,18 +291,18 @@ type Order struct {
 	ClOrdID               string    `json:"clOrdID"`
 	ClOrdLinkID           string    `json:"clOrdLinkID"`
 	ContingencyType       string    `json:"contingencyType"`
-	CumQty                int64     `json:"cumQty"`
+	CumQty                float64   `json:"cumQty"`
 	Currency              string    `json:"currency"`
 	DisplayQuantity       int64     `json:"displayQty"`
 	ExDestination         string    `json:"exDestination"`
 	ExecInst              string    `json:"execInst"`
-	LeavesQty             int64     `json:"leavesQty"`
+	LeavesQty             float64   `json:"leavesQty"`
 	MultiLegReportingType string    `json:"multiLegReportingType"`
 	OrdRejReason          string    `json:"ordRejReason"`
 	OrdStatus             string    `json:"ordStatus"`
 	OrdType               int64     `json:"ordType,string"`
 	OrderID               string    `json:"orderID"`
-	OrderQty              int64     `json:"orderQty"`
+	OrderQty              float64   `json:"orderQty"`
 	PegOffsetValue        float64   `json:"pegOffsetValue"`
 	PegPriceType          string    `json:"pegPriceType"`
 	Price                 float64   `json:"price"`
@@ -316,7 +316,7 @@ type Order struct {
 	Text                  string    `json:"text"`
 	TimeInForce           string    `json:"timeInForce"`
 	Timestamp             time.Time `json:"timestamp"`
-	TransactTime          string    `json:"transactTime"`
+	TransactTime          time.Time `json:"transactTime"`
 	Triggered             string    `json:"triggered"`
 	WorkingIndicator      bool      `json:"workingIndicator"`
 }

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -745,7 +745,7 @@ func (b *Bitmex) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		orderDetail := order.Detail{
 			Date:     resp[i].Timestamp,
 			Price:    resp[i].Price,
-			Amount:   float64(resp[i].OrderQty),
+			Amount:   resp[i].OrderQty,
 			Exchange: b.Name,
 			ID:       resp[i].OrderID,
 			Side:     orderSide,
@@ -792,18 +792,24 @@ func (b *Bitmex) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		if orderType == "" {
 			orderType = order.UnknownType
 		}
+		pair := currency.NewPairWithDelimiter(resp[i].Symbol, resp[i].SettlCurrency, format.Delimiter)
 
 		orderDetail := order.Detail{
-			Price:    resp[i].Price,
-			Amount:   float64(resp[i].OrderQty),
-			Exchange: b.Name,
-			ID:       resp[i].OrderID,
-			Side:     orderSide,
-			Type:     orderType,
-			Status:   order.Status(resp[i].OrdStatus),
-			Pair: currency.NewPairWithDelimiter(resp[i].Symbol,
-				resp[i].SettlCurrency,
-				format.Delimiter),
+			Price:                resp[i].Price,
+			AverageExecutedPrice: resp[i].AvgPx,
+			Amount:               resp[i].OrderQty,
+			ExecutedAmount:       resp[i].CumQty,
+			RemainingAmount:      resp[i].LeavesQty,
+			Cost:                 resp[i].CumQty * resp[i].AvgPx,
+			CostAsset:            pair.Quote,
+			Date:                 resp[i].TransactTime,
+			CloseTime:            resp[i].Timestamp,
+			Exchange:             b.Name,
+			ID:                   resp[i].OrderID,
+			Side:                 orderSide,
+			Type:                 orderType,
+			Status:               order.Status(resp[i].OrdStatus),
+			Pair:                 pair,
 		}
 
 		orders = append(orders, orderDetail)

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -865,6 +865,7 @@ func (b *Bittrex) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 				ExecutedAmount:  orderData[i].FillQuantity,
 				Price:           orderData[i].Limit,
 				Date:            orderData[i].CreatedAt,
+				CloseTime:       orderData[i].ClosedAt,
 				ID:              orderData[i].ID,
 				Exchange:        b.Name,
 				Type:            orderType,

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -867,7 +867,11 @@ func (b *BTCMarkets) GetOrderHistory(ctx context.Context, req *order.GetOrdersRe
 			tempResp.ID = tempData.Orders[c].OrderID
 			tempResp.Date = tempData.Orders[c].CreationTime
 			tempResp.Price = tempData.Orders[c].Price
+			tempResp.AverageExecutedPrice = tempData.Orders[c].Price
+			tempResp.Amount = tempData.Orders[c].Amount
 			tempResp.ExecutedAmount = tempData.Orders[c].Amount
+			tempResp.Cost = tempData.Orders[c].Amount * tempData.Orders[c].Price
+			tempResp.CostAsset = p.Quote
 			resp = append(resp, tempResp)
 		}
 	}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -875,11 +875,18 @@ func (b *BTSE) GetOrderHistory(ctx context.Context, getOrdersRequest *order.GetO
 			if !matchType(currentOrder[y].OrderType, orderDeref.Type) {
 				continue
 			}
+			orderTime := time.Unix(currentOrder[y].Timestamp, 0)
 			tempOrder := order.Detail{
-				Price:  currentOrder[y].Price,
-				Amount: currentOrder[y].Size,
-				Side:   order.Side(currentOrder[y].Side),
-				Pair:   orderDeref.Pairs[x],
+				Price:                currentOrder[y].Price,
+				AverageExecutedPrice: currentOrder[y].AverageFillPrice,
+				Amount:               currentOrder[y].Size,
+				ExecutedAmount:       currentOrder[y].FilledSize,
+				RemainingAmount:      currentOrder[y].Size - currentOrder[y].FilledSize,
+				Cost:                 currentOrder[y].OrderValue,
+				CostAsset:            orderDeref.Pairs[x].Quote,
+				Date:                 orderTime,
+				Side:                 order.Side(currentOrder[y].Side),
+				Pair:                 orderDeref.Pairs[x],
 			}
 			switch currentOrder[x].OrderState {
 			case "STATUS_ACTIVE":

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -125,7 +125,7 @@ type GeneralizedOrderResponse struct {
 	Funds          float64   `json:"funds,string"`
 	SpecifiedFunds float64   `json:"specified_funds,string"`
 	DoneReason     string    `json:"done_reason"`
-	DoneAt         string    `json:"done_at"`
+	DoneAt         time.Time `json:"done_at"`
 }
 
 // Funding holds funding data

--- a/exchanges/coinbene/coinbene_wrapper.go
+++ b/exchanges/coinbene/coinbene_wrapper.go
@@ -802,9 +802,12 @@ func (c *Coinbene) GetOrderHistory(ctx context.Context, getOrdersRequest *order.
 			tempResp.Date = tempData[y].OrderTime
 			tempResp.Status = order.Status(tempData[y].OrderStatus)
 			tempResp.Price = tempData[y].OrderPrice
+			tempResp.AverageExecutedPrice = tempData[y].AvgPrice
 			tempResp.Amount = tempData[y].Amount
 			tempResp.ExecutedAmount = tempData[y].FilledAmount
 			tempResp.RemainingAmount = tempData[y].Amount - tempData[y].FilledAmount
+			tempResp.Cost = tempData[y].Quantity
+			tempResp.CostAsset = tempResp.Pair.Quote
 			tempResp.Fee = tempData[y].TotalFee
 			resp = append(resp, tempResp)
 		}

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -643,20 +643,24 @@ func (e *EXMO) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest)
 
 	var orders []order.Detail
 	for i := range allTrades {
-		symbol, err := currency.NewPairDelimiter(allTrades[i].Pair, "_")
+		pair, err := currency.NewPairDelimiter(allTrades[i].Pair, "_")
 		if err != nil {
 			return nil, err
 		}
 		orderDate := time.Unix(allTrades[i].Date, 0)
 		orderSide := order.Side(strings.ToUpper(allTrades[i].Type))
 		orders = append(orders, order.Detail{
-			ID:       strconv.FormatInt(allTrades[i].TradeID, 10),
-			Amount:   allTrades[i].Quantity,
-			Date:     orderDate,
-			Price:    allTrades[i].Price,
-			Side:     orderSide,
-			Exchange: e.Name,
-			Pair:     symbol,
+			ID:                   strconv.FormatInt(allTrades[i].TradeID, 10),
+			Amount:               allTrades[i].Quantity,
+			ExecutedAmount:       allTrades[i].Quantity,
+			Cost:                 allTrades[i].Amount,
+			CostAsset:            pair.Quote,
+			Date:                 orderDate,
+			Price:                allTrades[i].Price,
+			AverageExecutedPrice: allTrades[i].Amount / allTrades[i].Quantity,
+			Side:                 orderSide,
+			Exchange:             e.Name,
+			Pair:                 pair,
 		})
 	}
 

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -1009,7 +1009,10 @@ func (f *FTX) GetOrderHistory(ctx context.Context, getOrdersRequest *order.GetOr
 			tempResp.ID = strconv.FormatInt(orderData[y].ID, 10)
 			tempResp.Amount = orderData[y].Size
 			tempResp.AssetType = assetType
+			tempResp.AverageExecutedPrice = orderData[y].AvgFillPrice
 			tempResp.ClientOrderID = orderData[y].ClientID
+			tempResp.Cost = orderData[y].FilledSize * orderData[y].AvgFillPrice
+			tempResp.CostAsset = p.Quote
 			tempResp.Date = orderData[y].CreatedAt
 			tempResp.Exchange = f.Name
 			tempResp.ExecutedAmount = orderData[y].Size - orderData[y].RemainingSize

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -792,21 +792,25 @@ func (g *Gateio) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 
 	var orders []order.Detail
 	for i := range trades {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(trades[i].Pair, format.Delimiter)
+		var pair currency.Pair
+		pair, err = currency.NewPairDelimiter(trades[i].Pair, format.Delimiter)
 		if err != nil {
 			return nil, err
 		}
 		side := order.Side(strings.ToUpper(trades[i].Type))
 		orderDate := time.Unix(trades[i].TimeUnix, 0)
 		orders = append(orders, order.Detail{
-			ID:       strconv.FormatInt(trades[i].OrderID, 10),
-			Amount:   trades[i].Amount,
-			Price:    trades[i].Rate,
-			Date:     orderDate,
-			Side:     side,
-			Exchange: g.Name,
-			Pair:     symbol,
+			ID:                   strconv.FormatInt(trades[i].OrderID, 10),
+			Amount:               trades[i].Amount,
+			ExecutedAmount:       trades[i].Amount,
+			Cost:                 trades[i].Rate * trades[i].Amount,
+			CostAsset:            pair.Quote,
+			Price:                trades[i].Rate,
+			AverageExecutedPrice: trades[i].Rate,
+			Date:                 orderDate,
+			Side:                 side,
+			Exchange:             g.Name,
+			Pair:                 pair,
 		})
 	}
 

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -763,13 +763,16 @@ func (g *Gemini) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		orderDate := time.Unix(trades[i].Timestamp, 0)
 
 		orders = append(orders, order.Detail{
-			Amount:   trades[i].Amount,
-			ID:       strconv.FormatInt(trades[i].OrderID, 10),
-			Exchange: g.Name,
-			Date:     orderDate,
-			Side:     side,
-			Fee:      trades[i].FeeAmount,
-			Price:    trades[i].Price,
+			ID:                   strconv.FormatInt(trades[i].OrderID, 10),
+			Amount:               trades[i].Amount,
+			ExecutedAmount:       trades[i].Amount,
+			Cost:                 trades[i].Amount * trades[i].Price,
+			Exchange:             g.Name,
+			Date:                 orderDate,
+			Side:                 side,
+			Fee:                  trades[i].FeeAmount,
+			Price:                trades[i].Price,
+			AverageExecutedPrice: trades[i].Price,
 			Pair: currency.NewPairWithDelimiter(trades[i].BaseCurrency,
 				trades[i].QuoteCurrency,
 				format.Delimiter),

--- a/exchanges/hitbtc/hitbtc_types.go
+++ b/exchanges/hitbtc/hitbtc_types.go
@@ -184,6 +184,7 @@ type OrderHistoryResponse struct {
 	Type          string    `json:"type"`
 	TimeInForce   string    `json:"timeInForce"`
 	Price         float64   `json:"price,string"`
+	AvgPrice      float64   `json:"avgPrice,string"`
 	Quantity      float64   `json:"quantity,string"`
 	PostOnly      bool      `json:"postOnly"`
 	CumQuantity   float64   `json:"cumQuantity,string"`

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -771,21 +771,27 @@ func (h *HitBTC) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 
 	var orders []order.Detail
 	for i := range allOrders {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(allOrders[i].Symbol,
+		var pair currency.Pair
+		pair, err = currency.NewPairDelimiter(allOrders[i].Symbol,
 			format.Delimiter)
 		if err != nil {
 			return nil, err
 		}
 		side := order.Side(strings.ToUpper(allOrders[i].Side))
 		orders = append(orders, order.Detail{
-			ID:       allOrders[i].ID,
-			Amount:   allOrders[i].Quantity,
-			Exchange: h.Name,
-			Price:    allOrders[i].Price,
-			Date:     allOrders[i].CreatedAt,
-			Side:     side,
-			Pair:     symbol,
+			ID:                   allOrders[i].ID,
+			Amount:               allOrders[i].Quantity,
+			ExecutedAmount:       allOrders[i].CumQuantity,
+			RemainingAmount:      allOrders[i].Quantity - allOrders[i].CumQuantity,
+			Cost:                 allOrders[i].CumQuantity * allOrders[i].AvgPrice,
+			CostAsset:            pair.Quote,
+			Exchange:             h.Name,
+			Price:                allOrders[i].Price,
+			AverageExecutedPrice: allOrders[i].AvgPrice,
+			Date:                 allOrders[i].CreatedAt,
+			LastUpdated:          allOrders[i].UpdatedAt,
+			Side:                 side,
+			Pair:                 pair,
 		})
 	}
 

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -1460,16 +1460,21 @@ func (h *HUOBI) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 			}
 			for x := range resp {
 				orderDetail := order.Detail{
-					ID:             strconv.FormatInt(resp[x].ID, 10),
-					Price:          resp[x].Price,
-					Amount:         resp[x].Amount,
-					Pair:           req.Pairs[i],
-					Exchange:       h.Name,
-					ExecutedAmount: resp[x].FilledAmount,
-					Date:           time.Unix(0, resp[x].CreatedAt*int64(time.Millisecond)),
-					Status:         order.Status(resp[x].State),
-					AccountID:      strconv.FormatInt(resp[x].AccountID, 10),
-					Fee:            resp[x].FilledFees,
+					ID:                   strconv.FormatInt(resp[x].ID, 10),
+					Price:                resp[x].Price,
+					AverageExecutedPrice: resp[x].FilledCashAmount / resp[x].FilledAmount,
+					Amount:               resp[x].Amount,
+					ExecutedAmount:       resp[x].FilledAmount,
+					RemainingAmount:      resp[x].Amount - resp[x].FilledAmount,
+					Cost:                 resp[x].FilledCashAmount,
+					CostAsset:            req.Pairs[i].Quote,
+					Pair:                 req.Pairs[i],
+					Exchange:             h.Name,
+					Date:                 time.Unix(0, resp[x].CreatedAt*int64(time.Millisecond)),
+					CloseTime:            time.Unix(0, resp[x].FinishedAt*int64(time.Millisecond)),
+					Status:               order.Status(resp[x].State),
+					AccountID:            strconv.FormatInt(resp[x].AccountID, 10),
+					Fee:                  resp[x].FilledFees,
 				}
 				setOrderSideAndType(resp[x].Type, &orderDetail)
 				orders = append(orders, orderDetail)

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -624,14 +624,17 @@ func (i *ItBit) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 		}
 
 		orders = append(orders, order.Detail{
-			ID:              allOrders[j].ID,
-			Side:            side,
-			Amount:          allOrders[j].Amount,
-			ExecutedAmount:  allOrders[j].AmountFilled,
-			RemainingAmount: (allOrders[j].Amount - allOrders[j].AmountFilled),
-			Exchange:        i.Name,
-			Date:            orderDate,
-			Pair:            symbol,
+			ID:                   allOrders[j].ID,
+			Side:                 side,
+			Amount:               allOrders[j].Amount,
+			ExecutedAmount:       allOrders[j].AmountFilled,
+			RemainingAmount:      allOrders[j].Amount - allOrders[j].AmountFilled,
+			Cost:                 allOrders[j].AmountFilled * allOrders[j].VolumeWeightedAveragePrice,
+			Price:                allOrders[j].Price,
+			AverageExecutedPrice: allOrders[j].VolumeWeightedAveragePrice,
+			Exchange:             i.Name,
+			Date:                 orderDate,
+			Pair:                 symbol,
 		})
 	}
 

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -604,7 +604,7 @@ func (k *Kraken) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		for name := range bal.Accounts {
 			for code := range bal.Accounts[name].Balances {
 				balances = append(balances, account.Balance{
-					CurrencyName: currency.NewCode(code),
+					CurrencyName: currency.NewCode(name),
 					TotalValue:   bal.Accounts[name].Balances[code],
 				})
 			}
@@ -1210,17 +1210,20 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Ge
 			side := order.Side(strings.ToUpper(resp.Closed[i].Description.Type))
 			orderType := order.Type(strings.ToUpper(resp.Closed[i].Description.OrderType))
 			orders = append(orders, order.Detail{
-				ID:              i,
-				Amount:          resp.Closed[i].Volume,
-				RemainingAmount: (resp.Closed[i].Volume - resp.Closed[i].VolumeExecuted),
-				ExecutedAmount:  resp.Closed[i].VolumeExecuted,
-				Exchange:        k.Name,
-				Date:            convert.TimeFromUnixTimestampDecimal(resp.Closed[i].OpenTime),
-				CloseTime:       convert.TimeFromUnixTimestampDecimal(resp.Closed[i].CloseTime),
-				Price:           resp.Closed[i].Description.Price,
-				Side:            side,
-				Type:            orderType,
-				Pair:            p,
+				ID:                   i,
+				Amount:               resp.Closed[i].Volume,
+				ExecutedAmount:       resp.Closed[i].VolumeExecuted,
+				RemainingAmount:      resp.Closed[i].Volume - resp.Closed[i].VolumeExecuted,
+				Cost:                 resp.Closed[i].Cost,
+				CostAsset:            p.Quote,
+				Exchange:             k.Name,
+				Date:                 convert.TimeFromUnixTimestampDecimal(resp.Closed[i].OpenTime),
+				CloseTime:            convert.TimeFromUnixTimestampDecimal(resp.Closed[i].CloseTime),
+				Price:                resp.Closed[i].Description.Price,
+				AverageExecutedPrice: resp.Closed[i].Cost / resp.Closed[i].VolumeExecuted,
+				Side:                 side,
+				Type:                 orderType,
+				Pair:                 p,
 			})
 		}
 	case asset.Futures:

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -789,10 +789,12 @@ func (l *Lbank) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Get
 					resp.Status = "Invalid Order Status"
 				}
 				resp.Price = tempResp.Orders[x].Price
+				resp.AverageExecutedPrice = tempResp.Orders[x].AvgPrice
 				resp.Amount = tempResp.Orders[x].Amount
 				resp.Date = time.Unix(tempResp.Orders[x].CreateTime, 0)
 				resp.ExecutedAmount = tempResp.Orders[x].DealAmount
 				resp.RemainingAmount = tempResp.Orders[x].Price - tempResp.Orders[x].DealAmount
+				resp.Cost = tempResp.Orders[x].DealAmount * tempResp.Orders[x].AvgPrice
 				resp.Fee, err = l.GetFeeByType(ctx,
 					&exchange.FeeBuilder{
 						FeeType:       exchange.CryptocurrencyTradeFee,

--- a/exchanges/okgroup/okgroup_types.go
+++ b/exchanges/okgroup/okgroup_types.go
@@ -319,6 +319,7 @@ type GetSpotOrderResponse struct {
 	Notional       string    `json:"notional"`
 	OrderID        string    `json:"order_id"`
 	Price          float64   `json:"price,string"`
+	PriceAvg       float64   `json:"price_avg,string"`
 	Side           string    `json:"side"`
 	Size           float64   `json:"size,string"`
 	Status         string    `json:"status"`

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -535,8 +535,8 @@ func (o *OKGroup) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 		if err != nil {
 			return nil, err
 		}
-		var spotOpenOrders []GetSpotOrderResponse
-		spotOpenOrders, err = o.GetSpotOrders(ctx,
+		var spotOrders []GetSpotOrderResponse
+		spotOrders, err = o.GetSpotOrders(ctx,
 			GetSpotOrdersRequest{
 				Status:       strings.Join([]string{"filled", "cancelled", "failure"}, "|"),
 				InstrumentID: fPair.String(),
@@ -544,18 +544,22 @@ func (o *OKGroup) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 		if err != nil {
 			return resp, err
 		}
-		for i := range spotOpenOrders {
+		for i := range spotOrders {
 			resp = append(resp, order.Detail{
-				ID:             spotOpenOrders[i].OrderID,
-				Price:          spotOpenOrders[i].Price,
-				Amount:         spotOpenOrders[i].Size,
-				Pair:           req.Pairs[x],
-				Exchange:       o.Name,
-				Side:           order.Side(spotOpenOrders[i].Side),
-				Type:           order.Type(spotOpenOrders[i].Type),
-				ExecutedAmount: spotOpenOrders[i].FilledSize,
-				Date:           spotOpenOrders[i].Timestamp,
-				Status:         order.Status(spotOpenOrders[i].Status),
+				ID:                   spotOrders[i].OrderID,
+				Price:                spotOrders[i].Price,
+				AverageExecutedPrice: spotOrders[i].PriceAvg,
+				Amount:               spotOrders[i].Size,
+				ExecutedAmount:       spotOrders[i].FilledSize,
+				RemainingAmount:      spotOrders[i].Size - spotOrders[i].FilledSize,
+				Cost:                 spotOrders[i].FilledSize * spotOrders[i].PriceAvg,
+				CostAsset:            req.Pairs[x].Quote,
+				Pair:                 req.Pairs[x],
+				Exchange:             o.Name,
+				Side:                 order.Side(spotOrders[i].Side),
+				Type:                 order.Type(spotOrders[i].Type),
+				Date:                 spotOrders[i].Timestamp,
+				Status:               order.Status(spotOrders[i].Status),
 			})
 		}
 	}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -819,8 +819,8 @@ func (p *Poloniex) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 
 	var orders []order.Detail
 	for key := range resp.Data {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(key, format.Delimiter)
+		var pair currency.Pair
+		pair, err = currency.NewPairDelimiter(key, format.Delimiter)
 		if err != nil {
 			return nil, err
 		}
@@ -839,13 +839,17 @@ func (p *Poloniex) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 			}
 
 			orders = append(orders, order.Detail{
-				ID:       strconv.FormatInt(resp.Data[key][i].GlobalTradeID, 10),
-				Side:     orderSide,
-				Amount:   resp.Data[key][i].Amount,
-				Date:     orderDate,
-				Price:    resp.Data[key][i].Rate,
-				Pair:     symbol,
-				Exchange: p.Name,
+				ID:                   strconv.FormatInt(resp.Data[key][i].GlobalTradeID, 10),
+				Side:                 orderSide,
+				Amount:               resp.Data[key][i].Amount,
+				ExecutedAmount:       resp.Data[key][i].Amount,
+				Cost:                 resp.Data[key][i].Amount * resp.Data[key][i].Rate,
+				CostAsset:            pair.Quote,
+				Date:                 orderDate,
+				Price:                resp.Data[key][i].Rate,
+				AverageExecutedPrice: resp.Data[key][i].Rate,
+				Pair:                 pair,
+				Exchange:             p.Name,
 			})
 		}
 	}

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -630,21 +630,25 @@ func (y *Yobit) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 
 	var orders []order.Detail
 	for i := range allOrders {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(allOrders[i].Pair, format.Delimiter)
+		var pair currency.Pair
+		pair, err = currency.NewPairDelimiter(allOrders[i].Pair, format.Delimiter)
 		if err != nil {
 			return nil, err
 		}
 		orderDate := time.Unix(int64(allOrders[i].Timestamp), 0)
 		side := order.Side(strings.ToUpper(allOrders[i].Type))
 		orders = append(orders, order.Detail{
-			ID:       strconv.FormatFloat(allOrders[i].OrderID, 'f', -1, 64),
-			Amount:   allOrders[i].Amount,
-			Price:    allOrders[i].Rate,
-			Side:     side,
-			Date:     orderDate,
-			Pair:     symbol,
-			Exchange: y.Name,
+			ID:                   strconv.FormatFloat(allOrders[i].OrderID, 'f', -1, 64),
+			Amount:               allOrders[i].Amount,
+			ExecutedAmount:       allOrders[i].Amount,
+			Cost:                 allOrders[i].Amount * allOrders[i].Rate,
+			CostAsset:            pair.Quote,
+			Price:                allOrders[i].Rate,
+			AverageExecutedPrice: allOrders[i].Rate,
+			Side:                 side,
+			Date:                 orderDate,
+			Pair:                 pair,
+			Exchange:             y.Name,
 		})
 	}
 

--- a/exchanges/zb/zb_types.go
+++ b/exchanges/zb/zb_types.go
@@ -40,7 +40,7 @@ type Order struct {
 	Price       float64 `json:"price"`
 	Status      int     `json:"status"`
 	TotalAmount float64 `json:"total_amount"`
-	TradeAmount int     `json:"trade_amount"`
+	TradeAmount float64 `json:"trade_amount"`
 	TradeDate   int     `json:"trade_date"`
 	TradeMoney  float64 `json:"trade_money"`
 	Type        int64   `json:"type"`

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -801,8 +801,8 @@ func (z *ZB) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest) (
 	}
 
 	for i := range allOrders {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(allOrders[i].Currency,
+		var pair currency.Pair
+		pair, err = currency.NewPairDelimiter(allOrders[i].Currency,
 			format.Delimiter)
 		if err != nil {
 			return nil, err
@@ -810,13 +810,18 @@ func (z *ZB) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest) (
 		orderDate := time.Unix(int64(allOrders[i].TradeDate), 0)
 		orderSide := orderSideMap[allOrders[i].Type]
 		orders = append(orders, order.Detail{
-			ID:       strconv.FormatInt(allOrders[i].ID, 10),
-			Amount:   allOrders[i].TotalAmount,
-			Exchange: z.Name,
-			Date:     orderDate,
-			Price:    allOrders[i].Price,
-			Side:     orderSide,
-			Pair:     symbol,
+			ID:                   strconv.FormatInt(allOrders[i].ID, 10),
+			Amount:               allOrders[i].TotalAmount,
+			ExecutedAmount:       allOrders[i].TradeAmount,
+			RemainingAmount:      allOrders[i].TotalAmount - allOrders[i].TradeAmount,
+			Cost:                 allOrders[i].TradeAmount * allOrders[i].TradePrice,
+			CostAsset:            pair.Quote,
+			Exchange:             z.Name,
+			Date:                 orderDate,
+			Price:                allOrders[i].Price,
+			AverageExecutedPrice: allOrders[i].TradePrice,
+			Side:                 orderSide,
+			Pair:                 pair,
 		})
 	}
 


### PR DESCRIPTION
# PR Description

Enrich order history responses, mainly with AverageExecutedPrice, ExecutedAmount, Cost, and CostAsset, also with some other minor changes like adding LastUpdated when available and minor renaming.

AverageExecutedPrice is necessary as for MARKET orders, price is not always populated (since you don't specify price for a MARKET order right)

Cost/CostAsset is useful when you want to figure out how the order would affect your quote currency balances. Cost would be AverageExecutedPrice * ExecutedAmount.

For some exchanges, the GetOrderHistory function is actually getting trade history under the hood, for those will assume Price = AverageExecutedPrice and Amount = ExecutedAmount, and calculate Cost correspondingly.

For exchanges that I'm not able to determine whether the Price field is Average Executed Price or price specified for the order, I did not enrich the Cost field.

I didn't test them all but I've tried my best to check with exchange docs for the fields.

Fixes # 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
