### PR TITLE
kraken futures: add support for market orders

### DIFF
--- a/exchanges/kraken/futures_types.go
+++ b/exchanges/kraken/futures_types.go
@@ -13,6 +13,7 @@ var (
 		order.Stop:              "stp",
 		order.PostOnly:          "post",
 		order.TakeProfit:        "take_profit",
+		order.Market:            "mkt",
 	}
 
 	validSide = []string{"buy", "sell"}

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -116,7 +116,7 @@ func (k *Kraken) FuturesSendOrder(ctx context.Context, orderType order.Type, sym
 	size, limitPrice, stopPrice float64) (FuturesSendOrderData, error) {
 	var resp FuturesSendOrderData
 
-	if ioc {
+	if ioc && orderType != order.Market {
 		orderType = order.ImmediateOrCancel
 	}
 


### PR DESCRIPTION
Kraken Futures supports a `mkt` order type which is a market order at
best price with a 1% order protection.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
