### PR TITLE
orders: Add derive modify struct method from order.Detail 

### DIFF
--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -403,7 +403,7 @@ func ({{.Variable}} *{{.CapitalName}}) SubmitOrder(ctx context.Context, s *order
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	// if err := action.Validate(); err != nil {
 	// 	return "", err
 	// }

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -405,7 +405,7 @@ func (m *OrderManager) Modify(ctx context.Context, mod *order.Modify) (*order.Mo
 	//
 	// XXX: This comes with a race condition, because [request -> changes] are not
 	// atomic.
-	err = m.orderStore.modifyExisting(mod.ID, &res)
+	err = m.orderStore.modifyExisting(mod.ID, res)
 
 	// Notify observers.
 	var message string
@@ -416,9 +416,9 @@ func (m *OrderManager) Modify(ctx context.Context, mod *order.Modify) (*order.Mo
 	}
 	m.orderStore.commsManager.PushEvent(base.Event{
 		Type:    "order",
-		Message: fmt.Sprintf(message, mod.Exchange, res.ID),
+		Message: fmt.Sprintf(message, mod.Exchange, res.OrderID),
 	})
-	return &order.ModifyResponse{OrderID: res.ID}, err
+	return &order.ModifyResponse{OrderID: res.OrderID}, err
 }
 
 // Submit will take in an order struct, send it to the exchange and
@@ -915,7 +915,7 @@ func (s *store) updateExisting(od *order.Detail) error {
 
 // modifyExisting depends on mod.Exchange and given ID to uniquely identify an order and
 // modify it.
-func (s *store) modifyExisting(id string, mod *order.Modify) error {
+func (s *store) modifyExisting(id string, mod *order.ModifyResponse) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 	r, ok := s.Orders[strings.ToLower(mod.Exchange)]

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -903,7 +903,7 @@ func (s *store) modifyExisting(id string, mod *order.ModifyResponse) error {
 		if r[x].ID != id {
 			continue
 		}
-		r[x].UpdateOrderFromModify(mod)
+		r[x].UpdateOrderFromModifyResponse(mod)
 		if !r[x].AssetType.IsFutures() {
 			return nil
 		}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -84,9 +84,12 @@ func (f omfExchange) GetActiveOrders(ctx context.Context, req *order.GetOrdersRe
 	}}, nil
 }
 
-func (f omfExchange) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	ans := *action
-	ans.ID = "modified_order_id"
+func (f omfExchange) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
+	ans, err := action.DeriveModifyResponse()
+	if err != nil {
+		return nil, err
+	}
+	ans.OrderID = "modified_order_id"
 	return ans, nil
 }
 
@@ -407,12 +410,12 @@ func TestStore_modifyOrder(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = m.orderStore.modifyExisting("fake_order_id", &order.Modify{
+	err = m.orderStore.modifyExisting("fake_order_id", &order.ModifyResponse{
 		Exchange: testExchange,
 
-		ID:     "another_fake_order_id",
-		Price:  16,
-		Amount: 256,
+		OrderID: "another_fake_order_id",
+		Price:   16,
+		Amount:  256,
 	})
 	if err != nil {
 		t.Error(err)

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -213,7 +213,6 @@ func (m *websocketRoutineManager) WebsocketDataHandler(exchName string, data int
 		}
 		m.syncer.PrintOrderbookSummary(base, "websocket", nil)
 	case *order.Detail:
-		m.printOrderSummary(d)
 		if !m.orderManager.Exists(d) {
 			err := m.orderManager.Add(d)
 			if err != nil {

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -231,17 +231,7 @@ func (m *websocketRoutineManager) WebsocketDataHandler(exchName string, data int
 				return err
 			}
 		}
-	case *order.Modify:
-		m.printOrderChangeSummary(d)
-		od, err := m.orderManager.GetByExchangeAndID(d.Exchange, d.ID)
-		if err != nil {
-			return err
-		}
-		od.UpdateOrderFromModify(d)
-		err = m.orderManager.UpdateExistingOrder(od)
-		if err != nil {
-			return err
-		}
+		m.printOrderSummary(d)
 	case order.ClassificationError:
 		return fmt.Errorf("%w %s", d.Err, d.Error())
 	case stream.UnhandledMessageWarning:
@@ -277,29 +267,6 @@ func (m *websocketRoutineManager) FormatCurrency(p currency.Pair) currency.Pair 
 	}
 	return p.Format(m.currencyConfig.CurrencyPairFormat.Delimiter,
 		m.currencyConfig.CurrencyPairFormat.Uppercase)
-}
-
-// printOrderChangeSummary this function will be deprecated when a order manager
-// update is done.
-func (m *websocketRoutineManager) printOrderChangeSummary(o *order.Modify) {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 || o == nil {
-		return
-	}
-
-	log.Debugf(log.WebsocketMgr,
-		"Order Change: %s %s %s %s %s %s OrderID:%s ClientOrderID:%s Price:%f Amount:%f Executed Amount:%f Remaining Amount:%f",
-		o.Exchange,
-		o.AssetType,
-		o.Pair,
-		o.Status,
-		o.Type,
-		o.Side,
-		o.ID,
-		o.ClientOrderID,
-		o.Price,
-		o.Amount,
-		o.ExecutedAmount,
-		o.RemainingAmount)
 }
 
 // printOrderSummary this function will be deprecated when a order manager

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -238,6 +238,7 @@ func (m *websocketRoutineManager) websocketDataHandler(exchName string, data int
 			if err != nil {
 				return err
 			}
+			m.printOrderSummary(d, false)
 		} else {
 			od, err := m.orderManager.GetByExchangeAndID(d.Exchange, d.ID)
 			if err != nil {
@@ -249,8 +250,8 @@ func (m *websocketRoutineManager) websocketDataHandler(exchName string, data int
 			if err != nil {
 				return err
 			}
+			m.printOrderSummary(d, true)
 		}
-		m.printOrderSummary(d)
 	case order.ClassificationError:
 		return fmt.Errorf("%w %s", d.Err, d.Error())
 	case stream.UnhandledMessageWarning:
@@ -290,12 +291,19 @@ func (m *websocketRoutineManager) FormatCurrency(p currency.Pair) currency.Pair 
 
 // printOrderSummary this function will be deprecated when a order manager
 // update is done.
-func (m *websocketRoutineManager) printOrderSummary(o *order.Detail) {
+func (m *websocketRoutineManager) printOrderSummary(o *order.Detail, isUpdate bool) {
 	if m == nil || atomic.LoadInt32(&m.started) == 0 || o == nil {
 		return
 	}
+
+	orderNotif := "New Order:"
+	if isUpdate {
+		orderNotif = "Order Change:"
+	}
+
 	log.Debugf(log.WebsocketMgr,
-		"New Order: %s %s %s %s %s %s OrderID:%s ClientOrderID:%s Price:%f Amount:%f Executed Amount:%f Remaining Amount:%f",
+		"%s %s %s %s %s %s %s OrderID:%s ClientOrderID:%s Price:%f Amount:%f Executed Amount:%f Remaining Amount:%f",
+		orderNotif,
 		o.Exchange,
 		o.AssetType,
 		o.Pair,

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -203,7 +203,7 @@ func TestWebsocketRoutineManagerHandleData(t *testing.T) {
 		t.Error("Bad pipeline")
 	}
 
-	err = m.WebsocketDataHandler(exchName, &order.Modify{
+	err = m.WebsocketDataHandler(exchName, &order.Detail{
 		Exchange: "Bitstamp",
 		ID:       orderID,
 		Status:   order.Active,

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1063,8 +1063,8 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Binance) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *Binance) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -676,12 +676,12 @@ func (b *Bitfinex) SubmitOrder(ctx context.Context, o *order.Submit) (order.Subm
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
 func (b *Bitfinex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
-	if err := action.Validate(); err != nil {
-		return nil, err
-	}
-
 	if !b.Websocket.CanUseAuthenticatedWebsocketForWrapper() {
 		return nil, common.ErrNotYetImplemented
+	}
+
+	if err := action.Validate(); err != nil {
+		return nil, err
 	}
 
 	orderIDInt, err := strconv.ParseInt(action.ID, 10, 64)
@@ -689,15 +689,15 @@ func (b *Bitfinex) ModifyOrder(ctx context.Context, action *order.Modify) (*orde
 		return &order.ModifyResponse{OrderID: action.ID}, err
 	}
 
-	request := WsUpdateOrderRequest{
+	wsRequest := WsUpdateOrderRequest{
 		OrderID: orderIDInt,
 		Price:   action.Price,
 		Amount:  action.Amount,
 	}
 	if action.Side == order.Sell && action.Amount > 0 {
-		request.Amount *= -1
+		wsRequest.Amount *= -1
 	}
-	err = b.WsModifyOrder(&request)
+	err = b.WsModifyOrder(&wsRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -675,14 +675,14 @@ func (b *Bitfinex) SubmitOrder(ctx context.Context, o *order.Submit) (order.Subm
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitfinex) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func (b *Bitfinex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	if err := action.Validate(); err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	orderIDInt, err := strconv.ParseInt(action.ID, 10, 64)
 	if err != nil {
-		return order.Modify{ID: action.ID}, err
+		return &order.ModifyResponse{OrderID: action.ID}, err
 	}
 	if b.Websocket.CanUseAuthenticatedWebsocketForWrapper() {
 		request := WsUpdateOrderRequest{
@@ -694,17 +694,16 @@ func (b *Bitfinex) ModifyOrder(ctx context.Context, action *order.Modify) (order
 			request.Amount *= -1
 		}
 		err = b.WsModifyOrder(&request)
-		return order.Modify{
+		return &order.ModifyResponse{
 			Exchange:  action.Exchange,
 			AssetType: action.AssetType,
 			Pair:      action.Pair,
-			ID:        action.ID,
-
-			Price:  action.Price,
-			Amount: action.Amount,
+			OrderID:   action.ID,
+			Price:     action.Price,
+			Amount:    action.Amount,
 		}, err
 	}
-	return order.Modify{}, common.ErrNotYetImplemented
+	return nil, common.ErrNotYetImplemented
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -395,8 +395,8 @@ func (b *Bitflyer) SubmitOrder(_ context.Context, _ *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitflyer) ModifyOrder(_ context.Context, _ *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *Bitflyer) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -387,22 +387,6 @@ func (b *Bithumb) PlaceTrade(ctx context.Context, orderCurrency, transactionType
 		b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, privatePlaceTrade, params, &response)
 }
 
-// ModifyTrade modifies an order already on the exchange books
-func (b *Bithumb) ModifyTrade(ctx context.Context, orderID, orderCurrency, transactionType string, units float64, price int64) (OrderPlace, error) {
-	response := OrderPlace{}
-
-	params := url.Values{}
-	params.Set("order_currency", strings.ToUpper(orderCurrency))
-	params.Set("payment_currency", "KRW")
-	params.Set("type", strings.ToUpper(transactionType))
-	params.Set("units", strconv.FormatFloat(units, 'f', -1, 64))
-	params.Set("price", strconv.FormatInt(price, 10))
-	params.Set("order_id", orderID)
-
-	return response,
-		b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, privatePlaceTrade, params, &response)
-}
-
 // GetOrderDetails returns specific order details
 //
 // orderID: Order number registered for purchase/sales

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -89,7 +89,6 @@ func (b *Bithumb) SetDefaults() {
 				GetOrder:            true,
 				CancelOrder:         true,
 				SubmitOrder:         true,
-				ModifyOrder:         true,
 				DepositHistory:      true,
 				WithdrawalHistory:   true,
 				UserTradeHistory:    true,
@@ -512,31 +511,8 @@ func (b *Bithumb) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bithumb) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
-	if err := action.Validate(); err != nil {
-		return nil, err
-	}
-
-	o, err := b.ModifyTrade(ctx,
-		action.ID,
-		action.Pair.Base.String(),
-		action.Side.Lower(),
-		action.Amount,
-		int64(action.Price))
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := action.DeriveModifyResponse()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(o.Data) > 0 {
-		resp.OrderID = o.Data[0].ContID
-	}
-
-	return resp, nil
+func (b *Bithumb) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -512,9 +512,9 @@ func (b *Bithumb) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bithumb) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func (b *Bithumb) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	if err := action.Validate(); err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	o, err := b.ModifyTrade(ctx,
@@ -525,18 +525,17 @@ func (b *Bithumb) ModifyOrder(ctx context.Context, action *order.Modify) (order.
 		int64(action.Price))
 
 	if err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
-	return order.Modify{
+	return &order.ModifyResponse{
 		Exchange:  action.Exchange,
 		AssetType: action.AssetType,
 		Pair:      action.Pair,
-		ID:        o.Data[0].ContID,
-
-		Price:  float64(int64(action.Price)),
-		Amount: action.Amount,
-		Side:   action.Side,
+		OrderID:   o.Data[0].ContID,
+		Price:     float64(int64(action.Price)),
+		Amount:    action.Amount,
+		Side:      action.Side,
 	}, nil
 }
 

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -523,20 +523,20 @@ func (b *Bithumb) ModifyOrder(ctx context.Context, action *order.Modify) (*order
 		action.Side.Lower(),
 		action.Amount,
 		int64(action.Price))
-
 	if err != nil {
 		return nil, err
 	}
 
-	return &order.ModifyResponse{
-		Exchange:  action.Exchange,
-		AssetType: action.AssetType,
-		Pair:      action.Pair,
-		OrderID:   o.Data[0].ContID,
-		Price:     float64(int64(action.Price)),
-		Amount:    action.Amount,
-		Side:      action.Side,
-	}, nil
+	resp, err := action.DeriveModifyResponse()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(o.Data) > 0 {
+		resp.OrderID = o.Data[0].ContID
+	}
+
+	return resp, nil
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -313,7 +313,7 @@ func (b *Bitmex) wsHandleData(respRaw []byte) error {
 						Err:      err,
 					}
 				}
-				b.Websocket.DataHandler <- &order.Modify{
+				b.Websocket.DataHandler <- &order.Detail{
 					Exchange:  b.Name,
 					ID:        response.Data[i].OrderID,
 					AccountID: strconv.FormatInt(response.Data[i].Account, 10),
@@ -424,7 +424,7 @@ func (b *Bitmex) wsHandleData(respRaw []byte) error {
 							Err:      err,
 						}
 					}
-					b.Websocket.DataHandler <- &order.Modify{
+					b.Websocket.DataHandler <- &order.Detail{
 						Price:     response.Data[x].Price,
 						Amount:    response.Data[x].OrderQuantity,
 						Exchange:  b.Name,

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -632,6 +632,8 @@ func (b *Bitmex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.
 	}
 
 	resp.OrderID = o.OrderID
+	resp.RemainingAmount = o.OrderQty
+	resp.LastUpdated = o.TransactTime
 	return resp, nil
 }
 

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -609,15 +609,15 @@ func (b *Bitmex) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitmex) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func (b *Bitmex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	if err := action.Validate(); err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	var params OrderAmendParams
 
 	if math.Mod(action.Amount, 1) != 0 {
-		return order.Modify{}, errors.New("contract amount can not have decimals")
+		return nil, errors.New("contract amount can not have decimals")
 	}
 
 	params.OrderID = action.ID
@@ -626,17 +626,16 @@ func (b *Bitmex) ModifyOrder(ctx context.Context, action *order.Modify) (order.M
 
 	o, err := b.AmendOrder(ctx, &params)
 	if err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
-	return order.Modify{
+	return &order.ModifyResponse{
 		Exchange:  action.Exchange,
 		AssetType: action.AssetType,
 		Pair:      action.Pair,
-		ID:        o.OrderID,
-
-		Price:  action.Price,
-		Amount: float64(params.OrderQty),
+		OrderID:   o.OrderID,
+		Price:     action.Price,
+		Amount:    float64(params.OrderQty),
 	}, nil
 }
 

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -561,8 +561,8 @@ func (b *Bitstamp) SubmitOrder(ctx context.Context, s *order.Submit) (order.Subm
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitstamp) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *Bitstamp) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/bittrex/bittrex_websocket.go
+++ b/exchanges/bittrex/bittrex_websocket.go
@@ -615,7 +615,7 @@ func (b *Bittrex) WsProcessUpdateOrder(data *OrderUpdateMessage) error {
 		}
 	}
 
-	b.Websocket.DataHandler <- &order.Modify{
+	b.Websocket.DataHandler <- &order.Detail{
 		ImmediateOrCancel: data.Delta.TimeInForce == string(ImmediateOrCancel),
 		FillOrKill:        data.Delta.TimeInForce == string(GoodTilCancelled),
 		PostOnly:          data.Delta.TimeInForce == string(PostOnlyGoodTilCancelled),

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -587,8 +587,8 @@ func (b *Bittrex) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bittrex) ModifyOrder(_ context.Context, _ *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *Bittrex) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -579,8 +579,8 @@ func (b *BTCMarkets) SubmitOrder(ctx context.Context, s *order.Submit) (order.Su
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *BTCMarkets) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *BTCMarkets) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrNotYetImplemented
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -551,8 +551,8 @@ func (b *BTSE) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitRe
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *BTSE) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (b *BTSE) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -578,8 +578,8 @@ func (c *CoinbasePro) SubmitOrder(ctx context.Context, s *order.Submit) (order.S
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (c *CoinbasePro) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (c *CoinbasePro) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -194,7 +194,7 @@ func (c *COINUT) wsHandleData(ctx context.Context, respRaw []byte) error {
 		if err != nil {
 			return err
 		}
-		c.Websocket.DataHandler <- &order.Modify{
+		c.Websocket.DataHandler <- &order.Detail{
 			Exchange:    c.Name,
 			ID:          strconv.FormatInt(cancel.OrderID, 10),
 			Status:      order.Cancelled,
@@ -208,7 +208,7 @@ func (c *COINUT) wsHandleData(ctx context.Context, respRaw []byte) error {
 			return err
 		}
 		for i := range cancels.Results {
-			c.Websocket.DataHandler <- &order.Modify{
+			c.Websocket.DataHandler <- &order.Detail{
 				Exchange:    c.Name,
 				ID:          strconv.FormatInt(cancels.Results[i].OrderID, 10),
 				Status:      order.Cancelled,

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -679,8 +679,8 @@ func (c *COINUT) SubmitOrder(ctx context.Context, o *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (c *COINUT) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (c *COINUT) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -500,8 +500,8 @@ func (e *EXMO) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitRe
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (e *EXMO) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (e *EXMO) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -688,6 +688,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 	}
 
 	var id string
+	var remainingAmount float64
 	switch {
 	case action.TriggerPrice != 0:
 		var a TriggerOrderData
@@ -702,6 +703,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 			return nil, err
 		}
 		id = strconv.FormatInt(a.ID, 10)
+		remainingAmount = a.Size - a.FilledSize
 	case action.ID == "":
 		o, err := f.ModifyOrderByClientID(ctx,
 			action.ClientOrderID,
@@ -712,6 +714,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 			return nil, err
 		}
 		id = strconv.FormatInt(o.ID, 10)
+		remainingAmount = o.RemainingSize
 	default:
 		o, err := f.ModifyPlacedOrder(ctx,
 			action.ID,
@@ -722,12 +725,14 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 			return nil, err
 		}
 		id = strconv.FormatInt(o.ID, 10)
+		remainingAmount = o.RemainingSize
 	}
 	resp, err := action.DeriveModifyResponse()
 	if err != nil {
 		return nil, err
 	}
 	resp.OrderID = id
+	resp.RemainingAmount = remainingAmount
 	return resp, nil
 }
 

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -682,9 +682,9 @@ func (f *FTX) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitRes
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	if err := action.Validate(); err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	if action.TriggerPrice != 0 {
@@ -696,14 +696,13 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modi
 			action.Price,
 			0)
 		if err != nil {
-			return order.Modify{}, err
+			return nil, err
 		}
-		return order.Modify{
-			Exchange:  action.Exchange,
-			AssetType: action.AssetType,
-			Pair:      action.Pair,
-			ID:        strconv.FormatInt(a.ID, 10),
-
+		return &order.ModifyResponse{
+			Exchange:     action.Exchange,
+			AssetType:    action.AssetType,
+			Pair:         action.Pair,
+			OrderID:      strconv.FormatInt(a.ID, 10),
 			Price:        action.Price,
 			Amount:       action.Amount,
 			TriggerPrice: action.TriggerPrice,
@@ -719,7 +718,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modi
 			action.Price,
 			action.Amount)
 		if err != nil {
-			return order.Modify{}, err
+			return nil, err
 		}
 	} else {
 		o, err = f.ModifyPlacedOrder(ctx,
@@ -728,17 +727,16 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modi
 			action.Price,
 			action.Amount)
 		if err != nil {
-			return order.Modify{}, err
+			return nil, err
 		}
 	}
-	return order.Modify{
+	return &order.ModifyResponse{
 		Exchange:  action.Exchange,
 		AssetType: action.AssetType,
 		Pair:      action.Pair,
-		ID:        strconv.FormatInt(o.ID, 10),
-
-		Price:  action.Price,
-		Amount: action.Amount,
+		OrderID:   strconv.FormatInt(o.ID, 10),
+		Price:     action.Price,
+		Amount:    action.Amount,
 	}, err
 }
 

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -688,7 +688,8 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 	}
 
 	var id string
-	if action.TriggerPrice != 0 {
+	switch {
+	case action.TriggerPrice != 0:
 		var a TriggerOrderData
 		a, err := f.ModifyTriggerOrder(ctx,
 			action.ID,
@@ -701,7 +702,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 			return nil, err
 		}
 		id = strconv.FormatInt(a.ID, 10)
-	} else if action.ID == "" {
+	case action.ID == "":
 		o, err := f.ModifyOrderByClientID(ctx,
 			action.ClientOrderID,
 			action.ClientOrderID,
@@ -711,7 +712,7 @@ func (f *FTX) ModifyOrder(ctx context.Context, action *order.Modify) (*order.Mod
 			return nil, err
 		}
 		id = strconv.FormatInt(o.ID, 10)
-	} else {
+	default:
 		o, err := f.ModifyPlacedOrder(ctx,
 			action.ID,
 			action.ClientOrderID,

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -544,8 +544,8 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (g *Gateio) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (g *Gateio) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -573,8 +573,8 @@ func (g *Gemini) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (g *Gemini) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (g *Gemini) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -602,8 +602,8 @@ func (h *HitBTC) SubmitOrder(ctx context.Context, o *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (h *HitBTC) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (h *HitBTC) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -999,8 +999,8 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitR
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (h *HUOBI) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (h *HUOBI) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -52,17 +52,12 @@ type IBotExchange interface {
 	FormatWithdrawPermissions() string
 	SupportsWithdrawPermissions(permissions uint32) bool
 	GetFundingHistory(ctx context.Context) ([]FundHistory, error)
-	SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitResponse, error)
-	ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error)
-	CancelOrder(ctx context.Context, o *order.Cancel) error
-	CancelBatchOrders(ctx context.Context, o []order.Cancel) (order.CancelBatchResponse, error)
-	CancelAllOrders(ctx context.Context, orders *order.Cancel) (order.CancelAllResponse, error)
-	GetOrderInfo(ctx context.Context, orderID string, pair currency.Pair, assetType asset.Item) (order.Detail, error)
+
+	OrderManagement
+
 	GetDepositAddress(ctx context.Context, cryptocurrency currency.Code, accountID, chain string) (*deposit.Address, error)
 	GetAvailableTransferChains(ctx context.Context, cryptocurrency currency.Code) ([]string, error)
-	GetOrderHistory(ctx context.Context, getOrdersRequest *order.GetOrdersRequest) ([]order.Detail, error)
 	GetWithdrawalsHistory(ctx context.Context, code currency.Code) ([]WithdrawalHistory, error)
-	GetActiveOrders(ctx context.Context, getOrdersRequest *order.GetOrdersRequest) ([]order.Detail, error)
 	WithdrawCryptocurrencyFunds(ctx context.Context, withdrawRequest *withdraw.Request) (*withdraw.ExchangeResponse, error)
 	WithdrawFiatFunds(ctx context.Context, withdrawRequest *withdraw.Request) (*withdraw.ExchangeResponse, error)
 	WithdrawFiatFundsToInternationalBank(ctx context.Context, withdrawRequest *withdraw.Request) (*withdraw.ExchangeResponse, error)
@@ -99,6 +94,18 @@ type IBotExchange interface {
 	UpdateOrderExecutionLimits(ctx context.Context, a asset.Item) error
 
 	AccountManagement
+}
+
+// OrderManagement defines functionality for order management
+type OrderManagement interface {
+	SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitResponse, error)
+	ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error)
+	CancelOrder(ctx context.Context, o *order.Cancel) error
+	CancelBatchOrders(ctx context.Context, o []order.Cancel) (order.CancelBatchResponse, error)
+	CancelAllOrders(ctx context.Context, orders *order.Cancel) (order.CancelAllResponse, error)
+	GetOrderInfo(ctx context.Context, orderID string, pair currency.Pair, assetType asset.Item) (order.Detail, error)
+	GetActiveOrders(ctx context.Context, getOrdersRequest *order.GetOrdersRequest) ([]order.Detail, error)
+	GetOrderHistory(ctx context.Context, getOrdersRequest *order.GetOrdersRequest) ([]order.Detail, error)
 }
 
 // CurrencyStateManagement defines functionality for currency state management

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -431,8 +431,8 @@ func (i *ItBit) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitR
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (i *ItBit) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (i *ItBit) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -594,7 +594,7 @@ func (k *Kraken) wsProcessOpenOrders(ownOrders interface{}) error {
 					if err != nil {
 						return err
 					}
-					k.Websocket.DataHandler <- &order.Modify{
+					k.Websocket.DataHandler <- &order.Detail{
 						Leverage:        val.Description.Leverage,
 						Price:           val.Price,
 						Amount:          val.Volume,
@@ -612,7 +612,7 @@ func (k *Kraken) wsProcessOpenOrders(ownOrders interface{}) error {
 						Pair:            p,
 					}
 				} else {
-					k.Websocket.DataHandler <- &order.Modify{
+					k.Websocket.DataHandler <- &order.Detail{
 						Exchange: k.Name,
 						ID:       key,
 						Status:   oStatus,

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -786,8 +786,8 @@ func (k *Kraken) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submit
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (k *Kraken) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (k *Kraken) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -485,8 +485,8 @@ func (l *Lbank) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitR
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (l *Lbank) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (l *Lbank) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -445,8 +445,8 @@ func (l *LocalBitcoins) SubmitOrder(ctx context.Context, s *order.Submit) (order
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (l *LocalBitcoins) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (l *LocalBitcoins) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -316,8 +316,8 @@ func (o *OKGroup) SubmitOrder(ctx context.Context, s *order.Submit) (order.Submi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (o *OKGroup) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (o *OKGroup) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -867,7 +867,7 @@ func TestUpdateOrderFromModify(t *testing.T) {
 		Pair:              pair,
 	}
 
-	od.UpdateOrderFromModify(&om)
+	od.UpdateOrderFromModifyResponse(&om)
 	if od.InternalOrderID == "1" {
 		t.Error("Should not be able to update the internal order ID")
 	}

--- a/exchanges/order/order_types.go
+++ b/exchanges/order/order_types.go
@@ -83,40 +83,43 @@ type SubmitResponse struct {
 // Each exchange has their own requirements, so not all fields
 // are required to be populated
 type Modify struct {
+	// Order Identifiers
+	Exchange      string
+	ID            string
+	ClientOrderID string
+	Type          Type
+	Side          Side
+	AssetType     asset.Item
+	Pair          currency.Pair
+
+	// Change fields
 	ImmediateOrCancel bool
-	HiddenOrder       bool
-	FillOrKill        bool
 	PostOnly          bool
-	Leverage          float64
 	Price             float64
 	Amount            float64
-	LimitPriceUpper   float64
-	LimitPriceLower   float64
 	TriggerPrice      float64
-	QuoteAmount       float64
-	ExecutedAmount    float64
-	RemainingAmount   float64
-	Fee               float64
-	Exchange          string
-	InternalOrderID   string
-	ID                string
-	ClientOrderID     string
-	AccountID         string
-	ClientID          string
-	WalletAddress     string
-	Type              Type
-	Side              Side
-	Status            Status
-	AssetType         asset.Item
-	Date              time.Time
-	LastUpdated       time.Time
-	Pair              currency.Pair
-	Trades            []TradeHistory
 }
 
 // ModifyResponse is an order modifying return type
 type ModifyResponse struct {
-	OrderID string
+	Exchange      string
+	OrderID       string
+	ClientOrderID string
+	Pair          currency.Pair
+	Type          Type
+	Side          Side
+	Status        Status
+	AssetType     asset.Item
+	Date          time.Time
+	LastUpdated   time.Time
+
+	ImmediateOrCancel bool
+	PostOnly          bool
+
+	Price           float64
+	Amount          float64
+	RemainingAmount float64
+	TriggerPrice    float64
 }
 
 // Detail contains all properties of an order

--- a/exchanges/order/order_types.go
+++ b/exchanges/order/order_types.go
@@ -102,6 +102,7 @@ type Modify struct {
 
 // ModifyResponse is an order modifying return type
 type ModifyResponse struct {
+	// Order Identifiers
 	Exchange      string
 	OrderID       string
 	ClientOrderID string
@@ -110,16 +111,19 @@ type ModifyResponse struct {
 	Side          Side
 	Status        Status
 	AssetType     asset.Item
-	Date          time.Time
-	LastUpdated   time.Time
 
+	// Fields that will be copied over from Modify
 	ImmediateOrCancel bool
 	PostOnly          bool
+	Price             float64
+	Amount            float64
+	TriggerPrice      float64
 
-	Price           float64
-	Amount          float64
+	// Fields that need to be handled in scope after DeriveModifyResponse()
+	// if applicable
 	RemainingAmount float64
-	TriggerPrice    float64
+	Date            time.Time
+	LastUpdated     time.Time
 }
 
 // Detail contains all properties of an order

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -244,7 +244,7 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) {
 
 // UpdateOrderFromModify Will update an order detail (used in order management)
 // by comparing passed in and existing values
-func (d *Detail) UpdateOrderFromModify(m *ModifyResponse) {
+func (d *Detail) UpdateOrderFromModifyResponse(m *ModifyResponse) {
 	var updated bool
 	if m.OrderID != "" && d.ID != m.OrderID {
 		d.ID = m.OrderID

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -242,7 +242,7 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) {
 	}
 }
 
-// UpdateOrderFromModify Will update an order detail (used in order management)
+// UpdateOrderFromModifyResponse Will update an order detail (used in order management)
 // by comparing passed in and existing values
 func (d *Detail) UpdateOrderFromModifyResponse(m *ModifyResponse) {
 	var updated bool

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -408,23 +408,23 @@ func (d *Detail) DeriveModify() (*Modify, error) {
 // DeriveModifyResponse populates a modify response with its identifiers for
 // cross exchange standard. NOTE: New OrderID and/or ClientOrderID plus any
 // changes *might* need to be populated in scope.
-func (d *Modify) DeriveModifyResponse() (*ModifyResponse, error) {
-	if d == nil {
+func (m *Modify) DeriveModifyResponse() (*ModifyResponse, error) {
+	if m == nil {
 		return nil, errOrderDetailIsNil
 	}
 	return &ModifyResponse{
-		Exchange:          d.Exchange,
-		OrderID:           d.ID,
-		ClientOrderID:     d.ClientOrderID,
-		Type:              d.Type,
-		Side:              d.Side,
-		AssetType:         d.AssetType,
-		Pair:              d.Pair,
-		ImmediateOrCancel: d.ImmediateOrCancel,
-		PostOnly:          d.PostOnly,
-		Price:             d.Price,
-		Amount:            d.Amount,
-		TriggerPrice:      d.TriggerPrice,
+		Exchange:          m.Exchange,
+		OrderID:           m.ID,
+		ClientOrderID:     m.ClientOrderID,
+		Type:              m.Type,
+		Side:              m.Side,
+		AssetType:         m.AssetType,
+		Pair:              m.Pair,
+		ImmediateOrCancel: m.ImmediateOrCancel,
+		PostOnly:          m.PostOnly,
+		Price:             m.Price,
+		Amount:            m.Amount,
+		TriggerPrice:      m.TriggerPrice,
 	}, nil
 }
 

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -407,19 +407,24 @@ func (d *Detail) DeriveModify() (*Modify, error) {
 
 // DeriveModifyResponse populates a modify response with its identifiers for
 // cross exchange standard. NOTE: New OrderID and/or ClientOrderID plus any
-// changes need to be populated in scope.
+// changes *might* need to be populated in scope.
 func (d *Modify) DeriveModifyResponse() (*ModifyResponse, error) {
 	if d == nil {
 		return nil, errOrderDetailIsNil
 	}
 	return &ModifyResponse{
-		Exchange:      d.Exchange,
-		OrderID:       d.ID,
-		ClientOrderID: d.ClientOrderID,
-		Type:          d.Type,
-		Side:          d.Side,
-		AssetType:     d.AssetType,
-		Pair:          d.Pair,
+		Exchange:          d.Exchange,
+		OrderID:           d.ID,
+		ClientOrderID:     d.ClientOrderID,
+		Type:              d.Type,
+		Side:              d.Side,
+		AssetType:         d.AssetType,
+		Pair:              d.Pair,
+		ImmediateOrCancel: d.ImmediateOrCancel,
+		PostOnly:          d.PostOnly,
+		Price:             d.Price,
+		Amount:            d.Amount,
+		TriggerPrice:      d.TriggerPrice,
 	}, nil
 }
 

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -822,7 +822,7 @@ func (p *Poloniex) processAccountOrderUpdate(notification []interface{}) error {
 	// null returned so ok check is not needed
 	clientOrderID, _ := notification[4].(string)
 
-	p.Websocket.DataHandler <- &order.Modify{
+	p.Websocket.DataHandler <- &order.Detail{
 		Exchange:        p.Name,
 		RemainingAmount: cancelledAmount,
 		Amount:          amount + cancelledAmount,
@@ -1048,7 +1048,7 @@ func (p *Poloniex) processAccountTrades(notification []interface{}) error {
 		return err
 	}
 
-	p.Websocket.DataHandler <- &order.Modify{
+	p.Websocket.DataHandler <- &order.Detail{
 		Exchange: p.Name,
 		ID:       strconv.FormatFloat(orderID, 'f', -1, 64),
 		Fee:      totalFee,
@@ -1080,7 +1080,7 @@ func (p *Poloniex) processAccountKilledOrder(notification []interface{}) error {
 	// null returned so ok check is not needed
 	clientOrderID, _ := notification[2].(string)
 
-	p.Websocket.DataHandler <- &order.Modify{
+	p.Websocket.DataHandler <- &order.Detail{
 		Exchange:      p.Name,
 		ID:            strconv.FormatFloat(orderID, 'f', -1, 64),
 		Status:        order.Cancelled,

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -567,14 +567,14 @@ func (p *Poloniex) SubmitOrder(ctx context.Context, s *order.Submit) (order.Subm
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (p *Poloniex) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
+func (p *Poloniex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.ModifyResponse, error) {
 	if err := action.Validate(); err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	oID, err := strconv.ParseInt(action.ID, 10, 64)
 	if err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
 	resp, err := p.MoveOrder(ctx,
@@ -584,15 +584,14 @@ func (p *Poloniex) ModifyOrder(ctx context.Context, action *order.Modify) (order
 		action.PostOnly,
 		action.ImmediateOrCancel)
 	if err != nil {
-		return order.Modify{}, err
+		return nil, err
 	}
 
-	return order.Modify{
-		Exchange:  action.Exchange,
-		AssetType: action.AssetType,
-		Pair:      action.Pair,
-		ID:        strconv.FormatInt(resp.OrderNumber, 10),
-
+	return &order.ModifyResponse{
+		Exchange:          action.Exchange,
+		AssetType:         action.AssetType,
+		Pair:              action.Pair,
+		OrderID:           strconv.FormatInt(resp.OrderNumber, 10),
 		Price:             action.Price,
 		Amount:            action.Amount,
 		PostOnly:          action.PostOnly,

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -587,16 +587,12 @@ func (p *Poloniex) ModifyOrder(ctx context.Context, action *order.Modify) (*orde
 		return nil, err
 	}
 
-	return &order.ModifyResponse{
-		Exchange:          action.Exchange,
-		AssetType:         action.AssetType,
-		Pair:              action.Pair,
-		OrderID:           strconv.FormatInt(resp.OrderNumber, 10),
-		Price:             action.Price,
-		Amount:            action.Amount,
-		PostOnly:          action.PostOnly,
-		ImmediateOrCancel: action.ImmediateOrCancel,
-	}, nil
+	modResp, err := action.DeriveModifyResponse()
+	if err != nil {
+		return nil, err
+	}
+	modResp.OrderID = strconv.FormatInt(resp.OrderNumber, 10)
+	return modResp, nil
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/sharedtestvalues/customex.go
+++ b/exchanges/sharedtestvalues/customex.go
@@ -150,8 +150,8 @@ func (c *CustomEx) SubmitOrder(ctx context.Context, s *order.Submit) (order.Subm
 	return order.SubmitResponse{}, nil
 }
 
-func (c *CustomEx) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, nil
+func (c *CustomEx) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, nil
 }
 
 func (c *CustomEx) CancelOrder(ctx context.Context, o *order.Cancel) error {

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -439,8 +439,8 @@ func (y *Yobit) SubmitOrder(ctx context.Context, s *order.Submit) (order.SubmitR
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (y *Yobit) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (y *Yobit) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -220,7 +220,7 @@ func (z *ZB) wsHandleData(respRaw []byte) error {
 			return err
 		}
 
-		z.Websocket.DataHandler <- &order.Modify{
+		z.Websocket.DataHandler <- &order.Detail{
 			Exchange: z.Name,
 			ID:       strconv.FormatInt(o.Data.EntrustID, 10),
 			Pair:     p,

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -528,8 +528,8 @@ func (z *ZB) SubmitOrder(ctx context.Context, o *order.Submit) (order.SubmitResp
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (z *ZB) ModifyOrder(ctx context.Context, action *order.Modify) (order.Modify, error) {
-	return order.Modify{}, common.ErrFunctionNotSupported
+func (z *ZB) ModifyOrder(_ context.Context, _ *order.Modify) (*order.ModifyResponse, error) {
+	return nil, common.ErrFunctionNotSupported
 }
 
 // CancelOrder cancels an order by its corresponding ID number


### PR DESCRIPTION
# PR Description

* Easier population of struct data with limited guesswork via secondary method `DeriveModifyResponse`
* Standardize websocket responses to order.Detail
* restrict Modify struct size
* order.ModifyResponse for obvious response differentiation

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
