### PR TITLE
websocket: add SendMessageReturnResponse latency reporter

### DIFF
--- a/exchanges/stream/stream_types.go
+++ b/exchanges/stream/stream_types.go
@@ -41,11 +41,12 @@ type ChannelSubscription struct {
 
 // ConnectionSetup defines variables for an individual stream connection
 type ConnectionSetup struct {
-	ResponseCheckTimeout time.Duration
-	ResponseMaxLimit     time.Duration
-	RateLimit            int64
-	URL                  string
-	Authenticated        bool
+	ResponseCheckTimeout    time.Duration
+	ResponseMaxLimit        time.Duration
+	RateLimit               int64
+	URL                     string
+	Authenticated           bool
+	ConnectionLevelReporter Reporter
 }
 
 // PingHandler container for ping handler settings

--- a/exchanges/stream/stream_types.go
+++ b/exchanges/stream/stream_types.go
@@ -97,3 +97,9 @@ type WebsocketPositionUpdated struct {
 type UnhandledMessageWarning struct {
 	Message string
 }
+
+// Reporter interface groups observability functionality over
+// Websocket request latency.
+type Reporter interface {
+	Latency(name string, message []byte, t time.Duration)
+}

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -205,7 +205,7 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		RateLimit:         c.RateLimit,
 		Reporter:          globalReporter,
 	}
-	
+
 	if w.Reporter != nil {
 		newConn.Reporter = w.Reporter
 	}

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -203,11 +203,15 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		Wg:                w.Wg,
 		Match:             w.Match,
 		RateLimit:         c.RateLimit,
-		Reporter:          globalReporter,
+		Reporter:          c.ConnectionLevelReporter,
 	}
 
-	if w.Reporter != nil {
-		newConn.Reporter = w.Reporter
+	if c.ConnectionLevelReporter == nil {
+		c.ConnectionLevelReporter = w.ExchangeLevelReporter
+	}
+
+	if c.ConnectionLevelReporter == nil {
+		c.ConnectionLevelReporter = globalReporter
 	}
 
 	if c.Authenticated {

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -191,6 +191,14 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		connectionURL = c.URL
 	}
 
+	if c.ConnectionLevelReporter == nil {
+		c.ConnectionLevelReporter = w.ExchangeLevelReporter
+	}
+
+	if c.ConnectionLevelReporter == nil {
+		c.ConnectionLevelReporter = globalReporter
+	}
+
 	newConn := &WebsocketConnection{
 		ExchangeName:      w.exchangeName,
 		URL:               connectionURL,
@@ -204,14 +212,6 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		Match:             w.Match,
 		RateLimit:         c.RateLimit,
 		Reporter:          c.ConnectionLevelReporter,
-	}
-
-	if c.ConnectionLevelReporter == nil {
-		c.ConnectionLevelReporter = w.ExchangeLevelReporter
-	}
-
-	if c.ConnectionLevelReporter == nil {
-		c.ConnectionLevelReporter = globalReporter
 	}
 
 	if c.Authenticated {

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -195,6 +195,7 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		Wg:                w.Wg,
 		Match:             w.Match,
 		RateLimit:         c.RateLimit,
+		Reporter:          w.Reporter,
 	}
 
 	if c.Authenticated {

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -46,6 +46,14 @@ var (
 	errClosedConnection                     = errors.New("use of closed network connection")
 )
 
+var globalReporter Reporter
+
+// SetupGlobalReporter sets a reporter interface to be used
+// for all exchange requests
+func SetupGlobalReporter(r Reporter) {
+	globalReporter = r
+}
+
 // New initialises the websocket struct
 func New() *Websocket {
 	return &Websocket{
@@ -195,7 +203,11 @@ func (w *Websocket) SetupNewConnection(c ConnectionSetup) error {
 		Wg:                w.Wg,
 		Match:             w.Match,
 		RateLimit:         c.RateLimit,
-		Reporter:          w.Reporter,
+		Reporter:          globalReporter,
+	}
+	
+	if w.Reporter != nil {
+		newConn.Reporter = w.Reporter
 	}
 
 	if c.Authenticated {

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -94,7 +94,7 @@ type Websocket struct {
 	AuthConn Connection
 
 	// Latency reporter
-	Reporter Reporter
+	ExchangeLevelReporter Reporter
 }
 
 // WebsocketSetup defines variables for setting up a websocket connection

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -92,6 +92,9 @@ type Websocket struct {
 	Conn Connection
 	// Authenticated stream connection
 	AuthConn Connection
+
+	// Latency reporter
+	Reporter Reporter
 }
 
 // WebsocketSetup defines variables for setting up a websocket connection
@@ -138,4 +141,6 @@ type WebsocketConnection struct {
 	ResponseMaxLimit  time.Duration
 	Traffic           chan struct{}
 	readMessageErrors chan error
+
+	Reporter Reporter
 }


### PR DESCRIPTION
# PR Description

There's a latency reporter for HTTP requests. This PR adds a similar latency reporter around `SendMessageReturnReponse` websocket call.

Since this is a WS message request and the signature is generally added from inside the client, the reliable way to match against the request outside of the client is the request message itself, which is why it is sent to the latency reporter.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Tested manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
