### PR TITLE
Bitfinex: Fix ws Trades Fees on te

### DIFF
--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -188,15 +188,15 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 		}
 
 		chanID := int(chanF)
-		var datum string
-		if datum, ok = d[1].(string); ok {
+		var eventType string
+		if eventType, ok = d[1].(string); ok {
 			// Capturing heart beat
-			if datum == "hb" {
+			if eventType == "hb" {
 				return nil
 			}
 
 			// Capturing checksum and storing value
-			if datum == "cs" {
+			if eventType == "cs" {
 				var tokenF float64
 				tokenF, ok = d[2].(float64)
 				if !ok {
@@ -824,11 +824,13 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 						return errors.New("unable to type assert trade maker")
 					}
 					tData.Maker = maker == 1
-					if tData.Fee, ok = tradeData[9].(float64); !ok {
-						return errors.New("unable to type assert trade fee")
-					}
-					if tData.FeeCurrency, ok = tradeData[10].(string); !ok {
-						return errors.New("unable to type assert trade fee currency")
+					if eventType == "tu" {
+						if tData.Fee, ok = tradeData[9].(float64); !ok {
+							return errors.New("unable to type assert trade fee")
+						}
+						if tData.FeeCurrency, ok = tradeData[10].(string); !ok {
+							return errors.New("unable to type assert trade fee currency")
+						}
 					}
 					b.Websocket.DataHandler <- tData
 				}


### PR DESCRIPTION
The ws channel for authenticated Trades sends two types of update:
* te, Trade Executed
* tu, Trade Execution Update

Only the second one contains fee information.
[See the docs](https://docs.bitfinex.com/reference/ws-auth-trades)

This commit fixes:
`exchange Bitfinex websocket error - unable to type assert trade fee`
after an executed market trade on the te update

Side-note: I was tempted to type eventType but I've deliberately avoided yaking too much on this.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run