### PR TITLE
stream/buffer: Reduces map lookups by using key struct

### DIFF
--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -31,7 +31,6 @@ var (
 	errUpdateInsertFailure          = errors.New("orderbook update/insert update failure")
 	errRESTTimerLapse               = errors.New("rest sync timer lapse with active websocket connection")
 	errOrderbookFlushed             = errors.New("orderbook flushed")
-	errDataHandlerReaderSlow        = errors.New("data handler reader slow")
 )
 
 // Setup sets private variables

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -205,12 +205,7 @@ func (w *Orderbook) Update(u *orderbook.Update) error {
 	// A nil ticker means that a zero publish period has been set and the entire
 	// websocket updates will be sent to the engine websocket manager for
 	// display purposes. Same as being verbose.
-	select {
-	// Needs to be in select case as this can cause a knock on affect with
-	// websocket update and processing times.
-	case w.dataHandler <- book.ob:
-	default:
-	}
+	w.dataHandler <- book.ob
 	return nil
 }
 
@@ -355,22 +350,7 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 	}
 
 	holder.ob.Publish()
-	if !holder.InitialUpdate {
-		holder.InitialUpdate = true
-		select {
-		case w.dataHandler <- holder.ob:
-			return nil
-		default:
-			w.dataHandler <- holder.ob
-			return fmt.Errorf("%w %s %s %s", errDataHandlerReaderSlow, w.exchangeName, book.Pair, book.Asset)
-		}
-	}
-
-	select {
-	// Needs to be in select case as this directly impacts websocket reading.
-	case w.dataHandler <- holder.ob:
-	default:
-	}
+	w.dataHandler <- holder.ob
 	return nil
 }
 

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -60,7 +60,7 @@ func (w *Orderbook) Setup(exchangeConfig *config.Exchange, c *Config, dataHandle
 	w.updateEntriesByID = c.UpdateEntriesByID
 	w.exchangeName = exchangeConfig.Name
 	w.dataHandler = dataHandler
-	w.ob = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
+	w.ob = make(map[Key]*orderbookHolder)
 	w.verbose = exchangeConfig.Verbose
 
 	// set default publish period if missing
@@ -91,9 +91,9 @@ func (w *Orderbook) Update(u *orderbook.Update) error {
 	if err := w.validate(u); err != nil {
 		return err
 	}
-	w.m.Lock()
-	defer w.m.Unlock()
-	book, ok := w.ob[u.Pair.Base][u.Pair.Quote][u.Asset]
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	book, ok := w.ob[Key{Base: u.Pair.Base.Item, Quote: u.Pair.Quote.Item, Asset: u.Asset}]
 	if !ok {
 		return fmt.Errorf("%w for Exchange %s CurrencyPair: %s AssetType: %s",
 			errDepthNotFound,
@@ -204,7 +204,13 @@ func (w *Orderbook) Update(u *orderbook.Update) error {
 	// A nil ticker means that a zero publish period has been set and the entire
 	// websocket updates will be sent to the engine websocket manager for
 	// display purposes. Same as being verbose.
-	w.dataHandler <- book.ob
+	select {
+	// Needs to be in select case as this can cause a knock on affect with
+	// websocket update and processing times. This will also impede the
+	// websocket reader.
+	case w.dataHandler <- book.ob:
+	default:
+	}
 	return nil
 }
 
@@ -306,19 +312,9 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 		return err
 	}
 
-	w.m.Lock()
-	defer w.m.Unlock()
-	m1, ok := w.ob[book.Pair.Base]
-	if !ok {
-		m1 = make(map[currency.Code]map[asset.Item]*orderbookHolder)
-		w.ob[book.Pair.Base] = m1
-	}
-	m2, ok := m1[book.Pair.Quote]
-	if !ok {
-		m2 = make(map[asset.Item]*orderbookHolder)
-		m1[book.Pair.Quote] = m2
-	}
-	holder, ok := m2[book.Asset]
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	holder, ok := w.ob[Key{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}]
 	if !ok {
 		// Associate orderbook pointer with local exchange depth map
 		var depth *orderbook.Depth
@@ -333,16 +329,11 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 		if w.publishPeriod != 0 {
 			ticker = time.NewTicker(w.publishPeriod)
 		}
-		holder = &orderbookHolder{
-			ob:     depth,
-			buffer: &buffer,
-			ticker: ticker,
-		}
-		m2[book.Asset] = holder
+		holder = &orderbookHolder{ob: depth, buffer: &buffer, ticker: ticker}
+		w.ob[Key{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}] = holder
 	}
 
 	holder.updateID = book.LastUpdateID
-
 	holder.ob.LoadSnapshot(book.Bids,
 		book.Asks,
 		book.LastUpdateID,
@@ -364,21 +355,21 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 	}
 
 	holder.ob.Publish()
-	w.dataHandler <- holder.ob
+	select {
+	// Needs to be in select case as this directly impacts websocket reading.
+	case w.dataHandler <- holder.ob:
+	default:
+	}
 	return nil
 }
 
 // GetOrderbook returns an orderbook copy as orderbook.Base
 func (w *Orderbook) GetOrderbook(p currency.Pair, a asset.Item) (*orderbook.Base, error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-	book, ok := w.ob[p.Base][p.Quote][a]
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	book, ok := w.ob[Key{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
 	if !ok {
-		return nil, fmt.Errorf("%s %s %s %w",
-			w.exchangeName,
-			p,
-			a,
-			errDepthNotFound)
+		return nil, fmt.Errorf("%s %s %s %w", w.exchangeName, p, a, errDepthNotFound)
 	}
 	return book.ob.Retrieve()
 }
@@ -386,16 +377,16 @@ func (w *Orderbook) GetOrderbook(p currency.Pair, a asset.Item) (*orderbook.Base
 // FlushBuffer flushes w.ob data to be garbage collected and refreshed when a
 // connection is lost and reconnected
 func (w *Orderbook) FlushBuffer() {
-	w.m.Lock()
-	w.ob = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
-	w.m.Unlock()
+	w.mtx.Lock()
+	w.ob = make(map[Key]*orderbookHolder)
+	w.mtx.Unlock()
 }
 
 // FlushOrderbook flushes independent orderbook
 func (w *Orderbook) FlushOrderbook(p currency.Pair, a asset.Item) error {
-	w.m.Lock()
-	defer w.m.Unlock()
-	book, ok := w.ob[p.Base][p.Quote][a]
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	book, ok := w.ob[Key{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
 	if !ok {
 		return fmt.Errorf("cannot flush orderbook %s %s %s %w",
 			w.exchangeName,

--- a/exchanges/stream/buffer/buffer.go
+++ b/exchanges/stream/buffer/buffer.go
@@ -31,6 +31,7 @@ var (
 	errUpdateInsertFailure          = errors.New("orderbook update/insert update failure")
 	errRESTTimerLapse               = errors.New("rest sync timer lapse with active websocket connection")
 	errOrderbookFlushed             = errors.New("orderbook flushed")
+	errDataHandlerReaderSlow        = errors.New("data handler reader slow")
 )
 
 // Setup sets private variables
@@ -206,8 +207,7 @@ func (w *Orderbook) Update(u *orderbook.Update) error {
 	// display purposes. Same as being verbose.
 	select {
 	// Needs to be in select case as this can cause a knock on affect with
-	// websocket update and processing times. This will also impede the
-	// websocket reader.
+	// websocket update and processing times.
 	case w.dataHandler <- book.ob:
 	default:
 	}
@@ -355,6 +355,17 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 	}
 
 	holder.ob.Publish()
+	if !holder.InitialUpdate {
+		holder.InitialUpdate = true
+		select {
+		case w.dataHandler <- holder.ob:
+			return nil
+		default:
+			w.dataHandler <- holder.ob
+			return fmt.Errorf("%w %s %s %s", errDataHandlerReaderSlow, w.exchangeName, book.Pair, book.Asset)
+		}
+	}
+
 	select {
 	// Needs to be in select case as this directly impacts websocket reading.
 	case w.dataHandler <- holder.ob:

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -48,6 +48,7 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Items, err error)
 	ch := make(chan interface{})
 	go func(<-chan interface{}) { // reader
 		for range ch {
+			continue
 		}
 	}(ch)
 	holder = &Orderbook{
@@ -56,7 +57,10 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Items, err error)
 		ob:           newBook,
 	}
 	err = holder.LoadSnapshot(book)
-	return
+	if errors.Is(err, errDataHandlerReaderSlow) { // expected return error
+		err = nil
+	}
+	return holder, asks, bids, nil
 }
 
 func bidAskGenerator() []orderbook.Item {

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -60,7 +60,7 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Items, err error)
 	if errors.Is(err, errDataHandlerReaderSlow) { // expected return error
 		err = nil
 	}
-	return holder, asks, bids, nil
+	return holder, asks, bids, err
 }
 
 func bidAskGenerator() []orderbook.Item {

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -58,9 +58,6 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Items, err error)
 		ob:           newBook,
 	}
 	err = holder.LoadSnapshot(book)
-	if errors.Is(err, errDataHandlerReaderSlow) { // expected return error
-		err = nil
-	}
 	return holder, asks, bids, err
 }
 

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -3,7 +3,6 @@ package buffer
 import (
 	"errors"
 	"math/rand"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1179,68 +1178,5 @@ func TestFlushOrderbook(t *testing.T) {
 	_, err = w.GetOrderbook(cp, asset.Spot)
 	if !errors.Is(err, orderbook.ErrOrderbookInvalid) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, orderbook.ErrOrderbookInvalid)
-	}
-}
-
-var multiMapHolder = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
-
-// 62019669	        19.40 ns/op	       0 B/op	       0 allocs/op
-func BenchmarkMultiMapHolder(b *testing.B) {
-	var c1 currency.Code
-	var c2 currency.Code
-	var a asset.Item
-	for x := 0; x < 3000; x++ {
-		c1 = currency.NewCode(strconv.FormatInt(int64(x), 10))
-		c2 = currency.NewCode(strconv.FormatInt(int64(x), 10))
-
-		m1, ok := multiMapHolder[c1]
-		if !ok {
-			m1 = make(map[currency.Code]map[asset.Item]*orderbookHolder)
-			multiMapHolder[c1] = m1
-		}
-
-		m2, ok := m1[c2]
-		if !ok {
-			m2 = make(map[asset.Item]*orderbookHolder)
-			m1[c2] = m2
-		}
-
-		a = asset.Item(x)
-		m2[a] = &orderbookHolder{}
-	}
-
-	b.ResetTimer()
-
-	var ok bool
-	for x := 0; x < b.N; x++ {
-		_, ok = multiMapHolder[c1][c2][a]
-		if !ok {
-			b.Fatal("cound't find item")
-		}
-	}
-}
-
-var keyMapHolder = make(map[Key]*orderbookHolder)
-
-// 91994203	        13.28 ns/op	       0 B/op	       0 allocs/op
-func BenchmarkCurrentKeyMapHolder(b *testing.B) {
-	var c1 currency.Code
-	var c2 currency.Code
-	var a asset.Item
-	for x := 0; x < 3000; x++ {
-		c1 = currency.NewCode(strconv.FormatInt(int64(x), 10))
-		c2 = currency.NewCode(strconv.FormatInt(int64(x), 10))
-		a = asset.Item(x)
-		keyMapHolder[Key{Base: c1.Item, Quote: c2.Item, Asset: a}] = &orderbookHolder{}
-	}
-
-	b.ResetTimer()
-
-	var ok bool
-	for x := 0; x < b.N; x++ {
-		_, ok = keyMapHolder[Key{Base: c1.Item, Quote: c2.Item, Asset: a}]
-		if !ok {
-			b.Fatal("cound't find item")
-		}
 	}
 }

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -43,12 +43,11 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Items, err error)
 		PriceDuplication: true,
 	}
 
-	newBook := make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
+	newBook := make(map[Key]*orderbookHolder)
 
 	ch := make(chan interface{})
 	go func(<-chan interface{}) { // reader
 		for range ch {
-			continue
 		}
 	}(ch)
 	holder = &Orderbook{
@@ -92,7 +91,7 @@ func BenchmarkUpdateBidsByPrice(b *testing.B) {
 			UpdateTime: time.Now(),
 			Asset:      asset.Spot,
 		}
-		holder := ob.ob[cp.Base][cp.Quote][asset.Spot]
+		holder := ob.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 		holder.updateByPrice(update)
 	}
 }
@@ -112,7 +111,7 @@ func BenchmarkUpdateAsksByPrice(b *testing.B) {
 			UpdateTime: time.Now(),
 			Asset:      asset.Spot,
 		}
-		holder := ob.ob[cp.Base][cp.Quote][asset.Spot]
+		holder := ob.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 		holder.updateByPrice(update)
 	}
 }
@@ -239,7 +238,7 @@ func TestUpdates(t *testing.T) {
 		t.Error(err)
 	}
 
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	book.updateByPrice(&orderbook.Update{
 		Bids:       itemArray[5],
 		Asks:       itemArray[5],
@@ -295,7 +294,7 @@ func TestHittingTheBuffer(t *testing.T) {
 		}
 	}
 
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	askLen, err := book.ob.GetAskLength()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -343,7 +342,7 @@ func TestInsertWithIDs(t *testing.T) {
 		}
 	}
 
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	askLen, err := book.ob.GetAskLength()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -385,7 +384,7 @@ func TestSortIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	askLen, err := book.ob.GetAskLength()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -429,7 +428,7 @@ func TestOutOfOrderIDs(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	cpy, err := book.ob.Retrieve()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -559,7 +558,7 @@ func TestRunUpdateWithoutAnyUpdates(t *testing.T) {
 func TestRunSnapshotWithNoData(t *testing.T) {
 	t.Parallel()
 	var obl Orderbook
-	obl.ob = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
+	obl.ob = make(map[Key]*orderbookHolder)
 	obl.dataHandler = make(chan interface{}, 1)
 	var snapShot1 orderbook.Base
 	snapShot1.Asset = asset.Spot
@@ -577,7 +576,7 @@ func TestLoadSnapshot(t *testing.T) {
 	t.Parallel()
 	var obl Orderbook
 	obl.dataHandler = make(chan interface{}, 100)
-	obl.ob = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
+	obl.ob = make(map[Key]*orderbookHolder)
 	var snapShot1 orderbook.Base
 	snapShot1.Exchange = "SnapshotWithOverride"
 	asks := []orderbook.Item{
@@ -602,11 +601,11 @@ func TestFlushBuffer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if obl.ob[cp.Base][cp.Quote][asset.Spot] == nil {
+	if obl.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}] == nil {
 		t.Error("expected ob to have ask entries")
 	}
 	obl.FlushBuffer()
-	if obl.ob[cp.Base][cp.Quote][asset.Spot] != nil {
+	if obl.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}] != nil {
 		t.Error("expected ob be flushed")
 	}
 }
@@ -616,7 +615,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	t.Parallel()
 	var holder Orderbook
 	holder.dataHandler = make(chan interface{}, 100)
-	holder.ob = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)
+	holder.ob = make(map[Key]*orderbookHolder)
 	var snapShot1 orderbook.Base
 	snapShot1.Exchange = "WSORDERBOOKTEST1"
 	asks := []orderbook.Item{
@@ -779,7 +778,7 @@ func TestGetOrderbook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bufferOb := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	bufferOb := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	b, err := bufferOb.ob.Retrieve()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -872,7 +871,7 @@ func TestEnsureMultipleUpdatesViaPrice(t *testing.T) {
 	}
 
 	asks := bidAskGenerator()
-	book := holder.ob[cp.Base][cp.Quote][asset.Spot]
+	book := holder.ob[Key{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}]
 	book.updateByPrice(&orderbook.Update{
 		Bids:       asks,
 		Asks:       asks,

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -66,10 +66,6 @@ type orderbookHolder struct {
 	// currency.
 	ticker   *time.Ticker
 	updateID int64
-
-	// InitialUpdate determines initial sync state, the very first update from
-	// any pair is critical for initial sync.
-	InitialUpdate bool
 }
 
 // Key defines a unique orderbook key for a specific pair and asset

--- a/exchanges/stream/buffer/buffer_types.go
+++ b/exchanges/stream/buffer/buffer_types.go
@@ -66,6 +66,10 @@ type orderbookHolder struct {
 	// currency.
 	ticker   *time.Ticker
 	updateID int64
+
+	// InitialUpdate determines initial sync state, the very first update from
+	// any pair is critical for initial sync.
+	InitialUpdate bool
 }
 
 // Key defines a unique orderbook key for a specific pair and asset

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultJobBuffer = 1000
+	defaultJobBuffer = 5000
 	// defaultTrafficPeriod defines a period of pause for the traffic monitor,
 	// as there are periods with large incoming traffic alerts which requires a
 	// timer reset, this limits work on this routine to a more effective rate
@@ -62,7 +62,7 @@ func SetupGlobalReporter(r Reporter) {
 func New() *Websocket {
 	return &Websocket{
 		Init:              true,
-		DataHandler:       make(chan interface{}),
+		DataHandler:       make(chan interface{}, defaultJobBuffer),
 		ToRoutine:         make(chan interface{}, defaultJobBuffer),
 		TrafficAlert:      make(chan struct{}),
 		ReadMessageErrors: make(chan error),


### PR DESCRIPTION
# PR Description

Uses a key instead of multiple map to map lookups. This yields slightly better performance, with no additional allocations. There was also an obstruction due to a potential slow go schedular read on the data handler channel. Opted to ~~drop alert for improved websocket reader update through put.~~  buffer the channel to allow for that hand over to occur.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Benchmark - Edit by thrasher-

```
var multiMapHolder = make(map[currency.Code]map[currency.Code]map[asset.Item]*orderbookHolder)

// 62019669	        19.40 ns/op	       0 B/op	       0 allocs/op
func BenchmarkMultiMapHolder(b *testing.B) {
	var c1 currency.Code
	var c2 currency.Code
	var a asset.Item
	for x := 0; x < 3000; x++ {
		c1 = currency.NewCode(strconv.FormatInt(int64(x), 10))
		c2 = currency.NewCode(strconv.FormatInt(int64(x), 10))

		m1, ok := multiMapHolder[c1]
		if !ok {
			m1 = make(map[currency.Code]map[asset.Item]*orderbookHolder)
			multiMapHolder[c1] = m1
		}

		m2, ok := m1[c2]
		if !ok {
			m2 = make(map[asset.Item]*orderbookHolder)
			m1[c2] = m2
		}

		a = asset.Item(x)
		m2[a] = &orderbookHolder{}
	}

	b.ResetTimer()

	var ok bool
	for x := 0; x < b.N; x++ {
		_, ok = multiMapHolder[c1][c2][a]
		if !ok {
			b.Fatal("cound't find item")
		}
	}
}

var keyMapHolder = make(map[Key]*orderbookHolder)

// 91994203	        13.28 ns/op	       0 B/op	       0 allocs/op
func BenchmarkCurrentKeyMapHolder(b *testing.B) {
	var c1 currency.Code
	var c2 currency.Code
	var a asset.Item
	for x := 0; x < 3000; x++ {
		c1 = currency.NewCode(strconv.FormatInt(int64(x), 10))
		c2 = currency.NewCode(strconv.FormatInt(int64(x), 10))
		a = asset.Item(x)
		keyMapHolder[Key{Base: c1.Item, Quote: c2.Item, Asset: a}] = &orderbookHolder{}
	}

	b.ResetTimer()

	var ok bool
	for x := 0; x < b.N; x++ {
		_, ok = keyMapHolder[Key{Base: c1.Item, Quote: c2.Item, Asset: a}]
		if !ok {
			b.Fatal("cound't find item")
		}
	}
}
```
