### PR TITLE
okx: REST orderbook depth fix

### DIFF
--- a/contrib/spellcheck/exclude_lines.txt
+++ b/contrib/spellcheck/exclude_lines.txt
@@ -14,6 +14,7 @@
 	currency.GARD:     100,
 	currency.DASHS:      0.01,
 	currency.ALIS:       0.05,
+	currency.MIS:        0.002,
 	const pressXToJSON = `[0,"bu",[4131.85,4131.85]]`
 	wsTradeExecuted                        = "te"
 	wsBalanceUpdate                        = "bu"

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -104,7 +104,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetOrderBookDepth(t *testing.T) {
 	t.Parallel()
-	_, err := ok.GetOrderBookDepth(context.Background(), "BTC-USDT", 100)
+	_, err := ok.GetOrderBookDepth(context.Background(), "BTC-USDT", 400)
 	if err != nil {
 		t.Error("OKX GetOrderBookDepth() error", err)
 	}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -104,7 +104,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetOrderBookDepth(t *testing.T) {
 	t.Parallel()
-	_, err := ok.GetOrderBookDepth(context.Background(), "BTC-USDT", 2)
+	_, err := ok.GetOrderBookDepth(context.Background(), "BTC-USDT", 100)
 	if err != nil {
 		t.Error("OKX GetOrderBookDepth() error", err)
 	}

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -63,7 +63,7 @@ const (
 	operationLogin       = "login"
 )
 
-// Market Data Endoints
+// Market Data Endpoints
 
 // TickerResponse represents the market data endpoint ticker detail
 type TickerResponse struct {

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -485,7 +485,7 @@ func (ok *Okx) UpdateOrderbook(ctx context.Context, pair currency.Pair, assetTyp
 		return nil, errIncompleteCurrencyPair
 	}
 	instrumentID = format.Format(pair)
-	orderbookNew, err = ok.GetOrderBookDepth(ctx, instrumentID, 100)
+	orderbookNew, err = ok.GetOrderBookDepth(ctx, instrumentID, 400)
 	if err != nil {
 		return book, err
 	}

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -485,7 +485,7 @@ func (ok *Okx) UpdateOrderbook(ctx context.Context, pair currency.Pair, assetTyp
 		return nil, errIncompleteCurrencyPair
 	}
 	instrumentID = format.Format(pair)
-	orderbookNew, err = ok.GetOrderBookDepth(ctx, instrumentID, 0)
+	orderbookNew, err = ok.GetOrderBookDepth(ctx, instrumentID, 100)
 	if err != nil {
 		return book, err
 	}


### PR DESCRIPTION
# PR Description
While looking at something completely different I was concerned at how OKx only had 1 entry in its orderbook when on REST. I assumed it was a bad pair, but websocket returns many more results...

Turns out OKx's default depth is **one**: [source](https://www.okx.com/docs-v5/en/#rest-api-market-data-get-order-book)

## Type of change
- [x] Typo fix 

## How has this been tested
- `TestGetOrderBookDepth`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
