### PR TITLE
websocket: Check for slice size to avoid panic when classifying empty binary message

### DIFF
--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -271,7 +271,7 @@ func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
 	var standardMessage []byte
 	var err error
 	// Detect GZIP
-	if resp[0] == 31 && resp[1] == 139 {
+	if len(resp) >= 2 && resp[0] == 31 && resp[1] == 139 {
 		b := bytes.NewReader(resp)
 		var gReader *gzip.Reader
 		gReader, err = gzip.NewReader(b)

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -268,36 +268,21 @@ func (w *WebsocketConnection) ReadMessage() Response {
 
 // parseBinaryResponse parses a websocket binary response into a usable byte array
 func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
-	var standardMessage []byte
+	var reader io.ReadCloser
 	var err error
-	// Detect GZIP
-	if len(resp) >= 2 && resp[0] == 31 && resp[1] == 139 {
-		b := bytes.NewReader(resp)
-		var gReader *gzip.Reader
-		gReader, err = gzip.NewReader(b)
+	if len(resp) >= 2 && resp[0] == 31 && resp[1] == 139 { // Detect GZIP
+		reader, err = gzip.NewReader(bytes.NewReader(resp))
 		if err != nil {
-			return standardMessage, err
-		}
-		standardMessage, err = io.ReadAll(gReader)
-		if err != nil {
-			return standardMessage, err
-		}
-		err = gReader.Close()
-		if err != nil {
-			return standardMessage, err
+			return nil, err
 		}
 	} else {
-		reader := flate.NewReader(bytes.NewReader(resp))
-		standardMessage, err = io.ReadAll(reader)
-		if err != nil {
-			return standardMessage, err
-		}
-		err = reader.Close()
-		if err != nil {
-			return standardMessage, err
-		}
+		reader = flate.NewReader(bytes.NewReader(resp))
 	}
-	return standardMessage, nil
+	standardMessage, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return standardMessage, reader.Close()
 }
 
 // GenerateMessageID Creates a messageID to checkout

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -908,7 +908,12 @@ func TestParseBinaryResponse(t *testing.T) {
 		t.Error(err3)
 	}
 	if !strings.EqualFold(string(resp2), "hello") {
-		t.Errorf("GZip conversion failed. Received: '%v', Expected: 'hello'", string(resp2))
+		t.Errorf("Deflate conversion failed. Received: '%v', Expected: 'hello'", string(resp2))
+	}
+
+	_, err4 := wc.parseBinaryResponse([]byte{})
+	if err4 == nil || err4.Error() != "unexpected EOF" {
+		t.Error("Expected error 'unexpected EOF'")
 	}
 }
 


### PR DESCRIPTION
# PR Description

WebsocketConnection.parseBinaryResponse() checks for incoming GZIP messages by testing 2 magic bytes - without performing a bounds check. Receiving bad messages can cause panic:

```
panic: runtime error: index out of range [0] with length 0

goroutine 2583960 [running]:
github.com/thrasher-corp/gocryptotrader/exchanges/stream.(*WebsocketConnection).parseBinaryResponse(0xc000624b40?, {0xc000679600?, 0xc000b97f08?, 0x3?})
        /home/user/go/src/github.com/thrasher-corp/gocryptotrader/exchanges/stream/websocket_connection.go:274 +0x265
github.com/thrasher-corp/gocryptotrader/exchanges/stream.(*WebsocketConnection).ReadMessage(0xc0003bd710)
        /home/user/go/src/github.com/thrasher-corp/gocryptotrader/exchanges/stream/websocket_connection.go:251 +0x235
github.com/thrasher-corp/gocryptotrader/exchanges/bybit.(*Bybit).wsReadData(0xc000069fd0?, {0x1953e50, 0xc0003bd710})
        /home/user/go/src/github.com/thrasher-corp/gocryptotrader/exchanges/bybit/bybit_websocket.go:182 +0x8d
created by github.com/thrasher-corp/gocryptotrader/exchanges/bybit.(*Bybit).WsConnect
        /home/user/go/src/github.com/thrasher-corp/gocryptotrader/exchanges/bybit/bybit_websocket.go:63 +0x23d
```

This change makes sure the test is within bounds, with an added regression test. 
Note that Deflating a 1 byte buffer doesn't make sense either, but in that case the flate reader will trigger its own error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
