### PR TITLE
Add an exchange name setter method

### DIFF
--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -354,6 +354,11 @@ func (b *Base) GetName() string {
 	return b.Name
 }
 
+// SetName is a method that overrides the name of the exchange base
+func (b *Base) SetName(name string) {
+	b.Name = name
+}
+
 // GetEnabledFeatures returns the exchanges enabled features
 func (b *Base) GetEnabledFeatures() FeaturesEnabled {
 	return b.Features.Enabled

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -757,6 +757,20 @@ func TestGetName(t *testing.T) {
 	}
 }
 
+func TestSetName(t *testing.T) {
+	t.Parallel()
+
+	b := Base{
+		Name: "TESTNAME",
+	}
+
+	b.SetName("OTHER_TEST_NAME")
+
+	if name := b.GetName(); name != "OTHER_TEST_NAME" {
+		t.Error("Exchange GetName() returned incorrect name")
+	}
+}
+
 func TestGetFeatures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Useful for services that import GCT as a lib and would like to
manipulate exchange attributes (eg. aliased exchanges use-case).

- [S] New feature (non-breaking change which adds functionality)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [X] TestSetName

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
