### PR TITLE
Binance: Add position fields to FuturesAccountInformation

### DIFF
--- a/exchanges/binance/cfutures_types.go
+++ b/exchanges/binance/cfutures_types.go
@@ -359,6 +359,25 @@ type FuturesAccountBalanceData struct {
 	UpdateTime         int64   `json:"updateTime"`
 }
 
+// FuturesAccountInformationPositions  holds account position data
+type FuturesAccountInformationPositions struct {
+	Symbol                 string    `json:"symbol"`
+	Amount                 float64   `json:"positionAmt,string"`
+	InitialMargin          float64   `json:"initialMargin,string"`
+	MaintMargin            float64   `json:"maintMargin,string"`
+	UnrealizedProfit       float64   `json:"unrealizedProfit,string"`
+	PositionInitialMargin  float64   `json:"positionInitialMargin,string"`
+	OpenOrderInitialMargin float64   `json:"openOrderInitialMargin,string"`
+	Leverage               float64   `json:"leverage,string"`
+	Isolated               bool      `json:"isolated"`
+	PositionSide           string    `json:"positionSide"`
+	EntryPrice             float64   `json:"entryPrice,string"`
+	MaxQty                 float64   `json:"maxQty,string"`
+	UpdateTime             time.Time `json:"updateTime"`
+	NotionalValue          float64   `json:"notionalValue,string"`
+	IsolatedWallet         float64   `json:"isolatedWallet,string"`
+}
+
 // FuturesAccountInformation stores account information for futures account
 type FuturesAccountInformation struct {
 	Assets []struct {
@@ -370,30 +389,17 @@ type FuturesAccountInformation struct {
 		InitialMargin          float64 `json:"initialMargin,string"`
 		PositionInitialMargin  float64 `json:"positionInitialMargin,string"`
 		OpenOrderInitialMargin float64 `json:"openOrderInitialMargin,string"`
-		Leverage               float64 `json:"leverage,string"`
-		Isolated               bool    `json:"isolated"`
-		PositionSide           string  `json:"positionSide"`
-		EntryPrice             float64 `json:"entryPrice,string"`
-		MaxQty                 float64 `json:"maxQty,string"`
+		MaxWithdrawAmount      float64 `json:"maxWithdrawAmount,string"`
+		CrossWalletBalance     float64 `json:"crossWalletBalance,string"`
+		CrossUnPNL             float64 `json:"crossUnPnl,string"`
+		AvailableBalance       float64 `json:"availableBalance,string"`
 	} `json:"assets"`
-	Positions []struct {
-		Symbol                 string  `json:"symbol"`
-		InitialMargin          float64 `json:"initialMargin,string"`
-		MaintMargin            float64 `json:"maintMargin,string"`
-		UnrealizedProfit       float64 `json:"unrealizedProfit,string"`
-		PositionInitialMargin  float64 `json:"positionInitialMargin,string"`
-		OpenOrderInitialMargin float64 `json:"openOrderInitialMargin,string"`
-		Leverage               float64 `json:"leverage,string"`
-		Isolated               bool    `json:"isolated"`
-		PositionSide           string  `json:"positionSide"`
-		EntryPrice             float64 `json:"entryPrice,string"`
-		MaxQty                 float64 `json:"maxQty,string"`
-	} `json:"positions"`
-	CanDeposit  bool  `json:"canDeposit"`
-	CanTrade    bool  `json:"canTrade"`
-	CanWithdraw bool  `json:"canWithdraw"`
-	FeeTier     int64 `json:"feeTier"`
-	UpdateTime  int64 `json:"updateTime"`
+	Positions   []FuturesAccountInformationPositions `json:"positions"`
+	CanDeposit  bool                                 `json:"canDeposit"`
+	CanTrade    bool                                 `json:"canTrade"`
+	CanWithdraw bool                                 `json:"canWithdraw"`
+	FeeTier     int64                                `json:"feeTier"`
+	UpdateTime  time.Time                            `json:"updateTime"`
 }
 
 // GenericAuthResponse is a general data response for a post auth request

--- a/exchanges/binance/type_convert.go
+++ b/exchanges/binance/type_convert.go
@@ -441,3 +441,43 @@ func (u *UFuturesSymbolInfo) UnmarshalJSON(data []byte) error {
 	u.OnboardDate = aux.OnboardDate.Time()
 	return nil
 }
+
+// UnmarshalJSON deserialises the JSON info, including the timestamp
+func (a *FuturesAccountInformationPositions) UnmarshalJSON(data []byte) error {
+	type Alias FuturesAccountInformationPositions
+
+	aux := &struct {
+		UpdateTime binanceTime `json:"updateTime"`
+		*Alias
+	}{
+		Alias: (*Alias)(a),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	a.UpdateTime = aux.UpdateTime.Time()
+
+	return nil
+}
+
+// UnmarshalJSON deserialises the JSON info, including the timestamp
+func (a *FuturesAccountInformation) UnmarshalJSON(data []byte) error {
+	type Alias FuturesAccountInformation
+
+	aux := &struct {
+		UpdateTime binanceTime `json:"updateTime"`
+		*Alias
+	}{
+		Alias: (*Alias)(a),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	a.UpdateTime = aux.UpdateTime.Time()
+
+	return nil
+}


### PR DESCRIPTION
# PR Description

FuturesAccountInformation.Positions had some fields missing, which are now added.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

By actually interacting with Binance Coin-M Futures.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
