### PR TITLE
OKX: Fix authenticated websocket blocking during login

### DIFF
--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -48,12 +48,6 @@ func TestMain(m *testing.M) {
 	exchCfg.API.Credentials.Key = apiKey
 	exchCfg.API.Credentials.Secret = apiSecret
 	exchCfg.API.Credentials.ClientID = passphrase
-	ok.WsResponseMultiplexer = wsRequestDataChannelsMultiplexer{
-		WsResponseChannelsMap: make(map[string]*wsRequestInfo),
-		Register:              make(chan *wsRequestInfo),
-		Unregister:            make(chan string),
-		Message:               make(chan *wsIncomingData),
-	}
 	ok.SetDefaults()
 	if apiKey != "" && apiSecret != "" && passphrase != "" {
 		exchCfg.API.AuthenticatedSupport = true

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -192,6 +192,13 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 		return err
 	}
 
+	ok.WsResponseMultiplexer = wsRequestDataChannelsMultiplexer{
+		WsResponseChannelsMap: make(map[string]*wsRequestInfo),
+		Register:              make(chan *wsRequestInfo),
+		Unregister:            make(chan string),
+		Message:               make(chan *wsIncomingData),
+	}
+
 	wsRunningEndpoint, err := ok.API.Endpoints.GetURL(exchange.WebsocketSpot)
 	if err != nil {
 		return err


### PR DESCRIPTION
# PR Description

Enabling authenticated ws for okx would block the entire exchange client.

The channels for the ws multiplexer weren't made.
So any interaction with it would block.
Tests passed because they invasively setup the multiplexer.

There are quite a few architectural risks with this implementation pattern, such as leaking an uncancellable goro in a for-select loop. Ideally WsConnect should take a cancellable context and any selects should watch for ctx.Done()

That's a very invasive and pervasive change though, so this fix is as minimal and atomic as possible.
Will consider opening a PR for cancellable context or improving this multiplexer pattern.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
