### PR TITLE
ftx: fix websocket authentication of subaccounts

### DIFF
--- a/exchanges/ftx/ftx_types.go
+++ b/exchanges/ftx/ftx_types.go
@@ -553,9 +553,10 @@ type OptionFillsData struct {
 
 // AuthenticationData stores authentication variables required
 type AuthenticationData struct {
-	Key  string `json:"key"`
-	Sign string `json:"sign"`
-	Time int64  `json:"time"`
+	Key        string `json:"key"`
+	Sign       string `json:"sign"`
+	Time       int64  `json:"time"`
+	SubAccount string `json:"subaccount,omitempty"`
 }
 
 // Authenticate stores authentication variables required

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -90,11 +90,13 @@ func (f *FTX) WsAuth() error {
 	sign := crypto.HexEncodeToString(hmac)
 	req := Authenticate{Operation: "login",
 		Args: AuthenticationData{
-			Key:  f.API.Credentials.Key,
-			Sign: sign,
-			Time: intNonce,
+			Key:        f.API.Credentials.Key,
+			Sign:       sign,
+			Time:       intNonce,
+			SubAccount: f.API.Credentials.Subaccount,
 		},
 	}
+
 	return f.Websocket.Conn.SendJSONMessage(req)
 }
 


### PR DESCRIPTION
Fixes FTX websocket auth when using subaccounts, according to https://docs.ftx.com/#authentication-2, when using subaccounts you need to provide it as an authentication parameter

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
