### PR TITLE
Backtester: Fix dividing by zero when missing data

### DIFF
--- a/backtester/common/common_types.go
+++ b/backtester/common/common_types.go
@@ -65,10 +65,10 @@ type EventHandler interface {
 // DataEventHandler interface used for loading and interacting with Data
 type DataEventHandler interface {
 	EventHandler
-	ClosePrice() decimal.Decimal
-	HighPrice() decimal.Decimal
-	LowPrice() decimal.Decimal
-	OpenPrice() decimal.Decimal
+	GetClosePrice() decimal.Decimal
+	GetHighPrice() decimal.Decimal
+	GetLowPrice() decimal.Decimal
+	GetOpenPrice() decimal.Decimal
 }
 
 // Directioner dictates the side of an order

--- a/backtester/data/data_test.go
+++ b/backtester/data/data_test.go
@@ -74,10 +74,10 @@ func TestStream(t *testing.T) {
 	f.GetAssetType()
 	f.GetReason()
 	f.AppendReason("fake")
-	f.ClosePrice()
-	f.HighPrice()
-	f.LowPrice()
-	f.OpenPrice()
+	f.GetClosePrice()
+	f.GetHighPrice()
+	f.GetLowPrice()
+	f.GetOpenPrice()
 
 	d.AppendStream(fakeDataHandler{time: 1})
 	d.AppendStream(fakeDataHandler{time: 4})
@@ -208,18 +208,18 @@ func (t fakeDataHandler) GetReason() string {
 func (t fakeDataHandler) AppendReason(string) {
 }
 
-func (t fakeDataHandler) ClosePrice() decimal.Decimal {
+func (t fakeDataHandler) GetClosePrice() decimal.Decimal {
 	return decimal.Zero
 }
 
-func (t fakeDataHandler) HighPrice() decimal.Decimal {
+func (t fakeDataHandler) GetHighPrice() decimal.Decimal {
 	return decimal.Zero
 }
 
-func (t fakeDataHandler) LowPrice() decimal.Decimal {
+func (t fakeDataHandler) GetLowPrice() decimal.Decimal {
 	return decimal.Zero
 }
 
-func (t fakeDataHandler) OpenPrice() decimal.Decimal {
+func (t fakeDataHandler) GetOpenPrice() decimal.Decimal {
 	return decimal.Zero
 }

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -40,7 +40,7 @@ func (e *Exchange) ExecuteOrder(o order.Event, data data.Handler, orderManager *
 		},
 		Direction:  o.GetDirection(),
 		Amount:     o.GetAmount(),
-		ClosePrice: data.Latest().ClosePrice(),
+		ClosePrice: data.Latest().GetClosePrice(),
 	}
 	eventFunds := o.GetAllocatedFunds()
 	cs, err := e.GetCurrencySettings(o.GetExchange(), o.GetAssetType(), o.Pair())

--- a/backtester/eventhandlers/portfolio/holdings/holdings_types.go
+++ b/backtester/eventhandlers/portfolio/holdings/holdings_types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
@@ -43,4 +44,11 @@ type Holding struct {
 	TotalValueLostToVolumeSizing decimal.Decimal `json:"total-value-lost-to-volume-sizing"`
 	TotalValueLostToSlippage     decimal.Decimal `json:"total-value-lost-to-slippage"`
 	TotalValueLost               decimal.Decimal `json:"total-value-lost"`
+}
+
+// ClosePriceReader is used for holdings calculations
+// without needing to consider event types
+type ClosePriceReader interface {
+	common.EventHandler
+	GetClosePrice() decimal.Decimal
 }

--- a/backtester/eventhandlers/statistics/currencystatistics.go
+++ b/backtester/eventhandlers/statistics/currencystatistics.go
@@ -65,9 +65,8 @@ func (c *CurrencyPairStatistic) CalculateResults(riskFreeRate decimal.Decimal) e
 		if c.Events[i].SignalEvent != nil && c.Events[i].SignalEvent.GetDirection() == common.MissingData {
 			c.ShowMissingDataWarning = true
 		}
-		if c.Events[i-1].DataEvent.GetClosePrice().IsZero() ||
-			(c.Events[i].DataEvent.GetClosePrice().IsZero() && !c.Events[i-1].DataEvent.GetClosePrice().IsZero()) {
-			// closing price for the current candle or previous candle is missing, use the previous
+		if c.Events[i].DataEvent.GetClosePrice().IsZero() || c.Events[i-1].DataEvent.GetClosePrice().IsZero() {
+			// closing price for the current candle or previous candle is zero, use the previous
 			// benchmark rate to allow some consistency
 			c.ShowMissingDataWarning = true
 			benchmarkRates[i] = benchmarkRates[i-1]

--- a/backtester/eventhandlers/statistics/currencystatistics_test.go
+++ b/backtester/eventhandlers/statistics/currencystatistics_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventhandlers/portfolio/compliance"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventhandlers/portfolio/holdings"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventtypes/event"
@@ -105,6 +106,7 @@ func TestCalculateResults(t *testing.T) {
 		SignalEvent: &signal.Signal{
 			Base:       even2,
 			ClosePrice: decimal.NewFromInt(1337),
+			Direction:  common.MissingData,
 		},
 	}
 
@@ -115,6 +117,41 @@ func TestCalculateResults(t *testing.T) {
 	}
 	if !cs.MarketMovement.Equal(decimal.NewFromFloat(-33.15)) {
 		t.Error("expected -33.15")
+	}
+	ev3 := ev2
+	ev3.DataEvent = &kline.Kline{
+		Base:   even2,
+		Open:   decimal.NewFromInt(1339),
+		Close:  decimal.NewFromInt(1339),
+		Low:    decimal.NewFromInt(1339),
+		High:   decimal.NewFromInt(1339),
+		Volume: decimal.NewFromInt(1339),
+	}
+	cs.Events = append(cs.Events, ev, ev3)
+	cs.Events[0].DataEvent = &kline.Kline{
+		Base:   even2,
+		Open:   decimal.Zero,
+		Close:  decimal.Zero,
+		Low:    decimal.Zero,
+		High:   decimal.Zero,
+		Volume: decimal.Zero,
+	}
+	err = cs.CalculateResults(decimal.NewFromFloat(0.03))
+	if err != nil {
+		t.Error(err)
+	}
+
+	cs.Events[1].DataEvent = &kline.Kline{
+		Base:   even2,
+		Open:   decimal.Zero,
+		Close:  decimal.Zero,
+		Low:    decimal.Zero,
+		High:   decimal.Zero,
+		Volume: decimal.Zero,
+	}
+	err = cs.CalculateResults(decimal.NewFromFloat(0.03))
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/backtester/eventhandlers/statistics/fundingstatistics.go
+++ b/backtester/eventhandlers/statistics/fundingstatistics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/funding"
+	"github.com/thrasher-corp/gocryptotrader/backtester/funding/trackingcurrencies"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	gctmath "github.com/thrasher-corp/gocryptotrader/common/math"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -176,7 +177,6 @@ func CalculateIndividualFundingStatistics(disableUSDTracking bool, reportItem *f
 			item.HighestClosePrice.Time = closePrices[i].Time
 		}
 	}
-
 	for i := range relatedStats {
 		if relatedStats[i].stat == nil {
 			return nil, fmt.Errorf("%w related stats", common.ErrNilArguments)
@@ -213,6 +213,9 @@ func CalculateIndividualFundingStatistics(disableUSDTracking bool, reportItem *f
 				Value: item.ReportItem.Snapshots[j].USDValue,
 			}
 		}
+	}
+	if trackingcurrencies.CurrencyIsUSDTracked(item.ReportItem.Currency) {
+		return item, nil
 	}
 	if item.ReportItem.USDPairCandle == nil {
 		return nil, fmt.Errorf("%w usd candles missing", errMissingSnapshots)

--- a/backtester/eventhandlers/statistics/fundingstatistics.go
+++ b/backtester/eventhandlers/statistics/fundingstatistics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/funding"
-	"github.com/thrasher-corp/gocryptotrader/backtester/funding/trackingcurrencies"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	gctmath "github.com/thrasher-corp/gocryptotrader/common/math"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -213,9 +212,6 @@ func CalculateIndividualFundingStatistics(disableUSDTracking bool, reportItem *f
 				Value: item.ReportItem.Snapshots[j].USDValue,
 			}
 		}
-	}
-	if trackingcurrencies.CurrencyIsUSDTracked(item.ReportItem.Currency) {
-		return item, nil
 	}
 	if item.ReportItem.USDPairCandle == nil {
 		return nil, fmt.Errorf("%w usd candles missing", errMissingSnapshots)

--- a/backtester/eventhandlers/statistics/statistics.go
+++ b/backtester/eventhandlers/statistics/statistics.go
@@ -354,7 +354,7 @@ func (s *Statistic) PrintAllEventsChronologically() {
 								currencyStatistic.Events[i].DataEvent.GetExchange(),
 								currencyStatistic.Events[i].DataEvent.GetAssetType(),
 								currencyStatistic.Events[i].DataEvent.Pair(),
-								currencyStatistic.Events[i].DataEvent.ClosePrice().Round(8),
+								currencyStatistic.Events[i].DataEvent.GetClosePrice().Round(8),
 								currencyStatistic.Events[i].DataEvent.GetReason()))
 					default:
 						errs = append(errs, fmt.Errorf("%v %v %v unexpected data received %+v", exch, a, pair, currencyStatistic.Events[i]))

--- a/backtester/eventhandlers/strategies/base/base.go
+++ b/backtester/eventhandlers/strategies/base/base.go
@@ -32,10 +32,10 @@ func (s *Strategy) GetBaseData(d data.Handler) (signal.Signal, error) {
 			Interval:     latest.GetInterval(),
 			Reason:       latest.GetReason(),
 		},
-		ClosePrice: latest.ClosePrice(),
-		HighPrice:  latest.HighPrice(),
-		OpenPrice:  latest.OpenPrice(),
-		LowPrice:   latest.LowPrice(),
+		ClosePrice: latest.GetClosePrice(),
+		HighPrice:  latest.GetHighPrice(),
+		OpenPrice:  latest.GetOpenPrice(),
+		LowPrice:   latest.GetLowPrice(),
 	}, nil
 }
 

--- a/backtester/eventhandlers/strategies/dollarcostaverage/dollarcostaverage.go
+++ b/backtester/eventhandlers/strategies/dollarcostaverage/dollarcostaverage.go
@@ -52,7 +52,7 @@ func (s *Strategy) OnSignal(d data.Handler, _ funding.IFundTransferer, _ portfol
 		return &es, nil
 	}
 
-	es.SetPrice(d.Latest().ClosePrice())
+	es.SetPrice(d.Latest().GetClosePrice())
 	es.SetDirection(order.Buy)
 	es.AppendReason("DCA purchases on every iteration")
 	return &es, nil

--- a/backtester/eventhandlers/strategies/rsi/rsi.go
+++ b/backtester/eventhandlers/strategies/rsi/rsi.go
@@ -55,7 +55,7 @@ func (s *Strategy) OnSignal(d data.Handler, _ funding.IFundTransferer, _ portfol
 	if err != nil {
 		return nil, err
 	}
-	es.SetPrice(d.Latest().ClosePrice())
+	es.SetPrice(d.Latest().GetClosePrice())
 
 	if offset := d.Offset(); offset <= int(s.rsiPeriod.IntPart()) {
 		es.AppendReason("Not enough data for signal generation")

--- a/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
+++ b/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
@@ -102,7 +102,7 @@ func (s *Strategy) OnSimultaneousSignals(d []data.Handler, f funding.IFundTransf
 		if err != nil {
 			return nil, err
 		}
-		es.SetPrice(d[i].Latest().ClosePrice())
+		es.SetPrice(d[i].Latest().GetClosePrice())
 		offset := d[i].Offset()
 
 		if offset <= int(s.mfiPeriod.IntPart()) {

--- a/backtester/eventtypes/kline/kline.go
+++ b/backtester/eventtypes/kline/kline.go
@@ -2,22 +2,22 @@ package kline
 
 import "github.com/shopspring/decimal"
 
-// ClosePrice returns the closing price of a kline
-func (k *Kline) ClosePrice() decimal.Decimal {
+// GetClosePrice returns the closing price of a kline
+func (k *Kline) GetClosePrice() decimal.Decimal {
 	return k.Close
 }
 
-// HighPrice returns the high price of a kline
-func (k *Kline) HighPrice() decimal.Decimal {
+// GetHighPrice returns the high price of a kline
+func (k *Kline) GetHighPrice() decimal.Decimal {
 	return k.High
 }
 
-// LowPrice returns the low price of a kline
-func (k *Kline) LowPrice() decimal.Decimal {
+// GetLowPrice returns the low price of a kline
+func (k *Kline) GetLowPrice() decimal.Decimal {
 	return k.Low
 }
 
-// OpenPrice returns the open price of a kline
-func (k *Kline) OpenPrice() decimal.Decimal {
+// GetOpenPrice returns the open price of a kline
+func (k *Kline) GetOpenPrice() decimal.Decimal {
 	return k.Open
 }

--- a/backtester/eventtypes/kline/kline_test.go
+++ b/backtester/eventtypes/kline/kline_test.go
@@ -11,7 +11,7 @@ func TestClose(t *testing.T) {
 	k := Kline{
 		Close: decimal.NewFromInt(1337),
 	}
-	if !k.ClosePrice().Equal(decimal.NewFromInt(1337)) {
+	if !k.GetClosePrice().Equal(decimal.NewFromInt(1337)) {
 		t.Error("expected decimal.NewFromInt(1337)")
 	}
 }
@@ -21,7 +21,7 @@ func TestHigh(t *testing.T) {
 	k := Kline{
 		High: decimal.NewFromInt(1337),
 	}
-	if !k.HighPrice().Equal(decimal.NewFromInt(1337)) {
+	if !k.GetHighPrice().Equal(decimal.NewFromInt(1337)) {
 		t.Error("expected decimal.NewFromInt(1337)")
 	}
 }
@@ -31,7 +31,7 @@ func TestLow(t *testing.T) {
 	k := Kline{
 		Low: decimal.NewFromInt(1337),
 	}
-	if !k.LowPrice().Equal(decimal.NewFromInt(1337)) {
+	if !k.GetLowPrice().Equal(decimal.NewFromInt(1337)) {
 		t.Error("expected decimal.NewFromInt(1337)")
 	}
 }
@@ -41,7 +41,7 @@ func TestOpen(t *testing.T) {
 	k := Kline{
 		Open: decimal.NewFromInt(1337),
 	}
-	if !k.OpenPrice().Equal(decimal.NewFromInt(1337)) {
+	if !k.GetOpenPrice().Equal(decimal.NewFromInt(1337)) {
 		t.Error("expected decimal.NewFromInt(1337)")
 	}
 }

--- a/backtester/funding/funding.go
+++ b/backtester/funding/funding.go
@@ -74,10 +74,7 @@ func (f *FundManager) CreateSnapshot(t time.Time) {
 			Available: f.items[i].available,
 			Time:      t,
 		}
-		if trackingcurrencies.CurrencyIsUSDTracked(f.items[i].currency) {
-			iss.USDValue = f.items[i].available
-			iss.USDClosePrice = decimal.NewFromInt(1)
-		} else if !f.disableUSDTracking && !trackingcurrencies.CurrencyIsUSDTracked(f.items[i].currency) {
+		if !f.disableUSDTracking {
 			var usdClosePrice decimal.Decimal
 			if f.items[i].usdTrackingCandles == nil {
 				continue
@@ -85,7 +82,7 @@ func (f *FundManager) CreateSnapshot(t time.Time) {
 			usdCandles := f.items[i].usdTrackingCandles.GetStream()
 			for j := range usdCandles {
 				if usdCandles[j].GetTime().Equal(t) {
-					usdClosePrice = usdCandles[j].ClosePrice()
+					usdClosePrice = usdCandles[j].GetClosePrice()
 					break
 				}
 			}
@@ -108,6 +105,7 @@ func (f *FundManager) AddUSDTrackingData(k *kline.DataFromKline) error {
 	}
 	baseSet := false
 	quoteSet := false
+	var basePairedWith currency.Code
 	for i := range f.items {
 		if baseSet && quoteSet {
 			return nil
@@ -118,10 +116,16 @@ func (f *FundManager) AddUSDTrackingData(k *kline.DataFromKline) error {
 				if f.items[i].usdTrackingCandles == nil &&
 					trackingcurrencies.CurrencyIsUSDTracked(k.Item.Pair.Quote) {
 					f.items[i].usdTrackingCandles = k
+					if f.items[i].pairedWith != nil {
+						basePairedWith = f.items[i].pairedWith.currency
+					}
 				}
 				baseSet = true
 			}
 			if trackingcurrencies.CurrencyIsUSDTracked(f.items[i].currency) {
+				if f.items[i].pairedWith != nil && f.items[i].currency != basePairedWith {
+					continue
+				}
 				if f.items[i].usdTrackingCandles == nil {
 					usdCandles := gctkline.Item{
 						Exchange: k.Item.Exchange,
@@ -208,10 +212,10 @@ func (f *FundManager) GenerateReport() *Report {
 		if !f.disableUSDTracking &&
 			f.items[i].usdTrackingCandles != nil {
 			usdStream := f.items[i].usdTrackingCandles.GetStream()
-			item.USDInitialFunds = f.items[i].initialFunds.Mul(usdStream[0].ClosePrice())
-			item.USDFinalFunds = f.items[i].available.Mul(usdStream[len(usdStream)-1].ClosePrice())
-			item.USDInitialCostForOne = usdStream[0].ClosePrice()
-			item.USDFinalCostForOne = usdStream[len(usdStream)-1].ClosePrice()
+			item.USDInitialFunds = f.items[i].initialFunds.Mul(usdStream[0].GetClosePrice())
+			item.USDFinalFunds = f.items[i].available.Mul(usdStream[len(usdStream)-1].GetClosePrice())
+			item.USDInitialCostForOne = usdStream[0].GetClosePrice()
+			item.USDFinalCostForOne = usdStream[len(usdStream)-1].GetClosePrice()
 			item.USDPairCandle = f.items[i].usdTrackingCandles
 		}
 

--- a/backtester/funding/funding.go
+++ b/backtester/funding/funding.go
@@ -74,7 +74,10 @@ func (f *FundManager) CreateSnapshot(t time.Time) {
 			Available: f.items[i].available,
 			Time:      t,
 		}
-		if !f.disableUSDTracking {
+		if trackingcurrencies.CurrencyIsUSDTracked(f.items[i].currency) {
+			iss.USDValue = f.items[i].available
+			iss.USDClosePrice = decimal.NewFromInt(1)
+		} else if !f.disableUSDTracking && !trackingcurrencies.CurrencyIsUSDTracked(f.items[i].currency) {
 			var usdClosePrice decimal.Decimal
 			if f.items[i].usdTrackingCandles == nil {
 				continue


### PR DESCRIPTION
# PR Description

This PR fixes the issue raised by @MeanSquaredError where there would be a zero value being divided. The fix is to use a previous benchmark's data when a price is zero/missing. Its not accurate, but a warning is displayed and it skews data a lot less than calculating with zeroes.

Verification that the strategy posted [here](https://github.com/thrasher-corp/gocryptotrader/issues/840) now works:
![image](https://user-images.githubusercontent.com/9261323/142353809-1108b669-1cf5-411e-97e1-814f63bff128.png)

I also noticed a couple of other issues during testing:
- Strategies such as `dca-api-candles-multiple-currencies.strat` would fail due to multiple instances of USDT funding Items and USD tracking candles not being appropriately set
- The initial valuation calculation in Holdings/the output report were _way_ off. The calculation is now based upon the initial closing price

Before:
![image](https://user-images.githubusercontent.com/9261323/142353688-f5212fd0-118f-4514-ae7d-bee67bc35489.png)

After:
![image](https://user-images.githubusercontent.com/9261323/142353963-2d7193a3-2029-4f3d-a550-47e0e68ac98a.png)


Fixes # (issue)
https://github.com/thrasher-corp/gocryptotrader/issues/840

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
Updated testing
- [x] go test ./... -race
- [x] golangci-lint run


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes

