### PR TITLE
cmd/wrapper_coverage: cancel context to not send REST requests

### DIFF
--- a/cmd/config_builder/builder.go
+++ b/cmd/config_builder/builder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"sync"
@@ -34,7 +35,7 @@ func main() {
 	cfgs := make([]config.Exchange, 0, len(exchanges))
 	for x := range exchanges {
 		var cfg *config.Exchange
-		cfg, err = exchanges[x].GetDefaultConfig()
+		cfg, err = exchanges[x].GetDefaultConfig(context.Background())
 		if err != nil {
 			log.Printf("Failed to get exchanges default config. Err: %s", err)
 			continue

--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -27,7 +27,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func ({{.Variable}} *{{.CapitalName}}) GetDefaultConfig() (*config.Exchange, error) {
+func ({{.Variable}} *{{.CapitalName}}) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	{{.Variable}}.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = {{.Variable}}.Name
@@ -37,7 +37,7 @@ func ({{.Variable}} *{{.CapitalName}}) GetDefaultConfig() (*config.Exchange, err
 	{{.Variable}}.SetupDefaults(exchCfg)
 
 	if {{.Variable}}.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err := {{.Variable}}.UpdateTradablePairs(context.TODO(), true)
+		err := {{.Variable}}.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +181,7 @@ func ({{.Variable}} *{{.CapitalName}}) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the {{.CapitalName}} go routine
-func ({{.Variable}} *{{.CapitalName}}) Start(wg *sync.WaitGroup) error {
+func ({{.Variable}} *{{.CapitalName}}) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
@@ -194,7 +194,7 @@ func ({{.Variable}} *{{.CapitalName}}) Start(wg *sync.WaitGroup) error {
 }
 
 // Run implements the {{.CapitalName}} wrapper
-func ({{.Variable}} *{{.CapitalName}}) Run() {
+func ({{.Variable}} *{{.CapitalName}}) Run(ctx context.Context) {
 	if {{.Variable}}.Verbose {
 	{{ if .WS }} log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -207,7 +207,7 @@ func ({{.Variable}} *{{.CapitalName}}) Run() {
 		return
 	}
 
-	err := {{.Variable}}.UpdateTradablePairs(context.TODO(), false)
+	err := {{.Variable}}.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -187,7 +187,7 @@ func ({{.Variable}} *{{.CapitalName}}) Start(ctx context.Context, wg *sync.WaitG
 	}
 	wg.Add(1)
 	go func() {
-		{{.Variable}}.Run()
+		{{.Variable}}.Run(ctx)
 		wg.Done()
 	}()
 	return nil

--- a/cmd/exchange_wrapper_coverage/main.go
+++ b/cmd/exchange_wrapper_coverage/main.go
@@ -111,8 +111,8 @@ func testWrappers(e exchange.IBotExchange) ([]string, error) {
 				// Need to deploy a context.Context value as nil value is not
 				// checked throughout codebase. Cancelled to minimise external
 				// calls and speed up operation.
-				cancelled, fn := context.WithTimeout(context.Background(), 0)
-				defer fn()
+				cancelled, cancelfn := context.WithTimeout(context.Background(), 0)
+				cancelfn()
 				inputs[y] = reflect.ValueOf(cancelled)
 				continue
 			}

--- a/cmd/exchange_wrapper_coverage/main.go
+++ b/cmd/exchange_wrapper_coverage/main.go
@@ -109,8 +109,11 @@ func testWrappers(e exchange.IBotExchange) ([]string, error) {
 
 			if input.Implements(contextParam) {
 				// Need to deploy a context.Context value as nil value is not
-				// checked throughout codebase.
-				inputs[y] = reflect.ValueOf(context.Background())
+				// checked throughout codebase. Cancelled to minimise external
+				// calls and speed up operation.
+				cancelled, fn := context.WithTimeout(context.Background(), 0)
+				defer fn()
+				inputs[y] = reflect.ValueOf(cancelled)
 				continue
 			}
 			inputs[y] = reflect.Zero(input)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -888,11 +888,11 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 	}
 
 	if wg != nil {
-		return exch.Start(wg)
+		return exch.Start(context.TODO(), wg)
 	}
 
 	tempWG := sync.WaitGroup{}
-	err = exch.Start(&tempWG)
+	err = exch.Start(context.TODO(), &tempWG)
 	if err != nil {
 		return err
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -265,7 +265,7 @@ func OrdersSetup(t *testing.T) *OrderManager {
 	}
 	exch.SetDefaults()
 
-	cfg, err := exch.GetDefaultConfig()
+	cfg, err := exch.GetDefaultConfig(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/engine/withdraw_manager_test.go
+++ b/engine/withdraw_manager_test.go
@@ -25,7 +25,7 @@ func withdrawManagerTestHelper(t *testing.T) (*ExchangeManager, *portfolioManage
 	em := SetupExchangeManager()
 	b := new(bybit.Bybit)
 	b.SetDefaults()
-	cfg, err := b.GetDefaultConfig()
+	cfg, err := b.GetDefaultConfig(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config for Alphapoint
-func (a *Alphapoint) GetDefaultConfig() (*config.Exchange, error) {
+func (a *Alphapoint) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	return nil, common.ErrFunctionNotSupported
 }
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -63,12 +63,12 @@ func getTime() (start, end time.Time) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/binanceus/binanceus_test.go
+++ b/exchanges/binanceus/binanceus_test.go
@@ -61,12 +61,12 @@ func TestMain(m *testing.M) {
 		log.Fatal("Binanceus TestMain()", err)
 	}
 	bi.setupOrderbookManager()
-	err = bi.Start(nil)
+	err = bi.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		log.Fatalf("%s received: '%v' but expected: '%v'", bi.Name, err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = bi.Start(&testWg)
+	err = bi.Start(context.Background(), &testWg)
 	if err != nil {
 		log.Fatal("Binanceus Starting error ", err)
 	}

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (bi *Binanceus) GetDefaultConfig() (*config.Exchange, error) {
+func (bi *Binanceus) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	bi.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = bi.Name
@@ -44,7 +44,7 @@ func (bi *Binanceus) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if bi.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err := bi.UpdateTradablePairs(context.TODO(), true)
+		err := bi.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -216,20 +216,20 @@ func (bi *Binanceus) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Binanceus go routine
-func (bi *Binanceus) Start(wg *sync.WaitGroup) error {
+func (bi *Binanceus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		bi.Run()
+		bi.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Binanceus wrapper
-func (bi *Binanceus) Run() {
+func (bi *Binanceus) Run(ctx context.Context) {
 	if bi.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -242,7 +242,7 @@ func (bi *Binanceus) Run() {
 		return
 	}
 
-	err := bi.UpdateTradablePairs(context.TODO(), false)
+	err := bi.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -66,12 +66,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -32,7 +32,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bitfinex) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bitfinex) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -45,7 +45,7 @@ func (b *Bitfinex) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -241,20 +241,20 @@ func (b *Bitfinex) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bitfinex go routine
-func (b *Bitfinex) Start(wg *sync.WaitGroup) error {
+func (b *Bitfinex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bitfinex wrapper
-func (b *Bitfinex) Run() {
+func (b *Bitfinex) Run(ctx context.Context) {
 	if b.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -267,7 +267,7 @@ func (b *Bitfinex) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), false)
+	err := b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -53,12 +53,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bitflyer) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bitflyer) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -41,7 +41,7 @@ func (b *Bitflyer) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -123,20 +123,20 @@ func (b *Bitflyer) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bitflyer go routine
-func (b *Bitflyer) Start(wg *sync.WaitGroup) error {
+func (b *Bitflyer) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bitflyer wrapper
-func (b *Bitflyer) Run() {
+func (b *Bitflyer) Run(ctx context.Context) {
 	if b.Verbose {
 		b.PrintEnabledPairs()
 	}
@@ -145,7 +145,7 @@ func (b *Bitflyer) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), false)
+	err := b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
 	}

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -61,12 +61,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -36,7 +36,7 @@ const wsRateLimitMillisecond = 1000
 var errNotEnoughPairs = errors.New("at least one currency is required to fetch order history")
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bithumb) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bithumb) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -49,7 +49,7 @@ func (b *Bithumb) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -195,25 +195,25 @@ func (b *Bithumb) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bithumb go routine
-func (b *Bithumb) Start(wg *sync.WaitGroup) error {
+func (b *Bithumb) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bithumb wrapper
-func (b *Bithumb) Run() {
+func (b *Bithumb) Run(ctx context.Context) {
 	if b.Verbose {
 		b.PrintEnabledPairs()
 	}
 
-	err := b.UpdateOrderExecutionLimits(context.TODO(), asset.Empty)
+	err := b.UpdateOrderExecutionLimits(ctx, asset.Empty)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to set exchange order execution limits. Err: %v",
@@ -225,7 +225,7 @@ func (b *Bithumb) Run() {
 		return
 	}
 
-	err = b.UpdateTradablePairs(context.TODO(), false)
+	err = b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
 	}

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -59,12 +59,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -32,7 +32,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bitmex) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bitmex) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -45,7 +45,7 @@ func (b *Bitmex) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -207,20 +207,20 @@ func (b *Bitmex) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bitmex go routine
-func (b *Bitmex) Start(wg *sync.WaitGroup) error {
+func (b *Bitmex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bitmex wrapper
-func (b *Bitmex) Run() {
+func (b *Bitmex) Run(ctx context.Context) {
 	if b.Verbose {
 		wsEndpoint, err := b.API.Endpoints.GetURL(exchange.WebsocketSpot)
 		if err != nil {
@@ -238,7 +238,7 @@ func (b *Bitmex) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), false)
+	err := b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
 	}

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -44,12 +44,12 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bitstamp) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bitstamp) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -41,7 +41,7 @@ func (b *Bitstamp) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -192,20 +192,20 @@ func (b *Bitstamp) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bitstamp go routine
-func (b *Bitstamp) Start(wg *sync.WaitGroup) error {
+func (b *Bitstamp) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bitstamp wrapper
-func (b *Bitstamp) Run() {
+func (b *Bitstamp) Run(ctx context.Context) {
 	if b.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -270,7 +270,7 @@ func (b *Bitstamp) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := b.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var wg sync.WaitGroup
-	err = b.Start(&wg)
+	err = b.Start(context.Background(), &wg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *Bittrex) GetDefaultConfig() (*config.Exchange, error) {
+func (b *Bittrex) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -42,7 +42,7 @@ func (b *Bittrex) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -193,20 +193,20 @@ func (b *Bittrex) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Bittrex go routine
-func (b *Bittrex) Start(wg *sync.WaitGroup) error {
+func (b *Bittrex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bittrex wrapper
-func (b *Bittrex) Run() {
+func (b *Bittrex) Run(ctx context.Context) {
 	if b.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -219,7 +219,7 @@ func (b *Bittrex) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), false)
+	err := b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -68,12 +68,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -34,7 +34,7 @@ import (
 var errFailedToConvertToCandle = errors.New("cannot convert time series data to kline.Candle, insufficient data")
 
 // GetDefaultConfig returns a default exchange config
-func (b *BTCMarkets) GetDefaultConfig() (*config.Exchange, error) {
+func (b *BTCMarkets) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -47,7 +47,7 @@ func (b *BTCMarkets) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -202,20 +202,20 @@ func (b *BTCMarkets) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the BTC Markets go routine
-func (b *BTCMarkets) Start(wg *sync.WaitGroup) error {
+func (b *BTCMarkets) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the BTC Markets wrapper
-func (b *BTCMarkets) Run() {
+func (b *BTCMarkets) Run(ctx context.Context) {
 	if b.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s (url: %s).\n",
@@ -270,7 +270,7 @@ func (b *BTCMarkets) Run() {
 		}
 	}
 
-	err = b.UpdateOrderExecutionLimits(context.TODO(), asset.Spot)
+	err = b.UpdateOrderExecutionLimits(ctx, asset.Spot)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s Failed to update order execution limits. Error: %v\n",
@@ -281,7 +281,7 @@ func (b *BTCMarkets) Run() {
 		return
 	}
 
-	err = b.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err = b.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -61,12 +61,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (b *BTSE) GetDefaultConfig() (*config.Exchange, error) {
+func (b *BTSE) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	b.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = b.Name
@@ -44,7 +44,7 @@ func (b *BTSE) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if b.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = b.UpdateTradablePairs(context.TODO(), true)
+		err = b.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -211,20 +211,20 @@ func (b *BTSE) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the BTSE go routine
-func (b *BTSE) Start(wg *sync.WaitGroup) error {
+func (b *BTSE) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		b.Run()
+		b.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the BTSE wrapper
-func (b *BTSE) Run() {
+func (b *BTSE) Run(ctx context.Context) {
 	if b.Verbose {
 		b.PrintEnabledPairs()
 	}
@@ -233,7 +233,7 @@ func (b *BTSE) Run() {
 		return
 	}
 
-	err := b.UpdateTradablePairs(context.TODO(), false)
+	err := b.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s Failed to update tradable pairs. Error: %s", b.Name, err)

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -69,12 +69,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := b.Start(nil)
+	err := b.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = b.Start(&testWg)
+	err = b.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (by *Bybit) GetDefaultConfig() (*config.Exchange, error) {
+func (by *Bybit) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	by.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = by.Name
@@ -43,7 +43,7 @@ func (by *Bybit) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if by.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err := by.UpdateTradablePairs(context.TODO(), true)
+		err := by.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -247,20 +247,20 @@ func (by *Bybit) AuthenticateWebsocket(ctx context.Context) error {
 }
 
 // Start starts the Bybit go routine
-func (by *Bybit) Start(wg *sync.WaitGroup) error {
+func (by *Bybit) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		by.Run()
+		by.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Bybit wrapper
-func (by *Bybit) Run() {
+func (by *Bybit) Run(ctx context.Context) {
 	if by.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -273,7 +273,7 @@ func (by *Bybit) Run() {
 		return
 	}
 
-	err := by.UpdateTradablePairs(context.TODO(), false)
+	err := by.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -65,12 +65,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := c.Start(nil)
+	err := c.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = c.Start(&testWg)
+	err = c.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (c *CoinbasePro) GetDefaultConfig() (*config.Exchange, error) {
+func (c *CoinbasePro) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	c.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = c.Name
@@ -43,7 +43,7 @@ func (c *CoinbasePro) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if c.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = c.UpdateTradablePairs(context.TODO(), true)
+		err = c.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -196,20 +196,20 @@ func (c *CoinbasePro) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the coinbasepro go routine
-func (c *CoinbasePro) Start(wg *sync.WaitGroup) error {
+func (c *CoinbasePro) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		c.Run()
+		c.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the coinbasepro wrapper
-func (c *CoinbasePro) Run() {
+func (c *CoinbasePro) Run(ctx context.Context) {
 	if c.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s. (url: %s).\n",
@@ -277,7 +277,7 @@ func (c *CoinbasePro) Run() {
 		return
 	}
 
-	err := c.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := c.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", c.Name, err)
 	}

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -93,12 +93,12 @@ func setupWSTestAuth(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := c.Start(nil)
+	err := c.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = c.Start(&testWg)
+	err = c.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (c *COINUT) GetDefaultConfig() (*config.Exchange, error) {
+func (c *COINUT) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	c.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = c.Name
@@ -44,7 +44,7 @@ func (c *COINUT) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if c.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = c.UpdateTradablePairs(context.TODO(), true)
+		err = c.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -179,20 +179,20 @@ func (c *COINUT) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the COINUT go routine
-func (c *COINUT) Start(wg *sync.WaitGroup) error {
+func (c *COINUT) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		c.Run()
+		c.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the COINUT wrapper
-func (c *COINUT) Run() {
+func (c *COINUT) Run(ctx context.Context) {
 	if c.Verbose {
 		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", c.Name, common.IsEnabled(c.Websocket.IsEnabled()), coinutWebsocketURL)
 		c.PrintEnabledPairs()
@@ -256,7 +256,7 @@ func (c *COINUT) Run() {
 		return
 	}
 
-	err := c.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := c.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", c.Name, err)
 	}

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -53,12 +53,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := e.Start(nil)
+	err := e.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = e.Start(&testWg)
+	err = e.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (e *EXMO) GetDefaultConfig() (*config.Exchange, error) {
+func (e *EXMO) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	e.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = e.Name
@@ -42,7 +42,7 @@ func (e *EXMO) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if e.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = e.UpdateTradablePairs(context.TODO(), true)
+		err = e.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -138,20 +138,20 @@ func (e *EXMO) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the EXMO go routine
-func (e *EXMO) Start(wg *sync.WaitGroup) error {
+func (e *EXMO) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		e.Run()
+		e.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the EXMO wrapper
-func (e *EXMO) Run() {
+func (e *EXMO) Run(ctx context.Context) {
 	if e.Verbose {
 		e.PrintEnabledPairs()
 	}
@@ -160,7 +160,7 @@ func (e *EXMO) Run() {
 		return
 	}
 
-	err := e.UpdateTradablePairs(context.TODO(), false)
+	err := e.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", e.Name, err)
 	}

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -62,12 +62,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := g.Start(nil)
+	err := g.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = g.Start(&testWg)
+	err = g.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (g *Gateio) GetDefaultConfig() (*config.Exchange, error) {
+func (g *Gateio) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	g.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = g.Name
@@ -44,7 +44,7 @@ func (g *Gateio) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if g.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = g.UpdateTradablePairs(context.TODO(), true)
+		err = g.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -193,20 +193,20 @@ func (g *Gateio) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the GateIO go routine
-func (g *Gateio) Start(wg *sync.WaitGroup) error {
+func (g *Gateio) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		g.Run()
+		g.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the GateIO wrapper
-func (g *Gateio) Run() {
+func (g *Gateio) Run(ctx context.Context) {
 	if g.Verbose {
 		g.PrintEnabledPairs()
 	}
@@ -215,7 +215,7 @@ func (g *Gateio) Run() {
 		return
 	}
 
-	err := g.UpdateTradablePairs(context.TODO(), false)
+	err := g.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", g.Name, err)
 	}

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -34,12 +34,12 @@ var g Gemini
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := g.Start(nil)
+	err := g.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = g.Start(&testWg)
+	err = g.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (g *Gemini) GetDefaultConfig() (*config.Exchange, error) {
+func (g *Gemini) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	g.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = g.Name
@@ -43,7 +43,7 @@ func (g *Gemini) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if g.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err := g.UpdateTradablePairs(context.TODO(), true)
+		err := g.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -192,20 +192,20 @@ func (g *Gemini) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Gemini go routine
-func (g *Gemini) Start(wg *sync.WaitGroup) error {
+func (g *Gemini) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		g.Run()
+		g.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Gemini wrapper
-func (g *Gemini) Run() {
+func (g *Gemini) Run(ctx context.Context) {
 	if g.Verbose {
 		g.PrintEnabledPairs()
 	}
@@ -263,7 +263,7 @@ func (g *Gemini) Run() {
 	if !g.GetEnabledFeatures().AutoPairUpdates && !forceUpdate {
 		return
 	}
-	err := g.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := g.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -59,12 +59,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := h.Start(nil)
+	err := h.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = h.Start(&testWg)
+	err = h.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (h *HitBTC) GetDefaultConfig() (*config.Exchange, error) {
+func (h *HitBTC) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	h.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = h.Name
@@ -44,7 +44,7 @@ func (h *HitBTC) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if h.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = h.UpdateTradablePairs(context.TODO(), true)
+		err = h.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -199,20 +199,20 @@ func (h *HitBTC) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the HitBTC go routine
-func (h *HitBTC) Start(wg *sync.WaitGroup) error {
+func (h *HitBTC) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		h.Run()
+		h.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the HitBTC wrapper
-func (h *HitBTC) Run() {
+func (h *HitBTC) Run(ctx context.Context) {
 	if h.Verbose {
 		log.Debugf(log.ExchangeSys, "%s Websocket: %s (url: %s).\n", h.Name, common.IsEnabled(h.Websocket.IsEnabled()), hitbtcWebsocketAddress)
 		h.PrintEnabledPairs()
@@ -273,7 +273,7 @@ func (h *HitBTC) Run() {
 		return
 	}
 
-	err := h.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := h.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -89,12 +89,12 @@ func setupWsTests(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := h.Start(nil)
+	err := h.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = h.Start(&testWg)
+	err = h.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (h *HUOBI) GetDefaultConfig() (*config.Exchange, error) {
+func (h *HUOBI) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	h.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = h.Name
@@ -43,7 +43,7 @@ func (h *HUOBI) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if h.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = h.UpdateTradablePairs(context.TODO(), true)
+		err = h.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -237,20 +237,20 @@ func (h *HUOBI) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the HUOBI go routine
-func (h *HUOBI) Start(wg *sync.WaitGroup) error {
+func (h *HUOBI) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		h.Run()
+		h.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the HUOBI wrapper
-func (h *HUOBI) Run() {
+func (h *HUOBI) Run(ctx context.Context) {
 	if h.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s (url: %s).\n",
@@ -328,7 +328,7 @@ func (h *HUOBI) Run() {
 		return
 	}
 
-	err = h.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err = h.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -25,7 +25,7 @@ import (
 // GoCryptoTrader
 type IBotExchange interface {
 	Setup(exch *config.Exchange) error
-	Start(wg *sync.WaitGroup) error
+	Start(ctx context.Context, wg *sync.WaitGroup) error
 	SetDefaults()
 	GetName() string
 	SetEnabled(bool)
@@ -56,7 +56,7 @@ type IBotExchange interface {
 	SetHTTPClientUserAgent(ua string) error
 	GetHTTPClientUserAgent() (string, error)
 	SetClientProxyAddress(addr string) error
-	GetDefaultConfig() (*config.Exchange, error)
+	GetDefaultConfig(ctx context.Context) (*config.Exchange, error)
 	GetBase() *Base
 	GetHistoricCandles(ctx context.Context, pair currency.Pair, a asset.Item, interval kline.Interval, start, end time.Time) (*kline.Item, error)
 	GetHistoricCandlesExtended(ctx context.Context, pair currency.Pair, a asset.Item, interval kline.Interval, start, end time.Time) (*kline.Item, error)

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -56,12 +56,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := i.Start(nil)
+	err := i.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = i.Start(&testWg)
+	err = i.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (i *ItBit) GetDefaultConfig() (*config.Exchange, error) {
+func (i *ItBit) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	i.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = i.Name
@@ -41,7 +41,7 @@ func (i *ItBit) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if i.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = i.UpdateTradablePairs(context.TODO(), true)
+		err = i.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -116,20 +116,20 @@ func (i *ItBit) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the ItBit go routine
-func (i *ItBit) Start(wg *sync.WaitGroup) error {
+func (i *ItBit) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		i.Run()
+		i.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the ItBit wrapper
-func (i *ItBit) Run() {
+func (i *ItBit) Run(ctx context.Context) {
 	if i.Verbose {
 		i.PrintEnabledPairs()
 	}

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -63,12 +63,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := k.Start(nil)
+	err := k.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = k.Start(&testWg)
+	err = k.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -32,7 +32,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (k *Kraken) GetDefaultConfig() (*config.Exchange, error) {
+func (k *Kraken) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	k.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = k.Name
@@ -45,7 +45,7 @@ func (k *Kraken) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if k.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = k.UpdateTradablePairs(context.TODO(), true)
+		err = k.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -254,20 +254,20 @@ func (k *Kraken) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Kraken go routine
-func (k *Kraken) Start(wg *sync.WaitGroup) error {
+func (k *Kraken) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		k.Run()
+		k.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Kraken wrapper
-func (k *Kraken) Run() {
+func (k *Kraken) Run(ctx context.Context) {
 	if k.Verbose {
 		k.PrintEnabledPairs()
 	}
@@ -331,7 +331,7 @@ func (k *Kraken) Run() {
 		return
 	}
 
-	err := k.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err := k.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -57,12 +57,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := l.Start(nil)
+	err := l.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = l.Start(&testWg)
+	err = l.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (l *Lbank) GetDefaultConfig() (*config.Exchange, error) {
+func (l *Lbank) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	l.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = l.Name
@@ -41,7 +41,7 @@ func (l *Lbank) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if l.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = l.UpdateTradablePairs(context.TODO(), true)
+		err = l.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -149,20 +149,20 @@ func (l *Lbank) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Lbank go routine
-func (l *Lbank) Start(wg *sync.WaitGroup) error {
+func (l *Lbank) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		l.Run()
+		l.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Lbank wrapper
-func (l *Lbank) Run() {
+func (l *Lbank) Run(ctx context.Context) {
 	if l.Verbose {
 		l.PrintEnabledPairs()
 	}
@@ -171,7 +171,7 @@ func (l *Lbank) Run() {
 		return
 	}
 
-	err := l.UpdateTradablePairs(context.TODO(), false)
+	err := l.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", l.Name, err)
 	}

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -69,12 +69,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := o.Start(nil)
+	err := o.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = o.Start(&testWg)
+	err = o.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (o *OKCoin) GetDefaultConfig() (*config.Exchange, error) {
+func (o *OKCoin) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	o.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = o.Name
@@ -42,7 +42,7 @@ func (o *OKCoin) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if o.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = o.UpdateTradablePairs(context.TODO(), true)
+		err = o.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -202,20 +202,20 @@ func (o *OKCoin) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the OKCoin go routine
-func (o *OKCoin) Start(wg *sync.WaitGroup) error {
+func (o *OKCoin) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		o.Run()
+		o.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the OKCoin wrapper
-func (o *OKCoin) Run() {
+func (o *OKCoin) Run(ctx context.Context) {
 	if o.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -285,7 +285,7 @@ func (o *OKCoin) Run() {
 		return
 	}
 
-	err = o.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err = o.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -73,12 +73,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := ok.Start(nil)
+	err := ok.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = ok.Start(&testWg)
+	err = ok.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -36,7 +36,7 @@ const (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (ok *Okx) GetDefaultConfig() (*config.Exchange, error) {
+func (ok *Okx) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	ok.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = ok.Name
@@ -49,7 +49,7 @@ func (ok *Okx) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if ok.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err := ok.UpdateTradablePairs(context.TODO(), false)
+		err := ok.UpdateTradablePairs(ctx, false)
 		if err != nil {
 			return nil, err
 		}
@@ -233,20 +233,20 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Okx go routine
-func (ok *Okx) Start(wg *sync.WaitGroup) error {
+func (ok *Okx) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		ok.Run()
+		ok.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Okx wrapper
-func (ok *Okx) Run() {
+func (ok *Okx) Run(ctx context.Context) {
 	if ok.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s.",
@@ -258,7 +258,7 @@ func (ok *Okx) Run() {
 	if !ok.GetEnabledFeatures().AutoPairUpdates {
 		return
 	}
-	err := ok.UpdateTradablePairs(context.TODO(), false)
+	err := ok.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -37,12 +37,12 @@ func areTestAPIKeysSet() bool {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := p.Start(nil)
+	err := p.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = p.Start(&testWg)
+	err = p.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (p *Poloniex) GetDefaultConfig() (*config.Exchange, error) {
+func (p *Poloniex) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	p.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = p.Name
@@ -44,7 +44,7 @@ func (p *Poloniex) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if p.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = p.UpdateTradablePairs(context.TODO(), true)
+		err = p.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -209,20 +209,20 @@ func (p *Poloniex) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the Poloniex go routine
-func (p *Poloniex) Start(wg *sync.WaitGroup) error {
+func (p *Poloniex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		p.Run()
+		p.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Poloniex wrapper
-func (p *Poloniex) Run() {
+func (p *Poloniex) Run(ctx context.Context) {
 	if p.Verbose {
 		log.Debugf(log.ExchangeSys,
 			"%s Websocket: %s (url: %s).\n",
@@ -254,7 +254,7 @@ func (p *Poloniex) Run() {
 		return
 	}
 
-	err = p.UpdateTradablePairs(context.TODO(), forceUpdate)
+	err = p.UpdateTradablePairs(ctx, forceUpdate)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/sharedtestvalues/customex.go
+++ b/exchanges/sharedtestvalues/customex.go
@@ -31,7 +31,7 @@ func (c *CustomEx) Setup(exch *config.Exchange) error {
 }
 
 // Start is a mock method for CustomEx
-func (c *CustomEx) Start(wg *sync.WaitGroup) error {
+func (c *CustomEx) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	return nil
 }
 
@@ -264,7 +264,7 @@ func (c *CustomEx) GetSubscriptions() ([]stream.ChannelSubscription, error) {
 }
 
 // GetDefaultConfig is a mock method for CustomEx
-func (c *CustomEx) GetDefaultConfig() (*config.Exchange, error) {
+func (c *CustomEx) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	return nil, nil
 }
 

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -54,12 +54,12 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := y.Start(nil)
+	err := y.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = y.Start(&testWg)
+	err = y.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (y *Yobit) GetDefaultConfig() (*config.Exchange, error) {
+func (y *Yobit) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	y.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = y.Name
@@ -42,7 +42,7 @@ func (y *Yobit) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if y.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = y.UpdateTradablePairs(context.TODO(), true)
+		err = y.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -126,20 +126,20 @@ func (y *Yobit) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the WEX go routine
-func (y *Yobit) Start(wg *sync.WaitGroup) error {
+func (y *Yobit) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		y.Run()
+		y.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the Yobit wrapper
-func (y *Yobit) Run() {
+func (y *Yobit) Run(ctx context.Context) {
 	if y.Verbose {
 		y.PrintEnabledPairs()
 	}
@@ -148,7 +148,7 @@ func (y *Yobit) Run() {
 		return
 	}
 
-	err := y.UpdateTradablePairs(context.TODO(), false)
+	err := y.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys,
 			"%s failed to update tradable pairs. Err: %s",

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -59,12 +59,12 @@ func setupWsAuth(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	err := z.Start(nil)
+	err := z.Start(context.Background(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
 	var testWg sync.WaitGroup
-	err = z.Start(&testWg)
+	err = z.Start(context.Background(), &testWg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // GetDefaultConfig returns a default exchange config
-func (z *ZB) GetDefaultConfig() (*config.Exchange, error) {
+func (z *ZB) GetDefaultConfig(ctx context.Context) (*config.Exchange, error) {
 	z.SetDefaults()
 	exchCfg := new(config.Exchange)
 	exchCfg.Name = z.Name
@@ -43,7 +43,7 @@ func (z *ZB) GetDefaultConfig() (*config.Exchange, error) {
 	}
 
 	if z.Features.Supports.RESTCapabilities.AutoPairUpdates {
-		err = z.UpdateTradablePairs(context.TODO(), true)
+		err = z.UpdateTradablePairs(ctx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -193,20 +193,20 @@ func (z *ZB) Setup(exch *config.Exchange) error {
 }
 
 // Start starts the ZB go routine
-func (z *ZB) Start(wg *sync.WaitGroup) error {
+func (z *ZB) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if wg == nil {
 		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
 	}
 	wg.Add(1)
 	go func() {
-		z.Run()
+		z.Run(ctx)
 		wg.Done()
 	}()
 	return nil
 }
 
 // Run implements the ZB wrapper
-func (z *ZB) Run() {
+func (z *ZB) Run(ctx context.Context) {
 	if z.Verbose {
 		z.PrintEnabledPairs()
 	}
@@ -215,7 +215,7 @@ func (z *ZB) Run() {
 		return
 	}
 
-	err := z.UpdateTradablePairs(context.TODO(), false)
+	err := z.UpdateTradablePairs(ctx, false)
 	if err != nil {
 		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", z.Name, err)
 	}

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -1,6 +1,7 @@
 package gct
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -36,7 +37,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	exch.SetDefaults()
-	cfg, err := exch.GetDefaultConfig()
+	cfg, err := exch.GetDefaultConfig(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# PR Description

Cancel context on generation so it inhibits the REST request functionality. This speeds up tool completion and reduces the chance of rate limiting.

Across the exchanges, context has been propagated through functions that send a REST request. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
