### PR TITLE
Bithumb: SubmitOrder- order.Buy replaced with IsLong

### DIFF
--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -520,14 +520,14 @@ func (b *Bithumb) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 	}
 
 	var orderID string
-	if s.Side == order.Buy {
+	if s.Side.IsLong() {
 		var result MarketBuy
 		result, err = b.MarketBuyOrder(ctx, fPair, s.Amount)
 		if err != nil {
 			return nil, err
 		}
 		orderID = result.OrderID
-	} else if s.Side == order.Sell {
+	} else if s.Side.IsShort() {
 		var result MarketSell
 		result, err = b.MarketSellOrder(ctx, fPair, s.Amount)
 		if err != nil {


### PR DESCRIPTION
# PR Description

The fix is intended to cover all order actions- Buy, Sell, Ask, Bid, Long and Short by using IsLong() instead of order.Buy

Fixes #1270 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
