### PR TITLE
Allow runtime activation of currency assets/pairs

### DIFF
--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -1130,6 +1130,25 @@ func TestSupportsPair(t *testing.T) {
 	}
 }
 
+func TestCurrencyPairActivation(t *testing.T) {
+	t.Parallel()
+
+	b := Base{
+		Name: "TESTNAME",
+		CurrencyPairs: currency.PairsManager{
+			Pairs: map[asset.Item]*currency.PairStore{
+				asset.Spot: {
+					AssetEnabled: convert.BoolPtr(false),
+				},
+			},
+		},
+	}
+
+	if err := b.ActivatePair(asset.Spot, currency.NewPair(currency.ETH, currency.USD)); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFormatExchangeCurrencies(t *testing.T) {
 	t.Parallel()
 
@@ -2392,6 +2411,19 @@ func TestAssetWebsocketFunctionality(t *testing.T) {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
+	// enable futures asset
+	err = b.StoreAssetPairFormat(asset.Futures, currency.PairStore{
+		RequestFormat: &currency.PairFormat{
+			Uppercase: true,
+		},
+		ConfigFormat: &currency.PairFormat{
+			Uppercase: true,
+		},
+	})
+	if err != nil {
+		log.Errorln(log.ExchangeSys, err)
+	}
+
 	err = b.DisableAssetWebsocketSupport(asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("expected error: %v but received: %v", nil, err)
@@ -2399,6 +2431,15 @@ func TestAssetWebsocketFunctionality(t *testing.T) {
 
 	if b.IsAssetWebsocketSupported(asset.Spot) {
 		t.Fatal("error asset is not turned off, unexpected response")
+	}
+
+	err = b.EnableAssetWebsocketSupport(asset.Futures)
+	if !errors.Is(err, nil) {
+		t.Fatalf("expected error: %v but received: %v", nil, err)
+	}
+
+	if !b.IsAssetWebsocketSupported(asset.Futures) {
+		t.Fatal("error asset is not turned on, unexpected response")
 	}
 
 	// Edge case


### PR DESCRIPTION
Allow runtime activation of currency assets/pairs instead of relying solely on proper configuration of .json.

- [X] New feature (non-breaking change which adds functionality)

- [X] go test ./... -race
- [X] golangci-lint run
- [X] TestCurrencyPairActivation, TestAssetWebsocketFunctionality

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
