### PR TITLE
Bitstamp: Add new trading fees API endpoint; refine fee calcuations and test coverage

### DIFF
--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -68,7 +68,11 @@ func (b *Bitstamp) GetFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) 
 
 	switch feeBuilder.FeeType {
 	case exchange.CryptocurrencyTradeFee:
-		fee, _ = b.GetTradingFee(ctx, feeBuilder)
+		tradingFee, err := b.getTradingFee(ctx, feeBuilder)
+		if err != nil {
+			return 0, fmt.Errorf("error getting trading fee: %w", err)
+		}
+		fee = tradingFee
 	case exchange.CryptocurrencyDepositFee:
 		fee = 0
 	case exchange.InternationalBankDepositFee:
@@ -85,7 +89,7 @@ func (b *Bitstamp) GetFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) 
 }
 
 // GetTradingFee returns a trading fee based on a currency
-func (b *Bitstamp) GetTradingFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) (float64, error) {
+func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var resp TradingFees
 	err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, bitstampAPITradingFees+"/"+strings.ToLower(feeBuilder.Pair.String()), true, nil, &resp)
 	if err != nil {

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -95,12 +95,9 @@ func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBu
 		return 0, err
 	}
 	fees := tradingFees.Fees
-	if len(fees) != 1 {
-		return 0, errors.New("did not receive exactly one fee from api")
-	}
-	fee := fees[0].Taker
+	fee := fees.Taker
 	if feeBuilder.IsMaker {
-		fee = fees[0].Maker
+		fee = fees.Maker
 	}
 	return fee / 100 * feeBuilder.PurchasePrice * feeBuilder.Amount, nil
 }
@@ -108,7 +105,6 @@ func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBu
 // GetAccountTradingFee returns a TradingFee for a pair
 func (b *Bitstamp) GetAccountTradingFee(ctx context.Context, pair currency.Pair) (TradingFees, error) {
 	path := bitstampAPITradingFees + "/" + strings.ToLower(pair.String())
-
 	var resp TradingFees
 	err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, path, true, nil, &resp)
 	return resp, err
@@ -116,8 +112,7 @@ func (b *Bitstamp) GetAccountTradingFee(ctx context.Context, pair currency.Pair)
 
 // GetAccountTradingFees returns a slice of TradingFee
 func (b *Bitstamp) GetAccountTradingFees(ctx context.Context) ([]TradingFees, error) {
-	path := bitstampAPITradingFees + "/"
-
+	path := bitstampAPITradingFees
 	var resp []TradingFees
 	err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, path, true, nil, &resp)
 	return resp, err

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -105,8 +105,13 @@ func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBu
 // GetAccountTradingFee returns a TradingFee for a pair
 func (b *Bitstamp) GetAccountTradingFee(ctx context.Context, pair currency.Pair) (TradingFees, error) {
 	path := bitstampAPITradingFees + "/" + strings.ToLower(pair.String())
+
 	var resp TradingFees
+	if pair.IsEmpty() {
+		return resp, currency.ErrCurrencyPairEmpty
+	}
 	err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, path, true, nil, &resp)
+
 	return resp, err
 }
 

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -90,10 +90,11 @@ func (b *Bitstamp) GetFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) 
 
 // GetTradingFee returns a trading fee based on a currency
 func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) (float64, error) {
-	fees, err := b.GetAccountTradingFee(ctx, feeBuilder.Pair)
+	tradingFees, err := b.GetAccountTradingFee(ctx, feeBuilder.Pair)
 	if err != nil {
 		return 0, err
 	}
+	fees := tradingFees.Fees
 	if len(fees) != 1 {
 		return 0, errors.New("did not receive exactly one fee from api")
 	}
@@ -105,12 +106,12 @@ func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBu
 }
 
 // GetAccountTradingFee returns a TradingFee for a pair
-func (b *Bitstamp) GetAccountTradingFee(ctx context.Context, pair currency.Pair) ([]MakerTakerFees, error) {
+func (b *Bitstamp) GetAccountTradingFee(ctx context.Context, pair currency.Pair) (TradingFees, error) {
 	path := bitstampAPITradingFees + "/" + strings.ToLower(pair.String())
 
 	var resp TradingFees
 	err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, path, true, nil, &resp)
-	return resp.Fees, err
+	return resp, err
 }
 
 // GetAccountTradingFees returns a slice of TradingFee

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -95,7 +95,14 @@ func (b *Bitstamp) getTradingFee(ctx context.Context, feeBuilder *exchange.FeeBu
 	if err != nil {
 		return 0, err
 	}
-	return resp.Fee * feeBuilder.PurchasePrice * feeBuilder.Amount, nil
+	if len(resp.Fees) != 1 {
+		return 0, errors.New("did not receive exactly one fee from api")
+	}
+	fee := resp.Fees[0].Taker
+	if feeBuilder.IsMaker {
+		fee = resp.Fees[0].Maker
+	}
+	return fee / 100 * feeBuilder.PurchasePrice * feeBuilder.Amount, nil
 }
 
 // getOfflineTradeFee calculates the worst case-scenario trading fee
@@ -124,22 +131,6 @@ func getInternationalBankDepositFee(amount float64) float64 {
 		return 300
 	}
 	return fee
-}
-
-// CalculateTradingFee returns fee on a currency pair
-func (b *Bitstamp) CalculateTradingFee(base, quote currency.Code, purchasePrice, amount float64, balances Balances) float64 {
-	var fee float64
-	/*if , ok := balances[base.String()]; ok {
-		switch quote {
-		case currency.BTC:
-			fee = v.BTCFee
-		case currency.USD:
-			fee = v.USDFee
-		case currency.EUR:
-			fee = v.EURFee
-		}
-	}*/
-	return fee * purchasePrice * amount
 }
 
 // GetTicker returns ticker information

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -252,7 +252,6 @@ func (b *Bitstamp) GetBalance(ctx context.Context) (Balances, error) {
 		balances[strings.ToUpper(curr)] = currBalance
 	}
 	return balances, nil
-
 }
 
 // GetUserTransactions returns an array of transactions

--- a/exchanges/bitstamp/bitstamp_live_test.go
+++ b/exchanges/bitstamp/bitstamp_live_test.go
@@ -26,9 +26,15 @@ func TestMain(m *testing.M) {
 		log.Fatal("Bitstamp Setup() init error", err)
 	}
 	bitstampConfig.API.AuthenticatedSupport = true
-	bitstampConfig.API.Credentials.Key = apiKey
-	bitstampConfig.API.Credentials.Secret = apiSecret
-	bitstampConfig.API.Credentials.ClientID = customerID
+	if apiKey != "" {
+		bitstampConfig.API.Credentials.Key = apiKey
+	}
+	if apiSecret != "" {
+		bitstampConfig.API.Credentials.Secret = apiSecret
+	}
+	if customerID != "" {
+		bitstampConfig.API.Credentials.ClientID = customerID
+	}
 	b.SetDefaults()
 	b.Websocket = sharedtestvalues.NewTestWebsocket()
 	err = b.Setup(bitstampConfig)

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -171,6 +171,8 @@ func TestGetAccountTradingFee(t *testing.T) {
 		assert.Equal(t, fee.Symbol, "ltcbtc", "Symbol should be correct")
 	}
 
+	_, err = b.GetAccountTradingFee(context.Background(), currency.EMPTYPAIR)
+	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "Should get back the right error")
 }
 
 func TestGetAccountTradingFees(t *testing.T) {

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -112,8 +112,7 @@ func TestGetFee(t *testing.T) {
 	fee, err = b.GetFee(context.Background(), feeBuilder)
 	if err != nil {
 		t.Error(err)
-	}
-	if expected := 0.002 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+	} else if expected := 0.002 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
 		t.Errorf("Bitstamp GetFee wrong Taker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -141,13 +141,22 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
+func TestGetTradingFee(t *testing.T) {
+	t.Parallel()
+	b.Verbose = true
+	feeBuilder := setFeeBuilder()
+	if _, err := b.GetTradingFee(context.Background(), feeBuilder); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestCalculateTradingFee(t *testing.T) {
 	t.Parallel()
 
 	newBalance := make(Balances)
 	newBalance["BTC"] = Balance{
-		USDFee: 1,
-		EURFee: 0,
+		/*USDFee: 1,
+		EURFee: 0,*/
 	}
 
 	if resp := b.CalculateTradingFee(currency.BTC, currency.USD, 0, 0, newBalance); resp != 0 {

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -275,14 +275,12 @@ func TestGetBalance(t *testing.T) {
 				Balance:       1337.42,
 				Reserved:      1295.00,
 				WithdrawalFee: 5.0,
-				USDFee:        0,
 			},
 			"BTC": {
 				Available:     9.1,
 				Balance:       11.2,
 				Reserved:      2.1,
 				WithdrawalFee: 0.00050000,
-				USDFee:        0.25,
 			},
 		} {
 			if got, ok := bal[k]; !ok {
@@ -299,9 +297,6 @@ func TestGetBalance(t *testing.T) {
 				}
 				if got.WithdrawalFee != e.WithdrawalFee {
 					t.Errorf("Incorrect WithdrawalFee for %s; Expected: %v Got: %v", k, e.WithdrawalFee, got.WithdrawalFee)
-				}
-				if got.USDFee != e.USDFee {
-					t.Errorf("Incorrect USDFee for %s; Expected: %v Got: %v", k, e.USDFee, got.USDFee)
 				}
 			}
 		}

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -184,7 +184,6 @@ func TestGetAccountTradingFees(t *testing.T) {
 
 	fees, err := b.GetAccountTradingFees(context.Background())
 	if assert.NoError(t, err, "GetAccountTradingFee should not error") {
-
 		if assert.Positive(t, len(fees), "Should get back multiple fees") {
 			fee := fees[0]
 			assert.NotEmpty(t, fee.Symbol, "Should get back a symbol")

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -99,8 +99,21 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	fee, err := b.GetFee(context.Background(), feeBuilder)
+	if err != nil {
 		t.Error(err)
+	} else if fee == 0 {
+		fee = 0.02
+	}
+
+	// CryptocurrencyTradeFee IsTaker
+	feeBuilder = setFeeBuilder()
+	feeBuilder.IsMaker = false
+	fee, err = b.GetFee(context.Background(), feeBuilder)
+	if err != nil {
+		t.Error(err)
+	} else if fee == 0 {
+		fee = 0.03
 	}
 
 	// CryptocurrencyTradeFee Negative purchase price
@@ -143,7 +156,6 @@ func TestGetFee(t *testing.T) {
 
 func TestGetTradingFee(t *testing.T) {
 	t.Parallel()
-	b.Verbose = true
 	feeBuilder := setFeeBuilder()
 	if _, err := b.GetTradingFee(context.Background(), feeBuilder); err != nil {
 		t.Error(err)

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -35,7 +35,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	return &exchange.FeeBuilder{
 		Amount:        5,
 		FeeType:       exchange.CryptocurrencyTradeFee,
-		Pair:          currency.NewPair(currency.BTC, currency.LTC),
+		Pair:          currency.NewPair(currency.LTC, currency.BTC),
 		PurchasePrice: 1800,
 	}
 }
@@ -151,6 +151,46 @@ func TestGetFee(t *testing.T) {
 	feeBuilder.FiatCurrency = currency.HKD
 	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestGetAccountTradingFee(t *testing.T) {
+	t.Parallel()
+
+	if !mockTests {
+		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
+	}
+
+	fee, err := b.GetAccountTradingFee(context.Background(), currency.NewPair(currency.LTC, currency.BTC))
+	if assert.NoError(t, err, "GetAccountTradingFee should not error") {
+		if mockTests {
+			assert.Positive(t, fee.Fees.Maker, "Maker should be positive")
+			assert.Positive(t, fee.Fees.Taker, "Taker should be positive")
+		}
+		assert.NotEmpty(t, fee.Symbol, "Symbol should not be empty")
+		assert.Equal(t, fee.Symbol, "ltcbtc", "Symbol should be correct")
+	}
+
+}
+
+func TestGetAccountTradingFees(t *testing.T) {
+	t.Parallel()
+
+	if !mockTests {
+		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
+	}
+
+	fees, err := b.GetAccountTradingFees(context.Background())
+	if assert.NoError(t, err, "GetAccountTradingFee should not error") {
+
+		if assert.Positive(t, len(fees), "Should get back multiple fees") {
+			fee := fees[0]
+			assert.NotEmpty(t, fee.Symbol, "Should get back a symbol")
+			if mockTests {
+				assert.Positive(t, fee.Fees.Maker, "Maker should be positive")
+				assert.Positive(t, fee.Fees.Taker, "Taker should be positive")
+			}
+		}
 	}
 }
 

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -33,10 +33,10 @@ var b = &Bitstamp{}
 
 func setFeeBuilder() *exchange.FeeBuilder {
 	return &exchange.FeeBuilder{
-		Amount:        1,
+		Amount:        5,
 		FeeType:       exchange.CryptocurrencyTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
-		PurchasePrice: 1,
+		PurchasePrice: 1800,
 	}
 }
 
@@ -102,8 +102,7 @@ func TestGetFee(t *testing.T) {
 	fee, err := b.GetFee(context.Background(), feeBuilder)
 	if err != nil {
 		t.Error(err)
-	}
-	if expected := 0.002 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+	} else if expected := 0.003 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
 		t.Errorf("Bitstamp GetFee wrong Maker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
@@ -114,7 +113,7 @@ func TestGetFee(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if expected := 0.003 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+	if expected := 0.002 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
 		t.Errorf("Bitstamp GetFee wrong Taker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
@@ -153,39 +152,6 @@ func TestGetFee(t *testing.T) {
 	feeBuilder.FiatCurrency = currency.HKD
 	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
 		t.Error(err)
-	}
-}
-
-func TestGetTradingFee(t *testing.T) {
-	t.Parallel()
-	feeBuilder := setFeeBuilder()
-	if _, err := b.getTradingFee(context.Background(), feeBuilder); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestCalculateTradingFee(t *testing.T) {
-	t.Parallel()
-
-	newBalance := make(Balances)
-	newBalance["BTC"] = Balance{
-		/*USDFee: 1,
-		EURFee: 0,*/
-	}
-
-	if resp := b.CalculateTradingFee(currency.BTC, currency.USD, 0, 0, newBalance); resp != 0 {
-		t.Error("GetFee() error")
-	}
-	if resp := b.CalculateTradingFee(currency.BTC, currency.USD, 2, 2, newBalance); resp != float64(4) {
-		t.Errorf("GetFee() error. Expected: %f, Received: %f", float64(4), resp)
-	}
-	if resp := b.CalculateTradingFee(currency.BTC, currency.EUR, 2, 2, newBalance); resp != float64(0) {
-		t.Errorf("GetFee() error. Expected: %f, Received: %f", float64(0), resp)
-	}
-
-	dummy1, dummy2 := currency.NewCode(""), currency.NewCode("")
-	if resp := b.CalculateTradingFee(dummy1, dummy2, 0, 0, newBalance); resp != 0 {
-		t.Error("GetFee() error")
 	}
 }
 

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -103,7 +103,7 @@ func TestGetFee(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if expected := 0.02 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+	if expected := 0.002 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
 		t.Errorf("Bitstamp GetFee wrong Maker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
@@ -114,7 +114,7 @@ func TestGetFee(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if expected := 0.03 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+	if expected := 0.003 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
 		t.Errorf("Bitstamp GetFee wrong Taker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
@@ -159,7 +159,7 @@ func TestGetFee(t *testing.T) {
 func TestGetTradingFee(t *testing.T) {
 	t.Parallel()
 	feeBuilder := setFeeBuilder()
-	if _, err := b.GetTradingFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.getTradingFee(context.Background(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -102,8 +102,9 @@ func TestGetFee(t *testing.T) {
 	fee, err := b.GetFee(context.Background(), feeBuilder)
 	if err != nil {
 		t.Error(err)
-	} else if fee == 0 {
-		fee = 0.02
+	}
+	if expected := 0.02 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+		t.Errorf("Bitstamp GetFee wrong Maker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
 	// CryptocurrencyTradeFee IsTaker
@@ -112,8 +113,9 @@ func TestGetFee(t *testing.T) {
 	fee, err = b.GetFee(context.Background(), feeBuilder)
 	if err != nil {
 		t.Error(err)
-	} else if fee == 0 {
-		fee = 0.03
+	}
+	if expected := 0.03 * feeBuilder.PurchasePrice * feeBuilder.Amount; fee != expected {
+		t.Errorf("Bitstamp GetFee wrong Taker fee; Pair: %s Expected: %v Got: %v", feeBuilder.Pair, expected, fee)
 	}
 
 	// CryptocurrencyTradeFee Negative purchase price

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -80,6 +80,7 @@ type TradingFees struct {
 	Fees []TradingFee
 }
 
+// TragindFee holds maker and taker fee information
 type TradingFee struct {
 	Maker float64 `json:"maker,string"`
 	Taker float64 `json:"taker,string"`

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -75,15 +75,21 @@ type EURUSDConversionRate struct {
 	Sell float64 `json:"sell,string"`
 }
 
+// TradingFees holds trading fee information
+type TradingFees struct {
+	Currency string  `json:"currency_pair"`
+	Fee      float64 `json:"fee,string"`
+}
+
 // Balance stores the balance info
 type Balance struct {
 	Available     float64
 	Balance       float64
 	Reserved      float64
 	WithdrawalFee float64
-	BTCFee        float64 // for cryptocurrency pairs
+	/*BTCFee        float64 // for cryptocurrency pairs
 	USDFee        float64
-	EURFee        float64
+	EURFee        float64*/
 }
 
 // Balances holds full balance information with the supplied APIKEYS

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -77,8 +77,12 @@ type EURUSDConversionRate struct {
 
 // TradingFees holds trading fee information
 type TradingFees struct {
-	Currency string  `json:"currency_pair"`
-	Fee      float64 `json:"fee,string"`
+	Fees []TradingFee
+}
+
+type TradingFee struct {
+	Maker float64 `json:"maker,string"`
+	Taker float64 `json:"taker,string"`
 }
 
 // Balance stores the balance info
@@ -87,9 +91,6 @@ type Balance struct {
 	Balance       float64
 	Reserved      float64
 	WithdrawalFee float64
-	/*BTCFee        float64 // for cryptocurrency pairs
-	USDFee        float64
-	EURFee        float64*/
 }
 
 // Balances holds full balance information with the supplied APIKEYS

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -77,11 +77,12 @@ type EURUSDConversionRate struct {
 
 // TradingFees holds trading fee information
 type TradingFees struct {
-	Fees []TradingFee
+	Symbol string `json:"currency_pair"`
+	Fees   []MakerTakerFees
 }
 
-// TradingFee holds maker and taker fee information
-type TradingFee struct {
+// MakerTakerFees holds maker and taker fee information
+type MakerTakerFees struct {
 	Maker float64 `json:"maker,string"`
 	Taker float64 `json:"taker,string"`
 }

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -77,8 +77,8 @@ type EURUSDConversionRate struct {
 
 // TradingFees holds trading fee information
 type TradingFees struct {
-	Symbol string `json:"currency_pair"`
-	Fees   []MakerTakerFees
+	Symbol string         `json:"currency_pair"`
+	Fees   MakerTakerFees `json:"fees"`
 }
 
 // MakerTakerFees holds maker and taker fee information

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -80,7 +80,7 @@ type TradingFees struct {
 	Fees []TradingFee
 }
 
-// TragindFee holds maker and taker fee information
+// TradingFee holds maker and taker fee information
 type TradingFee struct {
 	Maker float64 `json:"maker,string"`
 	Taker float64 `json:"taker,string"`

--- a/testdata/http_mock/bitstamp/bitstamp.json
+++ b/testdata/http_mock/bitstamp/bitstamp.json
@@ -148,6 +148,27 @@
     }
    ]
   },
+  "/api/v2/fees/trading/btcusd": {
+    "POST": [
+        {
+            "data": {
+                "fees": [
+                    {
+                        "maker": "0",
+                        "taker": "0"
+                    }
+                ]
+            },
+            "queryString": "",
+            "bodyParams": "key=\u0026nonce=1560481519007838128\u0026signature=C7558B2B2E75E9057994271CCC0200835887CDC63EC4103220489C52F749BFFA",
+            "headers": {
+                "Content-Type": [
+                    "application/x-www-form-urlencoded"
+                ]
+            }
+        }
+    ]
+},
   "/api/v2/buy/market/btcusd/": {
    "POST": [
     {

--- a/testdata/http_mock/bitstamp/bitstamp.json
+++ b/testdata/http_mock/bitstamp/bitstamp.json
@@ -188,7 +188,6 @@
                     }
                 }
             ],
-        
             "queryString": "",
             "bodyParams": "key=&nonce=1696325404980771000&signature=85B2B7E60567E352241BD98BDD08C0A435C2A77CB8F386739DD471BFFFA6C660",
             "headers": {

--- a/testdata/http_mock/bitstamp/bitstamp.json
+++ b/testdata/http_mock/bitstamp/bitstamp.json
@@ -148,16 +148,16 @@
     }
    ]
   },
-  "/api/v2/fees/trading/btcltc/": {
+  "/api/v2/fees/trading/ltcbtc/": {
     "POST": [
         {
             "data": {
-                "fees": [
+                "currency_pair": "ltcbtc",
+                "fees": 
                     {
                         "maker": "0.3",
                         "taker": "0.2"
                     }
-                ]
             },
             "queryString": "",
             "bodyParams": "key=\u0026nonce=1690610275327495000\u0026signature=B619E1AEF317B95D3BB28025F36EEF94CABCDE425CE3E13E8A1861C0A9777F2A",
@@ -169,6 +169,36 @@
         }
     ]
 },
+"/api/v2/fees/trading/": {
+    "POST": [
+        {
+            "data": [
+                {
+                "currency_pair":"ltcbtc",
+                "fees": {
+                        "maker": "0.3",
+                        "taker": "0.2"
+                    }
+                },
+                {
+                "currency_pair":"btcusd",
+                "fees": {
+                        "maker": "0.3",
+                        "taker": "0.2"
+                    }
+                }
+            ],
+        
+            "queryString": "",
+            "bodyParams": "key=&nonce=1696325404980771000&signature=85B2B7E60567E352241BD98BDD08C0A435C2A77CB8F386739DD471BFFFA6C660",
+            "headers": {
+                "Content-Type": [
+                    "application/x-www-form-urlencoded"
+                ]
+            }
+        }
+    ]
+  },
   "/api/v2/buy/market/btcusd/": {
    "POST": [
     {

--- a/testdata/http_mock/bitstamp/bitstamp.json
+++ b/testdata/http_mock/bitstamp/bitstamp.json
@@ -148,19 +148,19 @@
     }
    ]
   },
-  "/api/v2/fees/trading/btcusd": {
+  "/api/v2/fees/trading/btcltc/": {
     "POST": [
         {
             "data": {
                 "fees": [
                     {
-                        "maker": "0",
-                        "taker": "0"
+                        "maker": "0.3",
+                        "taker": "0.2"
                     }
                 ]
             },
             "queryString": "",
-            "bodyParams": "key=\u0026nonce=1560481519007838128\u0026signature=C7558B2B2E75E9057994271CCC0200835887CDC63EC4103220489C52F749BFFA",
+            "bodyParams": "key=\u0026nonce=1690610275327495000\u0026signature=B619E1AEF317B95D3BB28025F36EEF94CABCDE425CE3E13E8A1861C0A9777F2A",
             "headers": {
                 "Content-Type": [
                     "application/x-www-form-urlencoded"


### PR DESCRIPTION
# PR Description
A fix for issue #1271 
The trading fees have not been updated, always being 0.
Upon review, it showed a change in the trading fee fetching between v1 and v2.

Fixes # (issue)
Get trading fees directly from the API
## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestGetFee

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
