### PR TITLE
bugfix: exchange: coinbasepro: use base64 decoded string as input for crypto.GetHMAC on coinbasepro.go

### DIFF
--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -766,9 +766,13 @@ func (c *CoinbasePro) SendAuthenticatedHTTPRequest(ctx context.Context, ep excha
 		n := strconv.FormatInt(time.Now().Unix(), 10)
 		message := n + method + "/" + path + string(payload)
 
+		secret, err := crypto.Base64Decode(creds.Secret)
+		if err != nil {
+			return nil, err
+		}
 		hmac, err := crypto.GetHMAC(crypto.HashSHA256,
 			[]byte(message),
-			[]byte(creds.Secret))
+			secret)
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -766,9 +766,12 @@ func (c *CoinbasePro) SendAuthenticatedHTTPRequest(ctx context.Context, ep excha
 		n := strconv.FormatInt(time.Now().Unix(), 10)
 		message := n + method + "/" + path + string(payload)
 
-		secret, err := crypto.Base64Decode(creds.Secret)
-		if err != nil {
-			return nil, err
+		secret := []byte(creds.Secret)
+		if c.API.CredentialsValidator.RequiresBase64DecodeSecret {
+			secret, err = crypto.Base64Decode(creds.Secret)
+			if err != nil {
+				return nil, fmt.Errorf("credentials error: could not decode secret to base64 %v", err)
+			}
 		}
 		hmac, err := crypto.GetHMAC(crypto.HashSHA256,
 			[]byte(message),


### PR DESCRIPTION
# PR Description
This PR changes `CoinbasePro.SendAuthenticatedHTTPRequest` to decode the base64 encoded string `creds.Secret` before passing it to `crypto.GetHMAC`. Base 64 is enforced by `CoinbasePro.GetCredentials` but is disregarded (current implementation simply casts it to a byte array).  

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
