### PR TITLE
Orders: Fix ClientOrderID not updated in merge

### DIFF
--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -1091,6 +1091,7 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 		OrderID:           "1",
 		AccountID:         "1",
 		ClientID:          "1",
+		ClientOrderID:     "DukeOfWombleton",
 		WalletAddress:     "1",
 		Type:              1,
 		Side:              1,
@@ -1164,6 +1165,9 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 		t.Error("Failed to update")
 	}
 	if od.ClientID != "1" {
+		t.Error("Failed to update")
+	}
+	if od.ClientOrderID != "DukeOfWombleton" {
 		t.Error("Failed to update")
 	}
 	if od.WalletAddress != "1" {

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -184,6 +184,10 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) error {
 		d.ClientID = m.ClientID
 		updated = true
 	}
+	if m.ClientOrderID != "" && m.ClientOrderID != d.ClientOrderID {
+		d.ClientOrderID = m.ClientOrderID
+		updated = true
+	}
 	if m.WalletAddress != "" && m.WalletAddress != d.WalletAddress {
 		d.WalletAddress = m.WalletAddress
 		updated = true


### PR DESCRIPTION
UpdateOrderFromDetail did not merge the client order id in.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested


- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestUpdateOrderFromDetail

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
