### PR TITLE
exchange_template: Fix test regression

### DIFF
--- a/cmd/exchange_template/exchange_template.go
+++ b/cmd/exchange_template/exchange_template.go
@@ -232,24 +232,25 @@ func makeExchange(exchangeDirectory string, configTestFile *config.Config, exch 
 }
 
 func saveConfig(exchangeDirectory string, configTestFile *config.Config, newExchConfig *config.Exchange) error {
-	cmd := exec.Command("go", "fmt")
-	cmd.Dir = exchangeDirectory
-	out, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("unable to go fmt. output: %s err: %s", out, err)
-	}
-
-	configTestFile.Exchanges = append(configTestFile.Exchanges, *newExchConfig)
-	err = configTestFile.SaveConfigToFile(exchangeConfigPath)
-	if err != nil {
+	if err := runCommand(exchangeDirectory, "fmt"); err != nil {
 		return err
 	}
 
-	cmd = exec.Command("go", "test")
-	cmd.Dir = exchangeDirectory
-	out, err = cmd.Output()
+	configTestFile.Exchanges = append(configTestFile.Exchanges, *newExchConfig)
+	if err := configTestFile.SaveConfigToFile(exchangeConfigPath); err != nil {
+		return err
+	}
+
+	return runCommand(exchangeDirectory, "test")
+}
+
+func runCommand(dir, param string) error {
+	cmd := exec.Command("go", param)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("unable to go test. output: %s err: %s", out, err)
+		return fmt.Errorf("unable to go %s stdout: %s stderr: %s",
+			param, err, out)
 	}
 	return nil
 }

--- a/cmd/exchange_template/exchange_template.go
+++ b/cmd/exchange_template/exchange_template.go
@@ -250,7 +250,7 @@ func runCommand(dir, param string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("unable to go %s stdout: %s stderr: %s",
-			param, err, out)
+			param, out, err)
 	}
 	return nil
 }

--- a/cmd/exchange_template/exchange_template_test.go
+++ b/cmd/exchange_template/exchange_template_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -60,7 +62,17 @@ func TestNewExchange(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := os.RemoveAll(testExchangeDir); err != nil {
-		t.Errorf("unable to remove dir: %s, manual removal required", err)
+	cmd := exec.Command("go", "build")
+	cmd.Dir = testExchangeDir
+
+	if _, err = cmd.Output(); err != nil {
+		if stdErr, ok := err.(*exec.ExitError); ok {
+			err = fmt.Errorf("%s: stderr: %s", err, stdErr.Stderr)
+		}
+		t.Error(err)
+	}
+
+	if err = os.RemoveAll(testExchangeDir); err != nil {
+		t.Errorf("RemoveAll failed: %s, manual deletion of test directory required", err)
 	}
 }


### PR DESCRIPTION
# PR Description

Restores automatic testing of the example template tool to ensure that the templates are valid whenever there is an update done to the exchange wrappers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Manually breaking the exchange templates

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
