### PR TITLE
Order: Fix AmountStepIncrementSize conforms check

### DIFF
--- a/exchanges/order/limits.go
+++ b/exchanges/order/limits.go
@@ -242,9 +242,8 @@ func (m *MinMaxLevel) Conforms(price, amount float64, orderType Type) error {
 	}
 	if m.AmountStepIncrementSize != 0 {
 		dAmount := decimal.NewFromFloat(amount)
-		dMinAmount := decimal.NewFromFloat(m.MaximumBaseAmount)
 		dStep := decimal.NewFromFloat(m.AmountStepIncrementSize)
-		if !dAmount.Sub(dMinAmount).Mod(dStep).IsZero() {
+		if !dAmount.Mod(dStep).IsZero() {
 			return fmt.Errorf("%w stepSize: %.8f supplied %.8f",
 				ErrAmountExceedsStep,
 				m.AmountStepIncrementSize,


### PR DESCRIPTION
Was using max instead of min, and using either should be redundant anyway

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
