### PR TITLE
Kraken: Set AssetType in GetActiveOrders, CancelOrder and GetOrderInfo wrappers

### DIFF
--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -961,6 +961,14 @@ func TestSubmitOrder(t *testing.T) {
 // TestCancelExchangeOrder wrapper test
 func TestCancelExchangeOrder(t *testing.T) {
 	t.Parallel()
+
+	if err := k.CancelOrder(context.Background(), &order.Cancel{
+		AssetType: asset.Options,
+		OrderID:   "1337",
+	}); !errors.Is(err, asset.ErrNotSupported) {
+		t.Errorf("expected: %v, received: %v", asset.ErrNotSupported, err)
+	}
+
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
 	var orderCancellation = &order.Cancel{

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -1269,6 +1269,7 @@ func (k *Kraken) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 				Type:            orderType,
 				Pair:            p,
 				AssetType:       asset.Spot,
+				Status:          order.Open,
 			})
 		}
 	case asset.Futures:
@@ -1317,6 +1318,7 @@ func (k *Kraken) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 					Pair:      fPair,
 					Exchange:  k.Name,
 					AssetType: asset.Futures,
+					Status:    order.Open,
 				})
 			}
 		}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -915,7 +915,10 @@ func (k *Kraken) CancelOrder(ctx context.Context, o *order.Cancel) error {
 		if err != nil {
 			return err
 		}
+	default:
+		return fmt.Errorf("%w %v", asset.ErrNotSupported, o.AssetType)
 	}
+
 	return nil
 }
 
@@ -1263,6 +1266,7 @@ func (k *Kraken) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 				Side:            side,
 				Type:            orderType,
 				Pair:            p,
+				AssetType:       asset.Spot,
 			})
 		}
 	case asset.Futures:
@@ -1302,14 +1306,15 @@ func (k *Kraken) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 					return orders, err
 				}
 				orders = append(orders, order.Detail{
-					OrderID:  activeOrders.OpenOrders[a].OrderID,
-					Price:    activeOrders.OpenOrders[a].LimitPrice,
-					Amount:   activeOrders.OpenOrders[a].FilledSize,
-					Side:     oSide,
-					Type:     oType,
-					Date:     timeVar,
-					Pair:     fPair,
-					Exchange: k.Name,
+					OrderID:   activeOrders.OpenOrders[a].OrderID,
+					Price:     activeOrders.OpenOrders[a].LimitPrice,
+					Amount:    activeOrders.OpenOrders[a].FilledSize,
+					Side:      oSide,
+					Type:      oType,
+					Date:      timeVar,
+					Pair:      fPair,
+					Exchange:  k.Name,
+					AssetType: asset.Futures,
 				})
 			}
 		}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -1071,6 +1071,7 @@ func (k *Kraken) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pa
 			Fee:             orderInfo.Fee,
 			Trades:          trades,
 			Cost:            orderInfo.Cost,
+			AssetType:       asset.Spot,
 		}
 	case asset.Futures:
 		orderInfo, err := k.FuturesGetFills(ctx, time.Time{})
@@ -1098,14 +1099,15 @@ func (k *Kraken) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pa
 				return nil, err
 			}
 			orderDetail = order.Detail{
-				OrderID:  orderID,
-				Price:    orderInfo.Fills[y].Price,
-				Amount:   orderInfo.Fills[y].Size,
-				Side:     oSide,
-				Type:     fillOrderType,
-				Date:     timeVar,
-				Pair:     pair,
-				Exchange: k.Name,
+				OrderID:   orderID,
+				Price:     orderInfo.Fills[y].Price,
+				Amount:    orderInfo.Fills[y].Size,
+				Side:      oSide,
+				Type:      fillOrderType,
+				Date:      timeVar,
+				Pair:      pair,
+				Exchange:  k.Name,
+				AssetType: asset.Futures,
 			}
 		}
 	default:


### PR DESCRIPTION
# PR Description

Sets `AssetType` when using `GetActiveOrders` which ensures any methods like DeriveCancel have their asset type set properly. Also adds a default asset type check to CancelOrder.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] REST call

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
