### PR TITLE
log: fix bug,  expand test coverage and slightly optimize

### DIFF
--- a/backtester/data/kline/database/database_test.go
+++ b/backtester/data/kline/database/database_test.go
@@ -30,7 +30,11 @@ const (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 	var err error
 	testhelpers.PostgresTestDatabase = testhelpers.GetConnectionDetails()

--- a/backtester/main.go
+++ b/backtester/main.go
@@ -64,9 +64,12 @@ func main() {
 
 	var bt *backtest.BackTest
 	var cfg *config.Config
-	logConfig := log.GenDefaultSettings()
-	log.GlobalLogConfig = &logConfig
-	log.SetupGlobalLogger()
+	log.GlobalLogConfig = log.GenDefaultSettings()
+	err = log.SetupGlobalLogger()
+	if err != nil {
+		fmt.Printf("Could not setup global logger. Error: %v.\n", err)
+		os.Exit(1)
+	}
 
 	cfg, err = config.ReadConfigFromFile(configPath)
 	if err != nil {

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -101,11 +101,14 @@ func main() {
 	flag.BoolVar(&create, "create", false, "specifies whether to automatically create trello list, card and checklist in a given board")
 	flag.Parse()
 	var err error
-	c := log.GenDefaultSettings()
 	log.RWM.Lock()
-	log.GlobalLogConfig = &c
+	log.GlobalLogConfig = log.GenDefaultSettings()
 	log.RWM.Unlock()
-	log.SetupGlobalLogger()
+	err = log.SetupGlobalLogger()
+	if err != nil {
+		fmt.Printf("Could not setup global logger. Error: %v.\n", err)
+		os.Exit(1)
+	}
 	configData, err = readFileData(jsonFile)
 	if err != nil {
 		log.Error(log.Global, err)

--- a/cmd/apichecker/apicheck_test.go
+++ b/cmd/apichecker/apicheck_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	c := log.GenDefaultSettings()
 	c.Enabled = convert.BoolPtr(true)
 	log.RWM.Lock()
-	log.GlobalLogConfig = &c
+	log.GlobalLogConfig = c
 	log.RWM.Unlock()
 	log.Infoln(log.Global, "set verbose to true for more detailed output")
 	var err error

--- a/config/config.go
+++ b/config/config.go
@@ -1267,7 +1267,7 @@ func (c *Config) CheckLoggerConfig() error {
 	defer m.Unlock()
 
 	if c.Logging.Enabled == nil || c.Logging.Output == "" {
-		c.Logging = log.GenDefaultSettings()
+		c.Logging = *log.GenDefaultSettings()
 	}
 
 	if c.Logging.AdvancedSettings.ShowLogSystemName == nil {

--- a/database/repository/candle/candle_test.go
+++ b/database/repository/candle/candle_test.go
@@ -30,7 +30,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	var err error

--- a/database/repository/datahistoryjob/datahistoryjob_test.go
+++ b/database/repository/datahistoryjob/datahistoryjob_test.go
@@ -33,7 +33,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 	var err error
 	testhelpers.PostgresTestDatabase = testhelpers.GetConnectionDetails()

--- a/database/repository/datahistoryjobresult/datahistoryjobresult_test.go
+++ b/database/repository/datahistoryjobresult/datahistoryjobresult_test.go
@@ -30,7 +30,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 	var err error
 	testhelpers.PostgresTestDatabase = testhelpers.GetConnectionDetails()

--- a/database/repository/exchange/exchange_test.go
+++ b/database/repository/exchange/exchange_test.go
@@ -30,7 +30,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	var err error

--- a/database/repository/script/script_test.go
+++ b/database/repository/script/script_test.go
@@ -28,7 +28,11 @@ func TestMain(m *testing.M) {
 	}
 
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err = testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	t := m.Run()

--- a/database/repository/trade/trade_test.go
+++ b/database/repository/trade/trade_test.go
@@ -33,7 +33,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 	var err error
 	testhelpers.PostgresTestDatabase = testhelpers.GetConnectionDetails()

--- a/database/repository/withdraw/withdraw_test.go
+++ b/database/repository/withdraw/withdraw_test.go
@@ -29,7 +29,11 @@ var (
 
 func TestMain(m *testing.M) {
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	var err error

--- a/database/testhelpers/test_helpers.go
+++ b/database/testhelpers/test_helpers.go
@@ -122,8 +122,7 @@ func EnableVerboseTestOutput() error {
 	log.RWM.Lock()
 	log.GlobalLogConfig = log.GenDefaultSettings()
 	log.RWM.Unlock()
-	err := log.SetupGlobalLogger()
-	if err != nil {
+	if err := log.SetupGlobalLogger(); err != nil {
 		return err
 	}
 	DBLogger := database.Logger{}

--- a/database/testhelpers/test_helpers.go
+++ b/database/testhelpers/test_helpers.go
@@ -118,14 +118,16 @@ func migrateDB(db *sql.DB) error {
 }
 
 // EnableVerboseTestOutput enables debug output for SQL queries
-func EnableVerboseTestOutput() {
-	c := log.GenDefaultSettings()
+func EnableVerboseTestOutput() error {
 	log.RWM.Lock()
-	log.GlobalLogConfig = &c
+	log.GlobalLogConfig = log.GenDefaultSettings()
 	log.RWM.Unlock()
-	log.SetupGlobalLogger()
-
+	err := log.SetupGlobalLogger()
+	if err != nil {
+		return err
+	}
 	DBLogger := database.Logger{}
 	boil.DebugMode = true
 	boil.DebugWriter = DBLogger
+	return nil
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -90,11 +90,11 @@ func NewFromSettings(settings *Settings, flagSet map[string]bool) (*Engine, erro
 	if *b.Config.Logging.Enabled {
 		err = gctlog.SetupGlobalLogger()
 		if err != nil {
-			return nil, fmt.Errorf("failed to setup global logger. Err: %w", err)
+			return nil, fmt.Errorf("failed to setup global logger. %w", err)
 		}
 		err = gctlog.SetupSubLoggers(b.Config.Logging.SubLoggers)
 		if err != nil {
-			return nil, fmt.Errorf("failed to setup sub loggers. Err: %w", err)
+			return nil, fmt.Errorf("failed to setup sub loggers. %w", err)
 		}
 		gctlog.Infoln(gctlog.Global, "Logger initialised.")
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -84,12 +84,18 @@ func NewFromSettings(settings *Settings, flagSet map[string]bool) (*Engine, erro
 
 	b.Config, err = loadConfigWithSettings(settings, flagSet)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config. Err: %s", err)
+		return nil, fmt.Errorf("failed to load config. Err: %w", err)
 	}
 
 	if *b.Config.Logging.Enabled {
-		gctlog.SetupGlobalLogger()
-		gctlog.SetupSubLoggers(b.Config.Logging.SubLoggers)
+		err = gctlog.SetupGlobalLogger()
+		if err != nil {
+			return nil, fmt.Errorf("failed to setup global logger. Err: %w", err)
+		}
+		err = gctlog.SetupSubLoggers(b.Config.Logging.SubLoggers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to setup sub loggers. Err: %w", err)
+		}
 		gctlog.Infoln(gctlog.Global, "Logger initialised.")
 	}
 
@@ -99,12 +105,12 @@ func NewFromSettings(settings *Settings, flagSet map[string]bool) (*Engine, erro
 
 	err = utils.AdjustGoMaxProcs(settings.GoMaxProcs)
 	if err != nil {
-		return nil, fmt.Errorf("unable to adjust runtime GOMAXPROCS value. Err: %s", err)
+		return nil, fmt.Errorf("unable to adjust runtime GOMAXPROCS value. Err: %w", err)
 	}
 
 	b.gctScriptManager, err = gctscript.NewManager(&b.Config.GCTScript)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create script manager. Err: %s", err)
+		return nil, fmt.Errorf("failed to create script manager. Err: %w", err)
 	}
 
 	b.ExchangeManager = SetupExchangeManager()

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -33,8 +33,7 @@ func TestMain(m *testing.M) {
 	log.RWM.Lock()
 	log.GlobalLogConfig = log.GenDefaultSettings()
 	log.RWM.Unlock()
-	err := log.SetupGlobalLogger()
-	if err != nil {
+	if err := log.SetupGlobalLogger(); err != nil {
 		fmt.Println("Cannot setup global logger. Error:", err)
 		os.Exit(1)
 	}

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -3,6 +3,7 @@ package exchange
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -29,11 +30,14 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	c := log.GenDefaultSettings()
 	log.RWM.Lock()
-	log.GlobalLogConfig = &c
+	log.GlobalLogConfig = log.GenDefaultSettings()
 	log.RWM.Unlock()
-	log.SetupGlobalLogger()
+	err := log.SetupGlobalLogger()
+	if err != nil {
+		fmt.Println("Cannot setup global logger. Error:", err)
+		os.Exit(1)
+	}
 	os.Exit(m.Run())
 }
 

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -2,6 +2,7 @@ package kline
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -511,7 +512,11 @@ func TestItem_SortCandlesByTimestamp(t *testing.T) {
 func setupTest(t *testing.T) {
 	t.Helper()
 	if verbose {
-		testhelpers.EnableVerboseTestOutput()
+		err := testhelpers.EnableVerboseTestOutput()
+		if err != nil {
+			fmt.Printf("failed to enable verbose test output: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	var err error

--- a/gctscript/vm/vm_test.go
+++ b/gctscript/vm/vm_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 	c := log.GenDefaultSettings()
 	c.Enabled = convert.BoolPtr(false)
 	log.RWM.Lock()
-	log.GlobalLogConfig = &c
+	log.GlobalLogConfig = c
 	log.RWM.Unlock()
 	os.Exit(m.Run())
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -102,28 +102,20 @@ func CloseLogger() error {
 	return GlobalLogFile.Close()
 }
 
-func validSubLogger(s string) (bool, *SubLogger) {
-	if v, found := SubLoggers[s]; found {
-		return true, v
-	}
-	return false, nil
-}
-
 // Level retries the current sublogger levels
 func Level(s string) (*Levels, error) {
-	found, subLogger := validSubLogger(s)
+	subLogger, found := SubLoggers[s]
 	if !found {
 		return nil, fmt.Errorf("logger %v not found", s)
 	}
-
 	return &subLogger.Levels, nil
 }
 
 // SetLevel sets sublogger levels
 func SetLevel(s, level string) (*Levels, error) {
-	found, subLogger := validSubLogger(s)
+	subLogger, found := SubLoggers[s]
 	if !found {
-		return nil, fmt.Errorf("logger %v not found", s)
+		return nil, fmt.Errorf("sub logger %v not found", s)
 	}
 	subLogger.Levels = splitLevel(level)
 	return &subLogger.Levels, nil

--- a/log/logger.go
+++ b/log/logger.go
@@ -111,20 +111,20 @@ func validSubLogger(s string) (bool, *SubLogger) {
 
 // Level retries the current sublogger levels
 func Level(s string) (*Levels, error) {
-	found, logger := validSubLogger(s)
+	found, subLogger := validSubLogger(s)
 	if !found {
 		return nil, fmt.Errorf("logger %v not found", s)
 	}
 
-	return &logger.Levels, nil
+	return &subLogger.Levels, nil
 }
 
 // SetLevel sets sublogger levels
 func SetLevel(s, level string) (*Levels, error) {
-	found, logger := validSubLogger(s)
+	found, subLogger := validSubLogger(s)
 	if !found {
 		return nil, fmt.Errorf("logger %v not found", s)
 	}
-	logger.Levels = splitLevel(level)
-	return &logger.Levels, nil
+	subLogger.Levels = splitLevel(level)
+	return &subLogger.Levels, nil
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -36,7 +36,10 @@ func (sl *SubLogger) getFields() *logFields {
 	RWM.RLock()
 	defer RWM.RUnlock()
 
-	if !enabled() && sl == nil {
+	if sl == nil ||
+		(GlobalLogConfig != nil &&
+			GlobalLogConfig.Enabled != nil &&
+			!*GlobalLogConfig.Enabled) {
 		return nil
 	}
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -28,9 +28,8 @@ func NewSubLogger(name string) (*SubLogger, error) {
 // SetOutput overrides the default output with a new writer
 func (sl *SubLogger) SetOutput(o io.Writer) {
 	RWM.Lock()
-	defer RWM.Unlock()
-
 	sl.output = o
+	RWM.Unlock()
 }
 
 func (sl *SubLogger) getFields() *logFields {

--- a/log/logger.go
+++ b/log/logger.go
@@ -26,11 +26,30 @@ func NewSubLogger(name string) (*SubLogger, error) {
 }
 
 // SetOutput overrides the default output with a new writer
-func (s *SubLogger) SetOutput(o io.Writer) {
+func (sl *SubLogger) SetOutput(o io.Writer) {
 	RWM.Lock()
 	defer RWM.Unlock()
 
-	s.output = o
+	sl.output = o
+}
+
+func (sl *SubLogger) getFields() *logFields {
+	RWM.RLock()
+	defer RWM.RUnlock()
+
+	if !enabled() && sl == nil {
+		return nil
+	}
+
+	return &logFields{
+		info:   sl.Info,
+		warn:   sl.Warn,
+		debug:  sl.Debug,
+		error:  sl.Error,
+		name:   sl.name,
+		output: sl.output,
+		logger: logger,
+	}
 }
 
 func newLogger(c *Config) Logger {

--- a/log/logger.go
+++ b/log/logger.go
@@ -79,6 +79,6 @@ func SetLevel(s, level string) (Levels, error) {
 	if !found {
 		return Levels{}, fmt.Errorf("sub logger %v not found", s)
 	}
-	subLogger.levels = splitLevel(level)
+	subLogger.SetLevels(splitLevel(level))
 	return subLogger.levels, nil
 }

--- a/log/logger_multiwriter.go
+++ b/log/logger_multiwriter.go
@@ -66,6 +66,9 @@ func (mw *multiWriter) Write(p []byte) (n int, err error) {
 
 	for range mw.writers {
 		// NOTE: These results do not necessarily reflect the current io.writer
+		// due to the go scheduler and writer finishing at different times, the
+		// response coming from the channel might not match up with the for loop
+		// writer.
 		d := <-results
 		if d.err != nil {
 			return d.n, d.err

--- a/log/logger_multiwriter.go
+++ b/log/logger_multiwriter.go
@@ -41,18 +41,18 @@ func (mw *multiWriter) Remove(writer io.Writer) error {
 }
 
 // Write concurrent safe Write for each writer
-func (mw *multiWriter) Write(p []byte) (n int, err error) {
+func (mw *multiWriter) Write(p []byte) (int, error) {
 	type data struct {
 		n   int
 		err error
 	}
-	mw.mu.RLock()
-	defer mw.mu.RUnlock()
 
 	results := make(chan data, len(mw.writers))
+	mw.mu.RLock()
+	defer mw.mu.RUnlock()
 	for x := range mw.writers {
 		go func(w io.Writer, p []byte, ch chan<- data) {
-			n, err = w.Write(p)
+			n, err := w.Write(p)
 			if err != nil {
 				ch <- data{n, fmt.Errorf("%T %w", w, err)}
 				return

--- a/log/logger_rotate_types.go
+++ b/log/logger_rotate_types.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	defaultMaxSize = 250
-	megabyte       = 1024 * 1024
+	defaultMaxSize int64 = 250
+	megabyte       int64 = 1024 * 1024
 )
 
 // Rotate struct for each instance of Rotate

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -75,17 +75,15 @@ func GenDefaultSettings() Config {
 	}
 }
 
-func configureSubLogger(logger, levels string, output io.Writer) error {
-	found, logPtr := validSubLogger(logger)
+func configureSubLogger(subLogger, levels string, output io.Writer) error {
+	logPtr, found := SubLoggers[subLogger]
 	if !found {
-		return fmt.Errorf("logger %v not found", logger)
+		return fmt.Errorf("sub logger %v not found", subLogger)
 	}
 
 	logPtr.output = output
-
 	logPtr.Levels = splitLevel(levels)
-	SubLoggers[logger] = logPtr
-
+	SubLoggers[subLogger] = logPtr
 	return nil
 }
 
@@ -140,15 +138,14 @@ func splitLevel(level string) (l Levels) {
 	return
 }
 
-func registerNewSubLogger(logger string) *SubLogger {
+func registerNewSubLogger(subLogger string) *SubLogger {
 	temp := SubLogger{
-		name:   strings.ToUpper(logger),
+		name:   strings.ToUpper(subLogger),
 		output: os.Stdout,
 	}
 
 	temp.Levels = splitLevel("INFO|WARN|DEBUG|ERROR")
-	SubLoggers[logger] = &temp
-
+	SubLoggers[subLogger] = &temp
 	return &temp
 }
 

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -19,10 +19,7 @@ func getWriters(s *SubLoggerConfig) (io.Writer, error) {
 	if s == nil {
 		return nil, errSubloggerConfigIsNil
 	}
-	mw, err := MultiWriter()
-	if err != nil {
-		return nil, err
-	}
+	var writers []io.Writer
 	outputWriters := strings.Split(s.Output, "|")
 	for x := range outputWriters {
 		var writer io.Writer
@@ -40,12 +37,9 @@ func getWriters(s *SubLoggerConfig) (io.Writer, error) {
 			// additional routines for every write for no reason.
 			return nil, fmt.Errorf("%w: %s", errUnhandledOutputWriter, outputWriters[x])
 		}
-		err = mw.Add(writer)
-		if err != nil {
-			return nil, err
-		}
+		writers = append(writers, writer)
 	}
-	return mw, nil
+	return MultiWriter(writers...)
 }
 
 // GenDefaultSettings return struct with known sane/working logger settings

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -69,7 +69,6 @@ func GenDefaultSettings() *Config {
 	}
 }
 
-// TODO: protec
 func configureSubLogger(subLogger, levels string, output io.Writer) error {
 	RWM.Lock()
 	defer RWM.Unlock()

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -250,17 +250,6 @@ func TestSetLevel(t *testing.T) {
 	}
 }
 
-func TestValidSubLogger(t *testing.T) {
-	b, logPtr := validSubLogger("LOG")
-
-	if !b {
-		t.Skip("validSubLogger() should return found, pointer if valid logger found")
-	}
-	if logPtr == nil {
-		t.Error("validSubLogger() should return a pointer and not nil")
-	}
-}
-
 func TestCloseLogger(t *testing.T) {
 	if err := CloseLogger(); err != nil {
 		t.Errorf("CloseLogger() failed %v", err)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -20,15 +20,13 @@ func TestMain(m *testing.M) {
 		log.Fatal("Cannot create temporary file", err)
 	}
 	log.Println("temp dir created at:", tempDir)
-	defer func() {
-		err := os.Remove(tempDir)
-		if err != nil {
-			log.Println("failed to remove temp file:", tempDir)
-		}
-	}()
-
 	LogPath = tempDir
-	os.Exit(m.Run())
+	r := m.Run()
+	err = os.Remove(tempDir)
+	if err != nil {
+		log.Println("failed to remove temp file:", tempDir)
+	}
+	os.Exit(r)
 }
 
 func setupTestLoggers() {
@@ -220,8 +218,7 @@ func TestGetWriters(t *testing.T) {
 }
 
 func TestGenDefaultSettings(t *testing.T) {
-	cfg := GenDefaultSettings()
-	if cfg.Enabled == nil {
+	if cfg := GenDefaultSettings(); cfg.Enabled == nil {
 		t.Fatal("unexpected items in struct")
 	}
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -52,7 +52,7 @@ func setupTestLoggers() error {
 		},
 		SubLoggers: []SubLoggerConfig{
 			{
-				Name:   "TEST",
+				Name:   "lOg",
 				Level:  "INFO|DEBUG|WARN|ERROR",
 				Output: "stdout",
 			}},

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -80,11 +80,6 @@ func BenchmarkInfo(b *testing.B) {
 	}
 }
 
-func SetupTestDisabled(t *testing.T) {
-	t.Helper()
-	SetupDisabled()
-}
-
 func TestAddWriter(t *testing.T) {
 	_, err := MultiWriter(ioutil.Discard, ioutil.Discard)
 	if !errors.Is(err, errWriterAlreadyLoaded) {

--- a/log/logger_types.go
+++ b/log/logger_types.go
@@ -86,14 +86,6 @@ type Levels struct {
 	Info, Debug, Warn, Error bool
 }
 
-// SubLogger defines a sub logger can be used externally for packages wanted to
-// leverage GCT library logger features.
-type SubLogger struct {
-	name string
-	Levels
-	output io.Writer
-}
-
 type multiWriter struct {
 	writers []io.Writer
 	mu      sync.RWMutex

--- a/log/logger_types.go
+++ b/log/logger_types.go
@@ -10,10 +10,12 @@ const (
 	spacer          = " | "
 	// DefaultMaxFileSize for logger rotation file
 	DefaultMaxFileSize int64 = 100
+
+	defaultCapacityForSliceOfBytes = 100
 )
 
 var (
-	logger = &Logger{}
+	logger = Logger{}
 	// FileLoggingConfiguredCorrectly flag set during config check if file logging meets requirements
 	FileLoggingConfiguredCorrectly bool
 	// GlobalLogConfig holds global configuration options for logger
@@ -23,9 +25,8 @@ var (
 
 	eventPool = &sync.Pool{
 		New: func() interface{} {
-			return &Event{
-				data: make([]byte, 0, 80),
-			}
+			sliceOBytes := make([]byte, 0, defaultCapacityForSliceOfBytes)
+			return &sliceOBytes
 		},
 	}
 
@@ -90,12 +91,6 @@ type Levels struct {
 type SubLogger struct {
 	name string
 	Levels
-	output io.Writer
-}
-
-// Event holds the data sent to the log and which multiwriter to send to
-type Event struct {
-	data   []byte
 	output io.Writer
 }
 

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -134,22 +134,3 @@ func enabled() bool {
 		GlobalLogConfig.Enabled != nil &&
 		*GlobalLogConfig.Enabled
 }
-
-func (sl *SubLogger) getFields() *logFields {
-	RWM.RLock()
-	defer RWM.RUnlock()
-
-	if !enabled() && sl == nil {
-		return nil
-	}
-
-	return &logFields{
-		info:   sl.Info,
-		warn:   sl.Warn,
-		debug:  sl.Debug,
-		error:  sl.Error,
-		name:   sl.name,
-		output: sl.output,
-		logger: logger,
-	}
-}

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -128,9 +128,3 @@ func displayError(err error) {
 		log.Printf("Logger write error: %v\n", err)
 	}
 }
-
-func enabled() bool {
-	return GlobalLogConfig != nil &&
-		GlobalLogConfig.Enabled != nil &&
-		*GlobalLogConfig.Enabled
-}

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -7,28 +7,27 @@ import (
 
 // Info takes a pointer subLogger struct and string sends to newLogEvent
 func Info(sl *SubLogger, data string) {
-	fields := getFields(sl)
-	if fields == nil {
-		return
-	}
-	if !fields.info {
+	fields := sl.getFields()
+	if fields == nil || !fields.info {
 		return
 	}
 
-	displayError(fields.logger.newLogEvent(data, fields.logger.InfoHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(data,
+		fields.logger.InfoHeader,
+		fields.name,
+		fields.output))
 }
 
 // Infoln takes a pointer subLogger struct and interface sends to newLogEvent
 func Infoln(sl *SubLogger, v ...interface{}) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.info {
 		return
 	}
-	if !fields.info {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...), fields.logger.InfoHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...),
+		fields.logger.InfoHeader,
+		fields.name,
+		fields.output))
 }
 
 // Infof takes a pointer subLogger struct, string & interface formats and sends to Info()
@@ -38,28 +37,27 @@ func Infof(sl *SubLogger, data string, v ...interface{}) {
 
 // Debug takes a pointer subLogger struct and string sends to multiwriter
 func Debug(sl *SubLogger, data string) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.debug {
 		return
 	}
-	if !fields.debug {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(data, fields.logger.DebugHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(data,
+		fields.logger.DebugHeader,
+		fields.name,
+		fields.output))
 }
 
 // Debugln  takes a pointer subLogger struct, string and interface sends to newLogEvent
 func Debugln(sl *SubLogger, v ...interface{}) {
-	fields := getFields(sl)
-	if fields == nil {
-		return
-	}
-	if !fields.debug {
+	fields := sl.getFields()
+	if fields == nil || !fields.debug {
 		return
 	}
 
-	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...), fields.logger.DebugHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...),
+		fields.logger.DebugHeader,
+		fields.name,
+		fields.output))
 }
 
 // Debugf takes a pointer subLogger struct, string & interface formats and sends to Info()
@@ -69,28 +67,26 @@ func Debugf(sl *SubLogger, data string, v ...interface{}) {
 
 // Warn takes a pointer subLogger struct & string  and sends to newLogEvent()
 func Warn(sl *SubLogger, data string) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.warn {
 		return
 	}
-	if !fields.warn {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(data, fields.logger.WarnHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(data,
+		fields.logger.WarnHeader,
+		fields.name,
+		fields.output))
 }
 
 // Warnln takes a pointer subLogger struct & interface formats and sends to newLogEvent()
 func Warnln(sl *SubLogger, v ...interface{}) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.warn {
 		return
 	}
-	if !fields.warn {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...), fields.logger.WarnHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...),
+		fields.logger.WarnHeader,
+		fields.name,
+		fields.output))
 }
 
 // Warnf takes a pointer subLogger struct, string & interface formats and sends to Warn()
@@ -100,28 +96,26 @@ func Warnf(sl *SubLogger, data string, v ...interface{}) {
 
 // Error takes a pointer subLogger struct & interface formats and sends to newLogEvent()
 func Error(sl *SubLogger, data ...interface{}) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.error {
 		return
 	}
-	if !fields.error {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(fmt.Sprint(data...), fields.logger.ErrorHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(fmt.Sprint(data...),
+		fields.logger.ErrorHeader,
+		fields.name,
+		fields.output))
 }
 
 // Errorln takes a pointer subLogger struct, string & interface formats and sends to newLogEvent()
 func Errorln(sl *SubLogger, v ...interface{}) {
-	fields := getFields(sl)
-	if fields == nil {
+	fields := sl.getFields()
+	if fields == nil || !fields.error {
 		return
 	}
-	if !fields.error {
-		return
-	}
-
-	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...), fields.logger.ErrorHeader, fields.name, fields.output))
+	displayError(fields.logger.newLogEvent(fmt.Sprintln(v...),
+		fields.logger.ErrorHeader,
+		fields.name,
+		fields.output))
 }
 
 // Errorf takes a pointer subLogger struct, string & interface formats and sends to Debug()
@@ -136,26 +130,19 @@ func displayError(err error) {
 }
 
 func enabled() bool {
-	RWM.Lock()
-	defer RWM.Unlock()
-	if GlobalLogConfig == nil || GlobalLogConfig.Enabled == nil {
-		return false
-	}
-	if *GlobalLogConfig.Enabled {
-		return true
-	}
-	return false
+	return GlobalLogConfig != nil &&
+		GlobalLogConfig.Enabled != nil &&
+		*GlobalLogConfig.Enabled
 }
 
-func getFields(sl *SubLogger) *logFields {
-	if !enabled() {
-		return nil
-	}
-	if sl == nil {
-		return nil
-	}
+func (sl *SubLogger) getFields() *logFields {
 	RWM.RLock()
 	defer RWM.RUnlock()
+
+	if !enabled() && sl == nil {
+		return nil
+	}
+
 	return &logFields{
 		info:   sl.Info,
 		warn:   sl.Warn,
@@ -163,6 +150,6 @@ func getFields(sl *SubLogger) *logFields {
 		error:  sl.Error,
 		name:   sl.name,
 		output: sl.output,
-		logger: *logger,
+		logger: logger,
 	}
 }

--- a/log/sublogger.go
+++ b/log/sublogger.go
@@ -12,11 +12,11 @@ func NewSubLogger(name string) (*SubLogger, error) {
 	}
 	name = strings.ToUpper(name)
 	RWM.RLock()
-	_, ok := SubLoggers[name]
-	RWM.RUnlock()
-	if ok {
+	if _, ok := SubLoggers[name]; ok {
+		RWM.RUnlock()
 		return nil, errSubLoggerAlreadyregistered
 	}
+	RWM.RUnlock()
 	return registerNewSubLogger(name), nil
 }
 

--- a/log/sublogger.go
+++ b/log/sublogger.go
@@ -1,0 +1,66 @@
+package log
+
+import (
+	"io"
+	"strings"
+)
+
+// NewSubLogger allows for a new sub logger to be registered.
+func NewSubLogger(name string) (*SubLogger, error) {
+	if name == "" {
+		return nil, errEmptyLoggerName
+	}
+	name = strings.ToUpper(name)
+	RWM.RLock()
+	_, ok := SubLoggers[name]
+	RWM.RUnlock()
+	if ok {
+		return nil, errSubLoggerAlreadyregistered
+	}
+	return registerNewSubLogger(name), nil
+}
+
+// SetOutput overrides the default output with a new writer
+func (sl *SubLogger) SetOutput(o io.Writer) {
+	sl.mtx.Lock()
+	sl.output = o
+	sl.mtx.Unlock()
+}
+
+// SetLevels overrides the default levels with new levels; levelception
+func (sl *SubLogger) SetLevels(newLevels Levels) {
+	sl.mtx.Lock()
+	sl.levels = newLevels
+	sl.mtx.Unlock()
+}
+
+// GetLevels returns current functional log levels
+func (sl *SubLogger) GetLevels() Levels {
+	sl.mtx.RLock()
+	defer sl.mtx.RUnlock()
+	return sl.levels
+}
+
+func (sl *SubLogger) getFields() *logFields {
+	RWM.RLock()
+	defer RWM.RUnlock()
+
+	if sl == nil ||
+		(GlobalLogConfig != nil &&
+			GlobalLogConfig.Enabled != nil &&
+			!*GlobalLogConfig.Enabled) {
+		return nil
+	}
+
+	sl.mtx.RLock()
+	defer sl.mtx.RUnlock()
+	return &logFields{
+		info:   sl.levels.Info,
+		warn:   sl.levels.Warn,
+		debug:  sl.levels.Debug,
+		error:  sl.levels.Error,
+		name:   sl.name,
+		output: sl.output,
+		logger: logger,
+	}
+}

--- a/log/sublogger_types.go
+++ b/log/sublogger_types.go
@@ -1,6 +1,9 @@
 package log
 
-import "io"
+import (
+	"io"
+	"sync"
+)
 
 // Global vars related to the logger package
 var (
@@ -33,6 +36,15 @@ var (
 	Trade     *SubLogger
 	Fill      *SubLogger
 )
+
+// SubLogger defines a sub logger can be used externally for packages wanted to
+// leverage GCT library logger features.
+type SubLogger struct {
+	name   string
+	levels Levels
+	output io.Writer
+	mtx    sync.RWMutex
+}
 
 // logFields is used to store data in a non-global and thread-safe manner
 // so logs cannot be modified mid-log causing a data-race issue


### PR DESCRIPTION
# PR Description

Noticed some things that could be improved when testing another log PR. 

* Fix bug when adding and removing writers
* Optimize newLogEvent to return only the fix sized []byte from pool and and not a struct. Reuse param variables already included in stack. 
* Expand test coverage. 
* Fix some race issues.

NOTE: As a quick test I dropped the file size to 1MB, that proved to write to the initial log file and then rotate to other files which was expected. On a new instance it wrote to the old file filling up more then over flowing to other files which can make logs a bit disjointed. Maybe we can make improvements on this in the future.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
