### PR TITLE
Kraken: Fix auth request regression

### DIFF
--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -1050,16 +1050,16 @@ func (k *Kraken) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange.U
 		return err
 	}
 	var errCap SpotAuthError
-	if err = json.Unmarshal(interim, &errCap); err == nil {
-		if errCap.Error != nil {
-			switch e := errCap.Error.(type) {
-			case []string:
-				return fmt.Errorf("%w %v", request.ErrAuthRequestFailed, e[0])
-			case string, []interface{}, interface{}:
+	if err = json.Unmarshal(interim, &errCap); err == nil && errCap.Error != nil {
+		switch e := errCap.Error.(type) {
+		case []string:
+			return fmt.Errorf("%w %v", request.ErrAuthRequestFailed, e[0])
+		case []interface{}: // no error will be an empty []interface{}
+			if len(e) > 0 {
 				return fmt.Errorf("%w %v", request.ErrAuthRequestFailed, e)
-			default:
-				return fmt.Errorf("%w %v", request.ErrAuthRequestFailed, errCap.Error)
 			}
+		default:
+			return fmt.Errorf("%w %v", request.ErrAuthRequestFailed, e)
 		}
 	}
 	err = json.Unmarshal(interim, result)


### PR DESCRIPTION
# PR Description

This fix addresses a regression in Kraken's auth requests where an empty error message would cause them to fail 😆 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
