### PR TITLE
orders: Fix manager not processing immediately

### DIFF
--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -72,8 +73,12 @@ func (m *OrderManager) Start() error {
 	}
 	log.Debugln(log.OrderMgr, "Order manager starting...")
 	m.shutdown = make(chan struct{})
+	go func() {
+		m.processOrders()
+		m.run()
+	}()
+	runtime.Gosched()
 	m.orderStore.wg.Add(1)
-	go m.run()
 	return nil
 }
 

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -113,21 +113,16 @@ func (m *OrderManager) gracefulShutdown() {
 // run will periodically process orders
 func (m *OrderManager) run() {
 	log.Debugln(log.OrderMgr, "Order manager started.")
-	timer := time.NewTimer(orderManagerDelay)
 	for {
 		select {
 		case <-m.shutdown:
 			m.gracefulShutdown()
-			if !timer.Stop() {
-				<-timer.C
-			}
 			m.orderStore.wg.Done()
 			log.Debugln(log.OrderMgr, "Order manager shutdown.")
 			return
-		case <-timer.C:
+		case <-time.After(orderManagerInterval):
 			// Process orders go routine allows shutdown procedures to continue
 			go m.processOrders()
-			timer.Reset(orderManagerDelay)
 		}
 	}
 }

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -73,12 +72,8 @@ func (m *OrderManager) Start() error {
 	}
 	log.Debugln(log.OrderMgr, "Order manager starting...")
 	m.shutdown = make(chan struct{})
-	go func() {
-		m.processOrders()
-		m.run()
-	}()
-	runtime.Gosched()
 	m.orderStore.wg.Add(1)
+	go m.run()
 	return nil
 }
 
@@ -113,6 +108,7 @@ func (m *OrderManager) gracefulShutdown() {
 // run will periodically process orders
 func (m *OrderManager) run() {
 	log.Debugln(log.OrderMgr, "Order manager started.")
+	m.processOrders()
 	for {
 		select {
 		case <-m.shutdown:

--- a/engine/order_manager_types.go
+++ b/engine/order_manager_types.go
@@ -24,7 +24,7 @@ var (
 	errNilCommunicationsManager = errors.New("cannot start with nil communications manager")
 	errNilOrder                 = errors.New("nil order received")
 	errFuturesTrackingDisabled  = errors.New("tracking futures positions disabled. enable it via config under orderManager activelyTrackFuturesPositions")
-	orderManagerDelay           = time.Second * 10
+	orderManagerInterval        = time.Second * 10
 	defaultOrderSeekTime        = -time.Hour * 24 * 365
 )
 


### PR DESCRIPTION
This ensures that orders are processed as soon as orderManager claims to have started.
Specifically this will fix an eager call to CancelAllOrders not finding anything until after the first Interval run.

DriveBy:     orders: Fix reset timer call

This fix is small niggle.
The existing code was more complicated than it needed to be, whilst also ignoring the return of `timer.Reset` and the conditional need to drain the channel. It's unlikely but possible during transient resource starvation.
See [Timer docs](https://pkg.go.dev/time#Timer.Reset)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
