### PR TITLE
Okx: Fix GetFundingRateHistory limit

### DIFF
--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -3466,9 +3466,9 @@ func (ok *Okx) GetFundingRateHistory(ctx context.Context, instrumentID string, b
 	if !after.IsZero() {
 		params.Set("after", strconv.FormatInt(after.UnixMilli(), 10))
 	}
-	if limit > 0 && limit < 100 {
+	if limit > 0 && limit <= 100 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
-	} else {
+	} else if limit > 100 {
 		return nil, errLimitValueExceedsMaxOf100
 	}
 	var resp []FundingRateResponse


### PR DESCRIPTION
Fix limit of 100 rejected
Allow a limit of 0 for using the default value of limit (currently 100).

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
