### PR TITLE
kraken futures: generate a larger nonce on requests

### DIFF
--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -303,7 +303,7 @@ func (k *Kraken) SendFuturesAuthRequest(ctx context.Context, method, path string
 
 	interim := json.RawMessage{}
 	newRequest := func() (*request.Item, error) {
-		nonce := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		nonce := strconv.FormatInt(time.Now().UnixNano(), 10)
 
 		sig, err := k.signFuturesRequest(path, nonce, dataToSign)
 		if err != nil {


### PR DESCRIPTION
# PR Description

Generate a larger nonce on Kraken Futures requests to avoid same millisec collisions, a better mechanism is maybe possible but this quick fix should decrease dramatically the number of nonce collisions

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
