### PR TITLE
websocket: fix shutdown deadlock

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -568,6 +568,7 @@ func (w *Websocket) trafficMonitor() {
 						w.trafficTimeout)
 				}
 				trafficTimer.Stop()
+				w.Wg.Done() // without this the w.Shutdown() call below will deadlock
 				if !w.IsConnecting() && w.IsConnected() {
 					err := w.Shutdown()
 					if err != nil {
@@ -577,7 +578,6 @@ func (w *Websocket) trafficMonitor() {
 					}
 				}
 				w.setTrafficMonitorRunning(false)
-				w.Wg.Done()
 				return
 			}
 

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -568,8 +568,8 @@ func (w *Websocket) trafficMonitor() {
 						w.trafficTimeout)
 				}
 				trafficTimer.Stop()
-				w.Wg.Done() // without this the w.Shutdown() call below will deadlock
 				w.setTrafficMonitorRunning(false)
+				w.Wg.Done() // without this the w.Shutdown() call below will deadlock
 				if !w.IsConnecting() && w.IsConnected() {
 					err := w.Shutdown()
 					if err != nil {

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -569,6 +569,7 @@ func (w *Websocket) trafficMonitor() {
 				}
 				trafficTimer.Stop()
 				w.Wg.Done() // without this the w.Shutdown() call below will deadlock
+				w.setTrafficMonitorRunning(false)
 				if !w.IsConnecting() && w.IsConnected() {
 					err := w.Shutdown()
 					if err != nil {
@@ -577,7 +578,7 @@ func (w *Websocket) trafficMonitor() {
 							w.exchangeName, err)
 					}
 				}
-				w.setTrafficMonitorRunning(false)
+
 				return
 			}
 


### PR DESCRIPTION
# PR Description

I've been noticing some reconnection issues and tracking it down, it looks like there's a condition that causes deadlock during websocket shutdown. 

Since this is in the traffic monitor which doesn't seem to be doing anything other than monitoring for traffic this seems fairly safe to do.

Not sure how to write a reliable unit test.

might be the fix for #901, #761 and possibly #683 as the issues are all similar to what I was noticing in my logs

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
