### PR TITLE
btcmarkets: Add websocket orderbook checksum validation

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -237,9 +238,11 @@ func (b *Binance) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
-		SortBufferByUpdateIDs: true,
-		TradeFeed:             b.Features.Enabled.TradeFeed,
+		BufferConfig: buffer.Config{
+			SortBuffer:            true,
+			SortBufferByUpdateIDs: true,
+		},
+		TradeFeed: b.Features.Enabled.TradeFeed,
 	})
 	if err != nil {
 		return err

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -238,7 +238,7 @@ func (b *Binance) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:            true,
 			SortBufferByUpdateIDs: true,
 		},

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -214,7 +215,9 @@ func (b *Bitfinex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		UpdateEntriesByID:     true,
+		BufferConfig: buffer.Config{
+			UpdateEntriesByID: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -215,7 +215,7 @@ func (b *Bitfinex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			UpdateEntriesByID: true,
 		},
 	})

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -173,7 +174,9 @@ func (b *Bitmex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		UpdateEntriesByID:     true,
+		BufferConfig: buffer.Config{
+			UpdateEntriesByID: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -174,7 +174,7 @@ func (b *Bitmex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			UpdateEntriesByID: true,
 		},
 	})

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -174,7 +174,7 @@ func (b *Bittrex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,                              // Unsubscriber function outlined above.
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,             // GenerateDefaultSubscriptions function outlined above.
 		Features:              &b.Features.Supports.WebsocketCapabilities, // Defines the capabilities of the websocket outlined in supported features struct. This allows the websocket connection to be flushed appropriately if we have a pair/asset enable/disable change. This is outlined below.
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:            true,
 			SortBufferByUpdateIDs: true,
 		},

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -173,12 +174,10 @@ func (b *Bittrex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,                              // Unsubscriber function outlined above.
 		GenerateSubscriptions: b.GenerateDefaultSubscriptions,             // GenerateDefaultSubscriptions function outlined above.
 		Features:              &b.Features.Supports.WebsocketCapabilities, // Defines the capabilities of the websocket outlined in supported features struct. This allows the websocket connection to be flushed appropriately if we have a pair/asset enable/disable change. This is outlined below.
-
-		// Orderbook buffer specific variables for processing orderbook updates via websocket feed.
-		// Other orderbook buffer vars:
-		// UpdateEntriesByID     bool
-		SortBuffer:            true,
-		SortBufferByUpdateIDs: true,
+		BufferConfig: buffer.Config{
+			SortBuffer:            true,
+			SortBufferByUpdateIDs: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -112,7 +112,11 @@ func (b *BTCMarkets) GetTrades(ctx context.Context, marketID string, before, aft
 		&trades)
 }
 
-// GetOrderbook returns current orderbook
+// GetOrderbook returns current orderbook.
+// levels are:
+// 0 - Returns the top bids and ask orders only.
+// 1 - Returns top 50 bids and asks.
+// 2 - Returns full orderbook. WARNING: This is cached every 10 seconds.
 func (b *BTCMarkets) GetOrderbook(ctx context.Context, marketID string, level int64) (Orderbook, error) {
 	var orderbook Orderbook
 	var temp tempOrderbook

--- a/exchanges/btcmarkets/btcmarkets_types.go
+++ b/exchanges/btcmarkets/btcmarkets_types.go
@@ -2,6 +2,9 @@ package btcmarkets
 
 import (
 	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
 // Market holds a tradable market instrument
@@ -377,12 +380,14 @@ type WsTrade struct {
 
 // WsOrderbook message received for orderbook data
 type WsOrderbook struct {
-	Currency    string          `json:"marketId"`
-	Timestamp   time.Time       `json:"timestamp"`
-	Bids        [][]interface{} `json:"bids"`
-	Asks        [][]interface{} `json:"asks"`
-	MessageType string          `json:"messageType"`
-	Snapshot    bool            `json:"snapshot"`
+	Currency    currency.Pair      `json:"marketId"`
+	Snapshot    bool               `json:"snapshot"`
+	Timestamp   time.Time          `json:"timestamp"`
+	SnapshotID  int64              `json:"snapshotId"`
+	Bids        WebsocketOrderbook `json:"bids"`
+	Asks        WebsocketOrderbook `json:"asks"`
+	Checksum    uint32             `json:"checksum,string"`
+	MessageType string             `json:"messageType"`
 }
 
 // WsFundTransfer stores fund transfer data for websocket
@@ -429,3 +434,7 @@ type WsError struct {
 
 // CandleResponse holds OHLCV data for exchange
 type CandleResponse [][6]string
+
+// WebsocketOrderbook defines a specific websocket orderbook type to directly
+// unmarshal json.
+type WebsocketOrderbook orderbook.Items

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -24,6 +26,11 @@ import (
 
 const (
 	btcMarketsWSURL = "wss://socket.btcmarkets.net/v2"
+)
+
+var (
+	errTypeAssertionFailure = errors.New("type assertion failure")
+	errChecksumFailure      = errors.New("crc32 checksum failure")
 )
 
 // WsConnect connects to a websocket feed
@@ -61,6 +68,51 @@ func (b *BTCMarkets) wsReadData() {
 	}
 }
 
+// UnmarshalJSON implements the unmarshaler interface.
+func (w *WebsocketOrderbook) UnmarshalJSON(data []byte) error {
+	resp := make([][3]interface{}, len(data))
+	err := json.Unmarshal(data, &resp)
+	if err != nil {
+		return err
+	}
+
+	*w = WebsocketOrderbook(make(orderbook.Items, len(resp)))
+	for x := range resp {
+		sPrice, ok := resp[x][0].(string)
+		if !ok {
+			return fmt.Errorf("price string %w", errTypeAssertionFailure)
+		}
+		var price float64
+		price, err = strconv.ParseFloat(sPrice, 64)
+		if err != nil {
+			return err
+		}
+
+		sAmount, ok := resp[x][1].(string)
+		if !ok {
+			return fmt.Errorf("amount string %w", errTypeAssertionFailure)
+		}
+
+		var amount float64
+		amount, err = strconv.ParseFloat(sAmount, 64)
+		if err != nil {
+			return err
+		}
+
+		count, ok := resp[x][2].(float64)
+		if !ok {
+			return fmt.Errorf("count float64 %w", errTypeAssertionFailure)
+		}
+
+		(*w)[x] = orderbook.Item{
+			Amount:     amount,
+			Price:      price,
+			OrderCount: int64(count),
+		}
+	}
+	return nil
+}
+
 func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 	var wsResponse WsMessageType
 	err := json.Unmarshal(respRaw, &wsResponse)
@@ -79,65 +131,30 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			return err
 		}
 
-		p, err := currency.NewPairFromString(ob.Currency)
-		if err != nil {
-			return err
-		}
-
-		var bids, asks orderbook.Items
-		for x := range ob.Bids {
-			var price, amount float64
-			price, err = strconv.ParseFloat(ob.Bids[x][0].(string), 64)
-			if err != nil {
-				return err
-			}
-			amount, err = strconv.ParseFloat(ob.Bids[x][1].(string), 64)
-			if err != nil {
-				return err
-			}
-			bids = append(bids, orderbook.Item{
-				Amount:     amount,
-				Price:      price,
-				OrderCount: int64(ob.Bids[x][2].(float64)),
-			})
-		}
-		for x := range ob.Asks {
-			var price, amount float64
-			price, err = strconv.ParseFloat(ob.Asks[x][0].(string), 64)
-			if err != nil {
-				return err
-			}
-			amount, err = strconv.ParseFloat(ob.Asks[x][1].(string), 64)
-			if err != nil {
-				return err
-			}
-			asks = append(asks, orderbook.Item{
-				Amount:     amount,
-				Price:      price,
-				OrderCount: int64(ob.Asks[x][2].(float64)),
-			})
-		}
 		if ob.Snapshot {
-			bids.SortBids() // Alignment completely out, sort is needed.
 			err = b.Websocket.Orderbook.LoadSnapshot(&orderbook.Base{
-				Pair:            p,
-				Bids:            bids,
-				Asks:            asks,
+				Pair:            ob.Currency,
+				Bids:            orderbook.Items(ob.Bids),
+				Asks:            orderbook.Items(ob.Asks),
 				LastUpdated:     ob.Timestamp,
+				LastUpdateID:    ob.SnapshotID,
 				Asset:           asset.Spot,
 				Exchange:        b.Name,
 				VerifyOrderbook: b.CanVerifyOrderbook,
 			})
 		} else {
 			err = b.Websocket.Orderbook.Update(&buffer.Update{
-				UpdateTime: ob.Timestamp,
-				Asset:      asset.Spot,
-				Bids:       bids,
-				Asks:       asks,
-				Pair:       p,
+				UpdateTime:          ob.Timestamp,
+				UpdateID:            ob.SnapshotID,
+				Asset:               asset.Spot,
+				Bids:                orderbook.Items(ob.Bids),
+				Asks:                orderbook.Items(ob.Asks),
+				Pair:                ob.Currency,
+				ChecksumFn:          checksum,
+				Checksum:            ob.Checksum,
+				UpdateIDProgression: true,
 			})
 		}
-
 		if err != nil {
 			return err
 		}
@@ -364,4 +381,42 @@ func (b *BTCMarkets) Subscribe(channelsToSubscribe []stream.ChannelSubscription)
 	}
 	b.Websocket.AddSuccessfulSubscriptions(channelsToSubscribe...)
 	return nil
+}
+
+// checksum provides assurance on current in memory liquidity
+func checksum(ob *orderbook.Base, checksum uint32) error {
+	check := crc32.ChecksumIEEE([]byte(concat(ob.Bids) + concat(ob.Asks)))
+	if check != checksum {
+		return fmt.Errorf("%s %s %s ID: %v expected: %v but received: %v %w",
+			ob.Exchange,
+			ob.Pair,
+			ob.Asset,
+			ob.LastUpdateID,
+			checksum,
+			check,
+			errChecksumFailure)
+	}
+	return nil
+}
+
+// concat concatenates price and amounts together for checksum processing
+func concat(liquidity orderbook.Items) string {
+	length := 10
+	if len(liquidity) < 10 {
+		length = len(liquidity)
+	}
+	var concat string
+	for x := 0; x < length; x++ {
+		concat += trim(liquidity[x].Price) + trim(liquidity[x].Amount)
+	}
+	return concat
+}
+
+// trim turns value into string, removes the decimal point and all the leading
+// zeros.
+func trim(value float64) string {
+	valstr := strconv.FormatFloat(value, 'f', -1, 64)
+	valstr = strings.ReplaceAll(valstr, ".", "")
+	valstr = strings.TrimLeft(valstr, "0")
+	return valstr
 }

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -403,11 +403,11 @@ func concat(liquidity orderbook.Items) string {
 	if len(liquidity) < 10 {
 		length = len(liquidity)
 	}
-	var concat string
+	var c string
 	for x := 0; x < length; x++ {
-		concat += trim(liquidity[x].Price) + trim(liquidity[x].Amount)
+		c += trim(liquidity[x].Price) + trim(liquidity[x].Amount)
 	}
-	return concat
+	return c
 }
 
 // trim turns value into string, removes the decimal point and all the leading

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -144,14 +144,13 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			})
 		} else {
 			err = b.Websocket.Orderbook.Update(&buffer.Update{
-				UpdateTime:          ob.Timestamp,
-				UpdateID:            ob.SnapshotID,
-				Asset:               asset.Spot,
-				Bids:                orderbook.Items(ob.Bids),
-				Asks:                orderbook.Items(ob.Asks),
-				Pair:                ob.Currency,
-				Checksum:            ob.Checksum,
-				UpdateIDProgression: true,
+				UpdateTime: ob.Timestamp,
+				UpdateID:   ob.SnapshotID,
+				Asset:      asset.Spot,
+				Bids:       orderbook.Items(ob.Bids),
+				Asks:       orderbook.Items(ob.Asks),
+				Pair:       ob.Currency,
+				Checksum:   ob.Checksum,
 			})
 		}
 		if err != nil {

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -150,7 +150,6 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 				Bids:                orderbook.Items(ob.Bids),
 				Asks:                orderbook.Items(ob.Asks),
 				Pair:                ob.Currency,
-				ChecksumFn:          checksum,
 				Checksum:            ob.Checksum,
 				UpdateIDProgression: true,
 			})

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -386,7 +386,9 @@ func (b *BTCMarkets) UpdateOrderbook(ctx context.Context, p currency.Pair, asset
 		return book, err
 	}
 
-	tempResp, err := b.GetOrderbook(ctx, fpair.String(), 2)
+	// Retrieve level one book which is the top 50 ask and bids, this is not
+	// cached.
+	tempResp, err := b.GetOrderbook(ctx, fpair.String(), 1)
 	if err != nil {
 		return book, err
 	}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -168,7 +168,7 @@ func (b *BTCMarkets) Setup(exch *config.Exchange) error {
 		Subscriber:            b.Subscribe,
 		GenerateSubscriptions: b.generateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:          true,
 			UpdateIDProgression: true,
 			Checksum:            checksum,

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -167,7 +168,11 @@ func (b *BTCMarkets) Setup(exch *config.Exchange) error {
 		Subscriber:            b.Subscribe,
 		GenerateSubscriptions: b.generateDefaultSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
+		BufferConfig: buffer.Config{
+			SortBuffer:          true,
+			UpdateIDProgression: true,
+			Checksum:            checksum,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -180,7 +181,9 @@ func (c *CoinbasePro) Setup(exch *config.Exchange) error {
 		Unsubscriber:          c.Unsubscribe,
 		GenerateSubscriptions: c.GenerateDefaultSubscriptions,
 		Features:              &c.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
+		BufferConfig: buffer.Config{
+			SortBuffer: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -181,7 +181,7 @@ func (c *CoinbasePro) Setup(exch *config.Exchange) error {
 		Unsubscriber:          c.Unsubscribe,
 		GenerateSubscriptions: c.GenerateDefaultSubscriptions,
 		Features:              &c.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer: true,
 		},
 	})

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -162,8 +163,10 @@ func (c *COINUT) Setup(exch *config.Exchange) error {
 		Unsubscriber:          c.Unsubscribe,
 		GenerateSubscriptions: c.GenerateDefaultSubscriptions,
 		Features:              &c.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
-		SortBufferByUpdateIDs: true,
+		BufferConfig: buffer.Config{
+			SortBuffer:            true,
+			SortBufferByUpdateIDs: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -163,7 +163,7 @@ func (c *COINUT) Setup(exch *config.Exchange) error {
 		Unsubscriber:          c.Unsubscribe,
 		GenerateSubscriptions: c.GenerateDefaultSubscriptions,
 		Features:              &c.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:            true,
 			SortBufferByUpdateIDs: true,
 		},

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -178,8 +179,10 @@ func (h *HitBTC) Setup(exch *config.Exchange) error {
 		Unsubscriber:          h.Unsubscribe,
 		GenerateSubscriptions: h.GenerateDefaultSubscriptions,
 		Features:              &h.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
-		SortBufferByUpdateIDs: true,
+		BufferConfig: buffer.Config{
+			SortBuffer:            true,
+			SortBufferByUpdateIDs: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -179,7 +179,7 @@ func (h *HitBTC) Setup(exch *config.Exchange) error {
 		Unsubscriber:          h.Unsubscribe,
 		GenerateSubscriptions: h.GenerateDefaultSubscriptions,
 		Features:              &h.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:            true,
 			SortBufferByUpdateIDs: true,
 		},

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -226,7 +226,7 @@ func (k *Kraken) Setup(exch *config.Exchange) error {
 		Unsubscriber:          k.Unsubscribe,
 		GenerateSubscriptions: k.GenerateDefaultSubscriptions,
 		Features:              &k.Features.Supports.WebsocketCapabilities,
-		BufferConfig:          buffer.Config{SortBuffer: true},
+		OrderbookBufferConfig: buffer.Config{SortBuffer: true},
 	})
 	if err != nil {
 		return err

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -225,7 +226,7 @@ func (k *Kraken) Setup(exch *config.Exchange) error {
 		Unsubscriber:          k.Unsubscribe,
 		GenerateSubscriptions: k.GenerateDefaultSubscriptions,
 		Features:              &k.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
+		BufferConfig:          buffer.Config{SortBuffer: true},
 	})
 	if err != nil {
 		return err

--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -118,15 +118,11 @@ func (d *Depth) Flush() {
 
 // UpdateBidAskByPrice updates the bid and ask spread by supplied updates, this
 // will trim total length of depth level to a specified supplied number
-func (d *Depth) UpdateBidAskByPrice(bidUpdts, askUpdts Items, maxDepth int, lastUpdateID int64, updateIDOrdered bool, lastUpdated time.Time) {
+func (d *Depth) UpdateBidAskByPrice(bidUpdts, askUpdts Items, maxDepth int, lastUpdateID int64, lastUpdated time.Time) {
 	if len(bidUpdts) == 0 && len(askUpdts) == 0 {
 		return
 	}
 	d.m.Lock()
-	if updateIDOrdered && lastUpdateID <= d.lastUpdateID {
-		d.m.Unlock()
-		return
-	}
 	d.lastUpdateID = lastUpdateID
 	d.lastUpdated = lastUpdated
 	tn := getNow()

--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -118,11 +118,15 @@ func (d *Depth) Flush() {
 
 // UpdateBidAskByPrice updates the bid and ask spread by supplied updates, this
 // will trim total length of depth level to a specified supplied number
-func (d *Depth) UpdateBidAskByPrice(bidUpdts, askUpdts Items, maxDepth int, lastUpdateID int64, lastUpdated time.Time) {
+func (d *Depth) UpdateBidAskByPrice(bidUpdts, askUpdts Items, maxDepth int, lastUpdateID int64, updateIDOrdered bool, lastUpdated time.Time) {
 	if len(bidUpdts) == 0 && len(askUpdts) == 0 {
 		return
 	}
 	d.m.Lock()
+	if updateIDOrdered && lastUpdateID <= d.lastUpdateID {
+		d.m.Unlock()
+		return
+	}
 	d.lastUpdateID = lastUpdateID
 	d.lastUpdated = lastUpdated
 	tn := getNow()

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -144,19 +144,19 @@ func TestUpdateBidAskByPrice(t *testing.T) {
 	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
 
 	// empty
-	d.UpdateBidAskByPrice(nil, nil, 0, 1, true, time.Time{})
+	d.UpdateBidAskByPrice(nil, nil, 0, 1, time.Time{})
 
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, true, time.Time{})
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, time.Time{})
 	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
 	// This should not do anything, as it simulates a websocket update
 	// duplication.
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, true, time.Time{})
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, time.Time{})
 	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 2, false, time.Time{})
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 2, time.Time{})
 	if d.GetAskLength() != 0 || d.GetBidLength() != 0 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -150,12 +150,6 @@ func TestUpdateBidAskByPrice(t *testing.T) {
 	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
-	// This should not do anything, as it simulates a websocket update
-	// duplication.
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, time.Time{})
-	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
-		t.Fatal("orderbook amounts not updated correctly")
-	}
 	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 2, time.Time{})
 	if d.GetAskLength() != 0 || d.GetBidLength() != 0 {
 		t.Fatal("orderbook amounts not updated correctly")

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -142,11 +142,21 @@ func TestFlush(t *testing.T) {
 func TestUpdateBidAskByPrice(t *testing.T) {
 	d := newDepth(id)
 	d.LoadSnapshot(Items{{Price: 1337, Amount: 1, ID: 1}}, Items{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Time{}, false)
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 0, time.Time{})
+
+	// empty
+	d.UpdateBidAskByPrice(nil, nil, 0, 1, true, time.Time{})
+
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, true, time.Time{})
 	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}
-	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 0, time.Time{})
+	// This should not do anything, as it simulates a websocket update
+	// duplication.
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 2, ID: 1}}, Items{{Price: 1337, Amount: 2, ID: 2}}, 0, 1, true, time.Time{})
+	if d.Retrieve().Asks[0].Amount != 2 || d.Retrieve().Bids[0].Amount != 2 {
+		t.Fatal("orderbook amounts not updated correctly")
+	}
+	d.UpdateBidAskByPrice(Items{{Price: 1337, Amount: 0, ID: 1}}, Items{{Price: 1337, Amount: 0, ID: 2}}, 0, 2, false, time.Time{})
 	if d.GetAskLength() != 0 || d.GetBidLength() != 0 {
 		t.Fatal("orderbook amounts not updated correctly")
 	}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -183,7 +183,7 @@ func (p *Poloniex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          p.Unsubscribe,
 		GenerateSubscriptions: p.GenerateDefaultSubscriptions,
 		Features:              &p.Features.Supports.WebsocketCapabilities,
-		BufferConfig: buffer.Config{
+		OrderbookBufferConfig: buffer.Config{
 			SortBuffer:            true,
 			SortBufferByUpdateIDs: true,
 		},

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -182,8 +183,10 @@ func (p *Poloniex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          p.Unsubscribe,
 		GenerateSubscriptions: p.GenerateDefaultSubscriptions,
 		Features:              &p.Features.Supports.WebsocketCapabilities,
-		SortBuffer:            true,
-		SortBufferByUpdateIDs: true,
+		BufferConfig: buffer.Config{
+			SortBuffer:            true,
+			SortBufferByUpdateIDs: true,
+		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -94,6 +94,13 @@ func (w *Orderbook) Update(u *Update) error {
 
 	// out of order update ID can be skipped
 	if w.updateIDProgression && u.UpdateID <= book.updateID {
+		if w.verbose {
+			log.Warnf(log.WebsocketMgr,
+				"Exchange %s CurrencyPair: %s AssetType: %s out of order websocket update received",
+				w.exchangeName,
+				u.Pair,
+				u.Asset)
+		}
 		return nil
 	}
 

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -43,8 +43,11 @@ func (w *Orderbook) Setup(exchangeConfig *config.Exchange, c *Config, dataHandle
 		return fmt.Errorf(packageError, errIssueBufferEnabledButNoLimit)
 	}
 
+	// NOTE: These variables are set by config.json under "orderbook" for each
+	// individual exchange.
 	w.bufferEnabled = exchangeConfig.Orderbook.WebsocketBufferEnabled
 	w.obBufferLimit = exchangeConfig.Orderbook.WebsocketBufferLimit
+
 	w.sortBuffer = c.SortBuffer
 	w.sortBufferByUpdateIDs = c.SortBufferByUpdateIDs
 	w.updateEntriesByID = c.UpdateEntriesByID

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -200,6 +200,12 @@ func (w *Orderbook) processObUpdate(o *orderbookHolder, u *Update) error {
 		return o.updateByIDAndAction(u)
 	}
 	o.updateByPrice(u)
+	if u.ChecksumFn != nil {
+		err := u.ChecksumFn(o.ob.Retrieve(), u.Checksum)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -210,6 +216,7 @@ func (o *orderbookHolder) updateByPrice(updts *Update) {
 		updts.Asks,
 		updts.MaxDepth,
 		updts.UpdateID,
+		updts.UpdateIDProgression,
 		updts.UpdateTime)
 }
 

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -17,6 +17,7 @@ const packageError = "websocket orderbook buffer error: %w"
 
 var (
 	errExchangeConfigNil            = errors.New("exchange config is nil")
+	errBufferConfigNil              = errors.New("buffer config is nil")
 	errUnsetDataHandler             = errors.New("datahandler unset")
 	errIssueBufferEnabledButNoLimit = errors.New("buffer enabled but no limit set")
 	errUpdateIsNil                  = errors.New("update is nil")
@@ -31,7 +32,10 @@ func (w *Orderbook) Setup(exchangeConfig *config.Exchange, c *Config, dataHandle
 		// prior to calling this, so further checks are not needed.
 		return fmt.Errorf(packageError, errExchangeConfigNil)
 	}
-	if exchangeConfig == nil {
+	if c == nil {
+		return fmt.Errorf(packageError, errBufferConfigNil)
+	}
+	if dataHandler == nil {
 		return fmt.Errorf(packageError, errUnsetDataHandler)
 	}
 	if exchangeConfig.Orderbook.WebsocketBufferEnabled &&

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -432,6 +432,18 @@ func TestOrderbookLastUpdateID(t *testing.T) {
 		}
 	}
 
+	// out of order
+	holder.verbose = true
+	err = holder.Update(&Update{
+		Asks:     []orderbook.Item{{Price: 999999}},
+		Pair:     cp,
+		UpdateID: 1,
+		Asset:    asset.Spot,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ob, err := holder.GetOrderbook(cp, asset.Spot)
 	if err != nil {
 		t.Fatal(err)

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -416,7 +416,8 @@ func TestOrderbookLastUpdateID(t *testing.T) {
 		t.Fatalf("received: %v but expected: %v", err, errTest)
 	}
 
-	holder.checksum = nil
+	holder.checksum = func(state *orderbook.Base, checksum uint32) error { return nil }
+	holder.updateIDProgression = true
 
 	for i := range itemArray {
 		asks := itemArray[i]
@@ -425,7 +426,6 @@ func TestOrderbookLastUpdateID(t *testing.T) {
 			Pair:     cp,
 			UpdateID: int64(i) + 1,
 			Asset:    asset.Spot,
-			// ChecksumFn: func(state *orderbook.Base, checksum uint32) error { return nil },
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -19,13 +19,13 @@ type Config struct {
 	// SortBufferByUpdateIDs allows the sorting of the buffered updates by their
 	// corresponding update IDs. This is package defined.
 	SortBufferByUpdateIDs bool
-	// UpdateEntriesByID will match by IDs instead of price to perform the a set
-	// of actions. e.g. update, delete, insert
+	// UpdateEntriesByID will match by IDs instead of price to perform the an
+	// action. e.g. update, delete, insert.
 	UpdateEntriesByID bool
-	// updateIDProgression requires that the new update ID be greater than the
+	// UpdateIDProgression requires that the new update ID be greater than the
 	// prior ID. This will skip processing and not error.
 	UpdateIDProgression bool
-	// checksum is a package defined checksum calculation for updated books.
+	// Checksum is a package defined checksum calculation for updated books.
 	Checksum func(state *orderbook.Base, checksum uint32) error
 }
 
@@ -74,14 +74,8 @@ type Update struct {
 	Bids []orderbook.Item
 	Asks []orderbook.Item
 	Pair currency.Pair
-
 	// Checksum defines the expected value when the books have been verified
 	Checksum uint32
-
-	// UpdateIDProgression defines if the ID is used as counter and needs to be
-	// greater than last ID.
-	UpdateIDProgression bool
-
 	// Determines if there is a max depth of orderbooks and after an append we
 	// should remove any items that are outside of this scope. Kraken is the
 	// only exchange utilising this field.

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -47,6 +47,15 @@ type Update struct {
 	Asks []orderbook.Item
 	Pair currency.Pair
 
+	// ChecksumFn is a package defined checksum calculation for updated books
+	ChecksumFn func(state *orderbook.Base, checksum uint32) error
+	// Checksum defines the expected value when the books have been verified
+	Checksum uint32
+
+	// UpdateIDProgression defines if the ID is used as counter and needs to be
+	// greater than last ID.
+	UpdateIDProgression bool
+
 	// Determines if there is a max depth of orderbooks and after an append we
 	// should remove any items that are outside of this scope. Kraken is the
 	// only exchange utilising this field.

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -9,6 +9,26 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
+// Config defines the configuration variables for the websocket buffer; snapshot
+// and incremental update orderbook processing.
+type Config struct {
+	// SortBuffer enables a websocket to buffer incoming updates before
+	// processing. NOTE: This is set by config.json under
+	// "websocketBufferEnabled" for each individual exchange.
+	SortBuffer bool
+	// SortBufferByUpdateIDs allows the sorting of the buffered updates by their
+	// corresponding update IDs. This is package defined.
+	SortBufferByUpdateIDs bool
+	// UpdateEntriesByID will match by IDs instead of price to perform the a set
+	// of actions. e.g. update, delete, insert
+	UpdateEntriesByID bool
+	// updateIDProgression requires that the new update ID be greater than the
+	// prior ID. This will skip processing and not error.
+	UpdateIDProgression bool
+	// checksum is a package defined checksum calculation for updated books.
+	Checksum func(state *orderbook.Base, checksum uint32) error
+}
+
 // Orderbook defines a local cache of orderbooks for amending, appending
 // and deleting changes and updates the main store for a stream
 type Orderbook struct {
@@ -19,10 +39,17 @@ type Orderbook struct {
 	sortBufferByUpdateIDs bool // When timestamps aren't provided, an id can help sort
 	updateEntriesByID     bool // Use the update IDs to match ob entries
 	exchangeName          string
-	dataHandler           chan interface{}
+	dataHandler           chan<- interface{}
 	verbose               bool
-	publishPeriod         time.Duration
-	m                     sync.Mutex
+
+	// updateIDProgression requires that the new update ID be greater than the
+	// prior ID. This will skip processing and not error.
+	updateIDProgression bool
+	// checksum is a package defined checksum calculation for updated books.
+	checksum func(state *orderbook.Base, checksum uint32) error
+
+	publishPeriod time.Duration
+	m             sync.Mutex
 }
 
 // orderbookHolder defines a store of pending updates and a pointer to the
@@ -34,7 +61,8 @@ type orderbookHolder struct {
 	// coinbasepro can have up too 100 updates per second introducing overhead.
 	// The sync agent only requires an alert every 15 seconds for a specific
 	// currency.
-	ticker *time.Ticker
+	ticker   *time.Ticker
+	updateID int64
 }
 
 // Update stores orderbook updates and dictates what features to use when processing
@@ -47,8 +75,6 @@ type Update struct {
 	Asks []orderbook.Item
 	Pair currency.Pair
 
-	// ChecksumFn is a package defined checksum calculation for updated books
-	ChecksumFn func(state *orderbook.Base, checksum uint32) error
 	// Checksum defines the expected value when the books have been verified
 	Checksum uint32
 

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -12,12 +12,10 @@ import (
 // Config defines the configuration variables for the websocket buffer; snapshot
 // and incremental update orderbook processing.
 type Config struct {
-	// SortBuffer enables a websocket to buffer incoming updates before
-	// processing. NOTE: This is set by config.json under
-	// "websocketBufferEnabled" for each individual exchange.
+	// SortBuffer enables a websocket to sort incoming updates before processing.
 	SortBuffer bool
 	// SortBufferByUpdateIDs allows the sorting of the buffered updates by their
-	// corresponding update IDs. This is package defined.
+	// corresponding update IDs.
 	SortBufferByUpdateIDs bool
 	// UpdateEntriesByID will match by IDs instead of price to perform the an
 	// action. e.g. update, delete, insert.

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -148,7 +148,7 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 	w.Wg = new(sync.WaitGroup)
 	w.SetCanUseAuthenticatedEndpoints(s.ExchangeConfig.API.AuthenticatedWebsocketSupport)
 
-	if err := w.Orderbook.Setup(s.ExchangeConfig, &s.BufferConfig, w.DataHandler); err != nil {
+	if err := w.Orderbook.Setup(s.ExchangeConfig, &s.OrderbookBufferConfig, w.DataHandler); err != nil {
 		return err
 	}
 

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -148,21 +148,12 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 	w.Wg = new(sync.WaitGroup)
 	w.SetCanUseAuthenticatedEndpoints(s.ExchangeConfig.API.AuthenticatedWebsocketSupport)
 
-	if err := w.Orderbook.Setup(s.ExchangeConfig,
-		s.SortBuffer,
-		s.SortBufferByUpdateIDs,
-		s.UpdateEntriesByID,
-		w.DataHandler); err != nil {
+	if err := w.Orderbook.Setup(s.ExchangeConfig, &s.BufferConfig, w.DataHandler); err != nil {
 		return err
 	}
 
-	w.Trade.Setup(w.exchangeName,
-		s.TradeFeed,
-		w.DataHandler)
-
-	w.Fills.Setup(s.FillsFeed,
-		w.DataHandler)
-
+	w.Trade.Setup(w.exchangeName, s.TradeFeed, w.DataHandler)
+	w.Fills.Setup(s.FillsFeed, w.DataHandler)
 	return nil
 }
 

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -106,11 +106,12 @@ type WebsocketSetup struct {
 	GenerateSubscriptions  func() ([]ChannelSubscription, error)
 	Features               *protocol.Features
 	ConnectionMonitorDelay time.Duration
+
 	// Local orderbook buffer config values
-	SortBuffer            bool
-	SortBufferByUpdateIDs bool
-	UpdateEntriesByID     bool
-	TradeFeed             bool
+	BufferConfig buffer.Config
+
+	TradeFeed bool
+
 	// Fill data config values
 	FillsFeed bool
 }

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -108,7 +108,7 @@ type WebsocketSetup struct {
 	ConnectionMonitorDelay time.Duration
 
 	// Local orderbook buffer config values
-	BufferConfig buffer.Config
+	OrderbookBufferConfig buffer.Config
 
 	TradeFeed bool
 


### PR DESCRIPTION
# PR Description

*Adds websocket checksum orderbook validation. 
*Fetches level 1 book via wrapper instead of level 2 ~as this can be~ as level 2 can be cached up to 10 seconds. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
