### PR TITLE
Bitfinex: Fix WS handling of executed trades

### DIFF
--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -1348,8 +1348,9 @@ func (b *Bitfinex) wsHandleOrder(data []interface{}) {
 		}
 	}
 	if data[13] != nil {
-		if ordStatus, ok := data[13].(string); ok {
-			oStatus, err := order.StringToOrderStatus(ordStatus)
+		if combinedStatus, ok := data[13].(string); ok {
+			statusParts := strings.Split(combinedStatus, " @ ")
+			oStatus, err := order.StringToOrderStatus(statusParts[0])
 			if err != nil {
 				b.Websocket.DataHandler <- order.ClassificationError{
 					Exchange: b.Name,

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -1113,7 +1113,7 @@ func StringToOrderStatus(status string) (Status, error) {
 		return Active, nil
 	case PartiallyFilled.String(), "PARTIALLY MATCHED", "PARTIALLY FILLED":
 		return PartiallyFilled, nil
-	case Filled.String(), "FULLY MATCHED", "FULLY FILLED", "ORDER_FULLY_TRANSACTED", "EFFECTIVE":
+	case Filled.String(), "FULLY MATCHED", "FULLY FILLED", "ORDER_FULLY_TRANSACTED", "EFFECTIVE", "EXECUTED":
 		return Filled, nil
 	case PartiallyCancelled.String(), "PARTIALLY CANCELLED", "ORDER_PARTIALLY_TRANSACTED":
 		return PartiallyCancelled, nil


### PR DESCRIPTION
Fixes:
`[ERROR] | WEBSOCKET | ... | 'EXECUTED @ 29298.0(-0.0008)' unrecognised order status`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestWSHandleOrder