### PR TITLE
asset: Rename option to options

### DIFF
--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -34,10 +34,10 @@ const (
 	CoinMarginedFutures
 	USDTMarginedFutures
 	USDCMarginedFutures
-	Option
+	Options
 
 	futuresFlag   = PerpetualContract | PerpetualSwap | Futures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures
-	supportedFlag = Spot | Margin | MarginFunding | Index | Binary | PerpetualContract | PerpetualSwap | Futures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | Option
+	supportedFlag = Spot | Margin | MarginFunding | Index | Binary | PerpetualContract | PerpetualSwap | Futures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | Options
 
 	spot                   = "spot"
 	margin                 = "margin"
@@ -52,11 +52,11 @@ const (
 	coinMarginedFutures    = "coinmarginedfutures"
 	usdtMarginedFutures    = "usdtmarginedfutures"
 	usdcMarginedFutures    = "usdcmarginedfutures"
-	option                 = "option"
+	options                = "options"
 )
 
 var (
-	supportedList = Items{Spot, Margin, MarginFunding, Index, Binary, PerpetualContract, PerpetualSwap, Futures, UpsideProfitContract, DownsideProfitContract, CoinMarginedFutures, USDTMarginedFutures, USDCMarginedFutures, Option}
+	supportedList = Items{Spot, Margin, MarginFunding, Index, Binary, PerpetualContract, PerpetualSwap, Futures, UpsideProfitContract, DownsideProfitContract, CoinMarginedFutures, USDTMarginedFutures, USDCMarginedFutures, Options}
 )
 
 // Supported returns a list of supported asset types
@@ -93,8 +93,8 @@ func (a Item) String() string {
 		return usdtMarginedFutures
 	case USDCMarginedFutures:
 		return usdcMarginedFutures
-	case Option:
-		return option
+	case Options:
+		return options
 	default:
 		return ""
 	}
@@ -190,8 +190,8 @@ func New(input string) (Item, error) {
 		return USDTMarginedFutures, nil
 	case usdcMarginedFutures:
 		return USDCMarginedFutures, nil
-	case option:
-		return Option, nil
+	case options, "option":
+		return Options, nil
 	default:
 		return 0, fmt.Errorf("%w '%v', only supports %s",
 			ErrNotSupported,

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -4290,10 +4290,11 @@ func (ok *Okx) GuessAssetTypeFromInstrumentID(instrumentID string) (asset.Item, 
 	if strings.HasSuffix(instrumentID, okxInstTypeSwap) {
 		return asset.PerpetualSwap, nil
 	}
+	count := strings.Count(instrumentID, currency.DashDelimiter)
 	switch {
-	case strings.Count(instrumentID, currency.DashDelimiter) >= 3:
+	case count >= 3:
 		return asset.Options, nil
-	case strings.Count(instrumentID, currency.DashDelimiter) == 2:
+	case count == 2:
 		return asset.Futures, nil
 	default:
 		pair, err := currency.NewPairFromString(instrumentID)

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -3026,10 +3026,14 @@ func (ok *Okx) GetIndexTickers(ctx context.Context, quoteCurrency, instID string
 
 // GetInstrumentTypeFromAssetItem returns a string representation of asset.Item; which is an equivalent term for InstrumentType in Okx exchange.
 func (ok *Okx) GetInstrumentTypeFromAssetItem(assetType asset.Item) string {
-	if assetType == asset.PerpetualSwap {
+	switch assetType {
+	case asset.PerpetualSwap:
 		return okxInstTypeSwap
+	case asset.Options:
+		return okxInstTypeOption
+	default:
+		return assetType.String()
 	}
-	return assetType.String()
 }
 
 // GetUnderlying returns the instrument ID for the corresponding asset pairs and asset type( Instrument Type )
@@ -4274,14 +4278,6 @@ func GetAssetTypeFromInstrumentType(instrumentType string) (asset.Item, error) {
 	switch strings.ToUpper(instrumentType) {
 	case okxInstTypeSwap, okxInstTypeContract:
 		return asset.PerpetualSwap, nil
-	case okxInstTypeSpot:
-		return asset.Spot, nil
-	case okxInstTypeFutures:
-		return asset.Futures, nil
-	case okxInstTypeOption:
-		return asset.Option, nil
-	case okxInstTypeMargin:
-		return asset.Margin, nil
 	case okxInstTypeANY:
 		return asset.Empty, nil
 	default:
@@ -4297,7 +4293,7 @@ func (ok *Okx) GuessAssetTypeFromInstrumentID(instrumentID string) (asset.Item, 
 	filter := strings.Split(instrumentID, currency.DashDelimiter)
 	switch {
 	case len(filter) >= 4:
-		return asset.Option, nil
+		return asset.Options, nil
 	case len(filter) == 3:
 		return asset.Futures, nil
 	default:

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -4290,11 +4290,10 @@ func (ok *Okx) GuessAssetTypeFromInstrumentID(instrumentID string) (asset.Item, 
 	if strings.HasSuffix(instrumentID, okxInstTypeSwap) {
 		return asset.PerpetualSwap, nil
 	}
-	filter := strings.Split(instrumentID, currency.DashDelimiter)
 	switch {
-	case len(filter) >= 4:
+	case strings.Count(instrumentID, currency.DashDelimiter) >= 3:
 		return asset.Options, nil
-	case len(filter) == 3:
+	case strings.Count(instrumentID, currency.DashDelimiter) == 2:
 		return asset.Futures, nil
 	default:
 		pair, err := currency.NewPairFromString(instrumentID)

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -1967,7 +1967,7 @@ func TestSystemStatusResponse(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	if _, err := ok.FetchTradablePairs(context.Background(), asset.Option); err != nil {
+	if _, err := ok.FetchTradablePairs(context.Background(), asset.Options); err != nil {
 		t.Error("Okx FetchTradablePairs() error", err)
 	}
 }
@@ -2845,10 +2845,10 @@ func TestPublicStructureBlockTradesSubscription(t *testing.T) {
 }
 func TestBlockTickerSubscription(t *testing.T) {
 	t.Parallel()
-	if err := ok.BlockTickerSubscription("subscribe", asset.Option, currency.NewPair(currency.BTC, currency.USDT)); err != nil {
+	if err := ok.BlockTickerSubscription("subscribe", asset.Options, currency.NewPair(currency.BTC, currency.USDT)); err != nil {
 		t.Errorf("%s BlockTickerSubscription() error: %v", ok.Name, err)
 	}
-	if err := ok.BlockTickerSubscription("unsubscribe", asset.Option, currency.NewPair(currency.BTC, currency.USDT)); err != nil {
+	if err := ok.BlockTickerSubscription("unsubscribe", asset.Options, currency.NewPair(currency.BTC, currency.USDT)); err != nil {
 		t.Errorf("%s BlockTickerSubscription() error: %v", ok.Name, err)
 	}
 }
@@ -2980,7 +2980,7 @@ func TestWsPositionChannel(t *testing.T) {
 	if !areTestAPIKeysSet() {
 		t.SkipNow()
 	}
-	if err := ok.WsPositionChannel("subscribe", asset.Option, currency.NewPair(currency.USD, currency.BTC)); err != nil {
+	if err := ok.WsPositionChannel("subscribe", asset.Options, currency.NewPair(currency.USD, currency.BTC)); err != nil {
 		t.Errorf("%s WsPositionChannel() error : %v", ok.Name, err)
 	}
 }

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3170,3 +3170,23 @@ func TestGetAvailableTransferChains(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGuessAssetTypeFromInstrumentID(t *testing.T) {
+	t.Parallel()
+	ass, err := ok.GuessAssetTypeFromInstrumentID("BTC-USD-220930-28000-P")
+	if err != nil {
+		t.Error(err)
+	} else if ass != asset.Options {
+		t.Error("unexpected result")
+	}
+	if ass, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-221007"); err != nil {
+		t.Error(err)
+	} else if ass != asset.Futures {
+		t.Error("unexpected result")
+	}
+	if ass, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-SWAP"); err != nil {
+		t.Error(err)
+	} else if ass != asset.PerpetualSwap {
+		t.Error("unexpected result")
+	}
+}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3173,20 +3173,20 @@ func TestGetAvailableTransferChains(t *testing.T) {
 
 func TestGuessAssetTypeFromInstrumentID(t *testing.T) {
 	t.Parallel()
-	ass, err := ok.GuessAssetTypeFromInstrumentID("BTC-USD-220930-28000-P")
+	a, err := ok.GuessAssetTypeFromInstrumentID("BTC-USD-220930-28000-P")
 	if err != nil {
 		t.Error(err)
-	} else if ass != asset.Options {
+	} else if a != asset.Options {
 		t.Error("unexpected result")
 	}
-	if ass, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-221007"); err != nil {
+	if a, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-221007"); err != nil {
 		t.Error(err)
-	} else if ass != asset.Futures {
+	} else if a != asset.Futures {
 		t.Error("unexpected result")
 	}
-	if ass, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-SWAP"); err != nil {
+	if a, err = ok.GuessAssetTypeFromInstrumentID("BTC-USD-SWAP"); err != nil {
 		t.Error(err)
-	} else if ass != asset.PerpetualSwap {
+	} else if a != asset.PerpetualSwap {
 		t.Error("unexpected result")
 	}
 }

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -688,7 +688,7 @@ type OrderDetail struct {
 
 // OrderListRequestParams represents order list requesting parameters.
 type OrderListRequestParams struct {
-	InstrumentType string    `json:"instType"` // SPOT , MARGIN, SWAP, FUTURES , option
+	InstrumentType string    `json:"instType"` // SPOT , MARGIN, SWAP, FUTURES , OPTIONS
 	Underlying     string    `json:"uly"`
 	InstrumentID   string    `json:"instId"`
 	OrderType      string    `json:"orderType"`

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1185,7 +1185,7 @@ func (ok *Okx) wsProcessTickers(data []byte) error {
 		case asset.Spot, asset.Margin:
 			baseVolume = response.Data[i].Vol24H.Float64()
 			quoteVolume = response.Data[i].VolCcy24H.Float64()
-		case asset.PerpetualSwap, asset.Futures, asset.Option:
+		case asset.PerpetualSwap, asset.Futures, asset.Options:
 			baseVolume = response.Data[i].VolCcy24H.Float64()
 			quoteVolume = response.Data[i].Vol24H.Float64()
 		default:
@@ -1931,7 +1931,7 @@ func (ok *Okx) TickersSubscription(operation string, assetType asset.Item, pair 
 
 // OpenInterestSubscription to subscribe or unsubscribe to "open-interest" channel to retrieve the open interest. Data will by pushed every 3 seconds.
 func (ok *Okx) OpenInterestSubscription(operation string, assetType asset.Item, pair currency.Pair) error {
-	if assetType != asset.Futures && assetType != asset.Option && assetType != asset.PerpetualSwap {
+	if assetType != asset.Futures && assetType != asset.Options && assetType != asset.PerpetualSwap {
 		return fmt.Errorf("%w, only FUTURES, SWAP and OPTION asset types are supported", errInvalidInstrumentType)
 	}
 	return ok.wsChannelSubscription(operation, okxChannelOpenInterest, assetType, pair, false, true, false)
@@ -1952,7 +1952,7 @@ func (ok *Okx) TradesSubscription(operation string, assetType asset.Item, pair c
 
 // EstimatedDeliveryExercisePriceSubscription to subscribe or unsubscribe to "estimated-price" channel to retrieve the estimated delivery/exercise price of FUTURES contracts and OPTION.
 func (ok *Okx) EstimatedDeliveryExercisePriceSubscription(operation string, assetType asset.Item, pair currency.Pair) error {
-	if assetType != asset.Futures && assetType != asset.Option {
+	if assetType != asset.Futures && assetType != asset.Options {
 		return fmt.Errorf("%w, only FUTURES and OPTION asset types are supported", errInvalidInstrumentType)
 	}
 	return ok.wsChannelSubscription(operation, okxChannelEstimatedPrice, assetType, pair, true, true, false)
@@ -1990,7 +1990,7 @@ func (ok *Okx) OrderBooksSubscription(operation, channel string, assetType asset
 // OptionSummarySubscription a method to subscribe or unsubscribe to "opt-summary" channel
 // to retrieve detailed pricing information of all OPTION contracts. Data will be pushed at once.
 func (ok *Okx) OptionSummarySubscription(operation string, pair currency.Pair) error {
-	return ok.wsChannelSubscription(operation, okxChannelOptSummary, asset.Option, pair, false, false, true)
+	return ok.wsChannelSubscription(operation, okxChannelOptSummary, asset.Options, pair, false, false, true)
 }
 
 // FundingRateSubscription a method to subscribe and unsubscribe to "funding-rate" channel.

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -76,7 +76,7 @@ func (ok *Okx) SetDefaults() {
 		},
 	}
 
-	err := ok.SetGlobalPairsManager(fmt1.RequestFormat, fmt1.ConfigFormat, asset.Spot, asset.Futures, asset.PerpetualSwap, asset.Option, asset.Margin)
+	err := ok.SetGlobalPairsManager(fmt1.RequestFormat, fmt1.ConfigFormat, asset.Spot, asset.Futures, asset.PerpetualSwap, asset.Options, asset.Margin)
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
@@ -289,7 +289,7 @@ func (ok *Okx) FetchTradablePairs(ctx context.Context, a asset.Item) (currency.P
 		insts, err = ok.GetInstruments(ctx, &InstrumentsFetchParams{
 			InstrumentType: okxInstTypeSwap,
 		})
-	case asset.Option:
+	case asset.Options:
 		var underlyings []string
 		underlyings, err = ok.GetPublicUnderlyings(context.Background(), okxInstTypeOption)
 		if err != nil {
@@ -366,7 +366,7 @@ func (ok *Okx) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item) 
 	case asset.Spot, asset.Margin:
 		baseVolume = mdata.Vol24H.Float64()
 		quoteVolume = mdata.VolCcy24H.Float64()
-	case asset.PerpetualSwap, asset.Futures, asset.Option:
+	case asset.PerpetualSwap, asset.Futures, asset.Options:
 		baseVolume = mdata.VolCcy24H.Float64()
 		quoteVolume = mdata.Vol24H.Float64()
 	default:


### PR DESCRIPTION
# PR Description

The Instrument type "option" is what was added to the assets list. But, the instrument name "options" is supported by other exchanges. So, I have created(amended) the custom method calls for Okx outgoing calls to convert "options" to "option"; that way we can use the String() method call to get the asset Item name for other exchanges instead of creating a conversion method for each.

Also, we can use either "option" or "options" in the config.json files or with the asset.New() method and the result will be same.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
