### PR TITLE
engine/okgroup: fix panic when calling GetDepositAddress()

### DIFF
--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -691,10 +691,7 @@ func (bot *Engine) GetCryptocurrencyDepositAddressesByExchange(exchName string) 
 func (bot *Engine) GetExchangeCryptocurrencyDepositAddress(ctx context.Context, exchName, accountID, chain string, item currency.Code, bypassCache bool) (*deposit.Address, error) {
 	if bot.DepositAddressManager != nil && bot.DepositAddressManager.IsSynced() && !bypassCache {
 		resp, err := bot.DepositAddressManager.GetDepositAddressByExchangeAndCurrency(exchName, chain, item)
-		if err != nil {
-			return nil, err
-		}
-		return &resp, nil
+		return &resp, err
 	}
 	exch, err := bot.GetExchangeByName(exchName)
 	if err != nil {
@@ -780,12 +777,6 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 							exchName,
 							cryptocurrency,
 							err)
-						continue
-					}
-					if depositAddr == nil {
-						log.Errorf(log.Global, "%s failed to get cryptocurrency deposit address for %s. Err: Deposit address came back as nil.\n",
-							exchName,
-							cryptocurrency)
 						continue
 					}
 					depositAddrs = append(depositAddrs, *depositAddr)

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -782,6 +782,12 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 							err)
 						continue
 					}
+					if depositAddr == nil {
+						log.Errorf(log.Global, "%s failed to get cryptocurrency deposit address for %s. Err: Deposit address came back as nil.\n",
+							exchName,
+							cryptocurrency)
+						continue
+					}
 					depositAddrs = append(depositAddrs, *depositAddr)
 				}
 				cryptoAddr[cryptocurrency] = depositAddrs


### PR DESCRIPTION
# PR Description

Repairs panic when no wallet information was returned via `GetDepositAddress` and a nil address was returned with a nil error. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
