### PR TITLE
OKX: Fix balance using funding account

### DIFF
--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -90,7 +90,7 @@ const (
 	oneClickRepayHistory          = "trade/one-click-repay-history"
 	oneClickRepay                 = "trade/one-click-repay"
 
-	// Funding orders routes
+	// Funding account routes
 	assetCurrencies    = "asset/currencies"
 	assetBalance       = "asset/balances"
 	assetValuation     = "asset/asset-valuation"
@@ -1379,7 +1379,7 @@ func (ok *Okx) GetFundingCurrencies(ctx context.Context) ([]CurrencyResponse, er
 	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getCurrenciesEPL, http.MethodGet, assetCurrencies, nil, &resp, true)
 }
 
-// GetBalance retrieves the balances of all the assets and the amount that is available or on hold.
+// GetBalance retrieves the funding account balances of all the assets and the amount that is available or on hold.
 func (ok *Okx) GetBalance(ctx context.Context, currency string) ([]AssetBalance, error) {
 	var resp []AssetBalance
 	params := url.Values{}

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -1204,44 +1204,44 @@ type ConvertHistory struct {
 
 // Account holds currency account balance and related information
 type Account struct {
-	AdjEq       string           `json:"adjEq"`
-	Details     []AccountDetail  `json:"details"`
-	Imr         string           `json:"imr"` // Frozen equity for open positions and pending orders in USD level Applicable to Multi-currency margin and Portfolio margin
-	IsoEq       string           `json:"isoEq"`
-	MgnRatio    string           `json:"mgnRatio"`
-	Mmr         string           `json:"mmr"` // Maintenance margin requirement in USD level Applicable to Multi-currency margin and Portfolio margin
-	NotionalUsd string           `json:"notionalUsd"`
-	OrdFroz     string           `json:"ordFroz"` // Margin frozen for pending orders in USD level Applicable to Multi-currency margin and Portfolio margin
-	TotalEquity string           `json:"totalEq"` // Total Equity in USD level
-	UpdateTime  okxUnixMilliTime `json:"uTime"`   // UpdateTime
+	AdjEq       okxNumericalValue `json:"adjEq"`
+	Details     []AccountDetail   `json:"details"`
+	Imr         okxNumericalValue `json:"imr"` // Frozen equity for open positions and pending orders in USD level Applicable to Multi-currency margin and Portfolio margin
+	IsoEq       okxNumericalValue `json:"isoEq"`
+	MgnRatio    okxNumericalValue `json:"mgnRatio"`
+	Mmr         okxNumericalValue `json:"mmr"` // Maintenance margin requirement in USD level Applicable to Multi-currency margin and Portfolio margin
+	NotionalUsd okxNumericalValue `json:"notionalUsd"`
+	OrdFroz     okxNumericalValue `json:"ordFroz"` // Margin frozen for pending orders in USD level Applicable to Multi-currency margin and Portfolio margin
+	TotalEquity okxNumericalValue `json:"totalEq"` // Total Equity in USD level
+	UpdateTime  okxUnixMilliTime  `json:"uTime"`   // UpdateTime
 }
 
 // AccountDetail account detail information.
 type AccountDetail struct {
-	AvailableBalance              string           `json:"availBal"`
-	AvailableEquity               string           `json:"availEq"`
-	CashBalance                   string           `json:"cashBal"` // Cash Balance
-	Currency                      string           `json:"ccy"`
-	CrossLiab                     string           `json:"crossLiab"`
-	DiscountEquity                string           `json:"disEq"`
-	EquityOfCurrency              string           `json:"eq"`
-	EquityUsd                     string           `json:"eqUsd"`
-	FrozenBalance                 string           `json:"frozenBal"`
-	Interest                      string           `json:"interest"`
-	IsoEquity                     string           `json:"isoEq"`
-	IsolatedLiabilities           string           `json:"isoLiab"`
-	IsoUpl                        string           `json:"isoUpl"` // Isolated unrealized profit and loss of the currency applicable to Single-currency margin and Multi-currency margin and Portfolio margin
-	LiabilitiesOfCurrency         string           `json:"liab"`
-	MaxLoan                       string           `json:"maxLoan"`
-	MarginRatio                   string           `json:"mgnRatio"`      // Equity of the currency
-	NotionalLever                 string           `json:"notionalLever"` // Leverage of the currency applicable to Single-currency margin
-	OpenOrdersMarginFrozen        string           `json:"ordFrozen"`
-	Twap                          string           `json:"twap"`
-	UpdateTime                    okxUnixMilliTime `json:"uTime"`
-	UnrealizedProfit              string           `json:"upl"`
-	UnrealizedCurrencyLiabilities string           `json:"uplLiab"`
-	StrategyEquity                string           `json:"stgyEq"`  // strategy equity
-	TotalEquity                   string           `json:"totalEq"` // Total equity in USD level
+	AvailableBalance              okxNumericalValue `json:"availBal"`
+	AvailableEquity               okxNumericalValue `json:"availEq"`
+	CashBalance                   okxNumericalValue `json:"cashBal"` // Cash Balance
+	Currency                      string            `json:"ccy"`
+	CrossLiab                     okxNumericalValue `json:"crossLiab"`
+	DiscountEquity                okxNumericalValue `json:"disEq"`
+	EquityOfCurrency              okxNumericalValue `json:"eq"`
+	EquityUsd                     okxNumericalValue `json:"eqUsd"`
+	FrozenBalance                 okxNumericalValue `json:"frozenBal"`
+	Interest                      okxNumericalValue `json:"interest"`
+	IsoEquity                     okxNumericalValue `json:"isoEq"`
+	IsolatedLiabilities           okxNumericalValue `json:"isoLiab"`
+	IsoUpl                        okxNumericalValue `json:"isoUpl"` // Isolated unrealized profit and loss of the currency applicable to Single-currency margin and Multi-currency margin and Portfolio margin
+	LiabilitiesOfCurrency         okxNumericalValue `json:"liab"`
+	MaxLoan                       okxNumericalValue `json:"maxLoan"`
+	MarginRatio                   okxNumericalValue `json:"mgnRatio"`      // Equity of the currency
+	NotionalLever                 okxNumericalValue `json:"notionalLever"` // Leverage of the currency applicable to Single-currency margin
+	OpenOrdersMarginFrozen        okxNumericalValue `json:"ordFrozen"`
+	Twap                          okxNumericalValue `json:"twap"`
+	UpdateTime                    okxUnixMilliTime  `json:"uTime"`
+	UnrealizedProfit              okxNumericalValue `json:"upl"`
+	UnrealizedCurrencyLiabilities okxNumericalValue `json:"uplLiab"`
+	StrategyEquity                okxNumericalValue `json:"stgyEq"`  // strategy equity
+	TotalEquity                   okxNumericalValue `json:"totalEq"` // Total equity in USD level
 }
 
 // AccountPosition account position.


### PR DESCRIPTION
Fixes `UpdateAccountInfo` to use Trading account balances instead of Funding account.

It looks like this was an oversight.
No other exchange uses the funding account for balance and it wouldn't make sense.
Again, this aims to be minimally invasive and backwards compatible, so GetBalance is left alone to preserve compat.

There's one change that could be considered breaking, `EquityOfCurrency` is now just `Equity`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
