### PR TITLE
Okx: Fix panic during shutdown due to race

### DIFF
--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -3171,6 +3171,7 @@ type wsRequestDataChannelsMultiplexer struct {
 	Register              chan *wsRequestInfo
 	Unregister            chan string
 	Message               chan *wsIncomingData
+	shutdown              chan bool
 }
 
 // wsSubscriptionParameters represents toggling boolean values for subscription parameters.

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1644,6 +1644,8 @@ func (m *wsRequestDataChannelsMultiplexer) Run() {
 	for {
 		select {
 		case <-m.shutdown:
+			// We've consumed the shutdown, so create a new chan for subsequent runs
+			m.shutdown = make(chan bool)
 			return
 		case <-tickerData.C:
 			for x, myChan := range m.WsResponseChannelsMap {

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -226,6 +226,7 @@ func (ok *Okx) WsConnect() error {
 	if err != nil {
 		return err
 	}
+	ok.Websocket.Wg.Add(1)
 	go ok.wsFunnelConnectionData(ok.Websocket.Conn)
 	if ok.Verbose {
 		log.Debugf(log.ExchangeSys, "Successful connection to %v\n",
@@ -257,6 +258,7 @@ func (ok *Okx) WsAuth(ctx context.Context, dialer *websocket.Dialer) error {
 	if err != nil {
 		return fmt.Errorf("%v Websocket connection %v error. Error %v", ok.Name, okxAPIWebsocketPrivateURL, err)
 	}
+	ok.Websocket.Wg.Add(1)
 	go ok.wsFunnelConnectionData(ok.Websocket.AuthConn)
 	ok.Websocket.AuthConn.SetupPingHandler(stream.PingHandler{
 		MessageType: websocket.TextMessage,
@@ -333,7 +335,6 @@ func (ok *Okx) WsAuth(ctx context.Context, dialer *websocket.Dialer) error {
 // wsFunnelConnectionData receives data from multiple connection and pass the data
 // to wsRead through a channel responseStream
 func (ok *Okx) wsFunnelConnectionData(ws stream.Connection) {
-	ok.Websocket.Wg.Add(1)
 	defer ok.Websocket.Wg.Done()
 	for {
 		resp := ws.ReadMessage()
@@ -529,7 +530,6 @@ func (ok *Okx) handleSubscription(operation string, subscriptions []stream.Chann
 
 // WsReadData read coming messages thought the websocket connection and process the data.
 func (ok *Okx) WsReadData() {
-	ok.Websocket.Wg.Add(1)
 	defer ok.Websocket.Wg.Done()
 	for {
 		select {

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -228,8 +228,6 @@ func (ok *Okx) WsConnect() error {
 	}
 	ok.Websocket.Wg.Add(2)
 	go ok.wsFunnelConnectionData(ok.Websocket.Conn)
-	go ok.WsReadData()
-	go ok.WsResponseMultiplexer.Run()
 	if ok.Verbose {
 		log.Debugf(log.ExchangeSys, "Successful connection to %v\n",
 			ok.Websocket.GetWebsocketURL())

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -226,7 +226,6 @@ func (ok *Okx) WsConnect() error {
 	if err != nil {
 		return err
 	}
-	ok.Websocket.Wg.Add(2)
 	go ok.wsFunnelConnectionData(ok.Websocket.Conn)
 	if ok.Verbose {
 		log.Debugf(log.ExchangeSys, "Successful connection to %v\n",
@@ -258,7 +257,6 @@ func (ok *Okx) WsAuth(ctx context.Context, dialer *websocket.Dialer) error {
 	if err != nil {
 		return fmt.Errorf("%v Websocket connection %v error. Error %v", ok.Name, okxAPIWebsocketPrivateURL, err)
 	}
-	ok.Websocket.Wg.Add(1)
 	go ok.wsFunnelConnectionData(ok.Websocket.AuthConn)
 	ok.Websocket.AuthConn.SetupPingHandler(stream.PingHandler{
 		MessageType: websocket.TextMessage,
@@ -335,6 +333,7 @@ func (ok *Okx) WsAuth(ctx context.Context, dialer *websocket.Dialer) error {
 // wsFunnelConnectionData receives data from multiple connection and pass the data
 // to wsRead through a channel responseStream
 func (ok *Okx) wsFunnelConnectionData(ws stream.Connection) {
+	ok.Websocket.Wg.Add(1)
 	defer ok.Websocket.Wg.Done()
 	for {
 		resp := ws.ReadMessage()
@@ -530,6 +529,7 @@ func (ok *Okx) handleSubscription(operation string, subscriptions []stream.Chann
 
 // WsReadData read coming messages thought the websocket connection and process the data.
 func (ok *Okx) WsReadData() {
+	ok.Websocket.Wg.Add(1)
 	defer ok.Websocket.Wg.Done()
 	for {
 		select {

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -340,12 +340,10 @@ func (ok *Okx) wsReadData(ws stream.Connection) {
 		}
 		// Ensure that websocket shutdown will block until WsHandleData returns, so that the multiplexer is safe from new blocking channel sends.
 		ok.Websocket.Wg.Add(1)
-		go func(msg []byte) {
-			defer ok.Websocket.Wg.Done()
-			if err := ok.WsHandleData(msg); err != nil {
-				ok.Websocket.DataHandler <- err
-			}
-		}(resp.Raw)
+		if err := ok.WsHandleData(resp.Raw); err != nil {
+			ok.Websocket.DataHandler <- err
+		}
+		ok.Websocket.Wg.Done()
 	}
 }
 

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -338,12 +338,9 @@ func (ok *Okx) wsReadData(ws stream.Connection) {
 		if resp.Raw == nil {
 			return
 		}
-		// Ensure that websocket shutdown will block until WsHandleData returns, so that the multiplexer is safe from new blocking channel sends.
-		ok.Websocket.Wg.Add(1)
 		if err := ok.WsHandleData(resp.Raw); err != nil {
 			ok.Websocket.DataHandler <- err
 		}
-		ok.Websocket.Wg.Done()
 	}
 }
 

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -224,6 +224,8 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 	}); err != nil {
 		return err
 	}
+
+	//nolint:revive // We want this explicit return inside the if
 	if err := ok.Websocket.SetupNewConnection(stream.ConnectionSetup{
 		URL:                  okxAPIWebsocketPrivateURL,
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -213,6 +213,7 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 		return err
 	}
 
+	ok.Websocket.Wg.Add(2)
 	go ok.WsReadData()
 	go ok.WsResponseMultiplexer.Run()
 

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -225,18 +225,13 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 		return err
 	}
 
-	//nolint:revive // We want this explicit return inside the if
-	if err := ok.Websocket.SetupNewConnection(stream.ConnectionSetup{
+	return ok.Websocket.SetupNewConnection(stream.ConnectionSetup{
 		URL:                  okxAPIWebsocketPrivateURL,
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     okxWebsocketResponseMaxLimit,
 		Authenticated:        true,
 		RateLimit:            500,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 // Start starts the Okx go routine


### PR DESCRIPTION
Error:
```
panic: runtime error: slice bounds out of range [:13340] with capacity 8192
bufio.(*Reader).Read(0x14000038540, {0x1400059cffc?, 0x4?, 0x0?})
        /usr/local/go/src/bufio/bufio.go:250 +0x33c
github.com/gorilla/websocket.(*messageReader).Read(0x1400098bb78, {0x1400059cffc, 0x4, 0x4})
        /Users/gbjk/go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:1050 +0x208
io.ReadAll({0x12f36c618, 0x1400098bb78})
        /usr/local/go/src/io/io.go:701 +0xe4
io/ioutil.ReadAll(...)
        /usr/local/go/src/io/ioutil/ioutil.go:27
github.com/gorilla/websocket.(*Conn).ReadMessage(0x3?)
        /Users/gbjk/go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:1097 +0x54
github.com/thrasher-corp/gocryptotrader/exchanges/stream.(*WebsocketConnection).ReadMessage(0x140006622d0)
        /Users/gbjk/go/pkg/mod/github.com/gbjk/gocryptotrader@v0.0.0-20230619070715-ae6f283f6be6/exchanges/stream/websocket_connection.go:217 +0x30
github.com/thrasher-corp/gocryptotrader/exchanges/okx.(*Okx).wsFunnelConnectionData(0x140019321e0?, {0x106909450, 0x140006622d0})
        /Users/gbjk/go/pkg/mod/github.com/gbjk/gocryptotrader@v0.0.0-20230619070715-ae6f283f6be6/exchanges/okx/okx_websocket.go:346 +0x94
created by github.com/thrasher-corp/gocryptotrader/exchanges/okx.(*Okx).WsConnect
        /Users/gbjk/go/pkg/mod/github.com/gbjk/gocryptotrader@v0.0.0-20230619070715-ae6f283f6be6/exchanges/okx/okx_websocket.go:234 +0x134
exit status 2
```
This happens when there's a race in calls to bufio because it over-reads. See [this comment](https://github.com/golang/go/issues/42289#issuecomment-723393783) Detected using go -race:
```
WARNING: DATA RACE
Read at 0x00c000818bc0 by goroutine 2156:
  github.com/gorilla/websocket.(*Conn).NextReader()
      /Users/gbjk/go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:1000 +0x38
  github.com/gorilla/websocket.(*Conn).ReadMessage()
      /Users/gbjk/go/pkg/mod/github.com/gorilla/websocket@v1.5.0/conn.go:1093 +0x28
  github.com/thrasher-corp/gocryptotrader/exchanges/stream.(*WebsocketConnection).ReadMessage()
      /Users/gbjk/go/pkg/mod/github.com/gbjk/gocryptotrader@v0.0.0-20230619070715-ae6f283f6be6/exchanges/stream/websocket_connection.go:217 +0x44
  github.com/thrasher-corp/gocryptotrader/exchanges/okx.(*Okx).wsFunnelConnectionData()
```

Because we started a new wsFunnelConnectionData for each re-connect.

This bug might apply to other exchanges.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
