### PR TITLE
Exchanges: Set AccountInfo ID when available

### DIFF
--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -16,8 +16,16 @@ func init() {
 	service.mux = dispatch.GetNewMux()
 }
 
-// CollectAccountBalances converts a map of sub-account balances into a slice
-func CollectAccountBalances(accountBalances map[string][]Balance, assetType asset.Item) (accounts []SubAccount) {
+// CollectBalances converts a map of sub-account balances into a slice
+func CollectBalances(accountBalances map[string][]Balance, assetType asset.Item) (accounts []SubAccount, err error) {
+	if accountBalances == nil {
+		return nil, errAccountBalancesIsNil
+	}
+
+	if !assetType.IsValid() {
+		return nil, fmt.Errorf("%s, %w", assetType, asset.ErrNotSupported)
+	}
+
 	accounts = make([]SubAccount, len(accountBalances))
 	i := 0
 	for accountID, balances := range accountBalances {

--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -16,6 +16,21 @@ func init() {
 	service.mux = dispatch.GetNewMux()
 }
 
+// CollectAccountBalances converts a map of sub-account balances into a slice
+func CollectAccountBalances(accountBalances map[string][]Balance, assetType asset.Item) (accounts []SubAccount) {
+	accounts = make([]SubAccount, len(accountBalances))
+	i := 0
+	for accountID, balances := range accountBalances {
+		accounts[i] = SubAccount{
+			ID:         accountID,
+			AssetType:  assetType,
+			Currencies: balances,
+		}
+		i++
+	}
+	return
+}
+
 // SubscribeToExchangeAccount subcribes to your exchange account
 func SubscribeToExchangeAccount(exchange string) (dispatch.Pipe, error) {
 	exchange = strings.ToLower(exchange)

--- a/exchanges/account/account_test.go
+++ b/exchanges/account/account_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
-func TestCollectAccountBalances(t *testing.T) {
-	accounts := CollectAccountBalances(
+func TestCollectBalances(t *testing.T) {
+	accounts, err := CollectBalances(
 		map[string][]Balance{
 			"someAccountID": {
 				{CurrencyName: currency.BTC, TotalValue: 40000, Hold: 1},
@@ -30,15 +30,24 @@ func TestCollectAccountBalances(t *testing.T) {
 	if balance.CurrencyName != currency.BTC || balance.TotalValue != 40000 || balance.Hold != 1 {
 		t.Error("subAccount currency balance not set correctly")
 	}
+	if err != nil {
+		t.Error("err is not expected")
+	}
 
-	accounts = CollectAccountBalances(map[string][]Balance{}, asset.Spot)
+	accounts, err = CollectBalances(map[string][]Balance{}, asset.Spot)
 	if len(accounts) != 0 {
 		t.Error("accounts should be empty")
 	}
+	if err != nil {
+		t.Error("err is not expected")
+	}
 
-	accounts = CollectAccountBalances(nil, asset.Spot)
+	accounts, err = CollectBalances(nil, asset.Spot)
 	if len(accounts) != 0 {
 		t.Error("accounts should be empty")
+	}
+	if err == nil {
+		t.Errorf("expecting err %s", errAccountBalancesIsNil.Error())
 	}
 }
 

--- a/exchanges/account/account_test.go
+++ b/exchanges/account/account_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
+func TestCollectAccountBalances(t *testing.T) {
+	accounts := CollectAccountBalances(
+		map[string][]Balance{
+			"someAccountID": {
+				{CurrencyName: currency.BTC, TotalValue: 40000, Hold: 1},
+			},
+		},
+		asset.Spot,
+	)
+	subAccount := accounts[0]
+	balance := subAccount.Currencies[0]
+	if subAccount.ID != "someAccountID" {
+		t.Error("subAccount ID not set correctly")
+	}
+	if subAccount.AssetType != asset.Spot {
+		t.Error("subAccount AssetType not set correctly")
+	}
+	if balance.CurrencyName != currency.BTC || balance.TotalValue != 40000 || balance.Hold != 1 {
+		t.Error("subAccount currency balance not set correctly")
+	}
+
+	accounts = CollectAccountBalances(map[string][]Balance{}, asset.Spot)
+	if len(accounts) != 0 {
+		t.Error("accounts should be empty")
+	}
+
+	accounts = CollectAccountBalances(nil, asset.Spot)
+	if len(accounts) != 0 {
+		t.Error("accounts should be empty")
+	}
+}
+
 func TestHoldings(t *testing.T) {
 	err := dispatch.Start(dispatch.DefaultMaxWorkers, dispatch.DefaultJobsLimit)
 	if err != nil {

--- a/exchanges/account/account_types.go
+++ b/exchanges/account/account_types.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/gofrs/uuid"
@@ -11,7 +12,8 @@ import (
 
 // Vars for the ticker package
 var (
-	service *Service
+	service                 *Service
+	errAccountBalancesIsNil = errors.New("account balances is nil")
 )
 
 // Service holds ticker information for each individual exchange

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -742,16 +742,19 @@ func (b *Binance) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (
 		if err != nil {
 			return info, err
 		}
-		var currencyDetails []account.Balance
+		accountCurrencyDetails := make(map[string][]account.Balance)
 		for i := range accData {
-			currencyDetails = append(currencyDetails, account.Balance{
-				CurrencyName: currency.NewCode(accData[i].Asset),
-				TotalValue:   accData[i].Balance,
-				Hold:         accData[i].Balance - accData[i].AvailableBalance,
-			})
+			currencyDetails := accountCurrencyDetails[accData[i].AccountAlias]
+			accountCurrencyDetails[accData[i].AccountAlias] = append(
+				currencyDetails, account.Balance{
+					CurrencyName: currency.NewCode(accData[i].Asset),
+					TotalValue:   accData[i].Balance,
+					Hold:         accData[i].Balance - accData[i].AvailableBalance,
+				},
+			)
 		}
 
-		acc.Currencies = currencyDetails
+		info.Accounts = account.CollectAccountBalances(accountCurrencyDetails, assetType)
 	case asset.Margin:
 		accData, err := b.GetMarginAccount(ctx)
 		if err != nil {

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -754,7 +754,9 @@ func (b *Binance) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (
 			)
 		}
 
-		info.Accounts = account.CollectAccountBalances(accountCurrencyDetails, assetType)
+		if info.Accounts, err = account.CollectBalances(accountCurrencyDetails, assetType); err != nil {
+			return account.Holdings{}, err
+		}
 	case asset.Margin:
 		accData, err := b.GetMarginAccount(ctx)
 		if err != nil {

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -428,7 +428,8 @@ func (b *Bitmex) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 	for i := range userMargins {
 		accountID := strconv.FormatInt(userMargins[i].Account, 10)
 
-		wallet, err := b.GetWalletInfo(ctx, userMargins[i].Currency)
+		var wallet WalletInfo
+		wallet, err = b.GetWalletInfo(ctx, userMargins[i].Currency)
 		if err != nil {
 			continue
 		}
@@ -441,7 +442,9 @@ func (b *Bitmex) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		)
 	}
 
-	info.Accounts = account.CollectAccountBalances(accountBalances, assetType)
+	if info.Accounts, err = account.CollectBalances(accountBalances, assetType); err != nil {
+		return account.Holdings{}, err
+	}
 	info.Exchange = b.Name
 
 	if err := account.Process(&info); err != nil {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -325,19 +325,19 @@ func (c *CoinbasePro) UpdateAccountInfo(ctx context.Context, assetType asset.Ite
 		return response, err
 	}
 
-	var currencies []account.Balance
+	accountCurrencies := make(map[string][]account.Balance)
 	for i := range accountBalance {
 		var exchangeCurrency account.Balance
 		exchangeCurrency.CurrencyName = currency.NewCode(accountBalance[i].Currency)
 		exchangeCurrency.TotalValue = accountBalance[i].Available
 		exchangeCurrency.Hold = accountBalance[i].Hold
 
-		currencies = append(currencies, exchangeCurrency)
+		profileID := accountBalance[i].ProfileID
+		currencies := accountCurrencies[profileID]
+		accountCurrencies[profileID] = append(currencies, exchangeCurrency)
 	}
 
-	response.Accounts = append(response.Accounts, account.SubAccount{
-		Currencies: currencies,
-	})
+	response.Accounts = account.CollectAccountBalances(accountCurrencies, assetType)
 
 	err = account.Process(&response)
 	if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -337,7 +337,9 @@ func (c *CoinbasePro) UpdateAccountInfo(ctx context.Context, assetType asset.Ite
 		accountCurrencies[profileID] = append(currencies, exchangeCurrency)
 	}
 
-	response.Accounts = account.CollectAccountBalances(accountCurrencies, assetType)
+	if response.Accounts, err = account.CollectBalances(accountCurrencies, assetType); err != nil {
+		return account.Holdings{}, err
+	}
 
 	err = account.Process(&response)
 	if err != nil {


### PR DESCRIPTION
# PR Description

Set account id when available, changes affecting Binance USDTMarginFutures, Coinbase Spot.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Tested Binance/Coinbase by cross-checking api response.

Coinbase Pro is a bit confusing as they have both "profile id" and "account id"

Their response for account balances looks like below:
      #     [
      #         {
      #             id: '4aac9c60-cbda-4396-9da4-4aa71e95fba0',
      #             currency: 'BTC',
      #             balance: '0.0000000000000000',
      #             available: '0',
      #             hold: '0.0000000000000000',
      #             profile_id: 'b709263e-f42a-4c7d-949a-a95c83d065da'
      #         },
      #         {
      #             id: 'f75fa69a-1ad1-4a80-bd61-ee7faa6135a3',
      #             currency: 'USDC',
      #             balance: '0.0000000000000000',
      #             available: '0',
      #             hold: '0.0000000000000000',
      #             profile_id: 'b709263e-f42a-4c7d-949a-a95c83d065da'
      #         },
      #     ]
      #

Which I believe the id is what they call the "account id" but is more like an asset-specific id, and profile_id is what GCT call "ID" in subAccount
reference:
https://forums.coinbasecloud.dev/t/how-do-i-get-account-id-for-rest-api/231/3

Binance reference:
https://dev.binance.vision/t/binance-account-id/1418

I also tried to look at CCXT's implementation and api docs but couldn't find more exchanges that include account id in the response for balances (some returns separately but not from the balance endpoint, some like Binance Spot doesn't give you this piece of info at all as commented in the reference)

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
