### PR TITLE
huobi futures: improve market order type

### DIFF
--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -946,9 +946,17 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitR
 		var oType string
 		switch s.Type {
 		case order.Market:
-			oType = "opponent"
+			// https://huobiapi.github.io/docs/dm/v1/en/#order-and-trade
+			// At present, Huobi Futures does not support market price when placing an order.
+			// To increase the probability of a transaction, users can choose to place an order based on BBO price (opponent),
+			// optimal 5 (optimal_5), optimal 10 (optimal_10), optimal 20 (optimal_20), among which the success probability of
+			// optimal 20 is the largest, while the slippage always is the largest as well.
+			//
+			// It is important to note that the above methods will not guarantee the order to be filled in 100%.
+			// The system will obtain the optimal N price at that moment and place the order.
+			oType = "optimal_20"
 			if s.ImmediateOrCancel {
-				oType = "opponent_ioc"
+				oType = "optimal_20_ioc"
 			}
 		case order.Limit:
 			oType = "limit"


### PR DESCRIPTION
# PR Description

Numeus quants informed me that `optimal_20` is a more accurate depiction of a market order.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [X] go test ./... -race
- [X] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [X] Any dependent changes have been merged and published in downstream modules
