### PR TITLE
huobi futures: fix client order id submit order

### DIFF
--- a/exchanges/huobi/huobi_futures.go
+++ b/exchanges/huobi/huobi_futures.go
@@ -716,7 +716,14 @@ func (h *HUOBI) FOrder(ctx context.Context, contractCode currency.Pair, symbol, 
 		req["contract_code"] = codeValue
 	}
 	if clientOrderID != "" {
-		req["client_order_id"] = clientOrderID
+		// Client order id is an integer, convert it here
+		// https://huobiapi.github.io/docs/dm/v1/en/#place-an-order
+		id, err := strconv.Atoi(clientOrderID)
+		if err != nil {
+			return resp,
+				fmt.Errorf("unable to convert client order id to integer, %s: %w", clientOrderID, err)
+		}
+		req["client_order_id"] = id
 	}
 	req["direction"] = direction
 	if !common.StringDataCompareInsensitive(validOffsetTypes, offset) {


### PR DESCRIPTION
As per Huobi Futures documentation, client order id must be an
integer field in the request. For most other exchanges this is a string
field so to accomodate we keep the string representation and convert
to a number right before the request goes on the wire.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
