### PR TITLE
gctcli: Add command line parameter to ignore default context timeout

### DIFF
--- a/cmd/gctcli/main.go
+++ b/cmd/gctcli/main.go
@@ -30,6 +30,7 @@ var (
 	timeout       time.Duration
 	exchangeCreds account.Credentials
 	verbose       bool
+	ignoreTimeout bool
 )
 
 const defaultTimeout = time.Second * 30
@@ -56,7 +57,9 @@ func setupClient(c *cli.Context) (*grpc.ClientConn, context.CancelFunc, error) {
 	}
 
 	var cancel context.CancelFunc
-	c.Context, cancel = context.WithTimeout(c.Context, timeout)
+	if !ignoreTimeout {
+		c.Context, cancel = context.WithTimeout(c.Context, timeout)
+	}
 	if !exchangeCreds.IsEmpty() {
 		flag, values := exchangeCreds.GetMetaData()
 		c.Context = metadata.AppendToOutgoingContext(c.Context, flag, values)
@@ -145,6 +148,12 @@ func main() {
 			Name:        "verbose",
 			Usage:       "allows the request to generate a more verbose outputs server side",
 			Destination: &verbose,
+		},
+		&cli.BoolFlag{
+			Name:        "ignoretimeout",
+			Aliases:     []string{"it"},
+			Usage:       "ignores the context timeout for requests",
+			Destination: &ignoreTimeout,
 		},
 	}
 	app.Commands = []*cli.Command{


### PR DESCRIPTION
# PR Description
As someone who frequently debugs the application while testing, its lame to have the context cancelled while inspecting code which then just returns conctext cancelled errors. This PR just adds a quick flag to prevent it happening. Naturally its at the requester's peril to have no deadline that's why its opt in

You can use it as such:
`go run . --ignoretimeout gettickerstream binance btc-usdt spot`
or
`go run . --it gettickerstream binance btc-usdt spot`

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## How has this been tested

- [x] running the CLI for longer than 30 seconds

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
