### PR TITLE
binance: order history use request pair

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1403,10 +1403,6 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 					continue
 				}
 
-				pair, err := currency.NewPairFromString(resp[i].Symbol)
-				if err != nil {
-					return nil, err
-				}
 				orders = append(orders, order.Detail{
 					Amount:   resp[i].OrigQty,
 					Date:     resp[i].Time,
@@ -1415,7 +1411,7 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.GetOrdersReque
 					Side:     orderSide,
 					Type:     orderType,
 					Price:    resp[i].Price,
-					Pair:     pair,
+					Pair:     req.Pairs[x],
 					Status:   order.Status(resp[i].Status),
 				})
 			}


### PR DESCRIPTION
# PR Description

When retrieving orders from Binance for pair AVAX/USDT (or like RAMPUSDT), the response is returning AVA/XUSDT (or RAM/PUSDT) instead. Changed to use request pair to make order history work as expected first.

But the problem lies deeper in:

```
// NewPairFromString converts currency string into a new CurrencyPair
// with or without delimeter
func NewPairFromString(currencyPair string) (Pair, error) {
	for x := range delimiters {
		if strings.Contains(currencyPair, delimiters[x]) {
			return NewPairDelimiter(currencyPair, delimiters[x])
		}
	}
	if len(currencyPair) < 3 {
		return Pair{},
			fmt.Errorf("cannot create pair from %s string",
				currencyPair)
	}
	return NewPairFromStrings(currencyPair[0:3], currencyPair[3:])
}
```

Wondering if there's any reason to split the pair string at index 3? Is it simply because back in 2019 coins are usually with 3 characters? This could be a wider problem as e.g. AVA and AVAX are both trading in large exchanges, (another problem is there's also coins like RAM,RAMP, PUSD, USD, thus RAMPUSD could actually represent two pairs depending splitting at which index, a more sophisticated NewPairFromString() is needed).

Fixes # Pair being incorrectly parsed in Binance spot order history

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
