### PR TITLE
telegram: Fix pushing events to an authorised client list

### DIFF
--- a/cmd/documentation/communications_templates/telegram.tmpl
+++ b/cmd/documentation/communications_templates/telegram.tmpl
@@ -33,7 +33,7 @@ developed by Telegram Messenger LLP
 			Enabled:           true,
 			Verbose:           false,
 			VerificationToken: "token",
-			AuthorisedClients: "pepe,bob",
+			AuthorisedClients: map[string]int64{"pepe": 0}, // 0 represents a placeholder for the user's ID
 		},
 	}
 
@@ -49,7 +49,6 @@ via Telegram:
 /start			- Will authenticate your ID
 /status			- Displays the status of the bot
 /help			- Displays current command list
-/settings		- Displays current bot settings
 ```
 
 ### Please click GoDocs chevron above to view current GoDoc information for this package

--- a/cmd/documentation/communications_templates/telegram.tmpl
+++ b/cmd/documentation/communications_templates/telegram.tmpl
@@ -17,7 +17,10 @@ developed by Telegram Messenger LLP
 
 	+ [Enable via configuration](https://github.com/thrasher-corp/gocryptotrader/tree/master/config#enable-communications-via-config-example)
 
-	+ Individual package example below:
+	+ See the individual package example below. NOTE: For privacy considerations, it's not possible to directly request a user's ID through the 
+	Telegram Bot API unless the user interacts first. The user must message the bot directly. This allows the bot to identify and save the user's ID. 
+	If this wasn't set initially, the user's ID will be stored by this package following a successful authentication when any supported command is issued.
+	
 	```go
 	import (
 		"github.com/thrasher-corp/gocryptotrader/communications/base"
@@ -33,7 +36,7 @@ developed by Telegram Messenger LLP
 			Enabled:           true,
 			Verbose:           false,
 			VerificationToken: "token",
-			AuthorisedClients: map[string]int64{"pepe": 0}, // 0 represents a placeholder for the user's ID
+			AuthorisedClients: map[string]int64{"pepe": 0}, // 0 represents a placeholder for the user's ID, see note above for more info.
 		},
 	}
 

--- a/cmd/documentation/communications_templates/telegram.tmpl
+++ b/cmd/documentation/communications_templates/telegram.tmpl
@@ -20,19 +20,22 @@ developed by Telegram Messenger LLP
 	+ Individual package example below:
 	```go
 	import (
-	"github.com/thrasher-corp/gocryptotrader/communications/telegram"
-	"github.com/thrasher-corp/gocryptotrader/config"
+		"github.com/thrasher-corp/gocryptotrader/communications/base"
+		"github.com/thrasher-corp/gocryptotrader/communications/telegram"
 	)
 
 	t := new(telegram.Telegram)
 
 	// Define Telegram configuration
-	commsConfig := config.CommunicationsConfig{TelegramConfig: config.TelegramConfig{
-	Name: "Telegram",
-		Enabled: true,
-		Verbose: false,
-	VerificationToken: "token",
-	}}
+	commsConfig := &base.CommunicationsConfig{
+		TelegramConfig: base.TelegramConfig{
+			Name:              "Telegram",
+			Enabled:           true,
+			Verbose:           false,
+			VerificationToken: "token",
+			AuthorisedClients: "pepe,bob",
+		},
+	}
 
 	t.Setup(commsConfig)
 	err := t.Connect

--- a/communications/base/base.go
+++ b/communications/base/base.go
@@ -121,4 +121,5 @@ type TelegramConfig struct {
 	Enabled           bool   `json:"enabled"`
 	Verbose           bool   `json:"verbose"`
 	VerificationToken string `json:"verificationToken"`
+	AuthorisedClients string `json:"authorisedClients"`
 }

--- a/communications/base/base.go
+++ b/communications/base/base.go
@@ -117,9 +117,9 @@ type SMTPConfig struct {
 
 // TelegramConfig holds all variables to start and run the Telegram package
 type TelegramConfig struct {
-	Name              string `json:"name"`
-	Enabled           bool   `json:"enabled"`
-	Verbose           bool   `json:"verbose"`
-	VerificationToken string `json:"verificationToken"`
-	AuthorisedClients string `json:"authorisedClients"`
+	Name              string           `json:"name"`
+	Enabled           bool             `json:"enabled"`
+	Verbose           bool             `json:"verbose"`
+	VerificationToken string           `json:"verificationToken"`
+	AuthorisedClients map[string]int64 `json:"authorisedClients"`
 }

--- a/communications/base/base.go
+++ b/communications/base/base.go
@@ -45,7 +45,7 @@ func (b *Base) GetName() string {
 func (b *Base) GetStatus() string {
 	return `
 	GoCryptoTrader Service: Online
-	Service Started: ` + b.ServiceStarted.String()
+	Service Started: ` + b.ServiceStarted.UTC().String()
 }
 
 // SetServiceStarted sets the time the service started

--- a/communications/telegram/README.md
+++ b/communications/telegram/README.md
@@ -35,7 +35,10 @@ developed by Telegram Messenger LLP
 
 	+ [Enable via configuration](https://github.com/thrasher-corp/gocryptotrader/tree/master/config#enable-communications-via-config-example)
 
-	+ Individual package example below:
+	+ See the individual package example below. NOTE: For privacy considerations, it's not possible to directly request a user's ID through the 
+	Telegram Bot API unless the user interacts first. The user must message the bot directly. This allows the bot to identify and save the user's ID. 
+	If this wasn't set initially, the user's ID will be stored by this package following a successful authentication when any supported command is issued.
+	
 	```go
 	import (
 		"github.com/thrasher-corp/gocryptotrader/communications/base"
@@ -51,7 +54,7 @@ developed by Telegram Messenger LLP
 			Enabled:           true,
 			Verbose:           false,
 			VerificationToken: "token",
-			AuthorisedClients: map[string]int64{"pepe": 0} // 0 represents a placeholder for the user's ID
+			AuthorisedClients: map[string]int64{"pepe": 0}, // 0 represents a placeholder for the user's ID, see note above for more info.
 		},
 	}
 

--- a/communications/telegram/README.md
+++ b/communications/telegram/README.md
@@ -38,19 +38,22 @@ developed by Telegram Messenger LLP
 	+ Individual package example below:
 	```go
 	import (
-	"github.com/thrasher-corp/gocryptotrader/communications/telegram"
-	"github.com/thrasher-corp/gocryptotrader/config"
+		"github.com/thrasher-corp/gocryptotrader/communications/base"
+		"github.com/thrasher-corp/gocryptotrader/communications/telegram"
 	)
 
 	t := new(telegram.Telegram)
 
 	// Define Telegram configuration
-	commsConfig := config.CommunicationsConfig{TelegramConfig: config.TelegramConfig{
-	Name: "Telegram",
-		Enabled: true,
-		Verbose: false,
-	VerificationToken: "token",
-	}}
+	commsConfig := &base.CommunicationsConfig{
+		TelegramConfig: base.TelegramConfig{
+			Name:              "Telegram",
+			Enabled:           true,
+			Verbose:           false,
+			VerificationToken: "token",
+			AuthorisedClients: "pepe,bob",
+		},
+	}
 
 	t.Setup(commsConfig)
 	err := t.Connect

--- a/communications/telegram/README.md
+++ b/communications/telegram/README.md
@@ -51,7 +51,7 @@ developed by Telegram Messenger LLP
 			Enabled:           true,
 			Verbose:           false,
 			VerificationToken: "token",
-			AuthorisedClients: "pepe,bob",
+			AuthorisedClients: map[string]int64{"pepe": 0} // 0 represents a placeholder for the user's ID
 		},
 	}
 
@@ -67,7 +67,6 @@ via Telegram:
 /start			- Will authenticate your ID
 /status			- Displays the status of the bot
 /help			- Displays current command list
-/settings		- Displays current bot settings
 ```
 
 ### Please click GoDocs chevron above to view current GoDoc information for this package

--- a/communications/telegram/telegram.go
+++ b/communications/telegram/telegram.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,17 +27,15 @@ const (
 	methodGetUpdates  = "getUpdates"
 	methodSendMessage = "sendMessage"
 
-	cmdStart    = "/start"
-	cmdStatus   = "/status"
-	cmdHelp     = "/help"
-	cmdSettings = "/settings"
+	cmdStart  = "/start"
+	cmdStatus = "/status"
+	cmdHelp   = "/help"
 
 	cmdHelpReply = `GoCryptoTrader TelegramBot, thank you for using this service!
 	Current commands are:
 	/start  		- Will authenticate your ID
 	/status 		- Displays the status of the bot
-	/help 			- Displays current command list
-	/settings 	- Displays current bot settings`
+	/help 			- Displays current command list`
 
 	talkRoot = "GoCryptoTrader bot"
 )
@@ -44,6 +44,9 @@ var (
 	// ErrWaiter is the default timer to wait if an err occurs
 	// before retrying after successfully connecting
 	ErrWaiter = time.Second * 30
+
+	// ErrNotConnected is the error message returned if Telegram is not connected
+	ErrNotConnected = errors.New("Telegram not connected")
 )
 
 // Telegram is the overarching type across this package
@@ -64,12 +67,7 @@ func (t *Telegram) Setup(cfg *base.CommunicationsConfig) {
 	t.Enabled = cfg.TelegramConfig.Enabled
 	t.Token = cfg.TelegramConfig.VerificationToken
 	t.Verbose = cfg.TelegramConfig.Verbose
-	t.AuthorisedClients = make(map[string]int64)
-
-	users := strings.Split(cfg.TelegramConfig.AuthorisedClients, ",")
-	for x := range users {
-		t.AuthorisedClients[users[x]] = 0
-	}
+	t.AuthorisedClients = cfg.TelegramConfig.AuthorisedClients
 }
 
 // Connect starts an initial connection
@@ -86,16 +84,24 @@ func (t *Telegram) Connect() error {
 
 // PushEvent sends an event to a supplied recipient list via telegram
 func (t *Telegram) PushEvent(event base.Event) error {
+	if !t.Connected {
+		return ErrNotConnected
+	}
+
 	msg := fmt.Sprintf("Type: %s Message: %s",
 		event.Type, event.Message)
 
-	for _, ID := range t.AuthorisedClients {
-		err := t.SendMessage(msg, ID)
-		if err != nil {
-			return err
+	var errors error
+	for user, ID := range t.AuthorisedClients {
+		if ID == 0 {
+			log.Warnf(log.CommunicationMgr, "Telegram: Unable to send message to %s as their ID isn't set. A user must issue any supported command to begin a session.\n", user)
+			continue
+		}
+		if err := t.SendMessage(msg, ID); err != nil {
+			errors = common.AppendError(errors, err)
 		}
 	}
-	return nil
+	return errors
 }
 
 // PollerStart starts the long polling sequence
@@ -123,7 +129,11 @@ func (t *Telegram) PollerStart() {
 
 		for i := range resp.Result {
 			if resp.Result[i].UpdateID > t.Offset {
-				if string(resp.Result[i].Message.Text[0]) == "/" {
+				username := resp.Result[i].Message.From.UserName
+				if id, ok := t.AuthorisedClients[username]; ok && resp.Result[i].Message.Text[0] == '/' {
+					if id == 0 {
+						t.AuthorisedClients[username] = resp.Result[i].Message.From.ID
+					}
 					err = t.HandleMessages(resp.Result[i].Message.Text, resp.Result[i].Message.From.ID)
 					if err != nil {
 						log.Errorf(log.CommunicationMgr, "Telegram: Unable to HandleMessages. Error: %s\n", err)
@@ -164,6 +174,9 @@ func (t *Telegram) InitialConnect() error {
 	}
 
 	for userName, ID := range t.AuthorisedClients {
+		if ID == 0 {
+			continue
+		}
 		err = t.SendMessage(fmt.Sprintf("GoCryptoTrader bot has connected: Hello, %s!", userName), ID)
 		if err != nil {
 			log.Errorf(log.CommunicationMgr, "Telegram: Unable to send welcome message. Error: %s\n", err)
@@ -203,7 +216,11 @@ func (t *Telegram) HandleMessages(text string, chatID int64) error {
 // GetUpdates gets new updates via a long poll connection
 func (t *Telegram) GetUpdates() (GetUpdateResponse, error) {
 	var newUpdates GetUpdateResponse
-	path := fmt.Sprintf(apiURL, t.Token, methodGetUpdates)
+	vals := url.Values{}
+	if t.Offset != 0 {
+		vals.Set("offset", strconv.FormatInt(t.Offset+1, 10))
+	}
+	path := common.EncodeURLValues(fmt.Sprintf(apiURL, t.Token, methodGetUpdates), vals)
 	return newUpdates, t.SendHTTPRequest(path, nil, &newUpdates)
 }
 

--- a/communications/telegram/telegram_test.go
+++ b/communications/telegram/telegram_test.go
@@ -19,12 +19,13 @@ func TestSetup(t *testing.T) {
 			Enabled:           false,
 			Verbose:           false,
 			VerificationToken: "testest",
+			AuthorisedClients: "sender",
 		},
 	}}
 	commsCfg := cfg.GetCommunicationsConfig()
 	var T Telegram
 	T.Setup(&commsCfg)
-	if T.Name != "Telegram" || T.Enabled || T.Token != "testest" || T.Verbose {
+	if T.Name != "Telegram" || T.Enabled || T.Token != "testest" || T.Verbose || len(T.AuthorisedClients) != 1 {
 		t.Error("telegram Setup() error, unexpected setup values",
 			T.Name,
 			T.Enabled,

--- a/communications/telegram/telegram_test.go
+++ b/communications/telegram/telegram_test.go
@@ -48,7 +48,7 @@ func TestPushEvent(t *testing.T) {
 	if err != nil {
 		t.Error("telegram PushEvent() error", err)
 	}
-	T.AuthorisedClients = append(T.AuthorisedClients, 1337)
+	T.AuthorisedClients = map[string]int64{"sender": 1337}
 	err = T.PushEvent(base.Event{})
 	if err.Error() != testErrNotFound {
 		t.Errorf("telegram PushEvent() error, expected 'Not found' got '%s'",

--- a/communications/telegram/telegram_test.go
+++ b/communications/telegram/telegram_test.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/communications/base"
@@ -19,7 +20,7 @@ func TestSetup(t *testing.T) {
 			Enabled:           false,
 			Verbose:           false,
 			VerificationToken: "testest",
-			AuthorisedClients: "sender",
+			AuthorisedClients: map[string]int64{"sender": 0},
 		},
 	}}
 	commsCfg := cfg.GetCommunicationsConfig()
@@ -46,9 +47,17 @@ func TestPushEvent(t *testing.T) {
 	t.Parallel()
 	var T Telegram
 	err := T.PushEvent(base.Event{})
-	if err != nil {
-		t.Error("telegram PushEvent() error", err)
+	if !errors.Is(err, ErrNotConnected) {
+		t.Errorf("expected %s, got %s", ErrNotConnected, err)
 	}
+
+	T.Connected = true
+	T.AuthorisedClients = map[string]int64{"sender": 0}
+	err = T.PushEvent(base.Event{})
+	if err != nil {
+		t.Errorf("expected nil, got %s", err)
+	}
+
 	T.AuthorisedClients = map[string]int64{"sender": 1337}
 	err = T.PushEvent(base.Event{})
 	if err.Error() != testErrNotFound {
@@ -72,11 +81,6 @@ func TestHandleMessages(t *testing.T) {
 			err)
 	}
 	err = T.HandleMessages(cmdStatus, chatID)
-	if err.Error() != testErrNotFound {
-		t.Errorf("telegram HandleMessages() error, expected 'Not found' got '%s'",
-			err)
-	}
-	err = T.HandleMessages(cmdSettings, chatID)
 	if err.Error() != testErrNotFound {
 		t.Errorf("telegram HandleMessages() error, expected 'Not found' got '%s'",
 			err)

--- a/config/config.go
+++ b/config/config.go
@@ -299,8 +299,11 @@ func (c *Config) CheckCommunicationsConfig() {
 		c.Communications.TelegramConfig = base.TelegramConfig{
 			Name:              "Telegram",
 			VerificationToken: "testest",
-			AuthorisedClients: map[string]int64{"user_example": 0},
 		}
+	}
+
+	if c.Communications.TelegramConfig.AuthorisedClients == nil {
+		c.Communications.TelegramConfig.AuthorisedClients = map[string]int64{"user_example": 0}
 	}
 
 	if c.Communications.SlackConfig.Name != "Slack" ||

--- a/config/config.go
+++ b/config/config.go
@@ -334,7 +334,8 @@ func (c *Config) CheckCommunicationsConfig() {
 		}
 	}
 	if c.Communications.TelegramConfig.Enabled {
-		if c.Communications.TelegramConfig.VerificationToken == "" {
+		if c.Communications.TelegramConfig.VerificationToken == "" ||
+			c.Communications.TelegramConfig.AuthorisedClients == "" {
 			c.Communications.TelegramConfig.Enabled = false
 			log.Warnln(log.ConfigMgr, "Telegram enabled in config but variable data not set, disabling.")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -299,6 +299,7 @@ func (c *Config) CheckCommunicationsConfig() {
 		c.Communications.TelegramConfig = base.TelegramConfig{
 			Name:              "Telegram",
 			VerificationToken: "testest",
+			AuthorisedClients: map[string]int64{"user_example": 0},
 		}
 	}
 
@@ -334,8 +335,10 @@ func (c *Config) CheckCommunicationsConfig() {
 		}
 	}
 	if c.Communications.TelegramConfig.Enabled {
-		if c.Communications.TelegramConfig.VerificationToken == "" ||
-			c.Communications.TelegramConfig.AuthorisedClients == "" {
+		if _, ok := c.Communications.TelegramConfig.AuthorisedClients["user_example"]; ok ||
+			len(c.Communications.TelegramConfig.AuthorisedClients) == 0 ||
+			c.Communications.TelegramConfig.VerificationToken == "" ||
+			c.Communications.TelegramConfig.VerificationToken == "testest" {
 			c.Communications.TelegramConfig.Enabled = false
 			log.Warnln(log.ConfigMgr, "Telegram enabled in config but variable data not set, disabling.")
 		}

--- a/config_example.json
+++ b/config_example.json
@@ -173,7 +173,8 @@
    "name": "Telegram",
    "enabled": false,
    "verbose": false,
-   "verificationToken": "testest"
+   "verificationToken": "testest",
+   "authorisedClients": ""
   }
  },
  "remoteControl": {

--- a/config_example.json
+++ b/config_example.json
@@ -174,7 +174,9 @@
    "enabled": false,
    "verbose": false,
    "verificationToken": "testest",
-   "authorisedClients": ""
+   "authorisedClients": {
+    "user_example": 0
+   }
   }
  },
  "remoteControl": {

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -173,7 +173,8 @@
    "name": "Telegram",
    "enabled": false,
    "verbose": false,
-   "verificationToken": "testest"
+   "verificationToken": "testest",
+   "authorisedClients": ""
   }
  },
  "remoteControl": {

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -174,7 +174,9 @@
    "enabled": false,
    "verbose": false,
    "verificationToken": "testest",
-   "authorisedClients": ""
+   "authorisedClients": {
+    "user_example": 0
+   }
   }
  },
  "remoteControl": {


### PR DESCRIPTION
# PR Description

Takes the work done in https://github.com/thrasher-corp/gocryptotrader/pull/1194 by @shanhuhai5739 and adds an authorised client list so only authenticated users can receive pushed events.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Telegram

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
