### PR TITLE
CoinbasePro: Fix funds parameter for market orders

### DIFF
--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -490,11 +490,12 @@ func areTestAPIKeysSet() bool {
 	return c.ValidateAPICredentials(c.GetDefaultCredentials()) == nil
 }
 
-func TestSubmitLimitOrder(t *testing.T) {
+func TestSubmitOrder(t *testing.T) {
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
+	// limit order
 	var orderSubmission = &order.Submit{
 		Exchange: c.Name,
 		Pair: currency.Pair{
@@ -515,13 +516,9 @@ func TestSubmitLimitOrder(t *testing.T) {
 	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
-}
-func TestSubmitMarketOrderFromAmount(t *testing.T) {
-	if areTestAPIKeysSet() && !canManipulateRealOrders {
-		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
-	}
 
-	var orderSubmission = &order.Submit{
+	// market order from amount
+	orderSubmission = &order.Submit{
 		Exchange: c.Name,
 		Pair: currency.Pair{
 			Delimiter: "-",
@@ -534,20 +531,15 @@ func TestSubmitMarketOrderFromAmount(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	response, err = c.SubmitOrder(context.Background(), orderSubmission)
 	if areTestAPIKeysSet() && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
-}
 
-func TestSubmitMarketOrderFromQuoteAmount(t *testing.T) {
-	if areTestAPIKeysSet() && !canManipulateRealOrders {
-		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
-	}
-
-	var orderSubmission = &order.Submit{
+	// market order from quote amount
+	orderSubmission = &order.Submit{
 		Exchange: c.Name,
 		Pair: currency.Pair{
 			Delimiter: "-",
@@ -560,7 +552,7 @@ func TestSubmitMarketOrderFromQuoteAmount(t *testing.T) {
 		ClientID:    "meowOrder",
 		AssetType:   asset.Spot,
 	}
-	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	response, err = c.SubmitOrder(context.Background(), orderSubmission)
 	if areTestAPIKeysSet() && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !areTestAPIKeysSet() && err == nil {

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -490,7 +490,7 @@ func areTestAPIKeysSet() bool {
 	return c.ValidateAPICredentials(c.GetDefaultCredentials()) == nil
 }
 
-func TestSubmitOrder(t *testing.T) {
+func TestSubmitLimitOrder(t *testing.T) {
 	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
@@ -505,9 +505,60 @@ func TestSubmitOrder(t *testing.T) {
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
-		Amount:    1,
+		Amount:    0.001,
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
+	}
+	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	if areTestAPIKeysSet() && (err != nil || response.Status != order.New) {
+		t.Errorf("Order failed to be placed: %v", err)
+	} else if !areTestAPIKeysSet() && err == nil {
+		t.Error("Expecting an error when no keys are set")
+	}
+}
+func TestSubmitMarketOrderFromAmount(t *testing.T) {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	var orderSubmission = &order.Submit{
+		Exchange: c.Name,
+		Pair: currency.Pair{
+			Delimiter: "-",
+			Base:      currency.BTC,
+			Quote:     currency.USD,
+		},
+		Side:      order.Buy,
+		Type:      order.Market,
+		Amount:    0.001,
+		ClientID:  "meowOrder",
+		AssetType: asset.Spot,
+	}
+	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	if areTestAPIKeysSet() && (err != nil || response.Status != order.New) {
+		t.Errorf("Order failed to be placed: %v", err)
+	} else if !areTestAPIKeysSet() && err == nil {
+		t.Error("Expecting an error when no keys are set")
+	}
+}
+
+func TestSubmitMarketOrderFromQuoteAmount(t *testing.T) {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	var orderSubmission = &order.Submit{
+		Exchange: c.Name,
+		Pair: currency.Pair{
+			Delimiter: "-",
+			Base:      currency.BTC,
+			Quote:     currency.USD,
+		},
+		Side:        order.Buy,
+		Type:        order.Market,
+		QuoteAmount: 1,
+		ClientID:    "meowOrder",
+		AssetType:   asset.Spot,
 	}
 	response, err := c.SubmitOrder(context.Background(), orderSubmission)
 	if areTestAPIKeysSet() && (err != nil || response.Status != order.New) {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -549,7 +549,7 @@ func (c *CoinbasePro) SubmitOrder(ctx context.Context, s *order.Submit) (*order.
 		orderID, err = c.PlaceMarketOrder(ctx,
 			"",
 			s.Amount,
-			s.Amount,
+			s.QuoteAmount,
 			s.Side.Lower(),
 			fpair.String(),
 			"")


### PR DESCRIPTION
# PR Description

This PR fixes an issue when placing Market orders with the CoinbasePro wrapper interface.

To trigger this issue the Submit struct needs to look like this:

```
gctPair, err := currency.NewPairFromString(pair.Symbol)
if err != nil {
    // ...
}
submit := order.Submit{
    Exchange:  "coinbasepro",
    Amount:    0.001,
    Type:      order.Market,
    Side:      order.Buy,
    AssetType: asset.Spot,
    Pair:      gctPair,
}
resp, err := e.SubmitOrder(ctx, &submit)
```

The code was passing `Amount` both as `size` and `funds` parameters. These two parameters are optional (one of them must be provided) but have different units. The exchange complained about the precision of "funds" being too accurate, while only the size should have been set.

Error:

`CoinbasePro unsuccessful HTTP status code: 400 raw response: {\"message\":\"funds is too accurate. Smallest unit is 0.01\"}`

Looking at the Submit struct and the code that uses it, it looks like the intended source for `funds` should be `QuoteAmount`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Tested the fix from an external project that imports gocryptotrader's coinbasepro interface and uses it standalone. Tested against coinbasepro production server.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
