### PR TITLE
dispatch: channel reuse fix

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -241,8 +241,7 @@ func (d *Dispatcher) subscribe(id uuid.UUID) (chan interface{}, error) {
 	}
 
 	// Get an unused channel from the channel pool
-	getResult := d.outbound.Get()
-	ch, ok := getResult.(chan interface{})
+	ch, ok := d.outbound.Get().(chan interface{})
 	if !ok {
 		return nil, errTypeAssertionFailure
 	}

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -218,7 +218,7 @@ func (d *Dispatcher) publish(id uuid.UUID, data interface{}) error {
 
 // Subscribe subscribes a system and returns a communication chan, this does not
 // ensure initial push.
-func (d *Dispatcher) subscribe(id uuid.UUID) (<-chan interface{}, error) {
+func (d *Dispatcher) subscribe(id uuid.UUID) (chan interface{}, error) {
 	if d == nil {
 		return nil, errDispatcherNotInitialized
 	}
@@ -241,7 +241,8 @@ func (d *Dispatcher) subscribe(id uuid.UUID) (<-chan interface{}, error) {
 	}
 
 	// Get an unused channel from the channel pool
-	ch, ok := d.outbound.Get().(chan interface{})
+	getResult := d.outbound.Get()
+	ch, ok := getResult.(chan interface{})
 	if !ok {
 		return nil, errTypeAssertionFailure
 	}
@@ -251,7 +252,7 @@ func (d *Dispatcher) subscribe(id uuid.UUID) (<-chan interface{}, error) {
 }
 
 // Unsubscribe unsubs a routine from the dispatcher
-func (d *Dispatcher) unsubscribe(id uuid.UUID, usedChan <-chan interface{}) error {
+func (d *Dispatcher) unsubscribe(id uuid.UUID, usedChan chan interface{}) error {
 	if d == nil {
 		return errDispatcherNotInitialized
 	}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -426,7 +426,7 @@ func TestMux(t *testing.T) {
 			return
 		}
 		errChan <- nil
-	}(pipe.C, errChan, &wg)
+	}(pipe.c, errChan, &wg)
 
 	wg.Wait()
 
@@ -506,7 +506,7 @@ func TestMuxPublish(t *testing.T) {
 		}
 	}(mux)
 
-	<-pipe.C
+	<-pipe.Channel()
 
 	// Shut down dispatch system
 	err = d.stop()

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -183,7 +183,7 @@ func TestUnsubscribe(t *testing.T) {
 	}
 
 	// will return nil if not running
-	err = d.unsubscribe(nonEmptyUUID, make(<-chan interface{}))
+	err = d.unsubscribe(nonEmptyUUID, make(chan interface{}))
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -193,7 +193,7 @@ func TestUnsubscribe(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 
-	err = d.unsubscribe(nonEmptyUUID, make(<-chan interface{}))
+	err = d.unsubscribe(nonEmptyUUID, make(chan interface{}))
 	if !errors.Is(err, errDispatcherUUIDNotFoundInRouteList) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errDispatcherUUIDNotFoundInRouteList)
 	}
@@ -203,7 +203,7 @@ func TestUnsubscribe(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 
-	err = d.unsubscribe(id, make(<-chan interface{}))
+	err = d.unsubscribe(id, make(chan interface{}))
 	if !errors.Is(err, errChannelNotFoundInUUIDRef) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errChannelNotFoundInUUIDRef)
 	}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -223,6 +223,16 @@ func TestUnsubscribe(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
+
+	ch2, err := d.subscribe(id)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
+
+	err = d.unsubscribe(id, ch2)
+	if !errors.Is(err, nil) {
+		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
+	}
 }
 
 func TestPublish(t *testing.T) {

--- a/dispatch/dispatch_types.go
+++ b/dispatch/dispatch_types.go
@@ -72,7 +72,7 @@ type Mux struct {
 // Pipe defines an outbound object to the desired routine
 type Pipe struct {
 	// Channel to get all our lovely information
-	C chan interface{}
+	c chan interface{}
 	// ID to tracked system
 	id uuid.UUID
 	// Reference to multiplexer

--- a/dispatch/dispatch_types.go
+++ b/dispatch/dispatch_types.go
@@ -72,7 +72,7 @@ type Mux struct {
 // Pipe defines an outbound object to the desired routine
 type Pipe struct {
 	// Channel to get all our lovely information
-	C <-chan interface{}
+	C chan interface{}
 	// ID to tracked system
 	id uuid.UUID
 	// Reference to multiplexer

--- a/dispatch/mux.go
+++ b/dispatch/mux.go
@@ -42,7 +42,7 @@ func (m *Mux) Subscribe(id uuid.UUID) (Pipe, error) {
 }
 
 // Unsubscribe returns channel to the pool for the full signature set
-func (m *Mux) Unsubscribe(id uuid.UUID, ch <-chan interface{}) error {
+func (m *Mux) Unsubscribe(id uuid.UUID, ch chan interface{}) error {
 	if m == nil {
 		return errMuxIsNil
 	}

--- a/dispatch/mux.go
+++ b/dispatch/mux.go
@@ -38,7 +38,7 @@ func (m *Mux) Subscribe(id uuid.UUID) (Pipe, error) {
 		return Pipe{}, err
 	}
 
-	return Pipe{C: ch, id: id, m: m}, nil
+	return Pipe{c: ch, id: id, m: m}, nil
 }
 
 // Unsubscribe returns channel to the pool for the full signature set
@@ -83,5 +83,10 @@ func (m *Mux) GetID() (uuid.UUID, error) {
 
 // Release returns the channel to the communications pool to be reused
 func (p *Pipe) Release() error {
-	return p.m.Unsubscribe(p.id, p.C)
+	return p.m.Unsubscribe(p.id, p.c)
+}
+
+// Channel returns the Pipe's channel
+func (p *Pipe) Channel() <-chan interface{} {
+	return p.c
 }

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -714,7 +714,7 @@ func (s *RPCServer) GetAccountInfoStream(r *gctrpc.GetAccountInfoRequest, stream
 	}()
 
 	for {
-		data, ok := <-pipe.C
+		data, ok := <-pipe.Channel()
 		if !ok {
 			return errDispatchSystem
 		}
@@ -2188,7 +2188,7 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 	}()
 
 	for {
-		data, ok := <-pipe.C
+		data, ok := <-pipe.Channel()
 		if !ok {
 			return errDispatchSystem
 		}
@@ -2273,7 +2273,7 @@ func (s *RPCServer) GetTickerStream(r *gctrpc.GetTickerStreamRequest, stream gct
 	}()
 
 	for {
-		data, ok := <-pipe.C
+		data, ok := <-pipe.Channel()
 		if !ok {
 			return errDispatchSystem
 		}
@@ -2326,7 +2326,7 @@ func (s *RPCServer) GetExchangeTickerStream(r *gctrpc.GetExchangeTickerStreamReq
 	}()
 
 	for {
-		data, ok := <-pipe.C
+		data, ok := <-pipe.Channel()
 		if !ok {
 			return errDispatchSystem
 		}

--- a/exchanges/account/account_test.go
+++ b/exchanges/account/account_test.go
@@ -213,7 +213,7 @@ func TestGetHoldings(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			c := time.NewTimer(time.Second)
 			select {
-			case <-p.C:
+			case <-p.Channel():
 			case <-c.C:
 			}
 		}


### PR DESCRIPTION
# PR Description

When unsubscribing using the dispatcher, a `<-chan interface{}` is put in a pool. When subscribing results in getting a used channel as a `chan interface{}` from the pool, a type assertion error happens. 

One solution would be to store all used channels as bidirectional channels. Alternative solutions could be possible too.

Fixes #1236

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Added a section to the dispatch test 'TestUnsubscribe' that would fail with the current code:

```
=== NAME  TestUnsubscribe
    dispatch_test.go:229: received: 'type assertion failure' but expected: '<nil>'
```

But passes with the proposed solution.

- [x] go test ./... -race
- [ ] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
