### PR TITLE
exchanges/order: Improve order side handling in SubmitOrder

### DIFF
--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -970,13 +970,13 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 	switch s.AssetType {
 	case asset.Spot, asset.Margin:
 		var sideType string
-		switch s.Side {
-		case order.Buy:
+		switch {
+		case s.Side.IsLong():
 			sideType = order.Buy.String()
-		case order.Sell:
+		case s.Side.IsShort():
 			sideType = order.Sell.String()
 		default:
-			return nil, fmt.Errorf("%w %v", order.ErrSideIsInvalid, s.Side)
+			return nil, fmt.Errorf("%w %s", order.ErrSideIsInvalid, s.Side)
 		}
 		timeInForce := BinanceRequestParamsTimeGTC
 		var requestParamsOrderType RequestParamsOrderType

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -970,12 +970,14 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 	switch s.AssetType {
 	case asset.Spot, asset.Margin:
 		var sideType string
-		if s.Side == order.Buy {
+		switch s.Side {
+		case order.Buy:
 			sideType = order.Buy.String()
-		} else {
+		case order.Sell:
 			sideType = order.Sell.String()
+		default:
+			return nil, fmt.Errorf("%w %v", order.ErrSideIsInvalid, s.Side)
 		}
-
 		timeInForce := BinanceRequestParamsTimeGTC
 		var requestParamsOrderType RequestParamsOrderType
 		switch s.Type {

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -970,13 +970,10 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 	switch s.AssetType {
 	case asset.Spot, asset.Margin:
 		var sideType string
-		switch {
-		case s.Side.IsLong():
+		if s.Side.IsLong() {
 			sideType = order.Buy.String()
-		case s.Side.IsShort():
+		} else {
 			sideType = order.Sell.String()
-		default:
-			return nil, fmt.Errorf("%w %s", order.ErrSideIsInvalid, s.Side)
 		}
 		timeInForce := BinanceRequestParamsTimeGTC
 		var requestParamsOrderType RequestParamsOrderType

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -595,7 +595,7 @@ func (bi *Binanceus) SubmitOrder(ctx context.Context, s *order.Submit) (*order.S
 	if s.AssetType != asset.Spot {
 		return nil, fmt.Errorf("%s %w", s.AssetType, asset.ErrNotSupported)
 	}
-	if s.Side == order.Buy {
+	if s.Side.IsLong() {
 		sideType = order.Buy.String()
 	} else {
 		sideType = order.Sell.String()

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -671,7 +671,7 @@ func (b *Bitfinex) SubmitOrder(ctx context.Context, o *order.Submit) (*order.Sub
 			orderType,
 			o.Amount,
 			o.Price,
-			o.Side == order.Buy,
+			o.Side.IsLong(),
 			false)
 		if err != nil {
 			return nil, err

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -520,14 +520,14 @@ func (b *Bithumb) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 	}
 
 	var orderID string
-	if s.Side == order.Buy {
+	if s.Side.IsLong() {
 		var result MarketBuy
 		result, err = b.MarketBuyOrder(ctx, fPair, s.Amount)
 		if err != nil {
 			return nil, err
 		}
 		orderID = result.OrderID
-	} else if s.Side == order.Sell {
+	} else if s.Side.IsShort() {
 		var result MarketSell
 		result, err = b.MarketSellOrder(ctx, fPair, s.Amount)
 		if err != nil {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -577,7 +577,7 @@ func (b *Bitstamp) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		fPair.String(),
 		s.Price,
 		s.Amount,
-		s.Side == order.Buy,
+		s.Side.IsLong(),
 		s.Type == order.Market)
 	if err != nil {
 		return nil, err

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -581,11 +581,11 @@ func (b *Bittrex) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 		return nil, err
 	}
 
-	if s.Side == order.Ask {
+	if s.Side.IsShort() {
 		s.Side = order.Sell
 	}
 
-	if s.Side == order.Bid {
+	if s.Side.IsLong() {
 		s.Side = order.Buy
 	}
 

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -580,11 +580,11 @@ func (b *BTCMarkets) SubmitOrder(ctx context.Context, s *order.Submit) (*order.S
 		return nil, err
 	}
 
-	if s.Side == order.Sell {
-		s.Side = order.Ask
+	if s.Side.IsLong() {
+		s.Side = order.Buy
 	}
-	if s.Side == order.Buy {
-		s.Side = order.Bid
+	if s.Side.IsShort() {
+		s.Side = order.Sell
 	}
 
 	fPair, err := b.FormatExchangeCurrency(s.Pair, asset.Spot)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -581,10 +581,10 @@ func (b *BTCMarkets) SubmitOrder(ctx context.Context, s *order.Submit) (*order.S
 	}
 
 	if s.Side.IsLong() {
-		s.Side = order.Buy
+		s.Side = order.Bid
 	}
 	if s.Side.IsShort() {
-		s.Side = order.Sell
+		s.Side = order.Ask
 	}
 
 	fPair, err := b.FormatExchangeCurrency(s.Pair, asset.Spot)

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -947,10 +947,10 @@ func (by *Bybit) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 	}
 
 	var sideType string
-	switch s.Side {
-	case order.Buy:
+	switch {
+	case s.Side.IsLong():
 		sideType = sideBuy
-	case order.Sell:
+	case s.Side.IsShort():
 		sideType = sideSell
 	default:
 		return nil, errInvalidSide

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -652,7 +652,7 @@ func (c *COINUT) SubmitOrder(ctx context.Context, o *order.Submit) (*order.Submi
 			currencyID,
 			o.Amount,
 			o.Price,
-			o.Side == order.Buy,
+			o.Side.IsLong(),
 			uint32(clientIDInt))
 		if err != nil {
 			return nil, err

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -536,7 +536,7 @@ func (e *EXMO) SubmitOrder(ctx context.Context, s *order.Submit) (*order.SubmitR
 	case order.Limit:
 		return nil, fmt.Errorf("%w %v", order.ErrUnsupportedOrderType, s.Type)
 	case order.Market:
-		if s.Side == order.Sell {
+		if s.Side.IsShort() {
 			orderType = "market_sell"
 		} else {
 			orderType = "market_buy"

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -1017,15 +1017,11 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		return nil, err
 	}
 	var orderTypeFormat string
-	switch s.Side {
-	case order.Buy:
+	switch {
+	case s.Side.IsLong():
 		orderTypeFormat = order.Buy.Lower()
-	case order.Sell:
+	case s.Side.IsShort():
 		orderTypeFormat = order.Sell.Lower()
-	case order.Bid:
-		orderTypeFormat = order.Bid.Lower()
-	case order.Ask:
-		orderTypeFormat = order.Ask.Lower()
 	default:
 		return nil, errInvalidOrderSide
 	}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -985,14 +985,14 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submit
 			AccountID: int(accountID),
 		}
 		switch {
-		case s.Side == order.Buy && s.Type == order.Market:
+		case s.Side.IsLong() && s.Type == order.Market:
 			formattedType = SpotNewOrderRequestTypeBuyMarket
-		case s.Side == order.Sell && s.Type == order.Market:
+		case s.Side.IsShort() && s.Type == order.Market:
 			formattedType = SpotNewOrderRequestTypeSellMarket
-		case s.Side == order.Buy && s.Type == order.Limit:
+		case s.Side.IsLong() && s.Type == order.Limit:
 			formattedType = SpotNewOrderRequestTypeBuyLimit
 			params.Price = s.Price
-		case s.Side == order.Sell && s.Type == order.Limit:
+		case s.Side.IsShort() && s.Type == order.Limit:
 			formattedType = SpotNewOrderRequestTypeSellLimit
 			params.Price = s.Price
 		}
@@ -1008,10 +1008,10 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submit
 		}
 	case asset.CoinMarginedFutures:
 		var oDirection string
-		switch s.Side {
-		case order.Buy:
+		switch {
+		case s.Side.IsLong():
 			oDirection = "BUY"
-		case order.Sell:
+		case s.Side.IsShort():
 			oDirection = "SELL"
 		}
 		var oType string
@@ -1040,10 +1040,10 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submit
 		orderID = orderResp.Data.OrderIDString
 	case asset.Futures:
 		var oDirection string
-		switch s.Side {
-		case order.Buy:
+		switch {
+		case s.Side.IsLong():
 			oDirection = "BUY"
-		case order.Sell:
+		case s.Side.IsShort():
 			oDirection = "SELL"
 		}
 		var oType string

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -496,7 +496,7 @@ func (l *Lbank) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submit
 		return nil, err
 	}
 
-	if s.Side != order.Buy && s.Side != order.Sell {
+	if !s.Side.IsLong() && !s.Side.IsShort() {
 		return nil,
 			fmt.Errorf("%s order side is not supported by the exchange",
 				s.Side)

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -633,7 +633,7 @@ func (p *Poloniex) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		s.Amount,
 		false,
 		s.Type == order.Market,
-		s.Side == order.Buy)
+		s.Side.IsLong())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

# PR Description

The fix is intended to cover all order actions- Buy, Sell, Ask, Bid, Long and Short by using IsLong() instead of order.Buy. Combined the exchanges in stead of creating a PR for each one separately

Fixes #1270 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
