### PR TITLE
currency: Add methods to pairs type

### DIFF
--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -133,6 +133,17 @@ func (p Pairs) Contains(check Pair, exact bool) bool {
 	return false
 }
 
+// Has checks to see if a specified currency code exists inside a currency pair
+// array
+func (p Pairs) Has(check Code) bool {
+	for i := range p {
+		if p[i].Contains(check) {
+			return true
+		}
+	}
+	return false
+}
+
 // RemovePairsByFilter checks to see if a pair contains a specific currency
 // and removes it from the list of pairs
 func (p Pairs) RemovePairsByFilter(filter Code) Pairs {
@@ -155,6 +166,19 @@ func (p Pairs) GetPairsByFilter(filter Code) Pairs {
 			continue
 		}
 		pairs = append(pairs, p[i])
+	}
+	return pairs
+}
+
+// GetPairsByCurrencies returns all pairs that have both matches to the
+// currencies passed in. This allows for the construction of enabled pairs by
+// required currency codes.
+func (p Pairs) GetPairsByCurrencies(enabled Currencies) Pairs {
+	pairs := make(Pairs, 0, len(p))
+	for i := range p {
+		if enabled.Contains(p[i].Base) && enabled.Contains(p[i].Quote) {
+			pairs = append(pairs, p[i])
+		}
 	}
 	return pairs
 }

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -133,9 +133,9 @@ func (p Pairs) Contains(check Pair, exact bool) bool {
 	return false
 }
 
-// Has checks to see if a specified currency code exists inside a currency pair
-// array
-func (p Pairs) Has(check Code) bool {
+// ContainsCurrency checks to see if a specified currency code exists inside a
+// currency pair array
+func (p Pairs) ContainsCurrency(check Code) bool {
 	for i := range p {
 		if p[i].Contains(check) {
 			return true
@@ -171,12 +171,12 @@ func (p Pairs) GetPairsByFilter(filter Code) Pairs {
 }
 
 // GetPairsByCurrencies returns all pairs that have both matches to the
-// currencies passed in. This allows for the construction of enabled pairs by
-// required currency codes.
-func (p Pairs) GetPairsByCurrencies(enabled Currencies) Pairs {
+// currencies passed in. This allows for the construction of pairs by required
+// currency codes.
+func (p Pairs) GetPairsByCurrencies(currencies Currencies) Pairs {
 	pairs := make(Pairs, 0, len(p))
 	for i := range p {
-		if enabled.Contains(p[i].Base) && enabled.Contains(p[i].Quote) {
+		if currencies.Contains(p[i].Base) && currencies.Contains(p[i].Quote) {
 			pairs = append(pairs, p[i])
 		}
 	}

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPairsUpper(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
 	if err != nil {
 		t.Fatal(err)
@@ -18,6 +19,7 @@ func TestPairsUpper(t *testing.T) {
 }
 
 func TestPairsLower(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"BTC_USD", "BTC_AUD", "BTC_LTC"})
 	if err != nil {
 		t.Fatal(err)
@@ -29,6 +31,7 @@ func TestPairsLower(t *testing.T) {
 }
 
 func TestPairsString(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
 	if err != nil {
 		t.Fatal(err)
@@ -44,6 +47,7 @@ func TestPairsString(t *testing.T) {
 }
 
 func TestPairsFromString(t *testing.T) {
+	t.Parallel()
 	if _, err := NewPairsFromString("", ""); !errors.Is(err, errNoDelimiter) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errNoDelimiter)
 	}
@@ -71,6 +75,7 @@ func TestPairsFromString(t *testing.T) {
 }
 
 func TestPairsJoin(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +89,7 @@ func TestPairsJoin(t *testing.T) {
 }
 
 func TestPairsFormat(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
 	if err != nil {
 		t.Fatal(err)
@@ -118,6 +124,7 @@ func TestPairsFormat(t *testing.T) {
 }
 
 func TestPairsUnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	var unmarshalHere Pairs
 	configPairs := ""
 	encoded, err := json.Marshal(configPairs)
@@ -158,6 +165,7 @@ func TestPairsUnmarshalJSON(t *testing.T) {
 }
 
 func TestPairsMarshalJSON(t *testing.T) {
+	t.Parallel()
 	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
 	if err != nil {
 		t.Fatal(err)
@@ -182,6 +190,7 @@ func TestPairsMarshalJSON(t *testing.T) {
 }
 
 func TestRemovePairsByFilter(t *testing.T) {
+	t.Parallel()
 	var pairs = Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -195,6 +204,7 @@ func TestRemovePairsByFilter(t *testing.T) {
 }
 
 func TestGetPairsByFilter(t *testing.T) {
+	t.Parallel()
 	var pairs = Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -209,6 +219,7 @@ func TestGetPairsByFilter(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
+	t.Parallel()
 	var pairs = Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -223,6 +234,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
+	t.Parallel()
 	var pairs = Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -244,6 +256,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
+	t.Parallel()
 	var pairs = Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -302,6 +315,7 @@ func TestDeriveFrom(t *testing.T) {
 }
 
 func TestGetCrypto(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -312,6 +326,7 @@ func TestGetCrypto(t *testing.T) {
 }
 
 func TestGetFiat(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -322,6 +337,7 @@ func TestGetFiat(t *testing.T) {
 }
 
 func TestGetCurrencies(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -332,6 +348,7 @@ func TestGetCurrencies(t *testing.T) {
 }
 
 func TestGetStables(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -373,6 +390,7 @@ func BenchmarkGetCrypto(b *testing.B) {
 }
 
 func TestGetMatch(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -405,6 +423,7 @@ func TestGetMatch(t *testing.T) {
 }
 
 func TestGetStablesMatch(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -506,7 +525,8 @@ func BenchmarkRemovePairsByFilter(b *testing.B) {
 	}
 }
 
-func TestHas(t *testing.T) {
+func TestPairsContainsCurrency(t *testing.T) {
+	t.Parallel()
 	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -517,27 +537,28 @@ func TestHas(t *testing.T) {
 		NewPair(DAI, XRP),
 	}
 
-	if !pairs.Has(BTC) {
+	if !pairs.ContainsCurrency(BTC) {
 		t.Fatalf("expected %s to be %v", BTC, true)
 	}
-	if !pairs.Has(USD) {
+	if !pairs.ContainsCurrency(USD) {
 		t.Fatalf("expected %s to be %v", USD, true)
 	}
-	if !pairs.Has(LTC) {
+	if !pairs.ContainsCurrency(LTC) {
 		t.Fatalf("expected %s to be %v", LTC, true)
 	}
-	if !pairs.Has(DAI) {
+	if !pairs.ContainsCurrency(DAI) {
 		t.Fatalf("expected %s to be %v", DAI, true)
 	}
-	if !pairs.Has(XRP) {
+	if !pairs.ContainsCurrency(XRP) {
 		t.Fatalf("expected %s to be %v", XRP, true)
 	}
-	if pairs.Has(ATOM3L) {
+	if pairs.ContainsCurrency(ATOM3L) {
 		t.Fatalf("expected %s to be %v", ATOM3L, false)
 	}
 }
 
 func TestGetPairsByCurrencies(t *testing.T) {
+	t.Parallel()
 	available := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
@@ -554,8 +575,8 @@ func TestGetPairsByCurrencies(t *testing.T) {
 	}
 
 	enabled = available.GetPairsByCurrencies(Currencies{USD, BTC})
-	if !enabled.Contains(NewPair(USD, BTC), false) {
-		t.Fatalf("received %v but expected to contain %v", enabled, NewPair(USD, BTC))
+	if !enabled.Contains(NewPair(BTC, USD), true) {
+		t.Fatalf("received %v but expected to contain %v", enabled, NewPair(BTC, USD))
 	}
 
 	enabled = available.GetPairsByCurrencies(Currencies{USD, BTC, LTC, NZD, USDT, DAI})

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -505,3 +505,61 @@ func BenchmarkRemovePairsByFilter(b *testing.B) {
 		_ = pairs.RemovePairsByFilter(USD)
 	}
 }
+
+func TestHas(t *testing.T) {
+	pairs := Pairs{
+		NewPair(BTC, USD),
+		NewPair(LTC, USD),
+		NewPair(USD, NZD),
+		NewPair(LTC, USDT),
+		NewPair(LTC, DAI),
+		NewPair(USDT, XRP),
+		NewPair(DAI, XRP),
+	}
+
+	if !pairs.Has(BTC) {
+		t.Fatalf("expected %s to be %v", BTC, true)
+	}
+	if !pairs.Has(USD) {
+		t.Fatalf("expected %s to be %v", USD, true)
+	}
+	if !pairs.Has(LTC) {
+		t.Fatalf("expected %s to be %v", LTC, true)
+	}
+	if !pairs.Has(DAI) {
+		t.Fatalf("expected %s to be %v", DAI, true)
+	}
+	if !pairs.Has(XRP) {
+		t.Fatalf("expected %s to be %v", XRP, true)
+	}
+	if pairs.Has(ATOM3L) {
+		t.Fatalf("expected %s to be %v", ATOM3L, false)
+	}
+}
+
+func TestGetPairsByCurrencies(t *testing.T) {
+	available := Pairs{
+		NewPair(BTC, USD),
+		NewPair(LTC, USD),
+		NewPair(USD, NZD),
+		NewPair(LTC, USDT),
+		NewPair(LTC, DAI),
+		NewPair(USDT, XRP),
+		NewPair(DAI, XRP),
+	}
+
+	enabled := available.GetPairsByCurrencies(Currencies{USD})
+	if len(enabled) != 0 {
+		t.Fatalf("received %v but expected %v", enabled, "no pairs")
+	}
+
+	enabled = available.GetPairsByCurrencies(Currencies{USD, BTC})
+	if !enabled.Contains(NewPair(USD, BTC), false) {
+		t.Fatalf("received %v but expected to contain %v", enabled, NewPair(USD, BTC))
+	}
+
+	enabled = available.GetPairsByCurrencies(Currencies{USD, BTC, LTC, NZD, USDT, DAI})
+	if len(enabled) != 5 {
+		t.Fatalf("received %v but expected  %v", enabled, 5)
+	}
+}


### PR DESCRIPTION
# PR Description

Adds a method to see if a code is contained in the currency pairs list. `Has()`
Adds a method to construct from a pairs list with a list of currencies. `GetPairsByCurrencies`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
