### PR TITLE
engine: filter and warning for empty string when syncing all deposit addresses

### DIFF
--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -743,7 +743,7 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 						}
 						for z := range availChains {
 							if availChains[z] == "" {
-								log.Warnf(log.Global, "%s %s. Available transfer chain is populated with an empty string\n",
+								log.Warnf(log.Global, "%s %s available transfer chain is populated with an empty string\n",
 									exchName,
 									cryptocurrency)
 								continue

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -742,6 +742,13 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 							depositAddrs = append(depositAddrs, *depositAddr)
 						}
 						for z := range availChains {
+							if availChains[z] == "" {
+								log.Warnf(log.Global, "%s %s. Err: Available transfer chain is populated with an empty string\n",
+									exchName,
+									cryptocurrency)
+								continue
+							}
+
 							depositAddr, err := exch.GetDepositAddress(context.TODO(), currency.NewCode(cryptocurrency), "", availChains[z])
 							if err != nil {
 								log.Errorf(log.Global, "%s failed to get cryptocurrency deposit address for %s [chain %s]. Err: %s\n",

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -743,7 +743,7 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 						}
 						for z := range availChains {
 							if availChains[z] == "" {
-								log.Warnf(log.Global, "%s %s. Err: Available transfer chain is populated with an empty string\n",
+								log.Warnf(log.Global, "%s %s. Available transfer chain is populated with an empty string\n",
 									exchName,
 									cryptocurrency)
 								continue

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -1029,7 +1029,7 @@ func (f fakeDepositExchange) GetAvailableTransferChains(_ context.Context, c cur
 		return nil, nil
 	}
 	if c.Equal(currency.USDT) {
-		return []string{"sol", "btc", "usdt"}, nil
+		return []string{"sol", "btc", "usdt", ""}, nil
 	}
 	return []string{"BITCOIN"}, nil
 }


### PR DESCRIPTION

# PR Description

Going over a PR empty string were being inserted by accident this attempts to bypass and alert improper potential implementation. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
