### PR TITLE
websocket: Fix redundant connection monitor error upon disconnect

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -261,12 +261,14 @@ func (w *Websocket) Connect() error {
 	w.setConnectingStatus(false)
 	w.setInit(true)
 
-	err = w.connectionMonitor()
-	if err != nil {
-		log.Errorf(log.WebsocketMgr,
-			"%s cannot start websocket connection monitor %v",
-			w.GetName(),
-			err)
+	if !w.IsConnectionMonitorRunning() {
+		err = w.connectionMonitor()
+		if err != nil {
+			log.Errorf(log.WebsocketMgr,
+				"%s cannot start websocket connection monitor %v",
+				w.GetName(),
+				err)
+		}
 	}
 
 	subs, err := w.GenerateSubs() // regenerate state on new connection


### PR DESCRIPTION
When an existing ws disconnects the connection manager goro will call Connect.
This fix prevents Connect trying to start another connection manager if it's already running

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
