### PR TITLE
standards test: ignore CheckOrderExecutionLimits func

### DIFF
--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -494,6 +494,7 @@ var excludedMethodNames = map[string]struct{}{
 	"SubscribeToWebsocketChannels":     {}, // Unnecessary websocket test
 	"GetOrderExecutionLimits":          {}, // Not widely supported/implemented feature
 	"UpdateCurrencyStates":             {}, // Not widely supported/implemented feature
+	"CheckOrderExecutionLimits":        {}, // Not widely supported/implemented feature
 	"UpdateOrderExecutionLimits":       {}, // Not widely supported/implemented feature
 	"CanTradePair":                     {}, // Not widely supported/implemented feature
 	"CanTrade":                         {}, // Not widely supported/implemented feature


### PR DESCRIPTION
# PR Description
PR #1255 highlights that when populated, the function will be called when it shouldn't be. Order execution limits is not currently made in a way that works with the exchange wrapper standards test suite. Given that the other functions for order limits are ignored, this just adds onto that rather than reworking limits.go to support the tests because its not a common function to be supported.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
