### PR TITLE
OKx: Fix websocket subscriptions and casing

### DIFF
--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -623,7 +623,7 @@ func (ok *Okx) GetOrderList(ctx context.Context, arg *OrderListRequestParams) ([
 	}
 	params := url.Values{}
 	if arg.InstrumentType != "" {
-		params.Set("instType", strings.ToUpper(arg.InstrumentType))
+		params.Set("instType", arg.InstrumentType)
 	}
 	if arg.InstrumentID != "" {
 		params.Set("instId", arg.InstrumentID)
@@ -3060,7 +3060,7 @@ func (ok *Okx) GetInstrumentTypeFromAssetItem(assetType asset.Item) string {
 	case asset.Options:
 		return okxInstTypeOption
 	default:
-		return assetType.String()
+		return strings.ToUpper(assetType.String())
 	}
 }
 

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -36,7 +36,7 @@ var (
 		okxChannelCandle5m,
 		okxChannelTickers,
 	}
-	// defaultSubscribedChannels list of channels which are subscribed when authenticated
+	// defaultAuthChannels list of channels which are subscribed when authenticated
 	defaultAuthChannels = []string{
 		okxChannelAccount,
 		okxChannelOrders,

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1232,7 +1232,7 @@ func (ok *Okx) wsProcessTickers(data []byte) error {
 func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, error) {
 	var subscriptions []stream.ChannelSubscription
 	assets := ok.GetAssetTypes(true)
-	subs := make([]string, len(defaultSubscribedChannels))
+	var subs []string
 	copy(subs, defaultSubscribedChannels)
 	if ok.Websocket.CanUseAuthenticatedEndpoints() {
 		subs = append(subs,

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1735,7 +1735,7 @@ func (ok *Okx) wsChannelSubscription(operation, channel string, assetType asset.
 	var format currency.PairFormat
 	var err error
 	if tInstrumentType {
-		instrumentType = strings.ToLower(ok.GetInstrumentTypeFromAssetItem(assetType))
+		instrumentType = ok.GetInstrumentTypeFromAssetItem(assetType)
 		if instrumentType != okxInstTypeSpot &&
 			instrumentType != okxInstTypeMargin &&
 			instrumentType != okxInstTypeSwap &&
@@ -1792,7 +1792,7 @@ func (ok *Okx) wsAuthChannelSubscription(operation, channel string, assetType as
 	var err error
 	var format currency.PairFormat
 	if params.InstrumentType {
-		instrumentType = strings.ToUpper(ok.GetInstrumentTypeFromAssetItem(assetType))
+		instrumentType = ok.GetInstrumentTypeFromAssetItem(assetType)
 		if instrumentType != okxInstTypeMargin &&
 			instrumentType != okxInstTypeSwap &&
 			instrumentType != okxInstTypeFutures &&

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -28,13 +28,21 @@ import (
 // responseStream a channel thought which the data coming from the two websocket connection will go through.
 var responseStream = make(chan stream.Response)
 
-// defaultSubscribedChannels list of channels which are subscribed by default
-var defaultSubscribedChannels = []string{
-	okxChannelTrades,
-	okxChannelOrderBooks,
-	okxChannelCandle5m,
-	okxChannelTickers,
-}
+var (
+	// defaultSubscribedChannels list of channels which are subscribed by default
+	defaultSubscribedChannels = []string{
+		okxChannelTrades,
+		okxChannelOrderBooks,
+		okxChannelCandle5m,
+		okxChannelTickers,
+	}
+	// defaultSubscribedChannels list of channels which are subscribed when authenticated
+	defaultAuthChannels = []string{
+		okxChannelAccount,
+		okxChannelOrders,
+	}
+)
+
 var (
 	candlestickChannelsMap    = map[string]bool{okxChannelCandle1Y: true, okxChannelCandle6M: true, okxChannelCandle3M: true, okxChannelCandle1M: true, okxChannelCandle1W: true, okxChannelCandle1D: true, okxChannelCandle2D: true, okxChannelCandle3D: true, okxChannelCandle5D: true, okxChannelCandle12H: true, okxChannelCandle6H: true, okxChannelCandle4H: true, okxChannelCandle2H: true, okxChannelCandle1H: true, okxChannelCandle30m: true, okxChannelCandle15m: true, okxChannelCandle5m: true, okxChannelCandle3m: true, okxChannelCandle1m: true, okxChannelCandle1Yutc: true, okxChannelCandle3Mutc: true, okxChannelCandle1Mutc: true, okxChannelCandle1Wutc: true, okxChannelCandle1Dutc: true, okxChannelCandle2Dutc: true, okxChannelCandle3Dutc: true, okxChannelCandle5Dutc: true, okxChannelCandle12Hutc: true, okxChannelCandle6Hutc: true}
 	candlesticksMarkPriceMap  = map[string]bool{okxChannelMarkPriceCandle1Y: true, okxChannelMarkPriceCandle6M: true, okxChannelMarkPriceCandle3M: true, okxChannelMarkPriceCandle1M: true, okxChannelMarkPriceCandle1W: true, okxChannelMarkPriceCandle1D: true, okxChannelMarkPriceCandle2D: true, okxChannelMarkPriceCandle3D: true, okxChannelMarkPriceCandle5D: true, okxChannelMarkPriceCandle12H: true, okxChannelMarkPriceCandle6H: true, okxChannelMarkPriceCandle4H: true, okxChannelMarkPriceCandle2H: true, okxChannelMarkPriceCandle1H: true, okxChannelMarkPriceCandle30m: true, okxChannelMarkPriceCandle15m: true, okxChannelMarkPriceCandle5m: true, okxChannelMarkPriceCandle3m: true, okxChannelMarkPriceCandle1m: true, okxChannelMarkPriceCandle1Yutc: true, okxChannelMarkPriceCandle3Mutc: true, okxChannelMarkPriceCandle1Mutc: true, okxChannelMarkPriceCandle1Wutc: true, okxChannelMarkPriceCandle1Dutc: true, okxChannelMarkPriceCandle2Dutc: true, okxChannelMarkPriceCandle3Dutc: true, okxChannelMarkPriceCandle5Dutc: true, okxChannelMarkPriceCandle12Hutc: true, okxChannelMarkPriceCandle6Hutc: true}
@@ -1232,13 +1240,10 @@ func (ok *Okx) wsProcessTickers(data []byte) error {
 func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, error) {
 	var subscriptions []stream.ChannelSubscription
 	assets := ok.GetAssetTypes(true)
-	var subs []string
-	copy(subs, defaultSubscribedChannels)
+	subs := make([]string, 0, len(defaultSubscribedChannels)+len(defaultAuthChannels))
+	subs = append(subs, defaultSubscribedChannels...)
 	if ok.Websocket.CanUseAuthenticatedEndpoints() {
-		subs = append(subs,
-			okxChannelAccount,
-			okxChannelOrders,
-		)
+		subs = append(subs, defaultAuthChannels...)
 	}
 	for c := range subs {
 		switch subs[c] {

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1238,32 +1238,33 @@ func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, err
 			okxChannelOrders,
 		)
 	}
-	for x := range assets {
-		pairs, err := ok.GetEnabledPairs(assets[x])
-		if err != nil {
-			return nil, err
-		}
-		for y := range defaultSubscribedChannels {
-			if defaultSubscribedChannels[y] == okxChannelCandle5m ||
-				defaultSubscribedChannels[y] == okxChannelTickers ||
-				defaultSubscribedChannels[y] == okxChannelOrders ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks5 ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooks50TBT ||
-				defaultSubscribedChannels[y] == okxChannelOrderBooksTBT ||
-				defaultSubscribedChannels[y] == okxChannelTrades {
+	for c := range defaultSubscribedChannels {
+		switch defaultSubscribedChannels[c] {
+		case okxChannelOrders:
+			for x := range assets {
+				subscriptions = append(subscriptions, stream.ChannelSubscription{
+					Channel: defaultSubscribedChannels[c],
+					Asset:   assets[x],
+				})
+			}
+		case okxChannelCandle5m, okxChannelTickers, okxChannelOrderBooks, okxChannelFundingRate, okxChannelOrderBooks5, okxChannelOrderBooks50TBT, okxChannelOrderBooksTBT, okxChannelTrades:
+			for x := range assets {
+				pairs, err := ok.GetEnabledPairs(assets[x])
+				if err != nil {
+					return nil, err
+				}
 				for p := range pairs {
 					subscriptions = append(subscriptions, stream.ChannelSubscription{
-						Channel:  defaultSubscribedChannels[y],
+						Channel:  defaultSubscribedChannels[c],
 						Asset:    assets[x],
 						Currency: pairs[p],
 					})
 				}
-			} else {
-				subscriptions = append(subscriptions, stream.ChannelSubscription{
-					Channel: defaultSubscribedChannels[y],
-				})
 			}
+		default:
+			subscriptions = append(subscriptions, stream.ChannelSubscription{
+				Channel: defaultSubscribedChannels[c],
+			})
 		}
 	}
 	if len(subscriptions) >= 240 {

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1232,18 +1232,20 @@ func (ok *Okx) wsProcessTickers(data []byte) error {
 func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, error) {
 	var subscriptions []stream.ChannelSubscription
 	assets := ok.GetAssetTypes(true)
+	subs := make([]string, len(defaultSubscribedChannels))
+	copy(subs, defaultSubscribedChannels)
 	if ok.Websocket.CanUseAuthenticatedEndpoints() {
-		defaultSubscribedChannels = append(defaultSubscribedChannels,
+		subs = append(subs,
 			okxChannelAccount,
 			okxChannelOrders,
 		)
 	}
-	for c := range defaultSubscribedChannels {
-		switch defaultSubscribedChannels[c] {
+	for c := range subs {
+		switch subs[c] {
 		case okxChannelOrders:
 			for x := range assets {
 				subscriptions = append(subscriptions, stream.ChannelSubscription{
-					Channel: defaultSubscribedChannels[c],
+					Channel: subs[c],
 					Asset:   assets[x],
 				})
 			}
@@ -1255,7 +1257,7 @@ func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, err
 				}
 				for p := range pairs {
 					subscriptions = append(subscriptions, stream.ChannelSubscription{
-						Channel:  defaultSubscribedChannels[c],
+						Channel:  subs[c],
 						Asset:    assets[x],
 						Currency: pairs[p],
 					})
@@ -1263,7 +1265,7 @@ func (ok *Okx) GenerateDefaultSubscriptions() ([]stream.ChannelSubscription, err
 			}
 		default:
 			subscriptions = append(subscriptions, stream.ChannelSubscription{
-				Channel: defaultSubscribedChannels[c],
+				Channel: subs[c],
 			})
 		}
 	}

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -403,7 +403,7 @@ func (ok *Okx) UpdateTickers(ctx context.Context, assetType asset.Item) error {
 		return err
 	}
 	instrumentType := ok.GetInstrumentTypeFromAssetItem(assetType)
-	ticks, err := ok.GetTickers(ctx, strings.ToUpper(instrumentType), "", "")
+	ticks, err := ok.GetTickers(ctx, instrumentType, "", "")
 	if err != nil {
 		return err
 	}
@@ -1260,7 +1260,7 @@ func (ok *Okx) GetOrderHistory(ctx context.Context, req *order.GetOrdersRequest)
 	if !ok.SupportsAsset(req.AssetType) {
 		return nil, fmt.Errorf("%w: %v", asset.ErrNotSupported, req.AssetType)
 	}
-	instrumentType := strings.ToUpper(ok.GetInstrumentTypeFromAssetItem(req.AssetType))
+	instrumentType := ok.GetInstrumentTypeFromAssetItem(req.AssetType)
 	endTime := req.EndTime
 	var resp []order.Detail
 allOrders:


### PR DESCRIPTION
# PR Description
G K's profile says he will be away for a bit, and #1202 has not had an answer. This PR shamelessly steals the work from #1202  and also applies a fix for instrument type casing allowing "orders" auth subscription to work:

```
[DEBUG] | WEBSOCKET | 08/06/2023 13:22:19 | Okx websocket connection: message received: {"event":"subscribe","arg":{"channel":"orders","instType":"FUTURES"}}
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested
I tested #1202 and then also tested that now things subscribe properly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
