### PR TITLE
Okx: Fix default subscriptions

### DIFF
--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1228,32 +1228,33 @@ func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, err
 			okxChannelOrders,
 		)
 	}
-	for x := range assets {
-		pairs, err := ok.GetEnabledPairs(assets[x])
-		if err != nil {
-			return nil, err
-		}
-		for y := range defaultSubscribedChannels {
-			if defaultSubscribedChannels[y] == okxChannelCandle5m ||
-				defaultSubscribedChannels[y] == okxChannelTickers ||
-				defaultSubscribedChannels[y] == okxChannelOrders ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks5 ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks50TBT ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooksTBT ||
-				defaultSubscribedChannels[y] == okxChannelTrades {
+	for c := range defaultSubscribedChannels {
+		switch defaultSubscribedChannels[c] {
+		case okxChannelOrders:
+			for x := range assets {
+				subscriptions = append(subscriptions, stream.ChannelSubscription{
+					Channel: defaultSubscribedChannels[c],
+					Asset:   assets[x],
+				})
+			}
+		case okxChannelCandle5m, okxChannelTickers, okxChannelOrderBooks, okxChannelFundingRate, okxChannelOrderBooks5, okxChannelOrderBooks50TBT, okxChannelOrderBooksTBT, okxChannelTrades:
+			for x := range assets {
+				pairs, err := ok.GetEnabledPairs(assets[x])
+				if err != nil {
+					return nil, err
+				}
 				for p := range pairs {
 					subscriptions = append(subscriptions, stream.ChannelSubscription{
-						Channel:  defaultSubscribedChannels[y],
+						Channel:  defaultSubscribedChannels[c],
 						Asset:    assets[x],
 						Currency: pairs[p],
 					})
 				}
-			} else {
-				subscriptions = append(subscriptions, stream.ChannelSubscription{
-					Channel: defaultSubscribedChannels[y],
-				})
 			}
+		default:
+			subscriptions = append(subscriptions, stream.ChannelSubscription{
+				Channel: defaultSubscribedChannels[c],
+			})
 		}
 	}
 	if len(subscriptions) >= 240 {


### PR DESCRIPTION
This fixes subscriptions for every pair for orders, since instId is optional, and we'd max out our 240 subs if we used it.

Also fixes any case where there's no asset to supply being subscribed N times



## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
