### PR TITLE
currency: boost retrieval speed when calling currency.NewCode()

### DIFF
--- a/currency/code.go
+++ b/currency/code.go
@@ -142,12 +142,12 @@ func (b *BaseCodes) UpdateCurrency(update *Item) error {
 		return errSymbolEmpty
 	}
 
-	update.Symbol = strings.ToUpper(update.Symbol)
-	update.Lower = strings.ToLower(update.Symbol)
-
 	if update.Role == Unset {
 		return fmt.Errorf("cannot update currency %w for %s", errRoleUnset, update.Symbol)
 	}
+
+	update.Symbol = strings.ToUpper(update.Symbol)
+	update.Lower = strings.ToLower(update.Symbol)
 
 	b.mtx.Lock()
 	defer b.mtx.Unlock()

--- a/currency/code.go
+++ b/currency/code.go
@@ -89,22 +89,24 @@ func (b *BaseCodes) GetFullCurrencyData() (File, error) {
 	var file File
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	for i := range b.Items {
-		switch b.Items[i].Role {
-		case Unset:
-			file.UnsetCurrency = append(file.UnsetCurrency, b.Items[i])
-		case Fiat:
-			file.FiatCurrency = append(file.FiatCurrency, b.Items[i])
-		case Cryptocurrency:
-			file.Cryptocurrency = append(file.Cryptocurrency, b.Items[i])
-		case Token:
-			file.Token = append(file.Token, b.Items[i])
-		case Contract:
-			file.Contracts = append(file.Contracts, b.Items[i])
-		case Stable:
-			file.Stable = append(file.Stable, b.Items[i])
-		default:
-			return file, errors.New("role undefined")
+	for _, stored := range b.Items {
+		for x := range stored {
+			switch stored[x].Role {
+			case Unset:
+				file.UnsetCurrency = append(file.UnsetCurrency, stored[x])
+			case Fiat:
+				file.FiatCurrency = append(file.FiatCurrency, stored[x])
+			case Cryptocurrency:
+				file.Cryptocurrency = append(file.Cryptocurrency, stored[x])
+			case Token:
+				file.Token = append(file.Token, stored[x])
+			case Contract:
+				file.Contracts = append(file.Contracts, stored[x])
+			case Stable:
+				file.Stable = append(file.Stable, stored[x])
+			default:
+				return file, errors.New("role undefined")
+			}
 		}
 	}
 	file.LastMainUpdate = b.LastMainUpdate.Unix()
@@ -116,8 +118,13 @@ func (b *BaseCodes) GetFullCurrencyData() (File, error) {
 func (b *BaseCodes) GetCurrencies() Currencies {
 	b.mtx.Lock()
 	currencies := make(Currencies, len(b.Items))
-	for i := range b.Items {
-		currencies[i] = Code{Item: b.Items[i]}
+	var target int
+	for _, stored := range b.Items {
+		if len(stored) == 0 {
+			continue
+		}
+		currencies[target] = Code{Item: stored[0]}
+		target++
 	}
 	b.mtx.Unlock()
 	return currencies
@@ -130,33 +137,39 @@ func (b *BaseCodes) UpdateCurrency(fullName, symbol, blockchain string, id int, 
 	}
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	for i := range b.Items {
-		if b.Items[i].Symbol != symbol || (b.Items[i].Role != Unset && b.Items[i].Role != r) {
-			continue
-		}
 
-		if fullName != "" {
-			b.Items[i].FullName = fullName
+	stored, ok := b.Items[symbol]
+	if ok {
+		for x := range stored {
+			if stored[x].Role != Unset && stored[x].Role != r {
+				continue
+			}
+
+			if fullName != "" {
+				stored[x].FullName = fullName
+			}
+			if r != Unset {
+				stored[x].Role = r
+			}
+			if blockchain != "" {
+				stored[x].AssocChain = blockchain
+			}
+			if id != 0 {
+				stored[x].ID = id
+			}
+			return nil
 		}
-		if r != Unset {
-			b.Items[i].Role = r
-		}
-		if blockchain != "" {
-			b.Items[i].AssocChain = blockchain
-		}
-		if id != 0 {
-			b.Items[i].ID = id
-		}
-		return nil
+		// If updating details fails, fall over and add a new item.
 	}
 
-	b.Items = append(b.Items, &Item{
+	b.Items[symbol] = append(b.Items[symbol], &Item{
 		Symbol:     symbol,
 		FullName:   fullName,
 		Role:       r,
 		AssocChain: blockchain,
 		ID:         id,
 	})
+
 	return nil
 }
 
@@ -181,26 +194,30 @@ func (b *BaseCodes) Register(c string, newRole Role) Code {
 
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	for i := range b.Items {
-		if b.Items[i].Symbol != c {
-			continue
-		}
 
-		if newRole != Unset {
-			if b.Items[i].Role == Unset {
-				b.Items[i].Role = newRole
-			} else if b.Items[i].Role != newRole {
-				// This will duplicate item with same name but different role.
-				// TODO: This will need a specific update to NewCode to add in
-				// a specific param to find the exact name and role.
-				continue
-			}
-		}
-
-		return Code{Item: b.Items[i], UpperCase: format}
+	if b.Items == nil {
+		b.Items = make(map[string][]*Item)
 	}
+
+	stored, ok := b.Items[c]
+	if ok {
+		for x := range stored {
+			if newRole != Unset {
+				if stored[x].Role == Unset {
+					stored[x].Role = newRole
+				} else if stored[x].Role != newRole {
+					// This will duplicate item with same name but different role.
+					// TODO: This will need a specific update to NewCode to add in
+					// a specific param to find the exact name and role.
+					continue
+				}
+			}
+			return Code{Item: stored[x], UpperCase: format}
+		}
+	}
+
 	newItem := &Item{Symbol: c, Lower: strings.ToLower(c), Role: newRole}
-	b.Items = append(b.Items, newItem)
+	b.Items[c] = append(b.Items[c], newItem)
 	return Code{Item: newItem, UpperCase: format}
 }
 
@@ -219,14 +236,21 @@ func (b *BaseCodes) LoadItem(item *Item) error {
 
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	for i := range b.Items {
-		if b.Items[i].Symbol != item.Symbol ||
-			(b.Items[i].Role != Unset && item.Role != Unset && b.Items[i].Role != item.Role) {
-			continue
+
+	stored, ok := b.Items[item.Symbol]
+	if ok {
+		for x := range stored {
+			if stored[x].Role == item.Role {
+				return nil
+			}
+
+			if stored[x].Role == Unset && item.Role != Unset {
+				stored[x].Role = item.Role
+				return nil
+			}
 		}
-		return nil
 	}
-	b.Items = append(b.Items, item)
+	b.Items[item.Symbol] = append(b.Items[item.Symbol], item)
 	return nil
 }
 

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -634,13 +634,12 @@ func TestItemString(t *testing.T) {
 	}
 }
 
-var testCode Code
-
 // 28848025	        40.84 ns/op	       8 B/op	       1 allocs/op // Current
 //
 //	546290	      2192 ns/op	       8 B/op	       1 allocs/op // Previous
 func BenchmarkNewCode(b *testing.B) {
+        b.ReportAllocs()
 	for x := 0; x < b.N; x++ {
-		testCode = NewCode("someCode")
+		_ = NewCode("someCode")
 	}
 }

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -152,15 +152,19 @@ func (b *BaseCodes) assertRole(t *testing.T, c Code, r Role) {
 	t.Helper()
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	for x := range b.Items {
-		if b.Items[x] != c.Item {
-			continue
+	stored, ok := b.Items[c.Item.Symbol]
+	if ok {
+		for x := range stored {
+			if stored[x] != c.Item {
+				continue
+			}
+			if stored[x].Role != r {
+				t.Fatal("unexpected role")
+			}
+			return
 		}
-		if b.Items[x].Role != r {
-			t.Fatal("unexpected role")
-		}
-		return
 	}
+
 	t.Fatal("code pointer not found")
 }
 
@@ -377,37 +381,37 @@ func TestBaseCode(t *testing.T) {
 		t.Error("Expected 'Role undefined'")
 	}
 
-	main.Items[0].FullName = "Hello"
-	err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// main.Items[0].FullName = "Hello"
+	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
 
-	if main.Items[0].FullName != "MEWOW" {
-		t.Error("Fullname not updated")
-	}
-	err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = main.UpdateCurrency("WOWCATS", "CATS", "", 3, Fiat)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// if main.Items[0].FullName != "MEWOW" {
+	// 	t.Error("Fullname not updated")
+	// }
+	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// err = main.UpdateCurrency("WOWCATS", "CATS", "", 3, Fiat)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
 
-	// Creates a new item under a different currency role
-	if main.Items[0].ID != 3 {
-		t.Error("ID not updated")
-	}
+	// // Creates a new item under a different currency role
+	// if main.Items[0].ID != 3 {
+	// 	t.Error("ID not updated")
+	// }
 
-	main.Items[0].Role = Unset
-	err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Cryptocurrency)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if main.Items[0].ID != 1338 {
-		t.Error("ID not updated")
-	}
+	// main.Items[0].Role = Unset
+	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Cryptocurrency)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// if main.Items[0].ID != 1338 {
+	// 	t.Error("ID not updated")
+	// }
 }
 
 func TestCodeString(t *testing.T) {
@@ -507,29 +511,22 @@ func TestCodeMarshalJSON(t *testing.T) {
 
 func TestIsFiatCurrency(t *testing.T) {
 	if EMPTYCODE.IsFiatCurrency() {
-		t.Errorf("TestIsFiatCurrency cannot match currency, %s.",
-			EMPTYCODE)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", EMPTYCODE)
 	}
 	if !USD.IsFiatCurrency() {
-		t.Errorf(
-			"TestIsFiatCurrency cannot match currency, %s.", USD)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USD)
 	}
 	if !CNY.IsFiatCurrency() {
-		t.Errorf(
-			"TestIsFiatCurrency cannot match currency, %s.", CNY)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", CNY)
 	}
 	if LINO.IsFiatCurrency() {
-		t.Errorf(
-			"TestIsFiatCurrency cannot match currency, %s.", LINO,
-		)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", LINO)
 	}
 	if USDT.IsFiatCurrency() {
-		t.Errorf(
-			"TestIsFiatCurrency cannot match currency, %s.", USD)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USD)
 	}
 	if DAI.IsFiatCurrency() {
-		t.Errorf(
-			"TestIsFiatCurrency cannot match currency, %s.", USD)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USD)
 	}
 }
 

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -159,12 +159,11 @@ func (b *BaseCodes) assertRole(t *testing.T, c Code, r Role) {
 				continue
 			}
 			if stored[x].Role != r {
-				t.Fatal("unexpected role")
+				t.Fatalf("unexpected role received: %v but expected: %v", stored[x].Role, r)
 			}
 			return
 		}
 	}
-
 	t.Fatal("code pointer not found")
 }
 
@@ -235,29 +234,42 @@ func TestBaseCode(t *testing.T) {
 	}
 
 	main.Register("XBTUSD", Unset)
-
-	err := main.UpdateCurrency("Bitcoin Perpetual",
-		"XBTUSD",
-		"",
-		0,
-		Contract)
+	err := main.UpdateCurrency(&Item{
+		FullName: "Bitcoin Perpetual",
+		Symbol:   "XBTUSD",
+		Role:     Contract,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	main.Register("BTC", Unset)
-	err = main.UpdateCurrency("Bitcoin", "BTC", "", 1337, Unset)
+	err = main.UpdateCurrency(&Item{
+		FullName: "Bitcoin",
+		Symbol:   "BTC",
+		ID:       1337,
+	})
 	if !errors.Is(err, errRoleUnset) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errRoleUnset)
 	}
 
-	err = main.UpdateCurrency("Bitcoin", "BTC", "", 1337, Cryptocurrency)
+	err = main.UpdateCurrency(&Item{
+		FullName: "Bitcoin",
+		Symbol:   "BTC",
+		ID:       1337,
+		Role:     Cryptocurrency,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	aud := main.Register("AUD", Unset)
-	err = main.UpdateCurrency("Unreal Dollar", "AUD", "", 1111, Fiat)
+	err = main.UpdateCurrency(&Item{
+		FullName: "Unreal Dollar",
+		Symbol:   "AUD",
+		ID:       1111,
+		Role:     Fiat,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,13 +278,23 @@ func TestBaseCode(t *testing.T) {
 		t.Error("Expected fullname to update for AUD")
 	}
 
-	err = main.UpdateCurrency("Australian Dollar", "AUD", "", 1336, Fiat)
+	err = main.UpdateCurrency(&Item{
+		FullName: "Australian Dollar",
+		Symbol:   "AUD",
+		ID:       1336,
+		Role:     Fiat,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	aud.Item.Role = Unset
-	err = main.UpdateCurrency("Australian Dollar", "AUD", "", 1336, Fiat)
+	err = main.UpdateCurrency(&Item{
+		FullName: "Australian Dollar",
+		Symbol:   "AUD",
+		ID:       1336,
+		Role:     Fiat,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +303,13 @@ func TestBaseCode(t *testing.T) {
 	}
 
 	main.Register("PPT", Unset)
-	err = main.UpdateCurrency("Populous", "PPT", "ETH", 1335, Token)
+	err = main.UpdateCurrency(&Item{
+		FullName:   "Populous",
+		Symbol:     "PPT",
+		AssocChain: "ETH",
+		ID:         1335,
+		Role:       Token,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,37 +409,50 @@ func TestBaseCode(t *testing.T) {
 		t.Error("Expected 'Role undefined'")
 	}
 
-	// main.Items[0].FullName = "Hello"
-	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
+	main.Items["CATS"][0].FullName = "Hello"
+	err = main.UpdateCurrency(&Item{
+		FullName: "MEWOW",
+		Symbol:   "CATS",
+		ID:       1338,
+		Role:     Fiat,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// if main.Items[0].FullName != "MEWOW" {
-	// 	t.Error("Fullname not updated")
-	// }
-	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Fiat)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// err = main.UpdateCurrency("WOWCATS", "CATS", "", 3, Fiat)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
+	if main.Items["CATS"][0].FullName != "MEWOW" {
+		t.Error("Fullname not updated")
+	}
 
-	// // Creates a new item under a different currency role
-	// if main.Items[0].ID != 3 {
-	// 	t.Error("ID not updated")
-	// }
+	err = main.UpdateCurrency(&Item{
+		FullName: "WOWCATS",
+		Symbol:   "CATS",
+		ID:       3,
+		Role:     Fiat,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// main.Items[0].Role = Unset
-	// err = main.UpdateCurrency("MEWOW", "CATS", "", 1338, Cryptocurrency)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// if main.Items[0].ID != 1338 {
-	// 	t.Error("ID not updated")
-	// }
+	// Creates a new item under a different currency role
+	if main.Items["CATS"][0].ID != 3 {
+		t.Error("ID not updated")
+	}
+
+	main.Items["CATS"][0].Role = Unset
+
+	err = main.UpdateCurrency(&Item{
+		FullName: "MEWOW",
+		Symbol:   "CATS",
+		ID:       1338,
+		Role:     Cryptocurrency,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if main.Items["CATS"][0].ID != 1338 {
+		t.Error("ID not updated")
+	}
 }
 
 func TestCodeString(t *testing.T) {
@@ -523,10 +564,10 @@ func TestIsFiatCurrency(t *testing.T) {
 		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", LINO)
 	}
 	if USDT.IsFiatCurrency() {
-		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USD)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USDT)
 	}
 	if DAI.IsFiatCurrency() {
-		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", USD)
+		t.Errorf("TestIsFiatCurrency cannot match currency, %s.", DAI)
 	}
 }
 
@@ -590,5 +631,16 @@ func TestItemString(t *testing.T) {
 		t.Errorf("Currency String() error expected '%s' but received '%s'",
 			expected,
 			&newItem)
+	}
+}
+
+var testCode Code
+
+// 28848025	        40.84 ns/op	       8 B/op	       1 allocs/op // Current
+//
+//	546290	      2192 ns/op	       8 B/op	       1 allocs/op // Previous
+func BenchmarkNewCode(b *testing.B) {
+	for x := 0; x < b.N; x++ {
+		testCode = NewCode("someCode")
 	}
 }

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -153,6 +153,9 @@ func (b *BaseCodes) assertRole(t *testing.T, c Code, r Role) {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	stored, ok := b.Items[c.Item.Symbol]
+	if !ok {
+		t.Fatal("code pointer not found")
+	}
 	if ok {
 		for x := range stored {
 			if stored[x] != c.Item {
@@ -638,7 +641,7 @@ func TestItemString(t *testing.T) {
 //
 //	546290	      2192 ns/op	       8 B/op	       1 allocs/op // Previous
 func BenchmarkNewCode(b *testing.B) {
-        b.ReportAllocs()
+	b.ReportAllocs()
 	for x := 0; x < b.N; x++ {
 		_ = NewCode("someCode")
 	}

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -156,16 +156,14 @@ func (b *BaseCodes) assertRole(t *testing.T, c Code, r Role) {
 	if !ok {
 		t.Fatal("code pointer not found")
 	}
-	if ok {
-		for x := range stored {
-			if stored[x] != c.Item {
-				continue
-			}
-			if stored[x].Role != r {
-				t.Fatalf("unexpected role received: %v but expected: %v", stored[x].Role, r)
-			}
-			return
+	for x := range stored {
+		if stored[x] != c.Item {
+			continue
 		}
+		if stored[x].Role != r {
+			t.Fatalf("unexpected role received: %v but expected: %v", stored[x].Role, r)
+		}
+		return
 	}
 	t.Fatal("code pointer not found")
 }

--- a/currency/code_types.go
+++ b/currency/code_types.go
@@ -63,6 +63,18 @@ func (*Item) Lock() {}
 // Unlock implements the sync.Locker interface and forces a govet check nocopy
 func (*Item) Unlock() {}
 
+// copy does a full copy of item
+func (i *Item) copy() *Item {
+	return &Item{
+		ID:         i.ID,
+		FullName:   i.FullName,
+		Symbol:     i.Symbol,
+		Lower:      i.Lower,
+		Role:       i.Role,
+		AssocChain: i.AssocChain,
+	}
+}
+
 // Const declarations for individual currencies/tokens/fiat
 // An ever growing list. Cares not for equivalence, just is
 var (

--- a/currency/code_types.go
+++ b/currency/code_types.go
@@ -28,7 +28,7 @@ type Role uint8
 
 // BaseCodes defines a basket of bare currency codes
 type BaseCodes struct {
-	Items          []*Item
+	Items          map[string][]*Item
 	LastMainUpdate time.Time
 	mtx            sync.Mutex
 }

--- a/currency/code_types.go
+++ b/currency/code_types.go
@@ -63,18 +63,6 @@ func (*Item) Lock() {}
 // Unlock implements the sync.Locker interface and forces a govet check nocopy
 func (*Item) Unlock() {}
 
-// copy does a full copy of item
-func (i *Item) copy() *Item {
-	return &Item{
-		ID:         i.ID,
-		FullName:   i.FullName,
-		Symbol:     i.Symbol,
-		Lower:      i.Lower,
-		Role:       i.Role,
-		AssocChain: i.AssocChain,
-	}
-}
-
 // Const declarations for individual currencies/tokens/fiat
 // An ever growing list. Cares not for equivalence, just is
 var (

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -228,9 +228,14 @@ func (s *Storage) SetupConversionRates() {
 // to the running list
 func (s *Storage) SetDefaultFiatCurrencies(c Currencies) error {
 	for i := range c {
-		update := c[i].Item.copy()
-		update.Role = Fiat
-		err := s.currencyCodes.UpdateCurrency(update)
+		err := s.currencyCodes.UpdateCurrency(&Item{
+			ID:         c[i].Item.ID,
+			FullName:   c[i].Item.FullName,
+			Symbol:     c[i].Item.Symbol,
+			Lower:      c[i].Item.Lower,
+			Role:       Fiat,
+			AssocChain: c[i].Item.AssocChain,
+		})
 		if err != nil {
 			return err
 		}
@@ -244,9 +249,14 @@ func (s *Storage) SetDefaultFiatCurrencies(c Currencies) error {
 // list
 func (s *Storage) SetStableCoins(c Currencies) error {
 	for i := range c {
-		update := c[i].Item.copy()
-		update.Role = Stable
-		err := s.currencyCodes.UpdateCurrency(update)
+		err := s.currencyCodes.UpdateCurrency(&Item{
+			ID:         c[i].Item.ID,
+			FullName:   c[i].Item.FullName,
+			Symbol:     c[i].Item.Symbol,
+			Lower:      c[i].Item.Lower,
+			Role:       Stable,
+			AssocChain: c[i].Item.AssocChain,
+		})
 		if err != nil {
 			return err
 		}
@@ -259,9 +269,14 @@ func (s *Storage) SetStableCoins(c Currencies) error {
 // it to the running list
 func (s *Storage) SetDefaultCryptocurrencies(c Currencies) error {
 	for i := range c {
-		update := c[i].Item.copy()
-		update.Role = Cryptocurrency
-		err := s.currencyCodes.UpdateCurrency(update)
+		err := s.currencyCodes.UpdateCurrency(&Item{
+			ID:         c[i].Item.ID,
+			FullName:   c[i].Item.FullName,
+			Symbol:     c[i].Item.Symbol,
+			Lower:      c[i].Item.Lower,
+			Role:       Cryptocurrency,
+			AssocChain: c[i].Item.AssocChain,
+		})
 		if err != nil {
 			return err
 		}

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -49,6 +49,7 @@ var (
 
 // SetDefaults sets storage defaults for basic package functionality
 func (s *Storage) SetDefaults() {
+	s.currencyCodes.Items = make(map[string][]*Item)
 	s.defaultBaseCurrency = USD
 	s.baseCurrency = s.defaultBaseCurrency
 	fiatCurrencies := make([]Code, 0, len(symbols))


### PR DESCRIPTION
# PR Description

* Implement map of currency.Item instead of slice
* Use upper case currency code string as key identifier 
* cleaned up some coderinos

This should have a good knock on affect to the speed of currency.NewPair functions as it was iterating over 3k items * 2 for each currency side and this was compounded across different routines.  

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
