### PR TITLE
Bitstamp: Fix websocket orderbook snapshot blanking LastUpdate

### DIFF
--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -19,7 +19,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 const (
@@ -665,6 +664,5 @@ func filterOrderbookZeroBidPrice(ob *orderbook.Base) {
 		return
 	}
 
-	log.Warnf(log.ExchangeSys, "%s %s %s orderbook has zero bid price, filtering.", ob.Exchange, ob.Pair, ob.Asset)
 	ob.Bids = ob.Bids[0 : len(ob.Bids)-1]
 }

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -229,7 +229,7 @@ type websocketOrderBook struct {
 	Asks           [][2]string `json:"asks"`
 	Bids           [][2]string `json:"bids"`
 	Timestamp      int64       `json:"timestamp,string"`
-	Microtimestamp string      `json:"microtimestamp"`
+	Microtimestamp int64       `json:"microtimestamp,string"`
 }
 
 // OHLCResponse holds returned candle data

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -254,7 +254,7 @@ func (b *Bitstamp) wsUpdateOrderbook(update *websocketOrderBook, p currency.Pair
 		Bids:            make(orderbook.Items, len(update.Bids)),
 		Asks:            make(orderbook.Items, len(update.Asks)),
 		Pair:            p,
-		LastUpdated:     time.Unix(update.Timestamp, 0),
+		LastUpdated:     time.UnixMicro(update.Microtimestamp),
 		Asset:           assetType,
 		Exchange:        b.Name,
 		VerifyOrderbook: b.CanVerifyOrderbook,
@@ -309,7 +309,7 @@ func (b *Bitstamp) seedOrderBook(ctx context.Context) error {
 			VerifyOrderbook: b.CanVerifyOrderbook,
 			Bids:            make(orderbook.Items, len(orderbookSeed.Bids)),
 			Asks:            make(orderbook.Items, len(orderbookSeed.Asks)),
-			LastUpdated:     time.Now(),
+			LastUpdated:     time.Unix(orderbookSeed.Timestamp, 0),
 		}
 
 		for i := range orderbookSeed.Asks {

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -309,6 +309,7 @@ func (b *Bitstamp) seedOrderBook(ctx context.Context) error {
 			VerifyOrderbook: b.CanVerifyOrderbook,
 			Bids:            make(orderbook.Items, len(orderbookSeed.Bids)),
 			Asks:            make(orderbook.Items, len(orderbookSeed.Asks)),
+			LastUpdated:     time.Now(),
 		}
 
 		for i := range orderbookSeed.Asks {


### PR DESCRIPTION
Drive-By: Remove:
`Bitstamp BTC/USDT spot orderbook has zero bid price, filtering.` It's unactionable and happens every snapshot right now

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
