### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/backtester/config/config_test.go
+++ b/backtester/config/config_test.go
@@ -62,18 +62,9 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestReadConfigFromFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer func() {
-		err = os.RemoveAll(tempDir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	tempDir := t.TempDir()
 	var passFile *os.File
-	passFile, err = ioutil.TempFile(tempDir, "*.start")
+	passFile, err := ioutil.TempFile(tempDir, "*.start")
 	if err != nil {
 		t.Fatalf("Problem creating temp file at %v: %s\n", passFile, err)
 	}

--- a/backtester/report/report_test.go
+++ b/backtester/report/report_test.go
@@ -2,8 +2,6 @@ package report
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -27,16 +25,7 @@ func TestGenerateReport(t *testing.T) {
 	e := testExchange
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer func(path string) {
-		err = os.RemoveAll(path)
-		if err != nil {
-			t.Error(err)
-		}
-	}(tempDir)
+	tempDir := t.TempDir()
 	d := Data{
 		Config:       &config.Config{},
 		OutputPath:   filepath.Join("..", "results"),
@@ -322,8 +311,7 @@ func TestGenerateReport(t *testing.T) {
 			DisableUSDTracking: true,
 		},
 	}
-	err = d.GenerateReport()
-	if err != nil {
+	if err := d.GenerateReport(); err != nil {
 		t.Error(err)
 	}
 }

--- a/backtester/report/report_test.go
+++ b/backtester/report/report_test.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"errors"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -25,10 +24,13 @@ func TestGenerateReport(t *testing.T) {
 	e := testExchange
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
-	tempDir := t.TempDir()
 	d := Data{
-		Config:       &config.Config{},
-		OutputPath:   filepath.Join("..", "results"),
+		Config: &config.Config{
+			StrategySettings: config.StrategySettings{
+				DisableUSDTracking: true,
+			},
+		},
+		OutputPath:   t.TempDir(),
 		TemplatePath: "tpl.gohtml",
 		OriginalCandles: []*gctkline.Item{
 			{
@@ -301,14 +303,11 @@ func TestGenerateReport(t *testing.T) {
 			},
 			CurrencyPairStatistics: nil,
 			WasAnyDataMissing:      false,
-			FundingStatistics:      nil,
-		},
-	}
-	d.OutputPath = tempDir
-	d.Config.StrategySettings.DisableUSDTracking = true
-	d.Statistics.FundingStatistics = &statistics.FundingStatistics{
-		Report: &funding.Report{
-			DisableUSDTracking: true,
+			FundingStatistics: &statistics.FundingStatistics{
+				Report: &funding.Report{
+					DisableUSDTracking: true,
+				},
+			},
 		},
 	}
 	if err := d.GenerateReport(); err != nil {

--- a/common/file/archive/zip_test.go
+++ b/common/file/archive/zip_test.go
@@ -3,33 +3,12 @@ package archive
 import (
 	"archive/zip"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 )
 
-var (
-	tempDir string
-)
-
-func TestMain(m *testing.M) {
-	var err error
-	tempDir, err = ioutil.TempDir("", "gct-temp")
-	if err != nil {
-		fmt.Printf("failed to create tempDir: %v", err)
-		os.Exit(1)
-	}
-	t := m.Run()
-	err = os.RemoveAll(tempDir)
-	if err != nil {
-		fmt.Printf("Failed to remove tempDir %v", err)
-	}
-	os.Exit(t)
-}
-
 func TestUnZip(t *testing.T) {
+	tempDir := t.TempDir()
 	zipFile := filepath.Join("..", "..", "..", "testdata", "testdata.zip")
 	files, err := UnZip(zipFile, tempDir)
 	if err != nil {
@@ -53,6 +32,7 @@ func TestUnZip(t *testing.T) {
 }
 
 func TestZip(t *testing.T) {
+	tempDir := t.TempDir()
 	singleFile := filepath.Join("..", "..", "..", "testdata", "configtest.json")
 	outFile := filepath.Join(tempDir, "out.zip")
 	err := Zip(singleFile, outFile)

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -199,11 +199,7 @@ func TestWriter(t *testing.T) {
 	type args struct {
 		file string
 	}
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	testData := `data`
 
@@ -269,12 +265,8 @@ func TestWriterNoPermissionFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skip file permissions")
 	}
-	temp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(temp)
-	err = os.Chmod(temp, 0o555)
+	temp := t.TempDir()
+	err := os.Chmod(temp, 0o555)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -139,11 +139,7 @@ func TestEncryptTwiceReusesSaltButNewCipher(t *testing.T) {
 	c := &Config{
 		EncryptConfig: 1,
 	}
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Prepare input
 	passFile, err := ioutil.TempFile(tempDir, "*.pw")
@@ -203,15 +199,11 @@ func TestSaveAndReopenEncryptedConfig(t *testing.T) {
 	c := &Config{}
 	c.Name = "myCustomName"
 	c.EncryptConfig = 1
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Save encrypted config
 	enc := filepath.Join(tempDir, "encrypted.dat")
-	err = withInteractiveResponse(t, "pass\npass\n", func() error {
+	err := withInteractiveResponse(t, "pass\npass\n", func() error {
 		return c.SaveConfigToFile(enc)
 	})
 	if err != nil {
@@ -253,11 +245,7 @@ func setAnswersFile(t *testing.T, answerFile string) func() {
 
 func TestReadConfigWithPrompt(t *testing.T) {
 	// Prepare temp dir
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Ensure we'll get the prompt when loading
 	c := &Config{
@@ -266,7 +254,7 @@ func TestReadConfigWithPrompt(t *testing.T) {
 
 	// Save config
 	testConfigFile := filepath.Join(tempDir, "config.json")
-	err = c.SaveConfigToFile(testConfigFile)
+	err := c.SaveConfigToFile(testConfigFile)
 	if err != nil {
 		t.Fatalf("Problem saving config file in %s: %s\n", tempDir, err)
 	}

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -157,11 +157,17 @@ func TestEncryptTwiceReusesSaltButNewCipher(t *testing.T) {
 
 	// Temporarily replace Stdin with a custom input
 	oldIn := os.Stdin
-	defer func() { os.Stdin = oldIn }()
+	t.Cleanup(func() { os.Stdin = oldIn })
 	os.Stdin, err = os.Open(passFile.Name())
 	if err != nil {
 		t.Fatalf("Problem opening temp file at %s: %s\n", passFile.Name(), err)
 	}
+	t.Cleanup(func() {
+		err = os.Stdin.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	})
 
 	// Save encrypted config
 	enc1 := filepath.Join(tempDir, "encrypted.dat")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2176,11 +2176,7 @@ func TestMigrateConfig(t *testing.T) {
 		targetDir  string
 	}
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	tests := []struct {
 		name    string

--- a/engine/database_connection_test.go
+++ b/engine/database_connection_test.go
@@ -2,9 +2,7 @@ package engine
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
-	"os"
 	"sync"
 	"testing"
 
@@ -12,28 +10,19 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/database/drivers"
 )
 
-func CreateDatabase(t *testing.T) string {
+func CreateDatabase(t *testing.T) {
 	t.Helper()
 	// fun workarounds to globals ruining testing
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-	database.DB.DataPath = tmpDir
-	return tmpDir
-}
+	database.DB.DataPath = t.TempDir()
 
-func Cleanup(tmpDir string) {
-	if database.DB.IsConnected() {
-		err := database.DB.CloseConnection()
-		if err != nil {
-			log.Fatal(err)
+	t.Cleanup(func() {
+		if database.DB.IsConnected() {
+			err := database.DB.CloseConnection()
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
-		err = os.RemoveAll(tmpDir)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
+	})
 }
 
 func TestSetupDatabaseConnectionManager(t *testing.T) {
@@ -52,8 +41,7 @@ func TestSetupDatabaseConnectionManager(t *testing.T) {
 }
 
 func TestStartSQLite(t *testing.T) {
-	tmpDir := CreateDatabase(t)
-	defer Cleanup(tmpDir)
+	CreateDatabase(t)
 	m, err := SetupDatabaseConnectionManager(&database.Config{})
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
@@ -113,8 +101,7 @@ func TestStartPostgres(t *testing.T) {
 }
 
 func TestDatabaseConnectionManagerIsRunning(t *testing.T) {
-	tmpDir := CreateDatabase(t)
-	defer Cleanup(tmpDir)
+	CreateDatabase(t)
 	m, err := SetupDatabaseConnectionManager(&database.Config{
 		Enabled: true,
 		Driver:  database.DBSQLite,
@@ -144,8 +131,7 @@ func TestDatabaseConnectionManagerIsRunning(t *testing.T) {
 }
 
 func TestDatabaseConnectionManagerStop(t *testing.T) {
-	tmpDir := CreateDatabase(t)
-	defer Cleanup(tmpDir)
+	CreateDatabase(t)
 	m, err := SetupDatabaseConnectionManager(&database.Config{
 		Enabled: true,
 		Driver:  database.DBSQLite,
@@ -181,8 +167,7 @@ func TestDatabaseConnectionManagerStop(t *testing.T) {
 }
 
 func TestCheckConnection(t *testing.T) {
-	tmpDir := CreateDatabase(t)
-	defer Cleanup(tmpDir)
+	CreateDatabase(t)
 	var m *DatabaseConnectionManager
 	err := m.checkConnection()
 	if !errors.Is(err, ErrNilSubsystem) {
@@ -239,8 +224,7 @@ func TestCheckConnection(t *testing.T) {
 }
 
 func TestGetInstance(t *testing.T) {
-	tmpDir := CreateDatabase(t)
-	defer Cleanup(tmpDir)
+	CreateDatabase(t)
 	m, err := SetupDatabaseConnectionManager(&database.Config{
 		Enabled: true,
 		Driver:  database.DBSQLite,

--- a/engine/database_connection_test.go
+++ b/engine/database_connection_test.go
@@ -221,6 +221,11 @@ func TestCheckConnection(t *testing.T) {
 	if !errors.Is(err, database.ErrDatabaseNotConnected) {
 		t.Errorf("error '%v', expected '%v'", err, database.ErrDatabaseNotConnected)
 	}
+
+	err = m.Stop()
+	if !errors.Is(err, nil) {
+		t.Errorf("error '%v', expected '%v'", err, nil)
+	}
 }
 
 func TestGetInstance(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -77,16 +76,7 @@ func TestLoadConfigWithSettings(t *testing.T) {
 
 func TestStartStopDoesNotCausePanic(t *testing.T) {
 	t.Parallel()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer func() {
-		err = os.RemoveAll(tempDir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	tempDir := t.TempDir()
 	botOne, err := NewFromSettings(&Settings{
 		ConfigFile:   config.TestFile,
 		EnableDryRun: true,
@@ -116,24 +106,8 @@ func TestStartStopTwoDoesNotCausePanic(t *testing.T) {
 	if !enableExperimentalTest {
 		t.Skip("test is functional, however does not need to be included in go test runs")
 	}
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	tempDir2, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Problem creating temp dir at %s: %s\n", tempDir, err)
-	}
-	defer func() {
-		err = os.RemoveAll(tempDir)
-		if err != nil {
-			t.Error(err)
-		}
-		err = os.RemoveAll(tempDir2)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	tempDir := t.TempDir()
+	tempDir2 := t.TempDir()
 	botOne, err := NewFromSettings(&Settings{
 		ConfigFile:   config.TestFile,
 		EnableDryRun: true,

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -266,11 +265,7 @@ func RPCTestSetup(t *testing.T) *Engine {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dbm.dbConn.DataPath = tempDir
+	dbm.dbConn.DataPath = t.TempDir()
 	engerino.DatabaseManager = dbm
 	var wg sync.WaitGroup
 	err = dbm.Start(&wg)

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -272,6 +272,13 @@ func RPCTestSetup(t *testing.T) *Engine {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		err = dbm.Stop()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	engerino.Config = &config.Config{}
 	em := SetupExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)


### PR DESCRIPTION
# PR Description

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Type of change

- [x] Refactoring

## How has this been tested

- [x] go test ./... -race (There are 41 tests that are already failing before this PR)
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation and regenerated documentation via the documentation tool~~
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
