### PR TITLE
BTSE: Filter no liquidity pairs

### DIFF
--- a/exchanges/btse/btse_types.go
+++ b/exchanges/btse/btse_types.go
@@ -55,6 +55,8 @@ type MarketSummary []struct {
 	MaxRiskLimit        int      `json:"maxRiskLimit"`
 	AvailableSettlement []string `json:"availableSettlement"`
 	Futures             bool     `json:"futures"`
+	IsMarketOpenToSpot  bool     `json:"isMarketOpenToSpot"`
+	IsMarketOpentoOTC   bool     `json:"isMarketOpenToOtc"`
 }
 
 // OHLCV holds Open, High Low, Close, Volume data for set symbol

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -251,8 +251,11 @@ func (b *BTSE) FetchTradablePairs(ctx context.Context, a asset.Item) (currency.P
 		if !m[x].Active ||
 			// BTSE returns 0 for both highest bid and lowest ask if there is
 			// no order book data, so we skip those pairs. There is no way to
-			// take or provide liquidity for these pairs. They are not found on
-			// the frontend either.
+			// take or provide liquidity for these pairs.
+
+			// TODO: Add support for an OTC asset as this eliminates many valid
+			// tradable pairs which are active, OTC only and available on the
+			// front-end.
 			(m[x].LowestAsk == 0 && m[x].HighestBid == 0) {
 			continue
 		}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -248,7 +248,12 @@ func (b *BTSE) FetchTradablePairs(ctx context.Context, a asset.Item) (currency.P
 	}
 	pairs := make([]currency.Pair, 0, len(m))
 	for x := range m {
-		if !m[x].Active {
+		if !m[x].Active ||
+			// BTSE returns 0 for both highest bid and lowest ask if there is
+			// no order book data, so we skip those pairs. There is no way to
+			// take or provide liquidity for these pairs. They are not found on
+			// the frontend either.
+			(m[x].LowestAsk == 0 && m[x].HighestBid == 0) {
 			continue
 		}
 		var pair currency.Pair


### PR DESCRIPTION
# PR Description

BTSE returns 0 for both highest bid and lowest ask if there is no order book data. There is no way to  take or provide liquidity for these pairs. They are not found on the frontend either.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
