### PR TITLE
CI: Fix golangci-lint linter issues, add prealloc linter and bump version depends for Go 1.18

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,14 +29,14 @@ environment:
   PSQL_SKIPSQLCMD: true
   PSQL_TESTDBNAME: gct_dev_ci
   
-stack: go 1.17.8
+stack: go 1.17.8 # this is not actually used on Windows images
 
 services:
   - postgresql96
 
 init:
   - set PATH=%POSTGRES_PATH%\bin;%PATH%
-  - set PATH=C:\go117\bin;%PATH%
+  - set PATH=C:\go118\bin;%PATH%
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%
@@ -55,7 +55,7 @@ before_test:
 
 test_script:
   # test back-end
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
   - '%GOPATH%\bin\golangci-lint.exe run --verbose'
   - ps: >-
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'true') {

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,6 @@ environment:
   PSQL_SSLMODE: disable
   PSQL_SKIPSQLCMD: true
   PSQL_TESTDBNAME: gct_dev_ci
-  GOROOT: C:\go117
-  GOBIN: C:\go117\bin\
   
 stack: go 1.17.8
 
@@ -37,7 +35,8 @@ services:
   - postgresql96
 
 init:
-  - SET PATH=%POSTGRES_PATH%\bin;%PATH%
+  - set PATH=%POSTGRES_PATH%\bin;%PATH%
+  - set PATH=C:\go117\bin;%PATH%
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,7 @@ environment:
   PSQL_SKIPSQLCMD: true
   PSQL_TESTDBNAME: gct_dev_ci
   GOROOT: C:\go117
+  GOBIN: C:\go117\bin\
   
 stack: go 1.17.8
 
@@ -37,8 +38,6 @@ services:
 
 init:
   - SET PATH=%POSTGRES_PATH%\bin;%PATH%
-  - SET PATH=%PATH:C:\go;=%
-  - SET PATH=%GOROOT%;%PATH%
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,13 +28,17 @@ environment:
   PSQL_SSLMODE: disable
   PSQL_SKIPSQLCMD: true
   PSQL_TESTDBNAME: gct_dev_ci
-stack: go 1.17.x
+  GOROOT: C:\go117
+  
+stack: go 1.17.8
 
 services:
   - postgresql96
 
 init:
   - SET PATH=%POSTGRES_PATH%\bin;%PATH%
+  - SET PATH=%PATH:C:\go;=%
+  - SET PATH=%GOROOT%;%PATH%
 
 install:
   - set Path=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%Path%

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-    time: "19:30"
+    interval: "weekly"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/web"
@@ -12,4 +15,3 @@ updates:
     interval: "weekly"
   # deprecated for now as it requires a more in-depth overhaul
   open-pull-requests-limit: 0
-

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,8 +5,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17.x'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.42.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,8 +8,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.x'
+          go-version: '1.18.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42.1
+          version: v1.45.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 env:
-  GO_VERSION: 1.17.x
+  GO_VERSION: 1.18.x
 jobs:
   backend-psql:
     name: GoCryptoTrader back-end with PSQL

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 6m
+  timeout: 8m
   issues-exit-code: 1
   tests: true
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
     - vendor
     - web/
     - testdata
+    - database/models/
 
 linters:
   disable-all: true
@@ -24,12 +25,17 @@ linters:
 
 # disabled by default linters
     - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
+#   - contextcheck
 #   - cyclop
+    - decorder
     - depguard
     - dogsled
 #   - dupl
     - durationcheck
+    - errchkjson
     - errname
 #   - errorlint
 #   - exhaustive
@@ -58,10 +64,13 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
+    - grouper
     - ifshort
 #   - importas
 #   - interfacer // deprecated by its owner
+#   - ireturn
 #   - lll 
+#   - maintidx
     - makezero
 #   - maligned
     - misspell
@@ -72,7 +81,7 @@ linters:
     - noctx
     - nolintlint
 #   - paralleltest
-#   - prealloc
+    - prealloc
     - predeclared
 #   - promlinter
     - revive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /go/src/github.com/thrasher-corp/gocryptotrader
 COPY . .
 RUN GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/backtester/backtest/backtest.go
+++ b/backtester/backtest/backtest.go
@@ -648,7 +648,7 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 		if cfg.DataSettings.DatabaseData.Path == "" {
 			cfg.DataSettings.DatabaseData.Path = filepath.Join(gctcommon.GetDefaultDataDir(runtime.GOOS), "database")
 		}
-		gctdatabase.DB.DataPath = filepath.Join(cfg.DataSettings.DatabaseData.Path)
+		gctdatabase.DB.DataPath = cfg.DataSettings.DatabaseData.Path
 		err = gctdatabase.DB.SetConfig(&cfg.DataSettings.DatabaseData.Config)
 		if err != nil {
 			return nil, err

--- a/backtester/config/config.go
+++ b/backtester/config/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/shopspring/decimal"
@@ -21,7 +21,7 @@ func ReadConfigFromFile(path string) (*Config, error) {
 		return nil, errors.New("file not found")
 	}
 
-	fileData, err := ioutil.ReadFile(path)
+	fileData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/backtester/config/config_test.go
+++ b/backtester/config/config_test.go
@@ -210,7 +210,7 @@ func TestGenerateConfigForDCAAPICandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-api-candles.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -288,7 +288,7 @@ func TestGenerateConfigForDCAAPICandlesExchangeLevelFunding(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-api-candles-exchange-level-funding.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-exchange-level-funding.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -356,7 +356,7 @@ func TestGenerateConfigForDCAAPITrades(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-api-trades.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-trades.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -429,7 +429,7 @@ func TestGenerateConfigForDCAAPICandlesMultipleCurrencies(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-api-candles-multiple-currencies.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-multiple-currencies.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -503,7 +503,7 @@ func TestGenerateConfigForDCAAPICandlesSimultaneousProcessing(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-api-candles-simultaneous-processing.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-simultaneous-processing.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -566,7 +566,7 @@ func TestGenerateConfigForDCALiveCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-candles-live.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-candles-live.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -645,7 +645,7 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "rsi-api-candles.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "rsi-api-candles.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -704,7 +704,7 @@ func TestGenerateConfigForDCACSVCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-csv-candles.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-candles.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -759,7 +759,7 @@ func TestGenerateConfigForDCACSVTrades(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-csv-trades.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-trades.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -827,7 +827,7 @@ func TestGenerateConfigForDCADatabaseCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "dca-database-candles.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-database-candles.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}
@@ -956,7 +956,7 @@ func TestGenerateConfigForTop2Bottom2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(filepath.Join(p, "examples", "t2b2-api-candles-exchange-funding.strat"), result, 0770)
+		err = os.WriteFile(filepath.Join(p, "examples", "t2b2-api-candles-exchange-funding.strat"), result, 0o770)
 		if err != nil {
 			t.Error(err)
 		}

--- a/backtester/config/config_test.go
+++ b/backtester/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventhandlers/strategies/base"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventhandlers/strategies/top2bottom2"
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/database"
 	"github.com/thrasher-corp/gocryptotrader/database/drivers"
@@ -210,7 +211,7 @@ func TestGenerateConfigForDCAAPICandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -288,7 +289,7 @@ func TestGenerateConfigForDCAAPICandlesExchangeLevelFunding(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-exchange-level-funding.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-exchange-level-funding.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -356,7 +357,7 @@ func TestGenerateConfigForDCAAPITrades(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-trades.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-trades.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -429,7 +430,7 @@ func TestGenerateConfigForDCAAPICandlesMultipleCurrencies(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-multiple-currencies.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-multiple-currencies.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -503,7 +504,7 @@ func TestGenerateConfigForDCAAPICandlesSimultaneousProcessing(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-simultaneous-processing.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-api-candles-simultaneous-processing.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -566,7 +567,7 @@ func TestGenerateConfigForDCALiveCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-candles-live.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-candles-live.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -645,7 +646,7 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "rsi-api-candles.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "rsi-api-candles.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -704,7 +705,7 @@ func TestGenerateConfigForDCACSVCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-candles.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-candles.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -759,7 +760,7 @@ func TestGenerateConfigForDCACSVTrades(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-trades.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-csv-trades.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -827,7 +828,7 @@ func TestGenerateConfigForDCADatabaseCandles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "dca-database-candles.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "dca-database-candles.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}
@@ -956,7 +957,7 @@ func TestGenerateConfigForTop2Bottom2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(filepath.Join(p, "examples", "t2b2-api-candles-exchange-funding.strat"), result, 0o770)
+		err = os.WriteFile(filepath.Join(p, "examples", "t2b2-api-candles-exchange-funding.strat"), result, file.DefaultPermissionOctal)
 		if err != nil {
 			t.Error(err)
 		}

--- a/backtester/config/configbuilder/main.go
+++ b/backtester/config/configbuilder/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/backtester/config"
 	"github.com/thrasher-corp/gocryptotrader/backtester/eventhandlers/strategies"
 	gctcommon "github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/database"
 	dbPSQL "github.com/thrasher-corp/gocryptotrader/database/drivers/postgres"
 	dbsqlite3 "github.com/thrasher-corp/gocryptotrader/database/drivers/sqlite3"
@@ -140,7 +141,7 @@ func main() {
 		if path == "" {
 			path = wd
 		}
-		err = os.WriteFile(path, resp, 0o770)
+		err = os.WriteFile(path, resp, file.DefaultPermissionOctal)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/backtester/config/configbuilder/main.go
+++ b/backtester/config/configbuilder/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -141,7 +140,7 @@ func main() {
 		if path == "" {
 			path = wd
 		}
-		err = ioutil.WriteFile(path, resp, 0770)
+		err = os.WriteFile(path, resp, 0o770)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -235,10 +234,10 @@ func parseExchangeSettings(reader *bufio.Reader, cfg *config.Config) error {
 func parseStrategySettings(cfg *config.Config, reader *bufio.Reader) error {
 	fmt.Println("Firstly, please select which strategy you wish to use")
 	strats := strategies.GetStrategies()
-	var strategiesToUse []string
+	strategiesToUse := make([]string, len(strats))
 	for i := range strats {
 		fmt.Printf("%v. %s\n", i+1, strats[i].Name())
-		strategiesToUse = append(strategiesToUse, strats[i].Name())
+		strategiesToUse[i] = strats[i].Name()
 	}
 	var err error
 	cfg.StrategySettings.Name, err = parseStratName(quickParse(reader), strategiesToUse)

--- a/backtester/data/kline/kline.go
+++ b/backtester/data/kline/kline.go
@@ -58,7 +58,7 @@ func (d *DataFromKline) AppendResults(ki *gctkline.Item) {
 	if d.addedTimes == nil {
 		d.addedTimes = make(map[time.Time]bool)
 	}
-	var klineData []common.DataEventHandler
+
 	var gctCandles []gctkline.Candle
 	for i := range ki.Candles {
 		if _, ok := d.addedTimes[ki.Candles[i].Time]; !ok {
@@ -66,10 +66,11 @@ func (d *DataFromKline) AppendResults(ki *gctkline.Item) {
 			d.addedTimes[ki.Candles[i].Time] = true
 		}
 	}
-	var candleTimes []time.Time
 
+	klineData := make([]common.DataEventHandler, len(gctCandles))
+	candleTimes := make([]time.Time, len(gctCandles))
 	for i := range gctCandles {
-		klineData = append(klineData, &kline.Kline{
+		klineData[i] = &kline.Kline{
 			Base: event.Base{
 				Offset:       int64(i + 1),
 				Exchange:     ki.Exchange,
@@ -84,8 +85,8 @@ func (d *DataFromKline) AppendResults(ki *gctkline.Item) {
 			Close:            decimal.NewFromFloat(gctCandles[i].Close),
 			Volume:           decimal.NewFromFloat(gctCandles[i].Volume),
 			ValidationIssues: gctCandles[i].ValidationIssues,
-		})
-		candleTimes = append(candleTimes, gctCandles[i].Time)
+		}
+		candleTimes[i] = gctCandles[i].Time
 	}
 	for i := range d.RangeHolder.Ranges {
 		for j := range d.RangeHolder.Ranges[i].Intervals {

--- a/backtester/data/kline/kline_test.go
+++ b/backtester/data/kline/kline_test.go
@@ -135,8 +135,7 @@ func TestStreamOpen(t *testing.T) {
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	d := DataFromKline{}
-	bad := d.StreamOpen()
-	if len(bad) > 0 {
+	if bad := d.StreamOpen(); len(bad) > 0 {
 		t.Error("expected no stream")
 	}
 	d.SetStream([]common.DataEventHandler{
@@ -156,8 +155,7 @@ func TestStreamOpen(t *testing.T) {
 		},
 	})
 	d.Next()
-	open := d.StreamOpen()
-	if len(open) == 0 {
+	if open := d.StreamOpen(); len(open) == 0 {
 		t.Error("expected open")
 	}
 }
@@ -168,8 +166,7 @@ func TestStreamVolume(t *testing.T) {
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	d := DataFromKline{}
-	bad := d.StreamVol()
-	if len(bad) > 0 {
+	if bad := d.StreamVol(); len(bad) > 0 {
 		t.Error("expected no stream")
 	}
 	d.SetStream([]common.DataEventHandler{
@@ -189,8 +186,7 @@ func TestStreamVolume(t *testing.T) {
 		},
 	})
 	d.Next()
-	open := d.StreamVol()
-	if len(open) == 0 {
+	if open := d.StreamVol(); len(open) == 0 {
 		t.Error("expected volume")
 	}
 }
@@ -201,8 +197,7 @@ func TestStreamClose(t *testing.T) {
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	d := DataFromKline{}
-	bad := d.StreamClose()
-	if len(bad) > 0 {
+	if bad := d.StreamClose(); len(bad) > 0 {
 		t.Error("expected no stream")
 	}
 	d.SetStream([]common.DataEventHandler{
@@ -222,8 +217,7 @@ func TestStreamClose(t *testing.T) {
 		},
 	})
 	d.Next()
-	open := d.StreamClose()
-	if len(open) == 0 {
+	if open := d.StreamClose(); len(open) == 0 {
 		t.Error("expected close")
 	}
 }
@@ -234,8 +228,7 @@ func TestStreamHigh(t *testing.T) {
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	d := DataFromKline{}
-	bad := d.StreamHigh()
-	if len(bad) > 0 {
+	if bad := d.StreamHigh(); len(bad) > 0 {
 		t.Error("expected no stream")
 	}
 	d.SetStream([]common.DataEventHandler{
@@ -255,8 +248,7 @@ func TestStreamHigh(t *testing.T) {
 		},
 	})
 	d.Next()
-	open := d.StreamHigh()
-	if len(open) == 0 {
+	if open := d.StreamHigh(); len(open) == 0 {
 		t.Error("expected high")
 	}
 }
@@ -269,8 +261,7 @@ func TestStreamLow(t *testing.T) {
 	d := DataFromKline{
 		RangeHolder: &gctkline.IntervalRangeHolder{},
 	}
-	bad := d.StreamLow()
-	if len(bad) > 0 {
+	if bad := d.StreamLow(); len(bad) > 0 {
 		t.Error("expected no stream")
 	}
 	d.SetStream([]common.DataEventHandler{
@@ -290,8 +281,7 @@ func TestStreamLow(t *testing.T) {
 		},
 	})
 	d.Next()
-	open := d.StreamLow()
-	if len(open) == 0 {
+	if open := d.StreamLow(); len(open) == 0 {
 		t.Error("expected low")
 	}
 }

--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -229,12 +229,11 @@ func (e *Exchange) placeOrder(ctx context.Context, price, amount decimal.Decimal
 		return "", err
 	}
 	var orderID string
-	p, _ := price.Float64()
-	a, _ := amount.Float64()
-	fee, _ := f.ExchangeFee.Float64()
+	p := price.InexactFloat64()
+	fee := f.ExchangeFee.InexactFloat64()
 	o := &gctorder.Submit{
 		Price:       p,
-		Amount:      a,
+		Amount:      amount.InexactFloat64(),
 		Fee:         fee,
 		Exchange:    f.Exchange,
 		ID:          u.String(),
@@ -255,11 +254,10 @@ func (e *Exchange) placeOrder(ctx context.Context, price, amount decimal.Decimal
 			return orderID, err
 		}
 	} else {
-		rate, _ := f.Amount.Float64()
 		submitResponse := gctorder.SubmitResponse{
 			IsOrderPlaced: true,
 			OrderID:       u.String(),
-			Rate:          rate,
+			Rate:          f.Amount.InexactFloat64(),
 			Fee:           fee,
 			Cost:          p,
 			FullyMatched:  true,

--- a/backtester/eventhandlers/exchange/slippage/slippage.go
+++ b/backtester/eventhandlers/exchange/slippage/slippage.go
@@ -32,11 +32,9 @@ func EstimateSlippagePercentage(maximumSlippageRate, minimumSlippageRate decimal
 // CalculateSlippageByOrderbook will analyse a provided orderbook and return the result of attempting to
 // place the order on there
 func CalculateSlippageByOrderbook(ob *orderbook.Base, side gctorder.Side, amountOfFunds, feeRate decimal.Decimal) (price, amount decimal.Decimal) {
-	funds, _ := amountOfFunds.Float64()
-	fee, _ := feeRate.Float64()
-	result := ob.SimulateOrder(funds, side == gctorder.Buy)
+	result := ob.SimulateOrder(amountOfFunds.InexactFloat64(), side == gctorder.Buy)
 	rate := (result.MinimumPrice - result.MaximumPrice) / result.MaximumPrice
 	price = decimal.NewFromFloat(result.MinimumPrice * (rate + 1))
-	amount = decimal.NewFromFloat(result.Amount * (1 - fee))
+	amount = decimal.NewFromFloat(result.Amount * (1 - feeRate.InexactFloat64()))
 	return
 }

--- a/backtester/eventhandlers/statistics/currencystatistics.go
+++ b/backtester/eventhandlers/statistics/currencystatistics.go
@@ -55,10 +55,10 @@ func (c *CurrencyPairStatistic) CalculateResults(riskFreeRate decimal.Decimal) e
 	returnsPerCandle := make([]decimal.Decimal, len(c.Events))
 	benchmarkRates := make([]decimal.Decimal, len(c.Events))
 
-	var allDataEvents []common.DataEventHandler
+	allDataEvents := make([]common.DataEventHandler, len(c.Events))
 	for i := range c.Events {
 		returnsPerCandle[i] = c.Events[i].Holdings.ChangeInTotalValuePercent
-		allDataEvents = append(allDataEvents, c.Events[i].DataEvent)
+		allDataEvents[i] = c.Events[i].DataEvent
 		if i == 0 {
 			continue
 		}

--- a/backtester/eventhandlers/strategies/rsi/rsi.go
+++ b/backtester/eventhandlers/strategies/rsi/rsi.go
@@ -159,7 +159,7 @@ func (s *Strategy) SetDefaults() {
 // the decision to handle missing data occurs at the strategy level, not all strategies
 // may wish to modify data
 func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]float64, error) {
-	var resp []float64
+	resp := make([]float64, len(data))
 	var missingDataStreak int64
 	for i := range data {
 		if data[i].IsZero() && i > int(s.rsiPeriod.IntPart()) {
@@ -175,7 +175,7 @@ func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]fl
 				base.ErrTooMuchBadData)
 		}
 		d, _ := data[i].Float64()
-		resp = append(resp, d)
+		resp[i] = d
 	}
 	return resp, nil
 }

--- a/backtester/eventhandlers/strategies/rsi/rsi.go
+++ b/backtester/eventhandlers/strategies/rsi/rsi.go
@@ -174,8 +174,7 @@ func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]fl
 				t.Format(gctcommon.SimpleTimeFormat),
 				base.ErrTooMuchBadData)
 		}
-		d, _ := data[i].Float64()
-		resp[i] = d
+		resp[i] = data[i].InexactFloat64()
 	}
 	return resp, nil
 }

--- a/backtester/eventhandlers/strategies/strategies_test.go
+++ b/backtester/eventhandlers/strategies/strategies_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestGetStrategies(t *testing.T) {
 	t.Parallel()
-	resp := GetStrategies()
-	if len(resp) < 2 {
+	if resp := GetStrategies(); len(resp) < 2 {
 		t.Error("expected at least 2 strategies to be loaded")
 	}
 }

--- a/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
+++ b/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
@@ -92,7 +92,7 @@ func (s *Strategy) OnSimultaneousSignals(d []data.Handler, f funding.IFundTransf
 	if len(d) < 4 {
 		return nil, errStrategyCurrencyRequirements
 	}
-	var mfiFundEvents []mfiFundEvent
+	mfiFundEvents := make([]mfiFundEvent, 0, len(d))
 	var resp []signal.Event
 	for i := range d {
 		if d == nil {

--- a/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
+++ b/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
@@ -248,8 +248,7 @@ func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]fl
 				t.Format(gctcommon.SimpleTimeFormat),
 				base.ErrTooMuchBadData)
 		}
-		d, _ := data[i].Float64()
-		resp[i] = d
+		resp[i] = data[i].InexactFloat64()
 	}
 	return resp, nil
 }

--- a/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
+++ b/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
@@ -233,7 +233,7 @@ func (s *Strategy) SetDefaults() {
 // the decision to handle missing data occurs at the strategy level, not all strategies
 // may wish to modify data
 func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]float64, error) {
-	var resp []float64
+	resp := make([]float64, len(data))
 	var missingDataStreak int64
 	for i := range data {
 		if data[i].IsZero() && i > int(s.mfiPeriod.IntPart()) {
@@ -249,7 +249,7 @@ func (s *Strategy) massageMissingData(data []decimal.Decimal, t time.Time) ([]fl
 				base.ErrTooMuchBadData)
 		}
 		d, _ := data[i].Float64()
-		resp = append(resp, d)
+		resp[i] = d
 	}
 	return resp, nil
 }

--- a/backtester/eventtypes/event/event_test.go
+++ b/backtester/eventtypes/event/event_test.go
@@ -65,8 +65,7 @@ func TestEvent_GetTime(t *testing.T) {
 func TestEvent_IsEvent(t *testing.T) {
 	t.Parallel()
 	e := &Base{}
-	y := e.IsEvent()
-	if !y {
+	if y := e.IsEvent(); !y {
 		t.Error("it is an event")
 	}
 }

--- a/backtester/funding/funding.go
+++ b/backtester/funding/funding.go
@@ -199,7 +199,7 @@ func (f *FundManager) GenerateReport() *Report {
 		UsingExchangeLevelFunding: f.usingExchangeLevelFunding,
 		DisableUSDTracking:        f.disableUSDTracking,
 	}
-	var items []ReportItem
+	items := make([]ReportItem, len(f.items))
 	for i := range f.items {
 		item := ReportItem{
 			Exchange:     f.items[i].exchange,
@@ -243,7 +243,7 @@ func (f *FundManager) GenerateReport() *Report {
 			item.PairedWith = f.items[i].pairedWith.currency
 		}
 
-		items = append(items, item)
+		items[i] = item
 	}
 	report.Items = items
 	return &report

--- a/backtester/report/report.go
+++ b/backtester/report/report.go
@@ -177,7 +177,7 @@ func (d *Data) enhanceCandles() error {
 			Asset:     lookup.Asset,
 			Pair:      lookup.Pair,
 			Interval:  lookup.Interval,
-			Watermark: fmt.Sprintf("%v - %v - %v", strings.Title(lookup.Exchange), lookup.Asset.String(), strings.ToUpper(lookup.Pair.String())), // nolint // Title usage
+			Watermark: fmt.Sprintf("%v - %v - %v", strings.Title(lookup.Exchange), lookup.Asset.String(), lookup.Pair.Upper()), // nolint // Title usage
 		}
 
 		statsForCandles :=

--- a/backtester/report/report.go
+++ b/backtester/report/report.go
@@ -177,7 +177,7 @@ func (d *Data) enhanceCandles() error {
 			Asset:     lookup.Asset,
 			Pair:      lookup.Pair,
 			Interval:  lookup.Interval,
-			Watermark: fmt.Sprintf("%v - %v - %v", strings.Title(lookup.Exchange), lookup.Asset.String(), lookup.Pair.Upper()), // nolint // Title usage
+			Watermark: fmt.Sprintf("%s - %s - %s", strings.Title(lookup.Exchange), lookup.Asset.String(), lookup.Pair.Upper()), // nolint // Title usage
 		}
 
 		statsForCandles :=

--- a/backtester/report/report.go
+++ b/backtester/report/report.go
@@ -89,31 +89,33 @@ func (d *Data) CreateUSDTotalsChart() []TotalsChart {
 	if d.Statistics.FundingStatistics == nil || d.Statistics.FundingStatistics.Report.DisableUSDTracking {
 		return nil
 	}
-	var response []TotalsChart
-	var usdTotalChartPlot []ChartPlot
+
+	usdTotalChartPlot := make([]ChartPlot, len(d.Statistics.FundingStatistics.TotalUSDStatistics.HoldingValues))
 	for i := range d.Statistics.FundingStatistics.TotalUSDStatistics.HoldingValues {
-		usdTotalChartPlot = append(usdTotalChartPlot, ChartPlot{
+		usdTotalChartPlot[i] = ChartPlot{
 			Value:     d.Statistics.FundingStatistics.TotalUSDStatistics.HoldingValues[i].Value.InexactFloat64(),
 			UnixMilli: d.Statistics.FundingStatistics.TotalUSDStatistics.HoldingValues[i].Time.UTC().UnixMilli(),
-		})
+		}
 	}
-	response = append(response, TotalsChart{
+
+	response := make([]TotalsChart, len(d.Statistics.FundingStatistics.Items)+1)
+	response[0] = TotalsChart{
 		Name:       "Total USD value",
 		DataPoints: usdTotalChartPlot,
-	})
+	}
 
 	for i := range d.Statistics.FundingStatistics.Items {
-		var plots []ChartPlot
+		plots := make([]ChartPlot, len(d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots))
 		for j := range d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots {
-			plots = append(plots, ChartPlot{
+			plots[j] = ChartPlot{
 				Value:     d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots[j].USDValue.InexactFloat64(),
 				UnixMilli: d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots[j].Time.UTC().UnixMilli(),
-			})
+			}
 		}
-		response = append(response, TotalsChart{
+		response[i+1] = TotalsChart{
 			Name:       fmt.Sprintf("%v %v %v USD value", d.Statistics.FundingStatistics.Items[i].ReportItem.Exchange, d.Statistics.FundingStatistics.Items[i].ReportItem.Asset, d.Statistics.FundingStatistics.Items[i].ReportItem.Currency),
 			DataPoints: plots,
-		})
+		}
 	}
 
 	return response
@@ -125,19 +127,19 @@ func (d *Data) CreateHoldingsOverTimeChart() []TotalsChart {
 	if d.Statistics.FundingStatistics == nil {
 		return nil
 	}
-	var response []TotalsChart
+	response := make([]TotalsChart, len(d.Statistics.FundingStatistics.Items))
 	for i := range d.Statistics.FundingStatistics.Items {
-		var plots []ChartPlot
+		plots := make([]ChartPlot, len(d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots))
 		for j := range d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots {
-			plots = append(plots, ChartPlot{
+			plots[j] = ChartPlot{
 				Value:     d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots[j].Available.InexactFloat64(),
 				UnixMilli: d.Statistics.FundingStatistics.Items[i].ReportItem.Snapshots[j].Time.UTC().UnixMilli(),
-			})
+			}
 		}
-		response = append(response, TotalsChart{
+		response[i] = TotalsChart{
 			Name:       fmt.Sprintf("%v %v %v holdings", d.Statistics.FundingStatistics.Items[i].ReportItem.Exchange, d.Statistics.FundingStatistics.Items[i].ReportItem.Asset, d.Statistics.FundingStatistics.Items[i].ReportItem.Currency),
 			DataPoints: plots,
-		})
+		}
 	}
 
 	return response
@@ -177,7 +179,7 @@ func (d *Data) enhanceCandles() error {
 			Asset:     lookup.Asset,
 			Pair:      lookup.Pair,
 			Interval:  lookup.Interval,
-			Watermark: fmt.Sprintf("%v - %v - %v", strings.Title(lookup.Exchange), lookup.Asset.String(), strings.ToUpper(lookup.Pair.String())),
+			Watermark: fmt.Sprintf("%v - %v - %v", strings.Title(lookup.Exchange), lookup.Asset.String(), strings.ToUpper(lookup.Pair.String())), // nolint // Title usage
 		}
 
 		statsForCandles :=

--- a/backtester/report/report.go
+++ b/backtester/report/report.go
@@ -46,9 +46,7 @@ func (d *Data) GenerateReport() error {
 	d.HoldingsOverTimeChart = d.CreateHoldingsOverTimeChart()
 
 	tmpl := template.Must(
-		template.ParseFiles(
-			filepath.Join(d.TemplatePath),
-		),
+		template.ParseFiles(d.TemplatePath),
 	)
 	var nickName string
 	if d.Config.Nickname != "" {

--- a/backtester/report/report_test.go
+++ b/backtester/report/report_test.go
@@ -40,7 +40,7 @@ func TestGenerateReport(t *testing.T) {
 	d := Data{
 		Config:       &config.Config{},
 		OutputPath:   filepath.Join("..", "results"),
-		TemplatePath: filepath.Join("tpl.gohtml"),
+		TemplatePath: "tpl.gohtml",
 		OriginalCandles: []*gctkline.Item{
 			{
 				Candles: []gctkline.Candle{

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -304,9 +304,9 @@ func checkExistingExchanges(exchName string) bool {
 
 // checkMissingExchanges checks if any supported exchanges are missing api checker functionality
 func checkMissingExchanges() []string {
-	var tempArray []string
+	tempArray := make([]string, len(usageData.Exchanges))
 	for x := range usageData.Exchanges {
-		tempArray = append(tempArray, usageData.Exchanges[x].Name)
+		tempArray[x] = usageData.Exchanges[x].Name
 	}
 	supportedExchs := exchange.Exchanges
 	for z := 0; z < len(supportedExchs); {
@@ -322,7 +322,7 @@ func checkMissingExchanges() []string {
 // readFileData reads the file data from the given json file
 func readFileData(fileName string) (Config, error) {
 	var c Config
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return c, err
 	}
@@ -448,7 +448,7 @@ func checkUpdates(fileName string) error {
 	unsup := checkMissingExchanges()
 	log.Warnf(log.Global, "The following exchanges are not supported by apichecker: %v\n", unsup)
 	log.Debugf(log.Global, "Saving the updates to the following file: %s\n", fileName)
-	return ioutil.WriteFile(fileName, file, 0770)
+	return os.WriteFile(fileName, file, 0o770)
 }
 
 // checkChangeLog checks the exchanges which support changelog updates.json
@@ -559,9 +559,9 @@ func addExch(exchName, checkType string, data interface{}, isUpdate bool) error 
 				return err
 			}
 		}
-		return ioutil.WriteFile(jsonFile, file, 0770)
+		return os.WriteFile(jsonFile, file, 0o770)
 	}
-	return ioutil.WriteFile(testJSONFile, file, 0770)
+	return os.WriteFile(testJSONFile, file, 0o770)
 }
 
 // fillData fills exchange data based on the given checkType
@@ -749,7 +749,7 @@ func htmlScrapeHitBTC(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 	defer temp.Body.Close()
 
-	a, err := ioutil.ReadAll(temp.Body)
+	a, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func htmlScrapeBTCMarkets(htmlData *HTMLScrapingData) ([]string, error) {
 		return nil, err
 	}
 	defer temp.Body.Close()
-	tempData, err := ioutil.ReadAll(temp.Body)
+	tempData, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return resp, err
 	}
@@ -862,7 +862,7 @@ func htmlScrapeANX(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 	defer temp.Body.Close()
 
-	a, err := ioutil.ReadAll(temp.Body)
+	a, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -901,7 +901,7 @@ func htmlScrapeExmo(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 
 	defer httpResp.Body.Close()
-	a, err := ioutil.ReadAll(httpResp.Body)
+	a, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,7 +1010,7 @@ func htmlScrapeBitstamp(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 	defer temp.Body.Close()
 
-	a, err := ioutil.ReadAll(temp.Body)
+	a, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1145,7 +1145,7 @@ func htmlScrapeLocalBitcoins(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 	defer temp.Body.Close()
 
-	a, err := ioutil.ReadAll(temp.Body)
+	a, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1284,7 +1284,7 @@ func updateFile(name string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(name, file, 0770)
+	return os.WriteFile(name, file, 0o770)
 }
 
 // SendGetReq sends get req
@@ -1690,7 +1690,7 @@ func htmlScrapeBitfinex(htmlData *HTMLScrapingData) ([]string, error) {
 	}
 	defer temp.Body.Close()
 
-	a, err := ioutil.ReadAll(temp.Body)
+	a, err := io.ReadAll(temp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -1775,7 +1775,7 @@ func sendHTTPGetRequest(path string, headers map[string]string) (*http.Response,
 	req, err := http.NewRequestWithContext(context.TODO(),
 		http.MethodGet,
 		path,
-		nil)
+		http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
+	gctfile "github.com/thrasher-corp/gocryptotrader/common/file"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/log"
@@ -448,7 +449,7 @@ func checkUpdates(fileName string) error {
 	unsup := checkMissingExchanges()
 	log.Warnf(log.Global, "The following exchanges are not supported by apichecker: %v\n", unsup)
 	log.Debugf(log.Global, "Saving the updates to the following file: %s\n", fileName)
-	return os.WriteFile(fileName, file, 0o770)
+	return os.WriteFile(fileName, file, gctfile.DefaultPermissionOctal)
 }
 
 // checkChangeLog checks the exchanges which support changelog updates.json
@@ -559,9 +560,9 @@ func addExch(exchName, checkType string, data interface{}, isUpdate bool) error 
 				return err
 			}
 		}
-		return os.WriteFile(jsonFile, file, 0o770)
+		return os.WriteFile(jsonFile, file, gctfile.DefaultPermissionOctal)
 	}
-	return os.WriteFile(testJSONFile, file, 0o770)
+	return os.WriteFile(testJSONFile, file, gctfile.DefaultPermissionOctal)
 }
 
 // fillData fills exchange data based on the given checkType
@@ -1284,7 +1285,7 @@ func updateFile(name string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(name, file, 0o770)
+	return os.WriteFile(name, file, gctfile.DefaultPermissionOctal)
 }
 
 // SendGetReq sends get req

--- a/cmd/apichecker/apicheck_test.go
+++ b/cmd/apichecker/apicheck_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
+	gctfile "github.com/thrasher-corp/gocryptotrader/common/file"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
@@ -85,7 +86,7 @@ func removeTestFileVars() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(testJSONFile, file, 0o770)
+	return os.WriteFile(testJSONFile, file, gctfile.DefaultPermissionOctal)
 }
 
 func canTestTrello() bool {

--- a/cmd/apichecker/apicheck_test.go
+++ b/cmd/apichecker/apicheck_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -86,7 +85,7 @@ func removeTestFileVars() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(testJSONFile, file, 0770)
+	return os.WriteFile(testJSONFile, file, 0o770)
 }
 
 func canTestTrello() bool {
@@ -439,8 +438,7 @@ func TestUpdate(t *testing.T) {
 
 func TestCheckMissingExchanges(t *testing.T) {
 	t.Parallel()
-	a := checkMissingExchanges()
-	if len(a) > len(exchange.Exchanges) {
+	if a := checkMissingExchanges(); len(a) > len(exchange.Exchanges) {
 		t.Fatal("invalid response")
 	}
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/config"
@@ -38,7 +38,7 @@ func main() {
 		key = string(result)
 	}
 
-	fileData, err := ioutil.ReadFile(inFile)
+	fileData, err := os.ReadFile(inFile)
 	if err != nil {
 		log.Fatalf("Unable to read input file %s. Error: %s.", inFile, err)
 	}

--- a/cmd/config_builder/builder.go
+++ b/cmd/config_builder/builder.go
@@ -30,8 +30,8 @@ func main() {
 	wg.Wait()
 	log.Println("Done.")
 
-	var cfgs []config.Exchange
 	exchanges := engine.Bot.GetExchanges()
+	cfgs := make([]config.Exchange, 0, len(exchanges))
 	for x := range exchanges {
 		var cfg *config.Exchange
 		cfg, err = exchanges[x].GetDefaultConfig()

--- a/cmd/dbseed/exchange.go
+++ b/cmd/dbseed/exchange.go
@@ -51,11 +51,11 @@ func seedExchangeFromDefaultList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	var allExchanges []exchangeDB.Details
+	allExchanges := make([]exchangeDB.Details, len(exchange.Exchanges))
 	for x := range exchange.Exchanges {
-		allExchanges = append(allExchanges, exchangeDB.Details{
+		allExchanges[x] = exchangeDB.Details{
 			Name: exchange.Exchanges[x],
-		})
+		}
 	}
 	err = exchangeDB.InsertMany(allExchanges)
 	if err != nil {

--- a/cmd/dbseed/main.go
+++ b/cmd/dbseed/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
@@ -44,7 +43,7 @@ func main() {
 	workingDir, err = os.Getwd()
 	if err != nil {
 		log.Println("error getting current working path")
-		workingDir = filepath.Join(".")
+		workingDir = "."
 	}
 
 	fmt.Println("GoCryptoTrader database seeding tool")

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -329,7 +328,7 @@ func GetConfiguration() (Config, error) {
 	configFilePath := filepath.Join(toolDir, "config.json")
 
 	if file.Exists(configFilePath) {
-		config, err := ioutil.ReadFile(configFilePath)
+		config, err := os.ReadFile(configFilePath)
 		if err != nil {
 			return c, err
 		}
@@ -360,7 +359,7 @@ func GetConfiguration() (Config, error) {
 		return c, err
 	}
 
-	if err := ioutil.WriteFile(configFilePath, data, 0770); err != nil {
+	if err := os.WriteFile(configFilePath, data, 0o770); err != nil {
 		return c, err
 	}
 
@@ -485,7 +484,7 @@ func GetPackageName(name string, capital bool) string {
 		i = len(newStrings) - 1
 	}
 	if capital {
-		return strings.Replace(strings.Title(newStrings[i]), "_", " ", -1)
+		return strings.Replace(strings.Title(newStrings[i]), "_", " ", -1) // nolint // ignore staticcheck strings.Title warning
 	}
 	return newStrings[i]
 }
@@ -540,7 +539,7 @@ func UpdateDocumentation(details DocumentationDetails) {
 			continue
 		}
 		if name == engineFolder {
-			d, err := ioutil.ReadDir(details.Directories[i])
+			d, err := os.ReadDir(details.Directories[i])
 			if err != nil {
 				fmt.Println("Excluding file:", err)
 			}

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -359,7 +359,7 @@ func GetConfiguration() (Config, error) {
 		return c, err
 	}
 
-	if err := os.WriteFile(configFilePath, data, 0o770); err != nil {
+	if err := os.WriteFile(configFilePath, data, file.DefaultPermissionOctal); err != nil {
 		return c, err
 	}
 

--- a/cmd/exchange_template/exchange_template.go
+++ b/cmd/exchange_template/exchange_template.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -138,7 +139,7 @@ func makeExchange(exchangeDirectory string, configTestFile *config.Config, exch 
 	if !os.IsNotExist(err) {
 		return nil, errors.New("directory already exists")
 	}
-	err = os.MkdirAll(exchangeDirectory, 0o770)
+	err = os.MkdirAll(exchangeDirectory, file.DefaultPermissionOctal)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func makeExchange(exchangeDirectory string, configTestFile *config.Config, exch 
 		outputFile := filepath.Join(exchangeDirectory, filename)
 		newFile(outputFile)
 		var f *os.File
-		f, err = os.OpenFile(outputFile, os.O_WRONLY, 0o770)
+		f, err = os.OpenFile(outputFile, os.O_WRONLY, file.DefaultPermissionOctal)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exchange_template/exchange_template.go
+++ b/cmd/exchange_template/exchange_template.go
@@ -138,14 +138,14 @@ func makeExchange(exchangeDirectory string, configTestFile *config.Config, exch 
 	if !os.IsNotExist(err) {
 		return nil, errors.New("directory already exists")
 	}
-	err = os.MkdirAll(exchangeDirectory, 0770)
+	err = os.MkdirAll(exchangeDirectory, 0o770)
 	if err != nil {
 		return nil, err
 	}
 
 	fmt.Printf("Output directory: %s\n", exchangeDirectory)
 
-	exch.CapitalName = strings.Title(exch.Name)
+	exch.CapitalName = strings.Title(exch.Name) // nolint:staticcheck // Ignore Title usage warning
 	exch.Variable = exch.Name[0:2]
 	newExchConfig := &config.Exchange{}
 	newExchConfig.Name = exch.CapitalName
@@ -214,7 +214,7 @@ func makeExchange(exchangeDirectory string, configTestFile *config.Config, exch 
 		outputFile := filepath.Join(exchangeDirectory, filename)
 		newFile(outputFile)
 		var f *os.File
-		f, err = os.OpenFile(outputFile, os.O_WRONLY, 0770)
+		f, err = os.OpenFile(outputFile, os.O_WRONLY, 0o770)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -334,18 +334,20 @@ func ({{.Variable}} *{{.CapitalName}}) UpdateOrderbook(ctx context.Context, pair
 		return book, err
 	}
 
+	book.Bids = make([]orderbook.Item, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Quantity, 
 			Price: orderbookNew.Bids[x].Price,
-		})
+		}
 	}
 
+	book.Asks = make([]orderbook.Item, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderBookNew.Asks[x].Quantity,
 			Price: orderBookNew.Asks[x].Price,
-		})
+		}
 	}
 	*/
 

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -282,7 +282,7 @@ func parseOrderType(orderType string) order.Type {
 }
 
 func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) []ExchangeAssetPairResponses {
-	var response []ExchangeAssetPairResponses
+	response := make([]ExchangeAssetPairResponses, 0)
 	testOrderSide := parseOrderSide(config.OrderSubmission.OrderSide)
 	testOrderType := parseOrderType(config.OrderSubmission.OrderType)
 	assetTypes := base.GetAssetTypes(false)
@@ -834,7 +834,7 @@ func testWrappers(e exchange.IBotExchange, base *exchange.Base, config *Config) 
 }
 
 func jsonifyInterface(params []interface{}) json.RawMessage {
-	response, _ := json.MarshalIndent(params, "", " ")
+	response, _ := json.MarshalIndent(params, "", " ") // nolint:errchkjson // TODO: ignore this for now
 	return response
 }
 

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -841,7 +840,7 @@ func jsonifyInterface(params []interface{}) json.RawMessage {
 
 func loadConfig() (Config, error) {
 	var config Config
-	keys, err := ioutil.ReadFile("wrapperconfig.json")
+	keys, err := os.ReadFile("wrapperconfig.json")
 	if err != nil {
 		return config, err
 	}

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -4226,7 +4226,7 @@ func gctScriptUpload(c *cli.Context) error {
 	defer closeConn(conn, cancel)
 	client := gctrpc.NewGoCryptoTraderClient(conn)
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}

--- a/cmd/gctcli/pair_management.go
+++ b/cmd/gctcli/pair_management.go
@@ -198,7 +198,7 @@ func enableDisableExchangePair(c *cli.Context) error {
 
 	pairList := strings.Split(pairs, ",")
 
-	var validPairs []*gctrpc.CurrencyPair
+	validPairs := make([]*gctrpc.CurrencyPair, len(pairList))
 	for i := range pairList {
 		if !validPair(pairList[i]) {
 			return errInvalidPair
@@ -209,11 +209,11 @@ func enableDisableExchangePair(c *cli.Context) error {
 			return err
 		}
 
-		validPairs = append(validPairs, &gctrpc.CurrencyPair{
+		validPairs[i] = &gctrpc.CurrencyPair{
 			Delimiter: p.Delimiter,
 			Base:      p.Base.String(),
 			Quote:     p.Quote.String(),
-		})
+		}
 	}
 
 	conn, cancel, err := setupClient(c)

--- a/cmd/gen_sqlboiler_config/main.go
+++ b/cmd/gen_sqlboiler_config/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/database"
@@ -56,7 +57,7 @@ func main() {
 	}
 
 	path := filepath.Join(outputFolder, "sqlboiler.json")
-	err = os.WriteFile(path, jsonOutput, 0o770)
+	err = os.WriteFile(path, jsonOutput, file.DefaultPermissionOctal)
 	if err != nil {
 		fmt.Printf("Write failed: %v", err)
 		os.Exit(1)

--- a/cmd/gen_sqlboiler_config/main.go
+++ b/cmd/gen_sqlboiler_config/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -57,7 +56,7 @@ func main() {
 	}
 
 	path := filepath.Join(outputFolder, "sqlboiler.json")
-	err = ioutil.WriteFile(path, jsonOutput, 0770)
+	err = os.WriteFile(path, jsonOutput, 0o770)
 	if err != nil {
 		fmt.Printf("Write failed: %v", err)
 		os.Exit(1)

--- a/common/cache/cache_test.go
+++ b/common/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"testing"
+
+	"github.com/thrasher-corp/gocryptotrader/common/convert"
 )
 
 func TestCache(t *testing.T) {
@@ -16,7 +18,7 @@ func TestCache(t *testing.T) {
 	if v == nil {
 		t.Fatal("expected cache to contain \"hello\" key")
 	}
-	if v.(string) != "world" {
+	if convert.InterfaceToStringOrZeroValue(v) != "world" {
 		t.Fatal("expected \"hello\" key to contain value \"world\"")
 	}
 
@@ -76,39 +78,39 @@ func TestAdd(t *testing.T) {
 	if v == nil {
 		t.Fatal("expected cache to contain \"2\" key")
 	}
-	if v.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(v) != 2 {
 		t.Fatal("expected \"2\" key to contain value \"2\"")
 	}
 	k, v := lruCache.getNewest()
-	if k.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(k) != 2 {
 		t.Fatal("expected latest key to be 2")
 	}
-	if v.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(v) != 2 {
 		t.Fatal("expected latest value to be 2")
 	}
 	lruCache.Add(3, 3)
 	k, _ = lruCache.getNewest()
-	if k.(int) != 3 {
+	if convert.InterfaceToIntOrZeroValue(k) != 3 {
 		t.Fatal("expected latest key to be 3")
 	}
 	k, _ = lruCache.getOldest()
-	if k.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(k) != 2 {
 		t.Fatal("expected oldest key to be 2")
 	}
 	k, v = lruCache.getOldest()
-	if k.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(k) != 2 {
 		t.Fatal("expected oldest key to be 2")
 	}
-	if v.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(v) != 2 {
 		t.Fatal("expected latest value to be 2")
 	}
 	lruCache.Add(2, 2)
 	k, _ = lruCache.getNewest()
-	if k.(int) != 2 {
+	if convert.InterfaceToIntOrZeroValue(k) != 2 {
 		t.Fatal("expected latest key to be 2")
 	}
 	k, _ = lruCache.getOldest()
-	if k.(int) != 3 {
+	if convert.InterfaceToIntOrZeroValue(k) != 3 {
 		t.Fatal("expected oldest key to be 3")
 	}
 }

--- a/common/cache/cache_test.go
+++ b/common/cache/cache_test.go
@@ -20,8 +20,7 @@ func TestCache(t *testing.T) {
 		t.Fatal("expected \"hello\" key to contain value \"world\"")
 	}
 
-	r := lruCache.Remove("hello")
-	if !r {
+	if r := lruCache.Remove("hello"); !r {
 		t.Fatal("expected \"hello\" key to be removed from cache")
 	}
 

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -24,7 +24,9 @@ func NewLRUCache(capacity uint64) *LRU {
 func (l *LRU) Add(key, value interface{}) {
 	if f, o := l.items[key]; o {
 		l.l.MoveToFront(f)
-		f.Value.(*item).value = value
+		if v, ok := f.Value.(*item); ok {
+			v.value = value
+		}
 		return
 	}
 
@@ -40,7 +42,9 @@ func (l *LRU) Add(key, value interface{}) {
 func (l *LRU) Get(key interface{}) interface{} {
 	if i, f := l.items[key]; f {
 		l.l.MoveToFront(i)
-		return i.Value.(*item).value
+		if v, ok := i.Value.(*item); ok {
+			return v.value
+		}
 	}
 	return nil
 }
@@ -48,7 +52,9 @@ func (l *LRU) Get(key interface{}) interface{} {
 // GetOldest returns the oldest entry
 func (l *LRU) getOldest() (key, value interface{}) {
 	if x := l.l.Back(); x != nil {
-		return x.Value.(*item).key, x.Value.(*item).value
+		if v, ok := x.Value.(*item); ok {
+			return v.key, v.value
+		}
 	}
 	return
 }
@@ -56,7 +62,9 @@ func (l *LRU) getOldest() (key, value interface{}) {
 // GetNewest returns the newest entry
 func (l *LRU) getNewest() (key, value interface{}) {
 	if x := l.l.Front(); x != nil {
-		return x.Value.(*item).key, x.Value.(*item).value
+		if v, ok := x.Value.(*item); ok {
+			return v.key, v.value
+		}
 	}
 	return
 }
@@ -99,5 +107,7 @@ func (l *LRU) removeOldestEntry() {
 // removeElement element from the cache
 func (l *LRU) removeElement(e *list.Element) {
 	l.l.Remove(e)
-	delete(l.items, e.Value.(*item).key)
+	if v, ok := e.Value.(*item); ok {
+		delete(l.items, v.key)
+	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
@@ -347,7 +348,7 @@ func CreateDir(dir string) error {
 	}
 
 	log.Warnf(log.Global, "Directory %s does not exist.. creating.\n", dir)
-	return os.MkdirAll(dir, 0o770)
+	return os.MkdirAll(dir, file.DefaultPermissionOctal)
 }
 
 // ChangePermission lists all the directories and files in an array
@@ -356,8 +357,8 @@ func ChangePermission(directory string) error {
 		if err != nil {
 			return err
 		}
-		if info.Mode().Perm() != 0o770 {
-			return os.Chmod(path, 0o770)
+		if info.Mode().Perm() != file.DefaultPermissionOctal {
+			return os.Chmod(path, file.DefaultPermissionOctal)
 		}
 		return nil
 	})

--- a/common/common.go
+++ b/common/common.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -257,7 +256,7 @@ func SendHTTPRequest(ctx context.Context, method, urlPath string, headers map[st
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 
 	if verbose {
 		log.Debugf(log.Global, "HTTP status: %s, Code: %v",
@@ -348,7 +347,7 @@ func CreateDir(dir string) error {
 	}
 
 	log.Warnf(log.Global, "Directory %s does not exist.. creating.\n", dir)
-	return os.MkdirAll(dir, 0770)
+	return os.MkdirAll(dir, 0o770)
 }
 
 // ChangePermission lists all the directories and files in an array
@@ -357,8 +356,8 @@ func ChangePermission(directory string) error {
 		if err != nil {
 			return err
 		}
-		if info.Mode().Perm() != 0770 {
-			return os.Chmod(path, 0770)
+		if info.Mode().Perm() != 0o770 {
+			return os.Chmod(path, 0o770)
 		}
 		return nil
 	})

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 )
 
 func TestSendHTTPRequest(t *testing.T) {
@@ -543,8 +545,8 @@ func TestChangePermission(t *testing.T) {
 		if err != nil {
 			t.Fatalf("os.Stat failed. Err: %v", err)
 		}
-		if a.Mode().Perm() != 0o770 {
-			t.Fatalf("expected file permissions differ. expecting 0o770 got %#o", a.Mode().Perm())
+		if a.Mode().Perm() != file.DefaultPermissionOctal {
+			t.Fatalf("expected file permissions differ. expecting file.DefaultPermissionOctal got %#o", a.Mode().Perm())
 		}
 		err = os.Remove(testDir)
 		if err != nil {

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -509,7 +509,7 @@ func TestChangePermission(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error on non-existent path")
 		}
-		err = os.Mkdir(testDir, 0777)
+		err = os.Mkdir(testDir, 0o777)
 		if err != nil {
 			t.Fatalf("Mkdir failed. Err: %v", err)
 		}
@@ -530,7 +530,7 @@ func TestChangePermission(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error on non-existent path")
 		}
-		err = os.Mkdir(testDir, 0777)
+		err = os.Mkdir(testDir, 0o777)
 		if err != nil {
 			t.Fatalf("Mkdir failed. Err: %v", err)
 		}
@@ -543,8 +543,8 @@ func TestChangePermission(t *testing.T) {
 		if err != nil {
 			t.Fatalf("os.Stat failed. Err: %v", err)
 		}
-		if a.Mode().Perm() != 0770 {
-			t.Fatalf("expected file permissions differ. expecting 0770 got %#o", a.Mode().Perm())
+		if a.Mode().Perm() != 0o770 {
+			t.Fatalf("expected file permissions differ. expecting 0o770 got %#o", a.Mode().Perm())
 		}
 		err = os.Remove(testDir)
 		if err != nil {

--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -164,3 +164,24 @@ func numberToHumanFriendlyString(str string, dec int, decPoint, thousandsSep str
 
 	return s
 }
+
+func InterfaceToFloat64OrZeroValue(r interface{}) float64 {
+	if v, ok := r.(float64); ok {
+		return v
+	}
+	return 0
+}
+
+func InterfaceToIntOrZeroValue(r interface{}) int {
+	if v, ok := r.(int); ok {
+		return v
+	}
+	return 0
+}
+
+func InterfaceToStringOrZeroValue(r interface{}) string {
+	if v, ok := r.(string); ok {
+		return v
+	}
+	return ""
+}

--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -119,8 +119,7 @@ func DecimalToHumanFriendlyString(number decimal.Decimal, rounding int, decPoint
 		neg = true
 	}
 	str := number.String()
-	rnd := strings.Split(str, ".")
-	if len(rnd) == 1 {
+	if rnd := strings.Split(str, "."); len(rnd) == 1 {
 		rounding = 0
 	} else if len(rnd[1]) < rounding {
 		rounding = len(rnd[1])
@@ -165,6 +164,7 @@ func numberToHumanFriendlyString(str string, dec int, decPoint, thousandsSep str
 	return s
 }
 
+// InterfaceToFloat64OrZeroValue returns the type assertion value or variable zero value
 func InterfaceToFloat64OrZeroValue(r interface{}) float64 {
 	if v, ok := r.(float64); ok {
 		return v
@@ -172,6 +172,7 @@ func InterfaceToFloat64OrZeroValue(r interface{}) float64 {
 	return 0
 }
 
+// InterfaceToIntOrZeroValue returns the type assertion value or variable zero value
 func InterfaceToIntOrZeroValue(r interface{}) int {
 	if v, ok := r.(int); ok {
 		return v
@@ -179,6 +180,7 @@ func InterfaceToIntOrZeroValue(r interface{}) int {
 	return 0
 }
 
+// InterfaceToStringOrZeroValue returns the type assertion value or variable zero value
 func InterfaceToStringOrZeroValue(r interface{}) string {
 	if v, ok := r.(string); ok {
 		return v

--- a/common/convert/convert_test.go
+++ b/common/convert/convert_test.go
@@ -282,3 +282,36 @@ func TestNumberToHumanFriendlyString(t *testing.T) {
 		t.Error("expected no comma")
 	}
 }
+
+func TestInterfaceToFloat64OrZeroValue(t *testing.T) {
+	var x interface{}
+	if r := InterfaceToFloat64OrZeroValue(x); r != 0 {
+		t.Errorf("expected 0, got: %v", r)
+	}
+	x = float64(420)
+	if r := InterfaceToFloat64OrZeroValue(x); r != 420 {
+		t.Errorf("expected 420, got: %v", x)
+	}
+}
+
+func TestInterfaceToIntOrZeroValue(t *testing.T) {
+	var x interface{}
+	if r := InterfaceToIntOrZeroValue(x); r != 0 {
+		t.Errorf("expected 0, got: %v", r)
+	}
+	x = int(420)
+	if r := InterfaceToIntOrZeroValue(x); r != 420 {
+		t.Errorf("expected 420, got: %v", x)
+	}
+}
+
+func TestInterfaceToStringOrZeroValue(t *testing.T) {
+	var x interface{}
+	if r := InterfaceToStringOrZeroValue(x); r != "" {
+		t.Errorf("expected empty string, got: %v", r)
+	}
+	x = string("meow")
+	if r := InterfaceToStringOrZeroValue(x); r != "meow" {
+		t.Errorf("expected meow, got: %v", x)
+	}
+}

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -148,7 +148,7 @@ func TestGetHMAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sha1) != string(expectedSha1) {
+	if !bytes.Equal(sha1, expectedSha1) {
 		t.Errorf("Common GetHMAC error: Expected '%x'. Actual '%x'",
 			expectedSha1, sha1,
 		)
@@ -157,7 +157,7 @@ func TestGetHMAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sha256) != string(expectedsha256) {
+	if !bytes.Equal(sha256, expectedsha256) {
 		t.Errorf("Common GetHMAC error: Expected '%x'. Actual '%x'",
 			expectedsha256, sha256,
 		)
@@ -166,7 +166,7 @@ func TestGetHMAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sha512) != string(expectedsha512) {
+	if !bytes.Equal(sha512, expectedsha512) {
 		t.Errorf("Common GetHMAC error: Expected '%x'. Actual '%x'",
 			expectedsha512, sha512,
 		)
@@ -175,7 +175,7 @@ func TestGetHMAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sha512384) != string(expectedsha512384) {
+	if !bytes.Equal(sha512384, expectedsha512384) {
 		t.Errorf("Common GetHMAC error: Expected '%x'. Actual '%x'",
 			expectedsha512384, sha512384,
 		)
@@ -184,7 +184,7 @@ func TestGetHMAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(md5) != string(expectedmd5) {
+	if !bytes.Equal(md5, expectedmd5) {
 		t.Errorf("Common GetHMAC error: Expected '%x'. Actual '%x'",
 			expectedmd5, md5,
 		)

--- a/common/file/archive/zip.go
+++ b/common/file/archive/zip.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
@@ -52,7 +53,7 @@ func UnZip(src, dest string) (fileList []string, err error) {
 			continue
 		}
 
-		err = os.MkdirAll(filepath.Dir(fPath), 0o770)
+		err = os.MkdirAll(filepath.Dir(fPath), file.DefaultPermissionOctal)
 		if err != nil {
 			return
 		}

--- a/common/file/archive/zip.go
+++ b/common/file/archive/zip.go
@@ -52,7 +52,7 @@ func UnZip(src, dest string) (fileList []string, err error) {
 			continue
 		}
 
-		err = os.MkdirAll(filepath.Dir(fPath), 0770)
+		err = os.MkdirAll(filepath.Dir(fPath), 0o770)
 		if err != nil {
 			return
 		}

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -17,11 +16,11 @@ import (
 func Write(file string, data []byte) error {
 	basePath := filepath.Dir(file)
 	if !Exists(basePath) {
-		if err := os.MkdirAll(basePath, 0770); err != nil {
+		if err := os.MkdirAll(basePath, 0o770); err != nil {
 			return err
 		}
 	}
-	return ioutil.WriteFile(file, data, 0770)
+	return os.WriteFile(file, data, 0o770)
 }
 
 // Writer creates a writer to a file or returns an error if it fails. This
@@ -30,11 +29,11 @@ func Write(file string, data []byte) error {
 func Writer(file string) (*os.File, error) {
 	basePath := filepath.Dir(file)
 	if !Exists(basePath) {
-		if err := os.MkdirAll(basePath, 0770); err != nil {
+		if err := os.MkdirAll(basePath, 0o770); err != nil {
 			return nil, err
 		}
 	}
-	return os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0770)
+	return os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o770)
 }
 
 // Move moves a file from a source path to a destination path
@@ -59,7 +58,7 @@ func Move(sourcePath, destPath string) error {
 
 	destDir := filepath.Dir(destPath)
 	if !Exists(destDir) {
-		err = os.MkdirAll(destDir, 0770)
+		err = os.MkdirAll(destDir, 0o770)
 		if err != nil {
 			return err
 		}

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
 
 // DefaultPermissionOctal is the default file and folder permission octal used throughout GCT
-const DefaultPermissionOctal = 0o770
+const DefaultPermissionOctal fs.FileMode = 0o770
 
 // Write writes selected data to a file or returns an error if it fails. This
 // func also ensures that all files are set to this permission (only rw access

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -10,17 +10,20 @@ import (
 	"path/filepath"
 )
 
+// DefaultPermissionOctal is the default file and folder permission octal used throughout GCT
+const DefaultPermissionOctal = 0o770
+
 // Write writes selected data to a file or returns an error if it fails. This
 // func also ensures that all files are set to this permission (only rw access
 // for the running user and the group the user is a member of)
 func Write(file string, data []byte) error {
 	basePath := filepath.Dir(file)
 	if !Exists(basePath) {
-		if err := os.MkdirAll(basePath, 0o770); err != nil {
+		if err := os.MkdirAll(basePath, DefaultPermissionOctal); err != nil {
 			return err
 		}
 	}
-	return os.WriteFile(file, data, 0o770)
+	return os.WriteFile(file, data, DefaultPermissionOctal)
 }
 
 // Writer creates a writer to a file or returns an error if it fails. This
@@ -29,11 +32,11 @@ func Write(file string, data []byte) error {
 func Writer(file string) (*os.File, error) {
 	basePath := filepath.Dir(file)
 	if !Exists(basePath) {
-		if err := os.MkdirAll(basePath, 0o770); err != nil {
+		if err := os.MkdirAll(basePath, DefaultPermissionOctal); err != nil {
 			return nil, err
 		}
 	}
-	return os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o770)
+	return os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, DefaultPermissionOctal)
 }
 
 // Move moves a file from a source path to a destination path
@@ -58,7 +61,7 @@ func Move(sourcePath, destPath string) error {
 
 	destDir := filepath.Dir(destPath)
 	if !Exists(destDir) {
-		err = os.MkdirAll(destDir, 0o770)
+		err = os.MkdirAll(destDir, DefaultPermissionOctal)
 		if err != nil {
 			return err
 		}

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) {
 func TestMove(t *testing.T) {
 	tester := func(in, out string, write bool) error {
 		if write {
-			if err := os.WriteFile(in, []byte("GoCryptoTrader"), 0o770); err != nil {
+			if err := os.WriteFile(in, []byte("GoCryptoTrader"), DefaultPermissionOctal); err != nil {
 				return err
 			}
 		}

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) {
 func TestMove(t *testing.T) {
 	tester := func(in, out string, write bool) error {
 		if write {
-			if err := ioutil.WriteFile(in, []byte("GoCryptoTrader"), 0770); err != nil {
+			if err := os.WriteFile(in, []byte("GoCryptoTrader"), 0o770); err != nil {
 				return err
 			}
 		}
@@ -65,7 +65,7 @@ func TestMove(t *testing.T) {
 			return err
 		}
 
-		contents, err := ioutil.ReadFile(out)
+		contents, err := os.ReadFile(out)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func TestExists(t *testing.T) {
 		t.Error("non-existent file should not exist")
 	}
 	tmpFile := filepath.Join(os.TempDir(), "gct-test.txt")
-	if err := ioutil.WriteFile(tmpFile, []byte("hello world"), os.ModeAppend); err != nil {
+	if err := os.WriteFile(tmpFile, []byte("hello world"), os.ModeAppend); err != nil {
 		t.Fatal(err)
 	}
 	if e := Exists(tmpFile); !e {
@@ -258,7 +258,7 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if data, err := ioutil.ReadFile(got.Name()); err != nil || string(data) != testData {
+			if data, err := os.ReadFile(got.Name()); err != nil || string(data) != testData {
 				t.Errorf("Could not write the file, or contents were wrong: expected = %s, got =%s", testData, string(data))
 			}
 		})
@@ -274,7 +274,7 @@ func TestWriterNoPermissionFails(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(temp)
-	err = os.Chmod(temp, 0555)
+	err = os.Chmod(temp, 0o555)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -380,9 +380,7 @@ func DecimalGeometricMean(values []decimal.Decimal) (decimal.Decimal, error) {
 // DecimalPow is lovely because shopspring decimal cannot
 // handle ^0.x and instead returns 1
 func DecimalPow(x, y decimal.Decimal) decimal.Decimal {
-	fX, _ := x.Float64()
-	fY, _ := y.Float64()
-	pow := math.Pow(fX, fY)
+	pow := math.Pow(x.InexactFloat64(), y.InexactFloat64())
 	return decimal.NewFromFloat(pow)
 }
 
@@ -405,7 +403,7 @@ func DecimalFinancialGeometricMean(values []decimal.Decimal) (decimal.Decimal, e
 		// as we cannot have negative or zero value geometric numbers
 		// adding a 1 to the percentage movements allows for differentiation between
 		// negative numbers (eg -0.1 translates to 0.9) and positive numbers (eg 0.1 becomes 1.1)
-		modVal, _ := values[i].Add(decimal.NewFromInt(1)).Float64()
+		modVal := values[i].Add(decimal.NewFromInt(1)).InexactFloat64()
 		product *= modVal
 	}
 	prod := 1 / float64(len(values))

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -89,9 +89,9 @@ func InformationRatio(returnsRates, benchmarkRates []float64, averageValues, ave
 	if len(benchmarkRates) != len(returnsRates) {
 		return 0, errInformationBadLength
 	}
-	var diffs []float64
+	diffs := make([]float64, len(returnsRates))
 	for i := range returnsRates {
-		diffs = append(diffs, returnsRates[i]-benchmarkRates[i])
+		diffs[i] = returnsRates[i] - benchmarkRates[i]
 	}
 	stdDev, err := PopulationStandardDeviation(diffs)
 	if err != nil {
@@ -135,11 +135,11 @@ func SampleStandardDeviation(values []float64) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	var superMean []float64
+	superMean := make([]float64, len(values))
 	var combined float64
 	for i := range values {
 		result := math.Pow(values[i]-mean, 2)
-		superMean = append(superMean, result)
+		superMean[i] = result
 		combined += result
 	}
 	avg := combined / (float64(len(superMean)) - 1)
@@ -232,9 +232,9 @@ func SharpeRatio(movementPerCandle []float64, riskFreeRatePerInterval, average f
 	if totalIntervals == 0 {
 		return 0, errZeroValue
 	}
-	var excessReturns []float64
+	excessReturns := make([]float64, len(movementPerCandle))
 	for i := range movementPerCandle {
-		excessReturns = append(excessReturns, movementPerCandle[i]-riskFreeRatePerInterval)
+		excessReturns[i] = movementPerCandle[i] - riskFreeRatePerInterval
 	}
 	standardDeviation, err := PopulationStandardDeviation(excessReturns)
 	if err != nil {
@@ -284,9 +284,9 @@ func DecimalInformationRatio(returnsRates, benchmarkRates []decimal.Decimal, ave
 	if len(benchmarkRates) != len(returnsRates) {
 		return decimal.Zero, errInformationBadLength
 	}
-	var diffs []decimal.Decimal
+	diffs := make([]decimal.Decimal, len(returnsRates))
 	for i := range returnsRates {
-		diffs = append(diffs, returnsRates[i].Sub(benchmarkRates[i]))
+		diffs[i] = returnsRates[i].Sub(benchmarkRates[i])
 	}
 	stdDev, err := DecimalPopulationStandardDeviation(diffs)
 	if err != nil && !errors.Is(err, ErrInexactConversion) {
@@ -339,11 +339,11 @@ func DecimalSampleStandardDeviation(values []decimal.Decimal) (decimal.Decimal, 
 	if err != nil {
 		return decimal.Zero, err
 	}
-	var superMean []decimal.Decimal
+	superMean := make([]decimal.Decimal, len(values))
 	var combined decimal.Decimal
 	for i := range values {
 		pow := values[i].Sub(mean).Pow(decimal.NewFromInt(2))
-		superMean = append(superMean, pow)
+		superMean[i] = pow
 		combined.Add(pow)
 	}
 	avg := combined.Div(decimal.NewFromInt(int64(len(superMean))).Sub(decimal.NewFromInt(1)))
@@ -461,9 +461,9 @@ func DecimalSharpeRatio(movementPerCandle []decimal.Decimal, riskFreeRatePerInte
 	if totalIntervals.IsZero() {
 		return decimal.Zero, errZeroValue
 	}
-	var excessReturns []decimal.Decimal
+	excessReturns := make([]decimal.Decimal, len(movementPerCandle))
 	for i := range movementPerCandle {
-		excessReturns = append(excessReturns, movementPerCandle[i].Sub(riskFreeRatePerInterval))
+		excessReturns[i] = movementPerCandle[i].Sub(riskFreeRatePerInterval)
 	}
 	standardDeviation, err := DecimalPopulationStandardDeviation(excessReturns)
 	if err != nil && !errors.Is(err, ErrInexactConversion) {

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -184,9 +184,9 @@ func TestInformationRatio(t *testing.T) {
 		t.Error(avgComparison)
 	}
 
-	var eachDiff []float64
+	eachDiff := make([]float64, len(figures))
 	for i := range figures {
-		eachDiff = append(eachDiff, figures[i]-comparisonFigures[i])
+		eachDiff[i] = figures[i] - comparisonFigures[i]
 	}
 	stdDev, err := PopulationStandardDeviation(eachDiff)
 	if err != nil {
@@ -583,9 +583,9 @@ func TestDecimalInformationRatio(t *testing.T) {
 		t.Error(avgComparison)
 	}
 
-	var eachDiff []decimal.Decimal
+	eachDiff := make([]decimal.Decimal, len(figures))
 	for i := range figures {
-		eachDiff = append(eachDiff, figures[i].Sub(comparisonFigures[i]))
+		eachDiff[i] = figures[i].Sub(comparisonFigures[i])
 	}
 	stdDev, err := DecimalPopulationStandardDeviation(eachDiff)
 	if err != nil && !errors.Is(err, ErrInexactConversion) {
@@ -703,10 +703,10 @@ func TestDecimalStandardDeviation2(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var superMean []decimal.Decimal
+	superMean := make([]decimal.Decimal, len(r))
 	for i := range r {
 		result := r[i].Sub(mean).Pow(decimal.NewFromInt(2))
-		superMean = append(superMean, result)
+		superMean[i] = result
 	}
 	superMeany := superMean[0].Add(superMean[1].Add(superMean[2].Add(superMean[3].Add(superMean[4].Add(superMean[5]))))).Div(decimal.NewFromInt(5))
 	fSuperMeany, _ := superMeany.Float64()

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -709,8 +709,7 @@ func TestDecimalStandardDeviation2(t *testing.T) {
 		superMean[i] = result
 	}
 	superMeany := superMean[0].Add(superMean[1].Add(superMean[2].Add(superMean[3].Add(superMean[4].Add(superMean[5]))))).Div(decimal.NewFromInt(5))
-	fSuperMeany, _ := superMeany.Float64()
-	manualCalculation := decimal.NewFromFloat(math.Sqrt(fSuperMeany))
+	manualCalculation := decimal.NewFromFloat(math.Sqrt(superMeany.InexactFloat64()))
 	var codeCalcu decimal.Decimal
 	codeCalcu, err = DecimalSampleStandardDeviation(r)
 	if err != nil {

--- a/communications/base/base_test.go
+++ b/communications/base/base_test.go
@@ -108,8 +108,11 @@ func TestSetup(t *testing.T) {
 
 	for idx, provider := range ic {
 		exp := testConfigs[idx].shouldConnectCalled
-		act := provider.(*CommunicationProvider).ConnectCalled
-		if exp != act {
+		act, ok := provider.(*CommunicationProvider)
+		if !ok {
+			t.Fatal("unable to type assert provider")
+		}
+		if exp != act.ConnectCalled {
 			t.Fatalf("provider should be enabled and not be connected: exp=%v, act=%v", exp, act)
 		}
 	}
@@ -139,8 +142,11 @@ func TestPushEvent(t *testing.T) {
 
 	for idx, provider := range ic {
 		exp := testConfigs[idx].PushEventCalled
-		act := provider.(*CommunicationProvider).PushEventCalled
-		if exp != act {
+		act, ok := provider.(*CommunicationProvider)
+		if !ok {
+			t.Fatal("unable to type assert provider")
+		}
+		if exp != act.PushEventCalled {
 			t.Fatalf("provider should be enabled and connected: exp=%v, act=%v", exp, act)
 		}
 	}

--- a/communications/slack/slack.go
+++ b/communications/slack/slack.go
@@ -47,7 +47,7 @@ type Slack struct {
 	WebsocketConn   *websocket.Conn
 	Connected       bool
 	Shutdown        bool
-	sync.Mutex
+	mu              sync.Mutex
 }
 
 // IsConnected returns whether or not the connection is connected
@@ -91,9 +91,9 @@ func (s *Slack) BuildURL(token string) string {
 
 // GetChannelsString returns a list of all channels on the slack workspace
 func (s *Slack) GetChannelsString() []string {
-	var channels []string
+	channels := make([]string, len(s.Details.Channels))
 	for i := range s.Details.Channels {
-		channels = append(channels, s.Details.Channels[i].NameNormalized)
+		channels[i] = s.Details.Channels[i].NameNormalized
 	}
 	return channels
 }
@@ -355,8 +355,8 @@ func (s *Slack) WebsocketKeepAlive() {
 
 // WebsocketSend sends a message via the websocket connection
 func (s *Slack) WebsocketSend(eventType, text string) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	newMessage := SendMessage{
 		ID:      time.Now().Unix(),
 		Type:    eventType,

--- a/communications/slack/slack_test.go
+++ b/communications/slack/slack_test.go
@@ -206,7 +206,10 @@ func TestHandlePresenceChange(t *testing.T) {
 		t.Error("slack handlePresenceChange(), unmarshalled malformed json")
 	}
 
-	data, _ := json.Marshal(pres)
+	data, err := json.Marshal(pres)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = s.handlePresenceChange(data)
 	if err != nil {
 		t.Errorf("slack handlePresenceChange() Error: %s", err)
@@ -235,7 +238,10 @@ func TestHandleMessageResponse(t *testing.T) {
 	var msg Message
 	msg.User = "1337"
 	msg.Text = "Hello World!"
-	resp, _ := json.Marshal(msg)
+	resp, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = s.handleMessageResponse(resp, data)
 	if err != nil {
@@ -243,7 +249,10 @@ func TestHandleMessageResponse(t *testing.T) {
 	}
 
 	msg.Text = "!notacommand"
-	resp, _ = json.Marshal(msg)
+	resp, err = json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = s.handleMessageResponse(resp, data)
 	if err == nil {
@@ -286,7 +295,10 @@ func TestHandleReconnectResponse(t *testing.T) {
 	}
 	testURL.URL = "https://www.thrasher.io"
 
-	data, _ := json.Marshal(testURL)
+	data, err := json.Marshal(testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = s.handleReconnectResponse(data)
 	if err != nil || s.ReconnectURL != "https://www.thrasher.io" {

--- a/communications/smsglobal/smsglobal.go
+++ b/communications/smsglobal/smsglobal.go
@@ -42,15 +42,13 @@ func (s *SMSGlobal) Setup(cfg *base.CommunicationsConfig) {
 	s.Password = cfg.SMSGlobalConfig.Password
 	s.SendFrom = cfg.SMSGlobalConfig.From
 
-	var contacts []Contact
+	contacts := make([]Contact, len(cfg.SMSGlobalConfig.Contacts))
 	for x := range cfg.SMSGlobalConfig.Contacts {
-		contacts = append(contacts,
-			Contact{
-				Name:    cfg.SMSGlobalConfig.Contacts[x].Name,
-				Number:  cfg.SMSGlobalConfig.Contacts[x].Number,
-				Enabled: cfg.SMSGlobalConfig.Contacts[x].Enabled,
-			},
-		)
+		contacts[x] = Contact{
+			Name:    cfg.SMSGlobalConfig.Contacts[x].Name,
+			Number:  cfg.SMSGlobalConfig.Contacts[x].Number,
+			Enabled: cfg.SMSGlobalConfig.Contacts[x].Enabled,
+		}
 		log.Debugf(log.CommunicationMgr, "SMSGlobal: SMS Contact: %s. Number: %s. Enabled: %v\n",
 			cfg.SMSGlobalConfig.Contacts[x].Name,
 			cfg.SMSGlobalConfig.Contacts[x].Number,

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1420,7 +1419,7 @@ func GetFilePath(configFile string) (configPath string, isImplicitDefaultPath bo
 // config directory as `File` or `EncryptedFile` depending on whether the config
 // is encrypted
 func migrateConfig(configFile, targetDir string) (string, error) {
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return "", err
 	}
@@ -1518,7 +1517,7 @@ func ReadConfig(configReader io.Reader, keyProvider func() ([]byte, error)) (*Co
 
 // readEncryptedConf reads encrypted configuration and requests key from provider
 func readEncryptedConfWithKey(reader *bufio.Reader, keyProvider func() ([]byte, error)) (*Config, error) {
-	fileData, err := ioutil.ReadAll(reader)
+	fileData, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -137,7 +136,7 @@ func (c *Config) decryptConfigData(configReader io.Reader, key []byte) ([]byte, 
 		return nil, err
 	}
 	origKey := key
-	configData, err := ioutil.ReadAll(configReader)
+	configData, err := io.ReadAll(configReader)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -179,11 +179,11 @@ func TestEncryptTwiceReusesSaltButNewCipher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Problem storing config in file %s: %s\n", enc2, err)
 	}
-	data1, err := ioutil.ReadFile(enc1)
+	data1, err := os.ReadFile(enc1)
 	if err != nil {
 		t.Fatalf("Problem reading file %s: %s\n", enc1, err)
 	}
-	data2, err := ioutil.ReadFile(enc2)
+	data2, err := os.ReadFile(enc2)
 	if err != nil {
 		t.Fatalf("Problem reading file %s: %s\n", enc2, err)
 	}
@@ -281,7 +281,7 @@ func TestReadConfigWithPrompt(t *testing.T) {
 	}
 
 	// Verify results
-	data, err := ioutil.ReadFile(testConfigFile)
+	data, err := os.ReadFile(testConfigFile)
 	if err != nil {
 		t.Fatalf("Problem reading saved file at %s: %s\n", testConfigFile, err)
 	}
@@ -349,7 +349,7 @@ func TestSaveConfigToFileWithErrorInPasswordPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadFile(targetFile)
+	data, err := os.ReadFile(targetFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -920,7 +920,7 @@ func TestSupportsPair(t *testing.T) {
 			},
 		},
 	}
-	assetType := asset.Spot // nolint // ifshort false positive
+	assetType := asset.Spot
 	if cfg.SupportsPair("asdf",
 		currency.NewPair(currency.BTC, currency.USD), assetType) {
 		t.Error(

--- a/connchecker/connchecker.go
+++ b/connchecker/connchecker.go
@@ -74,7 +74,7 @@ type Checker struct {
 	shutdown      chan struct{}
 	wg            sync.WaitGroup
 	connected     bool
-	sync.Mutex
+	mu            sync.Mutex
 }
 
 // Shutdown cleanly shutsdown monitor routine
@@ -136,12 +136,12 @@ func (c *Checker) connectionTest() {
 	for i := range c.DNSList {
 		err := c.CheckDNS(c.DNSList[i])
 		if err == nil {
-			c.Lock()
+			c.mu.Lock()
 			if !c.connected {
 				log.Debugln(log.Global, ConnRe)
 				c.connected = true
 			}
-			c.Unlock()
+			c.mu.Unlock()
 			return
 		}
 	}
@@ -149,22 +149,22 @@ func (c *Checker) connectionTest() {
 	for i := range c.DomainList {
 		err := c.CheckHost(c.DomainList[i])
 		if err == nil {
-			c.Lock()
+			c.mu.Lock()
 			if !c.connected {
 				log.Debugln(log.Global, ConnRe)
 				c.connected = true
 			}
-			c.Unlock()
+			c.mu.Unlock()
 			return
 		}
 	}
 
-	c.Lock()
+	c.mu.Lock()
 	if c.connected {
 		log.Warnln(log.Global, ConnLost)
 		c.connected = false
 	}
-	c.Unlock()
+	c.mu.Unlock()
 }
 
 // CheckDNS checks current dns for connectivity
@@ -185,8 +185,8 @@ func (c *Checker) CheckHost(host string) error {
 
 // IsConnected returns if there is internet connectivity
 func (c *Checker) IsConnected() bool {
-	c.Lock()
+	c.mu.Lock()
 	isConnected := c.connected
-	c.Unlock()
+	c.mu.Unlock()
 	return isConnected
 }

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -354,7 +354,11 @@ func TestBaseCode(t *testing.T) {
 			len(full.UnsetCurrency))
 	}
 
-	if full.LastMainUpdate.(int64) != -62135596800 {
+	lastMainUpdate, ok := full.LastMainUpdate.(int64)
+	if !ok {
+		t.Error("unable to type assert LastMainUpdate")
+	}
+	if lastMainUpdate != -62135596800 {
 		t.Errorf("BaseCode GetFullCurrencyData() error expected -62135596800 but received %d",
 			full.LastMainUpdate)
 	}

--- a/currency/coinmarketcap/coinmarketcap.go
+++ b/currency/coinmarketcap/coinmarketcap.go
@@ -75,9 +75,9 @@ func (c *Coinmarketcap) GetCryptocurrencyInfo(currencyID ...int64) (CryptoCurren
 		return resp.Data, err
 	}
 
-	var currStr []string
+	currStr := make([]string, len(currencyID))
 	for i := range currencyID {
-		currStr = append(currStr, strconv.FormatInt(currencyID[i], 10))
+		currStr[i] = strconv.FormatInt(currencyID[i], 10)
 	}
 
 	val := url.Values{}
@@ -315,9 +315,9 @@ func (c *Coinmarketcap) GetCryptocurrencyLatestQuotes(currencyID ...int64) (Cryp
 		return resp.Data, err
 	}
 
-	var currStr []string
-	for _, d := range currencyID {
-		currStr = append(currStr, strconv.FormatInt(d, 10))
+	currStr := make([]string, len(currencyID))
+	for i := range currencyID {
+		currStr[i] = strconv.FormatInt(currencyID[i], 10)
 	}
 
 	val := url.Values{}
@@ -387,9 +387,9 @@ func (c *Coinmarketcap) GetExchangeInfo(exchangeID ...int64) (ExchangeInfo, erro
 		return resp.Data, err
 	}
 
-	var exchStr []string
-	for _, d := range exchangeID {
-		exchStr = append(exchStr, strconv.FormatInt(d, 10))
+	exchStr := make([]string, len(exchangeID))
+	for x := range exchangeID {
+		exchStr[x] = strconv.FormatInt(exchangeID[x], 10)
 	}
 
 	val := url.Values{}
@@ -524,9 +524,9 @@ func (c *Coinmarketcap) GetExchangeLatestQuotes(exchangeID ...int64) (ExchangeLa
 		return resp.Data, err
 	}
 
-	var exchStr []string
-	for _, d := range exchangeID {
-		exchStr = append(exchStr, strconv.FormatInt(d, 10))
+	exchStr := make([]string, len(exchangeID))
+	for x := range exchangeID {
+		exchStr[x] = strconv.FormatInt(exchangeID[x], 10)
 	}
 
 	val := url.Values{}

--- a/currency/forexprovider/currencyconverterapi/currencyconverterapi.go
+++ b/currency/forexprovider/currencyconverterapi/currencyconverterapi.go
@@ -38,9 +38,9 @@ func (c *CurrencyConverter) GetRates(baseCurrency, symbols string) (map[string]f
 		return c.Convert(baseCurrency, symbols)
 	}
 
-	var completedStrings []string
+	completedStrings := make([]string, len(splitSymbols))
 	for x := range splitSymbols {
-		completedStrings = append(completedStrings, baseCurrency+"_"+splitSymbols[x])
+		completedStrings[x] = baseCurrency + "_" + splitSymbols[x]
 	}
 
 	if (c.APIKey != "" && c.APIKey != "Key") || len(completedStrings) == 2 {
@@ -126,7 +126,7 @@ func (c *CurrencyConverter) GetSupportedCurrencies() ([]string, error) {
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(result.Results))
 	for key := range result.Results {
 		currencies = append(currencies, key)
 	}

--- a/currency/forexprovider/currencylayer/currencylayer.go
+++ b/currency/forexprovider/currencylayer/currencylayer.go
@@ -66,7 +66,7 @@ func (c *CurrencyLayer) GetSupportedCurrencies() ([]string, error) {
 		return nil, errors.New(resp.Error.Info)
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(resp.Currencies))
 	for key := range resp.Currencies {
 		currencies = append(currencies, key)
 	}

--- a/currency/forexprovider/exchangerate.host/exchangerate.go
+++ b/currency/forexprovider/exchangerate.host/exchangerate.go
@@ -229,7 +229,7 @@ func (e *ExchangeRateHost) GetSupportedCurrencies() ([]string, error) {
 		return nil, err
 	}
 
-	var symbols []string
+	symbols := make([]string, 0, len(s.Symbols))
 	for x := range s.Symbols {
 		symbols = append(symbols, x)
 	}

--- a/currency/forexprovider/exchangerate.host/exchangerate_test.go
+++ b/currency/forexprovider/exchangerate.host/exchangerate_test.go
@@ -84,8 +84,7 @@ func TestGetSupportedSymbols(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, ok := r.Symbols["AUD"]
-	if !ok {
+	if _, ok := r.Symbols["AUD"]; !ok {
 		t.Error("should contain AUD")
 	}
 }

--- a/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
+++ b/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
@@ -45,9 +45,10 @@ func (e *ExchangeRates) cleanCurrencies(baseCurrency, symbols string) string {
 			e.supportedCurrencies = supportedCurrencies
 		}
 	}
-	var cleanedCurrencies []string
+
 	symbols = strings.Replace(symbols, "RUR", "RUB", -1)
 	var s = strings.Split(symbols, ",")
+	cleanedCurrencies := make([]string, 0, len(s))
 	for _, x := range s {
 		// first make sure that the baseCurrency is not in the symbols list
 		// if it is set
@@ -244,7 +245,7 @@ func (e *ExchangeRates) GetSupportedCurrencies() ([]string, error) {
 		return nil, err
 	}
 
-	var supportedCurrencies []string
+	supportedCurrencies := make([]string, 0, len(symbols))
 	for x := range symbols {
 		supportedCurrencies = append(supportedCurrencies, x)
 	}

--- a/currency/forexprovider/fixer.io/fixer.go
+++ b/currency/forexprovider/fixer.io/fixer.go
@@ -55,7 +55,7 @@ func (f *Fixer) GetSupportedCurrencies() ([]string, error) {
 		return nil, errors.New(resp.Error.Type + resp.Error.Info)
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(resp.Map))
 	for key := range resp.Map {
 		currencies = append(currencies, key)
 	}

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -51,7 +51,7 @@ var (
 func (s *Storage) SetDefaults() {
 	s.defaultBaseCurrency = USD
 	s.baseCurrency = s.defaultBaseCurrency
-	var fiatCurrencies []Code
+	fiatCurrencies := make([]Code, 0, len(symbols))
 	for item := range symbols {
 		if item == USDT.Item {
 			continue
@@ -125,7 +125,7 @@ func (s *Storage) RunUpdater(overrides BotOverrides, settings *Config, filePath 
 		}
 	}
 
-	var fxSettings []base.Settings
+	fxSettings := make([]base.Settings, 0, len(settings.ForexProviders))
 	var primaryProvider bool
 	for i := range settings.ForexProviders {
 		enabled := (settings.ForexProviders[i].Name == "CurrencyConverter" && overrides.CurrencyConverter) ||
@@ -331,7 +331,7 @@ func (s *Storage) ForeignExchangeUpdater() {
 // SeedCurrencyAnalysisData sets a new instance of a coinmarketcap data.
 func (s *Storage) SeedCurrencyAnalysisData() error {
 	if s.currencyCodes.LastMainUpdate.IsZero() {
-		b, err := ioutil.ReadFile(s.path)
+		b, err := os.ReadFile(s.path)
 		if err != nil {
 			return s.FetchCurrencyAnalysisData()
 		}

--- a/database/repository/audit/audit.go
+++ b/database/repository/audit/audit.go
@@ -19,7 +19,7 @@ func Event(id, msgtype, message string) {
 		return
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	ctx = boil.SkipTimestamps(ctx)
 
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
@@ -76,7 +76,7 @@ func GetEvent(startTime, endTime time.Time, order string, limit int) (interface{
 	orderByQuery := qm.OrderBy(orderByQueryString)
 	limitQuery := qm.Limit(limit)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	if repository.GetSQLDialect() == database.DBSQLite3 {
 		return modelSQLite.AuditEvents(query, orderByQuery, limitQuery).All(ctx, database.DB.SQL)
 	}

--- a/database/repository/candle/candle.go
+++ b/database/repository/candle/candle.go
@@ -126,7 +126,7 @@ func DeleteCandles(in *Item) (int64, error) {
 }
 
 func deleteSQLite(ctx context.Context, queries []qm.QueryMod) (int64, error) {
-	retCandle, err := modelSQLite.Candles(queries...).All(context.Background(), database.DB.SQL)
+	retCandle, err := modelSQLite.Candles(queries...).All(ctx, database.DB.SQL)
 	if err != nil {
 		return 0, err
 	}
@@ -153,7 +153,7 @@ func deleteSQLite(ctx context.Context, queries []qm.QueryMod) (int64, error) {
 }
 
 func deletePostgres(ctx context.Context, queries []qm.QueryMod) (int64, error) {
-	retCandle, err := modelPSQL.Candles(queries...).All(context.Background(), database.DB.SQL)
+	retCandle, err := modelPSQL.Candles(queries...).All(ctx, database.DB.SQL)
 	if err != nil {
 		return 0, err
 	}

--- a/database/repository/candle/candle.go
+++ b/database/repository/candle/candle.go
@@ -45,7 +45,7 @@ func Series(exchangeName, base, quote string, interval int64, asset string, star
 	queries = append(queries, qm.Where("exchange_name_id = ?", exchangeUUID.String()))
 	if repository.GetSQLDialect() == database.DBSQLite3 {
 		queries = append(queries, qm.Where("timestamp between ? and ?", start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339)))
-		retCandle, errC := modelSQLite.Candles(queries...).All(context.Background(), database.DB.SQL)
+		retCandle, errC := modelSQLite.Candles(queries...).All(context.TODO(), database.DB.SQL)
 		if errC != nil {
 			return out, errC
 		}
@@ -68,7 +68,7 @@ func Series(exchangeName, base, quote string, interval int64, asset string, star
 		}
 	} else {
 		queries = append(queries, qm.Where("timestamp between ? and ?", start.UTC(), end.UTC()))
-		retCandle, errC := modelPSQL.Candles(queries...).All(context.Background(), database.DB.SQL)
+		retCandle, errC := modelPSQL.Candles(queries...).All(context.TODO(), database.DB.SQL)
 		if errC != nil {
 			return out, errC
 		}
@@ -108,7 +108,7 @@ func DeleteCandles(in *Item) (int64, error) {
 		return 0, errNoCandleData
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	queries := []qm.QueryMod{
 		qm.Where("base = ?", strings.ToUpper(in.Base)),
 		qm.Where("quote = ?", strings.ToUpper(in.Quote)),
@@ -189,7 +189,7 @@ func Insert(in *Item) (uint64, error) {
 		return 0, errNoCandleData
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err

--- a/database/repository/datahistoryjob/datahistoryjob.go
+++ b/database/repository/datahistoryjob/datahistoryjob.go
@@ -38,7 +38,7 @@ func Setup(db database.IDatabase) (*DBService, error) {
 
 // Upsert inserts or updates jobs into the database
 func (db *DBService) Upsert(jobs ...*DataHistoryJob) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	tx, err := db.sql.BeginTx(ctx, nil)
 	if err != nil {
@@ -156,7 +156,7 @@ func (db *DBService) GetPrerequisiteJob(nickname string) (*DataHistoryJob, error
 // SetRelationshipByID removes a relationship in the event of a changed
 // relationship during upsertion
 func (db *DBService) SetRelationshipByID(prerequisiteJobID, followingJobID string, status int64) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 	if strings.EqualFold(prerequisiteJobID, followingJobID) {
 		return errCannotSetSamePrerequisite
 	}
@@ -191,7 +191,7 @@ func (db *DBService) SetRelationshipByID(prerequisiteJobID, followingJobID strin
 // SetRelationshipByNickname removes a relationship in the event of a changed
 // relationship during upsertion
 func (db *DBService) SetRelationshipByNickname(prerequisiteNickname, followingNickname string, status int64) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 	if strings.EqualFold(prerequisiteNickname, followingNickname) {
 		return errCannotSetSamePrerequisite
 	}
@@ -331,7 +331,7 @@ func upsertPostgres(ctx context.Context, tx *sql.Tx, jobs ...*DataHistoryJob) er
 	return nil
 }
 func (db *DBService) getByNicknameSQLite(nickname string) (*DataHistoryJob, error) {
-	result, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", strings.ToLower(nickname))).One(context.Background(), db.sql)
+	result, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", strings.ToLower(nickname))).One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (db *DBService) getByNicknameSQLite(nickname string) (*DataHistoryJob, erro
 
 func (db *DBService) getByNicknamePostgres(nickname string) (*DataHistoryJob, error) {
 	query := postgres.Datahistoryjobs(qm.Where("nickname = ?", strings.ToLower(nickname)))
-	result, err := query.One(context.Background(), db.sql)
+	result, err := query.One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func (db *DBService) getByNicknamePostgres(nickname string) (*DataHistoryJob, er
 }
 
 func (db *DBService) getByIDSQLite(id string) (*DataHistoryJob, error) {
-	result, err := sqlite3.Datahistoryjobs(qm.Where("id = ?", id)).One(context.Background(), db.sql)
+	result, err := sqlite3.Datahistoryjobs(qm.Where("id = ?", id)).One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func (db *DBService) getByIDSQLite(id string) (*DataHistoryJob, error) {
 
 func (db *DBService) getByIDPostgres(id string) (*DataHistoryJob, error) {
 	query := postgres.Datahistoryjobs(qm.Where("id = ?", id))
-	result, err := query.One(context.Background(), db.sql)
+	result, err := query.One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +369,7 @@ func (db *DBService) getByIDPostgres(id string) (*DataHistoryJob, error) {
 
 func (db *DBService) getJobsBetweenSQLite(startDate, endDate time.Time) ([]DataHistoryJob, error) {
 	query := sqlite3.Datahistoryjobs(qm.Where("created BETWEEN ? AND ? ", startDate.UTC().Format(time.RFC3339), endDate.UTC().Format(time.RFC3339)))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (db *DBService) getJobsBetweenSQLite(startDate, endDate time.Time) ([]DataH
 
 func (db *DBService) getJobsBetweenPostgres(startDate, endDate time.Time) ([]DataHistoryJob, error) {
 	query := postgres.Datahistoryjobs(qm.Where("created BETWEEN ? AND  ? ", startDate, endDate))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (db *DBService) getJobAndAllResultsSQLite(nickname string) (*DataHistoryJob
 		qm.Load(sqlite3.DatahistoryjobRels.JobDatahistoryjobresults),
 		qm.Load(sqlite3.DatahistoryjobRels.ExchangeName),
 		qm.Where("nickname = ?", strings.ToLower(nickname)))
-	result, err := query.One(context.Background(), db.sql)
+	result, err := query.One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (db *DBService) getJobAndAllResultsPostgres(nickname string) (*DataHistoryJ
 	query := postgres.Datahistoryjobs(
 		qm.Load(postgres.DatahistoryjobRels.JobDatahistoryjobresults),
 		qm.Where("nickname = ?", strings.ToLower(nickname)))
-	result, err := query.One(context.Background(), db.sql)
+	result, err := query.One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (db *DBService) getAllIncompleteJobsAndResultsSQLite() ([]DataHistoryJob, e
 		qm.Load(sqlite3.DatahistoryjobRels.ExchangeName),
 		qm.Load(sqlite3.DatahistoryjobRels.JobDatahistoryjobresults),
 		qm.Where("status = ?", 0))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func (db *DBService) getAllIncompleteJobsAndResultsPostgres() ([]DataHistoryJob,
 	query := postgres.Datahistoryjobs(
 		qm.Load(postgres.DatahistoryjobRels.JobDatahistoryjobresults),
 		qm.Where("status = ?", 0))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -475,11 +475,11 @@ func (db *DBService) getAllIncompleteJobsAndResultsPostgres() ([]DataHistoryJob,
 }
 
 func (db *DBService) getRelatedUpcomingJobsSQLite(nickname string) ([]*DataHistoryJob, error) {
-	job, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.Background(), db.sql)
+	job, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
-	results, err := job.JobDatahistoryjobs().All(context.Background(), db.sql)
+	results, err := job.JobDatahistoryjobs().All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (db *DBService) getRelatedUpcomingJobsSQLite(nickname string) ([]*DataHisto
 
 func (db *DBService) getRelatedUpcomingJobsPostgres(nickname string) ([]*DataHistoryJob, error) {
 	q := postgres.Datahistoryjobs(qm.Load(postgres.DatahistoryjobRels.JobDatahistoryjobs), qm.Where("nickname = ?", nickname))
-	jobWithRelations, err := q.One(context.Background(), db.sql)
+	jobWithRelations, err := q.One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -556,11 +556,11 @@ func setRelationshipByIDPostgres(ctx context.Context, tx *sql.Tx, prerequisiteJo
 }
 
 func (db *DBService) getPrerequisiteJobSQLite(nickname string) (*DataHistoryJob, error) {
-	result, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.Background(), db.sql)
+	result, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
-	job, err := result.PrerequisiteJobDatahistoryjobs().One(context.Background(), db.sql)
+	job, err := result.PrerequisiteJobDatahistoryjobs().One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -569,11 +569,11 @@ func (db *DBService) getPrerequisiteJobSQLite(nickname string) (*DataHistoryJob,
 }
 
 func (db *DBService) getPrerequisiteJobPostgres(nickname string) (*DataHistoryJob, error) {
-	job, err := postgres.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.Background(), db.sql)
+	job, err := postgres.Datahistoryjobs(qm.Where("nickname = ?", nickname)).One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
-	result, err := job.PrerequisiteJobDatahistoryjobs().One(context.Background(), db.sql)
+	result, err := job.PrerequisiteJobDatahistoryjobs().One(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -631,7 +631,7 @@ func (db *DBService) createSQLiteDataHistoryJobResponse(result *sqlite3.Datahist
 	if result.R != nil && result.R.ExchangeName != nil {
 		exchange = result.R.ExchangeName
 	} else {
-		exchange, err = result.ExchangeName().One(context.Background(), db.sql)
+		exchange, err = result.ExchangeName().One(context.TODO(), db.sql)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve exchange '%v' %w", result.ExchangeNameID, err)
 		}
@@ -639,7 +639,7 @@ func (db *DBService) createSQLiteDataHistoryJobResponse(result *sqlite3.Datahist
 	var secondaryExchangeName string
 	if result.SecondaryExchangeID.String != "" {
 		var secondaryExchangeResult *sqlite3.Exchange
-		secondaryExchangeResult, err = result.SecondaryExchange().One(context.Background(), db.sql)
+		secondaryExchangeResult, err = result.SecondaryExchange().One(context.TODO(), db.sql)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve secondary exchange '%v' %w", result.SecondaryExchangeID, err)
 		}
@@ -661,7 +661,7 @@ func (db *DBService) createSQLiteDataHistoryJobResponse(result *sqlite3.Datahist
 		return nil, err
 	}
 
-	prereqJob, err := result.PrerequisiteJobDatahistoryjobs().One(context.Background(), db.sql)
+	prereqJob, err := result.PrerequisiteJobDatahistoryjobs().One(context.TODO(), db.sql)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
@@ -735,7 +735,7 @@ func (db *DBService) createPostgresDataHistoryJobResponse(result *postgres.Datah
 	if result.R != nil && result.R.ExchangeName != nil {
 		exchange = result.R.ExchangeName
 	} else {
-		exchange, err = result.ExchangeName().One(context.Background(), db.sql)
+		exchange, err = result.ExchangeName().One(context.TODO(), db.sql)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve exchange '%v' %w", result.ExchangeNameID, err)
 		}
@@ -744,7 +744,7 @@ func (db *DBService) createPostgresDataHistoryJobResponse(result *postgres.Datah
 	var secondaryExchangeName string
 	if result.SecondaryExchangeID.String != "" {
 		var secondaryExchangeResult *postgres.Exchange
-		secondaryExchangeResult, err = result.SecondaryExchange().One(context.Background(), db.sql)
+		secondaryExchangeResult, err = result.SecondaryExchange().One(context.TODO(), db.sql)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve secondary exchange '%v' %w", result.SecondaryExchangeID, err)
 		}
@@ -753,7 +753,7 @@ func (db *DBService) createPostgresDataHistoryJobResponse(result *postgres.Datah
 		}
 	}
 
-	prereqJob, err := result.PrerequisiteJobDatahistoryjobs().One(context.Background(), db.sql)
+	prereqJob, err := result.PrerequisiteJobDatahistoryjobs().One(context.TODO(), db.sql)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}

--- a/database/repository/datahistoryjob/datahistoryjob.go
+++ b/database/repository/datahistoryjob/datahistoryjob.go
@@ -368,13 +368,13 @@ func (db *DBService) getByIDPostgres(id string) (*DataHistoryJob, error) {
 }
 
 func (db *DBService) getJobsBetweenSQLite(startDate, endDate time.Time) ([]DataHistoryJob, error) {
-	var jobs []DataHistoryJob
 	query := sqlite3.Datahistoryjobs(qm.Where("created BETWEEN ? AND ? ", startDate.UTC().Format(time.RFC3339), endDate.UTC().Format(time.RFC3339)))
 	results, err := query.All(context.Background(), db.sql)
 	if err != nil {
-		return jobs, err
+		return nil, err
 	}
 
+	jobs := make([]DataHistoryJob, 0, len(results))
 	for i := range results {
 		job, err := db.createSQLiteDataHistoryJobResponse(results[i])
 		if err != nil {
@@ -387,13 +387,13 @@ func (db *DBService) getJobsBetweenSQLite(startDate, endDate time.Time) ([]DataH
 }
 
 func (db *DBService) getJobsBetweenPostgres(startDate, endDate time.Time) ([]DataHistoryJob, error) {
-	var jobs []DataHistoryJob
 	query := postgres.Datahistoryjobs(qm.Where("created BETWEEN ? AND  ? ", startDate, endDate))
 	results, err := query.All(context.Background(), db.sql)
 	if err != nil {
-		return jobs, err
+		return nil, err
 	}
 
+	jobs := make([]DataHistoryJob, 0, len(results))
 	for i := range results {
 		job, err := db.createPostgresDataHistoryJobResponse(results[i])
 		if err != nil {
@@ -440,7 +440,7 @@ func (db *DBService) getAllIncompleteJobsAndResultsSQLite() ([]DataHistoryJob, e
 		return nil, err
 	}
 
-	var jobs []DataHistoryJob
+	jobs := make([]DataHistoryJob, 0, len(results))
 	for i := range results {
 		job, err := db.createSQLiteDataHistoryJobResponse(results[i])
 		if err != nil {
@@ -462,7 +462,7 @@ func (db *DBService) getAllIncompleteJobsAndResultsPostgres() ([]DataHistoryJob,
 		return nil, err
 	}
 
-	var jobs []DataHistoryJob
+	jobs := make([]DataHistoryJob, 0, len(results))
 	for i := range results {
 		job, err := db.createPostgresDataHistoryJobResponse(results[i])
 		if err != nil {
@@ -483,7 +483,7 @@ func (db *DBService) getRelatedUpcomingJobsSQLite(nickname string) ([]*DataHisto
 	if err != nil {
 		return nil, err
 	}
-	var resp []*DataHistoryJob
+	resp := make([]*DataHistoryJob, 0, len(results))
 	for i := range results {
 		job, err := db.createSQLiteDataHistoryJobResponse(results[i])
 		if err != nil {
@@ -500,7 +500,7 @@ func (db *DBService) getRelatedUpcomingJobsPostgres(nickname string) ([]*DataHis
 	if err != nil {
 		return nil, err
 	}
-	var response []*DataHistoryJob
+	response := make([]*DataHistoryJob, 0, len(jobWithRelations.R.JobDatahistoryjobs))
 	for i := range jobWithRelations.R.JobDatahistoryjobs {
 		job, err := db.getByIDPostgres(jobWithRelations.R.JobDatahistoryjobs[i].ID)
 		if err != nil {

--- a/database/repository/datahistoryjobresult/datahistoryjobresult.go
+++ b/database/repository/datahistoryjobresult/datahistoryjobresult.go
@@ -169,7 +169,7 @@ func (db *DBService) getByJobIDSQLite(jobID string) ([]DataHistoryJobResult, err
 	if err != nil {
 		return nil, err
 	}
-	var resp []DataHistoryJobResult
+	resp := make([]DataHistoryJobResult, len(results))
 	for i := range results {
 		var start, end, run time.Time
 		start, err = time.Parse(time.RFC3339, results[i].IntervalStartTime)
@@ -184,7 +184,7 @@ func (db *DBService) getByJobIDSQLite(jobID string) ([]DataHistoryJobResult, err
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, DataHistoryJobResult{
+		resp[i] = DataHistoryJobResult{
 			ID:                results[i].ID,
 			JobID:             results[i].JobID,
 			IntervalStartDate: start,
@@ -192,7 +192,7 @@ func (db *DBService) getByJobIDSQLite(jobID string) ([]DataHistoryJobResult, err
 			Status:            int64(results[i].Status),
 			Result:            results[i].Result.String,
 			Date:              run,
-		})
+		}
 	}
 
 	return resp, nil
@@ -204,9 +204,9 @@ func (db *DBService) getByJobIDPostgres(jobID string) ([]DataHistoryJobResult, e
 	if err != nil {
 		return nil, err
 	}
-	var resp []DataHistoryJobResult
+	resp := make([]DataHistoryJobResult, len(results))
 	for i := range results {
-		resp = append(resp, DataHistoryJobResult{
+		resp[i] = DataHistoryJobResult{
 			ID:                results[i].ID,
 			JobID:             results[i].JobID,
 			IntervalStartDate: results[i].IntervalStartTime,
@@ -214,20 +214,20 @@ func (db *DBService) getByJobIDPostgres(jobID string) ([]DataHistoryJobResult, e
 			Status:            int64(results[i].Status),
 			Result:            results[i].Result.String,
 			Date:              results[i].RunTime,
-		})
+		}
 	}
 
 	return resp, nil
 }
 
 func (db *DBService) getJobResultsBetweenSQLite(jobID string, startDate, endDate time.Time) ([]DataHistoryJobResult, error) {
-	var results []DataHistoryJobResult
 	query := sqlite3.Datahistoryjobresults(qm.Where("job_id = ? AND run_time BETWEEN ? AND ? ", jobID, startDate.UTC().Format(time.RFC3339), endDate.UTC().Format(time.RFC3339)))
 	resp, err := query.All(context.Background(), db.sql)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
+	results := make([]DataHistoryJobResult, len(resp))
 	for i := range resp {
 		var start, end, run time.Time
 		start, err = time.Parse(time.RFC3339, resp[i].IntervalStartTime)
@@ -242,7 +242,7 @@ func (db *DBService) getJobResultsBetweenSQLite(jobID string, startDate, endDate
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, DataHistoryJobResult{
+		results[i] = DataHistoryJobResult{
 			ID:                resp[i].ID,
 			JobID:             resp[i].JobID,
 			IntervalStartDate: start,
@@ -250,22 +250,22 @@ func (db *DBService) getJobResultsBetweenSQLite(jobID string, startDate, endDate
 			Status:            int64(resp[i].Status),
 			Result:            resp[i].Result.String,
 			Date:              run,
-		})
+		}
 	}
 
 	return results, nil
 }
 
 func (db *DBService) getJobResultsBetweenPostgres(jobID string, startDate, endDate time.Time) ([]DataHistoryJobResult, error) {
-	var jobs []DataHistoryJobResult
 	query := postgres.Datahistoryjobresults(qm.Where("job_id = ? AND run_time BETWEEN ? AND  ? ", jobID, startDate, endDate))
 	results, err := query.All(context.Background(), db.sql)
 	if err != nil {
-		return jobs, err
+		return nil, err
 	}
 
+	var jobs []DataHistoryJobResult
 	for i := range results {
-		jobs = append(jobs, DataHistoryJobResult{
+		jobs[i] = DataHistoryJobResult{
 			ID:                results[i].ID,
 			JobID:             results[i].JobID,
 			IntervalStartDate: results[i].IntervalStartTime,
@@ -273,7 +273,7 @@ func (db *DBService) getJobResultsBetweenPostgres(jobID string, startDate, endDa
 			Status:            int64(results[i].Status),
 			Result:            results[i].Result.String,
 			Date:              results[i].RunTime,
-		})
+		}
 	}
 
 	return jobs, nil

--- a/database/repository/datahistoryjobresult/datahistoryjobresult.go
+++ b/database/repository/datahistoryjobresult/datahistoryjobresult.go
@@ -40,7 +40,7 @@ func (db *DBService) Upsert(jobs ...*DataHistoryJobResult) error {
 	if len(jobs) == 0 {
 		return nil
 	}
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	tx, err := db.sql.BeginTx(ctx, nil)
 	if err != nil {
@@ -165,7 +165,7 @@ func upsertPostgres(ctx context.Context, tx *sql.Tx, results ...*DataHistoryJobR
 
 func (db *DBService) getByJobIDSQLite(jobID string) ([]DataHistoryJobResult, error) {
 	query := sqlite3.Datahistoryjobresults(qm.Where("job_id = ?", jobID))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (db *DBService) getByJobIDSQLite(jobID string) ([]DataHistoryJobResult, err
 
 func (db *DBService) getByJobIDPostgres(jobID string) ([]DataHistoryJobResult, error) {
 	query := postgres.Datahistoryjobresults(qm.Where("job_id = ?", jobID))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (db *DBService) getByJobIDPostgres(jobID string) ([]DataHistoryJobResult, e
 
 func (db *DBService) getJobResultsBetweenSQLite(jobID string, startDate, endDate time.Time) ([]DataHistoryJobResult, error) {
 	query := sqlite3.Datahistoryjobresults(qm.Where("job_id = ? AND run_time BETWEEN ? AND ? ", jobID, startDate.UTC().Format(time.RFC3339), endDate.UTC().Format(time.RFC3339)))
-	resp, err := query.All(context.Background(), db.sql)
+	resp, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
@@ -258,12 +258,12 @@ func (db *DBService) getJobResultsBetweenSQLite(jobID string, startDate, endDate
 
 func (db *DBService) getJobResultsBetweenPostgres(jobID string, startDate, endDate time.Time) ([]DataHistoryJobResult, error) {
 	query := postgres.Datahistoryjobresults(qm.Where("job_id = ? AND run_time BETWEEN ? AND  ? ", jobID, startDate, endDate))
-	results, err := query.All(context.Background(), db.sql)
+	results, err := query.All(context.TODO(), db.sql)
 	if err != nil {
 		return nil, err
 	}
 
-	var jobs []DataHistoryJobResult
+	jobs := make([]DataHistoryJobResult, len(results))
 	for i := range results {
 		jobs[i] = DataHistoryJobResult{
 			ID:                results[i].ID,

--- a/database/repository/exchange/exchange.go
+++ b/database/repository/exchange/exchange.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/csv"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -178,7 +179,11 @@ func UUIDByName(exchange string) (uuid.UUID, error) {
 	exchange = strings.ToLower(exchange)
 	v := exchangeCache.Get(exchange)
 	if v != nil {
-		return v.(uuid.UUID), nil
+		u, ok := v.(uuid.UUID)
+		if !ok {
+			return uuid.UUID{}, errors.New("unable to type assert uuid")
+		}
+		return u, nil
 	}
 	ret, err := One(exchange)
 	if err != nil {

--- a/database/repository/exchange/exchange.go
+++ b/database/repository/exchange/exchange.go
@@ -38,7 +38,7 @@ func one(in, clause string) (out Details, err error) {
 
 	whereQM := qm.Where(clause+"= ?", in)
 	if repository.GetSQLDialect() == database.DBSQLite3 {
-		ret, errS := modelSQLite.Exchanges(whereQM).One(context.Background(), database.DB.SQL)
+		ret, errS := modelSQLite.Exchanges(whereQM).One(context.TODO(), database.DB.SQL)
 		if errS != nil {
 			return out, errS
 		}
@@ -48,7 +48,7 @@ func one(in, clause string) (out Details, err error) {
 			return out, errS
 		}
 	} else {
-		ret, errS := modelPSQL.Exchanges(whereQM).One(context.Background(), database.DB.SQL)
+		ret, errS := modelPSQL.Exchanges(whereQM).One(context.TODO(), database.DB.SQL)
 		if errS != nil {
 			return out, errS
 		}
@@ -68,7 +68,7 @@ func Insert(in Details) error {
 		return database.ErrDatabaseSupportDisabled
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func InsertMany(in []Details) error {
 		return database.ErrDatabaseSupportDisabled
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/database/repository/script/script.go
+++ b/database/repository/script/script.go
@@ -20,7 +20,7 @@ func Event(id, name, path string, data null.Bytes, executionType, status string,
 		return
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	ctx = boil.SkipTimestamps(ctx)
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
 	if err != nil {

--- a/database/repository/trade/trade.go
+++ b/database/repository/trade/trade.go
@@ -34,7 +34,7 @@ func Insert(trades ...Data) error {
 		}
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	ctx = boil.SkipTimestamps(ctx)
 
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
@@ -65,7 +65,7 @@ func Insert(trades ...Data) error {
 // VerifyTradeInIntervals will query for ONE trade within each kline interval and verify if data exists
 // if it does, it will set the range holder property "HasData" to true
 func VerifyTradeInIntervals(exchangeName, assetType, base, quote string, irh *kline.IntervalRangeHolder) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 	ctx = boil.SkipTimestamps(ctx)
 
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
@@ -237,7 +237,7 @@ func getByUUIDSQLite(uuid string) (Data, error) {
 	var td Data
 	var ts time.Time
 	query := sqlite3.Trades(qm.Where("id = ?", uuid))
-	result, err := query.One(context.Background(), database.DB.SQL)
+	result, err := query.One(context.TODO(), database.DB.SQL)
 	if err != nil {
 		return td, err
 	}
@@ -265,7 +265,7 @@ func getByUUIDSQLite(uuid string) (Data, error) {
 func getByUUIDPostgres(uuid string) (td Data, err error) {
 	query := postgres.Trades(qm.Where("id = ?", uuid))
 	var result *postgres.Trade
-	result, err = query.One(context.Background(), database.DB.SQL)
+	result, err = query.One(context.TODO(), database.DB.SQL)
 	if err != nil {
 		return td, err
 	}
@@ -318,7 +318,7 @@ func getInRangeSQLite(exchangeName, assetType, base, quote string, startDate, en
 	q := generateQuery(wheres, startDate, endDate, true)
 	query := sqlite3.Trades(q...)
 	var result []*sqlite3.Trade
-	result, err = query.All(context.Background(), database.DB.SQL)
+	result, err = query.All(context.TODO(), database.DB.SQL)
 	if err != nil {
 		return td, err
 	}
@@ -361,7 +361,7 @@ func getInRangePostgres(exchangeName, assetType, base, quote string, startDate, 
 	q := generateQuery(wheres, startDate, endDate, false)
 	query := postgres.Trades(q...)
 	var result []*postgres.Trade
-	result, err = query.All(context.Background(), database.DB.SQL)
+	result, err = query.All(context.TODO(), database.DB.SQL)
 	if err != nil {
 		return td, err
 	}
@@ -386,7 +386,7 @@ func getInRangePostgres(exchangeName, assetType, base, quote string, startDate, 
 
 // DeleteTrades will remove trades from the database using trade.Data
 func DeleteTrades(trades ...Data) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 	ctx = boil.SkipTimestamps(ctx)
 
 	tx, err := database.DB.SQL.BeginTx(ctx, nil)
@@ -402,9 +402,9 @@ func DeleteTrades(trades ...Data) error {
 		}
 	}()
 	if repository.GetSQLDialect() == database.DBSQLite3 || repository.GetSQLDialect() == database.DBSQLite {
-		err = deleteTradesSQLite(context.Background(), tx, trades...)
+		err = deleteTradesSQLite(context.TODO(), tx, trades...)
 	} else {
-		err = deleteTradesPostgres(context.Background(), tx, trades...)
+		err = deleteTradesPostgres(context.TODO(), tx, trades...)
 	}
 	if err != nil {
 		return err

--- a/database/repository/trade/trade.go
+++ b/database/repository/trade/trade.go
@@ -414,9 +414,9 @@ func DeleteTrades(trades ...Data) error {
 }
 
 func deleteTradesSQLite(ctx context.Context, tx *sql.Tx, trades ...Data) error {
-	var tradeIDs []interface{}
+	tradeIDs := make([]interface{}, len(trades))
 	for i := range trades {
-		tradeIDs = append(tradeIDs, trades[i].ID)
+		tradeIDs[i] = trades[i].ID
 	}
 	query := sqlite3.Trades(qm.WhereIn(`id in ?`, tradeIDs...))
 	_, err := query.DeleteAll(ctx, tx)
@@ -424,9 +424,9 @@ func deleteTradesSQLite(ctx context.Context, tx *sql.Tx, trades ...Data) error {
 }
 
 func deleteTradesPostgres(ctx context.Context, tx *sql.Tx, trades ...Data) error {
-	var tradeIDs []interface{}
+	tradeIDs := make([]interface{}, len(trades))
 	for i := range trades {
-		tradeIDs = append(tradeIDs, trades[i].ID)
+		tradeIDs[i] = trades[i].ID
 	}
 	query := postgres.Trades(qm.WhereIn(`id in ?`, tradeIDs...))
 	_, err := query.DeleteAll(ctx, tx)

--- a/database/repository/withdraw/withdraw.go
+++ b/database/repository/withdraw/withdraw.go
@@ -267,7 +267,11 @@ func GetEventsByDate(exchange string, start, end time.Time, limit int) ([]*withd
 }
 
 func generateWhereQuery(columns, id []string, limit int) []qm.QueryMod {
-	var queries []qm.QueryMod
+	x := len(columns)
+	if limit > 0 {
+		x++
+	}
+	queries := make([]qm.QueryMod, 0, x)
 	if limit > 0 {
 		queries = append(queries, qm.Limit(limit))
 	}

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -285,11 +285,11 @@ func (d *Dispatcher) subscribe(id uuid.UUID) (chan interface{}, error) {
 
 	// Read lock to read route list
 	d.rMtx.RLock()
-	_, ok := d.routes[id]
-	d.rMtx.RUnlock()
-	if !ok {
+	if _, ok := d.routes[id]; !ok {
+		d.rMtx.RUnlock()
 		return nil, errors.New("dispatcher uuid not found in route list")
 	}
+	d.rMtx.RUnlock()
 
 	// Get an unused channel from the channel pool
 	unusedChan, ok := d.outbound.Get().(chan interface{})
@@ -314,11 +314,11 @@ func (d *Dispatcher) unsubscribe(id uuid.UUID, usedChan chan interface{}) error 
 
 	// Read lock to read route list
 	d.rMtx.RLock()
-	_, ok := d.routes[id]
-	d.rMtx.RUnlock()
-	if !ok {
+	if _, ok := d.routes[id]; !ok {
+		d.rMtx.RUnlock()
 		return errors.New("dispatcher uuid does not reference any channels")
 	}
+	d.rMtx.RUnlock()
 
 	// Lock for write to delete references
 	d.rMtx.Lock()

--- a/dispatch/dispatch_types.go
+++ b/dispatch/dispatch_types.go
@@ -71,7 +71,6 @@ type job struct {
 type Mux struct {
 	// Reference to the main running dispatch service
 	d *Dispatcher
-	sync.RWMutex
 }
 
 // Pipe defines an outbound object to the desired routine

--- a/engine/apiserver.go
+++ b/engine/apiserver.go
@@ -112,8 +112,8 @@ func (m *apiServerManager) newRouter(isREST bool) *mux.Router {
 	if common.ExtractPort(m.websocketListenAddress) == 80 {
 		m.websocketListenAddress = common.ExtractHost(m.websocketListenAddress)
 	} else {
-		m.websocketListenAddress = strings.Join([]string{common.ExtractHost(m.websocketListenAddress),
-			strconv.Itoa(common.ExtractPort(m.websocketListenAddress))}, ":")
+		m.websocketListenAddress = common.ExtractHost(m.websocketListenAddress) + ":" +
+			strconv.Itoa(common.ExtractPort(m.websocketListenAddress))
 	}
 
 	if isREST {
@@ -302,11 +302,13 @@ func (m *apiServerManager) getIndex(w http.ResponseWriter, _ *http.Request) {
 
 // getAllActiveOrderbooks returns all enabled exchanges orderbooks
 func getAllActiveOrderbooks(m iExchangeManager) []EnabledExchangeOrderbooks {
-	var orderbookData []EnabledExchangeOrderbooks
 	exchanges, err := m.GetExchanges()
 	if err != nil {
 		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
+		return nil
 	}
+
+	orderbookData := make([]EnabledExchangeOrderbooks, 0, len(exchanges))
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()
@@ -342,11 +344,12 @@ func getAllActiveOrderbooks(m iExchangeManager) []EnabledExchangeOrderbooks {
 
 // getAllActiveTickers returns all enabled exchanges tickers
 func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
-	var tickers []EnabledExchangeCurrencies
 	exchanges, err := m.GetExchanges()
 	if err != nil {
 		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
+		return nil
 	}
+	var tickers []EnabledExchangeCurrencies
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()

--- a/engine/apiserver.go
+++ b/engine/apiserver.go
@@ -349,7 +349,8 @@ func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
 		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
 		return nil
 	}
-	var tickers []EnabledExchangeCurrencies
+
+	tickers := make([]EnabledExchangeCurrencies, 0, len(exchanges))
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()
@@ -385,11 +386,13 @@ func getAllActiveTickers(m iExchangeManager) []EnabledExchangeCurrencies {
 
 // getAllActiveAccounts returns all enabled exchanges accounts
 func getAllActiveAccounts(m iExchangeManager) []AllEnabledExchangeAccounts {
-	var accounts []AllEnabledExchangeAccounts
 	exchanges, err := m.GetExchanges()
 	if err != nil {
 		log.Errorf(log.APIServerMgr, "Cannot get exchanges: %v", err)
+		return nil
 	}
+
+	accounts := make([]AllEnabledExchangeAccounts, 0, len(exchanges))
 	for x := range exchanges {
 		assets := exchanges[x].GetAssetTypes(true)
 		exchName := exchanges[x].GetName()
@@ -683,12 +686,17 @@ func (m *apiServerManager) WebsocketClientHandler(w http.ResponseWriter, r *http
 }
 
 func wsAuth(client *websocketClient, data interface{}) error {
+	d, ok := data.([]byte)
+	if !ok {
+		return errors.New("unable to type assert data")
+	}
+
 	wsResp := WebsocketEventResponse{
 		Event: "auth",
 	}
 
 	var auth WebsocketAuth
-	err := json.Unmarshal(data.([]byte), &auth)
+	err := json.Unmarshal(d, &auth)
 	if err != nil {
 		wsResp.Error = err.Error()
 		sendErr := client.SendWebsocketMessage(wsResp)
@@ -741,11 +749,16 @@ func wsGetConfig(client *websocketClient, _ interface{}) error {
 }
 
 func wsSaveConfig(client *websocketClient, data interface{}) error {
+	d, ok := data.([]byte)
+	if !ok {
+		return errors.New("unable to type assert data")
+	}
+
 	wsResp := WebsocketEventResponse{
 		Event: "SaveConfig",
 	}
 	var respCfg config.Config
-	err := json.Unmarshal(data.([]byte), &respCfg)
+	err := json.Unmarshal(d, &respCfg)
 	if err != nil {
 		wsResp.Error = err.Error()
 		sendErr := client.SendWebsocketMessage(wsResp)
@@ -797,11 +810,16 @@ func wsGetTickers(client *websocketClient, data interface{}) error {
 }
 
 func wsGetTicker(client *websocketClient, data interface{}) error {
+	d, ok := data.([]byte)
+	if !ok {
+		return errors.New("unable to type assert data")
+	}
+
 	wsResp := WebsocketEventResponse{
 		Event: "GetTicker",
 	}
 	var tickerReq WebsocketOrderbookTickerRequest
-	err := json.Unmarshal(data.([]byte), &tickerReq)
+	err := json.Unmarshal(d, &tickerReq)
 	if err != nil {
 		wsResp.Error = err.Error()
 		sendErr := client.SendWebsocketMessage(wsResp)
@@ -852,11 +870,16 @@ func wsGetOrderbooks(client *websocketClient, data interface{}) error {
 }
 
 func wsGetOrderbook(client *websocketClient, data interface{}) error {
+	d, ok := data.([]byte)
+	if !ok {
+		return errors.New("unable to type assert data")
+	}
+
 	wsResp := WebsocketEventResponse{
 		Event: "GetOrderbook",
 	}
 	var orderbookReq WebsocketOrderbookTickerRequest
-	err := json.Unmarshal(data.([]byte), &orderbookReq)
+	err := json.Unmarshal(d, &orderbookReq)
 	if err != nil {
 		wsResp.Error = err.Error()
 		sendErr := client.SendWebsocketMessage(wsResp)

--- a/engine/apiserver_test.go
+++ b/engine/apiserver_test.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -253,7 +253,7 @@ func TestConfigAllJsonResponse(t *testing.T) {
 		t.Error(err)
 	}
 	resp := makeHTTPGetRequest(t, c)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Body not readable", err)
 	}

--- a/engine/datahistory_manager.go
+++ b/engine/datahistory_manager.go
@@ -121,7 +121,7 @@ func (m *DataHistoryManager) retrieveJobs() ([]*DataHistoryJob, error) {
 		return nil, err
 	}
 
-	var response []*DataHistoryJob
+	response := make([]*DataHistoryJob, 0, len(dbJobs))
 	for i := range dbJobs {
 		dbJob, err := m.convertDBModelToJob(&dbJobs[i])
 		if err != nil {
@@ -1332,13 +1332,13 @@ func (m *DataHistoryManager) GetAllJobStatusBetween(start, end time.Time) ([]*Da
 	if err != nil {
 		return nil, err
 	}
-	var results []*DataHistoryJob
+	results := make([]*DataHistoryJob, len(dbJobs))
 	for i := range dbJobs {
 		dbJob, err := m.convertDBModelToJob(&dbJobs[i])
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, dbJob)
+		results[i] = dbJob
 	}
 	return results, nil
 }

--- a/engine/exchange_manager.go
+++ b/engine/exchange_manager.go
@@ -82,7 +82,7 @@ func (m *ExchangeManager) GetExchanges() ([]exchange.IBotExchange, error) {
 	}
 	m.m.Lock()
 	defer m.m.Unlock()
-	var exchs []exchange.IBotExchange
+	exchs := make([]exchange.IBotExchange, 0, len(m.exchanges))
 	for _, x := range m.exchanges {
 		exchs = append(exchs, x)
 	}

--- a/engine/exchange_manager_test.go
+++ b/engine/exchange_manager_test.go
@@ -44,7 +44,7 @@ func TestExchangeManagerGetExchanges(t *testing.T) {
 	if err != nil {
 		t.Error("no exchange manager found")
 	}
-	if exchanges != nil {
+	if len(exchanges) != 0 {
 		t.Error("unexpected value")
 	}
 	b := new(bitfinex.Bitfinex)

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -326,8 +325,8 @@ func (bot *Engine) GetExchangeOTPByName(exchName string) (string, error) {
 
 // GetAuthAPISupportedExchanges returns a list of auth api enabled exchanges
 func (bot *Engine) GetAuthAPISupportedExchanges() []string {
-	var exchangeNames []string
 	exchanges := bot.GetExchanges()
+	exchangeNames := make([]string, 0, len(exchanges))
 	for x := range exchanges {
 		if !exchanges[x].GetAuthenticatedAPISupport(exchange.RestAuthentication) &&
 			!exchanges[x].GetAuthenticatedAPISupport(exchange.WebsocketAuthentication) {
@@ -443,7 +442,7 @@ func (bot *Engine) MapCurrenciesByExchange(p currency.Pairs, enabledExchangesOnl
 // GetExchangeNamesByCurrency returns a list of exchanges supporting
 // a currency pair based on whether the exchange is enabled or not
 func (bot *Engine) GetExchangeNamesByCurrency(p currency.Pair, enabled bool, assetType asset.Item) []string {
-	var exchanges []string
+	exchanges := make([]string, 0, len(bot.Config.Exchanges))
 	for x := range bot.Config.Exchanges {
 		if enabled != bot.Config.Exchanges[x].Enabled {
 			continue
@@ -862,7 +861,7 @@ func checkCerts(certDir string) error {
 		return genCert(certDir)
 	}
 
-	pemData, err := ioutil.ReadFile(certFile)
+	pemData, err := os.ReadFile(certFile)
 	if err != nil {
 		return fmt.Errorf("unable to open TLS cert file: %s", err)
 	}

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -755,12 +755,9 @@ func TestGetSpecificOrderbook(t *testing.T) {
 	t.Parallel()
 	e := CreateTestBot(t)
 
-	var bids []orderbook.Item
-	bids = append(bids, orderbook.Item{Price: 1000, Amount: 1})
-
 	base := orderbook.Base{
 		Pair:     currency.NewPair(currency.BTC, currency.USD),
-		Bids:     bids,
+		Bids:     []orderbook.Item{{Price: 1000, Amount: 1}},
 		Exchange: "Bitstamp",
 		Asset:    asset.Spot,
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -383,8 +383,7 @@ func TestExists(t *testing.T) {
 	if err := m.orderStore.add(o); err != nil {
 		t.Error(err)
 	}
-	b := m.orderStore.exists(o)
-	if !b {
+	if b := m.orderStore.exists(o); !b {
 		t.Error("Expected true")
 	}
 }

--- a/engine/portfolio_manager.go
+++ b/engine/portfolio_manager.go
@@ -240,7 +240,7 @@ func (m *portfolioManager) seedExchangeAccountInfo(accounts []account.Holdings) 
 
 // getExchangeAccountInfo returns all the current enabled exchanges
 func (m *portfolioManager) getExchangeAccountInfo(exchanges []exchange.IBotExchange) []account.Holdings {
-	var response []account.Holdings
+	response := make([]account.Holdings, 0, len(exchanges))
 	for x := range exchanges {
 		if exchanges[x] == nil || !exchanges[x].IsEnabled() {
 			continue

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -2115,7 +2115,13 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 			return errDispatchSystem
 		}
 
-		ob, ok := data.(orderbook.Base)
+		d, ok := data.(*interface{})
+		if !ok {
+			return errors.New("unable to type assert data")
+		}
+
+		dd := *d
+		ob, ok := dd.(orderbook.Base)
 		if !ok {
 			return errors.New("unable to type assert orderbook data")
 		}
@@ -2193,7 +2199,13 @@ func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gct
 			return errDispatchSystem
 		}
 
-		t, ok := data.(ticker.Price)
+		d, ok := data.(*interface{})
+		if !ok {
+			return errors.New("unable to type assert data")
+		}
+
+		dd := *d
+		t, ok := dd.(ticker.Price)
 		if !ok {
 			return errors.New("unable to type assert ticker data")
 		}
@@ -2246,7 +2258,13 @@ func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamReq
 			return errDispatchSystem
 		}
 
-		t, ok := data.(ticker.Price)
+		d, ok := data.(*interface{})
+		if !ok {
+			return errors.New("unable to type assert data")
+		}
+
+		dd := *d
+		t, ok := dd.(ticker.Price)
 		if !ok {
 			return errors.New("unable to type assert ticker data")
 		}

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -398,15 +397,16 @@ func (s *RPCServer) GetTicker(ctx context.Context, r *gctrpc.GetTickerRequest) (
 // enabled currency pairs
 func (s *RPCServer) GetTickers(ctx context.Context, _ *gctrpc.GetTickersRequest) (*gctrpc.GetTickersResponse, error) {
 	activeTickers := s.GetAllActiveTickers(ctx)
-	var tickers []*gctrpc.Tickers
+	tickers := make([]*gctrpc.Tickers, len(activeTickers))
 
 	for x := range activeTickers {
 		t := &gctrpc.Tickers{
 			Exchange: activeTickers[x].ExchangeName,
+			Tickers:  make([]*gctrpc.TickerResponse, len(activeTickers[x].ExchangeValues)),
 		}
 		for y := range activeTickers[x].ExchangeValues {
 			val := activeTickers[x].ExchangeValues[y]
-			t.Tickers = append(t.Tickers, &gctrpc.TickerResponse{
+			t.Tickers[y] = &gctrpc.TickerResponse{
 				Pair: &gctrpc.CurrencyPair{
 					Delimiter: val.Pair.Delimiter,
 					Base:      val.Pair.Base.String(),
@@ -420,9 +420,9 @@ func (s *RPCServer) GetTickers(ctx context.Context, _ *gctrpc.GetTickersRequest)
 				Ask:         val.Ask,
 				Volume:      val.Volume,
 				PriceAth:    val.PriceATH,
-			})
+			}
 		}
-		tickers = append(tickers, t)
+		tickers[x] = t
 	}
 
 	return &gctrpc.GetTickersResponse{Tickers: tickers}, nil
@@ -489,7 +489,7 @@ func (s *RPCServer) GetOrderbooks(ctx context.Context, _ *gctrpc.GetOrderbooksRe
 	if err != nil {
 		return nil, err
 	}
-	var obResponse []*gctrpc.Orderbooks
+	obResponse := make([]*gctrpc.Orderbooks, 0, len(exchanges))
 	var obs []*gctrpc.OrderbookResponse
 	for x := range exchanges {
 		if !exchanges[x].IsEnabled() {
@@ -523,19 +523,20 @@ func (s *RPCServer) GetOrderbooks(ctx context.Context, _ *gctrpc.GetOrderbooksRe
 					},
 					AssetType:   assets[y].String(),
 					LastUpdated: s.unixTimestamp(resp.LastUpdated),
+					Bids:        make([]*gctrpc.OrderbookItem, len(resp.Bids)),
+					Asks:        make([]*gctrpc.OrderbookItem, len(resp.Asks)),
 				}
 				for i := range resp.Bids {
-					ob.Bids = append(ob.Bids, &gctrpc.OrderbookItem{
+					ob.Bids[i] = &gctrpc.OrderbookItem{
 						Amount: resp.Bids[i].Amount,
 						Price:  resp.Bids[i].Price,
-					})
+					}
 				}
-
 				for i := range resp.Asks {
-					ob.Asks = append(ob.Asks, &gctrpc.OrderbookItem{
+					ob.Asks[i] = &gctrpc.OrderbookItem{
 						Amount: resp.Asks[i].Amount,
 						Price:  resp.Asks[i].Price,
-					})
+					}
 				}
 				obs = append(obs, ob)
 			}
@@ -600,7 +601,7 @@ func (s *RPCServer) UpdateAccountInfo(ctx context.Context, r *gctrpc.GetAccountI
 }
 
 func createAccountInfoRequest(h account.Holdings) (*gctrpc.GetAccountInfoResponse, error) {
-	var accounts []*gctrpc.Account
+	accounts := make([]*gctrpc.Account, len(h.Accounts))
 	for x := range h.Accounts {
 		var a gctrpc.Account
 		a.Id = h.Accounts[x].ID
@@ -621,7 +622,7 @@ func createAccountInfoRequest(h account.Holdings) (*gctrpc.GetAccountInfoRespons
 				Borrowed:          y.Borrowed,
 			})
 		}
-		accounts = append(accounts, &a)
+		accounts[x] = &a
 	}
 
 	return &gctrpc.GetAccountInfoResponse{Exchange: h.Exchange, Accounts: accounts}, nil
@@ -649,20 +650,20 @@ func (s *RPCServer) GetAccountInfoStream(r *gctrpc.GetAccountInfoRequest, stream
 		return err
 	}
 
-	var accounts []*gctrpc.Account
+	accounts := make([]*gctrpc.Account, len(initAcc.Accounts))
 	for x := range initAcc.Accounts {
-		var subAccounts []*gctrpc.AccountCurrencyInfo
+		subAccounts := make([]*gctrpc.AccountCurrencyInfo, len(initAcc.Accounts[x].Currencies))
 		for y := range initAcc.Accounts[x].Currencies {
-			subAccounts = append(subAccounts, &gctrpc.AccountCurrencyInfo{
+			subAccounts[y] = &gctrpc.AccountCurrencyInfo{
 				Currency:   initAcc.Accounts[x].Currencies[y].CurrencyName.String(),
 				TotalValue: initAcc.Accounts[x].Currencies[y].Total,
 				Hold:       initAcc.Accounts[x].Currencies[y].Hold,
-			})
+			}
 		}
-		accounts = append(accounts, &gctrpc.Account{
+		accounts[x] = &gctrpc.Account{
 			Id:         initAcc.Accounts[x].ID,
 			Currencies: subAccounts,
-		})
+		}
 	}
 
 	err = stream.Send(&gctrpc.GetAccountInfoResponse{
@@ -691,12 +692,7 @@ func (s *RPCServer) GetAccountInfoStream(r *gctrpc.GetAccountInfoRequest, stream
 			return errDispatchSystem
 		}
 
-		d := *data.(*interface{})
-		if d == nil {
-			return errors.New("unable to type assert data")
-		}
-
-		acc, ok := d.(account.Holdings)
+		acc, ok := data.(account.Holdings)
 		if !ok {
 			return errors.New("unable to type assert account holdings data")
 		}
@@ -734,15 +730,15 @@ func (s *RPCServer) GetConfig(_ context.Context, _ *gctrpc.GetConfigRequest) (*g
 
 // GetPortfolio returns the portfoliomanager details
 func (s *RPCServer) GetPortfolio(_ context.Context, _ *gctrpc.GetPortfolioRequest) (*gctrpc.GetPortfolioResponse, error) {
-	var addrs []*gctrpc.PortfolioAddress
 	botAddrs := s.portfolioManager.GetAddresses()
+	addrs := make([]*gctrpc.PortfolioAddress, len(botAddrs))
 	for x := range botAddrs {
-		addrs = append(addrs, &gctrpc.PortfolioAddress{
+		addrs[x] = &gctrpc.PortfolioAddress{
 			Address:     botAddrs[x].Address,
 			CoinType:    botAddrs[x].CoinType.String(),
 			Description: botAddrs[x].Description,
 			Balance:     botAddrs[x].Balance,
-		})
+		}
 	}
 
 	resp := &gctrpc.GetPortfolioResponse{
@@ -838,9 +834,9 @@ func (s *RPCServer) GetForexProviders(_ context.Context, _ *gctrpc.GetForexProvi
 		return nil, fmt.Errorf("forex providers is empty")
 	}
 
-	var forexProviders []*gctrpc.ForexProvider
+	forexProviders := make([]*gctrpc.ForexProvider, len(providers))
 	for x := range providers {
-		forexProviders = append(forexProviders, &gctrpc.ForexProvider{
+		forexProviders[x] = &gctrpc.ForexProvider{
 			Name:             providers[x].Name,
 			Enabled:          providers[x].Enabled,
 			Verbose:          providers[x].Verbose,
@@ -848,7 +844,7 @@ func (s *RPCServer) GetForexProviders(_ context.Context, _ *gctrpc.GetForexProvi
 			ApiKey:           providers[x].APIKey,
 			ApiKeyLevel:      int64(providers[x].APIKeyLvl),
 			PrimaryProvider:  providers[x].PrimaryProvider,
-		})
+		}
 	}
 	return &gctrpc.GetForexProvidersResponse{ForexProviders: forexProviders}, nil
 }
@@ -864,7 +860,7 @@ func (s *RPCServer) GetForexRates(_ context.Context, _ *gctrpc.GetForexRatesRequ
 		return nil, fmt.Errorf("forex rates is empty")
 	}
 
-	var forexRates []*gctrpc.ForexRatesConversion
+	forexRates := make([]*gctrpc.ForexRatesConversion, 0, len(rates))
 	for x := range rates {
 		rate, err := rates[x].GetRate()
 		if err != nil {
@@ -952,9 +948,9 @@ func (s *RPCServer) GetOrders(ctx context.Context, r *gctrpc.GetOrdersRequest) (
 		return nil, err
 	}
 
-	var orders []*gctrpc.OrderDetails
+	orders := make([]*gctrpc.OrderDetails, len(resp))
 	for x := range resp {
-		var trades []*gctrpc.TradeHistory
+		trades := make([]*gctrpc.TradeHistory, len(resp[x].Trades))
 		for i := range resp[x].Trades {
 			t := &gctrpc.TradeHistory{
 				Id:        resp[x].Trades[i].TID,
@@ -969,7 +965,7 @@ func (s *RPCServer) GetOrders(ctx context.Context, r *gctrpc.GetOrdersRequest) (
 			if !resp[x].Trades[i].Timestamp.IsZero() {
 				t.CreationTime = s.unixTimestamp(resp[x].Trades[i].Timestamp)
 			}
-			trades = append(trades, t)
+			trades[i] = t
 		}
 		o := &gctrpc.OrderDetails{
 			Exchange:      r.Exchange,
@@ -994,7 +990,7 @@ func (s *RPCServer) GetOrders(ctx context.Context, r *gctrpc.GetOrdersRequest) (
 		if !resp[x].LastUpdated.IsZero() {
 			o.UpdateTime = s.unixTimestamp(resp[x].LastUpdated)
 		}
-		orders = append(orders, o)
+		orders[x] = o
 	}
 
 	return &gctrpc.GetOrdersResponse{Orders: orders}, nil
@@ -1041,9 +1037,9 @@ func (s *RPCServer) GetManagedOrders(_ context.Context, r *gctrpc.GetOrdersReque
 		return nil, err
 	}
 
-	var orders []*gctrpc.OrderDetails
+	orders := make([]*gctrpc.OrderDetails, len(resp))
 	for x := range resp {
-		var trades []*gctrpc.TradeHistory
+		trades := make([]*gctrpc.TradeHistory, len(resp[x].Trades))
 		for i := range resp[x].Trades {
 			t := &gctrpc.TradeHistory{
 				Id:        resp[x].Trades[i].TID,
@@ -1058,7 +1054,7 @@ func (s *RPCServer) GetManagedOrders(_ context.Context, r *gctrpc.GetOrdersReque
 			if !resp[x].Trades[i].Timestamp.IsZero() {
 				t.CreationTime = s.unixTimestamp(resp[x].Trades[i].Timestamp)
 			}
-			trades = append(trades, t)
+			trades[i] = t
 		}
 		o := &gctrpc.OrderDetails{
 			Exchange:      r.Exchange,
@@ -1083,7 +1079,7 @@ func (s *RPCServer) GetManagedOrders(_ context.Context, r *gctrpc.GetOrdersReque
 		if !resp[x].LastUpdated.IsZero() {
 			o.UpdateTime = s.unixTimestamp(resp[x].LastUpdated)
 		}
-		orders = append(orders, o)
+		orders[x] = o
 	}
 
 	return &gctrpc.GetOrdersResponse{Orders: orders}, nil
@@ -1128,9 +1124,9 @@ func (s *RPCServer) GetOrder(ctx context.Context, r *gctrpc.GetOrderRequest) (*g
 	if err != nil {
 		return nil, fmt.Errorf("error whilst trying to retrieve info for order %s: %w", r.OrderId, err)
 	}
-	var trades []*gctrpc.TradeHistory
+	trades := make([]*gctrpc.TradeHistory, len(result.Trades))
 	for i := range result.Trades {
-		trades = append(trades, &gctrpc.TradeHistory{
+		trades[i] = &gctrpc.TradeHistory{
 			CreationTime: s.unixTimestamp(result.Trades[i].Timestamp),
 			Id:           result.Trades[i].TID,
 			Price:        result.Trades[i].Price,
@@ -1140,7 +1136,7 @@ func (s *RPCServer) GetOrder(ctx context.Context, r *gctrpc.GetOrderRequest) (*g
 			OrderSide:    result.Trades[i].Side.String(),
 			Fee:          result.Trades[i].Fee,
 			Total:        result.Trades[i].Total,
-		})
+		}
 	}
 
 	var creationTime, updateTime int64
@@ -1217,14 +1213,14 @@ func (s *RPCServer) SubmitOrder(ctx context.Context, r *gctrpc.SubmitOrderReques
 		return &gctrpc.SubmitOrderResponse{}, err
 	}
 
-	var trades []*gctrpc.Trades
+	trades := make([]*gctrpc.Trades, len(resp.Trades))
 	for i := range resp.Trades {
-		trades = append(trades, &gctrpc.Trades{
+		trades[i] = &gctrpc.Trades{
 			Amount:   resp.Trades[i].Amount,
 			Price:    resp.Trades[i].Price,
 			Fee:      resp.Trades[i].Fee,
 			FeeAsset: resp.Trades[i].FeeAsset,
-		})
+		}
 	}
 
 	return &gctrpc.SubmitOrderResponse{
@@ -1408,18 +1404,19 @@ func (s *RPCServer) CancelBatchOrders(ctx context.Context, r *gctrpc.CancelBatch
 	}
 
 	status := make(map[string]string)
-	var request []order.Cancel
 	orders := strings.Split(r.OrdersId, ",")
-	for _, orderID := range orders {
+	request := make([]order.Cancel, len(orders))
+	for x := range orders {
+		orderID := orders[x]
 		status[orderID] = order.Cancelled.String()
-		request = append(request, order.Cancel{
+		request[x] = order.Cancel{
 			AccountID:     r.AccountId,
 			ID:            orderID,
 			Side:          order.Side(r.Side),
 			WalletAddress: r.WalletAddress,
 			Pair:          pair,
 			AssetType:     assetType,
-		})
+		}
 	}
 
 	// TODO: Change to order manager
@@ -2118,12 +2115,7 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 			return errDispatchSystem
 		}
 
-		d := *data.(*interface{})
-		if d == nil {
-			return errors.New("unable to type assert data")
-		}
-
-		ob, ok := d.(orderbook.Base)
+		ob, ok := data.(orderbook.Base)
 		if !ok {
 			return errors.New("unable to type assert orderbook data")
 		}
@@ -2201,12 +2193,7 @@ func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gct
 			return errDispatchSystem
 		}
 
-		d := *data.(*interface{})
-		if d == nil {
-			return errors.New("unable to type assert data")
-		}
-
-		t, ok := d.(ticker.Price)
+		t, ok := data.(ticker.Price)
 		if !ok {
 			return errors.New("unable to type assert ticker data")
 		}
@@ -2259,12 +2246,7 @@ func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamReq
 			return errDispatchSystem
 		}
 
-		d := *data.(*interface{})
-		if d == nil {
-			return errors.New("unable to type assert data")
-		}
-
-		t, ok := d.(ticker.Price)
+		t, ok := data.(ticker.Price)
 		if !ok {
 			return errors.New("unable to type assert ticker data")
 		}
@@ -2453,16 +2435,16 @@ func (s *RPCServer) GetHistoricCandles(ctx context.Context, r *gctrpc.GetHistori
 }
 
 func fillMissingCandlesWithStoredTrades(startTime, endTime time.Time, klineItem *kline.Item) (*kline.Item, error) {
-	var response kline.Item
-	var candleTimes []time.Time
+	candleTimes := make([]time.Time, len(klineItem.Candles))
 	for i := range klineItem.Candles {
-		candleTimes = append(candleTimes, klineItem.Candles[i].Time)
+		candleTimes[i] = klineItem.Candles[i].Time
 	}
 	ranges, err := timeperiods.FindTimeRangesContainingData(startTime, endTime, klineItem.Interval.Duration(), candleTimes)
 	if err != nil {
 		return nil, err
 	}
 
+	var response kline.Item
 	for i := range ranges {
 		if ranges[i].HasDataInRange {
 			continue
@@ -2553,16 +2535,20 @@ func (s *RPCServer) GCTScriptQuery(_ context.Context, r *gctrpc.GCTScriptQueryRe
 	}
 
 	if v, f := gctscript.AllVMSync.Load(UUID); f {
+		vm, ok := v.(*gctscript.VM)
+		if !ok {
+			return nil, errors.New("unable to type assert gctscript.VM")
+		}
 		resp := &gctrpc.GCTScriptQueryResponse{
 			Status: MsgStatusOK,
 			Script: &gctrpc.GCTScript{
-				Name:    v.(*gctscript.VM).ShortName(),
-				UUID:    v.(*gctscript.VM).ID.String(),
-				Path:    v.(*gctscript.VM).Path,
-				NextRun: v.(*gctscript.VM).NextRun.String(),
+				Name:    vm.ShortName(),
+				UUID:    vm.ID.String(),
+				Path:    vm.Path,
+				NextRun: vm.NextRun.String(),
 			},
 		}
-		data, err := v.(*gctscript.VM).Read()
+		data, err := vm.Read()
 		if err != nil {
 			return nil, err
 		}
@@ -2615,12 +2601,16 @@ func (s *RPCServer) GCTScriptStop(_ context.Context, r *gctrpc.GCTScriptStopRequ
 	}
 
 	if v, f := gctscript.AllVMSync.Load(UUID); f {
-		err = v.(*gctscript.VM).Shutdown()
+		vm, ok := v.(*gctscript.VM)
+		if !ok {
+			return nil, errors.New("unable to type assert gctscript.VM")
+		}
+		err = vm.Shutdown()
 		status := " terminated"
 		if err != nil {
 			status = " " + err.Error()
 		}
-		return &gctrpc.GenericResponse{Status: MsgStatusOK, Data: v.(*gctscript.VM).ID.String() + status}, nil
+		return &gctrpc.GenericResponse{Status: MsgStatusOK, Data: vm.ID.String() + status}, nil
 	}
 	return &gctrpc.GenericResponse{Status: MsgStatusError, Data: "no running script found"}, nil
 }
@@ -2642,7 +2632,7 @@ func (s *RPCServer) GCTScriptUpload(_ context.Context, r *gctrpc.GCTScriptUpload
 			return nil, fmt.Errorf("%s script found and overwrite set to false", r.ScriptName)
 		}
 		f := filepath.Join(gctscript.ScriptPath, "version_history")
-		err = os.MkdirAll(f, 0770)
+		err = os.MkdirAll(f, 0o770)
 		if err != nil {
 			return nil, err
 		}
@@ -2726,7 +2716,7 @@ func (s *RPCServer) GCTScriptReadScript(_ context.Context, r *gctrpc.GCTScriptRe
 	if !strings.HasPrefix(filename, filepath.Clean(gctscript.ScriptPath)+string(os.PathSeparator)) {
 		return nil, fmt.Errorf("%s: invalid file path", filename)
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -3271,9 +3261,9 @@ func (s *RPCServer) FindMissingSavedCandleIntervals(_ context.Context, r *gctrpc
 		Pair:           r.Pair,
 		MissingPeriods: []string{},
 	}
-	var candleTimes []time.Time
+	candleTimes := make([]time.Time, len(klineItem.Candles))
 	for i := range klineItem.Candles {
-		candleTimes = append(candleTimes, klineItem.Candles[i].Time)
+		candleTimes[i] = klineItem.Candles[i].Time
 	}
 	var ranges []timeperiods.TimeRange
 	ranges, err = timeperiods.FindTimeRangesContainingData(start, end, klineItem.Interval.Duration(), candleTimes)
@@ -3373,9 +3363,9 @@ func (s *RPCServer) FindMissingSavedTradeIntervals(_ context.Context, r *gctrpc.
 		Pair:           r.Pair,
 		MissingPeriods: []string{},
 	}
-	var tradeTimes []time.Time
+	tradeTimes := make([]time.Time, len(trades))
 	for i := range trades {
-		tradeTimes = append(tradeTimes, trades[i].Timestamp)
+		tradeTimes[i] = trades[i].Timestamp
 	}
 	var ranges []timeperiods.TimeRange
 	ranges, err = timeperiods.FindTimeRangesContainingData(start, end, time.Hour, tradeTimes)
@@ -3892,9 +3882,9 @@ func (s *RPCServer) GetActiveDataHistoryJobs(_ context.Context, _ *gctrpc.GetInf
 		return nil, err
 	}
 
-	var response []*gctrpc.DataHistoryJob
+	response := make([]*gctrpc.DataHistoryJob, len(jobs))
 	for i := range jobs {
-		response = append(response, &gctrpc.DataHistoryJob{
+		response[i] = &gctrpc.DataHistoryJob{
 			Id:       jobs[i].ID.String(),
 			Nickname: jobs[i].Nickname,
 			Exchange: jobs[i].Exchange,
@@ -3919,7 +3909,7 @@ func (s *RPCServer) GetActiveDataHistoryJobs(_ context.Context, _ *gctrpc.GetInf
 			SecondaryExchangeName:    jobs[i].SecondaryExchangeSource,
 			IssueTolerancePercentage: jobs[i].IssueTolerancePercentage,
 			ReplaceOnIssue:           jobs[i].ReplaceOnIssue,
-		})
+		}
 	}
 	return &gctrpc.DataHistoryJobs{Results: response}, nil
 }
@@ -3946,9 +3936,9 @@ func (s *RPCServer) GetDataHistoryJobsBetween(_ context.Context, r *gctrpc.GetDa
 	if err != nil {
 		return nil, err
 	}
-	var respJobs []*gctrpc.DataHistoryJob
+	respJobs := make([]*gctrpc.DataHistoryJob, len(jobs))
 	for i := range jobs {
-		respJobs = append(respJobs, &gctrpc.DataHistoryJob{
+		respJobs[i] = &gctrpc.DataHistoryJob{
 			Id:       jobs[i].ID.String(),
 			Nickname: jobs[i].Nickname,
 			Exchange: jobs[i].Exchange,
@@ -3973,7 +3963,7 @@ func (s *RPCServer) GetDataHistoryJobsBetween(_ context.Context, r *gctrpc.GetDa
 			SecondaryExchangeName:    jobs[i].SecondaryExchangeSource,
 			IssueTolerancePercentage: jobs[i].IssueTolerancePercentage,
 			ReplaceOnIssue:           jobs[i].ReplaceOnIssue,
-		})
+		}
 	}
 	return &gctrpc.DataHistoryJobs{
 		Results: respJobs,
@@ -4309,17 +4299,15 @@ func (s *RPCServer) GetCollateral(ctx context.Context, r *gctrpc.GetCollateralRe
 	if err != nil {
 		return nil, err
 	}
-	var calculators []order.CollateralCalculator
-	var acc *account.SubAccount
-	var subAccounts []string
-
 	creds, err := exch.GetBase().GetCredentials(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	subAccounts := make([]string, len(ai.Accounts))
+	var acc *account.SubAccount
 	for i := range ai.Accounts {
-		subAccounts = append(subAccounts, ai.Accounts[i].ID)
+		subAccounts[i] = ai.Accounts[i].ID
 		if ai.Accounts[i].ID == "main" && creds.SubAccount == "" {
 			acc = &ai.Accounts[i]
 			break
@@ -4344,6 +4332,7 @@ func (s *RPCServer) GetCollateral(ctx context.Context, r *gctrpc.GetCollateralRe
 		}
 	}
 
+	calculators := make([]order.CollateralCalculator, 0, len(acc.Currencies))
 	for i := range acc.Currencies {
 		total := decimal.NewFromFloat(acc.Currencies[i].Total)
 		free := decimal.NewFromFloat(acc.Currencies[i].AvailableWithoutBorrow)

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -2637,7 +2636,7 @@ func (s *RPCServer) GCTScriptUpload(_ context.Context, r *gctrpc.GCTScriptUpload
 			return nil, fmt.Errorf("%s script found and overwrite set to false", r.ScriptName)
 		}
 		f := filepath.Join(gctscript.ScriptPath, "version_history")
-		err = os.MkdirAll(f, fs.FileMode(file.DefaultPermissionOctal))
+		err = os.MkdirAll(f, file.DefaultPermissionOctal)
 		if err != nil {
 			return nil, err
 		}

--- a/engine/withdraw_manager.go
+++ b/engine/withdraw_manager.go
@@ -99,7 +99,11 @@ func (m *WithdrawManager) WithdrawalEventByID(id string) (*withdraw.Response, er
 		return nil, ErrNilSubsystem
 	}
 	if v := withdraw.Cache.Get(id); v != nil {
-		return v.(*withdraw.Response), nil
+		wdResp, ok := v.(*withdraw.Response)
+		if !ok {
+			return nil, errors.New("unable to type assert withdraw.Response")
+		}
+		return wdResp, nil
 	}
 
 	l, err := dbwithdraw.GetEventByUUID(id)

--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -26,15 +26,13 @@ func CollectBalances(accountBalances map[string][]Balance, assetType asset.Item)
 		return nil, fmt.Errorf("%s, %w", assetType, asset.ErrNotSupported)
 	}
 
-	accounts = make([]SubAccount, len(accountBalances))
-	i := 0
+	accounts = make([]SubAccount, 0, len(accountBalances))
 	for accountID, balances := range accountBalances {
-		accounts[i] = SubAccount{
+		accounts = append(accounts, SubAccount{
 			ID:         accountID,
 			AssetType:  assetType,
 			Currencies: balances,
-		}
-		i++
+		})
 	}
 	return
 }

--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -40,16 +40,16 @@ func CollectBalances(accountBalances map[string][]Balance, assetType asset.Item)
 // SubscribeToExchangeAccount subcribes to your exchange account
 func SubscribeToExchangeAccount(exchange string) (dispatch.Pipe, error) {
 	exchange = strings.ToLower(exchange)
-	service.Lock()
+	service.mu.Lock()
 
 	acc, ok := service.accounts[exchange]
 	if !ok {
-		service.Unlock()
+		service.mu.Unlock()
 		return dispatch.Pipe{},
 			fmt.Errorf("%s exchange account holdings not found", exchange)
 	}
 
-	defer service.Unlock()
+	defer service.mu.Unlock()
 	return service.mux.Subscribe(acc.ID)
 }
 
@@ -78,8 +78,8 @@ func GetHoldings(exch string, assetType asset.Item) (Holdings, error) {
 		return Holdings{}, fmt.Errorf("assetType %v is invalid", assetType)
 	}
 
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 	h, ok := service.accounts[exch]
 	if !ok {
 		return Holdings{}, errors.New("exchange account holdings not found")
@@ -95,22 +95,22 @@ func GetHoldings(exch string, assetType asset.Item) (Holdings, error) {
 // Update updates holdings with new account info
 func (s *Service) Update(a *Holdings) error {
 	exch := strings.ToLower(a.Exchange)
-	s.Lock()
+	s.mu.Lock()
 	acc, ok := s.accounts[exch]
 	if !ok {
 		id, err := s.mux.GetID()
 		if err != nil {
-			s.Unlock()
+			s.mu.Unlock()
 			return err
 		}
 
 		s.accounts[exch] = &Account{h: a, ID: id}
-		s.Unlock()
+		s.mu.Unlock()
 		return nil
 	}
 
 	acc.h.Accounts = a.Accounts
-	defer s.Unlock()
+	defer s.mu.Unlock()
 
 	return s.mux.Publish([]uuid.UUID{acc.ID}, acc.h)
 }

--- a/exchanges/account/account_types.go
+++ b/exchanges/account/account_types.go
@@ -20,7 +20,7 @@ var (
 type Service struct {
 	accounts map[string]*Account
 	mux      *dispatch.Mux
-	sync.Mutex
+	mu       sync.Mutex
 }
 
 // Account holds a stream ID and a pointer to the exchange holdings

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -101,14 +101,14 @@ func (a *Alphapoint) UpdateAccountInfo(ctx context.Context, assetType asset.Item
 		return response, err
 	}
 
-	var balances []account.Balance
+	balances := make([]account.Balance, len(acc.Currencies))
 	for i := range acc.Currencies {
-		balances = append(balances, account.Balance{
+		balances[i] = account.Balance{
 			CurrencyName: currency.NewCode(acc.Currencies[i].Name),
 			Total:        float64(acc.Currencies[i].Balance),
 			Hold:         float64(acc.Currencies[i].Hold),
 			Free:         float64(acc.Currencies[i].Balance) - float64(acc.Currencies[i].Hold),
-		})
+		}
 	}
 
 	response.Accounts = append(response.Accounts, account.SubAccount{

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -181,18 +181,20 @@ func (a *Alphapoint) UpdateOrderbook(ctx context.Context, p currency.Pair, asset
 		return orderBook, err
 	}
 
+	orderBook.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		orderBook.Bids = append(orderBook.Bids, orderbook.Item{
+		orderBook.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Quantity,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
 
+	orderBook.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		orderBook.Asks = append(orderBook.Asks, orderbook.Item{
+		orderBook.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Quantity,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 
 	orderBook.Pair = p

--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -60,9 +60,9 @@ func (a Item) String() string {
 
 // Strings converts an asset type array to a string array
 func (a Items) Strings() []string {
-	var assets []string
+	assets := make([]string, len(a))
 	for x := range a {
-		assets = append(assets, string(a[x]))
+		assets[x] = a[x].String()
 	}
 	return assets
 }

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -82,10 +82,18 @@ func (b *Binance) FuturesExchangeInfo(ctx context.Context) (CExchangeInfo, error
 }
 
 // GetFuturesOrderbook gets orderbook data for CoinMarginedFutures,
-func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair, limit int64) (OrderBook, error) {
-	var resp OrderBook
-	var data OrderbookData
+func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair, limit int64) (*OrderBook, error) {
+	symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
+	if err != nil {
+		return nil, err
+	}
+
 	params := url.Values{}
+	params.Set("symbol", symbolValue)
+	if limit > 0 && limit <= 1000 {
+		params.Set("limit", strconv.FormatInt(limit, 10))
+	}
+
 	rateBudget := cFuturesDefaultRate
 	switch {
 	case limit == 5, limit == 10, limit == 20, limit == 50:
@@ -97,48 +105,47 @@ func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair,
 	case limit == 1000:
 		rateBudget = cFuturesOrderbook1000Rate
 	}
-	symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
-	if err != nil {
-		return resp, err
-	}
-	params.Set("symbol", symbolValue)
-	if limit > 0 && limit <= 1000 {
-		params.Set("limit", strconv.FormatInt(limit, 10))
-	}
+
+	var data OrderbookData
 	err = b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesOrderbook+params.Encode(), rateBudget, &data)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
+
+	var resp OrderBook
 	var price, quantity float64
+	resp.Asks = make([]OrderbookItem, len(data.Asks))
 	for x := range data.Asks {
 		price, err = strconv.ParseFloat(data.Asks[x][0], 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		quantity, err = strconv.ParseFloat(data.Asks[x][1], 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
-		resp.Asks = append(resp.Asks, OrderbookItem{
+		resp.Asks[x] = OrderbookItem{
 			Price:    price,
 			Quantity: quantity,
-		})
+		}
 	}
+
+	resp.Bids = make([]OrderbookItem, len(data.Bids))
 	for y := range data.Bids {
 		price, err = strconv.ParseFloat(data.Bids[y][0], 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		quantity, err = strconv.ParseFloat(data.Bids[y][1], 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
-		resp.Bids = append(resp.Bids, OrderbookItem{
+		resp.Bids[y] = OrderbookItem{
 			Price:    price,
 			Quantity: quantity,
-		})
+		}
 	}
-	return resp, nil
+	return &resp, nil
 }
 
 // GetFuturesPublicTrades gets recent public trades for CoinMarginedFutures,

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -232,13 +232,11 @@ func (b *Binance) GetIndexAndMarkPrice(ctx context.Context, symbol, pair string)
 
 // GetFuturesKlineData gets futures kline data for CoinMarginedFutures,
 func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair, interval string, limit int64, startTime, endTime time.Time) ([]FuturesCandleStick, error) {
-	var data [][10]interface{}
-	var resp []FuturesCandleStick
 	params := url.Values{}
 	if !symbol.IsEmpty() {
 		symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		params.Set("symbol", symbolValue)
 	}
@@ -246,453 +244,462 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
 	if !common.StringDataCompare(validFuturesIntervals, interval) {
-		return resp, errors.New("invalid interval parsed")
+		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
 		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
+			return nil, errors.New("startTime cannot be after endTime")
 		}
 		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
 		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
 	}
+
+	var data [][10]interface{}
 	rateBudget := getKlineRateBudget(limit)
 	err := b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesKlineData+params.Encode(), rateBudget, &data)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	var floatData float64
-	var strData string
-	var ok bool
-	var tempData FuturesCandleStick
+
+	resp := make([]FuturesCandleStick, len(data))
 	for x := range data {
+		var floatData float64
+		var strData string
+		var ok bool
+		var tempData FuturesCandleStick
 		floatData, ok = data[x][0].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for open time")
+			return nil, errors.New("type assertion failed for open time")
 		}
 		tempData.OpenTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][1].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for open")
+			return nil, errors.New("type assertion failed for open")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Open = floatData
 		strData, ok = data[x][2].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for high")
+			return nil, errors.New("type assertion failed for high")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.High = floatData
 		strData, ok = data[x][3].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for low")
+			return nil, errors.New("type assertion failed for low")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Low = floatData
 		strData, ok = data[x][4].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for close")
+			return nil, errors.New("type assertion failed for close")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Close = floatData
 		strData, ok = data[x][5].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for volume")
+			return nil, errors.New("type assertion failed for volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Volume = floatData
 		floatData, ok = data[x][6].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for close time")
+			return nil, errors.New("type assertion failed for close time")
 		}
 		tempData.CloseTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][7].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for base asset volume")
+			return nil, errors.New("type assertion failed for base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.BaseAssetVolume = floatData
 		floatData, ok = data[x][8].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy volume")
+			return nil, errors.New("type assertion failed for taker buy volume")
 		}
 		tempData.TakerBuyVolume = floatData
 		strData, ok = data[x][9].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy base asset volume")
+			return nil, errors.New("type assertion failed for taker buy base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.TakerBuyBaseAssetVolume = floatData
-		resp = append(resp, tempData)
+		resp[x] = tempData
 	}
 	return resp, nil
 }
 
 // GetContinuousKlineData gets continuous kline data
 func (b *Binance) GetContinuousKlineData(ctx context.Context, pair, contractType, interval string, limit int64, startTime, endTime time.Time) ([]FuturesCandleStick, error) {
-	var data [][10]interface{}
-	var resp []FuturesCandleStick
 	params := url.Values{}
 	params.Set("pair", pair)
 	if !common.StringDataCompare(validContractType, contractType) {
-		return resp, errors.New("invalid contractType")
+		return nil, errors.New("invalid contractType")
 	}
 	params.Set("contractType", contractType)
 	if limit > 0 && limit <= 1500 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
 	if !common.StringDataCompare(validFuturesIntervals, interval) {
-		return resp, errors.New("invalid interval parsed")
+		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
 		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
+			return nil, errors.New("startTime cannot be after endTime")
 		}
 		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
 		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	rateBudget := getKlineRateBudget(limit)
+	var data [][10]interface{}
 	err := b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesContinuousKline+params.Encode(), rateBudget, &data)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	var floatData float64
-	var strData string
-	var ok bool
-	var tempData FuturesCandleStick
+
+	resp := make([]FuturesCandleStick, len(data))
 	for x := range data {
+		var floatData float64
+		var strData string
+		var ok bool
+		var tempData FuturesCandleStick
 		floatData, ok = data[x][0].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for open time")
+			return nil, errors.New("type assertion failed for open time")
 		}
 		tempData.OpenTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][1].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for open")
+			return nil, errors.New("type assertion failed for open")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Open = floatData
 		strData, ok = data[x][2].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for high")
+			return nil, errors.New("type assertion failed for high")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.High = floatData
 		strData, ok = data[x][3].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for low")
+			return nil, errors.New("type assertion failed for low")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Low = floatData
 		strData, ok = data[x][4].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for close")
+			return nil, errors.New("type assertion failed for close")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Close = floatData
 		strData, ok = data[x][5].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for volume")
+			return nil, errors.New("type assertion failed for volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Volume = floatData
 		floatData, ok = data[x][6].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for close time")
+			return nil, errors.New("type assertion failed for close time")
 		}
 		tempData.CloseTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][7].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for base asset volume")
+			return nil, errors.New("type assertion failed for base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.BaseAssetVolume = floatData
 		floatData, ok = data[x][8].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy volume")
+			return nil, errors.New("type assertion failed for taker buy volume")
 		}
 		tempData.TakerBuyVolume = floatData
 		strData, ok = data[x][9].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy base asset volume")
+			return nil, errors.New("type assertion failed for taker buy base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.TakerBuyBaseAssetVolume = floatData
-		resp = append(resp, tempData)
+		resp[x] = tempData
 	}
 	return resp, nil
 }
 
 // GetIndexPriceKlines gets continuous kline data
 func (b *Binance) GetIndexPriceKlines(ctx context.Context, pair, interval string, limit int64, startTime, endTime time.Time) ([]FuturesCandleStick, error) {
-	var data [][10]interface{}
-	var resp []FuturesCandleStick
 	params := url.Values{}
 	params.Set("pair", pair)
 	if limit > 0 && limit <= 1500 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
 	if !common.StringDataCompare(validFuturesIntervals, interval) {
-		return resp, errors.New("invalid interval parsed")
+		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
 		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
+			return nil, errors.New("startTime cannot be after endTime")
 		}
 		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
 		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
 	}
+
 	rateBudget := getKlineRateBudget(limit)
+	var data [][10]interface{}
 	err := b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesIndexKline+params.Encode(), rateBudget, &data)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	var floatData float64
-	var strData string
-	var ok bool
-	var tempData FuturesCandleStick
+
+	resp := make([]FuturesCandleStick, len(data))
 	for x := range data {
+		var floatData float64
+		var strData string
+		var ok bool
+		var tempData FuturesCandleStick
 		floatData, ok = data[x][0].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for open time")
+			return nil, errors.New("type assertion failed for open time")
 		}
 		tempData.OpenTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][1].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for open")
+			return nil, errors.New("type assertion failed for open")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Open = floatData
 		strData, ok = data[x][2].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for high")
+			return nil, errors.New("type assertion failed for high")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.High = floatData
 		strData, ok = data[x][3].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for low")
+			return nil, errors.New("type assertion failed for low")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Low = floatData
 		strData, ok = data[x][4].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for close")
+			return nil, errors.New("type assertion failed for close")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Close = floatData
 		strData, ok = data[x][5].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for volume")
+			return nil, errors.New("type assertion failed for volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Volume = floatData
 		floatData, ok = data[x][6].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for close time")
+			return nil, errors.New("type assertion failed for close time")
 		}
 		tempData.CloseTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][7].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for base asset volume")
+			return nil, errors.New("type assertion failed for base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.BaseAssetVolume = floatData
 		floatData, ok = data[x][8].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy volume")
+			return nil, errors.New("type assertion failed for taker buy volume")
 		}
 		tempData.TakerBuyVolume = floatData
 		strData, ok = data[x][9].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy base asset volume")
+			return nil, errors.New("type assertion failed for taker buy base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.TakerBuyBaseAssetVolume = floatData
-		resp = append(resp, tempData)
+		resp[x] = tempData
 	}
 	return resp, nil
 }
 
 // GetMarkPriceKline gets mark price kline data
 func (b *Binance) GetMarkPriceKline(ctx context.Context, symbol currency.Pair, interval string, limit int64, startTime, endTime time.Time) ([]FuturesCandleStick, error) {
-	var data [][10]interface{}
-	var resp []FuturesCandleStick
-	params := url.Values{}
 	symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
+	params := url.Values{}
 	params.Set("symbol", symbolValue)
 	if limit > 0 && limit <= 1500 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
 	if !common.StringDataCompare(validFuturesIntervals, interval) {
-		return resp, errors.New("invalid interval parsed")
+		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
 		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
+			return nil, errors.New("startTime cannot be after endTime")
 		}
 		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
 		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
 	}
+
+	var data [][10]interface{}
 	rateBudget := getKlineRateBudget(limit)
 	err = b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesMarkPriceKline+params.Encode(), rateBudget, &data)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	var floatData float64
-	var strData string
-	var ok bool
-	var tempData FuturesCandleStick
+
+	resp := make([]FuturesCandleStick, len(data))
 	for x := range data {
+		var floatData float64
+		var strData string
+		var ok bool
+		var tempData FuturesCandleStick
 		floatData, ok = data[x][0].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for open time")
+			return nil, errors.New("type assertion failed for open time")
 		}
 		tempData.OpenTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][1].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for open")
+			return nil, errors.New("type assertion failed for open")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Open = floatData
 		strData, ok = data[x][2].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for high")
+			return nil, errors.New("type assertion failed for high")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.High = floatData
 		strData, ok = data[x][3].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for low")
+			return nil, errors.New("type assertion failed for low")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Low = floatData
 		strData, ok = data[x][4].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for close")
+			return nil, errors.New("type assertion failed for close")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Close = floatData
 		strData, ok = data[x][5].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for volume")
+			return nil, errors.New("type assertion failed for volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.Volume = floatData
 		floatData, ok = data[x][6].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for close time")
+			return nil, errors.New("type assertion failed for close time")
 		}
 		tempData.CloseTime = time.Unix(int64(floatData), 0)
 		strData, ok = data[x][7].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for base asset volume")
+			return nil, errors.New("type assertion failed for base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.BaseAssetVolume = floatData
 		floatData, ok = data[x][8].(float64)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy volume")
+			return nil, errors.New("type assertion failed for taker buy volume")
 		}
 		tempData.TakerBuyVolume = floatData
 		strData, ok = data[x][9].(string)
 		if !ok {
-			return resp, errors.New("type assertion failed for taker buy base asset volume")
+			return nil, errors.New("type assertion failed for taker buy base asset volume")
 		}
 		floatData, err = strconv.ParseFloat(strData, 64)
 		if err != nil {
-			return resp, err
+			return nil, err
 		}
 		tempData.TakerBuyBaseAssetVolume = floatData
-		resp = append(resp, tempData)
+		resp[x] = tempData
 	}
 	return resp, nil
 }
@@ -1466,12 +1473,12 @@ func (b *Binance) FuturesPositionsADLEstimate(ctx context.Context, symbol curren
 
 // FetchCoinMarginExchangeLimits fetches coin margined order execution limits
 func (b *Binance) FetchCoinMarginExchangeLimits(ctx context.Context) ([]order.MinMaxLevel, error) {
-	var limits []order.MinMaxLevel
 	coinFutures, err := b.FuturesExchangeInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	limits := make([]order.MinMaxLevel, 0, len(coinFutures.Symbols))
 	for x := range coinFutures.Symbols {
 		symbol := strings.Split(coinFutures.Symbols[x].Symbol, currency.UnderscoreDelimiter)
 		var cp currency.Pair

--- a/exchanges/binance/binance_live_test.go
+++ b/exchanges/binance/binance_live_test.go
@@ -36,6 +36,7 @@ func TestMain(m *testing.M) {
 		log.Fatal("Binance setup error", err)
 	}
 	b.setupOrderbookManager()
+	request.MaxRequestJobs = 100
 	b.Websocket.DataHandler = sharedtestvalues.GetWebsocketInterfaceChannelOverride()
 	log.Printf(sharedtestvalues.LiveTesting, b.Name)
 	os.Exit(m.Run())

--- a/exchanges/binance/binance_mock_test.go
+++ b/exchanges/binance/binance_mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/mock"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 )
 
@@ -57,6 +58,7 @@ func TestMain(m *testing.M) {
 			log.Fatal(err)
 		}
 	}
+	request.MaxRequestJobs = 100
 	log.Printf(sharedtestvalues.MockTesting, b.Name)
 	os.Exit(m.Run())
 }

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -482,31 +482,32 @@ func (b *Binance) SeedLocalCache(ctx context.Context, p currency.Pair) error {
 	if err != nil {
 		return err
 	}
-	return b.SeedLocalCacheWithBook(p, &ob)
+	return b.SeedLocalCacheWithBook(p, ob)
 }
 
 // SeedLocalCacheWithBook seeds the local orderbook cache
 func (b *Binance) SeedLocalCacheWithBook(p currency.Pair, orderbookNew *OrderBook) error {
-	var newOrderBook orderbook.Base
+	newOrderBook := orderbook.Base{
+		Pair:            p,
+		Asset:           asset.Spot,
+		Exchange:        b.Name,
+		LastUpdateID:    orderbookNew.LastUpdateID,
+		VerifyOrderbook: b.CanVerifyOrderbook,
+		Bids:            make(orderbook.Items, len(orderbookNew.Bids)),
+		Asks:            make(orderbook.Items, len(orderbookNew.Asks)),
+	}
 	for i := range orderbookNew.Bids {
-		newOrderBook.Bids = append(newOrderBook.Bids, orderbook.Item{
+		newOrderBook.Bids[i] = orderbook.Item{
 			Amount: orderbookNew.Bids[i].Quantity,
 			Price:  orderbookNew.Bids[i].Price,
-		})
+		}
 	}
 	for i := range orderbookNew.Asks {
-		newOrderBook.Asks = append(newOrderBook.Asks, orderbook.Item{
+		newOrderBook.Asks[i] = orderbook.Item{
 			Amount: orderbookNew.Asks[i].Quantity,
 			Price:  orderbookNew.Asks[i].Price,
-		})
+		}
 	}
-
-	newOrderBook.Pair = p
-	newOrderBook.Asset = asset.Spot
-	newOrderBook.Exchange = b.Name
-	newOrderBook.LastUpdateID = orderbookNew.LastUpdateID
-	newOrderBook.VerifyOrderbook = b.CanVerifyOrderbook
-
 	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }
 

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -626,7 +626,7 @@ func (b *Binance) Unsubscribe(channelsToUnsubscribe []stream.ChannelSubscription
 
 // ProcessUpdate processes the websocket orderbook update
 func (b *Binance) ProcessUpdate(cp currency.Pair, a asset.Item, ws *WebsocketDepthStream) error {
-	var updateBid []orderbook.Item
+	updateBid := make([]orderbook.Item, len(ws.UpdateBids))
 	for i := range ws.UpdateBids {
 		price, ok := ws.UpdateBids[i][0].(string)
 		if !ok {
@@ -644,10 +644,10 @@ func (b *Binance) ProcessUpdate(cp currency.Pair, a asset.Item, ws *WebsocketDep
 		if err != nil {
 			return err
 		}
-		updateBid = append(updateBid, orderbook.Item{Price: p, Amount: a})
+		updateBid[i] = orderbook.Item{Price: p, Amount: a}
 	}
 
-	var updateAsk []orderbook.Item
+	updateAsk := make([]orderbook.Item, len(ws.UpdateAsks))
 	for i := range ws.UpdateAsks {
 		price, ok := ws.UpdateAsks[i][0].(string)
 		if !ok {
@@ -665,7 +665,7 @@ func (b *Binance) ProcessUpdate(cp currency.Pair, a asset.Item, ws *WebsocketDep
 		if err != nil {
 			return err
 		}
-		updateAsk = append(updateAsk, orderbook.Item{Price: p, Amount: a})
+		updateAsk[i] = orderbook.Item{Price: p, Amount: a}
 	}
 
 	return b.Websocket.Orderbook.Update(&buffer.Update{

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -657,7 +657,7 @@ func (b *Binance) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTyp
 		Asset:           assetType,
 		VerifyOrderbook: b.CanVerifyOrderbook,
 	}
-	var orderbookNew OrderBook
+	var orderbookNew *OrderBook
 	var err error
 	switch assetType {
 	case asset.Spot, asset.Margin:
@@ -673,17 +673,20 @@ func (b *Binance) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTyp
 	if err != nil {
 		return book, err
 	}
+
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Quantity,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Quantity,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 
 	err = book.Process()

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -834,15 +834,16 @@ func (b *Binance) GetWithdrawalsHistory(ctx context.Context, c currency.Code) (r
 
 // GetRecentTrades returns the most recent trades for a currency and asset
 func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, assetType asset.Item) ([]trade.Data, error) {
-	var resp []trade.Data
-	limit := 1000
+	const limit = 1000
 	tradeData, err := b.GetMostRecentTrades(ctx,
 		RecentTradeRequestParams{p, limit})
 	if err != nil {
 		return nil, err
 	}
+
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			TID:          strconv.FormatInt(tradeData[i].ID, 10),
 			Exchange:     b.Name,
 			CurrencyPair: p,
@@ -850,7 +851,7 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, assetTyp
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Quantity,
 			Timestamp:    tradeData[i].Time,
-		})
+		}
 	}
 	if b.IsSaveTradeDataEnabled() {
 		err := trade.AddTradesToBuffer(b.Name, resp...)
@@ -874,11 +875,11 @@ func (b *Binance) GetHistoricTrades(ctx context.Context, p currency.Pair, a asse
 	if err != nil {
 		return nil, err
 	}
-	var result []trade.Data
+	result := make([]trade.Data, len(trades))
 	exName := b.GetName()
 	for i := range trades {
 		t := trades[i].toTradeData(p, exName, a)
-		result = append(result, *t)
+		result[i] = *t
 	}
 	return result, nil
 }

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1020,7 +1020,7 @@ func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, sta
 			if !ok {
 				return nil, errors.New("unable to type assert timestamp")
 			}
-			c.Timestamp = time.Unix(int64(timestamp/1000), 0)
+			c.Timestamp = time.UnixMilli(int64(timestamp))
 			if c.Open, ok = response[i][1].(float64); !ok {
 				return nil, errors.New("unable to type assert open")
 			}
@@ -1059,7 +1059,7 @@ func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, sta
 	if !ok {
 		return nil, errors.New("unable to type assert timestamp")
 	}
-	c.Timestamp = time.Unix(int64(timestamp/1000), 0)
+	c.Timestamp = time.UnixMilli(int64(timestamp))
 	if c.Open, ok = response[1].(float64); !ok {
 		return nil, errors.New("unable to type assert open")
 	}

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -526,82 +526,198 @@ func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]Ticker, error
 
 	var tickers = make(map[string]Ticker)
 	for x := range response {
+		symbol, ok := response[x][0].(string)
+		if !ok {
+			return nil, errors.New("unable to type assert symbol")
+		}
+
+		var t Ticker
 		if len(response[x]) > 11 {
-			tickers[response[x][0].(string)] = Ticker{
-				FlashReturnRate:    response[x][1].(float64),
-				Bid:                response[x][2].(float64),
-				BidPeriod:          int64(response[x][3].(float64)),
-				BidSize:            response[x][4].(float64),
-				Ask:                response[x][5].(float64),
-				AskPeriod:          int64(response[x][6].(float64)),
-				AskSize:            response[x][7].(float64),
-				DailyChange:        response[x][8].(float64),
-				DailyChangePerc:    response[x][9].(float64),
-				Last:               response[x][10].(float64),
-				Volume:             response[x][11].(float64),
-				High:               response[x][12].(float64),
-				Low:                response[x][13].(float64),
-				FFRAmountAvailable: response[x][16].(float64),
+			if t.FlashReturnRate, ok = response[x][1].(float64); !ok {
+				return nil, errors.New("unable to type assert flashReturnRate")
 			}
+			if t.Bid, ok = response[x][2].(float64); !ok {
+				return nil, errors.New("unable to type assert bid")
+			}
+			var bidPeriod float64
+			bidPeriod, ok = response[x][3].(float64)
+			if !ok {
+				return nil, errors.New("unable to type assert bidPeriod")
+			}
+			t.BidPeriod = int64(bidPeriod)
+			if t.BidSize, ok = response[x][4].(float64); !ok {
+				return nil, errors.New("unable to type assert bidSize")
+			}
+			if t.Ask, ok = response[x][5].(float64); !ok {
+				return nil, errors.New("unable to type assert ask")
+			}
+			var askPeriod float64
+			askPeriod, ok = response[x][6].(float64)
+			if !ok {
+				return nil, errors.New("unable to type assert askPeriod")
+			}
+			t.AskPeriod = int64(askPeriod)
+			if t.AskSize, ok = response[x][7].(float64); !ok {
+				return nil, errors.New("unable to type assert askSize")
+			}
+			if t.DailyChange, ok = response[x][8].(float64); !ok {
+				return nil, errors.New("unable to type assert dailyChange")
+			}
+			if t.DailyChangePerc, ok = response[x][9].(float64); !ok {
+				return nil, errors.New("unable to type assert dailyChangePerc")
+			}
+			if t.Last, ok = response[x][10].(float64); !ok {
+				return nil, errors.New("unable to type assert last")
+			}
+			if t.Volume, ok = response[x][11].(float64); !ok {
+				return nil, errors.New("unable to type assert volume")
+			}
+			if t.High, ok = response[x][12].(float64); !ok {
+				return nil, errors.New("unable to type assert high")
+			}
+			if t.Low, ok = response[x][13].(float64); !ok {
+				return nil, errors.New("unable to type assert low")
+			}
+			if t.FFRAmountAvailable, ok = response[x][16].(float64); !ok {
+				return nil, errors.New("unable to type assert FFRAmountAvailable")
+			}
+
+			tickers[symbol] = t
 			continue
 		}
-		tickers[response[x][0].(string)] = Ticker{
-			Bid:             response[x][1].(float64),
-			BidSize:         response[x][2].(float64),
-			Ask:             response[x][3].(float64),
-			AskSize:         response[x][4].(float64),
-			DailyChange:     response[x][5].(float64),
-			DailyChangePerc: response[x][6].(float64),
-			Last:            response[x][7].(float64),
-			Volume:          response[x][8].(float64),
-			High:            response[x][9].(float64),
-			Low:             response[x][10].(float64),
+
+		if t.Bid, ok = response[x][1].(float64); !ok {
+			return nil, errors.New("unable to type assert bid")
 		}
+		if t.BidSize, ok = response[x][2].(float64); !ok {
+			return nil, errors.New("unable to type assert bid size")
+		}
+		if t.Ask, ok = response[x][3].(float64); !ok {
+			return nil, errors.New("unable to type assert ask")
+		}
+		if t.AskSize, ok = response[x][4].(float64); !ok {
+			return nil, errors.New("unable to type assert ask size")
+		}
+		if t.DailyChange, ok = response[x][5].(float64); !ok {
+			return nil, errors.New("unable to type assert daily change")
+		}
+		if t.DailyChangePerc, ok = response[x][6].(float64); !ok {
+			return nil, errors.New("unable to type assert daily change perc")
+		}
+		if t.Last, ok = response[x][7].(float64); !ok {
+			return nil, errors.New("unable to type assert last")
+		}
+		if t.Volume, ok = response[x][8].(float64); !ok {
+			return nil, errors.New("unable to type assert volume")
+		}
+		if t.High, ok = response[x][9].(float64); !ok {
+			return nil, errors.New("unable to type assert high")
+		}
+		if t.Low, ok = response[x][10].(float64); !ok {
+			return nil, errors.New("unable to type assert low")
+		}
+		tickers[symbol] = t
 	}
 	return tickers, nil
 }
 
 // GetTicker returns ticker information for one symbol
-func (b *Bitfinex) GetTicker(ctx context.Context, symbol string) (Ticker, error) {
+func (b *Bitfinex) GetTicker(ctx context.Context, symbol string) (*Ticker, error) {
 	var response []interface{}
 
 	path := bitfinexAPIVersion2 + bitfinexTicker + symbol
 
 	err := b.SendHTTPRequest(ctx, exchange.RestSpot, path, &response, tickerFunction)
 	if err != nil {
-		return Ticker{}, err
+		return nil, err
 	}
 
+	var t Ticker
 	if len(response) > 10 {
-		return Ticker{
-			FlashReturnRate:    response[0].(float64),
-			Bid:                response[1].(float64),
-			BidPeriod:          int64(response[2].(float64)),
-			BidSize:            response[3].(float64),
-			Ask:                response[4].(float64),
-			AskPeriod:          int64(response[5].(float64)),
-			AskSize:            response[6].(float64),
-			DailyChange:        response[7].(float64),
-			DailyChangePerc:    response[8].(float64),
-			Last:               response[9].(float64),
-			Volume:             response[10].(float64),
-			High:               response[11].(float64),
-			Low:                response[12].(float64),
-			FFRAmountAvailable: response[15].(float64),
-		}, nil
+		var ok bool
+		if t.FlashReturnRate, ok = response[0].(float64); !ok {
+			return nil, errors.New("unable to type assert flashReturnRate")
+		}
+		if t.Bid, ok = response[1].(float64); !ok {
+			return nil, errors.New("unable to type assert bid")
+		}
+		var bidPeriod float64
+		bidPeriod, ok = response[2].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert bidPeriod")
+		}
+		t.BidPeriod = int64(bidPeriod)
+		if t.BidSize, ok = response[3].(float64); !ok {
+			return nil, errors.New("unable to type assert bidSize")
+		}
+		if t.Ask, ok = response[4].(float64); !ok {
+			return nil, errors.New("unable to type assert ask")
+		}
+		var askPeriod float64
+		askPeriod, ok = response[5].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert askPeriod")
+		}
+		t.AskPeriod = int64(askPeriod)
+		if t.AskSize, ok = response[6].(float64); !ok {
+			return nil, errors.New("unable to type assert askSize")
+		}
+		if t.DailyChange, ok = response[7].(float64); !ok {
+			return nil, errors.New("unable to type assert dailyChange")
+		}
+		if t.DailyChangePerc, ok = response[8].(float64); !ok {
+			return nil, errors.New("unable to type assert dailyChangePerc")
+		}
+		if t.Last, ok = response[9].(float64); !ok {
+			return nil, errors.New("unable to type assert last")
+		}
+		if t.Volume, ok = response[10].(float64); !ok {
+			return nil, errors.New("unable to type assert volume")
+		}
+		if t.High, ok = response[11].(float64); !ok {
+			return nil, errors.New("unable to type assert high")
+		}
+		if t.Low, ok = response[12].(float64); !ok {
+			return nil, errors.New("unable to type assert low")
+		}
+		if t.FFRAmountAvailable, ok = response[15].(float64); !ok {
+			return nil, errors.New("unable to type assert FFRAmountAvailable")
+		}
+		return &t, nil
 	}
-	return Ticker{
-		Bid:             response[0].(float64),
-		BidSize:         response[1].(float64),
-		Ask:             response[2].(float64),
-		AskSize:         response[3].(float64),
-		DailyChange:     response[4].(float64),
-		DailyChangePerc: response[5].(float64),
-		Last:            response[6].(float64),
-		Volume:          response[7].(float64),
-		High:            response[8].(float64),
-		Low:             response[9].(float64),
-	}, nil
+
+	var ok bool
+	if t.Bid, ok = response[0].(float64); !ok {
+		return nil, errors.New("unable to type assert bid")
+	}
+	if t.BidSize, ok = response[1].(float64); !ok {
+		return nil, errors.New("unable to type assert bidSize")
+	}
+	if t.Ask, ok = response[2].(float64); !ok {
+		return nil, errors.New("unable to type assert ask")
+	}
+	if t.AskSize, ok = response[3].(float64); !ok {
+		return nil, errors.New("unable to type assert askSize")
+	}
+	if t.DailyChange, ok = response[4].(float64); !ok {
+		return nil, errors.New("unable to type assert dailyChange")
+	}
+	if t.DailyChangePerc, ok = response[5].(float64); !ok {
+		return nil, errors.New("unable to type assert dailyChangePerc")
+	}
+	if t.Last, ok = response[6].(float64); !ok {
+		return nil, errors.New("unable to type assert last")
+	}
+	if t.Volume, ok = response[7].(float64); !ok {
+		return nil, errors.New("unable to type assert volume")
+	}
+	if t.High, ok = response[8].(float64); !ok {
+		return nil, errors.New("unable to type assert high")
+	}
+	if t.Low, ok = response[9].(float64); !ok {
+		return nil, errors.New("unable to type assert low")
+	}
+	return &t, nil
 }
 
 // GetTrades gets historic trades that occurred on the exchange
@@ -649,23 +765,47 @@ func (b *Bitfinex) GetTrades(ctx context.Context, currencyPair string, limit, ti
 			amount *= -1
 		}
 
+		tid, ok := resp[i][0].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert trade ID")
+		}
+		timestamp, ok := resp[i][1].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert timestamp")
+		}
+
 		if len(resp[i]) > 4 {
+			var rate float64
+			rate, ok = resp[i][3].(float64)
+			if !ok {
+				return nil, errors.New("unable to type assert rate")
+			}
+			var period float64
+			period, ok = resp[i][4].(float64)
+			if !ok {
+				return nil, errors.New("unable to type assert period")
+			}
+
 			history[i] = Trade{
-				TID:       int64(resp[i][0].(float64)),
-				Timestamp: int64(resp[i][1].(float64)),
+				TID:       int64(tid),
+				Timestamp: int64(timestamp),
 				Amount:    amount,
-				Rate:      resp[i][3].(float64),
-				Period:    int64(resp[i][4].(float64)),
+				Rate:      rate,
+				Period:    int64(period),
 				Type:      side,
 			}
 			continue
 		}
+		price, ok := resp[i][3].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert price")
+		}
 
 		history[i] = Trade{
-			TID:       int64(resp[i][0].(float64)),
-			Timestamp: int64(resp[i][1].(float64)),
+			TID:       int64(tid),
+			Timestamp: int64(timestamp),
 			Amount:    amount,
-			Price:     resp[i][3].(float64),
+			Price:     price,
 			Type:      side,
 		}
 	}
@@ -873,19 +1013,33 @@ func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, sta
 			return nil, err
 		}
 
-		var c []Candle
+		candles := make([]Candle, len(response))
 		for i := range response {
-			c = append(c, Candle{
-				Timestamp: time.Unix(int64(response[i][0].(float64)/1000), 0),
-				Open:      response[i][1].(float64),
-				Close:     response[i][2].(float64),
-				High:      response[i][3].(float64),
-				Low:       response[i][4].(float64),
-				Volume:    response[i][5].(float64),
-			})
+			var c Candle
+			timestamp, ok := response[i][0].(float64)
+			if !ok {
+				return nil, errors.New("unable to type assert timestamp")
+			}
+			c.Timestamp = time.Unix(int64(timestamp/1000), 0)
+			if c.Open, ok = response[i][1].(float64); !ok {
+				return nil, errors.New("unable to type assert open")
+			}
+			if c.Close, ok = response[i][2].(float64); !ok {
+				return nil, errors.New("unable to type assert close")
+			}
+			if c.High, ok = response[i][3].(float64); !ok {
+				return nil, errors.New("unable to type assert high")
+			}
+			if c.Low, ok = response[i][4].(float64); !ok {
+				return nil, errors.New("unable to type assert low")
+			}
+			if c.Volume, ok = response[i][5].(float64); !ok {
+				return nil, errors.New("unable to type assert volume")
+			}
+			candles[i] = c
 		}
 
-		return c, nil
+		return candles, nil
 	}
 
 	path += "/last"
@@ -900,14 +1054,29 @@ func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, sta
 		return nil, errors.New("no data returned")
 	}
 
-	return []Candle{{
-		Timestamp: time.Unix(int64(response[0].(float64))/1000, 0),
-		Open:      response[1].(float64),
-		Close:     response[2].(float64),
-		High:      response[3].(float64),
-		Low:       response[4].(float64),
-		Volume:    response[5].(float64),
-	}}, nil
+	var c Candle
+	timestamp, ok := response[0].(float64)
+	if !ok {
+		return nil, errors.New("unable to type assert timestamp")
+	}
+	c.Timestamp = time.Unix(int64(timestamp/1000), 0)
+	if c.Open, ok = response[1].(float64); !ok {
+		return nil, errors.New("unable to type assert open")
+	}
+	if c.Close, ok = response[2].(float64); !ok {
+		return nil, errors.New("unable to type assert close")
+	}
+	if c.High, ok = response[3].(float64); !ok {
+		return nil, errors.New("unable to type assert high")
+	}
+	if c.Low, ok = response[4].(float64); !ok {
+		return nil, errors.New("unable to type assert low")
+	}
+	if c.Volume, ok = response[5].(float64); !ok {
+		return nil, errors.New("unable to type assert volume")
+	}
+
+	return []Candle{c}, nil
 }
 
 // GetConfigurations fetchs currency and symbol site configuration data.

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1311,6 +1311,7 @@ func TestWsOrderSnapshot(t *testing.T) {
 }
 
 func TestWsNotifications(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
 	pressXToJSON := `[0,"n",[1575282446099,"fon-req",null,null,[41238905,null,null,null,-1000,null,null,null,null,null,null,null,null,null,0.002,2,null,null,null,null,null],null,"SUCCESS","Submitting funding bid of 1000.0 USD at 0.2000 for 2 days."]]`
 	err := b.wsHandleData([]byte(pressXToJSON))
 	if err != nil {
@@ -1320,6 +1321,82 @@ func TestWsNotifications(t *testing.T) {
 	pressXToJSON = `[0,"n",[1575287438.515,"on-req",null,null,[1185815098,null,1575287436979,"tETHUSD",1575287438515,1575287438515,-2.5,-2.5,"LIMIT",null,null,null,0,"ACTIVE",null,null,230,0,0,0,null,null,null,0,null,null,null,null,"API>BFX",null,null,null],null,"SUCCESS","Submitting limit sell order for -2.5 ETH."]]`
 	err = b.wsHandleData([]byte(pressXToJSON))
 	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSFundingOfferSnapshotAndUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	pressXToJSON := `[0,"fos",[[41237920,"fETH",1573912039000,1573912039000,0.5,0.5,"LIMIT",null,null,0,"ACTIVE",null,null,null,0.0024,2,0,0,null,0,null]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+
+	pressXToJSON = `[0,"fon",[41238747,"fUST",1575026670000,1575026670000,5000,5000,"LIMIT",null,null,0,"ACTIVE",null,null,null,0.006000000000000001,30,0,0,null,0,null]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSFundingCreditSnapshotAndUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	pressXToJSON := `[0,"fcs",[[26223578,"fUST",1,1575052261000,1575296187000,350,0,"ACTIVE",null,null,null,0,30,1575052261000,1575293487000,0,0,null,0,null,0,"tBTCUST"],[26223711,"fUSD",-1,1575291961000,1575296187000,180,0,"ACTIVE",null,null,null,0.002,7,1575282446000,1575295587000,0,0,null,0,null,0,"tETHUSD"]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+
+	pressXToJSON = `[0,"fcu",[26223578,"fUST",1,1575052261000,1575296787000,350,0,"ACTIVE",null,null,null,0,30,1575052261000,1575293487000,0,0,null,0,null,0,"tBTCUST"]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSFundingLoanSnapshotAndUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	pressXToJSON := `[0,"fls",[[2995442,"fUSD",-1,1575291961000,1575295850000,820,0,"ACTIVE",null,null,null,0.002,7,1575282446000,1575295850000,0,0,null,0,null,0]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+
+	pressXToJSON = `[0,"fln",[2995444,"fUSD",-1,1575298742000,1575298742000,1000,0,"ACTIVE",null,null,null,0.002,7,1575298742000,1575298742000,0,0,null,0,null,0]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSWalletSnapshot(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	pressXToJSON := `[0,"ws",[["exchange","SAN",19.76,0,null,null,null]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSBalanceUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	const pressXToJSON = `[0,"bu",[4131.85,4131.85]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSMarginInfoUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	const pressXToJSON = `[0,"miu",["base",[-13.014640000000007,0,49331.70267297,49318.68803297,27]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWSFundingTrade(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	pressXToJSON := `[0,"fte",[636854,"fUSD",1575282446000,41238905,-1000,0.002,7,null]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+
+	pressXToJSON = `[0,"ftu",[636854,"fUSD",1575282446000,41238905,-1000,0.002,7,null]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
 		t.Error(err)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1388,6 +1388,14 @@ func TestWSMarginInfoUpdate(t *testing.T) {
 	}
 }
 
+func TestWSFundingInfoUpdate(t *testing.T) {
+	b.WsAddSubscriptionChannel(0, "account", "N/A")
+	const pressXToJSON = `[0,"fiu",["sym","tETHUSD",[149361.09689202666,149639.26293509,830.0182168075556,895.0658432466332]]]`
+	if err := b.wsHandleData([]byte(pressXToJSON)); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestWSFundingTrade(t *testing.T) {
 	b.WsAddSubscriptionChannel(0, "account", "N/A")
 	pressXToJSON := `[0,"fte",[636854,"fUSD",1575282446000,41238905,-1000,0.002,7,null]]`

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -657,13 +657,13 @@ const (
 	wsOrderNewRequest                      = wsOrderNew + wsRequest
 	wsOrderUpdateRequest                   = wsOrderUpdate + wsRequest
 	wsOrderCancelRequest                   = wsOrderCancel + wsRequest
-	wsFundingOrderSnapshot                 = "fos"
-	wsFundingOrderNew                      = "fon"
-	wsFundingOrderUpdate                   = "fou"
-	wsFundingOrderCancel                   = "foc"
-	wsFundingOrderNewRequest               = wsFundingOrderNew + wsRequest
-	wsFundingOrderUpdateRequest            = wsFundingOrderUpdate + wsRequest
-	wsFundingOrderCancelRequest            = wsFundingOrderCancel + wsRequest
+	wsFundingOfferSnapshot                 = "fos"
+	wsFundingOfferNew                      = "fon"
+	wsFundingOfferUpdate                   = "fou"
+	wsFundingOfferCancel                   = "foc"
+	wsFundingOfferNewRequest               = wsFundingOfferNew + wsRequest
+	wsFundingOfferUpdateRequest            = wsFundingOfferUpdate + wsRequest
+	wsFundingOfferCancelRequest            = wsFundingOfferCancel + wsRequest
 	wsCancelMultipleOrders                 = "oc_multi"
 	wsBook                                 = "book"
 	wsCandles                              = "candles"
@@ -686,8 +686,8 @@ type WsAuthRequest struct {
 type WsFundingOffer struct {
 	ID             int64
 	Symbol         string
-	Created        int64
-	Updated        int64
+	Created        time.Time
+	Updated        time.Time
 	Amount         float64
 	OriginalAmount float64
 	Type           string
@@ -706,19 +706,18 @@ type WsFundingOffer struct {
 type WsCredit struct {
 	ID           int64
 	Symbol       string
-	Side         string
-	Created      int64
-	Updated      int64
+	Side         int8 // 1 if you are the lender, 0 if you are both the lender and borrower, -1 if you're the borrower
+	Created      time.Time
+	Updated      time.Time
 	Amount       float64
-	Flags        interface{}
+	Flags        interface{} // Future params object (stay tuned)
 	Status       string
 	Rate         float64
 	Period       int64
-	Opened       int64
-	LastPayout   int64
+	Opened       time.Time
+	LastPayout   time.Time
 	Notify       bool
 	Hidden       bool
-	Insure       bool
 	Renew        bool
 	RateReal     float64
 	NoClose      bool
@@ -755,13 +754,14 @@ type WsMarginInfoBase struct {
 	UserSwaps      float64
 	MarginBalance  float64
 	MarginNet      float64
+	MarginRequired float64
 }
 
 // WsFundingTrade recent funding trades received via websocket
 type WsFundingTrade struct {
 	ID         int64
 	Symbol     string
-	MTSCreated int64
+	MTSCreated time.Time
 	OfferID    int64
 	Amount     float64
 	Rate       float64

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -1298,6 +1298,8 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 		return errors.New("no orderbooks submitted")
 	}
 	var book orderbook.Base
+	book.Bids = make(orderbook.Items, 0, len(books))
+	book.Asks = make(orderbook.Items, 0, len(books))
 	for i := range books {
 		item := orderbook.Item{
 			ID:     books[i].ID,
@@ -1334,7 +1336,12 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType asset.Item, books
 // WsUpdateOrderbook updates the orderbook list, removing and adding to the
 // orderbook sides
 func (b *Bitfinex) WsUpdateOrderbook(p currency.Pair, assetType asset.Item, book []WebsocketBook, channelID int, sequenceNo int64, fundingRate bool) error {
-	orderbookUpdate := buffer.Update{Asset: assetType, Pair: p}
+	orderbookUpdate := buffer.Update{
+		Asset: assetType,
+		Pair:  p,
+		Bids:  make([]orderbook.Item, 0, len(book)),
+		Asks:  make([]orderbook.Item, 0, len(book)),
+	}
 
 	for i := range book {
 		item := orderbook.Item{

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -960,7 +960,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					}
 					if data[4] != nil {
 						if wallet.BalanceAvailable, ok = data[4].(float64); !ok {
-							return errors.New("unable to type assert wallet snapshot balance available interest")
+							return errors.New("unable to type assert wallet snapshot balance available")
 						}
 					}
 					b.Websocket.DataHandler <- wallet
@@ -1058,6 +1058,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					}
 					wsFundingTrade.Period = int64(period)
 					wsFundingTrade.Maker = data[7] != nil
+					b.Websocket.DataHandler <- wsFundingTrade
 				}
 			default:
 				b.Websocket.DataHandler <- stream.UnhandledMessageWarning{

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -365,29 +365,29 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 						var element []interface{}
 						element, ok = candleBundle[i].([]interface{})
 						if !ok {
-							return errors.New("type assertion for element data")
+							return errors.New("candle type assertion for element data")
 						}
 						if len(element) < 6 {
 							return errors.New("invalid candleBundle length")
 						}
 						var klineData stream.KlineData
 						if klineData.Timestamp, err = convert.TimeFromUnixTimestampFloat(element[0]); err != nil {
-							return fmt.Errorf("unable to convert timestamp: %w", err)
+							return fmt.Errorf("unable to convert candle timestamp: %w", err)
 						}
 						if klineData.OpenPrice, ok = element[1].(float64); !ok {
-							return errors.New("unable to type assert open price")
+							return errors.New("unable to type assert candle open price")
 						}
 						if klineData.ClosePrice, ok = element[2].(float64); !ok {
-							return errors.New("unable to type assert close price")
+							return errors.New("unable to type assert candle close price")
 						}
 						if klineData.HighPrice, ok = element[3].(float64); !ok {
-							return errors.New("unable to type assert high price")
+							return errors.New("unable to type assert candle high price")
 						}
 						if klineData.LowPrice, ok = element[4].(float64); !ok {
-							return errors.New("unable to type assert low price")
+							return errors.New("unable to type assert candle low price")
 						}
 						if klineData.Volume, ok = element[5].(float64); !ok {
-							return errors.New("unable to type assert volume")
+							return errors.New("unable to type assert candle volume")
 						}
 						klineData.Exchange = b.Name
 						klineData.AssetType = chanAsset
@@ -400,22 +400,22 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					}
 					var klineData stream.KlineData
 					if klineData.Timestamp, err = convert.TimeFromUnixTimestampFloat(candleData); err != nil {
-						return fmt.Errorf("unable to convert timestamp: %w", err)
+						return fmt.Errorf("unable to convert candle timestamp: %w", err)
 					}
 					if klineData.OpenPrice, ok = candleBundle[1].(float64); !ok {
-						return errors.New("unable to type assert open price")
+						return errors.New("unable to type assert candle open price")
 					}
 					if klineData.ClosePrice, ok = candleBundle[2].(float64); !ok {
-						return errors.New("unable to type assert close price")
+						return errors.New("unable to type assert candle close price")
 					}
 					if klineData.HighPrice, ok = candleBundle[3].(float64); !ok {
-						return errors.New("unable to type assert high price")
+						return errors.New("unable to type assert candle high price")
 					}
 					if klineData.LowPrice, ok = candleBundle[4].(float64); !ok {
-						return errors.New("unable to type assert low price")
+						return errors.New("unable to type assert candle low price")
 					}
 					if klineData.Volume, ok = candleBundle[5].(float64); !ok {
-						return errors.New("unable to type assert volume")
+						return errors.New("unable to type assert candle volume")
 					}
 					klineData.Exchange = b.Name
 					klineData.AssetType = chanAsset
@@ -438,59 +438,59 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 
 			if len(tickerData) == 10 {
 				if t.Bid, ok = tickerData[0].(float64); !ok {
-					return errors.New("unable to type assert bid")
+					return errors.New("unable to type assert ticker bid")
 				}
 				if t.Ask, ok = tickerData[2].(float64); !ok {
-					return errors.New("unable to type assert ask")
+					return errors.New("unable to type assert ticker ask")
 				}
 				if t.Last, ok = tickerData[6].(float64); !ok {
-					return errors.New("unable to type assert last")
+					return errors.New("unable to type assert ticker last")
 				}
 				if t.Volume, ok = tickerData[7].(float64); !ok {
-					return errors.New("unable to type assert volume")
+					return errors.New("unable to type assert ticker volume")
 				}
 				if t.High, ok = tickerData[8].(float64); !ok {
-					return errors.New("unable to type assert high")
+					return errors.New("unable to type assert  ticker high")
 				}
 				if t.Low, ok = tickerData[9].(float64); !ok {
-					return errors.New("unable to type assert hilowgh")
+					return errors.New("unable to type assert ticker low")
 				}
 			} else {
 				if t.FlashReturnRate, ok = tickerData[0].(float64); !ok {
-					return errors.New("unable to type assert flash return rate")
+					return errors.New("unable to type assert ticker flash return rate")
 				}
 				if t.Bid, ok = tickerData[1].(float64); !ok {
-					return errors.New("unable to type assert bid")
+					return errors.New("unable to type assert ticker bid")
 				}
 				if t.BidPeriod, ok = tickerData[2].(float64); !ok {
-					return errors.New("unable to type assert bid period")
+					return errors.New("unable to type assert ticker bid period")
 				}
 				if t.BidSize, ok = tickerData[3].(float64); !ok {
-					return errors.New("unable to type assert bid size")
+					return errors.New("unable to type assert ticker bid size")
 				}
 				if t.Ask, ok = tickerData[4].(float64); !ok {
-					return errors.New("unable to type assert ask")
+					return errors.New("unable to type assert ticker ask")
 				}
 				if t.AskPeriod, ok = tickerData[5].(float64); !ok {
-					return errors.New("unable to type assert ask period")
+					return errors.New("unable to type assert ticker ask period")
 				}
 				if t.AskSize, ok = tickerData[6].(float64); !ok {
-					return errors.New("unable to type assert ask size")
+					return errors.New("unable to type assert ticker ask size")
 				}
 				if t.Last, ok = tickerData[9].(float64); !ok {
-					return errors.New("unable to type assert last")
+					return errors.New("unable to type assert ticker last")
 				}
 				if t.Volume, ok = tickerData[10].(float64); !ok {
-					return errors.New("unable to type assert volume")
+					return errors.New("unable to type assert ticker volume")
 				}
 				if t.High, ok = tickerData[11].(float64); !ok {
-					return errors.New("unable to type assert high")
+					return errors.New("unable to type assert ticker high")
 				}
 				if t.Low, ok = tickerData[12].(float64); !ok {
-					return errors.New("unable to type assert low")
+					return errors.New("unable to type assert ticker low")
 				}
 				if t.FlashReturnRateAmount, ok = tickerData[15].(float64); !ok {
-					return errors.New("unable to type assert flash return rate")
+					return errors.New("unable to type assert ticker flash return rate")
 				}
 			}
 			b.Websocket.DataHandler <- t
@@ -507,12 +507,12 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 			case 2:
 				snapshot, ok := d[1].([]interface{})
 				if !ok {
-					return errors.New("unable to type assert snapshot data")
+					return errors.New("unable to type assert trade snapshot data")
 				}
 				for i := range snapshot {
 					elem, ok := snapshot[i].([]interface{})
 					if !ok {
-						return errors.New("unable to type assert snapshot element data")
+						return errors.New("unable to type assert trade snapshot element data")
 					}
 					tradeID, ok := elem[0].(float64)
 					if !ok {
@@ -520,11 +520,11 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					}
 					timestamp, ok := elem[1].(float64)
 					if !ok {
-						return errors.New("unable to type assert timestamp")
+						return errors.New("unable to type assert trade timestamp")
 					}
 					amount, ok := elem[2].(float64)
 					if !ok {
-						return errors.New("unable to type assert amount")
+						return errors.New("unable to type assert trade amount")
 					}
 					wsTrade := WebsocketTrade{
 						ID:        int64(tradeID),
@@ -534,18 +534,18 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					if len(elem) == 5 {
 						rate, ok := elem[3].(float64)
 						if !ok {
-							return errors.New("unable to type assert rate")
+							return errors.New("unable to type assert trade rate")
 						}
 						wsTrade.Rate = rate
 						period, ok := elem[4].(float64)
 						if !ok {
-							return errors.New("unable to type assert period")
+							return errors.New("unable to type assert trade period")
 						}
 						wsTrade.Period = int64(period)
 					} else {
 						price, ok := elem[3].(float64)
 						if !ok {
-							return errors.New("unable to type assert price")
+							return errors.New("unable to type assert trade price")
 						}
 						wsTrade.Rate = price
 					}
@@ -562,7 +562,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				}
 				data, ok := d[2].([]interface{})
 				if !ok {
-					return errors.New("data type assertion error")
+					return errors.New("trade data type assertion error")
 				}
 
 				tradeID, ok := data[0].(float64)
@@ -571,11 +571,11 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				}
 				timestamp, ok := data[1].(float64)
 				if !ok {
-					return errors.New("unable to type assert timestamp")
+					return errors.New("unable to type assert trade timestamp")
 				}
 				amount, ok := data[2].(float64)
 				if !ok {
-					return errors.New("unable to type assert amount")
+					return errors.New("unable to type assert trade amount")
 				}
 				wsTrade := WebsocketTrade{
 					ID:        int64(tradeID),
@@ -585,18 +585,18 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				if len(data) == 5 {
 					rate, ok := data[3].(float64)
 					if !ok {
-						return errors.New("unable to type assert rate")
+						return errors.New("unable to type assert trade rate")
 					}
 					period, ok := data[4].(float64)
 					if !ok {
-						return errors.New("unable to type assert period")
+						return errors.New("unable to type assert trade period")
 					}
 					wsTrade.Rate = rate
 					wsTrade.Period = int64(period)
 				} else {
 					price, ok := data[3].(float64)
 					if !ok {
-						return errors.New("unable to type assert price")
+						return errors.New("unable to type assert trade price")
 					}
 					wsTrade.Price = price
 				}
@@ -714,36 +714,36 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 							}
 							var position WebsocketPosition
 							if position.Pair, ok = positionData[0].(string); !ok {
-								return errors.New("unable to type assert pair")
+								return errors.New("unable to type assert position snapshot pair")
 							}
 							if position.Status, ok = positionData[1].(string); !ok {
-								return errors.New("unable to type assert status")
+								return errors.New("unable to type assert position snapshot status")
 							}
 							if position.Amount, ok = positionData[2].(float64); !ok {
-								return errors.New("unable to type assert amount")
+								return errors.New("unable to type assert position snapshot amount")
 							}
 							if position.Price, ok = positionData[3].(float64); !ok {
-								return errors.New("unable to type assert price")
+								return errors.New("unable to type assert position snapshot price")
 							}
 							if position.MarginFunding, ok = positionData[4].(float64); !ok {
-								return errors.New("unable to type assert margin funding")
+								return errors.New("unable to type assert position snapshot margin funding")
 							}
 							marginFundingType, ok := positionData[5].(float64)
 							if !ok {
-								return errors.New("unable to type assert margin funding type")
+								return errors.New("unable to type assert position snapshot margin funding type")
 							}
 							position.MarginFundingType = int64(marginFundingType)
 							if position.ProfitLoss, ok = positionData[6].(float64); !ok {
-								return errors.New("unable to type assert profit loss")
+								return errors.New("unable to type assert position snapshot profit loss")
 							}
 							if position.ProfitLossPercent, ok = positionData[7].(float64); !ok {
-								return errors.New("unable to type assert profit loss percent")
+								return errors.New("unable to type assert position snapshot profit loss percent")
 							}
 							if position.LiquidationPrice, ok = positionData[8].(float64); !ok {
-								return errors.New("unable to type assert liquidation price")
+								return errors.New("unable to type assert position snapshot liquidation price")
 							}
 							if position.Leverage, ok = positionData[9].(float64); !ok {
-								return errors.New("unable to type assert leverage")
+								return errors.New("unable to type assert position snapshot leverage")
 							}
 							snapshot[i] = position
 						}
@@ -754,36 +754,36 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				if positionData, ok := d[2].([]interface{}); ok && len(positionData) > 0 {
 					var position WebsocketPosition
 					if position.Pair, ok = positionData[0].(string); !ok {
-						return errors.New("unable to type assert pair")
+						return errors.New("unable to type assert position pair")
 					}
 					if position.Status, ok = positionData[1].(string); !ok {
-						return errors.New("unable to type assert status")
+						return errors.New("unable to type assert position status")
 					}
 					if position.Amount, ok = positionData[2].(float64); !ok {
-						return errors.New("unable to type assert amount")
+						return errors.New("unable to type assert position amount")
 					}
 					if position.Price, ok = positionData[3].(float64); !ok {
-						return errors.New("unable to type assert price")
+						return errors.New("unable to type assert position price")
 					}
 					if position.MarginFunding, ok = positionData[4].(float64); !ok {
-						return errors.New("unable to type assert margin funding")
+						return errors.New("unable to type assert margin position funding")
 					}
 					marginFundingType, ok := positionData[5].(float64)
 					if !ok {
-						return errors.New("unable to type assert margin funding type")
+						return errors.New("unable to type assert position margin funding type")
 					}
 					position.MarginFundingType = int64(marginFundingType)
 					if position.ProfitLoss, ok = positionData[6].(float64); !ok {
-						return errors.New("unable to type assert profit loss")
+						return errors.New("unable to type assert position profit loss")
 					}
 					if position.ProfitLossPercent, ok = positionData[7].(float64); !ok {
-						return errors.New("unable to type assert profit loss percent")
+						return errors.New("unable to type assert position profit loss percent")
 					}
 					if position.LiquidationPrice, ok = positionData[8].(float64); !ok {
-						return errors.New("unable to type assert liquidation price")
+						return errors.New("unable to type assert position liquidation price")
 					}
 					if position.Leverage, ok = positionData[9].(float64); !ok {
-						return errors.New("unable to type assert leverage")
+						return errors.New("unable to type assert position leverage")
 					}
 					b.Websocket.DataHandler <- position
 				}
@@ -868,7 +868,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 							if !ok {
 								return errors.New("unable to type assert wsFundingCreditSnapshot snapBundle data")
 							}
-							fundingCredit, err := wsHandleFundingData(data, true /* include position pair */)
+							fundingCredit, err := wsHandleFundingCreditLoanData(data, true /* include position pair */)
 							if err != nil {
 								return err
 							}
@@ -879,7 +879,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				}
 			case wsFundingCreditNew, wsFundingCreditUpdate, wsFundingCreditCancel:
 				if data, ok := d[2].([]interface{}); ok && len(data) > 0 {
-					fundingCredit, err := wsHandleFundingData(data, true /* include position pair */)
+					fundingCredit, err := wsHandleFundingCreditLoanData(data, true /* include position pair */)
 					if err != nil {
 						return err
 					}
@@ -894,7 +894,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 							if !ok {
 								return errors.New("unable to type assert wsFundingLoanSnapshot snapBundle data")
 							}
-							fundingLoanSnapshot, err := wsHandleFundingData(data, false)
+							fundingLoanSnapshot, err := wsHandleFundingCreditLoanData(data, false /* include position pair */)
 							if err != nil {
 								return err
 							}
@@ -905,7 +905,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 				}
 			case wsFundingLoanNew, wsFundingLoanUpdate, wsFundingLoanCancel:
 				if data, ok := d[2].([]interface{}); ok && len(data) > 0 {
-					fundingData, err := wsHandleFundingData(data, false)
+					fundingData, err := wsHandleFundingCreditLoanData(data, false /* include position pair */)
 					if err != nil {
 						return err
 					}
@@ -952,11 +952,16 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					if wallet.Currency, ok = data[1].(string); !ok {
 						return errors.New("unable to type assert wallet snapshot currency")
 					}
-					if wallet.UnsettledInterest, ok = data[3].(float64); !ok {
+					if wallet.Balance, ok = data[2].(float64); !ok {
 						return errors.New("unable to type assert wallet snapshot balance")
 					}
-					if wallet.BalanceAvailable, ok = data[4].(float64); !ok {
+					if wallet.UnsettledInterest, ok = data[3].(float64); !ok {
 						return errors.New("unable to type assert wallet snapshot unsettled interest")
+					}
+					if data[4] != nil {
+						if wallet.BalanceAvailable, ok = data[4].(float64); !ok {
+							return errors.New("unable to type assert wallet snapshot balance available interest")
+						}
 					}
 					b.Websocket.DataHandler <- wallet
 				}
@@ -1067,62 +1072,91 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 
 func wsHandleFundingOffer(data []interface{}, includeRateReal bool) (*WsFundingOffer, error) {
 	var offer WsFundingOffer
-	offerID, ok := data[0].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert funding offer ID")
+	var ok bool
+	if data[0] != nil {
+		var offerID float64
+		if offerID, ok = data[0].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer ID")
+		}
+		offer.ID = int64(offerID)
 	}
-	offer.ID = int64(offerID)
-	if offer.Symbol, ok = data[1].(string); !ok {
-		return nil, errors.New("unable to type assert funding offer symbol")
+	if data[1] != nil {
+		if offer.Symbol, ok = data[1].(string); !ok {
+			return nil, errors.New("unable to type assert funding offer symbol")
+		}
 	}
-	var created float64
-	if created, ok = data[2].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer created")
+	if data[2] != nil {
+		var created float64
+		if created, ok = data[2].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer created")
+		}
+		offer.Created = time.UnixMilli(int64(created))
 	}
-	offer.Created = time.UnixMilli(int64(created))
-	var updated float64
-	if updated, ok = data[3].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer updated")
+	if data[3] != nil {
+		var updated float64
+		if updated, ok = data[3].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer updated")
+		}
+		offer.Updated = time.UnixMilli(int64(updated))
 	}
-	offer.Updated = time.UnixMilli(int64(updated))
-	if offer.Amount, ok = data[4].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer amount")
+	if data[4] != nil {
+		if offer.Amount, ok = data[4].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer amount")
+		}
 	}
-	if offer.OriginalAmount, ok = data[5].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer original amount")
+	if data[5] != nil {
+		if offer.OriginalAmount, ok = data[5].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer original amount")
+		}
 	}
-	if offer.Type, ok = data[6].(string); !ok {
-		return nil, errors.New("unable to type assert funding offer type")
+	if data[6] != nil {
+		if offer.Type, ok = data[6].(string); !ok {
+			return nil, errors.New("unable to type assert funding offer type")
+		}
 	}
-	if offer.Flags, ok = data[9].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer flags")
+	if data[9] != nil {
+		if offer.Flags, ok = data[9].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer flags")
+		}
 	}
-	if offer.Status, ok = data[10].(string); !ok {
-		return nil, errors.New("unable to type assert funding offer status")
+	if data[10] != nil {
+		if offer.Status, ok = data[10].(string); !ok {
+			return nil, errors.New("unable to type assert funding offer status")
+		}
 	}
-	if offer.Rate, ok = data[14].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer rate")
+	if data[14] != nil {
+		if offer.Rate, ok = data[14].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer rate")
+		}
 	}
-	var period float64
-	if period, ok = data[15].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer period")
+	if data[15] != nil {
+		var period float64
+		if period, ok = data[15].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer period")
+		}
+		offer.Period = int64(period)
 	}
-	offer.Period = int64(period)
-	var notify float64
-	if notify, ok = data[16].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer notify")
+	if data[16] != nil {
+		var notify float64
+		if notify, ok = data[16].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer notify")
+		}
+		offer.Notify = notify == 1
 	}
-	offer.Notify = notify == 1
-	var hidden float64
-	if hidden, ok = data[17].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer hidden")
+	if data[17] != nil {
+		var hidden float64
+		if hidden, ok = data[17].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer hidden")
+		}
+		offer.Hidden = hidden == 1
 	}
-	offer.Hidden = hidden == 1
-	var renew float64
-	if renew, ok = data[19].(float64); !ok {
-		return nil, errors.New("unable to type assert funding offer renew")
+	if data[19] != nil {
+		var renew float64
+		if renew, ok = data[19].(float64); !ok {
+			return nil, errors.New("unable to type assert funding offer renew")
+		}
+		offer.Renew = renew == 1
 	}
-	offer.Renew = renew == 1
 	if includeRateReal && data[20] != nil {
 		if offer.RateReal, ok = data[20].(float64); !ok {
 			return nil, errors.New("unable to type assert funding offer rate real")
@@ -1131,84 +1165,119 @@ func wsHandleFundingOffer(data []interface{}, includeRateReal bool) (*WsFundingO
 	return &offer, nil
 }
 
-func wsHandleFundingData(data []interface{}, includePositionPair bool) (*WsCredit, error) {
+func wsHandleFundingCreditLoanData(data []interface{}, includePositionPair bool) (*WsCredit, error) {
 	var credit WsCredit
-	id, ok := data[0].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert credit ID")
+	var ok bool
+	if data[0] != nil {
+		var id float64
+		if id, ok = data[0].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit ID")
+		}
+		credit.ID = int64(id)
 	}
-	credit.ID = int64(id)
-	if credit.Symbol, ok = data[1].(string); !ok {
-		return nil, errors.New("unable to type assert symbol")
-	}
-	side, ok := data[2].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert side")
-	}
-	credit.Side = int8(side)
-	created, ok := data[3].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert created")
-	}
-	credit.Created = time.UnixMilli(int64(created))
-	updated, ok := data[4].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert updated")
-	}
-	credit.Updated = time.UnixMilli(int64(updated))
-	if credit.Amount, ok = data[5].(float64); !ok {
-		return nil, errors.New("unable to type assert amount")
-	}
-	credit.Flags = data[6]
-	if credit.Status, ok = data[7].(string); !ok {
-		return nil, errors.New("unable to type assert status")
-	}
-	if credit.Rate, ok = data[11].(float64); !ok {
-		return nil, errors.New("unable to type assert rate")
-	}
-	period, ok := data[12].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert period")
-	}
-	credit.Period = int64(period)
-	opened, ok := data[13].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert opened")
-	}
-	credit.Opened = time.UnixMilli(int64(opened))
-	lastPayout, ok := data[14].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert last payout")
-	}
-	credit.LastPayout = time.UnixMilli(int64(lastPayout))
-	notify, ok := data[15].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert notify")
-	}
-	credit.Notify = notify == 1
-	hidden, ok := data[16].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert hidden")
-	}
-	credit.Hidden = hidden == 1
-	renew, ok := data[18].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert renew")
-	}
-	credit.Renew = renew == 1
-	if data[19] != nil {
-		if credit.RateReal, ok = data[19].(float64); !ok {
-			return nil, errors.New("unable to type assert rate real")
+	if data[1] != nil {
+		if credit.Symbol, ok = data[1].(string); !ok {
+			return nil, errors.New("unable to type assert funding credit symbol")
 		}
 	}
-	noClose, ok := data[20].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert no close")
+	if data[2] != nil {
+		var side float64
+		if side, ok = data[2].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit side")
+		}
+		credit.Side = int8(side)
 	}
-	credit.NoClose = noClose == 1
+	if data[3] != nil {
+		var created float64
+		if created, ok = data[3].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit created")
+		}
+		credit.Created = time.UnixMilli(int64(created))
+	}
+	if data[4] != nil {
+		var updated float64
+		if updated, ok = data[4].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit updated")
+		}
+		credit.Updated = time.UnixMilli(int64(updated))
+	}
+	if data[5] != nil {
+		if credit.Amount, ok = data[5].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit amount")
+		}
+	}
+	if data[6] != nil {
+		credit.Flags = data[6]
+	}
+	if data[7] != nil {
+		if credit.Status, ok = data[7].(string); !ok {
+			return nil, errors.New("unable to type assert funding credit status")
+		}
+	}
+	if data[11] != nil {
+		if credit.Rate, ok = data[11].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit rate")
+		}
+	}
+	if data[12] != nil {
+		var period float64
+		if period, ok = data[12].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit period")
+		}
+		credit.Period = int64(period)
+	}
+	if data[13] != nil {
+		var opened float64
+		if opened, ok = data[13].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit opened")
+		}
+		credit.Opened = time.UnixMilli(int64(opened))
+	}
+	if data[14] != nil {
+		var lastPayout float64
+		if lastPayout, ok = data[14].(float64); !ok {
+			return nil, errors.New("unable to type assert last funding credit payout")
+		}
+		credit.LastPayout = time.UnixMilli(int64(lastPayout))
+	}
+	if data[15] != nil {
+		var notify float64
+		if notify, ok = data[15].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit notify")
+		}
+		credit.Notify = notify == 1
+	}
+	if data[16] != nil {
+		var hidden float64
+		if hidden, ok = data[16].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit hidden")
+		}
+		credit.Hidden = hidden == 1
+	}
+	if data[18] != nil {
+		var renew float64
+		if renew, ok = data[18].(float64); !ok {
+			return nil, errors.New("unable to type assert funding credit renew")
+		}
+		credit.Renew = renew == 1
+	}
+	if data[19] != nil {
+		if credit.RateReal, ok = data[19].(float64); !ok {
+			return nil, errors.New("unable to type assert rate funding credit real")
+		}
+	}
+	if data[20] != nil {
+		var noClose float64
+		if noClose, ok = data[20].(float64); !ok {
+			return nil, errors.New("unable to type assert no funding credit close")
+		}
+		credit.NoClose = noClose == 1
+	}
 	if includePositionPair {
-		if credit.PositionPair, ok = data[21].(string); !ok {
-			return nil, errors.New("unable to type assert position pair")
+		if data[21] != nil {
+			if credit.PositionPair, ok = data[21].(string); !ok {
+				return nil, errors.New("unable to type assert funding credit position pair")
+			}
 		}
 	}
 	return &credit, nil

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -842,7 +842,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 							if !ok {
 								return errors.New("unable to type assert wsFundingOrderSnapshot snapBundle data")
 							}
-							offer, err := wsHandleFundingOffer(data, true /* include rate real */)
+							offer, err := wsHandleFundingOffer(data, false /* include rate real */)
 							if err != nil {
 								return err
 							}
@@ -1005,11 +1005,14 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 			case wsFundingInfoUpdate:
 				if data, ok := d[2].([]interface{}); ok && len(data) > 0 {
 					if fundingType, ok := data[0].(string); ok && fundingType == "sym" {
-						symbolData, ok := data[1].([]interface{})
+						symbolData, ok := data[2].([]interface{})
 						if !ok {
 							return errors.New("unable to type assert wsFundingInfoUpdate symbolData")
 						}
 						var fundingInfo WsFundingInfo
+						if fundingInfo.Symbol, ok = data[1].(string); !ok {
+							return errors.New("unable to type assert symbol")
+						}
 						if fundingInfo.YieldLoan, ok = symbolData[0].(float64); !ok {
 							return errors.New("unable to type assert funding info update yield loan")
 						}
@@ -1019,7 +1022,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 						if fundingInfo.DurationLoan, ok = symbolData[2].(float64); !ok {
 							return errors.New("unable to type assert funding info update duration loan")
 						}
-						if fundingInfo.DurationLend, ok = symbolData[2].(float64); !ok {
+						if fundingInfo.DurationLend, ok = symbolData[3].(float64); !ok {
 							return errors.New("unable to type assert funding info update duration lend")
 						}
 						b.Websocket.DataHandler <- fundingInfo

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -438,7 +438,7 @@ func (b *Bitfinex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 	var orderbookNew Orderbook
 	orderbookNew, err = b.GetOrderbook(ctx, prefix+fPair.String(), "R0", 100)
 	if err != nil {
-		return nil, err
+		return o, err
 	}
 	if assetType == asset.MarginFunding {
 		o.IsFundingRate = true

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -442,36 +442,40 @@ func (b *Bitfinex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 	}
 	if assetType == asset.MarginFunding {
 		o.IsFundingRate = true
+		o.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 		for x := range orderbookNew.Asks {
-			o.Asks = append(o.Asks, orderbook.Item{
+			o.Asks[x] = orderbook.Item{
 				ID:     orderbookNew.Asks[x].OrderID,
 				Price:  orderbookNew.Asks[x].Rate,
 				Amount: orderbookNew.Asks[x].Amount,
 				Period: int64(orderbookNew.Asks[x].Period),
-			})
+			}
 		}
+		o.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 		for x := range orderbookNew.Bids {
-			o.Bids = append(o.Bids, orderbook.Item{
+			o.Bids[x] = orderbook.Item{
 				ID:     orderbookNew.Bids[x].OrderID,
 				Price:  orderbookNew.Bids[x].Rate,
 				Amount: orderbookNew.Bids[x].Amount,
 				Period: int64(orderbookNew.Bids[x].Period),
-			})
+			}
 		}
 	} else {
+		o.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 		for x := range orderbookNew.Asks {
-			o.Asks = append(o.Asks, orderbook.Item{
+			o.Asks[x] = orderbook.Item{
 				ID:     orderbookNew.Asks[x].OrderID,
 				Price:  orderbookNew.Asks[x].Price,
 				Amount: orderbookNew.Asks[x].Amount,
-			})
+			}
 		}
+		o.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 		for x := range orderbookNew.Bids {
-			o.Bids = append(o.Bids, orderbook.Item{
+			o.Bids[x] = orderbook.Item{
 				ID:     orderbookNew.Bids[x].OrderID,
 				Price:  orderbookNew.Bids[x].Price,
 				Amount: orderbookNew.Bids[x].Amount,
-			})
+			}
 		}
 	}
 	err = o.Process()

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -885,12 +885,12 @@ func (b *Bitfinex) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequ
 		return nil, err
 	}
 
-	var orders []order.Detail
 	resp, err := b.GetOpenOrders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderSide := order.Side(strings.ToUpper(resp[i].Side))
 		timestamp, err := strconv.ParseFloat(resp[i].Timestamp, 64)
@@ -937,7 +937,7 @@ func (b *Bitfinex) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequ
 			orderDetail.Type = order.Type(strings.ToUpper(orderType))
 		}
 
-		orders = append(orders, orderDetail)
+		orders[i] = orderDetail
 	}
 
 	order.FilterOrdersBySide(&orders, req.Side)
@@ -954,12 +954,12 @@ func (b *Bitfinex) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 		return nil, err
 	}
 
-	var orders []order.Detail
 	resp, err := b.GetInactiveOrders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderSide := order.Side(strings.ToUpper(resp[i].Side))
 		timestamp, err := strconv.ParseInt(resp[i].Timestamp, 10, 64)
@@ -1007,7 +1007,7 @@ func (b *Bitfinex) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 			orderDetail.Type = order.Type(strings.ToUpper(orderType))
 		}
 
-		orders = append(orders, orderDetail)
+		orders[i] = orderDetail
 	}
 
 	order.FilterOrdersBySide(&orders, req.Side)

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -288,16 +288,20 @@ func (b *Bitflyer) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 		return book, err
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Price:  orderbookNew.Asks[x].Price,
-			Amount: orderbookNew.Asks[x].Size})
+			Amount: orderbookNew.Asks[x].Size,
+		}
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Price:  orderbookNew.Bids[x].Price,
-			Amount: orderbookNew.Bids[x].Size})
+			Amount: orderbookNew.Bids[x].Size,
+		}
 	}
 
 	err = book.Process()

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -346,7 +346,7 @@ func (b *Bitflyer) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		var timestamp time.Time
 		timestamp, err = time.Parse("2006-01-02T15:04:05.999999999", tradeData[i].ExecDate)
@@ -358,7 +358,7 @@ func (b *Bitflyer) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			TID:          strconv.FormatInt(tradeData[i].ID, 10),
 			Exchange:     b.Name,
 			CurrencyPair: p,
@@ -367,7 +367,7 @@ func (b *Bitflyer) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Size,
 			Timestamp:    timestamp,
-		})
+		}
 	}
 
 	err = b.AddTradesToBuffer(resp...)

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -64,7 +64,7 @@ func (b *Bithumb) GetTradablePairs(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(result))
 	for x := range result {
 		currencies = append(currencies, x)
 	}
@@ -703,7 +703,7 @@ func (b *Bithumb) FetchExchangeLimits(ctx context.Context) ([]order.MinMaxLevel,
 		return nil, err
 	}
 
-	var limits []order.MinMaxLevel
+	limits := make([]order.MinMaxLevel, 0, len(ticks))
 	for code, data := range ticks {
 		c := currency.NewCode(code)
 		cp := currency.NewPair(c, currency.KRW)

--- a/exchanges/bithumb/bithumb_websocket_test.go
+++ b/exchanges/bithumb/bithumb_websocket_test.go
@@ -73,8 +73,7 @@ func TestWsHandleData(t *testing.T) {
 	}
 
 	handled := <-dummy.Websocket.DataHandler
-	_, ok := handled.(*ticker.Price)
-	if !ok {
+	if _, ok := handled.(*ticker.Price); !ok {
 		t.Fatal("unexpected value")
 	}
 

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -336,20 +336,20 @@ func (b *Bithumb) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTyp
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Data.Bids))
 	for i := range orderbookNew.Data.Bids {
-		book.Bids = append(book.Bids,
-			orderbook.Item{
-				Amount: orderbookNew.Data.Bids[i].Quantity,
-				Price:  orderbookNew.Data.Bids[i].Price,
-			})
+		book.Bids[i] = orderbook.Item{
+			Amount: orderbookNew.Data.Bids[i].Quantity,
+			Price:  orderbookNew.Data.Bids[i].Price,
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Data.Asks))
 	for i := range orderbookNew.Data.Asks {
-		book.Asks = append(book.Asks,
-			orderbook.Item{
-				Amount: orderbookNew.Data.Asks[i].Quantity,
-				Price:  orderbookNew.Data.Asks[i].Price,
-			})
+		book.Asks[i] = orderbook.Item{
+			Amount: orderbookNew.Data.Asks[i].Quantity,
+			Price:  orderbookNew.Data.Asks[i].Price,
+		}
 	}
 
 	err = book.Process()

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -368,7 +368,7 @@ func (b *Bithumb) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (
 		return info, err
 	}
 
-	var exchangeBalances []account.Balance
+	exchangeBalances := make([]account.Balance, 0, len(bal.Total))
 	for key, totalAmount := range bal.Total {
 		hold, ok := bal.InUse[key]
 		if !ok {
@@ -435,7 +435,7 @@ func (b *Bithumb) GetRecentTrades(ctx context.Context, p currency.Pair, assetTyp
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData.Data))
 	for i := range tradeData.Data {
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData.Data[i].Type)
@@ -447,7 +447,7 @@ func (b *Bithumb) GetRecentTrades(ctx context.Context, p currency.Pair, assetTyp
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     b.Name,
 			CurrencyPair: p,
 			AssetType:    assetType,
@@ -455,7 +455,7 @@ func (b *Bithumb) GetRecentTrades(ctx context.Context, p currency.Pair, assetTyp
 			Price:        tradeData.Data[i].Price,
 			Amount:       tradeData.Data[i].UnitsTraded,
 			Timestamp:    t,
-		})
+		}
 	}
 
 	err = b.AddTradesToBuffer(resp...)

--- a/exchanges/bithumb/bithumb_ws_orderbook.go
+++ b/exchanges/bithumb/bithumb_ws_orderbook.go
@@ -26,7 +26,8 @@ const (
 )
 
 func (b *Bithumb) processBooks(updates *WsOrderbooks) error {
-	var bids, asks []orderbook.Item
+	bids := make([]orderbook.Item, 0, len(updates.List))
+	asks := make([]orderbook.Item, 0, len(updates.List))
 	for x := range updates.List {
 		i := orderbook.Item{Price: updates.List[x].Price, Amount: updates.List[x].Quantity}
 		if updates.List[x].OrderSide == "bid" {
@@ -426,17 +427,19 @@ func (b *Bithumb) SeedLocalCache(ctx context.Context, p currency.Pair) error {
 // SeedLocalCacheWithBook seeds the local orderbook cache
 func (b *Bithumb) SeedLocalCacheWithBook(p currency.Pair, o *Orderbook) error {
 	var newOrderBook orderbook.Base
+	newOrderBook.Bids = make(orderbook.Items, len(o.Data.Bids))
 	for i := range o.Data.Bids {
-		newOrderBook.Bids = append(newOrderBook.Bids, orderbook.Item{
+		newOrderBook.Bids[i] = orderbook.Item{
 			Amount: o.Data.Bids[i].Quantity,
 			Price:  o.Data.Bids[i].Price,
-		})
+		}
 	}
+	newOrderBook.Asks = make(orderbook.Items, len(o.Data.Asks))
 	for i := range o.Data.Asks {
-		newOrderBook.Asks = append(newOrderBook.Asks, orderbook.Item{
+		newOrderBook.Asks[i] = orderbook.Item{
 			Amount: o.Data.Asks[i].Quantity,
 			Price:  o.Data.Asks[i].Price,
-		})
+		}
 	}
 
 	newOrderBook.Pair = p

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -58,8 +58,8 @@ const (
 
 	// Authenticated endpoints
 	bitmexEndpointAPIkeys               = "/apiKey"
-	bitmexEndpointDisableAPIkey         = "/apiKey/disable"
-	bitmexEndpointEnableAPIkey          = "/apiKey/enable"
+	bitmexEndpointDisableAPIkey         = "/apiKey/disable" // nolint:gosec // false positive
+	bitmexEndpointEnableAPIkey          = "/apiKey/enable"  // nolint:gosec // false positive
 	bitmexEndpointTrollboxSend          = "/chat"
 	bitmexEndpointExecution             = "/execution"
 	bitmexEndpointExecutionTradeHistory = "/execution/tradeHistory"

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -781,7 +781,7 @@ func TestWithdraw(t *testing.T) {
 		Amount:          -1,
 		Currency:        currency.BTC,
 		Description:     "WITHDRAW IT ALL",
-		OneTimePassword: 000000,
+		OneTimePassword: 000000, // nolint // gocritic false positive
 	}
 
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
@@ -860,7 +860,11 @@ func TestWsAuth(t *testing.T) {
 	timer := time.NewTimer(sharedtestvalues.WebsocketResponseDefaultTimeout)
 	select {
 	case resp := <-b.Websocket.DataHandler:
-		if !resp.(WebsocketSubscribeResp).Success {
+		sub, ok := resp.(WebsocketSubscribeResp)
+		if !ok {
+			t.Fatal("unable to type assert WebsocketSubscribeResp")
+		}
+		if !sub.Success {
 			t.Error("Expected successful subscription")
 		}
 	case <-timer.C:

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -491,17 +491,22 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, p currency.
 
 	switch action {
 	case bitmexActionInitialData:
-		var book orderbook.Base
+		book := orderbook.Base{
+			Asks: make(orderbook.Items, 0, len(data)),
+			Bids: make(orderbook.Items, 0, len(data)),
+		}
+
 		for i := range data {
 			item := orderbook.Item{
 				Price:  data[i].Price,
 				Amount: float64(data[i].Size),
 				ID:     data[i].ID,
 			}
+			side := strings.ToUpper(data[i].Side)
 			switch {
-			case strings.EqualFold(data[i].Side, order.Sell.String()):
+			case side == order.Sell.String():
 				book.Asks = append(book.Asks, item)
-			case strings.EqualFold(data[i].Side, order.Buy.String()):
+			case side == order.Buy.String():
 				book.Bids = append(book.Bids, item)
 			default:
 				return fmt.Errorf("could not process websocket orderbook update, order side could not be matched for %s",
@@ -520,7 +525,8 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, p currency.
 				err)
 		}
 	default:
-		var asks, bids []orderbook.Item
+		asks := make([]orderbook.Item, 0, len(data))
+		bids := make([]orderbook.Item, 0, len(data))
 		for i := range data {
 			nItem := orderbook.Item{
 				Price:  data[i].Price,

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -504,11 +504,10 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, p currency.
 				Amount: float64(data[i].Size),
 				ID:     data[i].ID,
 			}
-			side := strings.ToUpper(data[i].Side)
 			switch {
-			case side == order.Sell.String():
+			case strings.EqualFold(data[i].Side, order.Sell.String()):
 				book.Asks = append(book.Asks, item)
-			case side == order.Buy.String():
+			case strings.EqualFold(data[i].Side, order.Buy.String()):
 				book.Bids = append(book.Bids, item)
 			default:
 				return fmt.Errorf("could not process websocket orderbook update, order side could not be matched for %s",

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -97,18 +97,20 @@ func (b *Bitmex) WsConnect() error {
 	b.Websocket.Wg.Add(1)
 	go b.wsReadData()
 
-	err = b.websocketSendAuth(context.TODO())
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%v - authentication failed: %v\n",
-			b.Name,
-			err)
-	} else {
-		authsubs, err := b.GenerateAuthenticatedSubscriptions()
+	if b.Websocket.CanUseAuthenticatedEndpoints() {
+		err = b.websocketSendAuth(context.TODO())
 		if err != nil {
-			return err
+			log.Errorf(log.ExchangeSys,
+				"%v - authentication failed: %v\n",
+				b.Name,
+				err)
+		} else {
+			authsubs, err := b.GenerateAuthenticatedSubscriptions()
+			if err != nil {
+				return err
+			}
+			return b.Websocket.SubscribeToChannels(authsubs)
 		}
-		return b.Websocket.SubscribeToChannels(authsubs)
 	}
 	return nil
 }

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -397,14 +397,13 @@ func (b *Bitmex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 	book.Asks = make(orderbook.Items, 0, len(orderbookNew))
 	book.Bids = make(orderbook.Items, 0, len(orderbookNew))
 	for i := range orderbookNew {
-		side := strings.ToUpper(orderbookNew[i].Side)
 		switch {
-		case side == order.Sell.String():
+		case strings.EqualFold(orderbookNew[i].Side, order.Sell.String()):
 			book.Asks = append(book.Asks, orderbook.Item{
 				Amount: float64(orderbookNew[i].Size),
 				Price:  orderbookNew[i].Price,
 			})
-		case side == order.Buy.String():
+		case strings.EqualFold(orderbookNew[i].Side, order.Buy.String()):
 			book.Bids = append(book.Bids, orderbook.Item{
 				Amount: float64(orderbookNew[i].Size),
 				Price:  orderbookNew[i].Price,

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -233,9 +233,9 @@ func (b *Bitmex) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]st
 		return nil, err
 	}
 
-	var products []string
+	products := make([]string, len(marketInfo))
 	for x := range marketInfo {
-		products = append(products, marketInfo[x].Symbol.String())
+		products[x] = marketInfo[x].Symbol.String()
 	}
 
 	return products, nil
@@ -748,10 +748,9 @@ func (b *Bitmex) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
-	params := OrdersRequest{}
-	params.Filter = "{\"open\":true}"
-
+	params := OrdersRequest{
+		Filter: "{\"open\":true}",
+	}
 	resp, err := b.GetOrders(ctx, &params)
 	if err != nil {
 		return nil, err
@@ -762,6 +761,7 @@ func (b *Bitmex) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderSide := orderSideMap[resp[i].Side]
 		orderStatus, err := order.StringToOrderStatus(resp[i].OrdStatus)
@@ -789,7 +789,7 @@ func (b *Bitmex) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 				format.Delimiter),
 		}
 
-		orders = append(orders, orderDetail)
+		orders[i] = orderDetail
 	}
 
 	order.FilterOrdersBySide(&orders, req.Side)
@@ -807,7 +807,6 @@ func (b *Bitmex) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
 	params := OrdersRequest{}
 	resp, err := b.GetOrders(ctx, &params)
 	if err != nil {
@@ -819,6 +818,7 @@ func (b *Bitmex) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderSide := orderSideMap[resp[i].Side]
 		orderStatus, err := order.StringToOrderStatus(resp[i].OrdStatus)
@@ -848,7 +848,7 @@ func (b *Bitmex) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		}
 		orderDetail.InferCostsAndTimes()
 
-		orders = append(orders, orderDetail)
+		orders[i] = orderDetail
 	}
 
 	order.FilterOrdersBySide(&orders, req.Side)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -394,16 +394,21 @@ func (b *Bitmex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		return book, err
 	}
 
+	book.Asks = make(orderbook.Items, 0, len(orderbookNew))
+	book.Bids = make(orderbook.Items, 0, len(orderbookNew))
 	for i := range orderbookNew {
+		side := strings.ToUpper(orderbookNew[i].Side)
 		switch {
-		case strings.EqualFold(orderbookNew[i].Side, order.Sell.String()):
+		case side == order.Sell.String():
 			book.Asks = append(book.Asks, orderbook.Item{
 				Amount: float64(orderbookNew[i].Size),
-				Price:  orderbookNew[i].Price})
-		case strings.EqualFold(orderbookNew[i].Side, order.Buy.String()):
+				Price:  orderbookNew[i].Price,
+			})
+		case side == order.Buy.String():
 			book.Bids = append(book.Bids, orderbook.Item{
 				Amount: float64(orderbookNew[i].Size),
-				Price:  orderbookNew[i].Price})
+				Price:  orderbookNew[i].Price,
+			})
 		default:
 			return book,
 				fmt.Errorf("could not process orderbook, order side [%s] could not be matched",

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -305,7 +305,7 @@ func (b *Bitstamp) GetUserTransactions(ctx context.Context, currencyPair string)
 		}
 	}
 
-	var transactions []UserTransactions
+	transactions := make([]UserTransactions, len(response))
 	for x := range response {
 		tx := UserTransactions{}
 		tx.Date = response[x].Date
@@ -318,7 +318,7 @@ func (b *Bitstamp) GetUserTransactions(ctx context.Context, currencyPair string)
 		tx.BTCUSD = processNumber(response[x].BTCUSD)
 		tx.Fee = response[x].Fee
 		tx.OrderID = response[x].OrderID
-		transactions = append(transactions, tx)
+		transactions[x] = tx
 	}
 
 	return transactions, nil

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -221,10 +221,10 @@ type websocketOrderBookResponse struct {
 }
 
 type websocketOrderBook struct {
-	Asks           [][]string `json:"asks"`
-	Bids           [][]string `json:"bids"`
-	Timestamp      int64      `json:"timestamp,string"`
-	Microtimestamp string     `json:"microtimestamp"`
+	Asks           [][2]string `json:"asks"`
+	Bids           [][2]string `json:"bids"`
+	Timestamp      int64       `json:"timestamp,string"`
+	Microtimestamp string      `json:"microtimestamp"`
 }
 
 // OHLCResponse holds returned candle data

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -307,17 +307,19 @@ func (b *Bitstamp) seedOrderBook(ctx context.Context) error {
 		}
 
 		var newOrderBook orderbook.Base
+		newOrderBook.Asks = make(orderbook.Items, len(orderbookSeed.Asks))
 		for i := range orderbookSeed.Asks {
-			newOrderBook.Asks = append(newOrderBook.Asks, orderbook.Item{
+			newOrderBook.Asks[i] = orderbook.Item{
 				Price:  orderbookSeed.Asks[i].Price,
 				Amount: orderbookSeed.Asks[i].Amount,
-			})
+			}
 		}
+		newOrderBook.Bids = make(orderbook.Items, len(orderbookSeed.Bids))
 		for i := range orderbookSeed.Bids {
-			newOrderBook.Bids = append(newOrderBook.Bids, orderbook.Item{
+			newOrderBook.Bids[i] = orderbook.Item{
 				Price:  orderbookSeed.Bids[i].Price,
 				Amount: orderbookSeed.Bids[i].Amount,
-			})
+			}
 		}
 		newOrderBook.Pair = p[x]
 		newOrderBook.Asset = asset.Spot

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	bitstampWSURL = "wss://ws.bitstamp.net"
+	bitstampWSURL = "wss://ws.bitstamp.net" // nolint // gosec false positive
 )
 
 // WsConnect connects to a websocket feed
@@ -255,33 +255,29 @@ func (b *Bitstamp) wsUpdateOrderbook(update websocketOrderBook, p currency.Pair,
 	if len(update.Asks) == 0 && len(update.Bids) == 0 {
 		return errors.New("no orderbook data")
 	}
-	var asks, bids []orderbook.Item
+	asks := make([]orderbook.Item, len(update.Asks))
+	bids := make([]orderbook.Item, len(update.Bids))
 	for i := range update.Asks {
 		target, err := strconv.ParseFloat(update.Asks[i][0], 64)
 		if err != nil {
-			b.Websocket.DataHandler <- err
-			continue
+			return err
 		}
 		amount, err := strconv.ParseFloat(update.Asks[i][1], 64)
 		if err != nil {
-			b.Websocket.DataHandler <- err
-			continue
+			return err
 		}
-		asks = append(asks, orderbook.Item{Price: target, Amount: amount})
+		asks[i] = orderbook.Item{Price: target, Amount: amount}
 	}
 	for i := range update.Bids {
 		target, err := strconv.ParseFloat(update.Bids[i][0], 64)
 		if err != nil {
-			b.Websocket.DataHandler <- err
-			continue
+			return err
 		}
 		amount, err := strconv.ParseFloat(update.Bids[i][1], 64)
 		if err != nil {
-			b.Websocket.DataHandler <- err
-			continue
+			return err
 		}
-
-		bids = append(bids, orderbook.Item{Price: target, Amount: amount})
+		bids[i] = orderbook.Item{Price: target, Amount: amount}
 	}
 	return b.Websocket.Orderbook.LoadSnapshot(&orderbook.Base{
 		Bids:            bids,

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -406,18 +406,20 @@ func (b *Bitstamp) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -285,7 +285,7 @@ func (b *Bitstamp) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]
 		return nil, err
 	}
 
-	var products []string
+	products := make([]string, 0, len(pairs))
 	for x := range pairs {
 		if pairs[x].Trading != "Enabled" {
 			continue
@@ -436,7 +436,7 @@ func (b *Bitstamp) UpdateAccountInfo(ctx context.Context, assetType asset.Item) 
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, 0, len(accountBalance))
 	for k, v := range accountBalance {
 		currencies = append(currencies, account.Balance{
 			CurrencyName: currency.NewCode(k),
@@ -480,23 +480,23 @@ func (b *Bitstamp) GetWithdrawalsHistory(ctx context.Context, c currency.Code) (
 
 // GetRecentTrades returns the most recent trades for a currency and asset
 func (b *Bitstamp) GetRecentTrades(ctx context.Context, p currency.Pair, assetType asset.Item) ([]trade.Data, error) {
-	var err error
-	p, err = b.FormatExchangeCurrency(p, assetType)
+	p, err := b.FormatExchangeCurrency(p, assetType)
 	if err != nil {
 		return nil, err
 	}
-	var tradeData []Transactions
-	tradeData, err = b.GetTransactions(ctx, p.String(), "")
+
+	tradeData, err := b.GetTransactions(ctx, p.String(), "")
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		s := order.Buy
 		if tradeData[i].Type == 1 {
 			s = order.Sell
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     b.Name,
 			TID:          strconv.FormatInt(tradeData[i].TradeID, 10),
 			CurrencyPair: p,
@@ -505,7 +505,7 @@ func (b *Bitstamp) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
 			Timestamp:    time.Unix(tradeData[i].Date, 0),
-		})
+		}
 	}
 
 	err = b.AddTradesToBuffer(resp...)
@@ -720,7 +720,7 @@ func (b *Bitstamp) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequ
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderSide := order.Buy
 		if resp[i].Type == SellOrder {
@@ -745,7 +745,7 @@ func (b *Bitstamp) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequ
 			p = req.Pairs[0]
 		}
 
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			Amount:   resp[i].Amount,
 			ID:       strconv.FormatInt(resp[i].ID, 10),
 			Price:    resp[i].Price,
@@ -754,7 +754,7 @@ func (b *Bitstamp) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequ
 			Date:     tm,
 			Pair:     p,
 			Exchange: b.Name,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)
@@ -788,7 +788,7 @@ func (b *Bitstamp) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequ
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, 0, len(resp))
 	for i := range resp {
 		if resp[i].Type != MarketTrade {
 			continue

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -103,7 +103,7 @@ func (b *Bittrex) GetMarketSummary(ctx context.Context, marketName string) (Mark
 // GetOrderbook method returns current order book information by currency and depth.
 // "marketSymbol" ie ltc-btc
 // "depth" is either 1, 25 or 500. Server side, the depth defaults to 25.
-func (b *Bittrex) GetOrderbook(ctx context.Context, marketName string, depth int64) (OrderbookData, int64, error) {
+func (b *Bittrex) GetOrderbook(ctx context.Context, marketName string, depth int64) (*OrderbookData, int64, error) {
 	strDepth := strconv.FormatInt(depth, 10)
 
 	var resp OrderbookData
@@ -111,14 +111,14 @@ func (b *Bittrex) GetOrderbook(ctx context.Context, marketName string, depth int
 	resultHeader := http.Header{}
 	err := b.SendHTTPRequest(ctx, exchange.RestSpot, fmt.Sprintf(getOrderbook, marketName, strDepth), &resp, &resultHeader)
 	if err != nil {
-		return OrderbookData{}, 0, err
+		return nil, 0, err
 	}
 	sequence, err = strconv.ParseInt(resultHeader.Get("sequence"), 10, 64)
 	if err != nil {
-		return OrderbookData{}, 0, err
+		return nil, 0, err
 	}
 
-	return resp, sequence, nil
+	return &resp, sequence, nil
 }
 
 // GetMarketHistory retrieves the latest trades that have occurred for a specific market

--- a/exchanges/bittrex/bittrex_websocket.go
+++ b/exchanges/bittrex/bittrex_websocket.go
@@ -413,6 +413,12 @@ func (b *Bittrex) wsDecodeMessage(encodedMessage string, v interface{}) error {
 	if err != nil {
 		return err
 	}
+	if err = reader.Close(); err != nil {
+		log.Warnf(log.WebsocketMgr, "%s wsDecodeMessage: unable to close reader: %s",
+			b.Name,
+			err,
+		)
+	}
 	return json.Unmarshal(message, v)
 }
 

--- a/exchanges/bittrex/bittrex_websocket.go
+++ b/exchanges/bittrex/bittrex_websocket.go
@@ -61,7 +61,7 @@ var defaultSpotSubscribedChannelsAuth = []string{
 type TickerCache struct {
 	MarketSummaries map[string]*MarketSummaryData
 	Tickers         map[string]*TickerData
-	sync.RWMutex
+	mu              sync.RWMutex
 }
 
 // WsConnect connects to a websocket feed
@@ -520,8 +520,8 @@ func (b *Bittrex) WsProcessUpdateTicker(tickerData TickerData) error {
 
 	tickerPrice, err := ticker.GetTicker(b.Name, pair, asset.Spot)
 	if err != nil {
-		b.tickerCache.Lock()
-		defer b.tickerCache.Unlock()
+		b.tickerCache.mu.Lock()
+		defer b.tickerCache.mu.Unlock()
 		if b.tickerCache.MarketSummaries[tickerData.Symbol] != nil {
 			marketSummaryData := b.tickerCache.MarketSummaries[tickerData.Symbol]
 			tickerPrice = b.constructTicker(tickerData, marketSummaryData, pair, asset.Spot)
@@ -550,8 +550,8 @@ func (b *Bittrex) WsProcessUpdateMarketSummary(marketSummaryData *MarketSummaryD
 
 	tickerPrice, err := ticker.GetTicker(b.Name, pair, asset.Spot)
 	if err != nil {
-		b.tickerCache.Lock()
-		defer b.tickerCache.Unlock()
+		b.tickerCache.mu.Lock()
+		defer b.tickerCache.mu.Unlock()
 		if b.tickerCache.Tickers[marketSummaryData.Symbol] != nil {
 			tickerData := b.tickerCache.Tickers[marketSummaryData.Symbol]
 			tickerPrice = b.constructTicker(*tickerData, marketSummaryData, pair, asset.Spot)

--- a/exchanges/bittrex/bittrex_websocket.go
+++ b/exchanges/bittrex/bittrex_websocket.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -277,9 +277,9 @@ func (b *Bittrex) subscribeSlice(channelsToSubscribe []stream.ChannelSubscriptio
 		InvocationID: b.Websocket.Conn.GenerateMessageID(false),
 	}
 
-	var channels []string
+	channels := make([]string, len(channelsToSubscribe))
 	for i := range channelsToSubscribe {
-		channels = append(channels, channelsToSubscribe[i].Channel)
+		channels[i] = channelsToSubscribe[i].Channel
 	}
 	arguments := make([][]string, 0)
 	arguments = append(arguments, channels)
@@ -342,9 +342,9 @@ func (b *Bittrex) unsubscribeSlice(channelsToUnsubscribe []stream.ChannelSubscri
 		InvocationID: b.Websocket.Conn.GenerateMessageID(false),
 	}
 
-	var channels []string
+	channels := make([]string, len(channelsToUnsubscribe))
 	for i := range channelsToUnsubscribe {
-		channels = append(channels, channelsToUnsubscribe[i].Channel)
+		channels[i] = channelsToUnsubscribe[i].Channel
 	}
 	arguments := make([][]string, 0)
 	arguments = append(arguments, channels)
@@ -409,7 +409,7 @@ func (b *Bittrex) wsDecodeMessage(encodedMessage string, v interface{}) error {
 		return err
 	}
 	reader := flate.NewReader(bytes.NewBuffer(raw))
-	message, err := ioutil.ReadAll(reader)
+	message, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -376,24 +376,22 @@ func (b *Bittrex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTyp
 		Asset:           assetType,
 		VerifyOrderbook: b.CanVerifyOrderbook,
 		LastUpdateID:    sequence,
+		Bids:            make(orderbook.Items, len(orderbookData.Bid)),
+		Asks:            make(orderbook.Items, len(orderbookData.Ask)),
 	}
 
 	for x := range orderbookData.Bid {
-		book.Bids = append(book.Bids,
-			orderbook.Item{
-				Amount: orderbookData.Bid[x].Quantity,
-				Price:  orderbookData.Bid[x].Rate,
-			},
-		)
+		book.Bids[x] = orderbook.Item{
+			Amount: orderbookData.Bid[x].Quantity,
+			Price:  orderbookData.Bid[x].Rate,
+		}
 	}
 
 	for x := range orderbookData.Ask {
-		book.Asks = append(book.Asks,
-			orderbook.Item{
-				Amount: orderbookData.Ask[x].Quantity,
-				Price:  orderbookData.Ask[x].Rate,
-			},
-		)
+		book.Asks[x] = orderbook.Item{
+			Amount: orderbookData.Ask[x].Quantity,
+			Price:  orderbookData.Ask[x].Rate,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -49,19 +49,19 @@ func (b *Bittrex) setupOrderbookManager() {
 
 // ProcessUpdateOB processes the websocket orderbook update
 func (b *Bittrex) ProcessUpdateOB(pair currency.Pair, message *OrderbookUpdateMessage) error {
-	var updateBids []orderbook.Item
+	updateBids := make([]orderbook.Item, len(message.BidDeltas))
 	for x := range message.BidDeltas {
-		updateBids = append(updateBids, orderbook.Item{
+		updateBids[x] = orderbook.Item{
 			Price:  message.BidDeltas[x].Rate,
 			Amount: message.BidDeltas[x].Quantity,
-		})
+		}
 	}
-	var updateAsks []orderbook.Item
+	updateAsks := make([]orderbook.Item, len(message.AskDeltas))
 	for x := range message.AskDeltas {
-		updateAsks = append(updateAsks, orderbook.Item{
+		updateAsks[x] = orderbook.Item{
 			Price:  message.AskDeltas[x].Rate,
 			Amount: message.AskDeltas[x].Quantity,
-		})
+		}
 	}
 
 	return b.Websocket.Orderbook.Update(&buffer.Update{

--- a/exchanges/bittrex/bittrex_ws_orderbook.go
+++ b/exchanges/bittrex/bittrex_ws_orderbook.go
@@ -116,30 +116,33 @@ func (b *Bittrex) SeedLocalOBCache(ctx context.Context, p currency.Pair) error {
 	if err != nil {
 		return err
 	}
-	return b.SeedLocalCacheWithOrderBook(p, sequence, &ob)
+	return b.SeedLocalCacheWithOrderBook(p, sequence, ob)
 }
 
 // SeedLocalCacheWithOrderBook seeds the local orderbook cache
 func (b *Bittrex) SeedLocalCacheWithOrderBook(p currency.Pair, sequence int64, orderbookNew *OrderbookData) error {
-	var newOrderBook orderbook.Base
-	for i := range orderbookNew.Bid {
-		newOrderBook.Bids = append(newOrderBook.Bids, orderbook.Item{
-			Amount: orderbookNew.Bid[i].Quantity,
-			Price:  orderbookNew.Bid[i].Rate,
-		})
-	}
-	for i := range orderbookNew.Ask {
-		newOrderBook.Asks = append(newOrderBook.Asks, orderbook.Item{
-			Amount: orderbookNew.Ask[i].Quantity,
-			Price:  orderbookNew.Ask[i].Rate,
-		})
+	newOrderBook := orderbook.Base{
+		Pair:            p,
+		Asset:           asset.Spot,
+		Exchange:        b.Name,
+		LastUpdateID:    sequence,
+		VerifyOrderbook: b.CanVerifyOrderbook,
+		Bids:            make(orderbook.Items, len(orderbookNew.Bid)),
+		Asks:            make(orderbook.Items, len(orderbookNew.Ask)),
 	}
 
-	newOrderBook.Pair = p
-	newOrderBook.Asset = asset.Spot
-	newOrderBook.Exchange = b.Name
-	newOrderBook.LastUpdateID = sequence
-	newOrderBook.VerifyOrderbook = b.CanVerifyOrderbook
+	for i := range orderbookNew.Bid {
+		newOrderBook.Bids[i] = orderbook.Item{
+			Amount: orderbookNew.Bid[i].Quantity,
+			Price:  orderbookNew.Bid[i].Rate,
+		}
+	}
+	for i := range orderbookNew.Ask {
+		newOrderBook.Asks[i] = orderbook.Item{
+			Amount: orderbookNew.Ask[i].Quantity,
+			Price:  orderbookNew.Ask[i].Rate,
+		}
+	}
 
 	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -893,8 +893,8 @@ func TestChecksum(t *testing.T) {
 		},
 	}
 
-	expecting := 3802968298
-	err := checksum(b, uint32(expecting))
+	expecting := uint32(3802968298)
+	err := checksum(b, expecting)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -398,15 +398,20 @@ func (b *BTCMarkets) UpdateOrderbook(ctx context.Context, p currency.Pair, asset
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(tempResp.Bids))
 	for x := range tempResp.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: tempResp.Bids[x].Volume,
-			Price:  tempResp.Bids[x].Price})
+			Price:  tempResp.Bids[x].Price,
+		}
 	}
+
+	book.Asks = make(orderbook.Items, len(tempResp.Asks))
 	for y := range tempResp.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[y] = orderbook.Item{
 			Amount: tempResp.Asks[y].Volume,
-			Price:  tempResp.Asks[y].Price})
+			Price:  tempResp.Asks[y].Price,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -272,7 +272,10 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 		if err != nil {
 			return err
 		}
-		var newOB orderbook.Base
+		newOB := orderbook.Base{
+			Bids: make(orderbook.Items, 0, len(t.Data.BuyQuote)),
+			Asks: make(orderbook.Items, 0, len(t.Data.SellQuote)),
+		}
 		var price, amount float64
 		for i := range t.Data.SellQuote {
 			p := strings.Replace(t.Data.SellQuote[i].Price, ",", "", -1)

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -472,7 +472,7 @@ func (b *BTSE) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 
 	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		tradeTimestamp := time.Unix(tradeData[i].Time/1000, 0)
+		tradeTimestamp := time.UnixMilli(tradeData[i].Time)
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData[i].Side)
 		if err != nil {

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -359,21 +359,25 @@ func (b *BTSE) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType a
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, 0, len(a.BuyQuote))
 	for x := range a.BuyQuote {
 		if b.orderbookFilter(a.BuyQuote[x].Price, a.BuyQuote[x].Size) {
 			continue
 		}
 		book.Bids = append(book.Bids, orderbook.Item{
 			Price:  a.BuyQuote[x].Price,
-			Amount: a.BuyQuote[x].Size})
+			Amount: a.BuyQuote[x].Size,
+		})
 	}
+	book.Asks = make(orderbook.Items, 0, len(a.SellQuote))
 	for x := range a.SellQuote {
 		if b.orderbookFilter(a.SellQuote[x].Price, a.SellQuote[x].Size) {
 			continue
 		}
 		book.Asks = append(book.Asks, orderbook.Item{
 			Price:  a.SellQuote[x].Price,
-			Amount: a.SellQuote[x].Size})
+			Amount: a.SellQuote[x].Size,
+		})
 	}
 	book.Asks.Reverse() // Reverse asks for correct alignment
 	book.Pair = p

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -232,8 +232,7 @@ func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start,
 		values.Set("granularity", strconv.FormatInt(granularity, 10))
 	}
 
-	var resp [][]interface{}
-
+	var resp [][6]float64
 	path := common.EncodeURLValues(
 		fmt.Sprintf("%s/%s/%s", coinbaseproProducts, currencyPair, coinbaseproHistory),
 		values)
@@ -243,21 +242,14 @@ func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start,
 
 	history := make([]History, len(resp))
 	for x := range resp {
-		var s History
-		single := resp[x]
-		a, _ := single[0].(float64)
-		s.Time = int64(a)
-		b, _ := single[1].(float64)
-		s.Low = b
-		c, _ := single[2].(float64)
-		s.High = c
-		d, _ := single[3].(float64)
-		s.Open = d
-		e, _ := single[4].(float64)
-		s.Close = e
-		f, _ := single[5].(float64)
-		s.Volume = f
-		history[x] = s
+		history[x] = History{
+			Time:   time.Unix(int64(resp[x][0]), 0),
+			Low:    resp[x][1],
+			High:   resp[x][2],
+			Open:   resp[x][3],
+			Close:  resp[x][4],
+			Volume: resp[x][5],
+		}
 	}
 
 	return history, nil

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -80,59 +80,110 @@ func (c *CoinbasePro) GetOrderbook(ctx context.Context, symbol string, level int
 	}
 
 	if level == 3 {
-		ob := OrderbookL3{}
-		ob.Sequence = orderbook.Sequence
-		for _, x := range orderbook.Asks {
-			price, err := strconv.ParseFloat((x[0].(string)), 64)
-			if err != nil {
-				continue
-			}
-			amount, err := strconv.ParseFloat((x[1].(string)), 64)
-			if err != nil {
-				continue
-			}
-
-			ob.Asks = append(ob.Asks, OrderL3{Price: price, Amount: amount, OrderID: x[2].(string)})
+		ob := OrderbookL3{
+			Sequence: orderbook.Sequence,
+			Bids:     make([]OrderL3, len(orderbook.Bids)),
+			Asks:     make([]OrderL3, len(orderbook.Asks)),
 		}
-		for _, x := range orderbook.Bids {
-			price, err := strconv.ParseFloat((x[0].(string)), 64)
-			if err != nil {
-				continue
+		ob.Sequence = orderbook.Sequence
+		for x := range orderbook.Asks {
+			priceConv, ok := orderbook.Asks[x][0].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert price")
 			}
-			amount, err := strconv.ParseFloat((x[1].(string)), 64)
+			price, err := strconv.ParseFloat(priceConv, 64)
 			if err != nil {
-				continue
+				return nil, err
 			}
-
-			ob.Bids = append(ob.Bids, OrderL3{Price: price, Amount: amount, OrderID: x[2].(string)})
+			amountConv, ok := orderbook.Asks[x][1].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert price")
+			}
+			amount, err := strconv.ParseFloat(amountConv, 64)
+			if err != nil {
+				return nil, err
+			}
+			ordID, ok := orderbook.Asks[x][2].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert order ID")
+			}
+			ob.Asks[x] = OrderL3{Price: price, Amount: amount, OrderID: ordID}
+		}
+		for x := range orderbook.Bids {
+			priceConv, ok := orderbook.Bids[x][0].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert price")
+			}
+			price, err := strconv.ParseFloat(priceConv, 64)
+			if err != nil {
+				return nil, err
+			}
+			amountConv, ok := orderbook.Bids[x][1].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert price")
+			}
+			amount, err := strconv.ParseFloat(amountConv, 64)
+			if err != nil {
+				return nil, err
+			}
+			ordID, ok := orderbook.Bids[x][2].(string)
+			if !ok {
+				return nil, errors.New("unable to type assert order ID")
+			}
+			ob.Bids[x] = OrderL3{Price: price, Amount: amount, OrderID: ordID}
 		}
 		return ob, nil
 	}
-	ob := OrderbookL1L2{}
-	ob.Sequence = orderbook.Sequence
-	for _, x := range orderbook.Asks {
-		price, err := strconv.ParseFloat((x[0].(string)), 64)
-		if err != nil {
-			continue
-		}
-		amount, err := strconv.ParseFloat((x[1].(string)), 64)
-		if err != nil {
-			continue
-		}
-
-		ob.Asks = append(ob.Asks, OrderL1L2{Price: price, Amount: amount, NumOrders: x[2].(float64)})
+	ob := OrderbookL1L2{
+		Sequence: orderbook.Sequence,
+		Bids:     make([]OrderL1L2, len(orderbook.Bids)),
+		Asks:     make([]OrderL1L2, len(orderbook.Asks)),
 	}
-	for _, x := range orderbook.Bids {
-		price, err := strconv.ParseFloat((x[0].(string)), 64)
-		if err != nil {
-			continue
+	for x := range orderbook.Asks {
+		priceConv, ok := orderbook.Asks[x][0].(string)
+		if !ok {
+			return nil, errors.New("unable to type assert price")
 		}
-		amount, err := strconv.ParseFloat((x[1].(string)), 64)
+		price, err := strconv.ParseFloat(priceConv, 64)
 		if err != nil {
-			continue
+			return nil, err
 		}
-
-		ob.Bids = append(ob.Bids, OrderL1L2{Price: price, Amount: amount, NumOrders: x[2].(float64)})
+		amountConv, ok := orderbook.Asks[x][1].(string)
+		if !ok {
+			return nil, errors.New("unable to type assert amount")
+		}
+		amount, err := strconv.ParseFloat(amountConv, 64)
+		if err != nil {
+			return nil, err
+		}
+		numOrders, ok := orderbook.Asks[x][2].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert number of orders")
+		}
+		ob.Asks[x] = OrderL1L2{Price: price, Amount: amount, NumOrders: numOrders}
+	}
+	for x := range orderbook.Bids {
+		priceConv, ok := orderbook.Bids[x][0].(string)
+		if !ok {
+			return nil, errors.New("unable to type assert price")
+		}
+		price, err := strconv.ParseFloat(priceConv, 64)
+		if err != nil {
+			return nil, err
+		}
+		amountConv, ok := orderbook.Bids[x][1].(string)
+		if !ok {
+			return nil, errors.New("unable to type assert amount")
+		}
+		amount, err := strconv.ParseFloat(amountConv, 64)
+		if err != nil {
+			return nil, err
+		}
+		numOrders, ok := orderbook.Bids[x][2].(float64)
+		if !ok {
+			return nil, errors.New("unable to type assert number of orders")
+		}
+		ob.Bids[x] = OrderL1L2{Price: price, Amount: amount, NumOrders: numOrders}
 	}
 	return ob, nil
 }
@@ -158,8 +209,6 @@ func (c *CoinbasePro) GetTrades(ctx context.Context, currencyPair string) ([]Tra
 // GetHistoricRates returns historic rates for a product. Rates are returned in
 // grouped buckets based on requested granularity.
 func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start, end string, granularity int64) ([]History, error) {
-	var resp [][]interface{}
-	var history []History
 	values := url.Values{}
 
 	if len(start) > 0 {
@@ -183,16 +232,19 @@ func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start,
 		values.Set("granularity", strconv.FormatInt(granularity, 10))
 	}
 
+	var resp [][]interface{}
+
 	path := common.EncodeURLValues(
 		fmt.Sprintf("%s/%s/%s", coinbaseproProducts, currencyPair, coinbaseproHistory),
 		values)
-
 	if err := c.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp); err != nil {
-		return history, err
+		return nil, err
 	}
 
-	for _, single := range resp {
+	history := make([]History, len(resp))
+	for x := range resp {
 		var s History
+		single := resp[x]
 		a, _ := single[0].(float64)
 		s.Time = int64(a)
 		b, _ := single[1].(float64)
@@ -205,7 +257,7 @@ func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start,
 		s.Close = e
 		f, _ := single[5].(float64)
 		s.Volume = f
-		history = append(history, s)
+		history[x] = s
 	}
 
 	return history, nil

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -97,7 +97,7 @@ func (c *CoinbasePro) GetOrderbook(ctx context.Context, symbol string, level int
 			}
 			amountConv, ok := orderbook.Asks[x][1].(string)
 			if !ok {
-				return nil, errors.New("unable to type assert price")
+				return nil, errors.New("unable to type assert amount")
 			}
 			amount, err := strconv.ParseFloat(amountConv, 64)
 			if err != nil {
@@ -120,7 +120,7 @@ func (c *CoinbasePro) GetOrderbook(ctx context.Context, symbol string, level int
 			}
 			amountConv, ok := orderbook.Bids[x][1].(string)
 			if !ok {
-				return nil, errors.New("unable to type assert price")
+				return nil, errors.New("unable to type assert amount")
 			}
 			amount, err := strconv.ParseFloat(amountConv, 64)
 			if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -84,6 +84,17 @@ func TestGetProducts(t *testing.T) {
 	}
 }
 
+func TestGetOrderbook(t *testing.T) {
+	_, err := c.GetOrderbook(context.Background(), testPair.String(), 2)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = c.GetOrderbook(context.Background(), testPair.String(), 3)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestGetTicker(t *testing.T) {
 	_, err := c.GetTicker(context.Background(), testPair.String())
 	if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -39,12 +39,12 @@ type Trade struct {
 
 // History holds historic rate information
 type History struct {
-	Time   int64   `json:"time"`
-	Low    float64 `json:"low"`
-	High   float64 `json:"high"`
-	Open   float64 `json:"open"`
-	Close  float64 `json:"close"`
-	Volume float64 `json:"volume"`
+	Time   time.Time
+	Low    float64
+	High   float64
+	Open   float64
+	Close  float64
+	Volume float64
 }
 
 // Stats holds last 24 hr data for coinbasepro

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -427,18 +427,18 @@ type WebsocketTicker struct {
 
 // WebsocketOrderbookSnapshot defines a snapshot response
 type WebsocketOrderbookSnapshot struct {
-	ProductID string          `json:"product_id"`
-	Type      string          `json:"type"`
-	Bids      [][]interface{} `json:"bids"`
-	Asks      [][]interface{} `json:"asks"`
+	ProductID string      `json:"product_id"`
+	Type      string      `json:"type"`
+	Bids      [][2]string `json:"bids"`
+	Asks      [][2]string `json:"asks"`
 }
 
 // WebsocketL2Update defines an update on the L2 orderbooks
 type WebsocketL2Update struct {
-	Type      string          `json:"type"`
-	ProductID string          `json:"product_id"`
-	Time      string          `json:"time"`
-	Changes   [][]interface{} `json:"changes"`
+	Type      string      `json:"type"`
+	ProductID string      `json:"product_id"`
+	Time      string      `json:"time"`
+	Changes   [][3]string `json:"changes"`
 }
 
 type wsMsgType struct {

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -331,9 +331,9 @@ type OrderbookL3 struct {
 
 // OrderbookResponse is a generalized response for order books
 type OrderbookResponse struct {
-	Sequence int64           `json:"sequence"`
-	Bids     [][]interface{} `json:"bids"`
-	Asks     [][]interface{} `json:"asks"`
+	Sequence int64            `json:"sequence"`
+	Bids     [][3]interface{} `json:"bids"`
+	Asks     [][3]interface{} `json:"asks"`
 }
 
 // FillResponse contains fill information from the exchange

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -338,7 +338,11 @@ func (c *CoinbasePro) ProcessUpdate(update WebsocketL2Update) error {
 			return err
 		}
 
-		if update.Changes[i][0].(string) == order.Buy.Lower() {
+		orderSide, ok := update.Changes[i][0].(string)
+		if !ok {
+			return errors.New("unable to type assert orderSide")
+		}
+		if orderSide == order.Buy.Lower() {
 			bids = append(bids, orderbook.Item{Price: price, Amount: volume})
 		} else {
 			asks = append(asks, orderbook.Item{Price: price, Amount: volume})

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -295,11 +295,9 @@ func (c *CoinbasePro) FetchTradablePairs(ctx context.Context, asset asset.Item) 
 		return nil, err
 	}
 
-	var products []string
+	products := make([]string, len(pairs))
 	for x := range pairs {
-		products = append(products, pairs[x].BaseCurrency+
-			format.Delimiter+
-			pairs[x].QuoteCurrency)
+		products[x] = pairs[x].BaseCurrency + format.Delimiter + pairs[x].QuoteCurrency
 	}
 
 	return products, nil
@@ -490,14 +488,14 @@ func (c *CoinbasePro) GetRecentTrades(ctx context.Context, p currency.Pair, asse
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData[i].Side)
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     c.Name,
 			TID:          strconv.FormatInt(tradeData[i].TradeID, 10),
 			CurrencyPair: p,
@@ -506,7 +504,7 @@ func (c *CoinbasePro) GetRecentTrades(ctx context.Context, p currency.Pair, asse
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Size,
 			Timestamp:    tradeData[i].Time,
-		})
+		}
 	}
 
 	err = c.AddTradesToBuffer(resp...)
@@ -772,7 +770,7 @@ func (c *CoinbasePro) GetActiveOrders(ctx context.Context, req *order.GetOrdersR
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(respOrders))
 	for i := range respOrders {
 		var curr currency.Pair
 		curr, err = currency.NewPairDelimiter(respOrders[i].ProductID,
@@ -782,7 +780,7 @@ func (c *CoinbasePro) GetActiveOrders(ctx context.Context, req *order.GetOrdersR
 		}
 		orderSide := order.Side(strings.ToUpper(respOrders[i].Side))
 		orderType := order.Type(strings.ToUpper(respOrders[i].Type))
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			ID:             respOrders[i].ID,
 			Amount:         respOrders[i].Size,
 			ExecutedAmount: respOrders[i].FilledSize,
@@ -791,7 +789,7 @@ func (c *CoinbasePro) GetActiveOrders(ctx context.Context, req *order.GetOrdersR
 			Side:           orderSide,
 			Pair:           curr,
 			Exchange:       c.Name,
-		})
+		}
 	}
 
 	order.FilterOrdersByType(&orders, req.Type)
@@ -836,7 +834,7 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(respOrders))
 	for i := range respOrders {
 		var curr currency.Pair
 		curr, err = currency.NewPairDelimiter(respOrders[i].ProductID,
@@ -869,7 +867,7 @@ func (c *CoinbasePro) GetOrderHistory(ctx context.Context, req *order.GetOrdersR
 			Exchange:        c.Name,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByType(&orders, req.Type)

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -447,16 +447,21 @@ func (c *CoinbasePro) UpdateOrderbook(ctx context.Context, p currency.Pair, asse
 	if !ok {
 		return book, errors.New("unable to type assert orderbook data")
 	}
+
+	book.Bids = make(orderbook.Items, len(obNew.Bids))
 	for x := range obNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: obNew.Bids[x].Amount,
-			Price:  obNew.Bids[x].Price})
+			Price:  obNew.Bids[x].Price,
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(obNew.Asks))
 	for x := range obNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: obNew.Asks[x].Amount,
-			Price:  obNew.Asks[x].Price})
+			Price:  obNew.Asks[x].Price,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -488,7 +488,7 @@ func (i *instrumentMap) GetInstrumentIDs() []int64 {
 		return nil
 	}
 
-	var instruments []int64
+	instruments := make([]int64, 0, len(i.Instruments))
 	for _, x := range i.Instruments {
 		instruments = append(instruments, x)
 	}

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -82,7 +82,7 @@ func (c *COINUT) GetInstrumentTicker(ctx context.Context, instrumentID int64) (T
 }
 
 // GetInstrumentOrderbook returns the orderbooks for a specific instrument
-func (c *COINUT) GetInstrumentOrderbook(ctx context.Context, instrumentID, limit int64) (Orderbook, error) {
+func (c *COINUT) GetInstrumentOrderbook(ctx context.Context, instrumentID, limit int64) (*Orderbook, error) {
 	var result Orderbook
 	params := make(map[string]interface{})
 	params["inst_id"] = instrumentID
@@ -90,7 +90,7 @@ func (c *COINUT) GetInstrumentOrderbook(ctx context.Context, instrumentID, limit
 		params["top_n"] = limit
 	}
 
-	return result, c.SendHTTPRequest(ctx, exchange.RestSpot, coinutOrderbook, params, false, &result)
+	return &result, c.SendHTTPRequest(ctx, exchange.RestSpot, coinutOrderbook, params, false, &result)
 }
 
 // GetTrades returns trade information

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -517,20 +517,20 @@ func (c *COINUT) WsGetInstruments() (Instruments, error) {
 
 // WsProcessOrderbookSnapshot processes the orderbook snapshot
 func (c *COINUT) WsProcessOrderbookSnapshot(ob *WsOrderbookSnapshot) error {
-	var bids []orderbook.Item
+	bids := make([]orderbook.Item, len(ob.Buy))
 	for i := range ob.Buy {
-		bids = append(bids, orderbook.Item{
+		bids[i] = orderbook.Item{
 			Amount: ob.Buy[i].Volume,
 			Price:  ob.Buy[i].Price,
-		})
+		}
 	}
 
-	var asks []orderbook.Item
+	asks := make([]orderbook.Item, len(ob.Sell))
 	for i := range ob.Sell {
-		asks = append(asks, orderbook.Item{
+		asks[i] = orderbook.Item{
 			Amount: ob.Sell[i].Volume,
 			Price:  ob.Sell[i].Price,
-		})
+		}
 	}
 
 	var newOrderBook orderbook.Base
@@ -672,7 +672,12 @@ func (c *COINUT) Unsubscribe(channelToUnsubscribe []stream.ChannelSubscription) 
 			errs = append(errs, err)
 			continue
 		}
-		if response["status"].([]interface{})[0] != "OK" {
+
+		val, ok := response["status"].([]interface{})
+		if !ok {
+			errs = append(errs, errors.New("unable to type assert response status"))
+		}
+		if val[0] != "OK" {
 			errs = append(errs, fmt.Errorf("%v unsubscribe failed for channel %v",
 				c.Name,
 				channelToUnsubscribe[i].Channel))
@@ -796,7 +801,6 @@ func (c *COINUT) wsSubmitOrder(o *WsSubmitOrderParameters) (*order.Detail, error
 
 func (c *COINUT) wsSubmitOrders(orders []WsSubmitOrderParameters) ([]order.Detail, []error) {
 	var errs []error
-	var ordersResponse []order.Detail
 	if !c.Websocket.CanUseAuthenticatedEndpoints() {
 		errs = append(errs, fmt.Errorf("%v not authorised to submit orders",
 			c.Name))
@@ -833,6 +837,8 @@ func (c *COINUT) wsSubmitOrders(orders []WsSubmitOrderParameters) ([]order.Detai
 		errs = append(errs, err)
 		return nil, errs
 	}
+
+	ordersResponse := make([]order.Detail, 0, len(incoming))
 	for i := range incoming {
 		o, err := c.parseOrderContainer(&incoming[i])
 		if err != nil {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -503,16 +503,20 @@ func (c *COINUT) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Buy))
 	for x := range orderbookNew.Buy {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Buy[x].Quantity,
-			Price:  orderbookNew.Buy[x].Price})
+			Price:  orderbookNew.Buy[x].Price,
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Sell))
 	for x := range orderbookNew.Sell {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Sell[x].Quantity,
-			Price:  orderbookNew.Sell[x].Price})
+			Price:  orderbookNew.Sell[x].Price,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -286,7 +286,7 @@ func (c *COINUT) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]st
 	}
 
 	instruments = resp.Instruments
-	var pairs []string
+	pairs := make([]string, 0, len(instruments))
 	for i := range instruments {
 		c.instrumentMap.Seed(instruments[i][0].Base+instruments[i][0].Quote, instruments[i][0].InstrumentID)
 		p := instruments[i][0].Base + format.Delimiter + instruments[i][0].Quote
@@ -548,14 +548,14 @@ func (c *COINUT) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData.Trades))
 	for i := range tradeData.Trades {
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData.Trades[i].Side)
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     c.Name,
 			TID:          strconv.FormatInt(tradeData.Trades[i].TransactionID, 10),
 			CurrencyPair: p,
@@ -564,7 +564,7 @@ func (c *COINUT) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 			Price:        tradeData.Trades[i].Price,
 			Amount:       tradeData.Trades[i].Quantity,
 			Timestamp:    time.Unix(0, tradeData.Trades[i].Timestamp*int64(time.Microsecond)),
-		})
+		}
 	}
 
 	err = c.AddTradesToBuffer(resp...)

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -1106,8 +1106,8 @@ func (e *Endpoints) SetDefaultEndpoints(m map[URL]string) error {
 
 // SetRunning populates running URLs map
 func (e *Endpoints) SetRunning(key, val string) error {
-	e.Lock()
-	defer e.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	err := validateKey(key)
 	if err != nil {
 		return err
@@ -1136,8 +1136,8 @@ func validateKey(keyVal string) error {
 
 // GetURL gets default url from URLs map
 func (e *Endpoints) GetURL(key URL) (string, error) {
-	e.RLock()
-	defer e.RUnlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	val, ok := e.defaults[key.String()]
 	if !ok {
 		return "", fmt.Errorf("no endpoint path found for the given key: %v", key)
@@ -1147,12 +1147,12 @@ func (e *Endpoints) GetURL(key URL) (string, error) {
 
 // GetURLMap gets all urls for either running or default map based on the bool value supplied
 func (e *Endpoints) GetURLMap() map[string]string {
-	e.RLock()
+	e.mu.RLock()
 	var urlMap = make(map[string]string)
 	for k, v := range e.defaults {
 		urlMap[k] = v
 	}
-	e.RUnlock()
+	e.mu.RUnlock()
 	return urlMap
 }
 

--- a/exchanges/exchange_types.go
+++ b/exchanges/exchange_types.go
@@ -177,7 +177,7 @@ type FeaturesSupported struct {
 type Endpoints struct {
 	Exchange string
 	defaults map[string]string
-	sync.RWMutex
+	mu       sync.RWMutex
 }
 
 // API stores the exchange API settings

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -173,7 +173,7 @@ func (e *EXMO) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]stri
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(pairs))
 	for x := range pairs {
 		currencies = append(currencies, x)
 	}
@@ -352,7 +352,7 @@ func (e *EXMO) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (acc
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, 0, len(result.Balances))
 	for x, y := range result.Balances {
 		var exchangeCurrency account.Balance
 		exchangeCurrency.CurrencyName = currency.NewCode(x)
@@ -421,15 +421,16 @@ func (e *EXMO) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+
 	mapData := tradeData[p.String()]
+	resp := make([]trade.Data, len(mapData))
 	for i := range mapData {
 		var side order.Side
 		side, err = order.StringToOrderSide(mapData[i].Type)
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     e.Name,
 			TID:          strconv.FormatInt(mapData[i].TradeID, 10),
 			CurrencyPair: p,
@@ -438,7 +439,7 @@ func (e *EXMO) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 			Price:        mapData[i].Price,
 			Amount:       mapData[i].Quantity,
 			Timestamp:    time.Unix(mapData[i].Date, 0),
-		})
+		}
 	}
 
 	err = e.AddTradesToBuffer(resp...)
@@ -638,7 +639,7 @@ func (e *EXMO) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequest)
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, 0, len(resp))
 	for i := range resp {
 		var symbol currency.Pair
 		symbol, err = currency.NewPairDelimiter(resp[i].Pair, "_")
@@ -690,7 +691,7 @@ func (e *EXMO) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest)
 		}
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allTrades))
 	for i := range allTrades {
 		pair, err := currency.NewPairDelimiter(allTrades[i].Pair, "_")
 		if err != nil {
@@ -711,7 +712,7 @@ func (e *EXMO) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest)
 			Pair:           pair,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -298,6 +298,7 @@ func (e *EXMO) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType a
 			continue
 		}
 
+		book.Asks = make(orderbook.Items, len(data.Ask))
 		for y := range data.Ask {
 			var price, amount float64
 			price, err = strconv.ParseFloat(data.Ask[y][0], 64)
@@ -310,12 +311,13 @@ func (e *EXMO) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType a
 				return book, err
 			}
 
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[y] = orderbook.Item{
 				Price:  price,
 				Amount: amount,
-			})
+			}
 		}
 
+		book.Bids = make(orderbook.Items, len(data.Bid))
 		for y := range data.Bid {
 			var price, amount float64
 			price, err = strconv.ParseFloat(data.Bid[y][0], 64)
@@ -328,10 +330,10 @@ func (e *EXMO) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType a
 				return book, err
 			}
 
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[y] = orderbook.Item{
 				Price:  price,
 				Amount: amount,
-			})
+			}
 		}
 
 		err = book.Process()

--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -202,7 +202,7 @@ func (f *FTX) GetMarket(ctx context.Context, marketName string) (MarketData, err
 }
 
 // GetOrderbook gets orderbook for a given market with a given depth (default depth 20)
-func (f *FTX) GetOrderbook(ctx context.Context, marketName string, depth int64) (OrderbookData, error) {
+func (f *FTX) GetOrderbook(ctx context.Context, marketName string, depth int64) (*OrderbookData, error) {
 	result := struct {
 		Data TempOBData `json:"result"`
 	}{}
@@ -216,22 +216,24 @@ func (f *FTX) GetOrderbook(ctx context.Context, marketName string, depth int64) 
 	var resp OrderbookData
 	err := f.SendHTTPRequest(ctx, exchange.RestSpot, fmt.Sprintf(getOrderbook, marketName, strDepth), &result)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 	resp.MarketName = marketName
+	resp.Asks = make([]OData, len(result.Data.Asks))
 	for x := range result.Data.Asks {
-		resp.Asks = append(resp.Asks, OData{
+		resp.Asks[x] = OData{
 			Price: result.Data.Asks[x][0],
 			Size:  result.Data.Asks[x][1],
-		})
+		}
 	}
+	resp.Bids = make([]OData, len(result.Data.Bids))
 	for y := range result.Data.Bids {
-		resp.Bids = append(resp.Bids, OData{
+		resp.Bids[y] = OData{
 			Price: result.Data.Bids[y][0],
 			Size:  result.Data.Bids[y][1],
-		})
+		}
 	}
-	return resp, nil
+	return &resp, nil
 }
 
 // GetTrades gets trades based on the conditions specified

--- a/exchanges/ftx/ftx.go
+++ b/exchanges/ftx/ftx.go
@@ -1506,7 +1506,7 @@ func (f *FTX) FetchExchangeLimits(ctx context.Context) ([]order.MinMaxLevel, err
 		return nil, err
 	}
 
-	var limits []order.MinMaxLevel
+	limits := make([]order.MinMaxLevel, 0, len(data))
 	for x := range data {
 		if !data[x].Enabled {
 			continue

--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -999,7 +999,7 @@ func TestGetPublicOptionsTrades(t *testing.T) {
 	}
 	tmNow := time.Now()
 	result, err = f.GetPublicOptionsTrades(context.Background(),
-		tmNow.AddDate(0, -1, 0), tmNow, "5")
+		tmNow.AddDate(-1, 0, 0), tmNow, "5")
 	if err != nil {
 		t.Error(err)
 	}

--- a/exchanges/ftx/ftx_test.go
+++ b/exchanges/ftx/ftx_test.go
@@ -3,7 +3,6 @@ package ftx
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"math"
 	"os"
@@ -2036,19 +2035,19 @@ func TestCalculatePNL(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var orders []order.Detail
+	orders := make([]order.Detail, len(positions))
 	for i := range positions {
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			Side:      positions[i].Side,
 			Pair:      pair,
-			ID:        fmt.Sprintf("%v", positions[i].ID),
+			ID:        positions[i].ID,
 			Price:     positions[i].Price,
 			Amount:    positions[i].Amount,
 			AssetType: asset.Futures,
 			Exchange:  f.Name,
 			Fee:       positions[i].Fee,
 			Date:      positions[i].Date,
-		})
+		}
 	}
 
 	exch := f.Name

--- a/exchanges/ftx/ftx_websocket.go
+++ b/exchanges/ftx/ftx_websocket.go
@@ -480,24 +480,25 @@ func (f *FTX) WsProcessUpdateOB(data *WsOrderbookData, p currency.Pair, a asset.
 	update := buffer.Update{
 		Asset:      a,
 		Pair:       p,
+		Bids:       make([]orderbook.Item, len(data.Bids)),
+		Asks:       make([]orderbook.Item, len(data.Asks)),
 		UpdateTime: timestampFromFloat64(data.Time),
 	}
 
-	var err error
 	for x := range data.Bids {
-		update.Bids = append(update.Bids, orderbook.Item{
+		update.Bids[x] = orderbook.Item{
 			Price:  data.Bids[x][0],
 			Amount: data.Bids[x][1],
-		})
+		}
 	}
 	for x := range data.Asks {
-		update.Asks = append(update.Asks, orderbook.Item{
+		update.Asks[x] = orderbook.Item{
 			Price:  data.Asks[x][0],
 			Amount: data.Asks[x][1],
-		})
+		}
 	}
 
-	err = f.Websocket.Orderbook.Update(&update)
+	err := f.Websocket.Orderbook.Update(&update)
 	if err != nil {
 		return err
 	}
@@ -544,18 +545,19 @@ func (f *FTX) WsProcessPartialOB(data *WsOrderbookData, p currency.Pair, a asset
 			a,
 			p)
 	}
-	var bids, asks []orderbook.Item
+	bids := make(orderbook.Items, len(data.Bids))
+	asks := make(orderbook.Items, len(data.Asks))
 	for x := range data.Bids {
-		bids = append(bids, orderbook.Item{
+		bids[x] = orderbook.Item{
 			Price:  data.Bids[x][0],
 			Amount: data.Bids[x][1],
-		})
+		}
 	}
 	for x := range data.Asks {
-		asks = append(asks, orderbook.Item{
+		asks[x] = orderbook.Item{
 			Price:  data.Asks[x][0],
 			Amount: data.Asks[x][1],
-		})
+		}
 	}
 
 	newOrderBook := orderbook.Base{

--- a/exchanges/ftx/ftx_websocket_test.go
+++ b/exchanges/ftx/ftx_websocket_test.go
@@ -140,8 +140,12 @@ func TestFTX_wsHandleData_Details(t *testing.T) {
                 "createdAt": "2021-08-08T10:35:02.649437+00:00"
             }
         }`
-	if status := parseRaw(t, inputFilled).(*order.Detail).Status; status != order.Filled {
-		t.Errorf("have %s, want %s", status, order.Filled)
+	orderDetail, ok := parseRaw(t, inputFilled).(*order.Detail)
+	if !ok {
+		t.Error("unable to type asset order detail")
+	}
+	if orderDetail.Status != order.Filled {
+		t.Errorf("have %s, want %s", orderDetail.Status, order.Filled)
 	}
 
 	const inputCancelled = `{
@@ -166,8 +170,13 @@ func TestFTX_wsHandleData_Details(t *testing.T) {
                 "createdAt": "2021-08-08T10:35:02.649437+00:00"
             }
         }`
-	if status := parseRaw(t, inputCancelled).(*order.Detail).Status; status != order.Cancelled {
-		t.Errorf("have %s, want %s", status, order.Cancelled)
+
+	orderDetail, ok = parseRaw(t, inputCancelled).(*order.Detail)
+	if !ok {
+		t.Error("unable to type asset order detail")
+	}
+	if orderDetail.Status != order.Cancelled {
+		t.Errorf("have %s, want %s", orderDetail.Status, order.Cancelled)
 	}
 }
 

--- a/exchanges/ftx/ftx_websocket_test.go
+++ b/exchanges/ftx/ftx_websocket_test.go
@@ -143,8 +143,7 @@ func TestFTX_wsHandleData_Details(t *testing.T) {
 	orderDetail, ok := parseRaw(t, inputFilled).(*order.Detail)
 	if !ok {
 		t.Error("unable to type asset order detail")
-	}
-	if orderDetail.Status != order.Filled {
+	} else if orderDetail.Status != order.Filled {
 		t.Errorf("have %s, want %s", orderDetail.Status, order.Filled)
 	}
 
@@ -174,8 +173,7 @@ func TestFTX_wsHandleData_Details(t *testing.T) {
 	orderDetail, ok = parseRaw(t, inputCancelled).(*order.Detail)
 	if !ok {
 		t.Error("unable to type asset order detail")
-	}
-	if orderDetail.Status != order.Cancelled {
+	} else if orderDetail.Status != order.Cancelled {
 		t.Errorf("have %s, want %s", orderDetail.Status, order.Cancelled)
 	}
 }

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -526,45 +526,39 @@ func (f *FTX) GetFundingHistory(ctx context.Context) ([]exchange.FundHistory, er
 	if err != nil {
 		return nil, err
 	}
-	dData := make([]exchange.FundHistory, len(depositData))
-	for x := range depositData {
-		var tempData exchange.FundHistory
-		tempData.Fee = depositData[x].Fee
-		tempData.Timestamp = depositData[x].Time
-		tempData.ExchangeName = f.Name
-		tempData.CryptoToAddress = depositData[x].Address.Address
-		tempData.CryptoTxID = depositData[x].TxID
-		tempData.CryptoChain = depositData[x].Address.Method
-		tempData.Status = depositData[x].Status
-		tempData.Amount = depositData[x].Size
-		tempData.Currency = depositData[x].Coin
-		tempData.TransferID = strconv.FormatInt(depositData[x].ID, 10)
-		dData[x] = tempData
-	}
 	withdrawalData, err := f.FetchWithdrawalHistory(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	wdData := make([]exchange.FundHistory, len(withdrawalData))
-	for y := range withdrawalData {
-		var tempData exchange.FundHistory
-		tempData.Fee = withdrawalData[y].Fee
-		tempData.Timestamp = withdrawalData[y].Time
-		tempData.ExchangeName = f.Name
-		tempData.CryptoToAddress = withdrawalData[y].Address
-		tempData.CryptoTxID = withdrawalData[y].TXID
-		tempData.CryptoChain = withdrawalData[y].Method
-		tempData.Status = withdrawalData[y].Status
-		tempData.Amount = withdrawalData[y].Size
-		tempData.Currency = withdrawalData[y].Coin
-		tempData.TransferID = strconv.FormatInt(withdrawalData[y].ID, 10)
-		wdData[y] = tempData
+	fundingData := make([]exchange.FundHistory, 0, len(depositData)+len(withdrawalData))
+	for x := range depositData {
+		fundingData = append(fundingData, exchange.FundHistory{
+			Fee:             depositData[x].Fee,
+			Timestamp:       depositData[x].Time,
+			ExchangeName:    f.Name,
+			CryptoToAddress: depositData[x].Address.Address,
+			CryptoTxID:      depositData[x].TxID,
+			CryptoChain:     depositData[x].Address.Method,
+			Status:          depositData[x].Status,
+			Amount:          depositData[x].Size,
+			Currency:        depositData[x].Coin,
+			TransferID:      strconv.FormatInt(depositData[x].ID, 10),
+		})
 	}
-
-	fundingData := make([]exchange.FundHistory, len(dData)+len(wdData))
-	copy(fundingData, dData)
-	copy(fundingData, wdData)
+	for y := range withdrawalData {
+		fundingData = append(fundingData, exchange.FundHistory{
+			Fee:             withdrawalData[y].Fee,
+			Timestamp:       withdrawalData[y].Time,
+			ExchangeName:    f.Name,
+			CryptoToAddress: withdrawalData[y].Address,
+			CryptoTxID:      withdrawalData[y].TXID,
+			CryptoChain:     withdrawalData[y].Method,
+			Status:          withdrawalData[y].Status,
+			Amount:          withdrawalData[y].Size,
+			Currency:        withdrawalData[y].Coin,
+			TransferID:      strconv.FormatInt(withdrawalData[y].ID, 10),
+		})
+	}
 	return fundingData, nil
 }
 

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -1663,9 +1663,7 @@ func (f *FTX) GetFuturesPositions(ctx context.Context, a asset.Item, cp currency
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(fills, func(i, j int) bool {
-		return fills[i].Time.Before(fills[j].Time)
-	})
+
 	resp := make([]order.Detail, len(fills))
 	for i := range fills {
 		price := fills[i].Price
@@ -1685,6 +1683,10 @@ func (f *FTX) GetFuturesPositions(ctx context.Context, a asset.Item, cp currency
 			Date:      fills[i].Time,
 		}
 	}
+
+	sort.Slice(resp, func(i, j int) bool {
+		return resp[i].Date.Before(resp[j].Date)
+	})
 
 	return resp, nil
 }

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -431,6 +431,7 @@ func (f *FTX) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType as
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, 0, len(tempResp.Bids))
 	for x := range tempResp.Bids {
 		// Bear tokens have illiquid books and contain negative place holders.
 		if tempResp.Bids[x].Size < 0 && strings.Contains(p.String(), "BEAR") {
@@ -438,8 +439,10 @@ func (f *FTX) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType as
 		}
 		book.Bids = append(book.Bids, orderbook.Item{
 			Amount: tempResp.Bids[x].Size,
-			Price:  tempResp.Bids[x].Price})
+			Price:  tempResp.Bids[x].Price,
+		})
 	}
+	book.Asks = make(orderbook.Items, 0, len(tempResp.Asks))
 	for y := range tempResp.Asks {
 		// Bear tokens have illiquid books and contain negative place holders.
 		if tempResp.Asks[y].Size < 0 && strings.Contains(p.String(), "BEAR") {
@@ -447,7 +450,8 @@ func (f *FTX) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType as
 		}
 		book.Asks = append(book.Asks, orderbook.Item{
 			Amount: tempResp.Asks[y].Size,
-			Price:  tempResp.Asks[y].Price})
+			Price:  tempResp.Asks[y].Price,
+		})
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -83,11 +83,23 @@ func (g *Gateio) GetMarketInfo(ctx context.Context) (MarketInfoResponse, error) 
 			if !ok {
 				return result, errors.New("unable to type assert pairv")
 			}
+			decimalPlaces, ok := pairv["decimal_places"].(float64)
+			if !ok {
+				return result, errors.New("unable to type assert decimal_places")
+			}
+			minAmount, ok := pairv["min_amount"].(float64)
+			if !ok {
+				return result, errors.New("unable to type assert min_amount")
+			}
+			fee, ok := pairv["fee"].(float64)
+			if !ok {
+				return result, errors.New("unable to type assert fee")
+			}
 			result.Pairs = append(result.Pairs, MarketInfoPairsResponse{
 				Symbol:        itemk,
-				DecimalPlaces: pairv["decimal_places"].(float64),
-				MinAmount:     pairv["min_amount"].(float64),
-				Fee:           pairv["fee"].(float64),
+				DecimalPlaces: decimalPlaces,
+				MinAmount:     minAmount,
+				Fee:           fee,
 			})
 		}
 	}

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -150,64 +150,59 @@ func (g *Gateio) GetTrades(ctx context.Context, symbol string) (TradeHistory, er
 }
 
 // GetOrderbook returns the orderbook data for a suppled symbol
-func (g *Gateio) GetOrderbook(ctx context.Context, symbol string) (Orderbook, error) {
+func (g *Gateio) GetOrderbook(ctx context.Context, symbol string) (*Orderbook, error) {
 	urlPath := fmt.Sprintf("/%s/%s/%s", gateioAPIVersion, gateioOrderbook, symbol)
 	var resp OrderbookResponse
 	err := g.SendHTTPRequest(ctx, exchange.RestSpotSupplementary, urlPath, &resp)
 	if err != nil {
-		return Orderbook{}, err
+		return nil, err
 	}
 
-	if resp.Result != "true" {
-		return Orderbook{}, errors.New("result was not true")
-	}
-
-	var ob Orderbook
-
-	if len(resp.Asks) == 0 {
-		return ob, errors.New("asks are empty")
+	switch {
+	case resp.Result != "true":
+		return nil, errors.New("result was not true")
+	case len(resp.Asks) == 0:
+		return nil, errors.New("asks are empty")
+	case len(resp.Bids) == 0:
+		return nil, errors.New("bids are empty")
 	}
 
 	// Asks are in reverse order
-	for x := len(resp.Asks) - 1; x != 0; x-- {
-		data := resp.Asks[x]
+	ob := Orderbook{
+		Result:  resp.Result,
+		Elapsed: resp.Elapsed,
+		Bids:    make([]OrderbookItem, len(resp.Bids)),
+		Asks:    make([]OrderbookItem, 0, len(resp.Asks)),
+	}
 
-		price, err := strconv.ParseFloat(data[0], 64)
+	for x := len(resp.Asks) - 1; x != 0; x-- {
+		price, err := strconv.ParseFloat(resp.Asks[x][0], 64)
 		if err != nil {
-			continue
+			return nil, err
 		}
 
-		amount, err := strconv.ParseFloat(data[1], 64)
+		amount, err := strconv.ParseFloat(resp.Asks[x][1], 64)
 		if err != nil {
-			continue
+			return nil, err
 		}
 
 		ob.Asks = append(ob.Asks, OrderbookItem{Price: price, Amount: amount})
 	}
 
-	if len(resp.Bids) == 0 {
-		return ob, errors.New("bids are empty")
-	}
-
 	for x := range resp.Bids {
-		data := resp.Bids[x]
-
-		price, err := strconv.ParseFloat(data[0], 64)
+		price, err := strconv.ParseFloat(resp.Bids[x][0], 64)
 		if err != nil {
-			continue
+			return nil, err
 		}
 
-		amount, err := strconv.ParseFloat(data[1], 64)
+		amount, err := strconv.ParseFloat(resp.Bids[x][1], 64)
 		if err != nil {
-			continue
+			return nil, err
 		}
 
-		ob.Bids = append(ob.Bids, OrderbookItem{Price: price, Amount: amount})
+		ob.Bids[x] = OrderbookItem{Price: price, Amount: amount}
 	}
-
-	ob.Result = resp.Result
-	ob.Elapsed = resp.Elapsed
-	return ob, nil
+	return &ob, nil
 }
 
 // GetSpotKline returns kline data for the most recent time period

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -616,7 +616,7 @@ func (g *Gateio) Unsubscribe(channelsToUnsubscribe []stream.ChannelSubscription)
 	// & LTC_USDT this function will unsubscribe both. This function will be
 	// kept unlinked to the websocket subsystem and a full connection flush will
 	// occur when currency items are disabled.
-	var channelsThusFar []string
+	channelsThusFar := make([]string, 0, len(channelsToUnsubscribe))
 	for i := range channelsToUnsubscribe {
 		if common.StringDataCompare(channelsThusFar,
 			channelsToUnsubscribe[i].Channel) {

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -365,7 +365,7 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 			return err
 		}
 
-		var asks, bids []orderbook.Item
+		asks := make([]orderbook.Item, len(data.Asks))
 		var amount, price float64
 		for i := range data.Asks {
 			amount, err = strconv.ParseFloat(data.Asks[i][1], 64)
@@ -376,9 +376,10 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 			if err != nil {
 				return err
 			}
-			asks = append(asks, orderbook.Item{Amount: amount, Price: price})
+			asks[i] = orderbook.Item{Amount: amount, Price: price}
 		}
 
+		bids := make([]orderbook.Item, len(data.Bids))
 		for i := range data.Bids {
 			amount, err = strconv.ParseFloat(data.Bids[i][1], 64)
 			if err != nil {
@@ -388,7 +389,7 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 			if err != nil {
 				return err
 			}
-			bids = append(bids, orderbook.Item{Amount: amount, Price: price})
+			bids[i] = orderbook.Item{Amount: amount, Price: price}
 		}
 
 		var p currency.Pair

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -313,6 +313,22 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 		if err != nil {
 			return err
 		}
+
+		orderID, ok := invalidJSON["id"].(float64)
+		if !ok {
+			return errors.New("unable to type assert order id")
+		}
+
+		ctime, ok := invalidJSON["ctime"].(float64)
+		if !ok {
+			return errors.New("unable to type assert ctime")
+		}
+
+		mtime, ok := invalidJSON["mtime"].(float64)
+		if !ok {
+			return errors.New("unable to type assert mtime")
+		}
+
 		g.Websocket.DataHandler <- &order.Detail{
 			Price:           price,
 			Amount:          amount,
@@ -320,13 +336,13 @@ func (g *Gateio) wsHandleData(respRaw []byte) error {
 			RemainingAmount: left,
 			Fee:             fee,
 			Exchange:        g.Name,
-			ID:              strconv.FormatFloat(invalidJSON["id"].(float64), 'f', -1, 64),
+			ID:              strconv.FormatFloat(orderID, 'f', -1, 64),
 			Type:            oType,
 			Side:            oSide,
 			Status:          oStatus,
 			AssetType:       a,
-			Date:            convert.TimeFromUnixTimestampDecimal(invalidJSON["ctime"].(float64)),
-			LastUpdated:     convert.TimeFromUnixTimestampDecimal(invalidJSON["mtime"].(float64)),
+			Date:            convert.TimeFromUnixTimestampDecimal(ctime),
+			LastUpdated:     convert.TimeFromUnixTimestampDecimal(mtime),
 			Pair:            p,
 		}
 	case strings.Contains(result.Method, "depth"):

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -463,14 +463,14 @@ func (g *Gateio) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData.Data))
 	for i := range tradeData.Data {
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData.Data[i].Type)
 		if err != nil {
 			return nil, err
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     g.Name,
 			TID:          tradeData.Data[i].TradeID,
 			CurrencyPair: p,
@@ -479,7 +479,7 @@ func (g *Gateio) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 			Price:        tradeData.Data[i].Rate,
 			Amount:       tradeData.Data[i].Amount,
 			Timestamp:    time.Unix(tradeData.Data[i].Timestamp, 0),
-		})
+		}
 	}
 
 	err = g.AddTradesToBuffer(resp...)
@@ -829,7 +829,7 @@ func (g *Gateio) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(trades))
 	for i := range trades {
 		var pair currency.Pair
 		pair, err = currency.NewPairDelimiter(trades[i].Pair, format.Delimiter)
@@ -850,7 +850,7 @@ func (g *Gateio) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 			Pair:                 pair,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)
@@ -919,9 +919,9 @@ func (g *Gateio) GetAvailableTransferChains(ctx context.Context, cryptocurrency 
 		return nil, err
 	}
 
-	var availableChains []string
+	availableChains := make([]string, len(chains.MultichainAddresses))
 	for x := range chains.MultichainAddresses {
-		availableChains = append(availableChains, chains.MultichainAddresses[x].Chain)
+		availableChains[x] = chains.MultichainAddresses[x].Chain
 	}
 	return availableChains, nil
 }

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -319,18 +319,20 @@ func (g *Gateio) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -82,7 +82,7 @@ func (g *Gemini) GetTicker(ctx context.Context, currencyPair string) (TickerV2, 
 //
 // params - limit_bids or limit_asks [OPTIONAL] default 50, 0 returns all Values
 // Type is an integer ie "params.Set("limit_asks", 30)"
-func (g *Gemini) GetOrderbook(ctx context.Context, currencyPair string, params url.Values) (Orderbook, error) {
+func (g *Gemini) GetOrderbook(ctx context.Context, currencyPair string, params url.Values) (*Orderbook, error) {
 	path := common.EncodeURLValues(
 		fmt.Sprintf("/v%s/%s/%s",
 			geminiAPIVersion,
@@ -91,7 +91,7 @@ func (g *Gemini) GetOrderbook(ctx context.Context, currencyPair string, params u
 		params)
 
 	var orderbook Orderbook
-	return orderbook, g.SendHTTPRequest(ctx, exchange.RestSpot, path, &orderbook)
+	return &orderbook, g.SendHTTPRequest(ctx, exchange.RestSpot, path, &orderbook)
 }
 
 // GetTrades return the trades that have executed since the specified timestamp.

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -587,7 +587,11 @@ func TestWsAuth(t *testing.T) {
 	timer := time.NewTimer(sharedtestvalues.WebsocketResponseDefaultTimeout)
 	select {
 	case resp := <-g.Websocket.DataHandler:
-		if resp.(WsSubscriptionAcknowledgementResponse).Type != "subscription_ack" {
+		subAck, ok := resp.(WsSubscriptionAcknowledgementResponse)
+		if !ok {
+			t.Error("unable to type assert WsSubscriptionAcknowledgementResponse")
+		}
+		if subAck.Type != "subscription_ack" {
 			t.Error("Login failed")
 		}
 	case <-timer.C:

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -384,7 +384,7 @@ func (g *Gemini) wsHandleData(respRaw []byte) error {
 			}
 
 			tradeEvent := trade.Data{
-				Timestamp:    time.Unix(result.Timestamp/1000, 0),
+				Timestamp:    time.UnixMilli(result.Timestamp),
 				CurrencyPair: pair,
 				AssetType:    asset.Spot,
 				Exchange:     g.Name,
@@ -447,7 +447,7 @@ func (g *Gemini) wsHandleData(respRaw []byte) error {
 					return errors.New("unable to type assert interval")
 				}
 				g.Websocket.DataHandler <- stream.KlineData{
-					Timestamp:  time.Unix(int64(candle.Changes[i][0])/1000, 0),
+					Timestamp:  time.UnixMilli(int64(candle.Changes[i][0])),
 					Pair:       pair,
 					AssetType:  asset.Spot,
 					Exchange:   g.Name,
@@ -596,7 +596,7 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 			}
 		}
 		trades[x] = trade.Data{
-			Timestamp:    time.Unix(result.Trades[x].Timestamp/1000, 0),
+			Timestamp:    time.UnixMilli(result.Trades[x].Timestamp),
 			CurrencyPair: pair,
 			AssetType:    asset.Spot,
 			Exchange:     g.Name,

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -530,7 +530,9 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 		return err
 	}
 
-	var bids, asks []orderbook.Item
+	bids := make([]orderbook.Item, 0, len(result.Changes))
+	asks := make([]orderbook.Item, 0, len(result.Changes))
+
 	for x := range result.Changes {
 		price, err := strconv.ParseFloat(result.Changes[x][1], 64)
 		if err != nil {

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -90,7 +90,7 @@ func (g *Gemini) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, e
 
 // Subscribe sends a websocket message to receive data from the channel
 func (g *Gemini) Subscribe(channelsToSubscribe []stream.ChannelSubscription) error {
-	var channels []string
+	channels := make([]string, 0, len(channelsToSubscribe))
 	for x := range channelsToSubscribe {
 		if common.StringDataCompareInsensitive(channels, channelsToSubscribe[x].Channel) {
 			continue
@@ -111,12 +111,12 @@ func (g *Gemini) Subscribe(channelsToSubscribe []stream.ChannelSubscription) err
 		return err
 	}
 
-	var subs []wsSubscriptions
+	subs := make([]wsSubscriptions, len(channels))
 	for x := range channels {
-		subs = append(subs, wsSubscriptions{
+		subs[x] = wsSubscriptions{
 			Name:    channels[x],
 			Symbols: strings.Split(fmtPairs, ","),
-		})
+		}
 	}
 
 	wsSub := wsSubscribeRequest{
@@ -134,7 +134,7 @@ func (g *Gemini) Subscribe(channelsToSubscribe []stream.ChannelSubscription) err
 
 // Unsubscribe sends a websocket message to stop receiving data from the channel
 func (g *Gemini) Unsubscribe(channelsToUnsubscribe []stream.ChannelSubscription) error {
-	var channels []string
+	channels := make([]string, 0, len(channelsToUnsubscribe))
 	for x := range channelsToUnsubscribe {
 		if common.StringDataCompareInsensitive(channels, channelsToUnsubscribe[x].Channel) {
 			continue
@@ -155,12 +155,12 @@ func (g *Gemini) Unsubscribe(channelsToUnsubscribe []stream.ChannelSubscription)
 		return err
 	}
 
-	var subs []wsSubscriptions
+	subs := make([]wsSubscriptions, len(channels))
 	for x := range channels {
-		subs = append(subs, wsSubscriptions{
+		subs[x] = wsSubscriptions{
 			Name:    channels[x],
 			Symbols: strings.Split(fmtPairs, ","),
-		})
+		}
 	}
 
 	wsSub := wsSubscribeRequest{
@@ -442,12 +442,16 @@ func (g *Gemini) wsHandleData(respRaw []byte) error {
 				if len(candle.Changes[i]) != 6 {
 					continue
 				}
+				interval, ok := result["type"].(string)
+				if !ok {
+					return errors.New("unable to type assert interval")
+				}
 				g.Websocket.DataHandler <- stream.KlineData{
 					Timestamp:  time.Unix(int64(candle.Changes[i][0])/1000, 0),
 					Pair:       pair,
 					AssetType:  asset.Spot,
 					Exchange:   g.Name,
-					Interval:   result["type"].(string),
+					Interval:   interval,
 					OpenPrice:  candle.Changes[i][1],
 					HighPrice:  candle.Changes[i][2],
 					LowPrice:   candle.Changes[i][3],
@@ -582,7 +586,7 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 		return nil
 	}
 
-	var trades []trade.Data
+	trades := make([]trade.Data, len(result.Trades))
 	for x := range result.Trades {
 		tSide, err := order.StringToOrderSide(result.Trades[x].Side)
 		if err != nil {
@@ -591,7 +595,7 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 				Err:      err,
 			}
 		}
-		trades = append(trades, trade.Data{
+		trades[x] = trade.Data{
 			Timestamp:    time.Unix(result.Trades[x].Timestamp/1000, 0),
 			CurrencyPair: pair,
 			AssetType:    asset.Spot,
@@ -600,7 +604,7 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 			Amount:       result.Trades[x].Quantity,
 			Side:         tSide,
 			TID:          strconv.FormatInt(result.Trades[x].EventID, 10),
-		})
+		}
 	}
 
 	return trade.AddTradesToBuffer(g.Name, trades...)

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -319,14 +319,14 @@ func (g *Gemini) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, len(accountBalance))
 	for i := range accountBalance {
-		currencies = append(currencies, account.Balance{
+		currencies[i] = account.Balance{
 			CurrencyName: currency.NewCode(accountBalance[i].Currency),
 			Total:        accountBalance[i].Amount,
 			Hold:         accountBalance[i].Amount - accountBalance[i].Available,
 			Free:         accountBalance[i].Available,
-		})
+		}
 	}
 
 	response.Accounts = append(response.Accounts, account.SubAccount{
@@ -692,7 +692,7 @@ func (g *Gemini) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		var symbol currency.Pair
 		symbol, err = currency.NewPairFromFormattedPairs(resp[i].Symbol, availPairs, format)
@@ -709,7 +709,7 @@ func (g *Gemini) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		side := order.Side(strings.ToUpper(resp[i].Type))
 		orderDate := time.Unix(resp[i].Timestamp, 0)
 
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			Amount:          resp[i].OriginalAmount,
 			RemainingAmount: resp[i].RemainingAmount,
 			ID:              strconv.FormatInt(resp[i].OrderID, 10),
@@ -720,7 +720,7 @@ func (g *Gemini) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 			Price:           resp[i].Price,
 			Pair:            symbol,
 			Date:            orderDate,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)
@@ -767,7 +767,7 @@ func (g *Gemini) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(trades))
 	for i := range trades {
 		side := order.Side(strings.ToUpper(trades[i].Type))
 		orderDate := time.Unix(trades[i].Timestamp, 0)
@@ -789,7 +789,7 @@ func (g *Gemini) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 			),
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -431,16 +431,20 @@ func (g *Gemini) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount,
-			Price:  orderbookNew.Bids[x].Price})
+			Price:  orderbookNew.Bids[x].Price,
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount,
-			Price:  orderbookNew.Asks[x].Price})
+			Price:  orderbookNew.Asks[x].Price,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -159,7 +159,7 @@ func (h *HitBTC) GetTrades(ctx context.Context, currencyPair, by, sort string, f
 
 // GetOrderbook an order book is an electronic list of buy and sell orders for a
 // specific symbol, organized by price level.
-func (h *HitBTC) GetOrderbook(ctx context.Context, currencyPair string, limit int) (Orderbook, error) {
+func (h *HitBTC) GetOrderbook(ctx context.Context, currencyPair string, limit int) (*Orderbook, error) {
 	// limit Limit of orderbook levels, default 100. Set 0 to view full orderbook levels
 	vals := url.Values{}
 
@@ -167,21 +167,16 @@ func (h *HitBTC) GetOrderbook(ctx context.Context, currencyPair string, limit in
 		vals.Set("limit", strconv.Itoa(limit))
 	}
 
-	resp := OrderbookResponse{}
+	var resp Orderbook
 	path := fmt.Sprintf("/%s/%s?%s",
 		apiV2Orderbook,
 		currencyPair,
 		vals.Encode())
-
 	err := h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 	if err != nil {
-		return Orderbook{}, err
+		return nil, err
 	}
-
-	ob := Orderbook{}
-	ob.Asks = append(ob.Asks, resp.Asks...)
-	ob.Bids = append(ob.Bids, resp.Bids...)
-	return ob, nil
+	return &resp, nil
 }
 
 // GetCandles returns candles which is used for OHLC a specific currency.

--- a/exchanges/hitbtc/hitbtc_types.go
+++ b/exchanges/hitbtc/hitbtc_types.go
@@ -32,12 +32,6 @@ type Symbol struct {
 	FeeCurrency          string  `json:"feeCurrency"`                 // Default fee rate for market making trades
 }
 
-// OrderbookResponse is the full orderbook response
-type OrderbookResponse struct {
-	Asks []OrderbookItem `json:"ask"` // Ask side array of levels
-	Bids []OrderbookItem `json:"bid"` // Bid side array of levels
-}
-
 // OrderbookItem is a sub type for orderbook response
 type OrderbookItem struct {
 	Price  float64 `json:"price,string"` // Price level
@@ -46,8 +40,8 @@ type OrderbookItem struct {
 
 // Orderbook contains orderbook data
 type Orderbook struct {
-	Asks []OrderbookItem `json:"asks"`
-	Bids []OrderbookItem `json:"bids"`
+	Asks []OrderbookItem `json:"ask"`
+	Bids []OrderbookItem `json:"bid"`
 }
 
 // TradeHistory contains trade history data

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -46,9 +46,11 @@ func (h *HitBTC) WsConnect() error {
 	h.Websocket.Wg.Add(1)
 	go h.wsReadData()
 
-	err = h.wsLogin(context.TODO())
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%v - authentication failed: %v\n", h.Name, err)
+	if h.Websocket.CanUseAuthenticatedEndpoints() {
+		err = h.wsLogin(context.TODO())
+		if err != nil {
+			log.Errorf(log.ExchangeSys, "%v - authentication failed: %v\n", h.Name, err)
+		}
 	}
 
 	return nil

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -417,19 +417,20 @@ func (h *HitBTC) WsProcessOrderbookUpdate(update WsOrderbook) error {
 		return nil
 	}
 
-	var bids, asks []orderbook.Item
+	bids := make(orderbook.Items, len(update.Params.Bid))
 	for i := range update.Params.Bid {
-		bids = append(bids, orderbook.Item{
+		bids[i] = orderbook.Item{
 			Price:  update.Params.Bid[i].Price,
 			Amount: update.Params.Bid[i].Size,
-		})
+		}
 	}
 
+	asks := make(orderbook.Items, len(update.Params.Ask))
 	for i := range update.Params.Ask {
-		asks = append(asks, orderbook.Item{
+		asks[i] = orderbook.Item{
 			Price:  update.Params.Ask[i].Price,
 			Amount: update.Params.Ask[i].Size,
-		})
+		}
 	}
 
 	pairs, err := h.GetEnabledPairs(asset.Spot)

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -180,7 +180,7 @@ func (h *HitBTC) wsHandleData(respRaw []byte) error {
 		if err != nil {
 			return err
 		}
-		err = h.WsProcessOrderbookSnapshot(obSnapshot)
+		err = h.WsProcessOrderbookSnapshot(&obSnapshot)
 		if err != nil {
 			return err
 		}
@@ -190,7 +190,7 @@ func (h *HitBTC) wsHandleData(respRaw []byte) error {
 		if err != nil {
 			return err
 		}
-		err = h.WsProcessOrderbookUpdate(obUpdate)
+		err = h.WsProcessOrderbookUpdate(&obUpdate)
 		if err != nil {
 			return err
 		}
@@ -293,24 +293,26 @@ func (h *HitBTC) wsHandleData(respRaw []byte) error {
 }
 
 // WsProcessOrderbookSnapshot processes a full orderbook snapshot to a local cache
-func (h *HitBTC) WsProcessOrderbookSnapshot(ob WsOrderbook) error {
+func (h *HitBTC) WsProcessOrderbookSnapshot(ob *WsOrderbook) error {
 	if len(ob.Params.Bid) == 0 || len(ob.Params.Ask) == 0 {
 		return errors.New("no orderbooks to process")
 	}
 
-	var newOrderBook orderbook.Base
+	newOrderBook := orderbook.Base{
+		Bids: make(orderbook.Items, len(ob.Params.Bid)),
+		Asks: make(orderbook.Items, len(ob.Params.Ask)),
+	}
 	for i := range ob.Params.Bid {
-		newOrderBook.Bids = append(newOrderBook.Bids, orderbook.Item{
+		newOrderBook.Bids[i] = orderbook.Item{
 			Amount: ob.Params.Bid[i].Size,
 			Price:  ob.Params.Bid[i].Price,
-		})
+		}
 	}
-
 	for i := range ob.Params.Ask {
-		newOrderBook.Asks = append(newOrderBook.Asks, orderbook.Item{
+		newOrderBook.Asks[i] = orderbook.Item{
 			Amount: ob.Params.Ask[i].Size,
 			Price:  ob.Params.Ask[i].Price,
-		})
+		}
 	}
 
 	pairs, err := h.GetEnabledPairs(asset.Spot)
@@ -410,7 +412,7 @@ func (h *HitBTC) wsHandleOrderData(o *wsOrderData) error {
 }
 
 // WsProcessOrderbookUpdate updates a local cache
-func (h *HitBTC) WsProcessOrderbookUpdate(update WsOrderbook) error {
+func (h *HitBTC) WsProcessOrderbookUpdate(update *WsOrderbook) error {
 	if len(update.Params.Bid) == 0 && len(update.Params.Ask) == 0 {
 		// Periodically HitBTC sends empty updates which includes a sequence
 		// can return this as nil.

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -407,18 +407,19 @@ func (h *HitBTC) UpdateOrderbook(ctx context.Context, c currency.Pair, assetType
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
-
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -291,11 +291,9 @@ func (h *HitBTC) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]st
 		return nil, err
 	}
 
-	var pairs []string
+	pairs := make([]string, len(symbols))
 	for x := range symbols {
-		pairs = append(pairs, symbols[x].BaseCurrency+
-			format.Delimiter+
-			symbols[x].QuoteCurrency)
+		pairs[x] = symbols[x].BaseCurrency + format.Delimiter + symbols[x].QuoteCurrency
 	}
 	return pairs, nil
 }
@@ -439,7 +437,7 @@ func (h *HitBTC) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, 0, len(accountBalance))
 	for i := range accountBalance {
 		currencies = append(currencies, account.Balance{
 			CurrencyName: currency.NewCode(accountBalance[i].Currency),
@@ -734,7 +732,7 @@ func (h *HitBTC) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allOrders))
 	for i := range allOrders {
 		var symbol currency.Pair
 		symbol, err = currency.NewPairDelimiter(allOrders[i].Symbol,
@@ -743,7 +741,7 @@ func (h *HitBTC) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 			return nil, err
 		}
 		side := order.Side(strings.ToUpper(allOrders[i].Side))
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			ID:       allOrders[i].ID,
 			Amount:   allOrders[i].Quantity,
 			Exchange: h.Name,
@@ -751,7 +749,7 @@ func (h *HitBTC) GetActiveOrders(ctx context.Context, req *order.GetOrdersReques
 			Date:     allOrders[i].CreatedAt,
 			Side:     side,
 			Pair:     symbol,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)
@@ -784,7 +782,7 @@ func (h *HitBTC) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allOrders))
 	for i := range allOrders {
 		var pair currency.Pair
 		pair, err = currency.NewPairDelimiter(allOrders[i].Symbol,
@@ -812,7 +810,7 @@ func (h *HitBTC) GetOrderHistory(ctx context.Context, req *order.GetOrdersReques
 			Pair:                 pair,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -158,12 +158,12 @@ func (h *HUOBI) GetMarketDetailMerged(ctx context.Context, symbol currency.Pair)
 }
 
 // GetDepth returns the depth for the specified symbol
-func (h *HUOBI) GetDepth(ctx context.Context, obd OrderBookDataRequestParams) (Orderbook, error) {
-	vals := url.Values{}
+func (h *HUOBI) GetDepth(ctx context.Context, obd *OrderBookDataRequestParams) (*Orderbook, error) {
 	symbolValue, err := h.FormatSymbol(obd.Symbol, asset.Spot)
 	if err != nil {
-		return Orderbook{}, err
+		return nil, err
 	}
+	vals := url.Values{}
 	vals.Set("symbol", symbolValue)
 
 	if obd.Type != OrderBookDataRequestParamsTypeNone {
@@ -176,12 +176,11 @@ func (h *HUOBI) GetDepth(ctx context.Context, obd OrderBookDataRequestParams) (O
 	}
 
 	var result response
-
 	err = h.SendHTTPRequest(ctx, exchange.RestSpot, common.EncodeURLValues(huobiMarketDepth, vals), &result)
 	if result.ErrorMessage != "" {
-		return result.Depth, errors.New(result.ErrorMessage)
+		return nil, errors.New(result.ErrorMessage)
 	}
-	return result.Depth, err
+	return &result.Depth, err
 }
 
 // GetTrades returns the trades for the specified symbol

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1657,7 +1657,7 @@ func TestGetDepth(t *testing.T) {
 		t.Error(err)
 	}
 	_, err = h.GetDepth(context.Background(),
-		OrderBookDataRequestParams{
+		&OrderBookDataRequestParams{
 			Symbol: cp,
 			Type:   OrderBookDataRequestParamsTypeStep1,
 		})

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
@@ -55,6 +56,7 @@ func TestMain(m *testing.M) {
 	hConfig.API.Credentials.Key = apiKey
 	hConfig.API.Credentials.Secret = apiSecret
 	h.Websocket = sharedtestvalues.NewTestWebsocket()
+	request.MaxRequestJobs = 100
 	err = h.Setup(hConfig)
 	if err != nil {
 		log.Fatal("Huobi setup error", err)

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -553,10 +553,10 @@ type OrderBookDataRequestParams struct {
 
 // Orderbook stores the orderbook data
 type Orderbook struct {
-	ID         int64       `json:"id"`
-	Timetstamp int64       `json:"ts"`
-	Bids       [][]float64 `json:"bids"`
-	Asks       [][]float64 `json:"asks"`
+	ID         int64        `json:"id"`
+	Timetstamp int64        `json:"ts"`
+	Bids       [][2]float64 `json:"bids"`
+	Asks       [][2]float64 `json:"asks"`
 }
 
 // Trade stores the trade data

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -466,19 +466,36 @@ func (h *HUOBI) WsProcessOrderbook(update *WsDepth, symbol string) error {
 		return err
 	}
 
-	var bids, asks []orderbook.Item
+	bids := make(orderbook.Items, len(update.Tick.Bids))
 	for i := range update.Tick.Bids {
-		bids = append(bids, orderbook.Item{
-			Price:  update.Tick.Bids[i][0].(float64),
-			Amount: update.Tick.Bids[i][1].(float64),
-		})
+		price, ok := update.Tick.Bids[i][0].(float64)
+		if !ok {
+			return errors.New("unable to type assert bid price")
+		}
+		amount, ok := update.Tick.Bids[i][1].(float64)
+		if !ok {
+			return errors.New("unable to type assert bid amount")
+		}
+		bids[i] = orderbook.Item{
+			Price:  price,
+			Amount: amount,
+		}
 	}
 
+	asks := make(orderbook.Items, len(update.Tick.Asks))
 	for i := range update.Tick.Asks {
-		asks = append(asks, orderbook.Item{
-			Price:  update.Tick.Asks[i][0].(float64),
-			Amount: update.Tick.Asks[i][1].(float64),
-		})
+		price, ok := update.Tick.Asks[i][0].(float64)
+		if !ok {
+			return errors.New("unable to type assert ask price")
+		}
+		amount, ok := update.Tick.Asks[i][1].(float64)
+		if !ok {
+			return errors.New("unable to type assert ask amount")
+		}
+		asks[i] = orderbook.Item{
+			Price:  price,
+			Amount: amount,
+		}
 	}
 
 	var newOrderBook orderbook.Base

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -547,9 +547,9 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 	var err error
 	switch assetType {
 	case asset.Spot:
-		var orderbookNew Orderbook
+		var orderbookNew *Orderbook
 		orderbookNew, err = h.GetDepth(ctx,
-			OrderBookDataRequestParams{
+			&OrderBookDataRequestParams{
 				Symbol: p,
 				Type:   OrderBookDataRequestParamsTypeStep0,
 			})
@@ -557,38 +557,41 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 			return nil, err
 		}
 
+		book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 		for x := range orderbookNew.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[x] = orderbook.Item{
 				Amount: orderbookNew.Bids[x][1],
 				Price:  orderbookNew.Bids[x][0],
-			})
+			}
 		}
-
+		book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 		for x := range orderbookNew.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[x] = orderbook.Item{
 				Amount: orderbookNew.Asks[x][1],
 				Price:  orderbookNew.Asks[x][0],
-			})
+			}
 		}
 
 	case asset.Futures:
-		var orderbookNew OBData
+		var orderbookNew *OBData
 		orderbookNew, err = h.FGetMarketDepth(ctx, p, "step0")
 		if err != nil {
 			return nil, err
 		}
 
+		book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 		for x := range orderbookNew.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[x] = orderbook.Item{
 				Amount: orderbookNew.Asks[x].Quantity,
 				Price:  orderbookNew.Asks[x].Price,
-			})
+			}
 		}
+		book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 		for y := range orderbookNew.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[y] = orderbook.Item{
 				Amount: orderbookNew.Bids[y].Quantity,
 				Price:  orderbookNew.Bids[y].Price,
-			})
+			}
 		}
 
 	case asset.CoinMarginedFutures:
@@ -598,17 +601,20 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 			return nil, err
 		}
 
+		book.Asks = make(orderbook.Items, len(orderbookNew.Tick.Asks))
 		for x := range orderbookNew.Tick.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[x] = orderbook.Item{
 				Amount: orderbookNew.Tick.Asks[x][1],
 				Price:  orderbookNew.Tick.Asks[x][0],
-			})
+			}
 		}
+
+		book.Bids = make(orderbook.Items, len(orderbookNew.Tick.Bids))
 		for y := range orderbookNew.Tick.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[y] = orderbook.Item{
 				Amount: orderbookNew.Tick.Bids[y][1],
 				Price:  orderbookNew.Tick.Bids[y][0],
-			})
+			}
 		}
 	}
 	err = book.Process()

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -1831,9 +1831,9 @@ func (h *HUOBI) GetAvailableTransferChains(ctx context.Context, cryptocurrency c
 		return nil, errors.New("chain data isn't populated")
 	}
 
-	var availableChains []string
+	availableChains := make([]string, len(chains[0].ChainData))
 	for x := range chains[0].ChainData {
-		availableChains = append(availableChains, chains[0].ChainData[x].Chain)
+		availableChains[x] = chains[0].ChainData[x].Chain
 	}
 	return availableChains, nil
 }

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -554,7 +554,7 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 				Type:   OrderBookDataRequestParamsTypeStep0,
 			})
 		if err != nil {
-			return nil, err
+			return book, err
 		}
 
 		book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
@@ -576,7 +576,7 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		var orderbookNew *OBData
 		orderbookNew, err = h.FGetMarketDepth(ctx, p, "step0")
 		if err != nil {
-			return nil, err
+			return book, err
 		}
 
 		book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
@@ -598,7 +598,7 @@ func (h *HUOBI) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		var orderbookNew SwapMarketDepthData
 		orderbookNew, err = h.GetSwapMarketDepth(ctx, p, "step0")
 		if err != nil {
-			return nil, err
+			return book, err
 		}
 
 		book.Asks = make(orderbook.Items, len(orderbookNew.Tick.Asks))

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -49,11 +49,11 @@ func (i *ItBit) GetTicker(ctx context.Context, currencyPair string) (Ticker, err
 
 // GetOrderbook returns full order book for the specified market.
 // currencyPair - example "XBTUSD" "XBTSGD" "XBTEUR"
-func (i *ItBit) GetOrderbook(ctx context.Context, currencyPair string) (OrderbookResponse, error) {
+func (i *ItBit) GetOrderbook(ctx context.Context, currencyPair string) (*OrderbookResponse, error) {
 	response := OrderbookResponse{}
 	path := fmt.Sprintf("/%s/%s/%s", itbitMarkets, currencyPair, itbitOrderbook)
 
-	return response, i.SendHTTPRequest(ctx, exchange.RestSpot, path, &response)
+	return &response, i.SendHTTPRequest(ctx, exchange.RestSpot, path, &response)
 }
 
 // GetTradeHistory returns recent trades for a specified market.

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -288,7 +288,7 @@ func (i *ItBit) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (ac
 		}
 	}
 
-	var fullBalance []account.Balance
+	fullBalance := make([]account.Balance, 0, len(amounts))
 	for key := range amounts {
 		fullBalance = append(fullBalance, account.Balance{
 			CurrencyName: currency.NewCode(key),
@@ -343,9 +343,9 @@ func (i *ItBit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData.RecentTrades))
 	for x := range tradeData.RecentTrades {
-		resp = append(resp, trade.Data{
+		resp[x] = trade.Data{
 			Exchange:     i.Name,
 			TID:          tradeData.RecentTrades[x].MatchNumber,
 			CurrencyPair: p,
@@ -353,7 +353,7 @@ func (i *ItBit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 			Price:        tradeData.RecentTrades[x].Price,
 			Amount:       tradeData.RecentTrades[x].Amount,
 			Timestamp:    tradeData.RecentTrades[x].Timestamp,
-		})
+		}
 	}
 
 	err = i.AddTradesToBuffer(resp...)
@@ -547,7 +547,7 @@ func (i *ItBit) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequest
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, 0, len(allOrders))
 	for j := range allOrders {
 		var symbol currency.Pair
 		symbol, err := currency.NewPairDelimiter(allOrders[j].Instrument,
@@ -611,7 +611,7 @@ func (i *ItBit) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, 0, len(allOrders))
 	for j := range allOrders {
 		if allOrders[j].Type == "open" {
 			continue

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -221,9 +221,10 @@ func (i *ItBit) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 
 	orderbookNew, err := i.GetOrderbook(ctx, fpair.String())
 	if err != nil {
-		return nil, err
+		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
 		var price, amount float64
 		price, err = strconv.ParseFloat(orderbookNew.Bids[x][0], 64)
@@ -234,13 +235,13 @@ func (i *ItBit) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		if err != nil {
 			return book, err
 		}
-		book.Bids = append(book.Bids,
-			orderbook.Item{
-				Amount: amount,
-				Price:  price,
-			})
+		book.Bids[x] = orderbook.Item{
+			Amount: amount,
+			Price:  price,
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
 		var price, amount float64
 		price, err = strconv.ParseFloat(orderbookNew.Asks[x][0], 64)
@@ -251,11 +252,10 @@ func (i *ItBit) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		if err != nil {
 			return book, err
 		}
-		book.Asks = append(book.Asks,
-			orderbook.Item{
-				Amount: amount,
-				Price:  price,
-			})
+		book.Asks[x] = orderbook.Item{
+			Amount: amount,
+			Price:  price,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -353,9 +353,9 @@ func ConvertToNewInterval(item *Item, newInterval Interval) (*Item, error) {
 
 	oldIntervalsPerNewCandle := int64(newInterval / item.Interval)
 	var candleBundles [][]Candle
-	var candles []Candle
+	candles := make([]Candle, len(item.Candles))
 	for i := range item.Candles {
-		candles = append(candles, item.Candles[i])
+		candles[i] = item.Candles[i]
 		intervalCount := int64(i + 1)
 		if oldIntervalsPerNewCandle == intervalCount {
 			candleBundles = append(candleBundles, candles)

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -353,13 +353,13 @@ func ConvertToNewInterval(item *Item, newInterval Interval) (*Item, error) {
 
 	oldIntervalsPerNewCandle := int64(newInterval / item.Interval)
 	var candleBundles [][]Candle
-	candles := make([]Candle, len(item.Candles))
+	candles := make([]Candle, 0, oldIntervalsPerNewCandle)
 	for i := range item.Candles {
-		candles[i] = item.Candles[i]
+		candles = append(candles, item.Candles[i])
 		intervalCount := int64(i + 1)
 		if oldIntervalsPerNewCandle == intervalCount {
 			candleBundles = append(candleBundles, candles)
-			candles = []Candle{}
+			candles = candles[:0]
 		}
 	}
 	responseCandle := &Item{

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -234,7 +234,7 @@ func (k *Kraken) GetOHLC(ctx context.Context, symbol currency.Pair, interval str
 		return nil, errors.New("invalid data returned")
 	}
 
-	var OHLC []OpenHighLowClose
+	OHLC := make([]OpenHighLowClose, len(ohlcData))
 	for x := range ohlcData {
 		subData, ok := ohlcData[x].([]interface{})
 		if !ok {
@@ -270,7 +270,7 @@ func (k *Kraken) GetOHLC(ctx context.Context, symbol currency.Pair, interval str
 		if o.Count, ok = subData[7].(float64); !ok {
 			return nil, errors.New("unable to type assert count")
 		}
-		OHLC = append(OHLC, o)
+		OHLC[x] = o
 	}
 	return OHLC, nil
 }
@@ -364,7 +364,6 @@ func (k *Kraken) GetTrades(ctx context.Context, symbol currency.Pair) ([]RecentT
 	translatedAsset := assetTranslator.LookupCurrency(symbolValue)
 	values.Set("pair", translatedAsset)
 
-	var recentTrades []RecentTrades
 	var result interface{}
 
 	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenTrades, values.Encode())
@@ -422,10 +421,11 @@ func (k *Kraken) GetTrades(ctx context.Context, symbol currency.Pair) ([]RecentT
 		return nil, fmt.Errorf("no trades returned for symbol %v", symbol)
 	}
 
-	for _, x := range trades {
+	recentTrades := make([]RecentTrades, len(trades))
+	for x := range trades {
 		r := RecentTrades{}
 		var individualTrade []interface{}
-		individualTrade, ok = x.([]interface{})
+		individualTrade, ok = trades[x].([]interface{})
 		if !ok {
 			return nil, errors.New("unable to parse individual trade data")
 		}
@@ -456,7 +456,7 @@ func (k *Kraken) GetTrades(ctx context.Context, symbol currency.Pair) ([]RecentT
 		if !ok {
 			return nil, errors.New("unable to parse misc field for individual trade data")
 		}
-		recentTrades = append(recentTrades, r)
+		recentTrades[x] = r
 	}
 	return recentTrades, nil
 }

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -23,15 +23,15 @@ import (
 var errInvalidBatchOrderType = errors.New("invalid batch order type")
 
 // GetFuturesOrderbook gets orderbook data for futures
-func (k *Kraken) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair) (FuturesOrderbookData, error) {
-	var resp FuturesOrderbookData
-	params := url.Values{}
+func (k *Kraken) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair) (*FuturesOrderbookData, error) {
 	symbolValue, err := k.FormatSymbol(symbol, asset.Futures)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
+	params := url.Values{}
 	params.Set("symbol", symbolValue)
-	return resp, k.SendHTTPRequest(ctx, exchange.RestFutures, futuresOrderbook+"?"+params.Encode(), &resp)
+	var resp FuturesOrderbookData
+	return &resp, k.SendHTTPRequest(ctx, exchange.RestFutures, futuresOrderbook+"?"+params.Encode(), &resp)
 }
 
 // GetFuturesMarkets gets a list of futures markets and their data

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -767,7 +767,7 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 	if !k.IsSaveTradeDataEnabled() {
 		return nil
 	}
-	var trades []trade.Data
+	trades := make([]trade.Data, len(data))
 	for i := range data {
 		t, ok := data[i].([]interface{})
 		if !ok {
@@ -796,7 +796,7 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 			tSide = order.Sell
 		}
 
-		trades = append(trades, trade.Data{
+		trades[i] = trade.Data{
 			AssetType:    asset.Spot,
 			CurrencyPair: channelData.Pair,
 			Exchange:     k.Name,
@@ -804,7 +804,7 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 			Amount:       amount,
 			Timestamp:    convert.TimeFromUnixTimestampDecimal(timeData),
 			Side:         tSide,
-		})
+		}
 	}
 	return trade.AddTradesToBuffer(k.Name, trades...)
 }

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -788,7 +788,11 @@ func (k *Kraken) wsProcessTrades(channelData *WebsocketChannelData, data []inter
 			return err
 		}
 		var tSide = order.Buy
-		if t[3].(string) == "s" {
+		s, ok := t[3].(string)
+		if !ok {
+			return errors.New("unable to type assert side")
+		}
+		if s == "s" {
 			tSide = order.Sell
 		}
 
@@ -1372,7 +1376,7 @@ func (k *Kraken) wsAddOrder(request *WsAddOrderRequest) (string, error) {
 		return "", err
 	}
 	if resp.ErrorMessage != "" {
-		return "", fmt.Errorf(k.Name + " - " + resp.ErrorMessage)
+		return "", errors.New(k.Name + " - " + resp.ErrorMessage)
 	}
 	return resp.TransactionID, nil
 }
@@ -1436,7 +1440,7 @@ func (k *Kraken) wsCancelAllOrders() (*WsCancelOrderResponse, error) {
 		return &WsCancelOrderResponse{}, err
 	}
 	if resp.ErrorMessage != "" {
-		return &WsCancelOrderResponse{}, fmt.Errorf(k.Name + " - " + resp.ErrorMessage)
+		return &WsCancelOrderResponse{}, errors.New(k.Name + " - " + resp.ErrorMessage)
 	}
 	return &resp, nil
 }

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -532,40 +532,44 @@ func (k *Kraken) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 	var err error
 	switch assetType {
 	case asset.Spot:
-		var orderbookNew Orderbook
+		var orderbookNew *Orderbook
 		orderbookNew, err = k.GetDepth(ctx, p)
 		if err != nil {
 			return nil, err
 		}
+		book.Bids = make([]orderbook.Item, len(orderbookNew.Bids))
 		for x := range orderbookNew.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[x] = orderbook.Item{
 				Amount: orderbookNew.Bids[x].Amount,
 				Price:  orderbookNew.Bids[x].Price,
-			})
+			}
 		}
+		book.Asks = make([]orderbook.Item, len(orderbookNew.Asks))
 		for y := range orderbookNew.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[y] = orderbook.Item{
 				Amount: orderbookNew.Asks[y].Amount,
 				Price:  orderbookNew.Asks[y].Price,
-			})
+			}
 		}
 	case asset.Futures:
-		var futuresOB FuturesOrderbookData
+		var futuresOB *FuturesOrderbookData
 		futuresOB, err = k.GetFuturesOrderbook(ctx, p)
 		if err != nil {
 			return nil, err
 		}
+		book.Asks = make([]orderbook.Item, len(futuresOB.Orderbook.Asks))
 		for x := range futuresOB.Orderbook.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[x] = orderbook.Item{
 				Price:  futuresOB.Orderbook.Asks[x][0],
 				Amount: futuresOB.Orderbook.Asks[x][1],
-			})
+			}
 		}
+		book.Bids = make([]orderbook.Item, len(futuresOB.Orderbook.Bids))
 		for y := range futuresOB.Orderbook.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[y] = orderbook.Item{
 				Price:  futuresOB.Orderbook.Bids[y][0],
 				Amount: futuresOB.Orderbook.Bids[y][1],
-			})
+			}
 		}
 	default:
 		return book, fmt.Errorf("invalid assetType: %v", assetType)

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -535,7 +535,7 @@ func (k *Kraken) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		var orderbookNew *Orderbook
 		orderbookNew, err = k.GetDepth(ctx, p)
 		if err != nil {
-			return nil, err
+			return book, err
 		}
 		book.Bids = make([]orderbook.Item, len(orderbookNew.Bids))
 		for x := range orderbookNew.Bids {
@@ -555,7 +555,7 @@ func (k *Kraken) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 		var futuresOB *FuturesOrderbookData
 		futuresOB, err = k.GetFuturesOrderbook(ctx, p)
 		if err != nil {
-			return nil, err
+			return book, err
 		}
 		book.Asks = make([]orderbook.Item, len(futuresOB.Orderbook.Asks))
 		for x := range futuresOB.Orderbook.Asks {

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -128,19 +128,19 @@ func (l *Lbank) GetKlines(ctx context.Context, symbol, size, klineType, tm strin
 		return nil, err
 	}
 
-	var k []KlineResponse
+	k := make([]KlineResponse, len(klineTemp))
 	for x := range klineTemp {
 		if len(klineTemp[x]) < 6 {
 			return nil, errors.New("unexpected kline data length")
 		}
-		k = append(k, KlineResponse{
+		k[x] = KlineResponse{
 			TimeStamp:     time.Unix(int64(klineTemp[x][0]), 0).UTC(),
 			OpenPrice:     klineTemp[x][1],
 			HigestPrice:   klineTemp[x][2],
 			LowestPrice:   klineTemp[x][3],
 			ClosePrice:    klineTemp[x][4],
 			TradingVolume: klineTemp[x][5],
-		})
+		}
 	}
 	return k, nil
 }

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -89,14 +89,14 @@ func (l *Lbank) GetCurrencyPairs(ctx context.Context) ([]string, error) {
 }
 
 // GetMarketDepths returns arrays of asks, bids and timestamp
-func (l *Lbank) GetMarketDepths(ctx context.Context, symbol, size, merge string) (MarketDepthResponse, error) {
+func (l *Lbank) GetMarketDepths(ctx context.Context, symbol, size, merge string) (*MarketDepthResponse, error) {
 	var m MarketDepthResponse
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("size", size)
 	params.Set("merge", merge)
 	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion2, lbankMarketDepths, params.Encode())
-	return m, l.SendHTTPRequest(ctx, exchange.RestSpot, path, &m)
+	return &m, l.SendHTTPRequest(ctx, exchange.RestSpot, path, &m)
 }
 
 // GetTrades returns an array of available trades regarding a particular exchange

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -281,6 +281,8 @@ func (l *Lbank) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 	if err != nil {
 		return book, err
 	}
+
+	book.Asks = make(orderbook.Items, len(a.Data.Asks))
 	for i := range a.Data.Asks {
 		price, convErr := strconv.ParseFloat(a.Data.Asks[i][0], 64)
 		if convErr != nil {
@@ -290,10 +292,12 @@ func (l *Lbank) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		if convErr != nil {
 			return book, convErr
 		}
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[i] = orderbook.Item{
 			Price:  price,
-			Amount: amount})
+			Amount: amount,
+		}
 	}
+	book.Bids = make(orderbook.Items, len(a.Data.Bids))
 	for i := range a.Data.Bids {
 		price, convErr := strconv.ParseFloat(a.Data.Bids[i][0], 64)
 		if convErr != nil {
@@ -303,9 +307,10 @@ func (l *Lbank) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType 
 		if convErr != nil {
 			return book, convErr
 		}
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[i] = orderbook.Item{
 			Price:  price,
-			Amount: amount})
+			Amount: amount,
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -686,13 +686,13 @@ func (l *LocalBitcoins) GetTrades(ctx context.Context, currency string, values u
 // the maximum amount available for the trade request. Price is the hourly
 // updated price. The price is based on the price equation and commission %
 // entered by the ad author.
-func (l *LocalBitcoins) GetOrderbook(ctx context.Context, currency string) (*Orderbook, error) {
+func (l *LocalBitcoins) GetOrderbook(ctx context.Context, curr string) (*Orderbook, error) {
 	type response struct {
 		Bids [][2]string `json:"bids"`
 		Asks [][2]string `json:"asks"`
 	}
 
-	path := localbitcoinsAPIBitcoincharts + currency + localbitcoinsAPIOrderbook
+	path := localbitcoinsAPIBitcoincharts + curr + localbitcoinsAPIOrderbook
 	resp := response{}
 	if err := l.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp, orderBookLimiter); err != nil {
 		return nil, err

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -665,7 +665,7 @@ func (l *LocalBitcoins) GetTradableCurrencies(ctx context.Context) ([]string, er
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(resp))
 	for x := range resp {
 		currencies = append(currencies, x)
 	}

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -155,9 +155,9 @@ func (l *LocalBitcoins) FetchTradablePairs(ctx context.Context, asset asset.Item
 		return nil, err
 	}
 
-	var pairs []string
+	pairs := make([]string, len(currencies))
 	for x := range currencies {
-		pairs = append(pairs, "BTC"+currencies[x])
+		pairs[x] = "BTC" + currencies[x]
 	}
 
 	return pairs, nil
@@ -332,9 +332,9 @@ func (l *LocalBitcoins) GetRecentTrades(ctx context.Context, p currency.Pair, as
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     l.Name,
 			TID:          strconv.FormatInt(tradeData[i].TID, 10),
 			CurrencyPair: p,
@@ -342,7 +342,7 @@ func (l *LocalBitcoins) GetRecentTrades(ctx context.Context, p currency.Pair, as
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
 			Timestamp:    time.Unix(tradeData[i].Date, 0),
-		})
+		}
 	}
 
 	err = l.AddTradesToBuffer(resp...)
@@ -551,7 +551,7 @@ func (l *LocalBitcoins) GetActiveOrders(ctx context.Context, getOrdersRequest *o
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(resp))
 	for i := range resp {
 		orderDate, err := time.Parse(time.RFC3339, resp[i].Data.CreatedAt)
 		if err != nil {
@@ -562,14 +562,12 @@ func (l *LocalBitcoins) GetActiveOrders(ctx context.Context, getOrdersRequest *o
 				resp[i].Data.CreatedAt)
 		}
 
-		var side order.Side
-		if resp[i].Data.IsBuying {
-			side = order.Buy
-		} else if resp[i].Data.IsSelling {
+		side := order.Buy
+		if resp[i].Data.IsSelling {
 			side = order.Sell
 		}
 
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			Amount: resp[i].Data.AmountBTC,
 			Price:  resp[i].Data.Amount,
 			ID:     strconv.FormatInt(int64(resp[i].Data.Advertisement.ID), 10),
@@ -580,7 +578,7 @@ func (l *LocalBitcoins) GetActiveOrders(ctx context.Context, getOrdersRequest *o
 				resp[i].Data.Currency,
 				format.Delimiter),
 			Exchange: l.Name,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, getOrdersRequest.StartTime,
@@ -621,7 +619,7 @@ func (l *LocalBitcoins) GetOrderHistory(ctx context.Context, getOrdersRequest *o
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allTrades))
 	for i := range allTrades {
 		orderDate, err := time.Parse(time.RFC3339, allTrades[i].Data.CreatedAt)
 		if err != nil {
@@ -659,7 +657,7 @@ func (l *LocalBitcoins) GetOrderHistory(ctx context.Context, getOrdersRequest *o
 			log.Errorf(log.ExchangeSys, "%s %v", l.Name, err)
 		}
 
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			Amount: allTrades[i].Data.AmountBTC,
 			Price:  allTrades[i].Data.Amount,
 			ID:     strconv.FormatInt(int64(allTrades[i].Data.Advertisement.ID), 10),
@@ -671,7 +669,7 @@ func (l *LocalBitcoins) GetOrderHistory(ctx context.Context, getOrdersRequest *o
 				allTrades[i].Data.Currency,
 				format.Delimiter),
 			Exchange: l.Name,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, getOrdersRequest.StartTime,

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -248,18 +248,20 @@ func (l *LocalBitcoins) UpdateOrderbook(ctx context.Context, p currency.Pair, as
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount / orderbookNew.Bids[x].Price,
 			Price:  orderbookNew.Bids[x].Price,
-		})
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount / orderbookNew.Asks[x].Price,
 			Price:  orderbookNew.Asks[x].Price,
-		})
+		}
 	}
 
 	book.PriceDuplication = true

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -250,6 +250,9 @@ func (l *LocalBitcoins) UpdateOrderbook(ctx context.Context, p currency.Pair, as
 
 	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
+		if orderbookNew.Bids[x].Price == 0 {
+			return book, errors.New("orderbook bid price is 0")
+		}
 		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x].Amount / orderbookNew.Bids[x].Price,
 			Price:  orderbookNew.Bids[x].Price,
@@ -258,6 +261,9 @@ func (l *LocalBitcoins) UpdateOrderbook(ctx context.Context, p currency.Pair, as
 
 	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
+		if orderbookNew.Asks[x].Price == 0 {
+			return book, errors.New("orderbook ask price is 0")
+		}
 		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x].Amount / orderbookNew.Asks[x].Price,
 			Price:  orderbookNew.Asks[x].Price,

--- a/exchanges/mock/common.go
+++ b/exchanges/mock/common.go
@@ -42,7 +42,7 @@ func MatchURLVals(v1, v2 url.Values) bool {
 // DeriveURLValsFromJSONMap gets url vals from a map[string]string encoded JSON body
 func DeriveURLValsFromJSONMap(payload []byte) (url.Values, error) {
 	var vals = url.Values{}
-	if string(payload) == "" {
+	if len(payload) == 0 {
 		return vals, nil
 	}
 	intermediary := make(map[string]interface{})

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -298,13 +298,7 @@ const (
 
 // CheckJSON recursively parses json data to retract keywords, quite intensive.
 func CheckJSON(data interface{}, excluded *Exclusion) (interface{}, error) {
-	var context map[string]interface{}
-
-	if reflect.TypeOf(data).String() == "[]interface {}" {
-		d, ok := data.([]interface{}) // make linters happy, even with the above check
-		if !ok {
-			return nil, errors.New("unable to type assert data")
-		}
+	if d, ok := data.([]interface{}); ok {
 		var sData []interface{}
 		for i := range d {
 			v := d[i]
@@ -329,6 +323,7 @@ func CheckJSON(data interface{}, excluded *Exclusion) (interface{}, error) {
 		return nil, err
 	}
 
+	var context map[string]interface{}
 	err = json.Unmarshal(conv, &context)
 	if err != nil {
 		return nil, err

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -48,7 +48,7 @@ func HTTPRecord(res *http.Response, service string, respContents []byte) error {
 
 	fileout := filepath.Join(DefaultDirectory, service, service+".json")
 
-	contents, err := ioutil.ReadFile(fileout)
+	contents, err := os.ReadFile(fileout)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func HTTPRecord(res *http.Response, service string, respContents []byte) error {
 		if bodyErr != nil {
 			return bodyErr
 		}
-		payload, bodyErr := ioutil.ReadAll(bodycopy)
+		payload, bodyErr := io.ReadAll(bodycopy)
 		if bodyErr != nil {
 			return bodyErr
 		}
@@ -426,7 +426,7 @@ func GetExcludedItems() (Exclusion, error) {
 	m.Lock()
 	defer m.Unlock()
 	if !set {
-		file, err := ioutil.ReadFile(exclusionFile)
+		file, err := os.ReadFile(exclusionFile)
 		if err != nil {
 			if !strings.Contains(err.Error(), "no such file or directory") {
 				return excludedList, err
@@ -440,7 +440,7 @@ func GetExcludedItems() (Exclusion, error) {
 				return excludedList, mErr
 			}
 
-			mErr = ioutil.WriteFile(exclusionFile, data, os.ModePerm)
+			mErr = os.WriteFile(exclusionFile, data, os.ModePerm)
 			if mErr != nil {
 				return excludedList, mErr
 			}

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -299,10 +299,15 @@ const (
 // CheckJSON recursively parses json data to retract keywords, quite intensive.
 func CheckJSON(data interface{}, excluded *Exclusion) (interface{}, error) {
 	var context map[string]interface{}
+
 	if reflect.TypeOf(data).String() == "[]interface {}" {
+		d, ok := data.([]interface{}) // make linters happy, even with the above check
+		if !ok {
+			return nil, errors.New("unable to type assert data")
+		}
 		var sData []interface{}
-		for i := range data.([]interface{}) {
-			v := data.([]interface{})[i]
+		for i := range d {
+			v := d[i]
 			switch v.(type) {
 			case map[string]interface{}, []interface{}:
 				checkedData, err := CheckJSON(v, excluded)

--- a/exchanges/mock/server.go
+++ b/exchanges/mock/server.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -42,7 +43,7 @@ func NewVCRServer(path string) (string, *http.Client, error) {
 
 	var mockFile VCRMock
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		pathing := strings.Split(path, "/")
 		dirPathing := pathing[:len(pathing)-1]
@@ -126,7 +127,7 @@ func RegisterHandler(pattern string, mock map[string][]HTTPResponse, mux *http.S
 		case http.MethodPost, http.MethodPut:
 			switch r.Header.Get(contentType) {
 			case applicationURLEncoded:
-				readBody, err := ioutil.ReadAll(r.Body)
+				readBody, err := io.ReadAll(r.Body)
 				if err != nil {
 					log.Fatal("Mock Test Failure - ReadAll error", err)
 				}
@@ -154,7 +155,7 @@ func RegisterHandler(pattern string, mock map[string][]HTTPResponse, mux *http.S
 				return
 
 			case applicationJSON:
-				readBody, err := ioutil.ReadAll(r.Body)
+				readBody, err := io.ReadAll(r.Body)
 				if err != nil {
 					log.Fatalf("Mock Test Failure - %v", err)
 				}

--- a/exchanges/mock/server_test.go
+++ b/exchanges/mock/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -48,7 +47,7 @@ func TestNewVCRServer(t *testing.T) {
 		t.Fatal("marshal error", err)
 	}
 
-	err = ioutil.WriteFile(testFile, payload, os.ModePerm)
+	err = os.WriteFile(testFile, payload, os.ModePerm)
 	if err != nil {
 		t.Fatal("marshal error", err)
 	}

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1092,21 +1092,21 @@ func TestWithdrawInternationalBank(t *testing.T) {
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
 	_, err := o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: "BTC-USDT"},
+		&okgroup.GetOrderBookRequest{InstrumentID: "BTC-USDT"},
 		asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
 
 	_, err = o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: "Payload"},
+		&okgroup.GetOrderBookRequest{InstrumentID: "Payload"},
 		asset.Futures)
 	if err == nil {
 		t.Error("error cannot be nil")
 	}
 
 	_, err = o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: "BTC-USD-SWAP"},
+		&okgroup.GetOrderBookRequest{InstrumentID: "BTC-USD-SWAP"},
 		asset.PerpetualSwap)
 	if err == nil {
 		t.Error("error cannot be nil")

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -788,7 +788,7 @@ func TestSendWsMessages(t *testing.T) {
 	}
 	response := <-o.Websocket.DataHandler
 	if err, ok = response.(error); ok && err != nil {
-		if !strings.Contains(response.(error).Error(), subscriptions[0].Channel) {
+		if !strings.Contains(err.Error(), subscriptions[0].Channel) {
 			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
 		}
 	}
@@ -875,7 +875,10 @@ func TestOrderBookPartialChecksumCalculator(t *testing.T) {
 		t.Error(err)
 	}
 
-	calculatedChecksum := o.CalculatePartialOrderbookChecksum(&dataResponse)
+	calculatedChecksum, err := o.CalculatePartialOrderbookChecksum(&dataResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if calculatedChecksum != dataResponse.Checksum {
 		t.Errorf("Expected %v, received %v", dataResponse.Checksum, calculatedChecksum)
 	}

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -258,11 +258,9 @@ func (o *OKCoin) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]st
 		return nil, err
 	}
 
-	var pairs []string
+	pairs := make([]string, len(prods))
 	for x := range prods {
-		pairs = append(pairs, prods[x].BaseCurrency+
-			format.Delimiter+
-			prods[x].QuoteCurrency)
+		pairs[x] = prods[x].BaseCurrency + format.Delimiter + prods[x].QuoteCurrency
 	}
 
 	return pairs, nil

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1657,7 +1657,7 @@ func TestSendWsMessages(t *testing.T) {
 	}
 	response := <-o.Websocket.DataHandler
 	if err, ok = response.(error); ok && err != nil {
-		if !strings.Contains(response.(error).Error(), subscriptions[0].Channel) {
+		if !strings.Contains(err.Error(), subscriptions[0].Channel) {
 			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
 		}
 	}
@@ -1739,7 +1739,10 @@ func TestOrderBookPartialChecksumCalculator(t *testing.T) {
 		t.Error(err)
 	}
 
-	calculatedChecksum := o.CalculatePartialOrderbookChecksum(&dataResponse)
+	calculatedChecksum, err := o.CalculatePartialOrderbookChecksum(&dataResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if calculatedChecksum != dataResponse.Checksum {
 		t.Errorf("Expected %v, received %v", dataResponse.Checksum, calculatedChecksum)
 	}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1970,21 +1970,21 @@ func TestWithdrawInternationalBank(t *testing.T) {
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
 	_, err := o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: "BTC-USDT"},
+		&okgroup.GetOrderBookRequest{InstrumentID: "BTC-USDT"},
 		asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
 	contract := getFutureInstrumentID()
 	_, err = o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: contract},
+		&okgroup.GetOrderBookRequest{InstrumentID: contract},
 		asset.Futures)
 	if err != nil {
 		t.Error(err)
 	}
 
 	_, err = o.GetOrderBook(context.Background(),
-		okgroup.GetOrderBookRequest{InstrumentID: "BTC-USD-SWAP"},
+		&okgroup.GetOrderBookRequest{InstrumentID: "BTC-USD-SWAP"},
 		asset.PerpetualSwap)
 	if err != nil {
 		t.Error(err)

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -314,7 +314,7 @@ func (o *OKGroup) GetSpotTokenPairDetails(ctx context.Context) (resp []GetSpotTo
 // GetOrderBook Getting the order book of a trading pair. Pagination is not
 // supported here. The whole book will be returned for one request. Websocket is
 // recommended here.
-func (o *OKGroup) GetOrderBook(ctx context.Context, request GetOrderBookRequest, a asset.Item) (resp GetOrderBookResponse, _ error) {
+func (o *OKGroup) GetOrderBook(ctx context.Context, request *GetOrderBookRequest, a asset.Item) (resp *GetOrderBookResponse, _ error) {
 	var requestType, endpoint string
 	switch a {
 	case asset.Spot:

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -535,8 +535,7 @@ func FormatParameters(request interface{}) (parameters string) {
 		log.Errorf(log.ExchangeSys, "Could not parse %v to URL values. Check that the type has url fields", reflect.TypeOf(request).Name())
 		return
 	}
-	urlEncodedValues := v.Encode()
-	if len(urlEncodedValues) > 0 {
+	if urlEncodedValues := v.Encode(); len(urlEncodedValues) > 0 {
 		parameters = fmt.Sprintf("?%v", urlEncodedValues)
 	}
 	return

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -461,7 +461,7 @@ func (o *OKGroup) wsProcessTrades(respRaw []byte) error {
 	}
 
 	a := o.GetAssetTypeFromTableName(response.Table)
-	var trades []trade.Data
+	trades := make([]trade.Data, len(response.Data))
 	for i := range response.Data {
 		f := strings.Split(response.Data[i].InstrumentID, delimiterDash)
 
@@ -487,7 +487,7 @@ func (o *OKGroup) wsProcessTrades(respRaw []byte) error {
 		if response.Data[i].Quantity != 0 {
 			amount = response.Data[i].Quantity
 		}
-		trades = append(trades, trade.Data{
+		trades[i] = trade.Data{
 			Amount:       amount,
 			AssetType:    o.GetAssetTypeFromTableName(response.Table),
 			CurrencyPair: c,
@@ -496,7 +496,7 @@ func (o *OKGroup) wsProcessTrades(respRaw []byte) error {
 			Side:         tSide,
 			Timestamp:    response.Data[i].Timestamp,
 			TID:          response.Data[i].TradeID,
-		})
+		}
 	}
 	return trade.AddTradesToBuffer(o.Name, trades...)
 }
@@ -644,7 +644,7 @@ func (o *OKGroup) wsResubscribeToOrderbook(response *WebsocketOrderBooksData) er
 // AppendWsOrderbookItems adds websocket orderbook data bid/asks into an
 // orderbook item array
 func (o *OKGroup) AppendWsOrderbookItems(entries [][]interface{}) ([]orderbook.Item, error) {
-	var items []orderbook.Item
+	items := make([]orderbook.Item, len(entries))
 	for j := range entries {
 		amount, err := strconv.ParseFloat(entries[j][1].(string), 64)
 		if err != nil {
@@ -654,7 +654,7 @@ func (o *OKGroup) AppendWsOrderbookItems(entries [][]interface{}) ([]orderbook.I
 		if err != nil {
 			return nil, err
 		}
-		items = append(items, orderbook.Item{Amount: amount, Price: price})
+		items[j] = orderbook.Item{Amount: amount, Price: price}
 	}
 	return items, nil
 }

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -103,7 +103,7 @@ func (o *OKGroup) UpdateOrderbook(ctx context.Context, p currency.Pair, a asset.
 	}
 
 	orderbookNew, err := o.GetOrderBook(ctx,
-		GetOrderBookRequest{
+		&GetOrderBookRequest{
 			InstrumentID: fPair.String(),
 			Size:         200,
 		}, a)
@@ -111,6 +111,7 @@ func (o *OKGroup) UpdateOrderbook(ctx context.Context, p currency.Pair, a asset.
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
 		amount, convErr := strconv.ParseFloat(orderbookNew.Bids[x][1], 64)
 		if convErr != nil {
@@ -135,14 +136,15 @@ func (o *OKGroup) UpdateOrderbook(ctx context.Context, p currency.Pair, a asset.
 			}
 		}
 
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount:            amount,
 			Price:             price,
 			LiquidationOrders: liquidationOrders,
 			OrderCount:        orderCount,
-		})
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
 		amount, convErr := strconv.ParseFloat(orderbookNew.Asks[x][1], 64)
 		if convErr != nil {
@@ -167,12 +169,12 @@ func (o *OKGroup) UpdateOrderbook(ctx context.Context, p currency.Pair, a asset.
 			}
 		}
 
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount:            amount,
 			Price:             price,
 			LiquidationOrders: liquidationOrders,
 			OrderCount:        orderCount,
-		})
+		}
 	}
 
 	err = book.Process()

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -359,7 +359,7 @@ func (o *OKGroup) CancelAllOrders(ctx context.Context, orderCancellation *order.
 	orderIDs := strings.Split(orderCancellation.ID, ",")
 	resp := order.CancelAllResponse{}
 	resp.Status = make(map[string]string)
-	var orderIDNumbers []int64
+	orderIDNumbers := make([]int64, 0, len(orderIDs))
 	for i := range orderIDs {
 		orderIDNumber, err := strconv.ParseInt(orderIDs[i], 10, 64)
 		if err != nil {

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -99,7 +99,7 @@ func (o *OKGroup) UpdateOrderbook(ctx context.Context, p currency.Pair, a asset.
 
 	fPair, err := o.FormatExchangeCurrency(p, a)
 	if err != nil {
-		return nil, err
+		return book, err
 	}
 
 	orderbookNew, err := o.GetOrderBook(ctx,

--- a/exchanges/order/futures.go
+++ b/exchanges/order/futures.go
@@ -214,9 +214,9 @@ func (e *MultiPositionTracker) GetPositions() []PositionStats {
 	}
 	e.m.Lock()
 	defer e.m.Unlock()
-	var resp []PositionStats
+	resp := make([]PositionStats, len(e.positions))
 	for i := range e.positions {
-		resp = append(resp, e.positions[i].GetStats())
+		resp[i] = e.positions[i].GetStats()
 	}
 	return resp
 }

--- a/exchanges/order/limits.go
+++ b/exchanges/order/limits.go
@@ -404,7 +404,5 @@ func (l *Limits) ConformToAmount(amount float64) float64 {
 	// derive modulus
 	mod := dAmount.Mod(dStep)
 	// subtract modulus to get the floor
-	rVal := dAmount.Sub(mod)
-	fVal, _ := rVal.Float64()
-	return fVal
+	return dAmount.Sub(mod).InexactFloat64()
 }

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -483,7 +483,7 @@ func (t Type) Lower() string {
 
 // Title returns the type titleized, eg "Limit"
 func (t Type) Title() string {
-	return strings.Title(strings.ToLower(string(t)))
+	return strings.Title(strings.ToLower(string(t))) // nolint:staticcheck // Ignore Title usage warning
 }
 
 // String implements the stringer interface
@@ -498,7 +498,7 @@ func (s Side) Lower() string {
 
 // Title returns the side titleized, eg "Buy"
 func (s Side) Title() string {
-	return strings.Title(strings.ToLower(string(s)))
+	return strings.Title(strings.ToLower(string(s))) // nolint:staticcheck // Ignore Title usage warning
 }
 
 // IsShort returns if the side is short

--- a/exchanges/orderbook/calculator.go
+++ b/exchanges/orderbook/calculator.go
@@ -139,7 +139,7 @@ func sortOrdersByPrice(o *orderSummary, reverse bool) {
 }
 
 func (b *Base) findAmount(price float64, buy bool) (float64, orderSummary) {
-	var orders orderSummary
+	orders := make(orderSummary, 0)
 	var amt float64
 
 	if buy {

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -46,7 +46,7 @@ func TestRetrieve(t *testing.T) {
 		pair:             currency.NewPair(currency.THETA, currency.USD),
 		asset:            "Silly asset",
 		lastUpdated:      time.Now(),
-		lastUpdateID:     007,
+		lastUpdateID:     007, // nolint:gocritic //  octal literal false positive
 		priceDuplication: true,
 		isFundingRate:    true,
 		VerifyOrderbook:  true,

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -46,7 +46,7 @@ func TestRetrieve(t *testing.T) {
 		pair:             currency.NewPair(currency.THETA, currency.USD),
 		asset:            "Silly asset",
 		lastUpdated:      time.Now(),
-		lastUpdateID:     007, // nolint:gocritic //  octal literal false positive
+		lastUpdateID:     1337,
 		priceDuplication: true,
 		isFundingRate:    true,
 		VerifyOrderbook:  true,

--- a/exchanges/orderbook/linked_list_test.go
+++ b/exchanges/orderbook/linked_list_test.go
@@ -1434,7 +1434,7 @@ func TestShiftBookmark(t *testing.T) {
 		t.Fatal("nilBookmark not reassigned")
 	}
 
-	head := bookmarkedNode // nolint // ifshort false positive
+	head := bookmarkedNode
 	bookmarkedNode.Prev = nil
 	bookmarkedNode.Next = originalBookmarkNext
 	tip.Next = nil

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -33,8 +33,8 @@ func DeployDepth(exchange string, p currency.Pair, a asset.Item) (*Depth, error)
 
 // SubscribeToExchangeOrderbooks returns a pipe to an exchange feed
 func SubscribeToExchangeOrderbooks(exchange string) (dispatch.Pipe, error) {
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 	exch, ok := service.books[strings.ToLower(exchange)]
 	if !ok {
 		return dispatch.Pipe{}, fmt.Errorf("%w for %s exchange",
@@ -46,12 +46,12 @@ func SubscribeToExchangeOrderbooks(exchange string) (dispatch.Pipe, error) {
 // Update stores orderbook data
 func (s *Service) Update(b *Base) error {
 	name := strings.ToLower(b.Exchange)
-	s.Lock()
+	s.mu.Lock()
 	m1, ok := s.books[name]
 	if !ok {
 		id, err := s.Mux.GetID()
 		if err != nil {
-			s.Unlock()
+			s.mu.Unlock()
 			return err
 		}
 		m1 = Exchange{
@@ -80,7 +80,7 @@ func (s *Service) Update(b *Base) error {
 		m3[b.Pair.Quote.Item] = book
 	}
 	book.LoadSnapshot(b.Bids, b.Asks, b.LastUpdateID, b.LastUpdated, true)
-	s.Unlock()
+	s.mu.Unlock()
 	return s.Mux.Publish([]uuid.UUID{m1.ID}, book.Retrieve())
 }
 
@@ -96,8 +96,8 @@ func (s *Service) DeployDepth(exchange string, p currency.Pair, a asset.Item) (*
 	if !a.IsValid() {
 		return nil, errAssetTypeNotSet
 	}
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	m1, ok := s.books[strings.ToLower(exchange)]
 	if !ok {
 		id, err := s.Mux.GetID()
@@ -134,8 +134,8 @@ func (s *Service) DeployDepth(exchange string, p currency.Pair, a asset.Item) (*
 // GetDepth returns the actual depth struct for potential subsystems and
 // strategies to interact with
 func (s *Service) GetDepth(exchange string, p currency.Pair, a asset.Item) (*Depth, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	m1, ok := s.books[strings.ToLower(exchange)]
 	if !ok {
 		return nil, fmt.Errorf("%w for %s exchange",
@@ -168,8 +168,8 @@ func (s *Service) GetDepth(exchange string, p currency.Pair, a asset.Item) (*Dep
 // Retrieve gets orderbook depth data from the associated linked list and
 // returns the base equivalent copy
 func (s *Service) Retrieve(exchange string, p currency.Pair, a asset.Item) (*Base, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	m1, ok := s.books[strings.ToLower(exchange)]
 	if !ok {
 		return nil, fmt.Errorf("%w for %s exchange",

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -43,7 +43,7 @@ var service = Service{
 type Service struct {
 	books map[string]Exchange
 	*dispatch.Mux
-	sync.Mutex
+	mu sync.Mutex
 }
 
 // Exchange defines a holder for the exchange specific depth items with a

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -143,7 +143,7 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 		}
 		for currency, orderbook := range resp.Data {
 			ob := Orderbook{
-				Bids: make([]OrderbookItem, len(orderbook.Asks)),
+				Bids: make([]OrderbookItem, len(orderbook.Bids)),
 				Asks: make([]OrderbookItem, len(orderbook.Asks)),
 			}
 			for x := range orderbook.Asks {

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -100,7 +100,7 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 			return oba, fmt.Errorf("%s GetOrderbook() error: %s", p.Name, resp.Error)
 		}
 		ob := Orderbook{
-			Bids: make([]OrderbookItem, len(resp.Asks)),
+			Bids: make([]OrderbookItem, len(resp.Bids)),
 			Asks: make([]OrderbookItem, len(resp.Asks)),
 		}
 		for x := range resp.Asks {

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -105,9 +105,13 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 			if err != nil {
 				return oba, err
 			}
+			amt, ok := resp.Asks[x][1].(float64)
+			if !ok {
+				return oba, errors.New("unable to type assert amount")
+			}
 			ob.Asks = append(ob.Asks, OrderbookItem{
 				Price:  price,
-				Amount: resp.Asks[x][1].(float64),
+				Amount: amt,
 			})
 		}
 
@@ -116,9 +120,13 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 			if err != nil {
 				return oba, err
 			}
+			amt, ok := resp.Bids[x][1].(float64)
+			if !ok {
+				return oba, errors.New("unable to type assert amount")
+			}
 			ob.Bids = append(ob.Bids, OrderbookItem{
 				Price:  price,
-				Amount: resp.Bids[x][1].(float64),
+				Amount: amt,
 			})
 		}
 		oba.Data[currencyPair] = ob
@@ -440,7 +448,7 @@ func (p *Poloniex) GetAuthenticatedOrderStatus(ctx context.Context, orderID stri
 		if err != nil {
 			return o, err
 		}
-		return o, fmt.Errorf(errMsg.Error)
+		return o, errors.New(errMsg.Error)
 	case 1: // success
 		var status map[string]OrderStatusData
 		err = json.Unmarshal(rawOrderStatus.Result, &status)
@@ -483,7 +491,7 @@ func (p *Poloniex) GetAuthenticatedOrderTrades(ctx context.Context, orderID stri
 			return nil, err
 		}
 		if resp.Error != "" {
-			err = fmt.Errorf(resp.Error)
+			err = errors.New(resp.Error)
 		}
 	case '[': // data received
 		err = json.Unmarshal(result, &o)

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -543,9 +543,13 @@ func (p *Poloniex) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription,
 
 // Subscribe sends a websocket message to receive data from the channel
 func (p *Poloniex) Subscribe(sub []stream.ChannelSubscription) error {
-	creds, err := p.GetCredentials(context.TODO())
-	if err != nil {
-		return err
+	var creds *exchange.Credentials
+	if p.GetAuthenticatedAPISupport(exchange.WebsocketAuthentication) {
+		var err error
+		creds, err = p.GetCredentials(context.TODO())
+		if err != nil {
+			return err
+		}
 	}
 	var errs common.Errors
 channels:
@@ -555,7 +559,7 @@ channels:
 		}
 		switch {
 		case strings.EqualFold(strconv.FormatInt(wsAccountNotificationID, 10),
-			sub[i].Channel):
+			sub[i].Channel) && creds != nil:
 			err := p.wsSendAuthorisedCommand(creds.Secret, creds.Key, "subscribe")
 			if err != nil {
 				errs = append(errs, err)
@@ -586,9 +590,13 @@ channels:
 
 // Unsubscribe sends a websocket message to stop receiving data from the channel
 func (p *Poloniex) Unsubscribe(unsub []stream.ChannelSubscription) error {
-	creds, err := p.GetCredentials(context.TODO())
-	if err != nil {
-		return err
+	var creds *exchange.Credentials
+	if p.GetAuthenticatedAPISupport(exchange.WebsocketAuthentication) {
+		var err error
+		creds, err = p.GetCredentials(context.TODO())
+		if err != nil {
+			return err
+		}
 	}
 	var errs common.Errors
 channels:
@@ -598,7 +606,7 @@ channels:
 		}
 		switch {
 		case strings.EqualFold(strconv.FormatInt(wsAccountNotificationID, 10),
-			unsub[i].Channel):
+			unsub[i].Channel) && creds != nil:
 			err := p.wsSendAuthorisedCommand(creds.Secret, creds.Key, "unsubscribe")
 			if err != nil {
 				errs = append(errs, err)

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -421,6 +421,7 @@ func (p *Poloniex) WsProcessOrderbookSnapshot(data []interface{}) error {
 	}
 
 	var book orderbook.Base
+	book.Asks = make(orderbook.Items, 0, len(askData))
 	for price, volume := range askData {
 		p, err := strconv.ParseFloat(price, 64)
 		if err != nil {
@@ -438,6 +439,7 @@ func (p *Poloniex) WsProcessOrderbookSnapshot(data []interface{}) error {
 		book.Asks = append(book.Asks, orderbook.Item{Price: p, Amount: a})
 	}
 
+	book.Bids = make(orderbook.Items, 0, len(bidData))
 	for price, volume := range bidData {
 		p, err := strconv.ParseFloat(price, 64)
 		if err != nil {

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -512,7 +512,12 @@ func (p *Poloniex) WsProcessOrderbookUpdate(sequenceNumber float64, data []inter
 
 // GenerateDefaultSubscriptions Adds default subscriptions to websocket to be handled by ManageSubscriptions()
 func (p *Poloniex) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, error) {
-	var subscriptions []stream.ChannelSubscription
+	enabledCurrencies, err := p.GetEnabledPairs(asset.Spot)
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptions := make([]stream.ChannelSubscription, 0, len(enabledCurrencies))
 	subscriptions = append(subscriptions, stream.ChannelSubscription{
 		Channel: strconv.FormatInt(wsTickerDataID, 10),
 	})
@@ -523,10 +528,6 @@ func (p *Poloniex) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription,
 		})
 	}
 
-	enabledCurrencies, err := p.GetEnabledPairs(asset.Spot)
-	if err != nil {
-		return nil, err
-	}
 	for j := range enabledCurrencies {
 		enabledCurrencies[j].Delimiter = currency.UnderscoreDelimiter
 		subscriptions = append(subscriptions, stream.ChannelSubscription{

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -381,18 +381,20 @@ func (p *Poloniex) UpdateOrderbook(ctx context.Context, c currency.Pair, assetTy
 			continue
 		}
 
+		book.Bids = make(orderbook.Items, len(data.Bids))
 		for y := range data.Bids {
-			book.Bids = append(book.Bids, orderbook.Item{
+			book.Bids[y] = orderbook.Item{
 				Amount: data.Bids[y].Amount,
 				Price:  data.Bids[y].Price,
-			})
+			}
 		}
 
+		book.Asks = make(orderbook.Items, len(data.Asks))
 		for y := range data.Asks {
-			book.Asks = append(book.Asks, orderbook.Item{
+			book.Asks[y] = orderbook.Item{
 				Amount: data.Asks[y].Amount,
 				Price:  data.Asks[y].Price,
-			})
+			}
 		}
 		err = book.Process()
 		if err != nil {

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -260,7 +260,7 @@ func (p *Poloniex) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(resp))
 	for x := range resp {
 		currencies = append(currencies, x)
 	}
@@ -412,7 +412,7 @@ func (p *Poloniex) UpdateAccountInfo(ctx context.Context, assetType asset.Item) 
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, 0, len(accountBalance.Currency))
 	for x, y := range accountBalance.Currency {
 		currencies = append(currencies, account.Balance{
 			CurrencyName: currency.NewCode(x),

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -334,7 +334,7 @@ func (r *Requester) SetHTTPClient(newClient *http.Client) error {
 	return nil
 }
 
-// SetClientTimeout sets the timeout value for the exchanges HTTP Client and
+// SetHTTPClientTimeout sets the timeout value for the exchanges HTTP Client and
 // also the underlying transports idle connection timeout
 func (r *Requester) SetHTTPClientTimeout(timeout time.Duration) error {
 	if r == nil {

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -207,7 +206,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 			continue
 		}
 
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -273,7 +272,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 }
 
 func (r *Requester) drainBody(body io.ReadCloser) {
-	if _, err := io.Copy(ioutil.Discard, io.LimitReader(body, drainBodyLimit)); err != nil {
+	if _, err := io.Copy(io.Discard, io.LimitReader(body, drainBodyLimit)); err != nil {
 		log.Errorf(log.RequestSys,
 			"%s failed to drain request body %s",
 			r.name,

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -6,7 +6,7 @@ import (
 	"compress/gzip"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -156,7 +156,7 @@ func (w *WebsocketConnection) SetupPingHandler(handler PingHandler) {
 				time.Now().Add(handler.Delay))
 			if err == websocket.ErrCloseSent {
 				return nil
-			} else if e, ok := err.(net.Error); ok && e.Temporary() {
+			} else if e, ok := err.(net.Error); ok && e.Timeout() {
 				return nil
 			}
 			return err
@@ -260,7 +260,7 @@ func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
 		if err != nil {
 			return standardMessage, err
 		}
-		standardMessage, err = ioutil.ReadAll(gReader)
+		standardMessage, err = io.ReadAll(gReader)
 		if err != nil {
 			return standardMessage, err
 		}
@@ -270,7 +270,7 @@ func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
 		}
 	} else {
 		reader := flate.NewReader(bytes.NewReader(resp))
-		standardMessage, err = ioutil.ReadAll(reader)
+		standardMessage, err = io.ReadAll(reader)
 		if err != nil {
 			return standardMessage, err
 		}

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -308,8 +308,7 @@ func TestConnectionMessageErrors(t *testing.T) {
 		errText, ok := err.(error)
 		if !ok {
 			t.Error("unable to type assert error")
-		}
-		if errText.Error() != "errorText" {
+		} else if errText.Error() != "errorText" {
 			t.Errorf("Expected 'errorText', received %v", err)
 		}
 	case <-timer.C:

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -305,7 +305,11 @@ func TestConnectionMessageErrors(t *testing.T) {
 	ws.ReadMessageErrors <- errors.New("errorText")
 	select {
 	case err := <-ws.ToRoutine:
-		if err.(error).Error() != "errorText" {
+		errText, ok := err.(error)
+		if !ok {
+			t.Error("unable to type assert error")
+		}
+		if errText.Error() != "errorText" {
 			t.Errorf("Expected 'errorText', received %v", err)
 		}
 	case <-timer.C:

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -1045,12 +1045,12 @@ type GenSubs struct {
 
 // generateSubs default subs created from the enabled pairs list
 func (g *GenSubs) generateSubs() ([]ChannelSubscription, error) {
-	var superduperchannelsubs []ChannelSubscription
+	superduperchannelsubs := make([]ChannelSubscription, len(g.EnabledPairs))
 	for i := range g.EnabledPairs {
-		superduperchannelsubs = append(superduperchannelsubs, ChannelSubscription{
+		superduperchannelsubs[i] = ChannelSubscription{
 			Channel:  "TEST:" + strconv.FormatInt(int64(i), 10),
 			Currency: g.EnabledPairs[i],
-		})
+		}
 	}
 	return superduperchannelsubs, nil
 }

--- a/exchanges/ticker/ticker.go
+++ b/exchanges/ticker/ticker.go
@@ -29,8 +29,8 @@ func init() {
 // stream new ticker updates
 func SubscribeTicker(exchange string, p currency.Pair, a asset.Item) (dispatch.Pipe, error) {
 	exchange = strings.ToLower(exchange)
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 
 	tick, ok := service.Tickers[exchange][p.Base.Item][p.Quote.Item][a]
 	if !ok {
@@ -45,8 +45,8 @@ func SubscribeTicker(exchange string, p currency.Pair, a asset.Item) (dispatch.P
 // SubscribeToExchangeTickers subcribes to all tickers on an exchange
 func SubscribeToExchangeTickers(exchange string) (dispatch.Pipe, error) {
 	exchange = strings.ToLower(exchange)
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 	id, ok := service.Exchange[exchange]
 	if !ok {
 		return dispatch.Pipe{}, fmt.Errorf("%s exchange tickers not found",
@@ -59,8 +59,8 @@ func SubscribeToExchangeTickers(exchange string) (dispatch.Pipe, error) {
 // GetTicker checks and returns a requested ticker if it exists
 func GetTicker(exchange string, p currency.Pair, a asset.Item) (*Price, error) {
 	exchange = strings.ToLower(exchange)
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 	m1, ok := service.Tickers[exchange]
 	if !ok {
 		return nil, fmt.Errorf("no tickers for %s exchange", exchange)
@@ -90,8 +90,8 @@ func GetTicker(exchange string, p currency.Pair, a asset.Item) (*Price, error) {
 
 // FindLast searches for a currency pair and returns the first available
 func FindLast(p currency.Pair, a asset.Item) (float64, error) {
-	service.Lock()
-	defer service.Unlock()
+	service.mu.Lock()
+	defer service.mu.Unlock()
 	for _, m1 := range service.Tickers {
 		m2, ok := m1[p.Base.Item]
 		if !ok {
@@ -146,7 +146,7 @@ func ProcessTicker(p *Price) error {
 // update updates ticker price
 func (s *Service) update(p *Price) error {
 	name := strings.ToLower(p.ExchangeName)
-	s.Lock()
+	s.mu.Lock()
 
 	m1, ok := service.Tickers[name]
 	if !ok {
@@ -171,18 +171,18 @@ func (s *Service) update(p *Price) error {
 		newTicker := &Ticker{}
 		err := s.setItemID(newTicker, p, name)
 		if err != nil {
-			s.Unlock()
+			s.mu.Unlock()
 			return err
 		}
 		m3[p.AssetType] = newTicker
-		s.Unlock()
+		s.mu.Unlock()
 		return nil
 	}
 
 	t.Price = *p
 	// nolint: gocritic
 	ids := append(t.Assoc, t.Main)
-	s.Unlock()
+	s.mu.Unlock()
 	return s.mux.Publish(ids, p)
 }
 

--- a/exchanges/ticker/ticker_types.go
+++ b/exchanges/ticker/ticker_types.go
@@ -28,7 +28,7 @@ type Service struct {
 	Tickers  map[string]map[*currency.Item]map[*currency.Item]map[asset.Item]*Ticker
 	Exchange map[string]uuid.UUID
 	mux      *dispatch.Mux
-	sync.Mutex
+	mu       sync.Mutex
 }
 
 // Price struct stores the currency pair and pricing information

--- a/exchanges/trade/trade.go
+++ b/exchanges/trade/trade.go
@@ -72,7 +72,7 @@ func AddTradesToBuffer(exchangeName string, data ...Data) error {
 		processor.setup(&wg)
 		wg.Wait()
 	}
-	var validDatas []Data
+	validDatas := make([]Data, 0, len(data))
 	for i := range data {
 		if data[i].Price == 0 ||
 			data[i].Amount == 0 ||
@@ -179,13 +179,13 @@ func HasTradesInRanges(exchangeName, assetType, base, quote string, rangeHolder 
 
 func tradeToSQLData(trades ...Data) ([]tradesql.Data, error) {
 	sort.Sort(ByDate(trades))
-	var results []tradesql.Data
+	results := make([]tradesql.Data, len(trades))
 	for i := range trades {
 		tradeID, err := uuid.NewV4()
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, tradesql.Data{
+		results[i] = tradesql.Data{
 			ID:        tradeID.String(),
 			Timestamp: trades[i].Timestamp,
 			Exchange:  trades[i].Exchange,
@@ -196,7 +196,7 @@ func tradeToSQLData(trades ...Data) ([]tradesql.Data, error) {
 			Amount:    trades[i].Amount,
 			Side:      trades[i].Side.String(),
 			TID:       trades[i].TID,
-		})
+		}
 	}
 	return results, nil
 }

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -165,7 +165,7 @@ func (y *Yobit) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]str
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(info.Pairs))
 	for x := range info.Pairs {
 		currencies = append(currencies, strings.ToUpper(x))
 	}
@@ -307,7 +307,7 @@ func (y *Yobit) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (ac
 		return response, err
 	}
 
-	var currencies []account.Balance
+	currencies := make([]account.Balance, 0, len(accountBalance.FundsInclOrders))
 	for x, y := range accountBalance.FundsInclOrders {
 		var exchangeCurrency account.Balance
 		exchangeCurrency.CurrencyName = currency.NewCode(x)
@@ -363,19 +363,21 @@ func (y *Yobit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+
 	var tradeData []Trade
 	tradeData, err = y.GetTrades(ctx, p.String())
 	if err != nil {
 		return nil, err
 	}
+
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		tradeTS := time.Unix(tradeData[i].Timestamp, 0)
 		side := order.Buy
 		if tradeData[i].Type == "ask" {
 			side = order.Sell
 		}
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     y.Name,
 			TID:          strconv.FormatInt(tradeData[i].TID, 10),
 			CurrencyPair: p,
@@ -384,7 +386,7 @@ func (y *Yobit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
 			Timestamp:    tradeTS,
-		})
+		}
 	}
 
 	err = y.AddTradesToBuffer(resp...)
@@ -465,11 +467,12 @@ func (y *Yobit) CancelAllOrders(ctx context.Context, _ *order.Cancel) (order.Can
 		Status: make(map[string]string),
 	}
 
-	var allActiveOrders []map[string]ActiveOrders
 	enabledPairs, err := y.GetEnabledPairs(asset.Spot)
 	if err != nil {
 		return cancelAllOrdersResponse, err
 	}
+
+	allActiveOrders := make([]map[string]ActiveOrders, len(enabledPairs))
 	for i := range enabledPairs {
 		fCurr, err := y.FormatExchangeCurrency(enabledPairs[i], asset.Spot)
 		if err != nil {
@@ -480,7 +483,7 @@ func (y *Yobit) CancelAllOrders(ctx context.Context, _ *order.Cancel) (order.Can
 			return cancelAllOrdersResponse, err
 		}
 
-		allActiveOrders = append(allActiveOrders, activeOrdersForPair)
+		allActiveOrders[i] = activeOrdersForPair
 	}
 
 	for i := range allActiveOrders {
@@ -648,7 +651,7 @@ func (y *Yobit) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allOrders))
 	for i := range allOrders {
 		var pair currency.Pair
 		pair, err = currency.NewPairDelimiter(allOrders[i].Pair, format.Delimiter)
@@ -670,7 +673,7 @@ func (y *Yobit) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest
 			Exchange:             y.Name,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersBySide(&orders, req.Side)

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -227,12 +227,12 @@ func (z *ZB) GetOrderbook(ctx context.Context, symbol string) (*OrderbookRespons
 	}
 
 	// reverse asks data
-	data := make([][2]float64, 0, len(res.Asks))
-	for x := len(res.Asks); x > 0; x-- {
-		data = append(data, res.Asks[x-1])
+	eLen := len(res.Asks)
+	var target int
+	for i := eLen/2 - 1; i >= 0; i-- {
+		target = eLen - 1 - i
+		(res.Asks)[i], (res.Asks)[target] = (res.Asks)[target], (res.Asks)[i]
 	}
-
-	res.Asks = data
 	return &res, nil
 }
 

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -209,31 +209,31 @@ func (z *ZB) GetTickers(ctx context.Context) (map[string]TickerChildResponse, er
 }
 
 // GetOrderbook returns the orderbook for a given symbol
-func (z *ZB) GetOrderbook(ctx context.Context, symbol string) (OrderbookResponse, error) {
+func (z *ZB) GetOrderbook(ctx context.Context, symbol string) (*OrderbookResponse, error) {
 	urlPath := fmt.Sprintf("/%s/%s/%s?market=%s", zbData, zbAPIVersion, zbDepth, symbol)
 	var res OrderbookResponse
 
 	err := z.SendHTTPRequest(ctx, exchange.RestSpot, urlPath, &res, request.UnAuth)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 
 	if len(res.Asks) == 0 {
-		return res, fmt.Errorf("ZB GetOrderbook asks is empty")
+		return nil, errors.New("ZB GetOrderbook asks is empty")
 	}
 
 	if len(res.Bids) == 0 {
-		return res, fmt.Errorf("ZB GetOrderbook bids is empty")
+		return nil, errors.New("ZB GetOrderbook bids is empty")
 	}
 
 	// reverse asks data
-	var data [][]float64
+	data := make([][2]float64, 0, len(res.Asks))
 	for x := len(res.Asks); x > 0; x-- {
 		data = append(data, res.Asks[x-1])
 	}
 
 	res.Asks = data
-	return res, nil
+	return &res, nil
 }
 
 // GetSpotKline returns Kline data

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"sync"
@@ -288,8 +287,7 @@ func TestGetOrderHistory(t *testing.T) {
 
 func TestSubmitOrder(t *testing.T) {
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
-		t.Skip(fmt.Sprintf("Can place orders: %v",
-			canManipulateRealOrders))
+		t.Skipf("Can place orders: %v", canManipulateRealOrders)
 	}
 	if mockTests {
 		t.Skip("skipping authenticated function for mock testing")

--- a/exchanges/zb/zb_types.go
+++ b/exchanges/zb/zb_types.go
@@ -9,9 +9,9 @@ import (
 
 // OrderbookResponse holds the orderbook data for a symbol
 type OrderbookResponse struct {
-	Timestamp int64       `json:"timestamp"`
-	Asks      [][]float64 `json:"asks"`
-	Bids      [][]float64 `json:"bids"`
+	Timestamp int64        `json:"timestamp"`
+	Asks      [][2]float64 `json:"asks"`
+	Bids      [][2]float64 `json:"bids"`
 }
 
 // AccountsResponseCoin holds the accounts coin details

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -227,7 +227,7 @@ func (z *ZB) FetchTradablePairs(ctx context.Context, asset asset.Item) ([]string
 		return nil, err
 	}
 
-	var currencies []string
+	currencies := make([]string, 0, len(markets))
 	for x := range markets {
 		currencies = append(currencies, x)
 	}
@@ -354,7 +354,6 @@ func (z *ZB) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType ass
 // ZB exchange
 func (z *ZB) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (account.Holdings, error) {
 	var info account.Holdings
-	var balances []account.Balance
 	var coins []AccountsResponseCoin
 	if z.Websocket.CanUseAuthenticatedWebsocketForWrapper() {
 		resp, err := z.wsGetAccountInfoRequest(ctx)
@@ -370,6 +369,7 @@ func (z *ZB) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (accou
 		coins = bal.Result.Coins
 	}
 
+	balances := make([]account.Balance, len(coins))
 	for i := range coins {
 		hold, err := strconv.ParseFloat(coins[i].Freeze, 64)
 		if err != nil {
@@ -381,12 +381,12 @@ func (z *ZB) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (accou
 			return info, err
 		}
 
-		balances = append(balances, account.Balance{
+		balances[i] = account.Balance{
 			CurrencyName: currency.NewCode(coins[i].EnName),
 			Total:        hold + avail,
 			Hold:         hold,
 			Free:         avail,
-		})
+		}
 	}
 
 	info.Exchange = z.Name
@@ -1008,9 +1008,9 @@ func (z *ZB) GetAvailableTransferChains(ctx context.Context, cryptocurrency curr
 		return nil, err
 	}
 
-	var availableChains []string
+	availableChains := make([]string, len(chains))
 	for x := range chains {
-		availableChains = append(availableChains, chains[x].Blockchain)
+		availableChains[x] = chains[x].Blockchain
 	}
 	return availableChains, nil
 }

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -434,7 +434,7 @@ func (z *ZB) GetRecentTrades(ctx context.Context, p currency.Pair, assetType ass
 	if err != nil {
 		return nil, err
 	}
-	var resp []trade.Data
+	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData[i].Type)
@@ -442,7 +442,7 @@ func (z *ZB) GetRecentTrades(ctx context.Context, p currency.Pair, assetType ass
 			return nil, err
 		}
 
-		resp = append(resp, trade.Data{
+		resp[i] = trade.Data{
 			Exchange:     z.Name,
 			TID:          strconv.FormatInt(tradeData[i].Tid, 10),
 			CurrencyPair: p,
@@ -451,7 +451,7 @@ func (z *ZB) GetRecentTrades(ctx context.Context, p currency.Pair, assetType ass
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
 			Timestamp:    time.Unix(tradeData[i].Date, 0),
-		})
+		}
 	}
 
 	err = z.AddTradesToBuffer(resp...)
@@ -741,7 +741,7 @@ func (z *ZB) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequest) (
 		return nil, err
 	}
 
-	var orders []order.Detail
+	orders := make([]order.Detail, len(allOrders))
 	for i := range allOrders {
 		var symbol currency.Pair
 		symbol, err = currency.NewPairDelimiter(allOrders[i].Currency,
@@ -751,7 +751,7 @@ func (z *ZB) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequest) (
 		}
 		orderDate := time.Unix(int64(allOrders[i].TradeDate), 0)
 		orderSide := orderSideMap[allOrders[i].Type]
-		orders = append(orders, order.Detail{
+		orders[i] = order.Detail{
 			ID:       strconv.FormatInt(allOrders[i].ID, 10),
 			Amount:   allOrders[i].TotalAmount,
 			Exchange: z.Name,
@@ -759,7 +759,7 @@ func (z *ZB) GetActiveOrders(ctx context.Context, req *order.GetOrdersRequest) (
 			Price:    allOrders[i].Price,
 			Side:     orderSide,
 			Pair:     symbol,
-		})
+		}
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)
@@ -778,8 +778,8 @@ func (z *ZB) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest) (
 	if req.Side == order.AnySide || req.Side == "" {
 		return nil, errors.New("specific order side is required")
 	}
+
 	var allOrders []Order
-	var orders []order.Detail
 	var side int64
 
 	if z.Websocket.CanUseAuthenticatedWebsocketForWrapper() {
@@ -825,6 +825,7 @@ func (z *ZB) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest) (
 		return nil, err
 	}
 
+	orders := make([]order.Detail, len(allOrders))
 	for i := range allOrders {
 		var pair currency.Pair
 		pair, err = currency.NewPairDelimiter(allOrders[i].Currency,
@@ -847,7 +848,7 @@ func (z *ZB) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest) (
 			Pair:                 pair,
 		}
 		detail.InferCostsAndTimes()
-		orders = append(orders, detail)
+		orders[i] = detail
 	}
 
 	order.FilterOrdersByTimeRange(&orders, req.StartTime, req.EndTime)

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -330,18 +330,20 @@ func (z *ZB) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType ass
 		return book, err
 	}
 
+	book.Bids = make(orderbook.Items, len(orderbookNew.Bids))
 	for x := range orderbookNew.Bids {
-		book.Bids = append(book.Bids, orderbook.Item{
+		book.Bids[x] = orderbook.Item{
 			Amount: orderbookNew.Bids[x][1],
 			Price:  orderbookNew.Bids[x][0],
-		})
+		}
 	}
 
+	book.Asks = make(orderbook.Items, len(orderbookNew.Asks))
 	for x := range orderbookNew.Asks {
-		book.Asks = append(book.Asks, orderbook.Item{
+		book.Asks[x] = orderbook.Item{
 			Amount: orderbookNew.Asks[x][1],
 			Price:  orderbookNew.Asks[x][0],
-		})
+		}
 	}
 	err = book.Process()
 	if err != nil {

--- a/gctscript/modules/gct/gct.go
+++ b/gctscript/modules/gct/gct.go
@@ -2,7 +2,7 @@ package gct
 
 // AllModuleNames returns a list of all default module names.
 func AllModuleNames() []string {
-	var names []string
+	names := make([]string, 0, len(Modules))
 	for name := range Modules {
 		names = append(names, name)
 	}

--- a/gctscript/modules/ta/indicators/ema.go
+++ b/gctscript/modules/ta/indicators/ema.go
@@ -46,7 +46,7 @@ func ema(args ...objects.Object) (objects.Object, error) {
 		return nil, fmt.Errorf(modules.ErrParameterConvertFailed, OHLCV)
 	}
 
-	var ohlcvClose []float64
+	ohlcvClose := make([]float64, len(ohlcvInputData))
 	var allErrors []string
 	for x := range ohlcvInputData {
 		t, ok := ohlcvInputData[x].([]interface{})
@@ -61,7 +61,7 @@ func ema(args ...objects.Object) (objects.Object, error) {
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}
-		ohlcvClose = append(ohlcvClose, value)
+		ohlcvClose[x] = value
 	}
 
 	inTimePeriod, ok := objects.ToInt(args[1])

--- a/gctscript/modules/ta/indicators/macd.go
+++ b/gctscript/modules/ta/indicators/macd.go
@@ -47,7 +47,7 @@ func macd(args ...objects.Object) (objects.Object, error) {
 		return nil, fmt.Errorf(modules.ErrParameterConvertFailed, OHLCV)
 	}
 
-	var ohlcvClose []float64
+	ohlcvClose := make([]float64, len(ohlcvInputData))
 	var allErrors []string
 	for x := range ohlcvInputData {
 		t, ok := ohlcvInputData[x].([]interface{})
@@ -61,7 +61,7 @@ func macd(args ...objects.Object) (objects.Object, error) {
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}
-		ohlcvClose = append(ohlcvClose, value)
+		ohlcvClose[x] = value
 	}
 
 	inFastPeriod, ok := objects.ToInt(args[1])

--- a/gctscript/modules/ta/indicators/rsi.go
+++ b/gctscript/modules/ta/indicators/rsi.go
@@ -46,7 +46,7 @@ func rsi(args ...objects.Object) (objects.Object, error) {
 		return nil, fmt.Errorf(modules.ErrParameterConvertFailed, OHLCV)
 	}
 
-	var ohlcvClose []float64
+	ohlcvClose := make([]float64, len(ohlcvInputData))
 	var allErrors []string
 	for x := range ohlcvInputData {
 		t, ok := ohlcvInputData[x].([]interface{})
@@ -61,7 +61,7 @@ func rsi(args ...objects.Object) (objects.Object, error) {
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}
-		ohlcvClose = append(ohlcvClose, value)
+		ohlcvClose[x] = value
 	}
 
 	inTimePeriod, ok := objects.ToInt(args[1])

--- a/gctscript/modules/ta/indicators/sma.go
+++ b/gctscript/modules/ta/indicators/sma.go
@@ -46,7 +46,7 @@ func sma(args ...objects.Object) (objects.Object, error) {
 		return nil, fmt.Errorf(modules.ErrParameterConvertFailed, OHLCV)
 	}
 
-	var ohlcvClose []float64
+	ohlcvClose := make([]float64, len(ohlcvInputData))
 	var allErrors []string
 	for x := range ohlcvInputData {
 		t, ok := ohlcvInputData[x].([]interface{})
@@ -60,7 +60,7 @@ func sma(args ...objects.Object) (objects.Object, error) {
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}
-		ohlcvClose = append(ohlcvClose, value)
+		ohlcvClose[x] = value
 	}
 
 	inTimePeriod, ok := objects.ToInt(args[1])

--- a/gctscript/modules/ta/ta.go
+++ b/gctscript/modules/ta/ta.go
@@ -2,9 +2,9 @@ package ta
 
 // AllModuleNames returns a list of all default module names.
 func AllModuleNames() []string {
-	var names []string
-	for name := range Modules {
-		names = append(names, name)
+	names := make([]string, 0, len(Modules))
+	for x := range Modules {
+		names = append(names, x)
 	}
 	return names
 }

--- a/log/logger_rotate.go
+++ b/log/logger_rotate.go
@@ -64,7 +64,7 @@ func (r *Rotate) openOrCreateFile(n int64) error {
 		}
 	}
 
-	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0600)
+	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return r.openNew()
 	}
@@ -92,7 +92,7 @@ func (r *Rotate) openNew() error {
 		}
 	}
 
-	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("can't open new logfile: %s", err)
 	}

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -19,8 +19,9 @@ func getWriters(s *SubLoggerConfig) (io.Writer, error) {
 	if s == nil {
 		return nil, errSubloggerConfigIsNil
 	}
-	var writers []io.Writer
+
 	outputWriters := strings.Split(s.Output, "|")
+	writers := make([]io.Writer, 0, len(outputWriters))
 	for x := range outputWriters {
 		var writer io.Writer
 		switch strings.ToLower(outputWriters[x]) {
@@ -33,7 +34,7 @@ func getWriters(s *SubLoggerConfig) (io.Writer, error) {
 				writer = GlobalLogFile
 			}
 		default:
-			// Note: Do not want to add a ioutil.discard here as this adds
+			// Note: Do not want to add a io.Discard here as this adds
 			// additional routines for every write for no reason.
 			return nil, fmt.Errorf("%w: %s", errUnhandledOutputWriter, outputWriters[x])
 		}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -89,7 +89,7 @@ func BenchmarkInfo(b *testing.B) {
 
 func TestAddWriter(t *testing.T) {
 	t.Parallel()
-	_, err := multiWriter(ioutil.Discard, ioutil.Discard)
+	_, err := multiWriter(io.Discard, io.Discard)
 	if !errors.Is(err, errWriterAlreadyLoaded) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errWriterAlreadyLoaded)
 	}
@@ -98,7 +98,7 @@ func TestAddWriter(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	err = mw.Add(ioutil.Discard)
+	err = mw.Add(io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestRemoveWriter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = mw.Add(ioutil.Discard)
+	err = mw.Add(io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ var errWriteError = errors.New("write error")
 
 func TestMultiWriterWrite(t *testing.T) {
 	t.Parallel()
-	mw, err := multiWriter(ioutil.Discard, &bytes.Buffer{})
+	mw, err := multiWriter(io.Discard, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMultiWriterWrite(t *testing.T) {
 		t.Fatal("unexpected return")
 	}
 
-	mw, err = multiWriter(&WriteShorter{}, ioutil.Discard)
+	mw, err = multiWriter(&WriteShorter{}, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestMultiWriterWrite(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, io.ErrShortWrite)
 	}
 
-	mw, err = multiWriter(&WriteError{}, ioutil.Discard)
+	mw, err = multiWriter(&WriteError{}, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/portfolio/withdraw/validate_test.go
+++ b/portfolio/withdraw/validate_test.go
@@ -241,8 +241,12 @@ func TestValidateFiat(t *testing.T) {
 			}
 			err := test.request.Validate(test.validate)
 			if err != nil {
-				if test.output.(error).Error() != err.Error() {
-					t.Fatalf("Test Name %s expecting error [%s] but received [%s]", test.name, test.output.(error).Error(), err)
+				errOutput, ok := test.output.(error)
+				if !ok {
+					t.Fatalf("Test Name %s unable to type assert error", test.name)
+				}
+				if errOutput.Error() != err.Error() {
+					t.Fatalf("Test Name %s expecting error [%s] but received [%s]", test.name, errOutput.Error(), err)
 				}
 			}
 		})


### PR DESCRIPTION
# PR Description

Fixes golangci-lint [issues](https://github.com/thrasher-corp/gocryptotrader/runs/5843622967?check_suite_focus=true#step:3:78), adds prealloc linter and bumps AppVeyor CI versions. Also adds a new dependabot schedule to ensure Github Actions depends are kept up to date. Several other improvements were made along the way!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
