### PR TITLE
CommunicationsConfig: Fix Telegram can't receive messages

### DIFF
--- a/communications/telegram/telegram_test.go
+++ b/communications/telegram/telegram_test.go
@@ -48,7 +48,7 @@ func TestPushEvent(t *testing.T) {
 	if err != nil {
 		t.Error("telegram PushEvent() error", err)
 	}
-	T.AuthorisedClients = append(T.AuthorisedClients, 1337)
+	T.AuthorisedClients = map[string]int64{"sender": 1337}
 	err = T.PushEvent(base.Event{})
 	if err.Error() != testErrNotFound {
 		t.Errorf("telegram PushEvent() error, expected 'Not found' got '%s'",


### PR DESCRIPTION
# PR Description
After Telegram configures the robot, it still cannot receive the transaction order message. After reading the code, it is found that `AuthorizedClients []int64` is not referenced and assigned and cannot push the PushEvent message.

Fixes # (issue)
When the main process starts for the first time, obtain the Telegram robot information, initialize and allocate the `AuthorizedClients` object, and successfully trigger the `PushEvent` message when the transaction order event occurs

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
