### PR TITLE
requester: Remove httpclient.Do errors from latency measurement

### DIFF
--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -165,7 +165,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 
 		resp, err := r._HTTPClient.do(req)
 
-		if r.reporter != nil && err != nil {
+		if r.reporter != nil && err == nil {
 			r.reporter.Latency(r.name, p.Method, p.Path, time.Since(start))
 		}
 

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -165,7 +165,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 
 		resp, err := r._HTTPClient.do(req)
 
-		if r.reporter != nil {
+		if r.reporter != nil && err != nil {
 			r.reporter.Latency(r.name, p.Method, p.Path, time.Since(start))
 		}
 


### PR DESCRIPTION
# PR Description

When http client.Do fails I don't think it makes sense to measure latency since this is due to things like connectivity issues rather than measuring the latency of the request-response cycle.

I thought about passing around the resp/err to the Latency call to let this be checked down the line, but ultimately I don't really see a use case for it as the error is passed down the line anyway. 

Happy to hear differing opinions.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Manually by closing device connection

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
