### PR TITLE
gRPC: Add stream authentication to gRPC server

### DIFF
--- a/backtester/engine/grpcserver.go
+++ b/backtester/engine/grpcserver.go
@@ -80,6 +80,7 @@ func StartRPCServer(server *GRPCServer) error {
 	opts := []grpc.ServerOption{
 		grpc.Creds(creds),
 		grpc.UnaryInterceptor(grpcauth.UnaryServerInterceptor(server.authenticateClient)),
+		grpc.StreamInterceptor(grpcauth.StreamServerInterceptor(server.authenticateClient)),
 	}
 	s := grpc.NewServer(opts...)
 	btrpc.RegisterBacktesterServiceServer(s, server)

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -148,6 +148,7 @@ func StartRPCServer(engine *Engine) {
 	opts := []grpc.ServerOption{
 		grpc.Creds(creds),
 		grpc.UnaryInterceptor(grpcauth.UnaryServerInterceptor(s.authenticateClient)),
+		grpc.StreamInterceptor(grpcauth.StreamServerInterceptor(s.authenticateClient)),
 	}
 	server := grpc.NewServer(opts...)
 	gctrpc.RegisterGoCryptoTraderServiceServer(server, &s)


### PR DESCRIPTION
# PR Description

The gRPC server uses Basic Authentication to control access, on top of a self generated TLS certificate that is private to the currently running instance. (Additionally, by default the gRPC server listens on a local address only).

However, currently only unary calls are protected with basic authentication.

This PR adds basic authentication to streaming gRPC calls (on top of the TLS certificate used as credentials).

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Ensure the gRPC server is enabled.
To verify Basic Authentication works for unary calls, e.g. place a getticker request:
`gctcli --rpcuser <USERNAME> --rpcpassword <PASSWORD> getticker --exchange bybit --asset spot --pair BTC-USDT`

Now change the password or remove the credentials: the call will fail as intended.

Do the same for a ticker stream:
`gctcli --rpcuser <USERNAME> --rpcpassword <PASSWORD> gettickerstream --exchange bybit --asset spot --pair BTC-USDT`

When changing the password or removing the credentials, the call will still succeed.

After applying the fix, the gettickerstream call (and other calls) will require valid credentials.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
