### PR TITLE
Backtester: custom interval support

### DIFF
--- a/backtester/config/strategyconfig_test.go
+++ b/backtester/config/strategyconfig_test.go
@@ -985,7 +985,7 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 			},
 		},
 		DataSettings: DataSettings{
-			Interval: kline.OneHour * 3,
+			Interval: kline.ThreeHour,
 			DataType: common.CandleStr,
 			APIData: &APIData{
 				StartDate:        startDate,

--- a/backtester/config/strategyconfig_test.go
+++ b/backtester/config/strategyconfig_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	testExchange = "binance"
+	mainExchange = "binance"
 	dca          = "dollarcostaverage"
 	// change this if you modify a config and want it to save to the example folder
-	saveConfig = !false
+	saveConfig = false
 )
 
 var (

--- a/backtester/config/strategyconfig_test.go
+++ b/backtester/config/strategyconfig_test.go
@@ -985,11 +985,11 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 			},
 		},
 		DataSettings: DataSettings{
-			Interval: kline.OneHour * 2,
+			Interval: kline.OneHour * 3,
 			DataType: common.CandleStr,
 			APIData: &APIData{
 				StartDate:        startDate,
-				EndDate:          endDate,
+				EndDate:          endDate.Add(time.Hour), // Now divisible by 3 hour candle
 				InclusiveEndDate: false,
 			},
 		},

--- a/backtester/config/strategyconfig_test.go
+++ b/backtester/config/strategyconfig_test.go
@@ -985,10 +985,10 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 			},
 		},
 		DataSettings: DataSettings{
-			Interval: kline.Interval(time.Minute * 2),
+			Interval: kline.OneHour * 2,
 			DataType: common.CandleStr,
 			APIData: &APIData{
-				StartDate:        endDate.Add(-time.Hour),
+				StartDate:        startDate,
 				EndDate:          endDate,
 				InclusiveEndDate: false,
 			},

--- a/backtester/config/strategyconfig_test.go
+++ b/backtester/config/strategyconfig_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	mainExchange = "binance"
+	testExchange = "binance"
 	dca          = "dollarcostaverage"
 	// change this if you modify a config and want it to save to the example folder
-	saveConfig = false
+	saveConfig = !false
 )
 
 var (
@@ -985,10 +985,10 @@ func TestGenerateConfigForRSIAPICustomSettings(t *testing.T) {
 			},
 		},
 		DataSettings: DataSettings{
-			Interval: kline.OneDay,
+			Interval: kline.Interval(time.Minute * 2),
 			DataType: common.CandleStr,
 			APIData: &APIData{
-				StartDate:        time.Date(2021, 5, 1, 0, 0, 0, 0, time.Local),
+				StartDate:        endDate.Add(-time.Hour),
 				EndDate:          endDate,
 				InclusiveEndDate: false,
 			},

--- a/backtester/config/strategyexamples/custom-plugin-strategy.strat
+++ b/backtester/config/strategyexamples/custom-plugin-strategy.strat
@@ -43,8 +43,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-api-candles-exchange-level-funding.strat
+++ b/backtester/config/strategyexamples/dca-api-candles-exchange-level-funding.strat
@@ -73,8 +73,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-api-candles-multiple-currencies.strat
+++ b/backtester/config/strategyexamples/dca-api-candles-multiple-currencies.strat
@@ -70,8 +70,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-api-candles-simultaneous-processing.strat
+++ b/backtester/config/strategyexamples/dca-api-candles-simultaneous-processing.strat
@@ -70,8 +70,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-api-candles.strat
+++ b/backtester/config/strategyexamples/dca-api-candles.strat
@@ -43,8 +43,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-api-trades.strat
+++ b/backtester/config/strategyexamples/dca-api-trades.strat
@@ -43,8 +43,8 @@
   "data-type": "trade",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-08-04T00:00:00+10:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-08-04T00:00:00+10:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/dca-database-candles.strat
+++ b/backtester/config/strategyexamples/dca-database-candles.strat
@@ -43,8 +43,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "database-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "config": {
     "enabled": true,
     "verbose": false,

--- a/backtester/config/strategyexamples/rsi-api-candles.strat
+++ b/backtester/config/strategyexamples/rsi-api-candles.strat
@@ -44,12 +44,12 @@
   }
  ],
  "data-settings": {
-  "interval": 86400000000000,
+  "interval": 120000000000,
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-05-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-11-30T23:00:00+11:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/rsi-api-candles.strat
+++ b/backtester/config/strategyexamples/rsi-api-candles.strat
@@ -44,11 +44,11 @@
   }
  ],
  "data-settings": {
-  "interval": 120000000000,
+  "interval": 7200000000000,
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2022-11-30T23:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
    "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }

--- a/backtester/config/strategyexamples/rsi-api-candles.strat
+++ b/backtester/config/strategyexamples/rsi-api-candles.strat
@@ -44,12 +44,12 @@
   }
  ],
  "data-settings": {
-  "interval": 7200000000000,
+  "interval": 10800000000000,
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
    "start-date": "2022-08-01T00:00:00+10:00",
-   "end-date": "2022-12-01T00:00:00+11:00",
+   "end-date": "2022-12-01T01:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/config/strategyexamples/t2b2-api-candles-exchange-funding.strat
+++ b/backtester/config/strategyexamples/t2b2-api-candles-exchange-funding.strat
@@ -181,8 +181,8 @@
   "data-type": "candle",
   "verbose-exchange-requests": false,
   "api-data": {
-   "start-date": "2021-08-01T00:00:00+10:00",
-   "end-date": "2021-12-01T00:00:00+11:00",
+   "start-date": "2022-08-01T00:00:00+10:00",
+   "end-date": "2022-12-01T00:00:00+11:00",
    "inclusive-end-date": false
   }
  },

--- a/backtester/data/kline/kline.go
+++ b/backtester/data/kline/kline.go
@@ -130,9 +130,13 @@ candleLoop:
 	d.Item.RemoveDuplicates()
 	d.Item.SortCandlesByTimestamp(false)
 	if d.RangeHolder != nil {
+		d.RangeHolder, err = gctkline.CalculateCandleDateRanges(d.Item.Candles[0].Time, d.Item.Candles[len(d.Item.Candles)-1].Time.Add(d.Item.Interval.Duration()), d.Item.Interval, uint32(d.RangeHolder.Limit))
+		if err != nil {
+			return err
+		}
 		// offline data check when there is a known range
 		// live data does not need this
-		d.RangeHolder.SetHasDataFromCandles(d.Item.Candles)
+		return d.RangeHolder.SetHasDataFromCandles(d.Item.Candles)
 	}
 	return nil
 }

--- a/backtester/data/kline/kline_test.go
+++ b/backtester/data/kline/kline_test.go
@@ -57,8 +57,7 @@ func TestLoad(t *testing.T) {
 func TestHasDataAtTime(t *testing.T) {
 	t.Parallel()
 	dStart := time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
-	dInsert := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	dEnd := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	dEnd := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	exch := testExchange
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
@@ -89,7 +88,7 @@ func TestHasDataAtTime(t *testing.T) {
 		Interval: gctkline.OneDay,
 		Candles: []gctkline.Candle{
 			{
-				Time:   dInsert,
+				Time:   dStart,
 				Open:   1337,
 				High:   1337,
 				Low:    1337,
@@ -102,7 +101,7 @@ func TestHasDataAtTime(t *testing.T) {
 		t.Error(err)
 	}
 
-	has, err = d.HasDataAtTime(dInsert)
+	has, err = d.HasDataAtTime(dStart)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -115,8 +114,11 @@ func TestHasDataAtTime(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
 	d.RangeHolder = ranger
-	d.RangeHolder.SetHasDataFromCandles(d.Item.Candles)
-	has, err = d.HasDataAtTime(dInsert)
+	err = d.RangeHolder.SetHasDataFromCandles(d.Item.Candles)
+	if !errors.Is(err, nil) {
+		t.Errorf("received: %v, expected: %v", err, nil)
+	}
+	has, err = d.HasDataAtTime(dStart)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -134,7 +136,7 @@ func TestHasDataAtTime(t *testing.T) {
 	if has {
 		t.Error("expected false")
 	}
-	has, err = d.HasDataAtTime(dInsert)
+	has, err = d.HasDataAtTime(dStart)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -147,12 +149,15 @@ func TestAppend(t *testing.T) {
 	t.Parallel()
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
+	tt1 := time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
+	tt2 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	d := DataFromKline{
 		Base: &data.Base{},
 		Item: &gctkline.Item{
 			Exchange: testExchange,
 			Asset:    a,
 			Pair:     p,
+			Interval: gctkline.OneDay,
 		},
 		RangeHolder: &gctkline.IntervalRangeHolder{},
 	}
@@ -160,7 +165,15 @@ func TestAppend(t *testing.T) {
 		Interval: gctkline.OneDay,
 		Candles: []gctkline.Candle{
 			{
-				Time:   time.Now(),
+				Time:   tt1,
+				Open:   1337,
+				High:   1337,
+				Low:    1337,
+				Close:  1337,
+				Volume: 1337,
+			},
+			{
+				Time:   tt2,
 				Open:   1337,
 				High:   1337,
 				Low:    1337,
@@ -177,6 +190,7 @@ func TestAppend(t *testing.T) {
 	item.Exchange = testExchange
 	item.Pair = p
 	item.Asset = a
+
 	err = d.AppendResults(&item)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -117,8 +117,8 @@ func TestSetupFromConfig(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, gctcommon.ErrDateUnset)
 	}
 
-	cfg.DataSettings.APIData.StartDate = time.Now().Add(-time.Minute)
-	cfg.DataSettings.APIData.EndDate = time.Now()
+	cfg.DataSettings.APIData.StartDate = time.Now().Truncate(gctkline.OneMin.Duration()).Add(-gctkline.OneMin.Duration())
+	cfg.DataSettings.APIData.EndDate = cfg.DataSettings.APIData.StartDate.Add(gctkline.OneMin.Duration())
 	cfg.DataSettings.APIData.InclusiveEndDate = true
 	err = bt.SetupFromConfig(cfg, "", "", false)
 	if !errors.Is(err, gctcommon.ErrNotYetImplemented) {
@@ -169,8 +169,8 @@ func TestLoadDataAPI(t *testing.T) {
 			DataType: common.CandleStr,
 			Interval: gctkline.OneMin,
 			APIData: &config.APIData{
-				StartDate: time.Now().Add(-time.Minute * 5),
-				EndDate:   time.Now(),
+				StartDate: time.Now().Truncate(gctkline.OneMin.Duration()).Add(-time.Minute * 5),
+				EndDate:   time.Now().Truncate(gctkline.OneMin.Duration()),
 			}},
 		StrategySettings: config.StrategySettings{
 			Name: dollarcostaverage.Name,

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -753,7 +753,10 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 		if err != nil {
 			return nil, err
 		}
-		resp.RangeHolder.SetHasDataFromCandles(resp.Item.Candles)
+		err = resp.RangeHolder.SetHasDataFromCandles(resp.Item.Candles)
+		if err != nil {
+			return nil, err
+		}
 		summary := resp.RangeHolder.DataSummary(false)
 		if len(summary) > 0 {
 			log.Warnf(common.Setup, "%v", summary)
@@ -796,7 +799,11 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 		if err != nil {
 			return nil, err
 		}
-		resp.RangeHolder.SetHasDataFromCandles(resp.Item.Candles)
+		err = resp.RangeHolder.SetHasDataFromCandles(resp.Item.Candles)
+		if err != nil {
+			return nil, err
+		}
+
 		summary := resp.RangeHolder.DataSummary(false)
 		if len(summary) > 0 {
 			log.Warnf(common.Setup, "%v", summary)
@@ -881,10 +888,11 @@ func loadAPIData(cfg *config.Config, exch gctexchange.IBotExchange, fPair curren
 	if err != nil {
 		return nil, err
 	}
+
 	candles, err := api.LoadData(context.TODO(),
 		dataType,
-		cfg.DataSettings.APIData.StartDate,
-		cfg.DataSettings.APIData.EndDate,
+		dates.Start.Time,
+		dates.End.Time,
 		cfg.DataSettings.Interval.Duration(),
 		exch,
 		fPair,
@@ -892,7 +900,12 @@ func loadAPIData(cfg *config.Config, exch gctexchange.IBotExchange, fPair curren
 	if err != nil {
 		return nil, fmt.Errorf("%v. Please check your GoCryptoTrader configuration", err)
 	}
-	dates.SetHasDataFromCandles(candles.Candles)
+
+	err = dates.SetHasDataFromCandles(candles.Candles)
+	if err != nil {
+		return nil, err
+	}
+
 	summary := dates.DataSummary(false)
 	if len(summary) > 0 {
 		log.Warnf(common.Setup, "%v", summary)

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -833,14 +833,6 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 	}
 
 	resp.Item.UnderlyingPair = underlyingPair
-	err = b.ValidateKline(fPair, a, resp.Item.Interval)
-	if err != nil {
-		// TODO: In future allow custom candles.
-		if dataType != common.DataTrade || !strings.EqualFold(err.Error(), "interval not supported") {
-			return nil, err
-		}
-	}
-
 	err = resp.Load()
 	if err != nil {
 		return nil, err
@@ -899,8 +891,6 @@ func loadAPIData(cfg *config.Config, exch gctexchange.IBotExchange, fPair curren
 	if len(summary) > 0 {
 		log.Warnf(common.Setup, "%v", summary)
 	}
-	candles.FillMissingDataWithEmptyEntries(dates)
-	candles.RemoveOutsideRange(cfg.DataSettings.APIData.StartDate, cfg.DataSettings.APIData.EndDate)
 	return &kline.DataFromKline{
 		Base:        &data.Base{},
 		Item:        candles,

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -824,7 +824,7 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 		}
 	case cfg.DataSettings.LiveData != nil:
 		if !b.Features.Enabled.Kline.Intervals.ExchangeSupported(cfg.DataSettings.Interval) {
-			return nil, fmt.Errorf("%w don't trade live on custom candle interval of %v", gctkline.ErrCannotConstructInterval, cfg.DataSettings.DatabaseData)
+			return nil, fmt.Errorf("%w don't trade live on custom candle interval of %v", gctkline.ErrCannotConstructInterval, cfg.DataSettings.Interval)
 		}
 		bt.exchangeManager.Add(exch)
 		err = bt.LiveDataHandler.AppendDataSource(&liveDataSourceSetup{

--- a/backtester/eventhandlers/portfolio/setup.go
+++ b/backtester/eventhandlers/portfolio/setup.go
@@ -78,7 +78,6 @@ func (p *Portfolio) SetCurrencySettingsMap(setup *exchange.Settings) error {
 		m3 = make(map[*currency.Item]*Settings)
 		m2[setup.Pair.Base.Item] = m3
 	}
-
 	settings := &Settings{
 		Exchange:          setup.Exchange,
 		exchangeName:      name,

--- a/backtester/eventhandlers/strategies/dollarcostaverage/dollarcostaverage_test.go
+++ b/backtester/eventhandlers/strategies/dollarcostaverage/dollarcostaverage_test.go
@@ -49,8 +49,7 @@ func TestOnSignal(t *testing.T) {
 	}
 
 	dStart := time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
-	dInsert := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	dEnd := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	dEnd := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	exch := "binance"
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
@@ -58,7 +57,7 @@ func TestOnSignal(t *testing.T) {
 	err = d.SetStream([]data.Event{&eventkline.Kline{
 		Base: &event.Base{
 			Exchange:     exch,
-			Time:         dInsert,
+			Time:         dStart,
 			Interval:     gctkline.OneDay,
 			CurrencyPair: p,
 			AssetType:    a,
@@ -97,7 +96,7 @@ func TestOnSignal(t *testing.T) {
 		Interval: gctkline.OneDay,
 		Candles: []gctkline.Candle{
 			{
-				Time:   dInsert,
+				Time:   dStart,
 				Open:   1337,
 				High:   1337,
 				Low:    1337,
@@ -116,7 +115,11 @@ func TestOnSignal(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
 	da.RangeHolder = ranger
-	da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	err = da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	if !errors.Is(err, nil) {
+		t.Errorf("received: %v, expected: %v", err, nil)
+	}
+
 	resp, err = s.OnSignal(da, nil, nil)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
@@ -133,8 +136,7 @@ func TestOnSignals(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNilEvent)
 	}
 	dStart := time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
-	dInsert := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	dEnd := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	dEnd := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	exch := "binance"
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
@@ -143,7 +145,7 @@ func TestOnSignals(t *testing.T) {
 		Base: &event.Base{
 			Offset:       1,
 			Exchange:     exch,
-			Time:         dInsert,
+			Time:         dStart,
 			Interval:     gctkline.OneDay,
 			CurrencyPair: p,
 			AssetType:    a,
@@ -185,7 +187,7 @@ func TestOnSignals(t *testing.T) {
 		Interval: gctkline.OneDay,
 		Candles: []gctkline.Candle{
 			{
-				Time:   dInsert,
+				Time:   dStart,
 				Open:   1337,
 				High:   1337,
 				Low:    1337,
@@ -204,7 +206,11 @@ func TestOnSignals(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
 	da.RangeHolder = ranger
-	da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	err = da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	if !errors.Is(err, nil) {
+		t.Errorf("received: %v, expected: %v", err, nil)
+	}
+
 	resp, err = s.OnSimultaneousSignals([]data.Handler{da}, nil, nil)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)

--- a/backtester/eventhandlers/strategies/rsi/rsi_test.go
+++ b/backtester/eventhandlers/strategies/rsi/rsi_test.go
@@ -90,8 +90,7 @@ func TestOnSignal(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNilEvent)
 	}
 	dStart := time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
-	dInsert := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	dEnd := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	dEnd := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	exch := "binance"
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
@@ -100,7 +99,7 @@ func TestOnSignal(t *testing.T) {
 		Base: &event.Base{
 			Offset:       3,
 			Exchange:     exch,
-			Time:         dInsert,
+			Time:         dStart,
 			Interval:     gctkline.OneDay,
 			CurrencyPair: p,
 			AssetType:    a,
@@ -142,7 +141,7 @@ func TestOnSignal(t *testing.T) {
 		Interval: gctkline.OneDay,
 		Candles: []gctkline.Candle{
 			{
-				Time:   dInsert,
+				Time:   dStart,
 				Open:   1337,
 				High:   1337,
 				Low:    1337,
@@ -161,7 +160,11 @@ func TestOnSignal(t *testing.T) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
 	da.RangeHolder = ranger
-	da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	err = da.RangeHolder.SetHasDataFromCandles(da.Item.Candles)
+	if !errors.Is(err, nil) {
+		t.Errorf("received: %v, expected: %v", err, nil)
+	}
+
 	resp, err = s.OnSignal(da, nil, nil)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)

--- a/common/common.go
+++ b/common/common.go
@@ -466,14 +466,14 @@ func StartEndTimeCheck(start, end time.Time) error {
 	if end.IsZero() || end.Equal(zeroValueUnix) {
 		return fmt.Errorf("end %w", ErrDateUnset)
 	}
-	if start.After(time.Now()) {
-		return ErrStartAfterTimeNow
-	}
 	if start.After(end) {
 		return ErrStartAfterEnd
 	}
 	if start.Equal(end) {
 		return ErrStartEqualsEnd
+	}
+	if start.After(time.Now()) {
+		return ErrStartAfterTimeNow
 	}
 
 	return nil

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -670,14 +670,14 @@ func TestParseStartEndDate(t *testing.T) {
 		t.Errorf("received %v, expected %v", err, ErrStartEqualsEnd)
 	}
 
-	err = StartEndTimeCheck(ft, et)
-	if !errors.Is(err, ErrStartAfterTimeNow) {
-		t.Errorf("received %v, expected %v", err, ErrStartAfterTimeNow)
-	}
-
 	err = StartEndTimeCheck(et, pt)
 	if !errors.Is(err, ErrStartAfterEnd) {
 		t.Errorf("received %v, expected %v", err, ErrStartAfterEnd)
+	}
+
+	err = StartEndTimeCheck(ft, ft.Add(time.Hour))
+	if !errors.Is(err, ErrStartAfterTimeNow) {
+		t.Errorf("received %v, expected %v", err, ErrStartAfterTimeNow)
 	}
 
 	err = StartEndTimeCheck(pt, et)

--- a/engine/datahistory_manager.go
+++ b/engine/datahistory_manager.go
@@ -192,7 +192,10 @@ func (m *DataHistoryManager) compareJobsToData(jobs ...*DataHistoryJob) error {
 			if err != nil && !errors.Is(err, candle.ErrNoCandleDataFound) {
 				return fmt.Errorf("%s could not load candle data: %w", jobs[i].Nickname, err)
 			}
-			jobs[i].rangeHolder.SetHasDataFromCandles(candles.Candles)
+			err = jobs[i].rangeHolder.SetHasDataFromCandles(candles.Candles)
+			if err != nil {
+				return err
+			}
 		case dataHistoryTradeDataType:
 			for x := range jobs[i].rangeHolder.Ranges {
 				results, ok := jobs[i].Results[jobs[i].rangeHolder.Ranges[x].Start.Time.Unix()]
@@ -213,7 +216,10 @@ func (m *DataHistoryManager) compareJobsToData(jobs ...*DataHistoryJob) error {
 			if err != nil && !errors.Is(err, candle.ErrNoCandleDataFound) {
 				return fmt.Errorf("%s could not load candle data: %w", jobs[i].Nickname, err)
 			}
-			jobs[i].rangeHolder.SetHasDataFromCandles(candles.Candles)
+			err = jobs[i].rangeHolder.SetHasDataFromCandles(candles.Candles)
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("%s %w %s", jobs[i].Nickname, errUnknownDataType, jobs[i].DataType)
 		}
@@ -715,7 +721,10 @@ func (m *DataHistoryManager) processCandleData(job *DataHistoryJob, exch exchang
 		r.Status = dataHistoryStatusFailed
 		return r, nil //nolint:nilerr // error is returned in the job result
 	}
-	job.rangeHolder.SetHasDataFromCandles(candles.Candles)
+	err = job.rangeHolder.SetHasDataFromCandles(candles.Candles)
+	if err != nil {
+		return nil, err
+	}
 	for i := range job.rangeHolder.Ranges[intervalIndex].Intervals {
 		if !job.rangeHolder.Ranges[intervalIndex].Intervals[i].HasData {
 			r.Status = dataHistoryStatusFailed
@@ -770,7 +779,10 @@ func (m *DataHistoryManager) processTradeData(job *DataHistoryJob, exch exchange
 		r.Status = dataHistoryStatusFailed
 		return r, nil //nolint:nilerr // error is returned in the job result
 	}
-	job.rangeHolder.SetHasDataFromCandles(candles.Candles)
+	err = job.rangeHolder.SetHasDataFromCandles(candles.Candles)
+	if err != nil {
+		return nil, err
+	}
 	for i := range job.rangeHolder.Ranges[intervalIndex].Intervals {
 		if !job.rangeHolder.Ranges[intervalIndex].Intervals[i].HasData {
 			r.Status = dataHistoryStatusFailed

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -609,13 +609,14 @@ func TestPrepareJobs(t *testing.T) {
 func TestCompareJobsToData(t *testing.T) {
 	t.Parallel()
 	m, _ := createDHM(t)
+	tt := time.Now().Truncate(kline.OneMin.Duration())
 	dhj := &DataHistoryJob{
 		Nickname:           "TestGenerateJobSummary",
 		Exchange:           testExchange,
 		Asset:              asset.Spot,
 		Pair:               currency.NewPair(currency.BTC, currency.USD),
-		StartDate:          time.Now().Add(-time.Minute * 5),
-		EndDate:            time.Now(),
+		StartDate:          tt.Add(-time.Minute * 5),
+		EndDate:            tt,
 		Interval:           kline.OneMin,
 		ConversionInterval: kline.FiveMin,
 	}
@@ -1530,10 +1531,13 @@ func dataHistoryTraderLoader(exch, a, base, quote string, start, _ time.Time) ([
 	}, nil
 }
 
-func dataHistoryCandleLoader(exch string, cp currency.Pair, a asset.Item, i kline.Interval, start, _ time.Time) (*kline.Item, error) {
+func dataHistoryCandleLoader(exch string, cp currency.Pair, a asset.Item, i kline.Interval, start, end time.Time) (*kline.Item, error) {
 	start = start.Truncate(i.Duration())
 	var candles []kline.Candle
-	for x := 0; x < 24; x++ {
+	for {
+		if start.Equal(end) || start.After(end) {
+			break
+		}
 		candles = append(candles, kline.Candle{
 			Time:   start,
 			Open:   1,

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -609,7 +609,7 @@ func TestPrepareJobs(t *testing.T) {
 func TestCompareJobsToData(t *testing.T) {
 	t.Parallel()
 	m, _ := createDHM(t)
-	tt := time.Now().Truncate(kline.OneMin.Duration())
+	tt := time.Now().Truncate(kline.OneHour.Duration())
 	dhj := &DataHistoryJob{
 		Nickname:           "TestGenerateJobSummary",
 		Exchange:           testExchange,
@@ -655,70 +655,72 @@ func TestCompareJobsToData(t *testing.T) {
 	}
 }
 
-func TestRunJob(t *testing.T) { //nolint // TO-DO: Fix race t.Parallel() usage
+func TestRunJob(t *testing.T) { 
+	t.Parallel()
+	tt := time.Now().Truncate(kline.OneHour.Duration())
 	testCases := []*DataHistoryJob{
 		{
 			Nickname:  "TestRunJobDataHistoryCandleDataType",
-			Exchange:  "Binance",
+			Exchange:  testExchange,
 			Asset:     asset.Spot,
 			Pair:      currency.NewPair(currency.BTC, currency.USDT),
-			StartDate: time.Now().Add(-time.Minute * 30),
-			EndDate:   time.Now(),
+			StartDate: tt.Add(-time.Minute * 30),
+			EndDate:   tt,
 			Interval:  kline.FifteenMin,
 			DataType:  dataHistoryCandleDataType,
 		},
 		{
 			Nickname:  "TestRunJobDataHistoryTradeDataType",
-			Exchange:  "Binance",
+			Exchange:  testExchange,
 			Asset:     asset.Spot,
 			Pair:      currency.NewPair(currency.BTC, currency.USDT),
-			StartDate: time.Now().Add(-time.Minute * 15),
-			EndDate:   time.Now(),
+			StartDate: tt.Add(-time.Minute * 15),
+			EndDate:   tt,
 			Interval:  kline.OneMin,
 			DataType:  dataHistoryTradeDataType,
 		},
 		{
 			Nickname:           "TestRunJobDataHistoryConvertCandlesDataType",
-			Exchange:           "Binance",
+			Exchange:           testExchange,
 			Asset:              asset.Spot,
 			Pair:               currency.NewPair(currency.BTC, currency.USDT),
-			StartDate:          time.Now().Add(-time.Hour * 2),
-			EndDate:            time.Now(),
+			StartDate:          tt.Add(-time.Hour * 2),
+			EndDate:            tt,
 			Interval:           kline.FifteenMin,
 			DataType:           dataHistoryConvertCandlesDataType,
 			ConversionInterval: kline.OneHour,
 		},
 		{
 			Nickname:           "TestRunJobDataHistoryConvertTradesDataType",
-			Exchange:           "Binance",
+			Exchange:           testExchange,
 			Asset:              asset.Spot,
 			Pair:               currency.NewPair(currency.BTC, currency.USDT),
-			StartDate:          time.Now().Add(-time.Hour * 2),
-			EndDate:            time.Now(),
+			StartDate:          tt.Add(-time.Hour * 2),
+			EndDate:            tt,
 			Interval:           kline.FifteenMin,
 			DataType:           dataHistoryConvertTradesDataType,
 			ConversionInterval: kline.OneHour,
 		},
 		{
 			Nickname:  "TestRunJobDataHistoryCandleValidationDataType",
-			Exchange:  "Binance",
+			Exchange:  testExchange,
 			Asset:     asset.Spot,
 			Pair:      currency.NewPair(currency.BTC, currency.USDT),
-			StartDate: time.Now().Add(-time.Hour * 2),
-			EndDate:   time.Now(),
+			StartDate: tt.Add(-time.Hour * 2),
+			EndDate:   tt,
 			Interval:  kline.OneHour,
 			DataType:  dataHistoryCandleValidationDataType,
 		},
 		{
 			Nickname:                "TestRunJobDataHistoryCandleSecondaryValidationDataType",
-			Exchange:                "Binance",
+			Exchange:                testExchange,
 			Asset:                   asset.Spot,
 			Pair:                    currency.NewPair(currency.BTC, currency.USDT),
-			StartDate:               time.Now().Add(-time.Hour * 2),
-			EndDate:                 time.Now(),
+			StartDate:               tt.Add(-time.Hour * 2),
+			EndDate:                 tt,
 			Interval:                kline.OneMin,
 			DataType:                dataHistoryCandleValidationSecondarySourceType,
-			SecondaryExchangeSource: testExchange,
+			SecondaryExchangeSource: "Binance",
 		},
 	}
 
@@ -1077,8 +1079,8 @@ func TestProcessTradeData(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		StartDate: time.Now().Add(-kline.OneHour.Duration() * 2),
-		EndDate:   time.Now(),
+		StartDate: time.Now().Add(-kline.OneHour.Duration() * 2).Truncate(kline.OneHour.Duration()),
+		EndDate:   time.Now().Truncate(kline.OneHour.Duration()),
 		Interval:  kline.OneHour,
 	}
 	_, err = m.processTradeData(j, nil, time.Time{}, time.Time{}, 0)

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -655,7 +655,7 @@ func TestCompareJobsToData(t *testing.T) {
 	}
 }
 
-func TestRunJob(t *testing.T) { 
+func TestRunJob(t *testing.T) {
 	t.Parallel()
 	tt := time.Now().Truncate(kline.OneHour.Duration())
 	testCases := []*DataHistoryJob{

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -1020,8 +1020,8 @@ func TestProcessCandleData(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		StartDate: time.Now().Add(-kline.OneHour.Duration() * 2),
-		EndDate:   time.Now(),
+		StartDate: time.Now().Add(-kline.OneHour.Duration() * 2).Truncate(kline.OneHour.Duration()),
+		EndDate:   time.Now().Truncate(kline.OneHour.Duration()),
 		Interval:  kline.OneHour,
 	}
 	_, err = m.processCandleData(j, nil, time.Time{}, time.Time{}, 0)

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1307,8 +1307,8 @@ func TestGetOrders(t *testing.T) {
 		StartDate: time.Now().UTC().Add(time.Second).Format(common.SimpleTimeFormatWithTimezone),
 		EndDate:   time.Now().UTC().Add(-time.Hour).Format(common.SimpleTimeFormatWithTimezone),
 	})
-	if !errors.Is(err, common.ErrStartAfterTimeNow) {
-		t.Errorf("received %v, expected %v", err, common.ErrStartAfterTimeNow)
+	if !errors.Is(err, common.ErrStartAfterEnd) {
+		t.Errorf("received %v, expected %v", err, common.ErrStartAfterEnd)
 	}
 
 	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
@@ -1803,8 +1803,8 @@ func TestGetDataHistoryJobsBetween(t *testing.T) {
 		StartDate: time.Now().UTC().Add(time.Minute).Format(common.SimpleTimeFormatWithTimezone),
 		EndDate:   time.Now().UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
-	if !errors.Is(err, common.ErrStartAfterTimeNow) {
-		t.Fatalf("received %v, expected %v", err, common.ErrStartAfterTimeNow)
+	if !errors.Is(err, common.ErrStartAfterEnd) {
+		t.Fatalf("received %v, expected %v", err, common.ErrStartAfterEnd)
 	}
 
 	err = m.UpsertJob(dhj, false)

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1734,8 +1734,8 @@ func (b *Binance) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 		candles, err = b.GetSpotKline(ctx, &KlinesRequestParams{
 			Interval:  b.FormatExchangeKlineInterval(req.ExchangeInterval),
 			Symbol:    req.Pair,
-			StartTime: req.RangeHolder.Ranges[x].Start.Time.UTC(),
-			EndTime:   req.RangeHolder.Ranges[x].End.Time.UTC(),
+			StartTime: req.RangeHolder.Ranges[x].Start.Time,
+			EndTime:   req.RangeHolder.Ranges[x].End.Time,
 			Limit:     int(b.Features.Enabled.Kline.ResultLimit),
 		})
 		if err != nil {
@@ -1744,7 +1744,7 @@ func (b *Binance) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 
 		for i := range candles {
 			timeSeries = append(timeSeries, kline.Candle{
-				Time:   candles[i].OpenTime.UTC(),
+				Time:   candles[i].OpenTime,
 				Open:   candles[i].Open,
 				High:   candles[i].High,
 				Low:    candles[i].Low,

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1729,13 +1729,13 @@ func (b *Binance) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles []CandleStick
 		candles, err = b.GetSpotKline(ctx, &KlinesRequestParams{
 			Interval:  b.FormatExchangeKlineInterval(req.ExchangeInterval),
 			Symbol:    req.Pair,
-			StartTime: req.Ranges[x].Start.Time,
-			EndTime:   req.Ranges[x].End.Time,
+			StartTime: req.RangeHolder.Ranges[x].Start.Time.UTC(),
+			EndTime:   req.RangeHolder.Ranges[x].End.Time.UTC(),
 			Limit:     int(b.Features.Enabled.Kline.ResultLimit),
 		})
 		if err != nil {
@@ -1744,7 +1744,7 @@ func (b *Binance) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 
 		for i := range candles {
 			timeSeries = append(timeSeries, kline.Candle{
-				Time:   candles[i].OpenTime,
+				Time:   candles[i].OpenTime.UTC(),
 				Open:   candles[i].Open,
 				High:   candles[i].High,
 				Low:    candles[i].Low,

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -906,13 +906,13 @@ func (bi *Binanceus) GetHistoricCandlesExtended(ctx context.Context, pair curren
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles []CandleStick
 		candles, err = bi.GetSpotKline(ctx, &KlinesRequestParams{
 			Interval:  bi.GetIntervalEnum(req.ExchangeInterval),
 			Symbol:    req.Pair,
-			StartTime: req.Ranges[x].Start.Time,
-			EndTime:   req.Ranges[x].End.Time,
+			StartTime: req.RangeHolder.Ranges[x].Start.Time,
+			EndTime:   req.RangeHolder.Ranges[x].End.Time,
 			Limit:     int64(bi.Features.Enabled.Kline.ResultLimit),
 		})
 		if err != nil {

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -1130,13 +1130,13 @@ func (b *Bitfinex) GetHistoricCandlesExtended(ctx context.Context, pair currency
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles []Candle
 		candles, err = b.GetCandles(ctx,
 			cf,
 			b.FormatExchangeKlineInterval(req.ExchangeInterval),
-			req.Ranges[x].Start.Ticks*1000,
-			req.Ranges[x].End.Ticks*1000,
+			req.RangeHolder.Ranges[x].Start.Ticks*1000,
+			req.RangeHolder.Ranges[x].End.Ticks*1000,
 			b.Features.Enabled.Kline.ResultLimit,
 			true)
 		if err != nil {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -895,12 +895,12 @@ func (b *Bitstamp) GetHistoricCandlesExtended(ctx context.Context, pair currency
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles OHLCResponse
 		candles, err = b.OHLC(ctx,
 			req.RequestFormatted.String(),
-			req.Ranges[x].Start.Time,
-			req.Ranges[x].End.Time,
+			req.RangeHolder.Ranges[x].Start.Time,
+			req.RangeHolder.Ranges[x].End.Time,
 			b.FormatExchangeKlineInterval(req.ExchangeInterval),
 			strconv.FormatInt(int64(b.Features.Enabled.Kline.ResultLimit), 10),
 		)
@@ -910,8 +910,8 @@ func (b *Bitstamp) GetHistoricCandlesExtended(ctx context.Context, pair currency
 
 		for i := range candles.Data.OHLCV {
 			timstamp := time.Unix(candles.Data.OHLCV[i].Timestamp, 0)
-			if timstamp.Before(req.Ranges[x].Start.Time) ||
-				timstamp.After(req.Ranges[x].End.Time) {
+			if timstamp.Before(req.RangeHolder.Ranges[x].Start.Time) ||
+				timstamp.After(req.RangeHolder.Ranges[x].End.Time) {
 				continue
 			}
 			timeSeries = append(timeSeries, kline.Candle{

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -1053,13 +1053,13 @@ func (b *BTCMarkets) GetHistoricCandlesExtended(ctx context.Context, pair curren
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles CandleResponse
 		candles, err = b.GetMarketCandles(ctx,
 			req.RequestFormatted.String(),
 			b.FormatExchangeKlineInterval(req.ExchangeInterval),
-			req.Ranges[x].Start.Time,
-			req.Ranges[x].End.Time,
+			req.RangeHolder.Ranges[x].Start.Time,
+			req.RangeHolder.Ranges[x].End.Time,
 			-1,
 			-1,
 			-1)

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -1938,7 +1938,7 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		switch req.Asset {
 		case asset.Spot:
 			var candles []KlineItem
@@ -1946,8 +1946,8 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 				req.RequestFormatted.String(),
 				by.FormatExchangeKlineInterval(ctx, req.ExchangeInterval),
 				int64(by.Features.Enabled.Kline.ResultLimit),
-				req.Ranges[x].Start.Time,
-				req.Ranges[x].End.Time)
+				req.RangeHolder.Ranges[x].Start.Time,
+				req.RangeHolder.Ranges[x].End.Time)
 			if err != nil {
 				return nil, err
 			}
@@ -1968,7 +1968,7 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 				req.RequestFormatted,
 				by.FormatExchangeKlineIntervalFutures(ctx, req.ExchangeInterval),
 				int64(by.Features.Enabled.Kline.ResultLimit),
-				req.Ranges[x].Start.Time)
+				req.RangeHolder.Ranges[x].Start.Time)
 			if err != nil {
 				return nil, err
 			}
@@ -1989,7 +1989,7 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 				req.RequestFormatted,
 				by.FormatExchangeKlineIntervalFutures(ctx, req.ExchangeInterval),
 				int64(by.Features.Enabled.Kline.ResultLimit),
-				req.Ranges[x].Start.Time)
+				req.RangeHolder.Ranges[x].Start.Time)
 			if err != nil {
 				return nil, err
 			}
@@ -2009,7 +2009,7 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 			candles, err = by.GetUSDCKlines(ctx,
 				req.RequestFormatted,
 				by.FormatExchangeKlineIntervalFutures(ctx, req.ExchangeInterval),
-				req.Ranges[x].Start.Time,
+				req.RangeHolder.Ranges[x].Start.Time,
 				int64(by.Features.Enabled.Kline.ResultLimit))
 			if err != nil {
 				return nil, err

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -926,12 +926,12 @@ func (c *CoinbasePro) GetHistoricCandlesExtended(ctx context.Context, pair curre
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var history []History
 		history, err = c.GetHistoricRates(ctx,
 			req.RequestFormatted.String(),
-			req.Ranges[x].Start.Time.Format(time.RFC3339),
-			req.Ranges[x].End.Time.Format(time.RFC3339),
+			req.RangeHolder.Ranges[x].Start.Time.Format(time.RFC3339),
+			req.RangeHolder.Ranges[x].End.Time.Format(time.RFC3339),
 			int64(req.ExchangeInterval.Duration().Seconds()))
 		if err != nil {
 			return nil, err

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -1570,11 +1570,11 @@ func (b *Base) GetKlineExtendedRequest(pair currency.Pair, a asset.Item, interva
 	if err != nil {
 		return nil, err
 	}
-
+	r.IsExtended = true
 	dates, err := r.GetRanges(b.Features.Enabled.Kline.ResultLimit)
 	if err != nil {
 		return nil, err
 	}
 
-	return &kline.ExtendedRequest{Request: r, IntervalRangeHolder: dates}, nil
+	return &kline.ExtendedRequest{Request: r, RangeHolder: dates}, nil
 }

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -2880,7 +2880,7 @@ func TestGetKlineExtendedRequest(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", r.RequestFormatted.String(), "BTCUSDT")
 	}
 
-	if len(r.Ranges) != 15 { // 15 request at max 100 candles == 1440 1 min candles.
-		t.Fatalf("received: '%v' but expected: '%v'", len(r.Ranges), 15)
+	if len(r.RangeHolder.Ranges) != 15 { // 15 request at max 100 candles == 1440 1 min candles.
+		t.Fatalf("received: '%v' but expected: '%v'", len(r.RangeHolder.Ranges), 15)
 	}
 }

--- a/exchanges/ftx/ftx_wrapper.go
+++ b/exchanges/ftx/ftx_wrapper.go
@@ -1252,14 +1252,14 @@ func (f *FTX) GetHistoricCandlesExtended(ctx context.Context, pair currency.Pair
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var ohlcData []OHLCVData
 		ohlcData, err = f.GetHistoricalData(ctx,
 			req.RequestFormatted.String(),
 			int64(req.ExchangeInterval.Duration().Seconds()),
 			int64(f.Features.Enabled.Kline.ResultLimit),
-			req.Ranges[x].Start.Time,
-			req.Ranges[x].End.Time)
+			req.RangeHolder.Ranges[x].Start.Time,
+			req.RangeHolder.Ranges[x].End.Time)
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -901,14 +901,14 @@ func (h *HitBTC) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for y := range req.Ranges {
+	for y := range req.RangeHolder.Ranges {
 		var data []ChartData
 		data, err = h.GetCandles(ctx,
 			req.RequestFormatted.String(),
 			strconv.FormatInt(int64(h.Features.Enabled.Kline.ResultLimit), 10),
 			h.FormatExchangeKlineInterval(req.ExchangeInterval),
-			req.Ranges[y].Start.Time,
-			req.Ranges[y].End.Time)
+			req.RangeHolder.Ranges[y].Start.Time,
+			req.RangeHolder.Ranges[y].End.Time)
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -11,7 +11,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 // CreateKline creates candles out of trade history data for a set time interval
@@ -213,8 +212,6 @@ func (k *Item) RemoveDuplicates() {
 // ConvertCandles functionality will break.
 func (k *Item) RemoveOutsideRange(start, end time.Time) {
 	target := 0
-	origLen := len(k.Candles)
-	log.Debugf(log.ExchangeSys, "%v", origLen)
 	for _, keep := range k.Candles {
 		if keep.Time.Equal(start) || (keep.Time.After(start) && keep.Time.Before(end)) {
 			k.Candles[target] = keep
@@ -491,12 +488,12 @@ func (h *IntervalRangeHolder) CandleLen() int {
 // SetHasDataFromCandles will calculate whether there is data in each candle
 // allowing any missing data from an API request to be highlighted
 func (h *IntervalRangeHolder) SetHasDataFromCandles(incoming []Candle) error {
-	if h.CandleLen() != len(incoming) {
-		return fmt.Errorf("%w received %v, expected %v", errDataLengthMismatch, len(incoming), h.CandleLen())
-	}
 	var offset int
 	for x := range h.Ranges {
 		for y := range h.Ranges[x].Intervals {
+			if offset >= len(incoming) {
+				return nil
+			}
 			if !h.Ranges[x].Intervals[y].Start.Time.Equal(incoming[offset].Time) {
 				return fmt.Errorf("%w '%v' expected '%v'", errInvalidPeriod, incoming[offset].Time, h.Ranges[x].Intervals[y].Start.Time)
 			}

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -478,9 +478,7 @@ func (k *Item) GetClosePriceAtTime(t time.Time) (float64, error) {
 func (h *IntervalRangeHolder) CandleLen() int {
 	var count int
 	for i := range h.Ranges {
-		for range h.Ranges[i].Intervals {
-			count++
-		}
+		count += len(h.Ranges[i].Intervals)
 	}
 	return count
 }
@@ -495,7 +493,7 @@ func (h *IntervalRangeHolder) SetHasDataFromCandles(incoming []Candle) error {
 				return nil
 			}
 			if !h.Ranges[x].Intervals[y].Start.Time.Equal(incoming[offset].Time) {
-				return fmt.Errorf("%w '%v' expected '%v'", errInvalidPeriod, incoming[offset].Time, h.Ranges[x].Intervals[y].Start.Time)
+				return fmt.Errorf("%w '%v' expected '%v'", errInvalidPeriod, incoming[offset].Time.UTC(), h.Ranges[x].Intervals[y].Start.Time.UTC())
 			}
 			if incoming[offset].Low <= 0 && incoming[offset].High <= 0 &&
 				incoming[offset].Close <= 0 && incoming[offset].Open <= 0 &&

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -474,15 +474,6 @@ func (k *Item) GetClosePriceAtTime(t time.Time) (float64, error) {
 	return -1, fmt.Errorf("%w at %v", ErrNotFoundAtTime, t)
 }
 
-// CandleLen returns the amount of candles inside the rangeholder
-func (h *IntervalRangeHolder) CandleLen() int {
-	var count int
-	for i := range h.Ranges {
-		count += len(h.Ranges[i].Intervals)
-	}
-	return count
-}
-
 // SetHasDataFromCandles will calculate whether there is data in each candle
 // allowing any missing data from an API request to be highlighted
 func (h *IntervalRangeHolder) SetHasDataFromCandles(incoming []Candle) error {

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1278,15 +1278,3 @@ func TestSetHasDataFromCandles(t *testing.T) {
 		t.Errorf("received '%v' expected '%v'", true, false)
 	}
 }
-
-func TestCandlLen(t *testing.T) {
-	t.Parallel()
-	ohc := getOneHour()
-	i, err := CalculateCandleDateRanges(ohc[0].Time, ohc[len(ohc)-1].Time.Add(OneHour.Duration()), OneHour, 100000)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	if i.CandleLen() != len(ohc) {
-		t.Errorf("received '%v' expected '%v'", i.CandleLen(), len(ohc))
-	}
-}

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1215,24 +1215,23 @@ func TestDeployExchangeIntervals(t *testing.T) {
 
 func TestSetHasDataFromCandles(t *testing.T) {
 	t.Parallel()
-	oh := getOneHour()
-
-	i, err := CalculateCandleDateRanges(oh[0].Time, oh[len(oh)-1].Time, OneHour, 100000)
+	ohc := getOneHour()
+	i, err := CalculateCandleDateRanges(ohc[0].Time, ohc[len(ohc)-1].Time, OneHour, 100000)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
 
-	i.SetHasDataFromCandles(oh)
-	if !i.Start.Equal(oh[0].Time) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
+	i.SetHasDataFromCandles(ohc)
+	if !i.Start.Equal(ohc[0].Time) {
+		t.Errorf("received '%v' expected '%v'", i.Start.Time, ohc[0].Time)
 	}
-	if !i.End.Equal(oh[len(oh)-1].Time) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
+	if !i.End.Equal(ohc[len(ohc)-1].Time) {
+		t.Errorf("received '%v' expected '%v'", i.End.Time, ohc[len(ohc)-1].Time)
 	}
 
 	k := Item{
 		Interval: OneHour,
-		Candles:  oh[2:],
+		Candles:  ohc[2:],
 	}
 	err = k.addPadding(i.Start.Time, i.End.Time, false)
 	if !errors.Is(err, nil) {

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1244,7 +1244,6 @@ func TestSetHasDataFromCandles(t *testing.T) {
 	}
 	if i.HasDataAtDate(k.Candles[0].Time) {
 		t.Errorf("received '%v' expected '%v'", false, true)
-
 	}
 	if !i.HasDataAtDate(k.Candles[len(k.Candles)-1].Time) {
 		t.Errorf("received '%v' expected '%v'", true, false)

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1212,3 +1212,42 @@ func TestDeployExchangeIntervals(t *testing.T) {
 		t.Errorf("received '%v' expected '%v'", request, OneDay)
 	}
 }
+
+func TestSetHasDataFromCandles(t *testing.T) {
+	t.Parallel()
+	oh := getOneHour()
+
+	i, err := CalculateCandleDateRanges(oh[0].Time, oh[len(oh)-1].Time, OneHour, 100000)
+	if !errors.Is(err, nil) {
+		t.Errorf("received '%v' expected '%v'", err, nil)
+	}
+
+	i.SetHasDataFromCandles(oh)
+	if !i.Start.Equal(oh[0].Time) {
+		t.Errorf("received '%v' expected '%v'", err, nil)
+	}
+	if !i.End.Equal(oh[len(oh)-1].Time) {
+		t.Errorf("received '%v' expected '%v'", err, nil)
+	}
+
+	k := Item{
+		Interval: OneHour,
+		Candles:  oh[2:],
+	}
+	err = k.addPadding(i.Start.Time, i.End.Time, false)
+	if !errors.Is(err, nil) {
+		t.Errorf("received '%v' expected '%v'", err, nil)
+	}
+
+	i.SetHasDataFromCandles(k.Candles)
+	if !i.Start.Equal(k.Candles[0].Time) {
+		t.Errorf("received '%v' expected '%v'", i.Start.Time, k.Candles[0].Time)
+	}
+	if i.HasDataAtDate(k.Candles[0].Time) {
+		t.Errorf("received '%v' expected '%v'", false, true)
+
+	}
+	if !i.HasDataAtDate(k.Candles[len(k.Candles)-1].Time) {
+		t.Errorf("received '%v' expected '%v'", true, false)
+	}
+}

--- a/exchanges/kline/request_test.go
+++ b/exchanges/kline/request_test.go
@@ -320,9 +320,9 @@ func TestRequest_ProcessResponse(t *testing.T) {
 
 func TestExtendedRequest_ProcessResponse(t *testing.T) {
 	t.Parallel()
-
-	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	end := start.AddDate(0, 0, 1)
+	ohc := getOneHour()
+	start := ohc[0].Time
+	end := ohc[len(ohc)-1].Time.Add(OneHour.Duration())
 	pair := currency.NewPair(currency.BTC, currency.USDT)
 
 	var rExt *ExtendedRequest
@@ -342,7 +342,7 @@ func TestExtendedRequest_ProcessResponse(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
 	}
-
+	r.ProcessedCandles = ohc
 	dates, err := r.GetRanges(100)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
@@ -350,7 +350,7 @@ func TestExtendedRequest_ProcessResponse(t *testing.T) {
 
 	rExt = &ExtendedRequest{r, dates}
 
-	holder, err := rExt.ProcessResponse(getOneHour())
+	holder, err := rExt.ProcessResponse(ohc)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
 	}
@@ -360,6 +360,7 @@ func TestExtendedRequest_ProcessResponse(t *testing.T) {
 	}
 
 	// with conversion
+	ohc = getOneMinute()
 	r, err = CreateKlineRequest("name", pair, pair, asset.Spot, OneHour, OneMin, start, end)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
@@ -370,9 +371,9 @@ func TestExtendedRequest_ProcessResponse(t *testing.T) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
 	}
 
+	r.IsExtended = true
 	rExt = &ExtendedRequest{r, dates}
-
-	holder, err = rExt.ProcessResponse(getOneMinute())
+	holder, err = rExt.ProcessResponse(ohc)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v', but expected '%v'", err, nil)
 	}
@@ -390,7 +391,7 @@ func TestExtendedRequest_Size(t *testing.T) {
 		t.Fatalf("received: '%v', but expected '%v'", rExt.Size(), 0)
 	}
 
-	rExt = &ExtendedRequest{IntervalRangeHolder: &IntervalRangeHolder{Limit: 100, Ranges: []IntervalRange{{}, {}}}}
+	rExt = &ExtendedRequest{RangeHolder: &IntervalRangeHolder{Limit: 100, Ranges: []IntervalRange{{}, {}}}}
 	if rExt.Size() != 200 {
 		t.Fatalf("received: '%v', but expected '%v'", rExt.Size(), 200)
 	}

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -925,19 +925,19 @@ func (l *Lbank) GetHistoricCandlesExtended(ctx context.Context, pair currency.Pa
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var data []KlineResponse
 		data, err = l.GetKlines(ctx,
 			req.RequestFormatted.String(),
 			strconv.FormatInt(int64(l.Features.Enabled.Kline.ResultLimit), 10),
 			l.FormatExchangeKlineInterval(req.ExchangeInterval),
-			strconv.FormatInt(req.Ranges[x].Start.Ticks, 10))
+			strconv.FormatInt(req.RangeHolder.Ranges[x].Start.Ticks, 10))
 		if err != nil {
 			return nil, err
 		}
 		for i := range data {
-			if (data[i].TimeStamp.Unix() < req.Ranges[x].Start.Ticks) ||
-				(data[i].TimeStamp.Unix() > req.Ranges[x].End.Ticks) {
+			if (data[i].TimeStamp.Unix() < req.RangeHolder.Ranges[x].Start.Ticks) ||
+				(data[i].TimeStamp.Unix() > req.RangeHolder.Ranges[x].End.Ticks) {
 				continue
 			}
 			timeSeries = append(timeSeries, kline.Candle{

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -1048,12 +1048,12 @@ func (o *OKCoin) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 
 	gran := o.FormatExchangeKlineInterval(interval)
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for x := range req.Ranges {
+	for x := range req.RangeHolder.Ranges {
 		var candles []kline.Candle
 		candles, err = o.GetMarketData(ctx, &GetMarketDataRequest{
 			Asset:        a,
-			Start:        req.Ranges[x].Start.Time.UTC().Format(time.RFC3339),
-			End:          req.Ranges[x].End.Time.UTC().Format(time.RFC3339),
+			Start:        req.RangeHolder.Ranges[x].Start.Time.UTC().Format(time.RFC3339),
+			End:          req.RangeHolder.Ranges[x].End.Time.UTC().Format(time.RFC3339),
 			Granularity:  gran,
 			InstrumentID: req.RequestFormatted.String(),
 		})

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -1400,7 +1400,8 @@ func (ok *Okx) GetHistoricCandlesExtended(ctx context.Context, pair currency.Pai
 		return nil, err
 	}
 
-	if count := kline.TotalCandlesPerInterval(start, end, req.ExchangeInterval); count > 1440 {
+	count := kline.TotalCandlesPerInterval(req.Start, req.End, req.ExchangeInterval)
+	if count > 1440 {
 		return nil,
 			fmt.Errorf("candles count: %d max lookback: %d, %w",
 				count, 1440, kline.ErrRequestExceedsMaxLookback)

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -1407,15 +1407,15 @@ func (ok *Okx) GetHistoricCandlesExtended(ctx context.Context, pair currency.Pai
 	}
 
 	timeSeries := make([]kline.Candle, 0, req.Size())
-	for y := range req.Ranges {
+	for y := range req.RangeHolder.Ranges {
 		var candles []CandleStick
 		candles, err = ok.GetCandlesticksHistory(ctx,
 			req.RequestFormatted.Base.String()+
 				currency.DashDelimiter+
 				req.RequestFormatted.Quote.String(),
 			req.ExchangeInterval,
-			req.Ranges[y].Start.Time.Add(-time.Nanosecond), // Start time not inclusive of candle.
-			req.Ranges[y].End.Time,
+			req.RangeHolder.Ranges[y].Start.Time.Add(-time.Nanosecond), // Start time not inclusive of candle.
+			req.RangeHolder.Ranges[y].End.Time,
 			300)
 		if err != nil {
 			return nil, err

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	zbTradeURL                        = "https://api.zb.land"
-	zbMarketURL                       = "https://trade.zb.land/api"
+	zbTradeURL                        = "https://api.zb.com"
+	zbMarketURL                       = "https://trade.zb.com/api"
 	zbAPIVersion                      = "v1"
 	zbData                            = "data"
 	zbAccountInfo                     = "getAccountInfo"

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -877,7 +877,6 @@ func TestGetSpotKline(t *testing.T) {
 		arg.Since = startTime.UnixMilli()
 		arg.Type = "1day"
 	}
-
 	_, err := z.GetSpotKline(context.Background(), arg)
 	if err != nil {
 		t.Errorf("ZB GetSpotKline: %s", err)
@@ -890,7 +889,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	startTime := time.Now().Add(-time.Hour * 1)
+	startTime := time.Now().Add(-time.Hour * 24)
 	endTime := time.Now()
 	if mockTests {
 		startTime = time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -910,13 +909,20 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTime := time.Now().Add(-time.Hour * 1)
-	endTime := time.Now()
-	if mockTests {
-		startTime = time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)
-		endTime = time.Date(2020, 9, 2, 0, 0, 0, 0, time.UTC)
+	startTime := time.Now().Add(-time.Hour * 24 * 365)
+	endTime := startTime.Add(time.Hour * 1001)
+	_, err = z.GetHistoricCandlesExtended(context.Background(),
+		currencyPair, asset.Spot, kline.OneHour, startTime, endTime)
+	if !errors.Is(err, kline.ErrRequestExceedsMaxLookback) {
+		t.Fatal(err)
 	}
-	// Current endpoint is dead.
+
+	startTime = time.Now().Add(-time.Hour * 24 * 365)
+	endTime = time.Now()
+	if mockTests {
+		startTime = time.UnixMilli(1674489600000)
+		endTime = startTime.Add(kline.OneDay.Duration())
+	}
 	_, err = z.GetHistoricCandlesExtended(context.Background(),
 		currencyPair, asset.Spot, kline.OneDay, startTime, endTime)
 	if err != nil {

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	zbWebsocketAPI       = "wss://api.zb.land/websocket"
+	zbWebsocketAPI       = "wss://api.zb.com/websocket"
 	zWebsocketAddChannel = "addChannel"
 	zbWebsocketRateLimit = 20
 )

--- a/testdata/http_mock/zb/zb.json
+++ b/testdata/http_mock/zb/zb.json
@@ -2135,6 +2135,25 @@
      "queryString": "market=btc_usdt\u0026since=1598918400000\u0026size=1000\u0026type=1day",
      "bodyParams": "",
      "headers": {}
+    },
+    {
+     "data": {
+      "data": [
+       [
+        1674489600000,
+        22202.37,
+        22222,
+        22000.03,
+        22033.84,
+        2321.1898
+       ]
+      ],
+      "moneyType": "USDT",
+      "symbol": "BTC"
+     },
+     "queryString": "market=btc_usdt\u0026since=1674432000000\u0026size=1000\u0026type=1day",
+     "bodyParams": "",
+     "headers": {}
     }
    ]
   },


### PR DESCRIPTION
# PR Description

Adds support for converting to custom intervals on the Backtester thanks to #1091. Prevents settings intervals at less than 15 seconds. Prevents using custom candles on live trading because it makes no sense and is shooting yourself in the foot for no reason :chart_with_downwards_trend: 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
Coverage of all new areas

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
