### PR TITLE
request: provide observability over HTTP request latency

### DIFF
--- a/exchanges/request/options.go
+++ b/exchanges/request/options.go
@@ -20,3 +20,10 @@ func WithRetryPolicy(p RetryPolicy) RequesterOption {
 		r.retryPolicy = p
 	}
 }
+
+// WithReporter configures the reporter for a Requester.
+func WithReporter(rep Reporter) RequesterOption {
+	return func(r *Requester) {
+		r.reporter = rep
+	}
+}

--- a/exchanges/request/report.go
+++ b/exchanges/request/report.go
@@ -1,0 +1,17 @@
+package request
+
+import (
+	"time"
+)
+
+// Reporter interface groups observability functionality over
+// HTTP request latency.
+type Reporter interface {
+	Latency(name, method, path string, t time.Duration)
+}
+
+// SetupGlobalReporter sets a reporter interface to be used
+// for all exchange requests
+func SetupGlobalReporter(r Reporter) {
+	globalReporter = r
+}

--- a/exchanges/request/request_types.go
+++ b/exchanges/request/request_types.go
@@ -23,12 +23,14 @@ const (
 var (
 	MaxRequestJobs   = DefaultMaxRequestJobs
 	MaxRetryAttempts = DefaultMaxRetryAttempts
+	globalReporter   Reporter
 )
 
 // Requester struct for the request client
 type Requester struct {
 	HTTPClient         *http.Client
 	limiter            Limiter
+	reporter           Reporter
 	Name               string
 	UserAgent          string
 	maxRetries         int


### PR DESCRIPTION
# PR Description

This PR allows applications to set an optional global reporter that will provide observability over latency of all HTTP requests (eg. through Prometheus). It also allows a per-exchange setting that is overridden by a global one.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
