### PR TITLE
cli: rpc time parsing

### DIFF
--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -1162,11 +1162,11 @@ func getOrders(c *cli.Context) error {
 		}
 	}
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -1190,8 +1190,8 @@ func getOrders(c *cli.Context) error {
 			Base:      p.Base.String(),
 			Quote:     p.Quote.String(),
 		},
-		StartDate: negateLocalOffset(s),
-		EndDate:   negateLocalOffset(e),
+		StartDate: s.Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:   e.Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		return err
@@ -2991,11 +2991,11 @@ func withdrawlRequestByDate(c *cli.Context) error {
 		limit = limitStr
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, startTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, endTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -3014,8 +3014,8 @@ func withdrawlRequestByDate(c *cli.Context) error {
 	result, err := client.WithdrawalEventsByDate(c.Context,
 		&gctrpc.WithdrawalEventsByDateRequest{
 			Exchange: exchange,
-			Start:    negateLocalOffset(s),
-			End:      negateLocalOffset(e),
+			Start:    s.Format(common.SimpleTimeFormatWithTimezone),
+			End:      e.Format(common.SimpleTimeFormatWithTimezone),
 			Limit:    int32(limit),
 		},
 	)
@@ -3382,12 +3382,12 @@ func getAuditEvent(c *cli.Context) error {
 		}
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, startTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
 
-	e, err := time.Parse(common.SimpleTimeFormat, endTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -3407,8 +3407,8 @@ func getAuditEvent(c *cli.Context) error {
 
 	result, err := client.GetAuditEvent(c.Context,
 		&gctrpc.GetAuditEventRequest{
-			StartDate: negateLocalOffset(s),
-			EndDate:   negateLocalOffset(e),
+			StartDate: s.Format(common.SimpleTimeFormatWithTimezone),
+			EndDate:   e.Format(common.SimpleTimeFormatWithTimezone),
 			Limit:     int32(limit),
 			OrderBy:   orderingDirection,
 		})
@@ -3974,8 +3974,8 @@ func getHistoricCandles(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType:             assetType,
-			Start:                 negateLocalOffset(s),
-			End:                   negateLocalOffset(e),
+			Start:                 s.Format(common.SimpleTimeFormatWithTimezone),
+			End:                   e.Format(common.SimpleTimeFormatWithTimezone),
 			TimeInterval:          int64(candleInterval),
 			FillMissingWithTrades: fillMissingData,
 		})
@@ -4133,11 +4133,11 @@ func getHistoricCandlesExtended(c *cli.Context) error {
 
 	candleInterval := time.Duration(candleGranularity) * time.Second
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -4162,8 +4162,8 @@ func getHistoricCandlesExtended(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType:             assetType,
-			Start:                 negateLocalOffset(s),
-			End:                   negateLocalOffset(e),
+			Start:                 s.Format(common.SimpleTimeFormatWithTimezone),
+			End:                   e.Format(common.SimpleTimeFormatWithTimezone),
 			TimeInterval:          int64(candleInterval),
 			ExRequest:             true,
 			Sync:                  sync,
@@ -4282,11 +4282,11 @@ func findMissingSavedCandleIntervals(c *cli.Context) error {
 
 	candleInterval := time.Duration(candleGranularity) * time.Second
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -4311,8 +4311,8 @@ func findMissingSavedCandleIntervals(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType: assetType,
-			Start:     negateLocalOffset(s),
-			End:       negateLocalOffset(e),
+			Start:     s.Format(common.SimpleTimeFormatWithTimezone),
+			End:       e.Format(common.SimpleTimeFormatWithTimezone),
 			Interval:  int64(candleInterval),
 		})
 	if err != nil {
@@ -4503,11 +4503,11 @@ func getMarginRatesHistory(c *cli.Context) error {
 	}
 
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -4529,8 +4529,8 @@ func getMarginRatesHistory(c *cli.Context) error {
 			Exchange:           exchangeName,
 			Asset:              assetType,
 			Currency:           curr,
-			StartDate:          negateLocalOffset(s),
-			EndDate:            negateLocalOffset(e),
+			StartDate:          s.Format(common.SimpleTimeFormatWithTimezone),
+			EndDate:            e.Format(common.SimpleTimeFormatWithTimezone),
 			GetPredictedRate:   getPredictedRate,
 			GetLendingPayments: getLendingPayments,
 			GetBorrowRates:     getBorrowRates,

--- a/cmd/gctcli/data_history.go
+++ b/cmd/gctcli/data_history.go
@@ -399,11 +399,11 @@ func upsertDataHistoryJob(c *cli.Context) error {
 	}
 
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -504,8 +504,8 @@ func upsertDataHistoryJob(c *cli.Context) error {
 			Base:      p.Base.String(),
 			Quote:     p.Quote.String(),
 		},
-		StartDate:                negateLocalOffset(s),
-		EndDate:                  negateLocalOffset(e),
+		StartDate:                s.Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:                  e.Format(common.SimpleTimeFormatWithTimezone),
 		Interval:                 int64(candleInterval),
 		RequestSizeLimit:         int64(requestSizeLimit),
 		DataType:                 dataType,
@@ -544,11 +544,11 @@ func getDataHistoryJobsBetween(c *cli.Context) error {
 	} else {
 		endTime = c.Args().Get(1)
 	}
-	s, err := time.Parse(common.SimpleTimeFormat, startTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, endTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -566,8 +566,8 @@ func getDataHistoryJobsBetween(c *cli.Context) error {
 	client := gctrpc.NewGoCryptoTraderServiceClient(conn)
 	result, err := client.GetDataHistoryJobsBetween(c.Context,
 		&gctrpc.GetDataHistoryJobsBetweenRequest{
-			StartDate: negateLocalOffset(s),
-			EndDate:   negateLocalOffset(e),
+			StartDate: s.Format(common.SimpleTimeFormatWithTimezone),
+			EndDate:   e.Format(common.SimpleTimeFormatWithTimezone),
 		})
 	if err != nil {
 		return err

--- a/cmd/gctcli/futures.go
+++ b/cmd/gctcli/futures.go
@@ -583,11 +583,11 @@ func getFuturesPositions(c *cli.Context) error {
 		return err
 	}
 
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -612,8 +612,8 @@ func getFuturesPositions(c *cli.Context) error {
 				Base:      p.Base.String(),
 				Quote:     p.Quote.String(),
 			},
-			StartDate:               negateLocalOffset(s),
-			EndDate:                 negateLocalOffset(e),
+			StartDate:               s.Format(common.SimpleTimeFormatWithTimezone),
+			EndDate:                 e.Format(common.SimpleTimeFormatWithTimezone),
 			Status:                  status,
 			PositionLimit:           int64(limit),
 			Overwrite:               overwrite,
@@ -774,11 +774,11 @@ func getFundingRates(c *cli.Context) error {
 			return err
 		}
 	}
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -799,8 +799,8 @@ func getFundingRates(c *cli.Context) error {
 			Exchange:         exchangeName,
 			Asset:            assetType,
 			Pairs:            currencyPairs,
-			StartDate:        negateLocalOffset(s),
-			EndDate:          negateLocalOffset(e),
+			StartDate:        s.Format(common.SimpleTimeFormatWithTimezone),
+			EndDate:          e.Format(common.SimpleTimeFormatWithTimezone),
 			IncludePredicted: includePredicted,
 			IncludePayments:  includePayments,
 		})

--- a/cmd/gctcli/helpers.go
+++ b/cmd/gctcli/helpers.go
@@ -44,13 +44,9 @@ func closeConn(conn *grpc.ClientConn, cancel context.CancelFunc) {
 // so this function will minus the offset from the local sent time
 // to allow for proper use at RPCServer
 func negateLocalOffset(t time.Time) string {
-	_, offset := time.Now().Zone()
 	return t.In(time.UTC).Format(common.SimpleTimeFormat)
 }
 
-}
-
 func negateLocalOffsetTS(t time.Time) *timestamppb.Timestamp {
-	_, offset := time.Now().Zone()
-	return timestamppb.New(t.Add(time.Duration(-offset) * time.Second))
+	return timestamppb.New(t.In(time.UTC))
 }

--- a/cmd/gctcli/helpers.go
+++ b/cmd/gctcli/helpers.go
@@ -45,9 +45,7 @@ func closeConn(conn *grpc.ClientConn, cancel context.CancelFunc) {
 // to allow for proper use at RPCServer
 func negateLocalOffset(t time.Time) string {
 	_, offset := time.Now().Zone()
-	loc := time.FixedZone("", -offset)
-
-	return t.In(loc).Format(common.SimpleTimeFormat)
+	return t.Add(-time.Duration(offset) * time.Second).Format(common.SimpleTimeFormat)
 }
 
 func negateLocalOffsetTS(t time.Time) *timestamppb.Timestamp {

--- a/cmd/gctcli/helpers.go
+++ b/cmd/gctcli/helpers.go
@@ -45,7 +45,9 @@ func closeConn(conn *grpc.ClientConn, cancel context.CancelFunc) {
 // to allow for proper use at RPCServer
 func negateLocalOffset(t time.Time) string {
 	_, offset := time.Now().Zone()
-	return t.Add(-time.Duration(offset) * time.Second).Format(common.SimpleTimeFormat)
+	return t.In(time.UTC).Format(common.SimpleTimeFormat)
+}
+
 }
 
 func negateLocalOffsetTS(t time.Time) *timestamppb.Timestamp {

--- a/cmd/gctcli/helpers.go
+++ b/cmd/gctcli/helpers.go
@@ -6,11 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func clearScreen() error {
@@ -33,20 +30,4 @@ func closeConn(conn *grpc.ClientConn, cancel context.CancelFunc) {
 	if cancel != nil {
 		cancel()
 	}
-}
-
-// negateLocalOffset helps negate the offset of time generation
-// when the unix time gets to rpcserver, it no longer is the same time
-// that was sent as it handles it as a UTC value, even though when
-// using starttime it is generated as your local time
-// eg 2020-01-01 12:00:00 +10 will convert into
-// 2020-01-01 12:00:00 +00 when at RPCServer
-// so this function will minus the offset from the local sent time
-// to allow for proper use at RPCServer
-func negateLocalOffset(t time.Time) string {
-	return t.In(time.UTC).Format(common.SimpleTimeFormat)
-}
-
-func negateLocalOffsetTS(t time.Time) *timestamppb.Timestamp {
-	return timestamppb.New(t.In(time.UTC))
 }

--- a/cmd/gctcli/technical_analysis.go
+++ b/cmd/gctcli/technical_analysis.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"

--- a/cmd/gctcli/technical_analysis.go
+++ b/cmd/gctcli/technical_analysis.go
@@ -7,10 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"
 	"github.com/urfave/cli/v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -295,15 +298,14 @@ func getTecnicalAnalysis(c *cli.Context, algo string) error {
 		taEndTime, _ = c.Value("end").(string)
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, taStartTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, taStartTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, taEndTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, taEndTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
-
 	err = common.StartEndTimeCheck(s, e)
 	if err != nil {
 		return err
@@ -335,8 +337,8 @@ func getTecnicalAnalysis(c *cli.Context, algo string) error {
 		AssetType:     asset,
 		AlgorithmType: algo,
 		Interval:      taGranularity * int64(time.Second),
-		Start:         negateLocalOffsetTS(s),
-		End:           negateLocalOffsetTS(e),
+		Start:         timestamppb.New(s),
+		End:           timestamppb.New(e),
 		Period:        taPeriod,
 	}
 
@@ -411,11 +413,11 @@ func getBollingerBands(c *cli.Context) error {
 		taEndTime, _ = c.Value("end").(string)
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, taStartTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, taStartTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, taEndTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, taEndTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -488,8 +490,8 @@ func getBollingerBands(c *cli.Context) error {
 		AssetType:             asset,
 		AlgorithmType:         "BBANDS",
 		Interval:              taGranularity * int64(time.Second),
-		Start:                 negateLocalOffsetTS(s),
-		End:                   negateLocalOffsetTS(e),
+		Start:                 timestamppb.New(s),
+		End:                   timestamppb.New(e),
 		Period:                taPeriod,
 		StandardDeviationUp:   taStdDevUp,
 		StandardDeviationDown: taStdDevDown,
@@ -567,11 +569,11 @@ func getMACD(c *cli.Context) error {
 		taEndTime, _ = c.Value("end").(string)
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, taStartTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, taStartTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, taEndTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, taEndTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -629,8 +631,8 @@ func getMACD(c *cli.Context) error {
 		AssetType:     asset,
 		AlgorithmType: "MACD",
 		Interval:      taGranularity * int64(time.Second),
-		Start:         negateLocalOffsetTS(s),
-		End:           negateLocalOffsetTS(e),
+		Start:         timestamppb.New(s),
+		End:           timestamppb.New(e),
 		Period:        taPeriod,
 		SlowPeriod:    taSlowPeriod,
 		FastPeriod:    taFastPeriod,
@@ -707,11 +709,11 @@ func getCoco(c *cli.Context) error {
 		taEndTime, _ = c.Value("end").(string)
 	}
 
-	s, err := time.Parse(common.SimpleTimeFormat, taStartTime)
+	s, err := time.ParseInLocation(common.SimpleTimeFormat, taStartTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err := time.Parse(common.SimpleTimeFormat, taEndTime)
+	e, err := time.ParseInLocation(common.SimpleTimeFormat, taEndTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -781,8 +783,8 @@ func getCoco(c *cli.Context) error {
 		AssetType:      asset,
 		AlgorithmType:  "COCO",
 		Interval:       taGranularity * int64(time.Second),
-		Start:          negateLocalOffsetTS(s),
-		End:            negateLocalOffsetTS(e),
+		Start:          timestamppb.New(s),
+		End:            timestamppb.New(e),
 		Period:         taPeriod,
 		OtherExchange:  otherExchange,
 		OtherPair:      &gctrpc.CurrencyPair{Base: otherPair.Base.String(), Quote: otherPair.Quote.String()},

--- a/cmd/gctcli/trades.go
+++ b/cmd/gctcli/trades.go
@@ -267,11 +267,11 @@ func findMissingSavedTradeIntervals(c *cli.Context) error {
 	}
 
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -292,8 +292,8 @@ func findMissingSavedTradeIntervals(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType: assetType,
-			Start:     negateLocalOffset(s),
-			End:       negateLocalOffset(e),
+			Start:     s.Format(common.SimpleTimeFormatWithTimezone),
+			End:       e.Format(common.SimpleTimeFormatWithTimezone),
 		})
 	if err != nil {
 		return err
@@ -396,11 +396,11 @@ func getSavedTrades(c *cli.Context) error {
 	}
 
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -425,8 +425,8 @@ func getSavedTrades(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType: assetType,
-			Start:     negateLocalOffset(s),
-			End:       negateLocalOffset(e),
+			Start:     s.Format(common.SimpleTimeFormatWithTimezone),
+			End:       e.Format(common.SimpleTimeFormatWithTimezone),
 		})
 	if err != nil {
 		return err
@@ -547,11 +547,11 @@ func getHistoricTrades(c *cli.Context) error {
 		}
 	}
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -577,8 +577,8 @@ func getHistoricTrades(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType: assetType,
-			Start:     negateLocalOffset(s),
-			End:       negateLocalOffset(e),
+			Start:     s.Format(common.SimpleTimeFormatWithTimezone),
+			End:       e.Format(common.SimpleTimeFormatWithTimezone),
 		})
 	if err != nil {
 		return err
@@ -685,11 +685,11 @@ func convertSavedTradesToCandles(c *cli.Context) error {
 
 	candleInterval := time.Duration(candleGranularity) * time.Second
 	var s, e time.Time
-	s, err = time.Parse(common.SimpleTimeFormat, startTime)
+	s, err = time.ParseInLocation(common.SimpleTimeFormat, startTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for start: %v", err)
 	}
-	e, err = time.Parse(common.SimpleTimeFormat, endTime)
+	e, err = time.ParseInLocation(common.SimpleTimeFormat, endTime, time.Local)
 	if err != nil {
 		return fmt.Errorf("invalid time format for end: %v", err)
 	}
@@ -714,8 +714,8 @@ func convertSavedTradesToCandles(c *cli.Context) error {
 				Quote:     p.Quote.String(),
 			},
 			AssetType:    assetType,
-			Start:        negateLocalOffset(s),
-			End:          negateLocalOffset(e),
+			Start:        s.Format(common.SimpleTimeFormatWithTimezone),
+			End:          e.Format(common.SimpleTimeFormatWithTimezone),
 			TimeInterval: int64(candleInterval),
 			Sync:         sync,
 			Force:        force,

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -936,13 +936,13 @@ func (s *RPCServer) GetOrders(ctx context.Context, r *gctrpc.GetOrdersRequest) (
 
 	var start, end time.Time
 	if r.StartDate != "" {
-		start, err = time.Parse(common.SimpleTimeFormat, r.StartDate)
+		start, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if r.EndDate != "" {
-		end, err = time.Parse(common.SimpleTimeFormat, r.EndDate)
+		end, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 		if err != nil {
 			return nil, err
 		}
@@ -1913,11 +1913,11 @@ func (s *RPCServer) WithdrawalEventsByExchange(ctx context.Context, r *gctrpc.Wi
 
 // WithdrawalEventsByDate returns previous withdrawal request details by exchange
 func (s *RPCServer) WithdrawalEventsByDate(_ context.Context, r *gctrpc.WithdrawalEventsByDateRequest) (*gctrpc.WithdrawalEventsByExchangeResponse, error) {
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -2353,11 +2353,11 @@ func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamReq
 
 // GetAuditEvent returns matching audit events from database
 func (s *RPCServer) GetAuditEvent(_ context.Context, r *gctrpc.GetAuditEventRequest) (*gctrpc.GetAuditEventResponse, error) {
-	start, err := time.Parse(common.SimpleTimeFormat, r.StartDate)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.EndDate)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -2401,11 +2401,11 @@ func (s *RPCServer) GetAuditEvent(_ context.Context, r *gctrpc.GetAuditEventRequ
 
 // GetHistoricCandles returns historical candles for a given exchange
 func (s *RPCServer) GetHistoricCandles(ctx context.Context, r *gctrpc.GetHistoricCandlesRequest) (*gctrpc.GetHistoricCandlesResponse, error) {
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -2416,7 +2416,6 @@ func (s *RPCServer) GetHistoricCandles(ctx context.Context, r *gctrpc.GetHistori
 	if r.Pair == nil {
 		return nil, errCurrencyPairUnset
 	}
-
 	pair := currency.Pair{
 		Delimiter: r.Pair.Delimiter,
 		Base:      currency.NewCode(r.Pair.Base),
@@ -3180,11 +3179,11 @@ func (s *RPCServer) GetSavedTrades(_ context.Context, r *gctrpc.GetSavedTradesRe
 		return nil, err
 	}
 
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -3223,11 +3222,11 @@ func (s *RPCServer) ConvertTradesToCandles(_ context.Context, r *gctrpc.ConvertT
 	if r.End == "" || r.Start == "" || r.Exchange == "" || r.Pair == nil || r.AssetType == "" || r.Pair.String() == "" || r.TimeInterval == 0 {
 		return nil, errInvalidArguments
 	}
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -3328,11 +3327,11 @@ func (s *RPCServer) FindMissingSavedCandleIntervals(_ context.Context, r *gctrpc
 		return nil, err
 	}
 
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -3419,11 +3418,11 @@ func (s *RPCServer) FindMissingSavedTradeIntervals(_ context.Context, r *gctrpc.
 	if err != nil {
 		return nil, err
 	}
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -3537,11 +3536,11 @@ func (s *RPCServer) GetHistoricTrades(r *gctrpc.GetSavedTradesRequest, stream gc
 		return err
 	}
 	var trades []trade.Data
-	start, err := time.Parse(common.SimpleTimeFormat, r.Start)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.Start)
 	if err != nil {
 		return fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.End)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.End)
 	if err != nil {
 		return fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -3845,11 +3844,11 @@ func (s *RPCServer) UpsertDataHistoryJob(_ context.Context, r *gctrpc.UpsertData
 		return nil, err
 	}
 
-	start, err := time.Parse(common.SimpleTimeFormat, r.StartDate)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.EndDate)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -4016,11 +4015,11 @@ func (s *RPCServer) GetDataHistoryJobsBetween(_ context.Context, r *gctrpc.GetDa
 	if r == nil {
 		return nil, errNilRequestData
 	}
-	start, err := time.Parse(common.SimpleTimeFormat, r.StartDate)
+	start, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse start time %v", errInvalidTimes, err)
 	}
-	end, err := time.Parse(common.SimpleTimeFormat, r.EndDate)
+	end, err := time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 	if err != nil {
 		return nil, fmt.Errorf("%w cannot parse end time %v", errInvalidTimes, err)
 	}
@@ -4410,13 +4409,13 @@ func (s *RPCServer) GetFuturesPositions(ctx context.Context, r *gctrpc.GetFuture
 	}
 	var start, end time.Time
 	if r.StartDate != "" {
-		start, err = time.Parse(common.SimpleTimeFormat, r.StartDate)
+		start, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if r.EndDate != "" {
-		end, err = time.Parse(common.SimpleTimeFormat, r.EndDate)
+		end, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 		if err != nil {
 			return nil, err
 		}
@@ -4680,13 +4679,13 @@ func (s *RPCServer) GetFundingRates(ctx context.Context, r *gctrpc.GetFundingRat
 	start := time.Now().AddDate(-1, 0, 0)
 	end := time.Now()
 	if r.StartDate != "" {
-		start, err = time.Parse(common.SimpleTimeFormat, r.StartDate)
+		start, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if r.EndDate != "" {
-		end, err = time.Parse(common.SimpleTimeFormat, r.EndDate)
+		end, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 		if err != nil {
 			return nil, err
 		}
@@ -5196,13 +5195,13 @@ func (s *RPCServer) GetMarginRatesHistory(ctx context.Context, r *gctrpc.GetMarg
 	start := time.Now().AddDate(0, -1, 0)
 	end := time.Now()
 	if r.StartDate != "" {
-		start, err = time.Parse(common.SimpleTimeFormat, r.StartDate)
+		start, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.StartDate)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if r.EndDate != "" {
-		end, err = time.Parse(common.SimpleTimeFormat, r.EndDate)
+		end, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.EndDate)
 		if err != nil {
 			return nil, err
 		}
@@ -5242,7 +5241,7 @@ func (s *RPCServer) GetMarginRatesHistory(ctx context.Context, r *gctrpc.GetMarg
 		req.Rates = make([]margin.Rate, len(r.Rates))
 		for i := range r.Rates {
 			var offlineRate margin.Rate
-			offlineRate.Time, err = time.Parse(common.SimpleTimeFormat, r.Rates[i].Time)
+			offlineRate.Time, err = time.Parse(common.SimpleTimeFormatWithTimezone, r.Rates[i].Time)
 			if err != nil {
 				return nil, err
 			}

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -478,8 +478,8 @@ func TestGetSavedTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, ErrExchangeNotFound) {
 		t.Error(err)
@@ -492,14 +492,14 @@ func TestGetSavedTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err == nil {
 		t.Error(unexpectedLackOfError)
 		return
 	}
-	if err.Error() != "request for Bitstamp spot trade data between 2019-11-30 00:00:00 and 2020-01-01 01:01:01 and returned no results" {
+	if err.Error() != "request for Bitstamp spot trade data between 2019-11-30 00:00:00 UTC and 2020-01-01 01:01:01 UTC and returned no results" {
 		t.Error(err)
 	}
 	err = sqltrade.Insert(sqltrade.Data{
@@ -524,8 +524,8 @@ func TestGetSavedTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -551,8 +551,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 	})
 	if !errors.Is(err, ErrExchangeNotFound) {
@@ -568,8 +568,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 	})
 	if !errors.Is(err, errNoTrades) {
@@ -601,8 +601,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 	})
 	if err != nil {
@@ -621,8 +621,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 		Sync:         true,
 	})
@@ -639,8 +639,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 		Sync:         true,
 		Force:        true,
@@ -658,8 +658,8 @@ func TestConvertTradesToCandles(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:        time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:          time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 		UseDb:        true,
 	})
@@ -686,8 +686,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start:     defaultStart.Format(common.SimpleTimeFormat),
-		End:       defaultEnd.Format(common.SimpleTimeFormat),
+		Start:     defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:       defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		AssetType: asset.Spot.String(),
 	})
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
@@ -700,8 +700,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start:     defaultStart.Format(common.SimpleTimeFormat),
-		End:       defaultEnd.Format(common.SimpleTimeFormat),
+		Start:     defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:       defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		AssetType: asset.Spot.String(),
 	})
 	if !errors.Is(err, ErrExchangeNotFound) {
@@ -710,8 +710,8 @@ func TestGetHistoricCandles(t *testing.T) {
 
 	_, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange:  testExchange,
-		Start:     defaultStart.Format(common.SimpleTimeFormat),
-		End:       defaultEnd.Format(common.SimpleTimeFormat),
+		Start:     defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:       defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		Pair:      nil,
 		AssetType: asset.Spot.String(),
 	})
@@ -724,8 +724,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Base:  currency.BTC.String(),
 			Quote: currency.USD.String(),
 		},
-		Start: "2020-01-02 15:04:05",
-		End:   "2020-01-02 15:04:05",
+		Start: "2020-01-02 15:04:05 UTC",
+		End:   "2020-01-02 15:04:05 UTC",
 	})
 	if !errors.Is(err, common.ErrStartEqualsEnd) {
 		t.Errorf("received %v, expected %v", err, common.ErrStartEqualsEnd)
@@ -738,8 +738,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start:        defaultStart.Format(common.SimpleTimeFormat),
-		End:          defaultEnd.Format(common.SimpleTimeFormat),
+		Start:        defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:          defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		AssetType:    asset.Spot.String(),
 		TimeInterval: int64(kline.OneHour.Duration()),
 	})
@@ -758,8 +758,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        defaultStart.Format(common.SimpleTimeFormat),
-		End:          defaultEnd.Format(common.SimpleTimeFormat),
+		Start:        defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:          defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 		Sync:         true,
 		ExRequest:    true,
@@ -779,8 +779,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		AssetType:    asset.Spot.String(),
-		Start:        defaultStart.Format(common.SimpleTimeFormat),
-		End:          defaultEnd.Format(common.SimpleTimeFormat),
+		Start:        defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:          defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval: int64(kline.OneHour.Duration()),
 		UseDb:        true,
 	})
@@ -812,8 +812,8 @@ func TestGetHistoricCandles(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		AssetType:             asset.Spot.String(),
-		Start:                 defaultStart.Format(common.SimpleTimeFormat),
-		End:                   time.Date(2020, 0, 0, 3, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:                 defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:                   time.Date(2020, 0, 0, 3, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 		TimeInterval:          int64(kline.OneHour.Duration()),
 		UseDb:                 true,
 		FillMissingWithTrades: true,
@@ -852,8 +852,8 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start: defaultStart.UTC().Format(common.SimpleTimeFormat),
-		End:   defaultEnd.UTC().Format(common.SimpleTimeFormat),
+		Start: defaultStart.UTC().Format(common.SimpleTimeFormatWithTimezone),
+		End:   defaultEnd.UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -884,8 +884,8 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start: defaultStart.In(time.UTC).Format(common.SimpleTimeFormat),
-		End:   defaultEnd.In(time.UTC).Format(common.SimpleTimeFormat),
+		Start: defaultStart.In(time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:   defaultEnd.In(time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -917,8 +917,8 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 			Base:  cp.Base.String(),
 			Quote: cp.Quote.String(),
 		},
-		Start: defaultStart.In(time.UTC).Format(common.SimpleTimeFormat),
-		End:   defaultEnd.In(time.UTC).Format(common.SimpleTimeFormat),
+		Start: defaultStart.In(time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:   defaultEnd.In(time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -955,8 +955,8 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		Interval: int64(time.Hour),
-		Start:    defaultStart.Format(common.SimpleTimeFormat),
-		End:      defaultEnd.Format(common.SimpleTimeFormat),
+		Start:    defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:      defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil && err.Error() != "no candle data found: Bitstamp BTC USD 3600 spot" {
 		t.Error(err)
@@ -993,8 +993,8 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		Interval: int64(time.Hour),
-		Start:    defaultStart.Format(common.SimpleTimeFormat),
-		End:      defaultEnd.Format(common.SimpleTimeFormat),
+		Start:    defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:      defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -1030,8 +1030,8 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 			Quote: cp.Quote.String(),
 		},
 		Interval: int64(time.Hour),
-		Start:    defaultStart.Format(common.SimpleTimeFormat),
-		End:      defaultEnd.Format(common.SimpleTimeFormat),
+		Start:    defaultStart.Format(common.SimpleTimeFormatWithTimezone),
+		End:      defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if err != nil {
 		t.Error(err)
@@ -1089,8 +1089,8 @@ func TestGetRecentTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, ErrExchangeNotFound) {
 		t.Error(err)
@@ -1137,8 +1137,8 @@ func TestGetHistoricTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	}, nil)
 	if !errors.Is(err, ErrExchangeNotFound) {
 		t.Error(err)
@@ -1151,8 +1151,8 @@ func TestGetHistoricTrades(t *testing.T) {
 			Quote:     currency.USD.String(),
 		},
 		AssetType: asset.Spot.String(),
-		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
-		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormat),
+		Start:     time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
+		End:       time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC).Format(common.SimpleTimeFormatWithTimezone),
 	}, &dummyServer{})
 	if err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -1299,8 +1299,8 @@ func TestGetOrders(t *testing.T) {
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 		Pair:      p,
-		StartDate: time.Now().UTC().Add(time.Second).Format(common.SimpleTimeFormat),
-		EndDate:   time.Now().UTC().Add(-time.Hour).Format(common.SimpleTimeFormat),
+		StartDate: time.Now().UTC().Add(time.Second).Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:   time.Now().UTC().Add(-time.Hour).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, common.ErrStartAfterTimeNow) {
 		t.Errorf("received %v, expected %v", err, common.ErrStartAfterTimeNow)
@@ -1310,8 +1310,8 @@ func TestGetOrders(t *testing.T) {
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 		Pair:      p,
-		StartDate: time.Now().UTC().Add(-time.Hour).Format(common.SimpleTimeFormat),
-		EndDate:   time.Now().UTC().Add(time.Hour).Format(common.SimpleTimeFormat),
+		StartDate: time.Now().UTC().Add(-time.Hour).Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:   time.Now().UTC().Add(time.Hour).Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, exchange.ErrCredentialsAreEmpty) {
 		t.Errorf("received '%v', expected '%v'", err, exchange.ErrCredentialsAreEmpty)
@@ -1617,8 +1617,8 @@ func TestRPCServerUpsertDataHistoryJob(t *testing.T) {
 			Base:      "BTC",
 			Quote:     "USD",
 		},
-		StartDate:        time.Now().Add(-time.Hour * 24).Format(common.SimpleTimeFormat),
-		EndDate:          time.Now().Format(common.SimpleTimeFormat),
+		StartDate:        time.Now().Add(-time.Hour * 24).Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:          time.Now().Format(common.SimpleTimeFormatWithTimezone),
 		Interval:         int64(kline.OneHour.Duration()),
 		RequestSizeLimit: 10,
 		DataType:         int64(dataHistoryCandleDataType),
@@ -1795,8 +1795,8 @@ func TestGetDataHistoryJobsBetween(t *testing.T) {
 	}
 
 	_, err = s.GetDataHistoryJobsBetween(context.Background(), &gctrpc.GetDataHistoryJobsBetweenRequest{
-		StartDate: time.Now().UTC().Add(time.Minute).Format(common.SimpleTimeFormat),
-		EndDate:   time.Now().UTC().Format(common.SimpleTimeFormat),
+		StartDate: time.Now().UTC().Add(time.Minute).Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:   time.Now().UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, common.ErrStartAfterTimeNow) {
 		t.Fatalf("received %v, expected %v", err, common.ErrStartAfterTimeNow)
@@ -1808,8 +1808,8 @@ func TestGetDataHistoryJobsBetween(t *testing.T) {
 	}
 
 	r, err := s.GetDataHistoryJobsBetween(context.Background(), &gctrpc.GetDataHistoryJobsBetweenRequest{
-		StartDate: time.Now().Add(-time.Minute).UTC().Format(common.SimpleTimeFormat),
-		EndDate:   time.Now().Add(time.Minute).UTC().Format(common.SimpleTimeFormat),
+		StartDate: time.Now().Add(-time.Minute).UTC().Format(common.SimpleTimeFormatWithTimezone),
+		EndDate:   time.Now().Add(time.Minute).UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
@@ -1993,6 +1993,7 @@ func TestRPCServer_unixTimestamp(t *testing.T) {
 }
 
 func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
+	t.Parallel()
 	// Make a dummy pair we'll be using for this test.
 	pair := currency.NewPairWithDelimiter("XXXXX", "YYYYY", "")
 
@@ -2844,7 +2845,7 @@ func TestGetMarginRatesHistory(t *testing.T) {
 
 	request.Rates = []*gctrpc.MarginRate{
 		{
-			Time:       time.Now().Format(common.SimpleTimeFormat),
+			Time:       time.Now().Format(common.SimpleTimeFormatWithTimezone),
 			HourlyRate: "1337",
 		},
 	}
@@ -2855,7 +2856,7 @@ func TestGetMarginRatesHistory(t *testing.T) {
 
 	request.Rates = []*gctrpc.MarginRate{
 		{
-			Time:           time.Now().Format(common.SimpleTimeFormat),
+			Time:           time.Now().Format(common.SimpleTimeFormatWithTimezone),
 			HourlyRate:     "1337",
 			LendingPayment: &gctrpc.LendingPayment{Size: "1337"},
 			BorrowCost:     &gctrpc.BorrowCost{Size: "1337"},


### PR DESCRIPTION
# PR Description
I noticed this when parsing time for #1091 that the start end times looked more funky than I'd like them to be. Turns out the implementation of `negateLocalOffset` was off. 

When running `gethistoriccandles` it would be returning candle data hours outside of my expected timeframe. Its harder to measure since `gethistoriccandles` truncates the time, but it was well over 11 hours + truncated time. I was expecting candle data up to late 22nd Dec/early 23rd Dec. Instead I was getting 1pm on the 22nd. See below:
```
 "start": "2022-12-20 21:00:00",
 "end": "2022-12-22 13:00:00",
```

where now it is in line with my expectations where it is in line with the truncated time
```
 "start": "2022-12-21 08:00:00",
 "end": "2022-12-23 00:00:00",
```

This also matches `negateLocalOffsetTS`'s implementation

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested
Printing times in `commands.go` and matching them up in `rpcserver.go`
I was doing [these changes via gist](https://gist.github.com/gloriousCode/7261f4e5311d95799aa70a30ac256f7a)


