### PR TITLE
Binanceus: SubmitOrder- order.Buy replaced with IsLong

### DIFF
--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -595,7 +595,7 @@ func (bi *Binanceus) SubmitOrder(ctx context.Context, s *order.Submit) (*order.S
 	if s.AssetType != asset.Spot {
 		return nil, fmt.Errorf("%s %w", s.AssetType, asset.ErrNotSupported)
 	}
-	if s.Side == order.Buy {
+	if s.Side.IsLong() {
 		sideType = order.Buy.String()
 	} else {
 		sideType = order.Sell.String()


### PR DESCRIPTION

# PR Description

The fix is intended to cover all order actions- Buy, Sell, Ask, Bid, Long and Short by using IsLong() instead of order.Buy

Fixes #1270

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
