### PR TITLE
Kraken: Fix Balances reporting 0 Free

### DIFF
--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -494,22 +494,19 @@ func (k *Kraken) GetSpread(ctx context.Context, symbol currency.Pair) ([]Spread,
 }
 
 // GetBalance returns your balance associated with your keys
-func (k *Kraken) GetBalance(ctx context.Context) (map[string]float64, error) {
+func (k *Kraken) GetBalance(ctx context.Context) (map[string]Balance, error) {
 	var response struct {
-		Error  []string          `json:"error"`
-		Result map[string]string `json:"result"`
+		Error  []string           `json:"error"`
+		Result map[string]Balance `json:"result"`
 	}
 
 	if err := k.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenBalance, url.Values{}, &response); err != nil {
 		return nil, err
 	}
 
-	result := make(map[string]float64)
+	result := make(map[string]Balance)
 	for curency, balance := range response.Result {
-		var err error
-		if result[curency], err = strconv.ParseFloat(balance, 64); err != nil {
-			return nil, err
-		}
+		result[curency] = balance
 	}
 
 	return result, GetError(response.Error)

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -504,12 +504,7 @@ func (k *Kraken) GetBalance(ctx context.Context) (map[string]Balance, error) {
 		return nil, err
 	}
 
-	result := make(map[string]Balance)
-	for curency, balance := range response.Result {
-		result[curency] = balance
-	}
-
-	return result, GetError(response.Error)
+	return response.Result, GetError(response.Error)
 }
 
 // GetWithdrawInfo gets withdrawal fees

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -18,7 +18,7 @@ const (
 	krakenDepth            = "Depth"
 	krakenTrades           = "Trades"
 	krakenSpread           = "Spread"
-	krakenBalance          = "Balance"
+	krakenBalance          = "BalanceEx"
 	krakenTradeBalance     = "TradeBalance"
 	krakenOpenOrders       = "OpenOrders"
 	krakenClosedOrders     = "ClosedOrders"
@@ -202,6 +202,12 @@ type Spread struct {
 	Time time.Time
 	Bid  float64
 	Ask  float64
+}
+
+// Balance represents account asset balances
+type Balance struct {
+	Total float64 `json:"balance,string"`
+	Hold  float64 `json:"hold_trade,string"`
 }
 
 // TradeBalanceOptions type

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -613,7 +613,9 @@ func (k *Kraken) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 			}
 			balances = append(balances, account.Balance{
 				Currency: currency.NewCode(translatedCurrency),
-				Total:    bal[key],
+				Total:    bal[key].Total,
+				Hold:     bal[key].Hold,
+				Free:     bal[key].Total - bal[key].Hold,
 			})
 		}
 		info.Accounts = append(info.Accounts, account.SubAccount{


### PR DESCRIPTION
This switches to BalancesEx(tended) to get Held assets so we can construct a Total, Held and Free.
Without this fix we get 0 balance from GetFree()
Haven't added tests because no construct for mocks and it's private data. Considering adding mocks a bridge to far for this fix.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
