### PR TITLE
currency: Add OrderParameters helpers for currency pair

### DIFF
--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -217,7 +217,7 @@ func (p Pair) getAspect(c Code, selling, market bool) (*OrderAspect, error) {
 			aspect.AskLiquidity = !market
 		}
 	default:
-		return nil, errCurrencyNotAssociatedWithPair
+		return nil, fmt.Errorf("%w %v: %v", errCurrencyNotAssociatedWithPair,  c, p)
 	}
 	return &aspect, nil
 }

--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -3,6 +3,7 @@ package currency
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 // EMPTYFORMAT defines an empty pair format
@@ -148,76 +149,76 @@ func (p Pair) IsPopulated() bool {
 	return !p.Base.IsEmpty() && !p.Quote.IsEmpty()
 }
 
-// MarketSellOrderAspect returns an order aspect for when you want to sell a
-// currency which purchases another currency. This specifically returns what
-// liquidity side you will be affecting, what order side you will be placing and
-// what currency you will be purchasing.
-func (p Pair) MarketSellOrderAspect(wantingToSell Code) (*OrderAspect, error) {
-	return p.getAspect(wantingToSell, true, true)
+// MarketSellOrderDecisionDetails returns an order decision details for when you
+// want to sell a currency which purchases another currency. This specifically
+// returns what liquidity side you will be affecting, what order side you will
+// be placing and what currency you will be purchasing.
+func (p Pair) MarketSellOrderDecisionDetails(wantingToSell Code) (*OrderDecisionDetails, error) {
+	return p.getOrderDecisionDetails(wantingToSell, true, true)
 }
 
-// MarketBuyOrderAspect returns the order aspect for when you want to buy a
-// currency which sells another currency. This specifically returns what
-// liquidity side you will be affecting, what order side you will be placing and
-// what currency you will be selling.
-func (p Pair) MarketBuyOrderAspect(wantingToBuy Code) (*OrderAspect, error) {
-	return p.getAspect(wantingToBuy, false, true)
+// MarketBuyOrderDecisionDetails returns the order decision details for when you
+// want to buy a currency which sells another currency. This specifically
+// returns what liquidity side you will be affecting, what order side you will
+// be placing and what currency you will be selling.
+func (p Pair) MarketBuyOrderDecisionDetails(wantingToBuy Code) (*OrderDecisionDetails, error) {
+	return p.getOrderDecisionDetails(wantingToBuy, false, true)
 }
 
-// LimitSellOrderAspect returns the order aspect for when you want to sell a
-// currency which purchases another currency. This specifically returns what
-// liquidity side you will be affecting, what order side you will be placing and
-// what currency you will be purchasing.
-func (p Pair) LimitSellOrderAspect(wantingToSell Code) (*OrderAspect, error) {
-	return p.getAspect(wantingToSell, true, false)
+// LimitSellOrderDecisionDetails returns the order decision details for when you
+// want to sell a currency which purchases another currency. This specifically
+// returns what liquidity side you will be affecting, what order side you will
+// be placing and what currency you will be purchasing.
+func (p Pair) LimitSellOrderDecisionDetails(wantingToSell Code) (*OrderDecisionDetails, error) {
+	return p.getOrderDecisionDetails(wantingToSell, true, false)
 }
 
-// LimitBuyOrderAspect returns the order aspect for when you want to buy a
-// currency which sells another currency. This specifically returns what
-// liquidity side you will be affecting, what order side you will be placing and
-// what currency you will be selling.
-func (p Pair) LimitBuyOrderAspect(wantingToBuy Code) (*OrderAspect, error) {
-	return p.getAspect(wantingToBuy, false, false)
+// LimitBuyOrderDecisionDetails returns the order decision details for when you
+// want to buy a currency which sells another currency. This specifically
+// returns what liquidity side you will be affecting, what order side you will
+// be placing and what currency you will be selling.
+func (p Pair) LimitBuyOrderDecisionDetails(wantingToBuy Code) (*OrderDecisionDetails, error) {
+	return p.getOrderDecisionDetails(wantingToBuy, false, false)
 }
 
-// getAspect returns the order aspect for the currency pair using the provided
-// currency code, whether or not you are selling and whether or not you are
-// placing a market order.
-func (p Pair) getAspect(c Code, selling, market bool) (*OrderAspect, error) {
+// getOrderDecisionDetails returns the order decision details for the currency pair using
+// the provided currency code, whether or not you are selling and whether or not
+// you are placing a market order.
+func (p Pair) getOrderDecisionDetails(c Code, selling, market bool) (*OrderDecisionDetails, error) {
 	if p.IsEmpty() {
 		return nil, ErrCurrencyPairEmpty
 	}
 	if c.IsEmpty() {
 		return nil, ErrCurrencyCodeEmpty
 	}
-	aspect := OrderAspect{Pair: p}
+	dec := OrderDecisionDetails{Pair: p}
 	switch {
 	case p.Base.Equal(c):
 		if selling {
-			aspect.SellingCurrency = p.Base
-			aspect.PurchasingCurrency = p.Quote
-			aspect.BuySide = false
-			aspect.AskLiquidity = !market
+			dec.SellingCurrency = p.Base
+			dec.PurchasingCurrency = p.Quote
+			dec.IsBuySide = false
+			dec.IsAskLiquidity = !market
 		} else {
-			aspect.SellingCurrency = p.Quote
-			aspect.PurchasingCurrency = p.Base
-			aspect.BuySide = true
-			aspect.AskLiquidity = market
+			dec.SellingCurrency = p.Quote
+			dec.PurchasingCurrency = p.Base
+			dec.IsBuySide = true
+			dec.IsAskLiquidity = market
 		}
 	case p.Quote.Equal(c):
 		if selling {
-			aspect.SellingCurrency = p.Quote
-			aspect.PurchasingCurrency = p.Base
-			aspect.BuySide = true
-			aspect.AskLiquidity = market
+			dec.SellingCurrency = p.Quote
+			dec.PurchasingCurrency = p.Base
+			dec.IsBuySide = true
+			dec.IsAskLiquidity = market
 		} else {
-			aspect.SellingCurrency = p.Base
-			aspect.PurchasingCurrency = p.Quote
-			aspect.BuySide = false
-			aspect.AskLiquidity = !market
+			dec.SellingCurrency = p.Base
+			dec.PurchasingCurrency = p.Quote
+			dec.IsBuySide = false
+			dec.IsAskLiquidity = !market
 		}
 	default:
-		return nil, fmt.Errorf("%w %v: %v", errCurrencyNotAssociatedWithPair,  c, p)
+		return nil, fmt.Errorf("%w %v: %v", errCurrencyNotAssociatedWithPair, c, p)
 	}
-	return &aspect, nil
+	return &dec, nil
 }

--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -144,36 +144,37 @@ func (p Pair) Other(c Code) (Code, error) {
 	return EMPTYCODE, ErrCurrencyCodeEmpty
 }
 
-// IsPopulated returns true if the currency pair have both non-empty values for base and quote.
+// IsPopulated returns true if the currency pair have both non-empty values for
+// base and quote.
 func (p Pair) IsPopulated() bool {
 	return !p.Base.IsEmpty() && !p.Quote.IsEmpty()
 }
 
-// MarketSellOrderParameters returns an order parameters for when you want to
-// sell a currency which purchases another currency. This specifically returns
-// what liquidity side you will be affecting, what order side you will be
-// placing and what currency you will be purchasing.
+// MarketSellOrderParameters returns order parameters for when you want to sell
+// a currency which purchases another currency. This specifically returns what
+// liquidity side you will be affecting, what order side you will be placing and
+// what currency you will be purchasing.
 func (p Pair) MarketSellOrderParameters(wantingToSell Code) (*OrderParameters, error) {
 	return p.getOrderParameters(wantingToSell, true, true)
 }
 
-// MarketBuyOrderParameters returns the order parameters for when you want to
-// sell a currency which purchases another currency. This specifically returns
-// what liquidity side you will be affecting, what order side you will be
-// placing and what currency you will be purchasing.
+// MarketBuyOrderParameters returns order parameters for when you want to sell a
+// currency which purchases another currency. This specifically returns what
+// liquidity side you will be affecting, what order side you will be placing and
+// what currency you will be purchasing.
 func (p Pair) MarketBuyOrderParameters(wantingToBuy Code) (*OrderParameters, error) {
 	return p.getOrderParameters(wantingToBuy, false, true)
 }
 
-// LimitSellOrderParameters returns the order parameters for when you want to
-// sell a currency which purchases another currency. This specifically returns
-// what liquidity side you will be affecting, what order side you will be
-// placing and what currency you will be purchasing.
+// LimitSellOrderParameters returns order parameters for when you want to sell a
+// currency which purchases another currency. This specifically returns what
+// liquidity side you will be affecting, what order side you will be placing and
+// what currency you will be purchasing.
 func (p Pair) LimitSellOrderParameters(wantingToSell Code) (*OrderParameters, error) {
 	return p.getOrderParameters(wantingToSell, true, false)
 }
 
-// LimitBuyOrderParameters returns the order parameters for when you want to
+// LimitBuyOrderParameters returns order parameters for when you want to
 // sell a currency which purchases another currency. This specifically returns
 // what liquidity side you will be affecting, what order side you will be
 // placing and what currency you will be purchasing.
@@ -181,9 +182,9 @@ func (p Pair) LimitBuyOrderParameters(wantingToBuy Code) (*OrderParameters, erro
 	return p.getOrderParameters(wantingToBuy, false, false)
 }
 
-// getOrderDecisionDetails returns the order parameters for the currency pair
-// using the provided currency code, whether or not you are selling and whether
-// or not  you are placing a market order.
+// getOrderDecisionDetails returns order parameters for the currency pair using
+// the provided currency code, whether or not you are selling and whether or not
+// you are placing a market order.
 func (p Pair) getOrderParameters(c Code, selling, market bool) (*OrderParameters, error) {
 	if !p.IsPopulated() {
 		return nil, ErrCurrencyPairEmpty

--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -149,76 +149,76 @@ func (p Pair) IsPopulated() bool {
 	return !p.Base.IsEmpty() && !p.Quote.IsEmpty()
 }
 
-// MarketSellOrderDecisionDetails returns an order decision details for when you
-// want to sell a currency which purchases another currency. This specifically
-// returns what liquidity side you will be affecting, what order side you will
-// be placing and what currency you will be purchasing.
-func (p Pair) MarketSellOrderDecisionDetails(wantingToSell Code) (*OrderDecisionDetails, error) {
-	return p.getOrderDecisionDetails(wantingToSell, true, true)
+// MarketSellOrderParameters returns an order parameters for when you want to
+// sell a currency which purchases another currency. This specifically returns
+// what liquidity side you will be affecting, what order side you will be
+// placing and what currency you will be purchasing.
+func (p Pair) MarketSellOrderParameters(wantingToSell Code) (*OrderParameters, error) {
+	return p.getOrderParameters(wantingToSell, true, true)
 }
 
-// MarketBuyOrderDecisionDetails returns the order decision details for when you
-// want to buy a currency which sells another currency. This specifically
-// returns what liquidity side you will be affecting, what order side you will
-// be placing and what currency you will be selling.
-func (p Pair) MarketBuyOrderDecisionDetails(wantingToBuy Code) (*OrderDecisionDetails, error) {
-	return p.getOrderDecisionDetails(wantingToBuy, false, true)
+// MarketBuyOrderParameters returns the order parameters for when you want to
+// sell a currency which purchases another currency. This specifically returns
+// what liquidity side you will be affecting, what order side you will be
+// placing and what currency you will be purchasing.
+func (p Pair) MarketBuyOrderParameters(wantingToBuy Code) (*OrderParameters, error) {
+	return p.getOrderParameters(wantingToBuy, false, true)
 }
 
-// LimitSellOrderDecisionDetails returns the order decision details for when you
-// want to sell a currency which purchases another currency. This specifically
-// returns what liquidity side you will be affecting, what order side you will
-// be placing and what currency you will be purchasing.
-func (p Pair) LimitSellOrderDecisionDetails(wantingToSell Code) (*OrderDecisionDetails, error) {
-	return p.getOrderDecisionDetails(wantingToSell, true, false)
+// LimitSellOrderParameters returns the order parameters for when you want to
+// sell a currency which purchases another currency. This specifically returns
+// what liquidity side you will be affecting, what order side you will be
+// placing and what currency you will be purchasing.
+func (p Pair) LimitSellOrderParameters(wantingToSell Code) (*OrderParameters, error) {
+	return p.getOrderParameters(wantingToSell, true, false)
 }
 
-// LimitBuyOrderDecisionDetails returns the order decision details for when you
-// want to buy a currency which sells another currency. This specifically
-// returns what liquidity side you will be affecting, what order side you will
-// be placing and what currency you will be selling.
-func (p Pair) LimitBuyOrderDecisionDetails(wantingToBuy Code) (*OrderDecisionDetails, error) {
-	return p.getOrderDecisionDetails(wantingToBuy, false, false)
+// LimitBuyOrderParameters returns the order parameters for when you want to
+// sell a currency which purchases another currency. This specifically returns
+// what liquidity side you will be affecting, what order side you will be
+// placing and what currency you will be purchasing.
+func (p Pair) LimitBuyOrderParameters(wantingToBuy Code) (*OrderParameters, error) {
+	return p.getOrderParameters(wantingToBuy, false, false)
 }
 
-// getOrderDecisionDetails returns the order decision details for the currency pair using
-// the provided currency code, whether or not you are selling and whether or not
-// you are placing a market order.
-func (p Pair) getOrderDecisionDetails(c Code, selling, market bool) (*OrderDecisionDetails, error) {
+// getOrderDecisionDetails returns the order parameters for the currency pair
+// using the provided currency code, whether or not you are selling and whether
+// or not  you are placing a market order.
+func (p Pair) getOrderParameters(c Code, selling, market bool) (*OrderParameters, error) {
 	if !p.IsPopulated() {
 		return nil, ErrCurrencyPairEmpty
 	}
 	if c.IsEmpty() {
 		return nil, ErrCurrencyCodeEmpty
 	}
-	dec := OrderDecisionDetails{}
+	params := OrderParameters{}
 	switch {
 	case p.Base.Equal(c):
 		if selling {
-			dec.SellingCurrency = p.Base
-			dec.PurchasingCurrency = p.Quote
-			dec.IsBuySide = false
-			dec.IsAskLiquidity = !market
+			params.SellingCurrency = p.Base
+			params.PurchasingCurrency = p.Quote
+			params.IsBuySide = false
+			params.IsAskLiquidity = !market
 		} else {
-			dec.SellingCurrency = p.Quote
-			dec.PurchasingCurrency = p.Base
-			dec.IsBuySide = true
-			dec.IsAskLiquidity = market
+			params.SellingCurrency = p.Quote
+			params.PurchasingCurrency = p.Base
+			params.IsBuySide = true
+			params.IsAskLiquidity = market
 		}
 	case p.Quote.Equal(c):
 		if selling {
-			dec.SellingCurrency = p.Quote
-			dec.PurchasingCurrency = p.Base
-			dec.IsBuySide = true
-			dec.IsAskLiquidity = market
+			params.SellingCurrency = p.Quote
+			params.PurchasingCurrency = p.Base
+			params.IsBuySide = true
+			params.IsAskLiquidity = market
 		} else {
-			dec.SellingCurrency = p.Base
-			dec.PurchasingCurrency = p.Quote
-			dec.IsBuySide = false
-			dec.IsAskLiquidity = !market
+			params.SellingCurrency = p.Base
+			params.PurchasingCurrency = p.Quote
+			params.IsBuySide = false
+			params.IsAskLiquidity = !market
 		}
 	default:
 		return nil, fmt.Errorf("%w %v: %v", errCurrencyNotAssociatedWithPair, c, p)
 	}
-	return &dec, nil
+	return &params, nil
 }

--- a/currency/pair_methods.go
+++ b/currency/pair_methods.go
@@ -185,13 +185,13 @@ func (p Pair) LimitBuyOrderDecisionDetails(wantingToBuy Code) (*OrderDecisionDet
 // the provided currency code, whether or not you are selling and whether or not
 // you are placing a market order.
 func (p Pair) getOrderDecisionDetails(c Code, selling, market bool) (*OrderDecisionDetails, error) {
-	if p.IsEmpty() {
+	if !p.IsPopulated() {
 		return nil, ErrCurrencyPairEmpty
 	}
 	if c.IsEmpty() {
 		return nil, ErrCurrencyCodeEmpty
 	}
-	dec := OrderDecisionDetails{Pair: p}
+	dec := OrderDecisionDetails{}
 	switch {
 	case p.Base.Equal(c):
 		if selling {

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -978,15 +978,15 @@ func TestGetAspect(t *testing.T) {
 		{Pair: p, expectedError: ErrCurrencyCodeEmpty},
 		{Pair: p, currency: XRP, selling: true, market: true, expectedError: errCurrencyNotAssociatedWithPair},
 
-		{Pair: p, currency: BTC, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, Pair: p, IsBuySide: false, IsAskLiquidity: false}},
-		{Pair: p, currency: BTC, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, Pair: p, IsBuySide: true, IsAskLiquidity: true}},
-		{Pair: p, currency: BTC, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, Pair: p, IsBuySide: false, IsAskLiquidity: true}},
-		{Pair: p, currency: BTC, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, Pair: p, IsBuySide: true, IsAskLiquidity: false}},
+		{Pair: p, currency: BTC, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
+		{Pair: p, currency: BTC, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
+		{Pair: p, currency: BTC, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
+		{Pair: p, currency: BTC, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
 
-		{Pair: p, currency: USDT, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, Pair: p, IsBuySide: true, IsAskLiquidity: true}},
-		{Pair: p, currency: USDT, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, Pair: p, IsBuySide: false, IsAskLiquidity: false}},
-		{Pair: p, currency: USDT, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, Pair: p, IsBuySide: true, IsAskLiquidity: false}},
-		{Pair: p, currency: USDT, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, Pair: p, IsBuySide: false, IsAskLiquidity: true}},
+		{Pair: p, currency: USDT, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
+		{Pair: p, currency: USDT, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
+		{Pair: p, currency: USDT, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
+		{Pair: p, currency: USDT, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
 	}
 
 	for i, tc := range testCases {
@@ -1028,10 +1028,6 @@ func TestGetAspect(t *testing.T) {
 
 		if dec.IsAskLiquidity != tc.expectedDetails.IsAskLiquidity {
 			t.Fatalf("AskLiquidity test case %d: received %v, expected %v", i, dec.IsAskLiquidity, tc.expectedDetails.IsAskLiquidity)
-		}
-
-		if dec.Pair != tc.expectedDetails.Pair {
-			t.Fatalf("Pair test case %d: received %v, expected %v", i, dec.Pair, tc.expectedDetails.Pair)
 		}
 	}
 }

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -967,67 +967,67 @@ func TestGetAspect(t *testing.T) {
 
 	p := NewPair(BTC, USDT)
 	testCases := []struct {
-		Pair            Pair
-		currency        Code
-		market          bool
-		selling         bool
-		expectedDetails *OrderDecisionDetails
-		expectedError   error
+		Pair           Pair
+		currency       Code
+		market         bool
+		selling        bool
+		expectedParams *OrderParameters
+		expectedError  error
 	}{
 		{expectedError: ErrCurrencyPairEmpty},
 		{Pair: p, expectedError: ErrCurrencyCodeEmpty},
 		{Pair: p, currency: XRP, selling: true, market: true, expectedError: errCurrencyNotAssociatedWithPair},
 
-		{Pair: p, currency: BTC, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
-		{Pair: p, currency: BTC, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
-		{Pair: p, currency: BTC, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
-		{Pair: p, currency: BTC, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
+		{Pair: p, currency: BTC, selling: true, market: true, expectedParams: &OrderParameters{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
+		{Pair: p, currency: BTC, selling: false, market: true, expectedParams: &OrderParameters{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
+		{Pair: p, currency: BTC, selling: true, market: false, expectedParams: &OrderParameters{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
+		{Pair: p, currency: BTC, selling: false, market: false, expectedParams: &OrderParameters{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
 
-		{Pair: p, currency: USDT, selling: true, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
-		{Pair: p, currency: USDT, selling: false, market: true, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
-		{Pair: p, currency: USDT, selling: true, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
-		{Pair: p, currency: USDT, selling: false, market: false, expectedDetails: &OrderDecisionDetails{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
+		{Pair: p, currency: USDT, selling: true, market: true, expectedParams: &OrderParameters{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: true}},
+		{Pair: p, currency: USDT, selling: false, market: true, expectedParams: &OrderParameters{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: false}},
+		{Pair: p, currency: USDT, selling: true, market: false, expectedParams: &OrderParameters{SellingCurrency: USDT, PurchasingCurrency: BTC, IsBuySide: true, IsAskLiquidity: false}},
+		{Pair: p, currency: USDT, selling: false, market: false, expectedParams: &OrderParameters{SellingCurrency: BTC, PurchasingCurrency: USDT, IsBuySide: false, IsAskLiquidity: true}},
 	}
 
 	for i, tc := range testCases {
-		var dec *OrderDecisionDetails
+		var resp *OrderParameters
 		var err error
 		switch {
 		case tc.market && tc.selling:
-			dec, err = tc.Pair.MarketSellOrderDecisionDetails(tc.currency)
+			resp, err = tc.Pair.MarketSellOrderParameters(tc.currency)
 		case tc.market && !tc.selling:
-			dec, err = tc.Pair.MarketBuyOrderDecisionDetails(tc.currency)
+			resp, err = tc.Pair.MarketBuyOrderParameters(tc.currency)
 		case !tc.market && tc.selling:
-			dec, err = tc.Pair.LimitSellOrderDecisionDetails(tc.currency)
+			resp, err = tc.Pair.LimitSellOrderParameters(tc.currency)
 		case !tc.market && !tc.selling:
-			dec, err = tc.Pair.LimitBuyOrderDecisionDetails(tc.currency)
+			resp, err = tc.Pair.LimitBuyOrderParameters(tc.currency)
 		}
 
 		if !errors.Is(err, tc.expectedError) {
 			t.Fatalf("test case %d: received %v, expected %v", i, err, tc.expectedError)
 		}
 
-		if tc.expectedDetails == nil {
-			if dec != nil {
-				t.Fatalf("test case %d: received %v, expected nil", i, dec)
+		if tc.expectedParams == nil {
+			if resp != nil {
+				t.Fatalf("test case %d: received %v, expected nil", i, resp)
 			}
 			continue
 		}
 
-		if dec.SellingCurrency != tc.expectedDetails.SellingCurrency {
-			t.Fatalf("SellingCurrency test case %d: received %v, expected %v", i, dec.SellingCurrency, tc.expectedDetails.SellingCurrency)
+		if resp.SellingCurrency != tc.expectedParams.SellingCurrency {
+			t.Fatalf("SellingCurrency test case %d: received %v, expected %v", i, resp.SellingCurrency, tc.expectedParams.SellingCurrency)
 		}
 
-		if dec.PurchasingCurrency != tc.expectedDetails.PurchasingCurrency {
-			t.Fatalf("PurchasingCurrency test case %d: received %v, expected %v", i, dec.PurchasingCurrency, tc.expectedDetails.PurchasingCurrency)
+		if resp.PurchasingCurrency != tc.expectedParams.PurchasingCurrency {
+			t.Fatalf("PurchasingCurrency test case %d: received %v, expected %v", i, resp.PurchasingCurrency, tc.expectedParams.PurchasingCurrency)
 		}
 
-		if dec.IsBuySide != tc.expectedDetails.IsBuySide {
-			t.Fatalf("BuySide test case %d: received %v, expected %v", i, dec.IsBuySide, tc.expectedDetails.IsBuySide)
+		if resp.IsBuySide != tc.expectedParams.IsBuySide {
+			t.Fatalf("BuySide test case %d: received %v, expected %v", i, resp.IsBuySide, tc.expectedParams.IsBuySide)
 		}
 
-		if dec.IsAskLiquidity != tc.expectedDetails.IsAskLiquidity {
-			t.Fatalf("AskLiquidity test case %d: received %v, expected %v", i, dec.IsAskLiquidity, tc.expectedDetails.IsAskLiquidity)
+		if resp.IsAskLiquidity != tc.expectedParams.IsAskLiquidity {
+			t.Fatalf("AskLiquidity test case %d: received %v, expected %v", i, resp.IsAskLiquidity, tc.expectedParams.IsAskLiquidity)
 		}
 	}
 }

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -962,7 +962,7 @@ func TestIsPopulated(t *testing.T) {
 	}
 }
 
-func TestGetAspect(t *testing.T) {
+func TestGetOrderParameters(t *testing.T) {
 	t.Parallel()
 
 	p := NewPair(BTC, USDT)

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -3,6 +3,7 @@ package currency
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -990,44 +991,48 @@ func TestGetOrderParameters(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		var resp *OrderParameters
-		var err error
-		switch {
-		case tc.market && tc.selling:
-			resp, err = tc.Pair.MarketSellOrderParameters(tc.currency)
-		case tc.market && !tc.selling:
-			resp, err = tc.Pair.MarketBuyOrderParameters(tc.currency)
-		case !tc.market && tc.selling:
-			resp, err = tc.Pair.LimitSellOrderParameters(tc.currency)
-		case !tc.market && !tc.selling:
-			resp, err = tc.Pair.LimitBuyOrderParameters(tc.currency)
-		}
-
-		if !errors.Is(err, tc.expectedError) {
-			t.Fatalf("test case %d: received %v, expected %v", i, err, tc.expectedError)
-		}
-
-		if tc.expectedParams == nil {
-			if resp != nil {
-				t.Fatalf("test case %d: received %v, expected nil", i, resp)
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+			var resp *OrderParameters
+			var err error
+			switch {
+			case tc.market && tc.selling:
+				resp, err = tc.Pair.MarketSellOrderParameters(tc.currency)
+			case tc.market && !tc.selling:
+				resp, err = tc.Pair.MarketBuyOrderParameters(tc.currency)
+			case !tc.market && tc.selling:
+				resp, err = tc.Pair.LimitSellOrderParameters(tc.currency)
+			case !tc.market && !tc.selling:
+				resp, err = tc.Pair.LimitBuyOrderParameters(tc.currency)
 			}
-			continue
-		}
 
-		if resp.SellingCurrency != tc.expectedParams.SellingCurrency {
-			t.Fatalf("SellingCurrency test case %d: received %v, expected %v", i, resp.SellingCurrency, tc.expectedParams.SellingCurrency)
-		}
+			if !errors.Is(err, tc.expectedError) {
+				t.Fatalf("received %v, expected %v", err, tc.expectedError)
+			}
 
-		if resp.PurchasingCurrency != tc.expectedParams.PurchasingCurrency {
-			t.Fatalf("PurchasingCurrency test case %d: received %v, expected %v", i, resp.PurchasingCurrency, tc.expectedParams.PurchasingCurrency)
-		}
+			if tc.expectedParams == nil {
+				if resp != nil {
+					t.Fatalf("received %v, expected nil", resp)
+				}
+				return
+			}
 
-		if resp.IsBuySide != tc.expectedParams.IsBuySide {
-			t.Fatalf("BuySide test case %d: received %v, expected %v", i, resp.IsBuySide, tc.expectedParams.IsBuySide)
-		}
+			if resp.SellingCurrency != tc.expectedParams.SellingCurrency {
+				t.Fatalf("SellingCurrency received %v, expected %v", resp.SellingCurrency, tc.expectedParams.SellingCurrency)
+			}
 
-		if resp.IsAskLiquidity != tc.expectedParams.IsAskLiquidity {
-			t.Fatalf("AskLiquidity test case %d: received %v, expected %v", i, resp.IsAskLiquidity, tc.expectedParams.IsAskLiquidity)
-		}
+			if resp.PurchasingCurrency != tc.expectedParams.PurchasingCurrency {
+				t.Fatalf("PurchasingCurrency received %v, expected %v", resp.PurchasingCurrency, tc.expectedParams.PurchasingCurrency)
+			}
+
+			if resp.IsBuySide != tc.expectedParams.IsBuySide {
+				t.Fatalf("BuySide received %v, expected %v", resp.IsBuySide, tc.expectedParams.IsBuySide)
+			}
+
+			if resp.IsAskLiquidity != tc.expectedParams.IsAskLiquidity {
+				t.Fatalf("AskLiquidity received %v, expected %v", resp.IsAskLiquidity, tc.expectedParams.IsAskLiquidity)
+			}
+		})
 	}
 }

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -17,3 +17,21 @@ type PairDifference struct {
 	Remove           Pairs
 	FormatDifference bool
 }
+
+// OrderAspect defines the information that describes an order implementation
+// to the actual liquidity. This is used to determine the order side, the
+// liquidity side, the currency pair and the selling and purchasing currency.
+type OrderAspect struct {
+	// SellingCurrency is the currency that will be sold first
+	SellingCurrency Code
+	// Purchasing is the currency that will be purchased last
+	PurchasingCurrency Code
+	// BuySide is the side of the order that will be placed true for buy/long,
+	// false for sell/short.
+	BuySide bool
+	// AskLiquidity is the side of the orderbook that will be used, false for
+	// bid liquidity.
+	AskLiquidity bool
+	// Pair is the currency pair that will be used
+	Pair Pair
+}

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -18,10 +18,8 @@ type PairDifference struct {
 	FormatDifference bool
 }
 
-// OrderParameters defines the information that describes an order
-// implementation to the actual liquidity. This is used to determine the order
-// side, the liquidity side, the currency pair and the selling and purchasing
-// currency.
+// OrderParameters is used to determine the order side, liquidity side and the
+// selling & purchasing currency derived from the currency pair.
 type OrderParameters struct {
 	// SellingCurrency is the currency that will be sold first
 	SellingCurrency Code

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -31,7 +31,7 @@ type OrderAspect struct {
 	BuySide bool
 	// AskLiquidity is the side of the orderbook that will be used, false for
 	// bid liquidity.
-	AskLiquidity bool
+	IsAskLiquidity bool
 	// Pair is the currency pair that will be used
 	Pair Pair
 }

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -18,18 +18,19 @@ type PairDifference struct {
 	FormatDifference bool
 }
 
-// OrderAspect defines the information that describes an order implementation
-// to the actual liquidity. This is used to determine the order side, the
-// liquidity side, the currency pair and the selling and purchasing currency.
-type OrderAspect struct {
+// OrderDecisionDetails defines the information that describes an order
+// implementation to the actual liquidity. This is used to determine the order
+// side, the liquidity side, the currency pair and the selling and purchasing
+// currency.
+type OrderDecisionDetails struct {
 	// SellingCurrency is the currency that will be sold first
 	SellingCurrency Code
 	// Purchasing is the currency that will be purchased last
 	PurchasingCurrency Code
-	// BuySide is the side of the order that will be placed true for buy/long,
+	// IsBuySide is the side of the order that will be placed true for buy/long,
 	// false for sell/short.
-	BuySide bool
-	// AskLiquidity is the side of the orderbook that will be used, false for
+	IsBuySide bool
+	// IsAskLiquidity is the side of the orderbook that will be used, false for
 	// bid liquidity.
 	IsAskLiquidity bool
 	// Pair is the currency pair that will be used

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -33,6 +33,4 @@ type OrderDecisionDetails struct {
 	// IsAskLiquidity is the side of the orderbook that will be used, false for
 	// bid liquidity.
 	IsAskLiquidity bool
-	// Pair is the currency pair that will be used
-	Pair Pair
 }

--- a/currency/pair_types.go
+++ b/currency/pair_types.go
@@ -18,11 +18,11 @@ type PairDifference struct {
 	FormatDifference bool
 }
 
-// OrderDecisionDetails defines the information that describes an order
+// OrderParameters defines the information that describes an order
 // implementation to the actual liquidity. This is used to determine the order
 // side, the liquidity side, the currency pair and the selling and purchasing
 // currency.
-type OrderDecisionDetails struct {
+type OrderParameters struct {
 	// SellingCurrency is the currency that will be sold first
 	SellingCurrency Code
 	// Purchasing is the currency that will be purchased last


### PR DESCRIPTION
# PR Description

Adds minor helper methods for a currency pair to derive order parameter details from a currency either being sold; which can be derived from account balance, or a specific currency wishing to be purchased.

**Suggestions for naming conventions are welcomed**

_NOTE: This is mainly for spot_

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
