### PR TITLE
ftx: fix null currency.Pair UnmarshalJSON

### DIFF
--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -34,6 +34,11 @@ func (p *Pair) UnmarshalJSON(d []byte) error {
 		return err
 	}
 
+	if pair == "" {
+		*p = EMPTYPAIR
+		return nil
+	}
+
 	newPair, err := NewPairFromString(pair)
 	if err != nil {
 		return err

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -72,6 +72,9 @@ func TestPairUnmarshalJSON(t *testing.T) {
 	}
 
 	encoded, err = json.Marshal(EMPTYPAIR)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = json.Unmarshal(encoded, &unmarshalHere)
 	if err != nil {
 		t.Fatal("Pair UnmarshalJSON() error", err)

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -70,6 +70,19 @@ func TestPairUnmarshalJSON(t *testing.T) {
 		t.Errorf("Pairs UnmarshalJSON() error expected %s but received %s",
 			configPair, unmarshalHere)
 	}
+
+	encoded, err = json.Marshal(EMPTYPAIR)
+	err = json.Unmarshal(encoded, &unmarshalHere)
+	if err != nil {
+		t.Fatal("Pair UnmarshalJSON() error", err)
+	}
+	err = json.Unmarshal([]byte("null"), &unmarshalHere)
+	if err != nil {
+		t.Fatal("Pair UnmarshalJSON() error", err)
+	}
+	if unmarshalHere != EMPTYPAIR {
+		t.Fatalf("Expected EMPTPAIR got: %s", unmarshalHere)
+	}
 }
 
 func TestPairMarshalJSON(t *testing.T) {

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -84,7 +84,7 @@ func TestPairUnmarshalJSON(t *testing.T) {
 		t.Fatal("Pair UnmarshalJSON() error", err)
 	}
 	if unmarshalHere != EMPTYPAIR {
-		t.Fatalf("Expected EMPTPAIR got: %s", unmarshalHere)
+		t.Fatalf("Expected EMPTYPAIR got: %s", unmarshalHere)
 	}
 }
 


### PR DESCRIPTION
# PR Description

I'm not sure this is the best place for this fix, but with FTX on some submit order calls (spot, with IOC), the returned data includes both `market` with the asset pair and `future` with `null`.

The `null` ends up in currency pair `UnmarshalJSON` resulting in an error for a successful SubmitOrder call.
I am not entirely sure if this will be a breaking change

If this looks ok at face value I'm happy to add some unit tests[

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
