### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/database/models/postgres/boil_queries_test.go
+++ b/database/models/postgres/boil_queries_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"regexp"
 
@@ -38,7 +37,7 @@ type fKeyDestroyer struct {
 
 func (f *fKeyDestroyer) Read(b []byte) (int, error) {
 	if f.buf == nil {
-		all, err := ioutil.ReadAll(f.reader)
+		all, err := io.ReadAll(f.reader)
 		if err != nil {
 			return 0, err
 		}

--- a/database/models/postgres/psql_main_test.go
+++ b/database/models/postgres/psql_main_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,7 +166,7 @@ func (p *pgTester) pgEnv() []string {
 }
 
 func (p *pgTester) makePGPassFile() error {
-	tmp, err := ioutil.TempFile("", "pgpass")
+	tmp, err := os.CreateTemp("", "pgpass")
 	if err != nil {
 		return errors.Wrap(err, "failed to create option file")
 	}

--- a/database/models/sqlite3/boil_queries_test.go
+++ b/database/models/sqlite3/boil_queries_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"regexp"
 
@@ -38,7 +37,7 @@ type fKeyDestroyer struct {
 
 func (f *fKeyDestroyer) Read(b []byte) (int, error) {
 	if f.buf == nil {
-		all, err := ioutil.ReadAll(f.reader)
+		all, err := io.ReadAll(f.reader)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
# PR Description

"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
