### PR TITLE
binance: allow exposure of trade feed through websocket data channel

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -231,6 +231,7 @@ func (b *Binance) Setup(exch *config.Exchange) error {
 		Features:              &b.Features.Supports.WebsocketCapabilities,
 		SortBuffer:            true,
 		SortBufferByUpdateIDs: true,
+		TradeFeed:             b.Features.Enabled.TradeFeed,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Expose Binance trade feed through channel

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
