### PR TITLE
log: expose output writer interface

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -19,10 +19,18 @@ func NewSubLogger(name string) (*SubLogger, error) {
 		return nil, errEmptyLoggerName
 	}
 	name = strings.ToUpper(name)
-	if _, ok := subLoggers[name]; ok {
+	if _, ok := SubLoggers[name]; ok {
 		return nil, errSubLoggerAlreadyregistered
 	}
 	return registerNewSubLogger(name), nil
+}
+
+// SetOutput overrides the default output with a new writer
+func (s *SubLogger) SetOutput(o io.Writer) {
+	RWM.Lock()
+	defer RWM.Unlock()
+
+	s.output = o
 }
 
 func newLogger(c *Config) *Logger {
@@ -75,7 +83,7 @@ func CloseLogger() error {
 }
 
 func validSubLogger(s string) (bool, *SubLogger) {
-	if v, found := subLoggers[s]; found {
+	if v, found := SubLoggers[s]; found {
 		return true, v
 	}
 	return false, nil

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -68,7 +68,7 @@ func configureSubLogger(logger, levels string, output io.Writer) error {
 	logPtr.output = output
 
 	logPtr.Levels = splitLevel(levels)
-	subLoggers[logger] = logPtr
+	SubLoggers[logger] = logPtr
 
 	return nil
 }
@@ -95,9 +95,9 @@ func SetupGlobalLogger() {
 		}
 	}
 
-	for x := range subLoggers {
-		subLoggers[x].Levels = splitLevel(GlobalLogConfig.Level)
-		subLoggers[x].output = getWriters(&GlobalLogConfig.SubLoggerConfig)
+	for x := range SubLoggers {
+		SubLoggers[x].Levels = splitLevel(GlobalLogConfig.Level)
+		SubLoggers[x].output = getWriters(&GlobalLogConfig.SubLoggerConfig)
 	}
 
 	logger = newLogger(GlobalLogConfig)
@@ -128,7 +128,7 @@ func registerNewSubLogger(logger string) *SubLogger {
 	}
 
 	temp.Levels = splitLevel("INFO|WARN|DEBUG|ERROR")
-	subLoggers[logger] = &temp
+	SubLoggers[logger] = &temp
 
 	return &temp
 }

--- a/log/sublogger_types.go
+++ b/log/sublogger_types.go
@@ -4,7 +4,7 @@ import "io"
 
 // Global vars related to the logger package
 var (
-	subLoggers = map[string]*SubLogger{}
+	SubLoggers = map[string]*SubLogger{}
 
 	Global           *SubLogger
 	BackTester       *SubLogger


### PR DESCRIPTION
This allows applications that import GCT to define their own
writer on their own terms.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
