### PR TITLE
binance: adjust outbound start and end time payload strings and update unix to milliseconds

### DIFF
--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -813,7 +813,7 @@ func (b *Binance) SendAuthHTTPRequest(ctx context.Context, ePath exchange.URL, m
 	interim := json.RawMessage{}
 	err = b.SendPayload(ctx, f, func() (*request.Item, error) {
 		fullPath := endpointPath + path
-		params.Set("timestamp", strconv.FormatInt(time.Now().Unix()*1000, 10))
+		params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 		signature := params.Encode()
 		var hmacSigned []byte
 		hmacSigned, err = crypto.GetHMAC(crypto.HashSHA256,
@@ -1060,11 +1060,11 @@ func (b *Binance) WithdrawHistory(ctx context.Context, c currency.Code, status s
 	}
 
 	if !startTime.IsZero() {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UTC().UnixMilli(), 10))
 	}
 
 	if !endTime.IsZero() {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UTC().UnixMilli(), 10))
 	}
 
 	if offset != 0 {

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -99,13 +99,6 @@ func (b *Binance) GetCrossMarginInterestHistory(ctx context.Context) (CrossMargi
 	return resp, nil
 }
 
-// GetMarginMarkets returns exchange information. Check binance_types for more information
-func (b *Binance) GetMarginMarkets(ctx context.Context) (PerpsExchangeInfo, error) {
-	var resp PerpsExchangeInfo
-	return resp, b.SendHTTPRequest(ctx,
-		exchange.RestSpot, perpExchangeInfo, spotDefaultRate, &resp)
-}
-
 // GetExchangeInfo returns exchange information. Check binance_types for more
 // information
 func (b *Binance) GetExchangeInfo(ctx context.Context) (ExchangeInfo, error) {
@@ -1196,7 +1189,7 @@ func (b *Binance) FetchSpotExchangeLimits(ctx context.Context) ([]order.MinMaxLe
 				assets = append(assets, asset.Spot)
 			case "MARGIN":
 				assets = append(assets, asset.Margin)
-			case "LEVERAGED", "TRD_GRP_003": // unused permissions
+			case "LEVERAGED", "TRD_GRP_003", "TRD_GRP_004", "TRD_GRP_005": // unused permissions
 			default:
 				return nil, fmt.Errorf("unhandled asset type for exchange limits loading %s",
 					spot.Symbols[x].Permissions[y])

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -1008,11 +1008,11 @@ func (b *Binance) DepositHistory(ctx context.Context, c currency.Code, status st
 	}
 
 	if !startTime.IsZero() {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UTC().UnixMilli(), 10))
 	}
 
 	if !endTime.IsZero() {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UTC().UnixMilli(), 10))
 	}
 
 	if offset != 0 {

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -218,8 +218,8 @@ func (b *Binance) GetFuturesAggregatedTradesList(ctx context.Context, symbol cur
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesCompressedTrades+params.Encode(), cFuturesHistoricalTradesRate, &resp)
 }
@@ -258,8 +258,8 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	var data [][10]interface{}
@@ -377,8 +377,8 @@ func (b *Binance) GetContinuousKlineData(ctx context.Context, pair, contractType
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	rateBudget := getKlineRateBudget(limit)
@@ -492,8 +492,8 @@ func (b *Binance) GetIndexPriceKlines(ctx context.Context, pair, interval string
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	rateBudget := getKlineRateBudget(limit)
@@ -611,8 +611,8 @@ func (b *Binance) GetMarkPriceKline(ctx context.Context, symbol currency.Pair, i
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	var data [][10]interface{}
@@ -763,8 +763,8 @@ func (b *Binance) FuturesGetFundingHistory(ctx context.Context, symbol currency.
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesFundingRateHistory+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -830,8 +830,8 @@ func (b *Binance) GetFuturesLiquidationOrders(ctx context.Context, symbol curren
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
@@ -870,8 +870,8 @@ func (b *Binance) GetOpenInterestStats(ctx context.Context, pair, contractType, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesOpenInterestStats+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -892,8 +892,8 @@ func (b *Binance) GetTraderFuturesAccountRatio(ctx context.Context, pair, period
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesTopAccountsRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -914,8 +914,8 @@ func (b *Binance) GetTraderFuturesPositionsRatio(ctx context.Context, pair, peri
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesTopPositionsRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -936,8 +936,8 @@ func (b *Binance) GetMarketRatio(ctx context.Context, pair, period string, limit
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesLongShortRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -962,8 +962,8 @@ func (b *Binance) GetFuturesTakerVolume(ctx context.Context, pair, contractType,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesBuySellVolume+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -988,8 +988,8 @@ func (b *Binance) GetFuturesBasisData(ctx context.Context, pair, contractType, p
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesBasis+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -1253,8 +1253,8 @@ func (b *Binance) GetAllFuturesOrders(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodGet, cfuturesAllOrders, params, rateLimit, &resp)
 }
@@ -1343,8 +1343,8 @@ func (b *Binance) FuturesMarginChangeHistory(ctx context.Context, symbol currenc
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1385,8 +1385,8 @@ func (b *Binance) FuturesTradeHistory(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1418,8 +1418,8 @@ func (b *Binance) FuturesIncomeHistory(ctx context.Context, symbol currency.Pair
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1458,8 +1458,8 @@ func (b *Binance) FuturesForceOrders(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodGet, cfuturesUsersForceOrders, params, cFuturesDefaultRate, &resp)
 }

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -36,7 +36,6 @@ const (
 	cfuturesTickerPriceStats   = "/dapi/v1/ticker/24hr?"
 	cfuturesSymbolPriceTicker  = "/dapi/v1/ticker/price?"
 	cfuturesSymbolOrderbook    = "/dapi/v1/ticker/bookTicker?"
-	cfuturesLiquidationOrders  = "/dapi/v1/allForceOrders?"
 	cfuturesOpenInterest       = "/dapi/v1/openInterest?"
 	cfuturesOpenInterestStats  = "/futures/data/openInterestHist?"
 	cfuturesTopAccountsRatio   = "/futures/data/topLongShortAccountRatio?"
@@ -805,35 +804,6 @@ func (b *Binance) GetFuturesOrderbookTicker(ctx context.Context, symbol currency
 		params.Set("pair", pair)
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesSymbolOrderbook+params.Encode(), rateLimit, &resp)
-}
-
-// GetFuturesLiquidationOrders gets forced liquidation orders
-func (b *Binance) GetFuturesLiquidationOrders(ctx context.Context, symbol currency.Pair, pair string, limit int64, startTime, endTime time.Time) ([]AllLiquidationOrders, error) {
-	var resp []AllLiquidationOrders
-	params := url.Values{}
-	rateLimit := cFuturesAllForceOrdersRate
-	if !symbol.IsEmpty() {
-		rateLimit = cFuturesCurrencyForceOrdersRate
-		symbolValue, err := b.FormatSymbol(symbol, asset.CoinMarginedFutures)
-		if err != nil {
-			return resp, err
-		}
-		params.Set("symbol", symbolValue)
-	}
-	if pair != "" {
-		params.Set("pair", pair)
-	}
-	if limit > 0 && limit <= 1000 {
-		params.Set("limit", strconv.FormatInt(limit, 10))
-	}
-	if !startTime.IsZero() && !endTime.IsZero() {
-		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
-		}
-		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
-	}
-	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
 
 // GetOpenInterest gets open interest data for a symbol

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -218,8 +218,8 @@ func (b *Binance) GetFuturesAggregatedTradesList(ctx context.Context, symbol cur
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesCompressedTrades+params.Encode(), cFuturesHistoricalTradesRate, &resp)
 }
@@ -258,8 +258,8 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	var data [][10]interface{}
@@ -377,8 +377,8 @@ func (b *Binance) GetContinuousKlineData(ctx context.Context, pair, contractType
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	rateBudget := getKlineRateBudget(limit)
@@ -492,8 +492,8 @@ func (b *Binance) GetIndexPriceKlines(ctx context.Context, pair, interval string
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	rateBudget := getKlineRateBudget(limit)
@@ -611,8 +611,8 @@ func (b *Binance) GetMarkPriceKline(ctx context.Context, symbol currency.Pair, i
 		if startTime.After(endTime) {
 			return nil, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	var data [][10]interface{}
@@ -763,8 +763,8 @@ func (b *Binance) FuturesGetFundingHistory(ctx context.Context, symbol currency.
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesFundingRateHistory+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -830,8 +830,8 @@ func (b *Binance) GetFuturesLiquidationOrders(ctx context.Context, symbol curren
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
@@ -870,8 +870,8 @@ func (b *Binance) GetOpenInterestStats(ctx context.Context, pair, contractType, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesOpenInterestStats+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -892,8 +892,8 @@ func (b *Binance) GetTraderFuturesAccountRatio(ctx context.Context, pair, period
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesTopAccountsRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -914,8 +914,8 @@ func (b *Binance) GetTraderFuturesPositionsRatio(ctx context.Context, pair, peri
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesTopPositionsRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -936,8 +936,8 @@ func (b *Binance) GetMarketRatio(ctx context.Context, pair, period string, limit
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesLongShortRatio+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -962,8 +962,8 @@ func (b *Binance) GetFuturesTakerVolume(ctx context.Context, pair, contractType,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesBuySellVolume+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -988,8 +988,8 @@ func (b *Binance) GetFuturesBasisData(ctx context.Context, pair, contractType, p
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestCoinMargined, cfuturesBasis+params.Encode(), cFuturesDefaultRate, &resp)
 }
@@ -1253,8 +1253,8 @@ func (b *Binance) GetAllFuturesOrders(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodGet, cfuturesAllOrders, params, rateLimit, &resp)
 }
@@ -1343,8 +1343,8 @@ func (b *Binance) FuturesMarginChangeHistory(ctx context.Context, symbol currenc
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1385,8 +1385,8 @@ func (b *Binance) FuturesTradeHistory(ctx context.Context, symbol currency.Pair,
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1418,8 +1418,8 @@ func (b *Binance) FuturesIncomeHistory(ctx context.Context, symbol currency.Pair
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	if limit != 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
@@ -1458,8 +1458,8 @@ func (b *Binance) FuturesForceOrders(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestCoinMargined, http.MethodGet, cfuturesUsersForceOrders, params, cFuturesDefaultRate, &resp)
 }

--- a/exchanges/binance/binance_live_test.go
+++ b/exchanges/binance/binance_live_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 )
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -48,6 +48,18 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// getTime returns a static time for mocking endpoints, if mock is not enabled
+// this will default to time now with a window size of 30 days.
+func getTime(mockStartSeconds, mockEndSeconds int64) (start, end time.Time) {
+	if mockTests {
+		return time.Unix(mockStartSeconds, 0), time.Unix(mockEndSeconds, 0)
+	}
+
+	tn := time.Now()
+	offset := time.Hour * 24 * 30
+	return tn.Add(-offset), tn
+}
+
 func TestStart(t *testing.T) {
 	t.Parallel()
 	err := b.Start(nil)
@@ -241,7 +253,8 @@ func TestUCompressedTrades(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UCompressedTrades(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UCompressedTrades(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -253,7 +266,8 @@ func TestUKlineData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UKlineData(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UKlineData(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -277,7 +291,8 @@ func TestUGetFundingHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UGetFundingHistory(context.Background(), currency.NewPair(currency.LTC, currency.USDT), 1, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UGetFundingHistory(context.Background(), currency.NewPair(currency.LTC, currency.USDT), 1, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -319,18 +334,6 @@ func TestUSymbolOrderbookTicker(t *testing.T) {
 	}
 }
 
-func TestULiquidationOrders(t *testing.T) {
-	t.Parallel()
-	_, err := b.ULiquidationOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 0, time.Time{}, time.Time{})
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = b.ULiquidationOrders(context.Background(), currency.NewPair(currency.LTC, currency.USDT), 5, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestUOpenInterest(t *testing.T) {
 	t.Parallel()
 	_, err := b.UOpenInterest(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
@@ -345,7 +348,8 @@ func TestUOpenInterestStats(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UOpenInterestStats(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "1d", 10, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UOpenInterestStats(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "1d", 10, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -357,7 +361,8 @@ func TestUTopAcccountsLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UTopAcccountsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UTopAcccountsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -369,7 +374,8 @@ func TestUTopPostionsLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UTopPostionsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "1d", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UTopPostionsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "1d", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -381,7 +387,8 @@ func TestUGlobalLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UGlobalLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "4h", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.UGlobalLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "4h", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -389,7 +396,8 @@ func TestUGlobalLongShortRatio(t *testing.T) {
 
 func TestUTakerBuySellVol(t *testing.T) {
 	t.Parallel()
-	_, err := b.UTakerBuySellVol(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 10, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err := b.UTakerBuySellVol(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 10, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -698,7 +706,8 @@ func TestGetFundingRates(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.FundingRates(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "2", time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.FundingRates(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "2", start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -759,7 +768,8 @@ func TestGetFuturesKlineData(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = b.GetFuturesKlineData(context.Background(), currency.NewPairWithDelimiter("LTCUSD", "PERP", "_"), "5m", 5, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetFuturesKlineData(context.Background(), currency.NewPairWithDelimiter("LTCUSD", "PERP", "_"), "5m", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -771,7 +781,8 @@ func TestGetContinuousKlineData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetContinuousKlineData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetContinuousKlineData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -783,7 +794,8 @@ func TestGetIndexPriceKlines(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetIndexPriceKlines(context.Background(), "BTCUSD", "1M", 5, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetIndexPriceKlines(context.Background(), "BTCUSD", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -814,7 +826,8 @@ func TestFuturesGetFundingHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.FuturesGetFundingHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 50, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.FuturesGetFundingHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 50, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -855,18 +868,6 @@ func TestGetFuturesOrderbookTicker(t *testing.T) {
 	}
 }
 
-func TestGetFuturesLiquidationOrders(t *testing.T) {
-	t.Parallel()
-	_, err := b.GetFuturesLiquidationOrders(context.Background(), currency.EMPTYPAIR, "", 0, time.Time{}, time.Time{})
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = b.GetFuturesLiquidationOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetOpenInterest(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"))
@@ -881,7 +882,8 @@ func TestGetOpenInterestStats(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOpenInterestStats(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetOpenInterestStats(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -893,7 +895,8 @@ func TestGetTraderFuturesAccountRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTraderFuturesAccountRatio(context.Background(), "BTCUSD", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetTraderFuturesAccountRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -905,7 +908,8 @@ func TestGetTraderFuturesPositionsRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTraderFuturesPositionsRatio(context.Background(), "BTCUSD", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetTraderFuturesPositionsRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -917,7 +921,8 @@ func TestGetMarketRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetMarketRatio(context.Background(), "BTCUSD", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetMarketRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -929,7 +934,8 @@ func TestGetFuturesTakerVolume(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesTakerVolume(context.Background(), "BTCUSD", "ALL", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetFuturesTakerVolume(context.Background(), "BTCUSD", "ALL", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -941,7 +947,8 @@ func TestFuturesBasisData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesBasisData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Unix(1577836800, 0), time.Unix(1580515200, 0))
+	start, end := getTime(1577836800, 1580515200)
+	_, err = b.GetFuturesBasisData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1210,14 +1217,6 @@ func TestGetMarkPriceKline(t *testing.T) {
 	}
 }
 
-func TestGetMarginExchangeInfo(t *testing.T) {
-	t.Parallel()
-	_, err := b.GetMarginMarkets(context.Background())
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestGetExchangeInfo(t *testing.T) {
 	t.Parallel()
 	info, err := b.GetExchangeInfo(context.Background())
@@ -1278,9 +1277,10 @@ func TestGetMostRecentTrades(t *testing.T) {
 
 func TestGetHistoricalTrades(t *testing.T) {
 	t.Parallel()
-
 	_, err := b.GetHistoricalTrades(context.Background(), "BTCUSDT", 5, -1)
-	if err != nil {
+	if !mockTests && err == nil {
+		t.Errorf("Binance GetHistoricalTrades() error: %v", "expected error")
+	} else if mockTests && err != nil {
 		t.Errorf("Binance GetHistoricalTrades() error: %v", err)
 	}
 }
@@ -1299,13 +1299,14 @@ func TestGetAggregatedTrades(t *testing.T) {
 
 func TestGetSpotKline(t *testing.T) {
 	t.Parallel()
+	start, end := getTime(1577836800, 1580515200)
 	_, err := b.GetSpotKline(context.Background(),
 		&KlinesRequestParams{
 			Symbol:    currency.NewPair(currency.BTC, currency.USDT),
 			Interval:  kline.FiveMin.Short(),
 			Limit:     24,
-			StartTime: time.Unix(1577836800, 0),
-			EndTime:   time.Unix(1580515200, 0),
+			StartTime: start,
+			EndTime:   end,
 		})
 	if err != nil {
 		t.Error("Binance GetSpotKline() error", err)

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -50,7 +50,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // getTime returns a static time for mocking endpoints, if mock is not enabled
 // this will default to time now with a window size of 30 days.
-// Mock details are unix seconds; start = 1580515200 and end = 1580515200
+// Mock details are unix seconds; start = 1577836800 and end = 1580515200
 func getTime() (start, end time.Time) {
 	if mockTests {
 		return time.Unix(1577836800, 0), time.Unix(1580515200, 0)

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -50,9 +50,10 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // getTime returns a static time for mocking endpoints, if mock is not enabled
 // this will default to time now with a window size of 30 days.
-func getTime(mockStartSeconds, mockEndSeconds int64) (start, end time.Time) {
+// Mock details are unix seconds; start = 1580515200 and end = 1580515200
+func getTime() (start, end time.Time) {
 	if mockTests {
-		return time.Unix(mockStartSeconds, 0), time.Unix(mockEndSeconds, 0)
+		return time.Unix(1577836800, 0), time.Unix(1580515200, 0)
 	}
 
 	tn := time.Now()
@@ -253,7 +254,7 @@ func TestUCompressedTrades(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UCompressedTrades(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -266,7 +267,7 @@ func TestUKlineData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UKlineData(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -291,7 +292,7 @@ func TestUGetFundingHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UGetFundingHistory(context.Background(), currency.NewPair(currency.LTC, currency.USDT), 1, start, end)
 	if err != nil {
 		t.Error(err)
@@ -348,7 +349,7 @@ func TestUOpenInterestStats(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UOpenInterestStats(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "1d", 10, start, end)
 	if err != nil {
 		t.Error(err)
@@ -361,7 +362,7 @@ func TestUTopAcccountsLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UTopAcccountsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, start, end)
 	if err != nil {
 		t.Error(err)
@@ -374,7 +375,7 @@ func TestUTopPostionsLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UTopPostionsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "1d", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -387,7 +388,7 @@ func TestUGlobalLongShortRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.UGlobalLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "4h", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -396,7 +397,7 @@ func TestUGlobalLongShortRatio(t *testing.T) {
 
 func TestUTakerBuySellVol(t *testing.T) {
 	t.Parallel()
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err := b.UTakerBuySellVol(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 10, start, end)
 	if err != nil {
 		t.Error(err)
@@ -706,7 +707,7 @@ func TestGetFundingRates(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.FundingRates(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "2", start, end)
 	if err != nil {
 		t.Error(err)
@@ -768,7 +769,7 @@ func TestGetFuturesKlineData(t *testing.T) {
 		t.Error(err)
 	}
 
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetFuturesKlineData(context.Background(), currency.NewPairWithDelimiter("LTCUSD", "PERP", "_"), "5m", 5, start, end)
 	if err != nil {
 		t.Error(err)
@@ -781,7 +782,7 @@ func TestGetContinuousKlineData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetContinuousKlineData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
@@ -794,7 +795,7 @@ func TestGetIndexPriceKlines(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetIndexPriceKlines(context.Background(), "BTCUSD", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
@@ -826,7 +827,7 @@ func TestFuturesGetFundingHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.FuturesGetFundingHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 50, start, end)
 	if err != nil {
 		t.Error(err)
@@ -882,7 +883,7 @@ func TestGetOpenInterestStats(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetOpenInterestStats(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -895,7 +896,7 @@ func TestGetTraderFuturesAccountRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetTraderFuturesAccountRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -908,7 +909,7 @@ func TestGetTraderFuturesPositionsRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetTraderFuturesPositionsRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -921,7 +922,7 @@ func TestGetMarketRatio(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetMarketRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -934,7 +935,7 @@ func TestGetFuturesTakerVolume(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetFuturesTakerVolume(context.Background(), "BTCUSD", "ALL", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -947,7 +948,7 @@ func TestFuturesBasisData(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err = b.GetFuturesBasisData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
@@ -1299,7 +1300,7 @@ func TestGetAggregatedTrades(t *testing.T) {
 
 func TestGetSpotKline(t *testing.T) {
 	t.Parallel()
-	start, end := getTime(1577836800, 1580515200)
+	start, end := getTime()
 	_, err := b.GetSpotKline(context.Background(),
 		&KlinesRequestParams{
 			Symbol:    currency.NewPair(currency.BTC, currency.USDT),

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -33,7 +33,6 @@ const (
 	ufuturesTickerPriceStats   = "/fapi/v1/ticker/24hr?"
 	ufuturesSymbolPriceTicker  = "/fapi/v1/ticker/price?"
 	ufuturesSymbolOrderbook    = "/fapi/v1/ticker/bookTicker?"
-	ufuturesLiquidationOrders  = "/fapi/v1/allForceOrders?"
 	ufuturesOpenInterest       = "/fapi/v1/openInterest?"
 	ufuturesOpenInterestStats  = "/futures/data/openInterestHist?"
 	ufuturesTopAccountsRatio   = "/futures/data/topLongShortAccountRatio?"
@@ -463,32 +462,6 @@ func (b *Binance) USymbolOrderbookTicker(ctx context.Context, symbol currency.Pa
 	var resp []USymbolOrderbookTicker
 	err := b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesTickerPriceStats+params.Encode(), uFuturesOrderbookTickerAllRate, &resp)
 	return resp, err
-}
-
-// ULiquidationOrders gets public liquidation orders
-func (b *Binance) ULiquidationOrders(ctx context.Context, symbol currency.Pair, limit int64, startTime, endTime time.Time) ([]ULiquidationOrdersData, error) {
-	var resp []ULiquidationOrdersData
-	params := url.Values{}
-	rateLimit := uFuturesAllForceOrdersRate
-	if !symbol.IsEmpty() {
-		rateLimit = uFuturesCurrencyForceOrdersRate
-		symbolValue, err := b.FormatSymbol(symbol, asset.USDTMarginedFutures)
-		if err != nil {
-			return resp, err
-		}
-		params.Set("symbol", symbolValue)
-	}
-	if limit > 0 && limit < 1000 {
-		params.Set("limit", strconv.FormatInt(limit, 10))
-	}
-	if !startTime.IsZero() && !endTime.IsZero() {
-		if startTime.After(endTime) {
-			return resp, errors.New("startTime cannot be after endTime")
-		}
-		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
-	}
-	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
 
 // UOpenInterest gets open interest data for USDTMarginedFutures

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -212,8 +212,8 @@ func (b *Binance) UCompressedTrades(ctx context.Context, symbol currency.Pair, f
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesCompressedTrades+params.Encode(), uFuturesHistoricalTradesRate, &resp)
 }
@@ -396,8 +396,8 @@ func (b *Binance) UGetFundingHistory(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesFundingRateHistory+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -485,8 +485,8 @@ func (b *Binance) ULiquidationOrders(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
@@ -523,8 +523,8 @@ func (b *Binance) UOpenInterestStats(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesOpenInterestStats+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -549,8 +549,8 @@ func (b *Binance) UTopAcccountsLongShortRatio(ctx context.Context, symbol curren
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesTopAccountsRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -575,8 +575,8 @@ func (b *Binance) UTopPostionsLongShortRatio(ctx context.Context, symbol currenc
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesTopPositionsRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -601,8 +601,8 @@ func (b *Binance) UGlobalLongShortRatio(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesLongShortRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -627,8 +627,8 @@ func (b *Binance) UTakerBuySellVol(ctx context.Context, symbol currency.Pair, pe
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesBuySellVolume+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -895,8 +895,8 @@ func (b *Binance) UAllAccountOrders(ctx context.Context, symbol currency.Pair, o
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesAllOrders, params, uFuturesGetAllOrdersRate, &resp)
 }
@@ -988,8 +988,8 @@ func (b *Binance) UPositionMarginChangeHistory(ctx context.Context, symbol curre
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesMarginChangeHistory, params, uFuturesDefaultRate, &resp)
 }
@@ -1027,8 +1027,8 @@ func (b *Binance) UAccountTradesHistory(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesAccountTradeList, params, uFuturesAccountInformationRate, &resp)
 }
@@ -1055,8 +1055,8 @@ func (b *Binance) UAccountIncomeHistory(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesIncomeHistory, params, uFuturesIncomeHistoryRate, &resp)
 }
@@ -1115,8 +1115,8 @@ func (b *Binance) UAccountForcedOrders(ctx context.Context, symbol currency.Pair
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("start_time", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("end_time", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesUsersForceOrders, params, rateLimit, &resp)
 }

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -212,8 +212,8 @@ func (b *Binance) UCompressedTrades(ctx context.Context, symbol currency.Pair, f
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesCompressedTrades+params.Encode(), uFuturesHistoricalTradesRate, &resp)
 }
@@ -396,8 +396,8 @@ func (b *Binance) UGetFundingHistory(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesFundingRateHistory+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -485,8 +485,8 @@ func (b *Binance) ULiquidationOrders(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesLiquidationOrders+params.Encode(), rateLimit, &resp)
 }
@@ -523,8 +523,8 @@ func (b *Binance) UOpenInterestStats(ctx context.Context, symbol currency.Pair, 
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesOpenInterestStats+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -549,8 +549,8 @@ func (b *Binance) UTopAcccountsLongShortRatio(ctx context.Context, symbol curren
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesTopAccountsRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -575,8 +575,8 @@ func (b *Binance) UTopPostionsLongShortRatio(ctx context.Context, symbol currenc
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesTopPositionsRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -601,8 +601,8 @@ func (b *Binance) UGlobalLongShortRatio(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesLongShortRatio+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -627,8 +627,8 @@ func (b *Binance) UTakerBuySellVol(ctx context.Context, symbol currency.Pair, pe
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesBuySellVolume+params.Encode(), uFuturesDefaultRate, &resp)
 }
@@ -895,8 +895,8 @@ func (b *Binance) UAllAccountOrders(ctx context.Context, symbol currency.Pair, o
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesAllOrders, params, uFuturesGetAllOrdersRate, &resp)
 }
@@ -988,8 +988,8 @@ func (b *Binance) UPositionMarginChangeHistory(ctx context.Context, symbol curre
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesMarginChangeHistory, params, uFuturesDefaultRate, &resp)
 }
@@ -1027,8 +1027,8 @@ func (b *Binance) UAccountTradesHistory(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesAccountTradeList, params, uFuturesAccountInformationRate, &resp)
 }
@@ -1055,8 +1055,8 @@ func (b *Binance) UAccountIncomeHistory(ctx context.Context, symbol currency.Pai
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesIncomeHistory, params, uFuturesIncomeHistoryRate, &resp)
 }
@@ -1115,8 +1115,8 @@ func (b *Binance) UAccountForcedOrders(ctx context.Context, symbol currency.Pair
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
-		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendAuthHTTPRequest(ctx, exchange.RestUSDTMargined, http.MethodGet, ufuturesUsersForceOrders, params, rateLimit, &resp)
 }
@@ -1140,10 +1140,10 @@ func (b *Binance) FundingRates(ctx context.Context, symbol currency.Pair, limit 
 		params.Set("limit", limit)
 	}
 	if !startTime.IsZero() {
-		params.Set("startTime", strconv.FormatInt(startTime.UnixNano(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
 	}
 	if !endTime.IsZero() {
-		params.Set("endTime", strconv.FormatInt(endTime.UnixNano(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	return resp, b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, fundingRate+params.Encode(), uFuturesDefaultRate, &resp)
 }


### PR DESCRIPTION
# PR Description

`time.UTC().Unix()` -> `time.UTC().UnixMilli()`

ALSO: Sets correct outbound start and end time strings for USDT and coin margined futures

Fixes #1038

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] tested endpoint

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
