### PR TITLE
engine: Add websocket data handler register function

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -948,3 +948,13 @@ func (bot *Engine) SetupExchanges() error {
 func (bot *Engine) WaitForInitialCurrencySync() error {
 	return bot.currencyPairSyncer.WaitForInitialSync()
 }
+
+// RegisterWebsocketRoutineHandlerInterceptor registers an externally defined
+// interceptor function for diverting and handling websocket notifications
+// across all enabled exchanges.
+func (bot *Engine) RegisterWebsocketRoutineHandlerInterceptor(fn Interceptor) error {
+	if bot == nil {
+		return fmt.Errorf("%T %w", bot, ErrNilSubsystem)
+	}
+	return bot.websocketRoutineManager.registerInterceptor(fn)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -949,12 +949,13 @@ func (bot *Engine) WaitForInitialCurrencySync() error {
 	return bot.currencyPairSyncer.WaitForInitialSync()
 }
 
-// RegisterWebsocketRoutineHandlerInterceptor registers an externally defined
-// interceptor function for diverting and handling websocket notifications
-// across all enabled exchanges.
-func (bot *Engine) RegisterWebsocketRoutineHandlerInterceptor(fn Interceptor) error {
+// RegisterWebsocketDataHandler registers an externally defined data handler
+// for diverting and handling websocket notifications across all enabled
+// exchanges. InterceptorOnly as true will purge all other registered handlers
+// (including default) bypassing all other handling.
+func (bot *Engine) RegisterWebsocketDataHandler(fn WebsocketDataHandler, interceptorOnly bool) error {
 	if bot == nil {
 		return errNilBot
 	}
-	return bot.websocketRoutineManager.registerInterceptor(fn)
+	return bot.websocketRoutineManager.registerInterceptor(fn, interceptorOnly)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -959,3 +959,12 @@ func (bot *Engine) RegisterWebsocketDataHandler(fn WebsocketDataHandler, interce
 	}
 	return bot.websocketRoutineManager.registerWebsocketDataHandler(fn, interceptorOnly)
 }
+
+// SetDefaultWebsocketDataHandler sets the default websocket handler and
+// removing all pre-existing handlers
+func (bot *Engine) SetDefaultWebsocketDataHandler() error {
+	if bot == nil {
+		return errNilBot
+	}
+	return bot.websocketRoutineManager.setWebsocketDataHandler(bot.websocketRoutineManager.websocketDataHandler)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -957,5 +957,5 @@ func (bot *Engine) RegisterWebsocketDataHandler(fn WebsocketDataHandler, interce
 	if bot == nil {
 		return errNilBot
 	}
-	return bot.websocketRoutineManager.registerInterceptor(fn, interceptorOnly)
+	return bot.websocketRoutineManager.registerWebsocketDataHandler(fn, interceptorOnly)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -954,7 +954,7 @@ func (bot *Engine) WaitForInitialCurrencySync() error {
 // across all enabled exchanges.
 func (bot *Engine) RegisterWebsocketRoutineHandlerInterceptor(fn Interceptor) error {
 	if bot == nil {
-		return fmt.Errorf("%T %w", bot, ErrNilSubsystem)
+		return errNilBot
 	}
 	return bot.websocketRoutineManager.registerInterceptor(fn)
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -293,3 +293,17 @@ func TestFlagSetWith(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", isRunning, false)
 	}
 }
+
+func TestRegisterWebsocketRoutineHandlerInterceptor(t *testing.T) {
+	var e *Engine
+	err := e.RegisterWebsocketRoutineHandlerInterceptor(nil)
+	if !errors.Is(err, ErrNilSubsystem) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, ErrNilSubsystem)
+	}
+
+	e = &Engine{websocketRoutineManager: &websocketRoutineManager{}}
+	err = e.RegisterWebsocketRoutineHandlerInterceptor(func(_ string, _ interface{}) {})
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -295,14 +295,15 @@ func TestFlagSetWith(t *testing.T) {
 }
 
 func TestRegisterWebsocketRoutineHandlerInterceptor(t *testing.T) {
+	t.Parallel()
 	var e *Engine
-	err := e.RegisterWebsocketRoutineHandlerInterceptor(nil)
-	if !errors.Is(err, ErrNilSubsystem) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, ErrNilSubsystem)
+	err := e.RegisterWebsocketDataHandler(nil, false)
+	if !errors.Is(err, errNilBot) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, errNilBot)
 	}
 
 	e = &Engine{websocketRoutineManager: &websocketRoutineManager{}}
-	err = e.RegisterWebsocketRoutineHandlerInterceptor(func(_ string, _ interface{}) {})
+	err = e.RegisterWebsocketDataHandler(func(_ string, _ interface{}) error { return nil }, false)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -308,3 +308,18 @@ func TestRegisterWebsocketDataHandler(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 }
+
+func TestSetDefaultWebsocketDataHandler(t *testing.T) {
+	t.Parallel()
+	var e *Engine
+	err := e.SetDefaultWebsocketDataHandler()
+	if !errors.Is(err, errNilBot) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, errNilBot)
+	}
+
+	e = &Engine{websocketRoutineManager: &websocketRoutineManager{}}
+	err = e.SetDefaultWebsocketDataHandler()
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -294,7 +294,7 @@ func TestFlagSetWith(t *testing.T) {
 	}
 }
 
-func TestRegisterWebsocketRoutineHandlerInterceptor(t *testing.T) {
+func TestRegisterWebsocketDataHandler(t *testing.T) {
 	t.Parallel()
 	var e *Engine
 	err := e.RegisterWebsocketDataHandler(nil, false)

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -41,7 +41,7 @@ func setupWebsocketRoutineManager(exchangeManager iExchangeManager, orderManager
 		currencyConfig:  cfg,
 		shutdown:        make(chan struct{}),
 	}
-	return man, man.registerInterceptor(man.websocketDataHandler, false)
+	return man, man.registerWebsocketDataHandler(man.websocketDataHandler, false)
 }
 
 // Start runs the subsystem
@@ -339,11 +339,11 @@ func (m *websocketRoutineManager) printAccountHoldingsChangeSummary(o account.Ch
 		o.Account)
 }
 
-// registerInterceptor registers an externally (GCT Library) defined dedicated
-// filter to intercept specific data types for internal & external strategy use.
+// registerWebsocketDataHandler registers an externally (GCT Library) defined
+// dedicated filter specific data types for internal & external strategy use.
 // InterceptorOnly as true will purge all other registered handlers
 // (including default) bypassing all other handling.
-func (m *websocketRoutineManager) registerInterceptor(fn WebsocketDataHandler, interceptorOnly bool) error {
+func (m *websocketRoutineManager) registerWebsocketDataHandler(fn WebsocketDataHandler, interceptorOnly bool) error {
 	if m == nil {
 		return fmt.Errorf("%T %w", m, ErrNilSubsystem)
 	}

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -368,16 +368,15 @@ func (m *websocketRoutineManager) registerWebsocketDataHandler(fn WebsocketDataH
 		return errNilWebsocketDataHandlerFunction
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if interceptorOnly {
 		return m.setWebsocketDataHandler(fn)
 	}
 
+	m.mu.Lock()
 	// Push front so that any registered data handler has first preference
 	// over the gct default handler.
 	m.dataHandlers = append([]WebsocketDataHandler{fn}, m.dataHandlers...)
+	m.mu.Unlock()
 	return nil
 }
 
@@ -390,6 +389,8 @@ func (m *websocketRoutineManager) setWebsocketDataHandler(fn WebsocketDataHandle
 	if fn == nil {
 		return errNilWebsocketDataHandlerFunction
 	}
+	m.mu.Lock()
 	m.dataHandlers = []WebsocketDataHandler{fn}
+	m.mu.Unlock()
 	return nil
 }

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -147,7 +147,7 @@ func (m *websocketRoutineManager) websocketDataReceiver(ws *stream.Websocket) er
 	}
 
 	if atomic.LoadInt32(&m.started) == 0 {
-		return nil
+		return errRoutineManagerNotStarted
 	}
 
 	m.wg.Add(1)

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -307,3 +307,48 @@ func TestRegisterWebsocketDataHandlerWithFunctionality(t *testing.T) {
 	close(m.shutdown)
 	m.wg.Wait()
 }
+
+func TestSetWebsocketDataHandler(t *testing.T) {
+	t.Parallel()
+	var m *websocketRoutineManager
+	err := m.setWebsocketDataHandler(nil)
+	if !errors.Is(err, ErrNilSubsystem) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, ErrNilSubsystem)
+	}
+
+	m = new(websocketRoutineManager)
+	m.shutdown = make(chan struct{})
+
+	err = m.setWebsocketDataHandler(nil)
+	if !errors.Is(err, errNilWebsocketDataHandlerFunction) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, errNilWebsocketDataHandlerFunction)
+	}
+
+	err = m.registerWebsocketDataHandler(m.websocketDataHandler, false)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+
+	err = m.registerWebsocketDataHandler(m.websocketDataHandler, false)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+
+	err = m.registerWebsocketDataHandler(m.websocketDataHandler, false)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+
+	if len(m.dataHandlers) != 3 {
+		t.Fatal("unexpected data handler count")
+	}
+
+	err = m.setWebsocketDataHandler(m.websocketDataHandler)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+
+	if len(m.dataHandlers) != 1 {
+		t.Fatal("unexpected data handler count")
+	}
+}

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -292,9 +292,11 @@ func TestRegisterWebsocketDataHandlerWithFunctionality(t *testing.T) {
 
 	mock := stream.New()
 	mock.ToRoutine = make(chan interface{})
-
-	m.wg.Add(1)
-	go m.websocketDataReceiver(mock)
+	m.started = 1
+	err = m.websocketDataReceiver(mock)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mock.ToRoutine <- nil
 	mock.ToRoutine <- 1336

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -254,10 +254,10 @@ func TestWebsocketRoutineManagerHandleData(t *testing.T) {
 	}
 }
 
-func TestRegisterInterceptorWithFunctionality(t *testing.T) {
+func TestRegisterWebsocketDataHandlerWithFunctionality(t *testing.T) {
 	t.Parallel()
 	var m *websocketRoutineManager
-	err := m.registerInterceptor(nil, false)
+	err := m.registerWebsocketDataHandler(nil, false)
 	if !errors.Is(err, ErrNilSubsystem) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, ErrNilSubsystem)
 	}
@@ -265,7 +265,7 @@ func TestRegisterInterceptorWithFunctionality(t *testing.T) {
 	m = new(websocketRoutineManager)
 	m.shutdown = make(chan struct{})
 
-	err = m.registerInterceptor(nil, false)
+	err = m.registerWebsocketDataHandler(nil, false)
 	if !errors.Is(err, errNilWebsocketDataHandlerFunction) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errNilWebsocketDataHandlerFunction)
 	}
@@ -281,7 +281,7 @@ func TestRegisterInterceptorWithFunctionality(t *testing.T) {
 		return nil
 	}
 
-	err = m.registerInterceptor(fn, true)
+	err = m.registerWebsocketDataHandler(fn, true)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -14,6 +14,7 @@ var (
 	errNilCurrencyPairFormat           = errors.New("nil currency pair format received")
 	errNilWebsocketDataHandlerFunction = errors.New("websocket data handler function is nil")
 	errNilWebsocket                    = errors.New("websocket is nil")
+	errRoutineManagerNotStarted        = errors.New("websocket routine manager not started")
 )
 
 // websocketRoutineManager is used to process websocket updates from a unified location

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -13,6 +13,7 @@ var (
 	errNilCurrencyConfig               = errors.New("nil currency config received")
 	errNilCurrencyPairFormat           = errors.New("nil currency pair format received")
 	errNilWebsocketDataHandlerFunction = errors.New("websocket data handler function is nil")
+	errNilWebsocket                    = errors.New("websocket is nil")
 )
 
 // websocketRoutineManager is used to process websocket updates from a unified location

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -30,4 +30,4 @@ type websocketRoutineManager struct {
 
 // Interceptor defines a function signature for an externally defined function
 // that intercepts the data from the websocket routine manager.
-type Interceptor func(service string, incoming interface{})
+type Interceptor func(service string, incoming interface{}) error

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	errNilOrderManager       = errors.New("nil order manager received")
-	errNilCurrencyPairSyncer = errors.New("nil currency pair syncer received")
-	errNilCurrencyConfig     = errors.New("nil currency config received")
-	errNilCurrencyPairFormat = errors.New("nil currency pair format received")
+	errNilOrderManager                 = errors.New("nil order manager received")
+	errNilCurrencyPairSyncer           = errors.New("nil currency pair syncer received")
+	errNilCurrencyConfig               = errors.New("nil currency config received")
+	errNilCurrencyPairFormat           = errors.New("nil currency pair format received")
+	errNilWebsocketDataHandlerFunction = errors.New("websocket data handler function is nil")
 )
 
 // websocketRoutineManager is used to process websocket updates from a unified location
@@ -23,11 +24,11 @@ type websocketRoutineManager struct {
 	syncer          iCurrencyPairSyncer
 	currencyConfig  *currency.Config
 	shutdown        chan struct{}
-	interceptor     Interceptor
+	dataHandlers    []WebsocketDataHandler
 	wg              sync.WaitGroup
 	mu              sync.RWMutex
 }
 
-// Interceptor defines a function signature for an externally defined function
-// that intercepts the data from the websocket routine manager.
-type Interceptor func(service string, incoming interface{}) error
+// WebsocketDataHandler defines a function signature for a function that handles
+// data coming from websocket connections.
+type WebsocketDataHandler func(service string, incoming interface{}) error

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -7,6 +7,13 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/currency"
 )
 
+var (
+	errNilOrderManager       = errors.New("nil order manager received")
+	errNilCurrencyPairSyncer = errors.New("nil currency pair syncer received")
+	errNilCurrencyConfig     = errors.New("nil currency config received")
+	errNilCurrencyPairFormat = errors.New("nil currency pair format received")
+)
+
 // websocketRoutineManager is used to process websocket updates from a unified location
 type websocketRoutineManager struct {
 	started         int32
@@ -16,12 +23,11 @@ type websocketRoutineManager struct {
 	syncer          iCurrencyPairSyncer
 	currencyConfig  *currency.Config
 	shutdown        chan struct{}
+	interceptor     Interceptor
 	wg              sync.WaitGroup
+	mu              sync.RWMutex
 }
 
-var (
-	errNilOrderManager       = errors.New("nil order manager received")
-	errNilCurrencyPairSyncer = errors.New("nil currency pair syncer received")
-	errNilCurrencyConfig     = errors.New("nil currency config received")
-	errNilCurrencyPairFormat = errors.New("nil currency pair format received")
-)
+// Interceptor defines a function signature for an externally defined function
+// that intercepts the data from the websocket routine manager.
+type Interceptor func(service string, incoming interface{})


### PR DESCRIPTION
# PR Description

Allows to easily register a data handler method for websocket data if needed for external strategy inspection. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
