### PR TITLE
CI: Update go and golangci-lint versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,7 +54,7 @@ before_test:
 
 test_script:
   # test back-end
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
   - '%GOPATH%\bin\golangci-lint.exe run --verbose'
   - ps: >-
       if($env:APPVEYOR_SCHEDULED_BUILD -eq 'true') {

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,8 +8,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.x'
+          go-version: '1.21.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.0

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Setup build depends
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 env:
-  GO_VERSION: 1.20.x
+  GO_VERSION: 1.21.x
 jobs:
   backend-psql:
     name: GoCryptoTrader back-end with PSQL

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
 #   - cyclop
 #   - deadcode // abandoned by its owner, replaced by unused
     - decorder
-    - depguard
+#   - depguard
     - dogsled
 #   - dupl
     - dupword
@@ -68,6 +68,7 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
+#   - gosmopolitan
     - grouper
 #   - ifshort // deprecated by its owner
 #   - importas
@@ -79,9 +80,10 @@ linters:
 #   - maintidx
     - makezero
 #   - maligned // deprecated by its owner, replaced by govet 'fieldalignment'
+    - mirror
     - misspell
 #   - musttag
-    - nakedret
+#   - nakedret
 #   - nestif
     - nilerr
 #   - nilnil
@@ -117,16 +119,13 @@ linters:
     - whitespace
 #   - wrapcheck
 #   - wsl
+#   - zerologlint
 
 linters-settings:
   govet:
     check-shadowing: true
   goconst:
     min-occurrences: 6
-  depguard:
-    list-type: blacklist
-#  lll:
-#    line-length: 80 # NOTE: we'll enforce this at a later point
   gocritic:
     enabled-tags:
       - performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build
+FROM golang:1.21 as build
 WORKDIR /go/src/github.com/thrasher-corp/gocryptotrader
 COPY . .
 RUN GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085


### PR DESCRIPTION
# PR Description

Updates CI and golangci-lint versions now that Go 1.21 now that it is released. Release notes: https://go.dev/doc/go1.21. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x] Any dependent changes have been merged and published in downstream modules
