### PR TITLE
Expose trade feed websocket exchange data through data channel

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -281,6 +281,7 @@ type FeaturesEnabledConfig struct {
 	AutoPairUpdates bool `json:"autoPairUpdates"`
 	Websocket       bool `json:"websocketAPI"`
 	SaveTradeData   bool `json:"saveTradeData"`
+	TradeFeed       bool `json:"tradeFeed"`
 }
 
 // FeaturesConfig stores the exchanges supported and enabled features

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -167,6 +167,10 @@ func (b *Base) SetFeatureDefaults() {
 			b.SetSaveTradeDataStatus(b.Config.Features.Enabled.SaveTradeData)
 		}
 
+		if b.IsTradeFeedEnabled() != b.Config.Features.Enabled.TradeFeed {
+			b.SetTradeFeedStatus(b.Config.Features.Enabled.TradeFeed)
+		}
+
 		b.Features.Enabled.AutoPairUpdates = b.Config.Features.Enabled.AutoPairUpdates
 	}
 }
@@ -1205,6 +1209,27 @@ func (b *Base) SetSaveTradeDataStatus(enabled bool) {
 	b.Config.Features.Enabled.SaveTradeData = enabled
 	if b.Verbose {
 		log.Debugf(log.Trade, "Set %v 'SaveTradeData' to %v", b.Name, enabled)
+	}
+}
+
+// IsTradeFeedEnabled checks the state of
+// TradeFeed in a concurrent-friendly manner
+func (b *Base) IsTradeFeedEnabled() bool {
+	b.settingsMutex.RLock()
+	isEnabled := b.Features.Enabled.TradeFeed
+	b.settingsMutex.RUnlock()
+	return isEnabled
+}
+
+// SetTradeFeedStatus locks and sets the status of
+// the config and the exchange's setting for TradeFeed
+func (b *Base) SetTradeFeedStatus(enabled bool) {
+	b.settingsMutex.Lock()
+	defer b.settingsMutex.Unlock()
+	b.Features.Enabled.TradeFeed = enabled
+	b.Config.Features.Enabled.TradeFeed = enabled
+	if b.Verbose {
+		log.Debugf(log.Trade, "Set %v 'TradeFeed' to %v", b.Name, enabled)
 	}
 }
 

--- a/exchanges/exchange_types.go
+++ b/exchanges/exchange_types.go
@@ -157,6 +157,7 @@ type FeaturesEnabled struct {
 	AutoPairUpdates bool
 	Kline           kline.ExchangeCapabilitiesEnabled
 	SaveTradeData   bool
+	TradeFeed       bool
 }
 
 // FeaturesSupported stores the exchanges supported features

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -121,14 +121,25 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 	w.Wg = new(sync.WaitGroup)
 	w.SetCanUseAuthenticatedEndpoints(s.AuthenticatedWebsocketAPISupport)
 
-	return w.Orderbook.Setup(s.OrderbookBufferLimit,
+	if err := w.Orderbook.Setup(s.OrderbookBufferLimit,
 		s.BufferEnabled,
 		s.SortBuffer,
 		s.SortBufferByUpdateIDs,
 		s.UpdateEntriesByID,
 		s.Verbose,
 		w.exchangeName,
-		w.DataHandler)
+		w.DataHandler); err != nil {
+		return err
+	}
+
+	if err := w.Trade.Setup(w.exchangeName,
+		s.SaveTradeData,
+		s.TradeFeed,
+		w.DataHandler); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // SetupNewConnection sets up an auth or unauth streaming connection

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 )
 
 // Websocket functionality list and state consts
@@ -71,6 +72,9 @@ type Websocket struct {
 	// Orderbook is a local buffer of orderbooks
 	Orderbook buffer.Orderbook
 
+	// Trade is a notifier of occurring trades
+	Trade trade.Trade
+
 	// trafficAlert monitors if there is a halt in traffic throughput
 	TrafficAlert chan struct{}
 	// ReadMessageErrors will received all errors from ws.ReadMessage() and
@@ -105,6 +109,9 @@ type WebsocketSetup struct {
 	SortBuffer            bool
 	SortBufferByUpdateIDs bool
 	UpdateEntriesByID     bool
+	// Trade data config values
+	SaveTradeData bool
+	TradeFeed     bool
 }
 
 // WebsocketConnection contains all the data needed to send a message to a WS

--- a/exchanges/trade/trade.go
+++ b/exchanges/trade/trade.go
@@ -27,6 +27,29 @@ func (p *Processor) setup(wg *sync.WaitGroup) {
 	go p.Run(wg)
 }
 
+func (t *Trade) Setup(exchangeName string, saveTradeData, tradeFeedEnabled bool, c chan interface{}) error {
+	t.exchangeName = exchangeName
+	t.dataHandler = c
+	t.saveTradeData = saveTradeData
+	t.tradeFeedEnabled = tradeFeedEnabled
+
+	return nil
+}
+
+func (t *Trade) Update(data ...Data) error {
+	if t.saveTradeData {
+		if err := AddTradesToBuffer(t.exchangeName, data...); err != nil {
+			return err
+		}
+	}
+
+	if t.tradeFeedEnabled {
+		t.dataHandler <- data
+	}
+
+	return nil
+}
+
 // AddTradesToBuffer will push trade data onto the buffer
 func AddTradesToBuffer(exchangeName string, data ...Data) error {
 	cfg := database.DB.GetConfig()

--- a/exchanges/trade/trade_types.go
+++ b/exchanges/trade/trade_types.go
@@ -24,6 +24,13 @@ var (
 	ErrNoTradesSupplied = errors.New("no trades supplied")
 )
 
+type Trade struct {
+	exchangeName     string
+	dataHandler      chan interface{}
+	saveTradeData    bool
+	tradeFeedEnabled bool
+}
+
 // Data defines trade data
 type Data struct {
 	ID           uuid.UUID `json:"ID,omitempty"`


### PR DESCRIPTION
Most relevant to applications that import GCT as a lib, this allows
them to (through configuration, disabled by default) receive trade data
through the data channel similarly to the orderbook feed.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [?] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
