### PR TITLE
Kraken: use configured endpoint for futures

### DIFF
--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -25,8 +25,7 @@ import (
 
 const (
 	krakenAPIURL         = "https://api.kraken.com"
-	krakenFuturesURL     = "https://futures.kraken.com"
-	futuresURL           = "https://futures.kraken.com/derivatives"
+	krakenFuturesURL     = "https://futures.kraken.com/derivatives"
 	krakenSpotVersion    = "0"
 	krakenFuturesVersion = "3"
 )

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -316,7 +316,8 @@ func (k *Kraken) SendFuturesAuthRequest(ctx context.Context, method, path string
 			"Nonce":   nonce,
 		}
 
-		url, err := k.API.Endpoints.GetURL(exchange.RestFutures)
+		var url string
+		url, err = k.API.Endpoints.GetURL(exchange.RestFutures)
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -316,15 +316,15 @@ func (k *Kraken) SendFuturesAuthRequest(ctx context.Context, method, path string
 			"Nonce":   nonce,
 		}
 
-		var url string
-		url, err = k.API.Endpoints.GetURL(exchange.RestFutures)
+		var futuresURL string
+		futuresURL, err = k.API.Endpoints.GetURL(exchange.RestFutures)
 		if err != nil {
 			return nil, err
 		}
 
 		return &request.Item{
 			Method:        method,
-			Path:          url + common.EncodeURLValues(path, data),
+			Path:          futuresURL + common.EncodeURLValues(path, data),
 			Headers:       headers,
 			Result:        &interim,
 			AuthRequest:   true,

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -316,9 +316,14 @@ func (k *Kraken) SendFuturesAuthRequest(ctx context.Context, method, path string
 			"Nonce":   nonce,
 		}
 
+		url, err := k.API.Endpoints.GetURL(exchange.RestFutures)
+		if err != nil {
+			return nil, err
+		}
+
 		return &request.Item{
 			Method:        method,
-			Path:          futuresURL + common.EncodeURLValues(path, data),
+			Path:          url + common.EncodeURLValues(path, data),
 			Headers:       headers,
 			Result:        &interim,
 			AuthRequest:   true,

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -182,7 +182,7 @@ func (k *Kraken) SetDefaults() {
 	k.API.Endpoints = k.NewEndpoints()
 	err = k.API.Endpoints.SetDefaultEndpoints(map[exchange.URL]string{
 		exchange.RestSpot:      krakenAPIURL,
-		exchange.RestFutures:   futuresURL,
+		exchange.RestFutures:   krakenFuturesURL,
 		exchange.WebsocketSpot: krakenWSURL,
 	})
 	if err != nil {


### PR DESCRIPTION
# PR Description

👋 

Another small fix. Kraken futures doesn't use the configured url right now. This PR fixes it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Manually in verbose mode

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
