### PR TITLE
cli: fix description output using new version of urfave/cli/v2

### DIFF
--- a/backtester/btcli/commands.go
+++ b/backtester/btcli/commands.go
@@ -47,7 +47,7 @@ func executeStrategyFromFile(c *cli.Context) error {
 	defer closeConn(conn, cancel)
 
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var path string
@@ -132,7 +132,7 @@ func startRun(c *cli.Context) error {
 	defer closeConn(conn, cancel)
 
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var id string
@@ -206,7 +206,7 @@ func stopRun(c *cli.Context) error {
 	defer closeConn(conn, cancel)
 
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var id string
@@ -280,7 +280,7 @@ func clearRun(c *cli.Context) error {
 	defer closeConn(conn, cancel)
 
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var id string

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -87,7 +87,7 @@ var enableSubsystemCommand = &cli.Command{
 
 func enableSubsystem(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "enablesubsystem")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var subsystemName string
@@ -137,7 +137,7 @@ var disableSubsystemCommand = &cli.Command{
 
 func disableSubsystem(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "disablesubsystem")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var subsystemName string
@@ -279,7 +279,7 @@ var enableExchangeCommand = &cli.Command{
 
 func enableExchange(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "enableexchange")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -325,7 +325,7 @@ var disableExchangeCommand = &cli.Command{
 
 func disableExchange(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "disableexchange")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -371,7 +371,7 @@ var getExchangeOTPCommand = &cli.Command{
 
 func getExchangeOTPCode(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getexchangeotp")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -442,7 +442,7 @@ var getExchangeInfoCommand = &cli.Command{
 
 func getExchangeInfo(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getexchangeinfo")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -496,7 +496,7 @@ var getTickerCommand = &cli.Command{
 
 func getTicker(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getticker")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -604,7 +604,7 @@ var getAccountInfoCommand = &cli.Command{
 
 func getAccountInfo(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getaccountinfo")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange string
@@ -664,7 +664,7 @@ var getAccountInfoStreamCommand = &cli.Command{
 
 func getAccountInfoStream(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getaccountinfostream")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -735,7 +735,7 @@ var updateAccountInfoCommand = &cli.Command{
 
 func updateAccountInfo(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "updateaccountinfo")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange string
@@ -881,7 +881,7 @@ var addPortfolioAddressCommand = &cli.Command{
 
 func addPortfolioAddress(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "addportfolioaddress")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var address string
@@ -982,7 +982,7 @@ var removePortfolioAddressCommand = &cli.Command{
 
 func removePortfolioAddress(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "removeportfolioaddress")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var address string
@@ -1111,7 +1111,7 @@ var getOrdersCommand = &cli.Command{
 
 func getOrders(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getorders")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1224,7 +1224,7 @@ var getManagedOrdersCommand = &cli.Command{
 
 func getManagedOrders(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getmanagedorders")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1314,7 +1314,7 @@ var getOrderCommand = &cli.Command{
 
 func getOrder(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getorder")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1425,7 +1425,7 @@ var submitOrderCommand = &cli.Command{
 
 func submitOrder(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "submitorder")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1576,7 +1576,7 @@ var simulateOrderCommand = &cli.Command{
 
 func simulateOrder(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "simulateorder")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1693,7 +1693,7 @@ var cancelOrderCommand = &cli.Command{
 
 func cancelOrder(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "cancelorder")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -1835,7 +1835,7 @@ var cancelBatchOrdersCommand = &cli.Command{
 
 func cancelBatchOrders(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "cancelbatchorders")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -2012,7 +2012,7 @@ func cancelAllOrders(c *cli.Context) error {
 
 func modifyOrder(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "modifyorder")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	// Parse positional arguments.
@@ -2173,7 +2173,7 @@ var addEventCommand = &cli.Command{
 
 func addEvent(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "addevent")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -2299,7 +2299,7 @@ var removeEventCommand = &cli.Command{
 
 func removeEvent(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "removeevent")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var eventID int64
@@ -2349,7 +2349,7 @@ var getCryptocurrencyDepositAddressesCommand = &cli.Command{
 
 func getCryptocurrencyDepositAddresses(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getcryptocurrencydepositaddresses")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -2403,7 +2403,7 @@ var getCryptocurrencyDepositAddressCommand = &cli.Command{
 
 func getCryptocurrencyDepositAddress(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getcryptocurrencydepositaddress")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -2485,7 +2485,7 @@ var getAvailableTransferChainsCommand = &cli.Command{
 
 func getAvailableTransferChains(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getavailabletransferchains")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -2571,7 +2571,7 @@ var withdrawCryptocurrencyFundsCommand = &cli.Command{
 
 func withdrawCryptocurrencyFunds(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "withdrawcryptofunds")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange, cur, address, addressTag, chain, description string
@@ -2689,7 +2689,7 @@ var withdrawFiatFundsCommand = &cli.Command{
 
 func withdrawFiatFunds(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "withdrawfiatfunds")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange, cur, description, bankAccountID string
@@ -3041,7 +3041,7 @@ var getLoggerDetailsCommand = &cli.Command{
 
 func getLoggerDetails(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getloggerdetails")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var logger string
@@ -3094,7 +3094,7 @@ var setLoggerDetailsCommand = &cli.Command{
 
 func setLoggerDetails(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "setloggerdetails")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var logger string
@@ -3164,7 +3164,7 @@ var getTickerStreamCommand = &cli.Command{
 
 func getTickerStream(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "gettickerstream")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -3269,7 +3269,7 @@ var getExchangeTickerStreamCommand = &cli.Command{
 
 func getExchangeTickerStream(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getexchangetickerstream")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -3894,7 +3894,7 @@ var getHistoricCandlesCommand = &cli.Command{
 
 func getHistoricCandles(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "gethistoriccandles")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -4049,7 +4049,7 @@ var getHistoricCandlesExtendedCommand = &cli.Command{
 
 func getHistoricCandlesExtended(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "gethistoriccandlesextended")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -4224,7 +4224,7 @@ var findMissingSavedCandleIntervalsCommand = &cli.Command{
 
 func findMissingSavedCandleIntervals(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "findmissingsavedcandleintervals")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -4411,7 +4411,7 @@ var getMarginRatesHistoryCommand = &cli.Command{
 
 func getMarginRatesHistory(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string

--- a/cmd/gctcli/data_history.go
+++ b/cmd/gctcli/data_history.go
@@ -296,7 +296,7 @@ var (
 
 func getDataHistoryJob(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var id string
@@ -357,7 +357,7 @@ func getActiveDataHistoryJobs(c *cli.Context) error {
 
 func upsertDataHistoryJob(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var (
@@ -531,7 +531,7 @@ func upsertDataHistoryJob(c *cli.Context) error {
 
 func getDataHistoryJobsBetween(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	if c.IsSet("start_date") {
@@ -578,7 +578,7 @@ func getDataHistoryJobsBetween(c *cli.Context) error {
 
 func setDataHistoryJobStatus(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var id string
@@ -632,7 +632,7 @@ func setDataHistoryJobStatus(c *cli.Context) error {
 
 func getDataHistoryJobSummary(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var nickname string
@@ -663,7 +663,7 @@ func getDataHistoryJobSummary(c *cli.Context) error {
 
 func setPrerequisiteJob(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var nickname string

--- a/cmd/gctcli/futures.go
+++ b/cmd/gctcli/futures.go
@@ -264,7 +264,7 @@ var futuresCommands = &cli.Command{
 
 func getManagedPosition(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getmanagedposition")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -446,7 +446,7 @@ func getAllManagedPositions(c *cli.Context) error {
 
 func getFuturesPositions(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getfuturespositions")
+		return cli.ShowSubcommandHelp(c)
 	}
 	var (
 		exchangeName          string
@@ -633,7 +633,7 @@ func getFuturesPositions(c *cli.Context) error {
 
 func getCollateral(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 	var (
 		exchangeName, assetType                               string
@@ -707,7 +707,7 @@ func getCollateral(c *cli.Context) error {
 
 func getFundingRates(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getfundingrates")
+		return cli.ShowSubcommandHelp(c)
 	}
 	var (
 		exchangeName, assetType           string

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -66,7 +66,7 @@ var nominal = &cli.Command{
 func getNominal(c *cli.Context) error {
 	isSelling := c.Bool("sell")
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "nominal")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -152,7 +152,7 @@ var impact = &cli.Command{
 func getImpact(c *cli.Context) error {
 	isSelling := c.Bool("sell")
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "impact")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -276,7 +276,7 @@ var quoteRequired = &cli.Command{
 
 func getMovement(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, c.Command.Name)
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -372,7 +372,7 @@ var getOrderbookCommand = &cli.Command{
 
 func getOrderbook(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getorderbook")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -471,7 +471,7 @@ var getOrderbookStreamCommand = &cli.Command{
 
 func getOrderbookStream(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getorderbookstream")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -610,7 +610,7 @@ var getExchangeOrderbookStreamCommand = &cli.Command{
 
 func getExchangeOrderbookStream(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getexchangeorderbookstream")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -685,7 +685,7 @@ var whaleBombCommand = &cli.Command{
 
 func whaleBomb(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "whalebomb")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string

--- a/cmd/gctcli/pair_management.go
+++ b/cmd/gctcli/pair_management.go
@@ -125,7 +125,7 @@ var exchangePairManagerCommand = &cli.Command{
 		},
 		{
 			Name:  "disableall",
-			Usage: "dissable all pairs",
+			Usage: "disable all pairs",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:  "exchange",
@@ -162,11 +162,7 @@ var exchangePairManagerCommand = &cli.Command{
 func enableDisableExchangePair(c *cli.Context) error {
 	enable := c.Bool("enable")
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		if enable {
-			return cli.ShowCommandHelp(c, "enable")
-		}
-
-		return cli.ShowCommandHelp(c, "disable")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange string
@@ -288,10 +284,7 @@ func getExchangePairs(c *cli.Context) error {
 func enableDisableExchangeAsset(c *cli.Context) error {
 	enable := c.Bool("enable")
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		if enable {
-			return cli.ShowCommandHelp(c, "enableasset")
-		}
-		return cli.ShowCommandHelp(c, "disableasset")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange string
@@ -338,10 +331,7 @@ func enableDisableExchangeAsset(c *cli.Context) error {
 func enableDisableAllExchangePairs(c *cli.Context) error {
 	enable := c.Bool("enable")
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		if enable {
-			return cli.ShowCommandHelp(c, "enableall")
-		}
-		return cli.ShowCommandHelp(c, "disableall")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchange string

--- a/cmd/gctcli/trades.go
+++ b/cmd/gctcli/trades.go
@@ -219,7 +219,7 @@ var tradeCommand = &cli.Command{
 
 func findMissingSavedTradeIntervals(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "findmissingsavedtradeintervals")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -305,7 +305,7 @@ func findMissingSavedTradeIntervals(c *cli.Context) error {
 
 func setExchangeTradeProcessing(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "setexchangetradeprocessing")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -348,7 +348,7 @@ func setExchangeTradeProcessing(c *cli.Context) error {
 
 func getSavedTrades(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getsaved")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -438,7 +438,7 @@ func getSavedTrades(c *cli.Context) error {
 
 func getRecentTrades(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "getrecent")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -500,7 +500,7 @@ func getRecentTrades(c *cli.Context) error {
 
 func getHistoricTrades(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "gethistoric")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string
@@ -613,7 +613,7 @@ func getHistoricTrades(c *cli.Context) error {
 
 func convertSavedTradesToCandles(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
-		return cli.ShowCommandHelp(c, "convertsavedtradestocandles")
+		return cli.ShowSubcommandHelp(c)
 	}
 
 	var exchangeName string


### PR DESCRIPTION
# PR Description
With a version update of package `urfave/cli/v2`, it can now infer the command description without needing to explicitly tell it. Also, the old way doesn't work.

`master`

```
 go run . gethistoriccandles
No help topic for 'gethistoriccandles'
exit status 3
```

`this branch`

```
go run . gethistoriccandles
NAME:
   gctcli gethistoriccandles - gets historical candles for the specified granularity up to range size time from now.

USAGE:
   gctcli gethistoriccandles command [command options] <exchange> <pair> <asset> <rangesize> <granularity>

COMMANDS:
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --exchange value, -e value     the exchange to get the candles from
   --pair value                   the currency pair to get the candles for
   --asset value                  the asset type of the currency pair
   --rangesize value, -r value    the amount of time to go back from now to fetch candles in the given granularity (default: 10)
   --granularity value, -g value  interval in seconds. supported values are: 15, 60(1min), 180(3min), 300(5min), 600(10min),
                                    900(15min) 1800(30min), 3600(1h), 7200(2h), 14400(4h), 21600(6h), 28800(8h), 43200(12h),
                                    86400(1d), 259200(3d) 604800(1w), 1209600(2w), 1296000(15d), 2592000(1M), 31536000(1Y) (default: 86400)
   --fillmissingdatawithtrades    will create candles for missing intervals using stored trade data <true/false> (default: false)
   --help, -h                     show help (default: false)
```
<img src="https://cdn-icons-png.flaticon.com/256/6028/6028747.png" width="60" />



This also manages to understand the context of some double-commands such as `enableDisableAllExchangePairs` with:

```
 go run . pair disableall
NAME:
   gctcli pair disableall - disable all pairs
```

```
 go run . pair enableall
NAME:
   gctcli pair enableall - enable all pairs
```

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
Comparing master to this branch

