### PR TITLE
binance: fetch USD margined futures positions

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -714,16 +714,22 @@ func (b *Binance) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (
 		acc.Currencies = currencyDetails
 
 	case asset.USDTMarginedFutures:
-		accData, err := b.UAccountBalanceV2(ctx)
+		accData, err := b.UAccountInformationV2(ctx)
 		if err != nil {
 			return info, err
 		}
 		var currencyDetails []account.Balance
-		for i := range accData {
+		for i := range accData.Assets {
 			currencyDetails = append(currencyDetails, account.Balance{
-				CurrencyName: currency.NewCode(accData[i].Asset),
-				TotalValue:   accData[i].Balance,
-				Hold:         accData[i].Balance - accData[i].AvailableBalance,
+				CurrencyName: currency.NewCode(accData.Assets[i].Asset),
+				TotalValue:   accData.Assets[i].WalletBalance,
+				Hold:         accData.Assets[i].WalletBalance - accData.Assets[i].AvailableBalance,
+			})
+		}
+		for i := range accData.Positions {
+			currencyDetails = append(currencyDetails, account.Balance{
+				CurrencyName: currency.NewCode(accData.Positions[i].Symbol),
+				TotalValue:   accData.Positions[i].Amount,
 			})
 		}
 

--- a/exchanges/binance/ufutures_types.go
+++ b/exchanges/binance/ufutures_types.go
@@ -288,6 +288,7 @@ type UAccountInformationV2Data struct {
 		EntryPrice             float64 `json:"entryPrice,string"`
 		MaxNotional            float64 `json:"maxNotional,string"`
 		PositionSide           string  `json:"positionSide"`
+		Amount                 float64 `json:"positionAmt,string"`
 	} `json:"positions"`
 }
 


### PR DESCRIPTION
Fetch all account info out of Binance USD-Margined futures, including open positions (relevant to strategies that want to know their current balance).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
