### PR TITLE
Binance: Fix WorkingTime breaking executionReport

### DIFF
--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2530,7 +2530,7 @@ func TestSetExchangeOrderExecutionLimits(t *testing.T) {
 
 func TestWsOrderExecutionReport(t *testing.T) {
 	// cannot run in parallel due to inspecting the DataHandler result
-	payload := []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616627567900,"s":"BTCUSDT","c":"c4wyKsIhoAaittTYlIVLqk","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028400","p":"52789.10000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"NEW","X":"NEW","r":"NONE","i":5340845958,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":"BTC","T":1616627567900,"t":-1,"I":11388173160,"w":true,"m":false,"M":false,"O":1616627567900,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000"}}`)
+	payload := []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616627567900,"s":"BTCUSDT","c":"c4wyKsIhoAaittTYlIVLqk","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028400","p":"52789.10000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"NEW","X":"NEW","r":"NONE","i":5340845958,"l":"0.00000000","z":"0.00000000","L":"0.00000000","n":"0","N":"BTC","T":1616627567900,"t":-1,"I":11388173160,"w":true,"m":false,"M":false,"O":1616627567900,"Z":"0.00000000","Y":"0.00000000","Q":"0.00000000","W":1616627567900}}`)
 	// this is a buy BTC order, normally commission is charged in BTC, vice versa.
 	expectedResult := order.Detail{
 		Price:                52789.1,
@@ -2573,7 +2573,7 @@ func TestWsOrderExecutionReport(t *testing.T) {
 		t.Fatalf("expected type order.Detail, found %T", res)
 	}
 
-	payload = []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616633041556,"s":"BTCUSDT","c":"YeULctvPAnHj5HXCQo9Mob","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028600","p":"52436.85000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"TRADE","X":"FILLED","r":"NONE","i":5341783271,"l":"0.00028600","z":"0.00028600","L":"52436.85000000","n":"0.00000029","N":"BTC","T":1616633041555,"t":726946523,"I":11390206312,"w":false,"m":false,"M":true,"O":1616633041555,"Z":"14.99693910","Y":"14.99693910","Q":"0.00000000"}}`)
+	payload = []byte(`{"stream":"jTfvpakT2yT0hVIo5gYWVihZhdM2PrBgJUZ5PyfZ4EVpCkx4Uoxk5timcrQc","data":{"e":"executionReport","E":1616633041556,"s":"BTCUSDT","c":"YeULctvPAnHj5HXCQo9Mob","S":"BUY","o":"LIMIT","f":"GTC","q":"0.00028600","p":"52436.85000000","P":"0.00000000","F":"0.00000000","g":-1,"C":"","x":"TRADE","X":"FILLED","r":"NONE","i":5341783271,"l":"0.00028600","z":"0.00028600","L":"52436.85000000","n":"0.00000029","N":"BTC","T":1616633041555,"t":726946523,"I":11390206312,"w":false,"m":false,"M":true,"O":1616633041555,"Z":"14.99693910","Y":"14.99693910","Q":"0.00000000","W":1616633041555}}`)
 	err = b.wsHandleData(payload)
 	if err != nil {
 		t.Fatal(err)

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -842,6 +842,7 @@ type WsOrderUpdateData struct {
 	IsMaker                           bool      `json:"m"`
 	Ignored2                          bool      `json:"M"` // See the comment for "I".
 	OrderCreationTime                 time.Time `json:"O"`
+	WorkingTime                       time.Time `json:"W"`
 	CumulativeQuoteTransactedQuantity float64   `json:"Z,string"`
 	LastQuoteAssetTransactedQuantity  float64   `json:"Y,string"`
 	QuoteOrderQuantity                float64   `json:"Q,string"`

--- a/exchanges/binance/type_convert.go
+++ b/exchanges/binance/type_convert.go
@@ -386,6 +386,7 @@ func (a *wsOrderUpdate) UnmarshalJSON(data []byte) error {
 			EventTime         binanceTime `json:"E"`
 			OrderCreationTime binanceTime `json:"O"`
 			TransactionTime   binanceTime `json:"T"`
+			WorkingTime       binanceTime `json:"W"`
 			*WsOrderUpdateData
 		} `json:"data"`
 		*Alias
@@ -399,6 +400,7 @@ func (a *wsOrderUpdate) UnmarshalJSON(data []byte) error {
 	a.Data.EventTime = aux.Data.EventTime.Time()
 	a.Data.OrderCreationTime = aux.Data.OrderCreationTime.Time()
 	a.Data.TransactionTime = aux.Data.TransactionTime.Time()
+	a.Data.WorkingTime = aux.Data.WorkingTime.Time()
 	return nil
 }
 


### PR DESCRIPTION
Fixes:
`Could not convert to executionReport structure json: cannot unmarshal number into Go struct field .data.w of type bool`
Happens because a new W field is being unmarshalled into the old w.
This new field was added in the 2022-12-05 updates.
It's not always in an execution report, but only if isWorking=true

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run
- [x] Test TestWsOrderExecutionReport

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
