### PR TITLE
ftx: set TestGetPublicOptionsTrades start date one week from current date to allo…

### DIFF
--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -971,7 +971,7 @@ func TestGetPublicOptionsTrades(t *testing.T) {
 	}
 	tmNow := time.Now()
 	result, err = f.GetPublicOptionsTrades(context.Background(),
-		tmNow.AddDate(0, 0, -1), tmNow, "5")
+		tmNow.AddDate(0, 0, -7), tmNow, "5")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
…w for more options trade volume

# PR Description

It appears options volume has decreased on FTX which broke a tests limit capabilities, this PR adjusts it to allow 7 days worth of options trade volume.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
