### PR TITLE
huobi futures: fix return type when fetching positions

### DIFF
--- a/exchanges/huobi/huobi_futures.go
+++ b/exchanges/huobi/huobi_futures.go
@@ -481,8 +481,8 @@ func (h *HUOBI) FGetAccountInfo(ctx context.Context, symbol currency.Code) (FUse
 }
 
 // FGetPositionsInfo gets positions info for futures account
-func (h *HUOBI) FGetPositionsInfo(ctx context.Context, symbol currency.Code) (FUserAccountData, error) {
-	var resp FUserAccountData
+func (h *HUOBI) FGetPositionsInfo(ctx context.Context, symbol currency.Code) (FUsersPositionsInfo, error) {
+	var resp FUsersPositionsInfo
 	req := make(map[string]interface{})
 	if symbol != (currency.Code{}) {
 		codeValue, err := h.formatFuturesCode(symbol)


### PR DESCRIPTION
# PR Description

Fix wrong return type of FGetPositionsInfo

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
