### PR TITLE
Binance: add IOC support to SubmitOrder wrapper

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -934,6 +934,9 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 			timeInForce = ""
 			requestParamsOrderType = BinanceRequestParamsOrderMarket
 		case order.Limit:
+			if s.ImmediateOrCancel {
+				timeInForce = BinanceRequestParamsTimeIOC
+			}
 			requestParamsOrderType = BinanceRequestParamsOrderLimit
 		default:
 			return nil, errors.New("unsupported order type")


### PR DESCRIPTION
# PR Description

There is already an `ImmediateOrCancel` flag within `order.Submit`. Just using it when set in the `SubmitOrder` wrapper function

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Manually by using exchanges package directly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
