### PR TITLE
Backtester: mini bug fixes

### DIFF
--- a/backtester/config/config_test.go
+++ b/backtester/config/config_test.go
@@ -930,26 +930,12 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 				MakerFee: &makerFee,
 				TakerFee: &takerFee,
 			},
-			{
-				ExchangeName: testExchange,
-				Asset:        asset.Spot,
-				Base:         currency.ETH,
-				Quote:        currency.USDT,
-				SpotDetails: &SpotDetails{
-					InitialBaseFunds:  initialFunds10,
-					InitialQuoteFunds: initialFunds1000000,
-				},
-				BuySide:  minMax,
-				SellSide: minMax,
-				MakerFee: &makerFee,
-				TakerFee: &takerFee,
-			},
 		},
 		DataSettings: DataSettings{
 			Interval: kline.OneDay,
 			DataType: common.CandleStr,
 			APIData: &APIData{
-				StartDate:        startDate,
+				StartDate:        time.Date(2021, 5, 1, 0, 0, 0, 0, time.Local),
 				EndDate:          endDate,
 				InclusiveEndDate: false,
 			},

--- a/backtester/config/examples/ftx-cash-carry.strat
+++ b/backtester/config/examples/ftx-cash-carry.strat
@@ -1,5 +1,5 @@
 {
- "nickname": "Example Cash and Carry",
+ "nickname": "ExampleCashAndCarry",
  "goal": "To demonstrate a cash and carry strategy",
  "strategy-settings": {
   "name": "ftx-cash-carry",

--- a/backtester/config/examples/rsi-api-candles.strat
+++ b/backtester/config/examples/rsi-api-candles.strat
@@ -41,41 +41,13 @@
    "skip-candle-volume-fitting": false,
    "use-exchange-order-limits": false,
    "use-exchange-pnl-calculation": false
-  },
-  {
-   "exchange-name": "ftx",
-   "asset": "spot",
-   "base": "ETH",
-   "quote": "USDT",
-   "spot-details": {
-    "initial-base-funds": "10",
-    "initial-quote-funds": "1000000"
-   },
-   "buy-side": {
-    "minimum-size": "0.005",
-    "maximum-size": "2",
-    "maximum-total": "40000"
-   },
-   "sell-side": {
-    "minimum-size": "0.005",
-    "maximum-size": "2",
-    "maximum-total": "40000"
-   },
-   "min-slippage-percent": "0",
-   "max-slippage-percent": "0",
-   "maker-fee-override": "0.0002",
-   "taker-fee-override": "0.0007",
-   "maximum-holdings-ratio": "0",
-   "skip-candle-volume-fitting": false,
-   "use-exchange-order-limits": false,
-   "use-exchange-pnl-calculation": false
   }
  ],
  "data-settings": {
   "interval": 86400000000000,
   "data-type": "candle",
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
+   "start-date": "2021-05-01T00:00:00+10:00",
    "end-date": "2021-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }

--- a/backtester/engine/backtest_types.go
+++ b/backtester/engine/backtest_types.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	errNilConfig                   = errors.New("unable to setup backtester with nil config")
-	errInvalidConfigAsset          = errors.New("invalid asset in config")
 	errAmbiguousDataSource         = errors.New("ambiguous settings received. Only one data type can be set")
 	errNoDataSource                = errors.New("no data settings set in config")
 	errIntervalUnset               = errors.New("candle interval unset")

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -170,10 +170,10 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 			portfolioRisk.CurrencySettings[cfg.CurrencySettings[i].ExchangeName] = make(map[asset.Item]map[currency.Pair]*risk.CurrencySettings)
 		}
 		a := cfg.CurrencySettings[i].Asset
-		if err != nil {
+		if !a.IsValid() {
 			return nil, fmt.Errorf(
 				"%w for %v %v %v-%v. Err %v",
-				errInvalidConfigAsset,
+				asset.ErrNotSupported,
 				cfg.CurrencySettings[i].ExchangeName,
 				cfg.CurrencySettings[i].Asset,
 				cfg.CurrencySettings[i].Base,
@@ -266,6 +266,7 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 				if err != nil && !errors.Is(err, funding.ErrAlreadyExists) {
 					return nil, err
 				}
+				err = nil
 			case a.IsFutures():
 				// setup contract items
 				c := funding.CreateFuturesCurrencyCode(b, q)
@@ -293,7 +294,7 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 					return nil, err
 				}
 			default:
-				return nil, fmt.Errorf("%w: %v unsupported", errInvalidConfigAsset, a)
+				return nil, fmt.Errorf("%w: %v", asset.ErrNotSupported, a)
 			}
 		} else {
 			var bFunds, qFunds decimal.Decimal
@@ -352,6 +353,7 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 		if err != nil && !errors.Is(err, base.ErrCustomSettingsUnsupported) {
 			return nil, err
 		}
+		err = nil
 	}
 	stats := &statistics.Statistic{
 		StrategyName:                bt.Strategy.Name(),
@@ -446,6 +448,7 @@ func (bt *BackTest) setupExchangeSettings(cfg *config.Config) (exchange.Exchange
 			!errors.Is(err, funding.ErrUSDTrackingDisabled) {
 			return resp, err
 		}
+		err = nil
 
 		if cfg.CurrencySettings[i].USDTrackingPair {
 			continue
@@ -517,6 +520,7 @@ func (bt *BackTest) setupExchangeSettings(cfg *config.Config) (exchange.Exchange
 		if err != nil && !errors.Is(err, gctorder.ErrExchangeLimitNotLoaded) {
 			return resp, err
 		}
+		err = nil
 
 		if limits != (gctorder.MinMaxLevel{}) {
 			if !cfg.CurrencySettings[i].CanUseExchangeLimits {

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -266,7 +266,6 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 				if err != nil && !errors.Is(err, funding.ErrAlreadyExists) {
 					return nil, err
 				}
-				err = nil
 			case a.IsFutures():
 				// setup contract items
 				c := funding.CreateFuturesCurrencyCode(b, q)
@@ -353,7 +352,6 @@ func NewFromConfig(cfg *config.Config, templatePath, output string, verbose bool
 		if err != nil && !errors.Is(err, base.ErrCustomSettingsUnsupported) {
 			return nil, err
 		}
-		err = nil
 	}
 	stats := &statistics.Statistic{
 		StrategyName:                bt.Strategy.Name(),
@@ -448,7 +446,6 @@ func (bt *BackTest) setupExchangeSettings(cfg *config.Config) (exchange.Exchange
 			!errors.Is(err, funding.ErrUSDTrackingDisabled) {
 			return resp, err
 		}
-		err = nil
 
 		if cfg.CurrencySettings[i].USDTrackingPair {
 			continue
@@ -520,7 +517,6 @@ func (bt *BackTest) setupExchangeSettings(cfg *config.Config) (exchange.Exchange
 		if err != nil && !errors.Is(err, gctorder.ErrExchangeLimitNotLoaded) {
 			return resp, err
 		}
-		err = nil
 
 		if limits != (gctorder.MinMaxLevel{}) {
 			if !cfg.CurrencySettings[i].CanUseExchangeLimits {

--- a/backtester/eventhandlers/portfolio/portfolio.go
+++ b/backtester/eventhandlers/portfolio/portfolio.go
@@ -208,12 +208,12 @@ func (p *Portfolio) sizeOrder(d common.Directioner, cs *exchange.Settings, origi
 	switch d.GetDirection() {
 	case gctorder.Buy,
 		gctorder.Bid,
-		gctorder.Sell,
-		gctorder.Ask,
 		gctorder.Short,
 		gctorder.Long:
 		sizedOrder.AllocatedFunds = sizedOrder.Amount.Mul(sizedOrder.ClosePrice).Add(estFee)
-	case gctorder.ClosePosition:
+	case gctorder.Sell,
+		gctorder.Ask,
+		gctorder.ClosePosition:
 		sizedOrder.AllocatedFunds = sizedOrder.Amount
 	default:
 		return nil, errInvalidDirection

--- a/backtester/report/tpl.gohtml
+++ b/backtester/report/tpl.gohtml
@@ -1746,7 +1746,7 @@
 												</td>
 											{{ else if ne $ev.SignalEvent nil}}
 												<td>{{$ev.SignalEvent.GetTime}}</td>
-												<td>{{ $.Prettify.Decimal8 $ev.SignalEvent.GetPrice}} {{if $asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$pair.Quote}}{{end}}</td>
+												<td>{{ $.Prettify.Decimal8 $ev.SignalEvent.GetClosePrice}} {{if $asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$pair.Quote}}{{end}}</td>
 												<td>{{$ev.SignalEvent.GetDirection}}</td>
 												<td>
 													<ul>


### PR DESCRIPTION
# PR Description
While working on my other branch I noticed there were some strategies not working. Then I noticed they didn't work on `master` either.

This fixes some typos with errors and the report template. ~I set `err = nil` after each of the `errors.Is` processing exceptions to prevent this kind of fall-through from happening again, but I'm happy to revert those if you don't like it.~ edit: this is no longer the case

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
## How has this been tested
- [x] Testing dca-api-candles-exchange-level-funding.strat
- [x] Testing rsi-api-candles.strat
- [x] Testing t2b2-api-candles-exchange-funding.strat
- [x] go test ./... -race


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
