### PR TITLE
exchanges: make ErrPairNotFound an exportable error

### DIFF
--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -47,6 +47,9 @@ var (
 
 	errEndpointStringNotFound = errors.New("endpoint string not found")
 	errTransportNotSet        = errors.New("transport not set, cannot set timeout")
+
+	// ErrPairNotFound is an error message for when unable to find a currency pair
+	ErrPairNotFound = errors.New("pair not found")
 )
 
 func (b *Base) checkAndInitRequester() {
@@ -458,7 +461,8 @@ func (b *Base) GetRequestFormattedPairAndAssetType(p string) (currency.Pair, ass
 			}
 		}
 	}
-	return response, "", errors.New("pair not found: " + p)
+	return response, "",
+		fmt.Errorf("%s %w", p, ErrPairNotFound)
 }
 
 // GetAvailablePairs is a method that returns the available currency pairs


### PR DESCRIPTION
Stop erroring out when receiving execution reports from currency pairs
that have not been enabled. In the use-case where multiple services consume market data from different currency pairs on the same account it happens that eg. a service handling ETH/USDT gets execution reports from a separate service handling BTC/USDT on the same account, no big side effects but error rates increase somewhat damaging observability effectiveness.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
