### PR TITLE
Binance coin margined futures fixes

### DIFF
--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -1043,6 +1043,46 @@ func (b *Binance) FuturesNewOrder(ctx context.Context, x *FuturesNewOrderRequest
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodPost, cfuturesOrder, params, cFuturesOrdersDefaultRate, &resp)
 }
 
+// FuturesModifyOrder modifies a futures order
+//       https://binance-docs.github.io/apidocs/delivery/en/#modify-order-trade
+//
+//	Either orderId or origClientOrderId must be sent, and the orderId will prevail if both are sent.
+func (b *Binance) FuturesModifyOrder(ctx context.Context, symbol currency.Pair,
+	side, orderID, origClientOrderID string,
+	quantity, price float64,
+	recvWindow int64) (FuturesOrderModifyData, error) {
+	var resp FuturesOrderModifyData
+	params := url.Values{}
+	symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
+	if err != nil {
+		return resp, err
+	}
+	params.Set("symbol", symbolValue)
+	params.Set("side", side)
+
+	if orderID != "" {
+		params.Set("orderId", orderID)
+	}
+
+	if origClientOrderID != "" {
+		params.Set("origClientOrderId", origClientOrderID)
+	}
+
+	if quantity != 0 {
+		params.Set("quantity", strconv.FormatFloat(quantity, 'f', -1, 64))
+	}
+
+	if price != 0 {
+		params.Set("price", strconv.FormatFloat(price, 'f', -1, 64))
+	}
+
+	if recvWindow != 0 {
+		params.Set("recvWindow", strconv.FormatInt(recvWindow, 10))
+	}
+
+	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodPut, cfuturesOrder, params, cFuturesOrdersDefaultRate, &resp)
+}
+
 // FuturesBatchOrder sends a batch order request
 func (b *Binance) FuturesBatchOrder(ctx context.Context, data []PlaceBatchOrderData) ([]FuturesOrderPlaceData, error) {
 	var resp []FuturesOrderPlaceData

--- a/exchanges/binance/binance_live_test.go
+++ b/exchanges/binance/binance_live_test.go
@@ -3,6 +3,7 @@
 
 // This will build if build tag mock_test_off is parsed and will do live testing
 // using all tests in (exchange)_test.go
+//	eg. go test -run=TestFuturesNewOrder -tags mock_test_off ./exchanges/binance
 package binance
 
 import (

--- a/exchanges/binance/cfutures_types.go
+++ b/exchanges/binance/cfutures_types.go
@@ -283,6 +283,31 @@ type FuturesOrderGetData struct {
 	PriceProtect       bool      `json:"priceProtect"`
 }
 
+// FuturesOrderGetData stores futures order data for modify requests
+type FuturesOrderModifyData struct {
+	Symbol             string    `json:"symbol"`
+	Pair               string    `json:"pair"`
+	Status             string    `json:"status"`
+	OrderID            int64     `json:"orderId"`
+	ClientOrderID      string    `json:"clientOrderID"`
+	Price              float64   `json:"price,string"`
+	AveragePrice       float64   `json:"avgPrice,string"`
+	ExecutedQuantity   float64   `json:"executedQty,string"`
+	CumulativeQuantity float64   `json:"cumQty,string"`
+	CumulativeBase     float64   `json:"cumBase,string"`
+	TimeInForce        string    `json:"timeInForce"`
+	OrderType          string    `json:"type"`
+	ReduceOnly         bool      `json:"reduceOnly"`
+	ClosePosition      bool      `json:"closePosition"`
+	Side               string    `json:"buy"`
+	PositionSide       string    `json:"positionSide"`
+	StopPrice          float64   `json:"stopPrice,string"`
+	WorkingType        string    `json:"workingType"`
+	PriceProtect       bool      `json:"priceProtect"`
+	OriginalType       string    `json:"origType"`
+	UpdateTime         time.Time `json:"updateTime"`
+}
+
 // FuturesOrderData stores order data for futures
 type FuturesOrderData struct {
 	AvgPrice      float64   `json:"avgPrice,string"`


### PR DESCRIPTION
# PR Description

Fixes an unmarshaling issue with Binance's Coin Margined SubmitOrder and implements Modify Order.
Caveat: due to [temporary unavalability of the Modify Order request](https://www.binance.com/en/support/announcement/3d181103ed41430baee7e9ef5823443e) these are failing with 400 Bad Request, we can either merge this as is or wait until Binance fixes the API

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [X] TestModifyOrder

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
