### PR TITLE
ftx/ws/ticker: Populate best bid/ask quantities

### DIFF
--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -270,7 +270,9 @@ func (f *FTX) wsHandleData(respRaw []byte) error {
 			f.Websocket.DataHandler <- &ticker.Price{
 				ExchangeName: f.Name,
 				Bid:          resultData.Ticker.Bid,
+				BidSize:      resultData.Ticker.BidSize,
 				Ask:          resultData.Ticker.Ask,
+				AskSize:      resultData.Ticker.AskSize,
 				Last:         resultData.Ticker.Last,
 				LastUpdated:  timestampFromFloat64(resultData.Ticker.Time),
 				Pair:         p,


### PR DESCRIPTION
# PR Description

The "ticker" FTX WS event yields best bid and ask quantities, but these are not applied to the created ticker.Price structure.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
