### PR TITLE
egnine/sync-manager: add config support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -729,26 +729,26 @@ func (c *Config) CheckSyncManagerConfig() {
 		return
 	}
 	if c.SyncManagerConfig.TimeoutWebsocket <= 0 {
-		log.Warnf(log.ConfigMgr, "invalid sync manager websocket timeout value %v, defaulting to %v\n", c.SyncManagerConfig.TimeoutWebsocket, DefaultSyncerTimeoutWebsocket)
+		log.Warnf(log.ConfigMgr, "Invalid sync manager websocket timeout value %v, defaulting to %v\n", c.SyncManagerConfig.TimeoutWebsocket, DefaultSyncerTimeoutWebsocket)
 		c.SyncManagerConfig.TimeoutWebsocket = DefaultSyncerTimeoutWebsocket
 	}
 	if c.SyncManagerConfig.PairFormatDisplay == nil {
-		log.Warnf(log.ConfigMgr, "invalid sync manager pair format value %v, using default format eg BTC-USD\n", c.SyncManagerConfig.PairFormatDisplay)
+		log.Warnf(log.ConfigMgr, "Invalid sync manager pair format value %v, using default format eg BTC-USD\n", c.SyncManagerConfig.PairFormatDisplay)
 		c.SyncManagerConfig.PairFormatDisplay = &currency.PairFormat{
 			Uppercase: true,
 			Delimiter: currency.DashDelimiter,
 		}
 	}
 	if c.SyncManagerConfig.TimeoutREST <= 0 {
-		log.Warnf(log.ConfigMgr, "invalid sync manager REST timeout value %v, defaulting to %v\n", c.SyncManagerConfig.TimeoutREST, DefaultSyncerTimeoutREST)
+		log.Warnf(log.ConfigMgr, "Invalid sync manager REST timeout value %v, defaulting to %v\n", c.SyncManagerConfig.TimeoutREST, DefaultSyncerTimeoutREST)
 		c.SyncManagerConfig.TimeoutREST = DefaultSyncerTimeoutREST
 	}
 	if c.SyncManagerConfig.NumWorkers <= 0 {
-		log.Warnf(log.ConfigMgr, "invalid sync manager worker count value %v, defaulting to %v\n", c.SyncManagerConfig.NumWorkers, DefaultSyncerWorkers)
+		log.Warnf(log.ConfigMgr, "Invalid sync manager worker count value %v, defaulting to %v\n", c.SyncManagerConfig.NumWorkers, DefaultSyncerWorkers)
 		c.SyncManagerConfig.NumWorkers = DefaultSyncerWorkers
 	}
 	if c.SyncManagerConfig.FiatDisplayCurrency.IsEmpty() {
-		log.Warnf(log.ConfigMgr, "invalid sync manager fiat display currency value, defaulting to %v\n", currency.USD)
+		log.Warnf(log.ConfigMgr, "Invalid sync manager fiat display currency value, defaulting to %v\n", currency.USD)
 		c.SyncManagerConfig.FiatDisplayCurrency = currency.USD
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -747,6 +747,10 @@ func (c *Config) CheckSyncManagerConfig() {
 		log.Warnf(log.ConfigMgr, "invalid sync manager worker count value %v, defaulting to %v\n", c.SyncManagerConfig.NumWorkers, DefaultSyncerWorkers)
 		c.SyncManagerConfig.NumWorkers = DefaultSyncerWorkers
 	}
+	if c.SyncManagerConfig.FiatDisplayCurrency.IsEmpty() {
+		log.Warnf(log.ConfigMgr, "invalid sync manager fiat display currency value, defaulting to %v\n", currency.USD)
+		c.SyncManagerConfig.FiatDisplayCurrency = currency.USD
+	}
 }
 
 // GetEnabledPairs returns a list of currency pairs for a specific exchange

--- a/config/config.go
+++ b/config/config.go
@@ -702,7 +702,7 @@ func GetDefaultSyncManagerConfig() SyncManagerConfig {
 		Enabled:                 true,
 		SynchronizeTicker:       true,
 		SynchronizeOrderbook:    true,
-		SynchronizeTrades:       true,
+		SynchronizeTrades:       false,
 		SynchronizeContinuously: true,
 		TimeoutREST:             DefaultSyncerTimeoutREST,
 		TimeoutWebsocket:        DefaultSyncerTimeoutWebsocket,

--- a/config/config.go
+++ b/config/config.go
@@ -733,15 +733,18 @@ func (c *Config) CheckSyncManagerConfig() {
 		c.SyncManagerConfig.TimeoutWebsocket = DefaultSyncerTimeoutWebsocket
 	}
 	if c.SyncManagerConfig.PairFormatDisplay == nil {
-		log.Warnf(log.ConfigMgr, "invalid sync manager pair format value %v, defaulting to %v\n", c.SyncManagerConfig.PairFormatDisplay, c.CurrencyPairFormat)
-		c.SyncManagerConfig.PairFormatDisplay = c.CurrencyPairFormat
+		log.Warnf(log.ConfigMgr, "invalid sync manager pair format value %v, using default format eg BTC-USD\n", c.SyncManagerConfig.PairFormatDisplay)
+		c.SyncManagerConfig.PairFormatDisplay = &currency.PairFormat{
+			Uppercase: true,
+			Delimiter: currency.DashDelimiter,
+		}
 	}
 	if c.SyncManagerConfig.TimeoutREST <= 0 {
-		log.Warnf(log.ConfigMgr, "invalid sync manager REST timeout value %v, defaulting to %v\n", c.SyncManagerConfig.PairFormatDisplay, c.CurrencyPairFormat)
+		log.Warnf(log.ConfigMgr, "invalid sync manager REST timeout value %v, defaulting to %v\n", c.SyncManagerConfig.TimeoutREST, DefaultSyncerTimeoutREST)
 		c.SyncManagerConfig.TimeoutREST = DefaultSyncerTimeoutREST
 	}
 	if c.SyncManagerConfig.NumWorkers <= 0 {
-		log.Warnf(log.ConfigMgr, "invalid sync manager worker count value %v, defaulting to %v\n", c.SyncManagerConfig.PairFormatDisplay, DefaultSyncerWorkers)
+		log.Warnf(log.ConfigMgr, "invalid sync manager worker count value %v, defaulting to %v\n", c.SyncManagerConfig.NumWorkers, DefaultSyncerWorkers)
 		c.SyncManagerConfig.NumWorkers = DefaultSyncerWorkers
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2310,3 +2310,35 @@ func TestGetDefaultSyncManagerConfig(t *testing.T) {
 		t.Errorf("expected %v, received %v", DefaultSyncerTimeoutREST, cfg.TimeoutREST)
 	}
 }
+
+func TestCheckSyncManagerConfig(t *testing.T) {
+	t.Parallel()
+	c := Config{}
+	if c.SyncManagerConfig != (SyncManagerConfig{}) {
+		t.Error("expected empty config")
+	}
+	c.CheckSyncManagerConfig()
+	if c.SyncManagerConfig.TimeoutREST != DefaultSyncerTimeoutREST {
+		t.Error("expected default config")
+	}
+	c.SyncManagerConfig.TimeoutWebsocket = -1
+	c.SyncManagerConfig.PairFormatDisplay = nil
+	c.SyncManagerConfig.TimeoutREST = -1
+	c.SyncManagerConfig.NumWorkers = -1
+	c.CurrencyPairFormat = &currency.PairFormat{
+		Uppercase: true,
+	}
+	c.CheckSyncManagerConfig()
+	if c.SyncManagerConfig.TimeoutWebsocket != DefaultSyncerTimeoutWebsocket {
+		t.Errorf("received %v expected %v", c.SyncManagerConfig.TimeoutWebsocket, DefaultSyncerTimeoutWebsocket)
+	}
+	if c.SyncManagerConfig.PairFormatDisplay == nil {
+		t.Errorf("received %v expected %v", c.SyncManagerConfig.PairFormatDisplay, c.CurrencyPairFormat)
+	}
+	if c.SyncManagerConfig.TimeoutREST != DefaultSyncerTimeoutREST {
+		t.Errorf("received %v expected %v", c.SyncManagerConfig.TimeoutREST, DefaultSyncerTimeoutREST)
+	}
+	if c.SyncManagerConfig.NumWorkers != DefaultSyncerWorkers {
+		t.Errorf("received %v expected %v", c.SyncManagerConfig.NumWorkers, DefaultSyncerWorkers)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2299,3 +2299,14 @@ func TestExchangeConfigValidate(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 }
+
+func TestGetDefaultSyncManagerConfig(t *testing.T) {
+	t.Parallel()
+	cfg := GetDefaultSyncManagerConfig()
+	if cfg == (SyncManagerConfig{}) {
+		t.Error("expected config")
+	}
+	if cfg.TimeoutREST != DefaultSyncerTimeoutREST {
+		t.Errorf("expected %v, received %v", DefaultSyncerTimeoutREST, cfg.TimeoutREST)
+	}
+}

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -41,6 +41,12 @@ const (
 	defaultCurrencyStateManagerDelay     = time.Minute
 	defaultMaxJobsPerCycle               = 5
 	DefaultOrderbookPublishPeriod        = time.Second * 10
+	// DefaultSyncerWorkers limits the number of sync workers
+	DefaultSyncerWorkers = 15
+	// DefaultSyncerTimeoutREST the default time to switch from REST to websocket protocols without a response
+	DefaultSyncerTimeoutREST = time.Second * 15
+	// DefaultSyncerTimeoutWebsocket the default time to switch from websocket to REST protocols without a response
+	DefaultSyncerTimeoutWebsocket = time.Minute
 )
 
 // Constants here hold some messages
@@ -81,6 +87,7 @@ type Config struct {
 	GlobalHTTPTimeout    time.Duration             `json:"globalHTTPTimeout"`
 	Database             database.Config           `json:"database"`
 	Logging              log.Config                `json:"logging"`
+	SyncManagerConfig    SyncManagerConfig         `json:"syncManager"`
 	ConnectionMonitor    ConnectionMonitorConfig   `json:"connectionMonitor"`
 	OrderManager         OrderManager              `json:"orderManager"`
 	DataHistoryManager   DataHistoryManager        `json:"dataHistoryManager"`
@@ -128,6 +135,25 @@ type DataHistoryManager struct {
 type CurrencyStateManager struct {
 	Enabled *bool         `json:"enabled"`
 	Delay   time.Duration `json:"delay"`
+}
+
+// SyncManagerConfig stores the currency pair synchronization manager config
+type SyncManagerConfig struct {
+	Enabled                 bool                 `json:"enabled"`
+	SynchronizeTicker       bool                 `json:"synchronizeTicker"`
+	SynchronizeOrderbook    bool                 `json:"synchronizeOrderbook"`
+	SynchronizeTrades       bool                 `json:"synchronizeTrades"`
+	SynchronizeContinuously bool                 `json:"synchronizeContinuously"`
+	TimeoutREST             time.Duration        `json:"timeoutREST"`
+	TimeoutWebsocket        time.Duration        `json:"timeoutWebsocket"`
+	NumWorkers              int                  `json:"numWorkers"`
+	FiatDisplayCurrency     currency.Code        `json:"fiatDisplayCurrency"`
+	PairFormatDisplay       *currency.PairFormat `json:"pairFormatDisplay,omitempty"`
+	// log events
+	Verbose                 bool `json:"verbose"`
+	LogSyncUpdateEvents     bool `json:"logSyncUpdateEvents"`
+	LogSwitchProtocolEvents bool `json:"logSwitchProtocolEvents"`
+	LogInitialSyncEvents    bool `json:"logInitialSyncEvents"`
 }
 
 // ConnectionMonitorConfig defines the connection monitor variables to ensure

--- a/config_example.json
+++ b/config_example.json
@@ -37,6 +37,25 @@
    }
   }
  },
+  "syncManager": {
+    "enabled": true,
+    "synchronizeTicker": true,
+    "synchronizeOrderbook": true,
+    "synchronizeTrades": true,
+    "synchronizeContinuously": true,
+    "timeoutREST": 15000000000,
+    "timeoutWebsocket": 60000000000,
+    "numWorkers": 15,
+    "fiatDisplayCurrency": "USD",
+    "pairFormatDisplay": {
+      "uppercase": true,
+      "delimiter": "-"
+    },
+    "verbose": false,
+    "logSyncUpdateEvents": true,
+    "logSwitchProtocolEvents": true,
+    "logInitialSyncEvents": true
+  },
  "connectionMonitor": {
   "preferredDNSList": [
    "8.8.8.8",

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -492,9 +492,9 @@ func (bot *Engine) Start() error {
 
 	if bot.Config.SyncManagerConfig.Enabled && bot.Settings.EnableExchangeSyncManager {
 		cfg := bot.Config.SyncManagerConfig
-		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
-		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
-		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing || cfg.SynchronizeTicker
+		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing || cfg.SynchronizeOrderbook
+		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously || cfg.SynchronizeContinuously
 		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
 		cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -492,18 +492,12 @@ func (bot *Engine) Start() error {
 
 	if bot.Config.SyncManagerConfig.Enabled && bot.Settings.EnableExchangeSyncManager {
 		cfg := bot.Config.SyncManagerConfig
-		if !bot.Settings.EnableTickerSyncing {
-			cfg.SynchronizeTicker = false
-		}
-		if !bot.Settings.EnableOrderbookSyncing {
-			cfg.SynchronizeOrderbook = false
-		}
-		if !bot.Settings.EnableTradeSyncing {
-			cfg.SynchronizeTrades = false
-		}
-		if !bot.Settings.SyncContinuously {
-			cfg.SynchronizeContinuously = false
-		}
+		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
+		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
+		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
+		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+		cfg.Verbose = bot.Settings.Verbose && cfg.Verbose
+
 		if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&
 			bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {
 			cfg.TimeoutREST = bot.Settings.SyncTimeoutREST
@@ -515,9 +509,6 @@ func (bot *Engine) Start() error {
 		if cfg.NumWorkers != bot.Settings.SyncWorkersCount &&
 			bot.Settings.SyncWorkersCount != config.DefaultSyncerWorkers {
 			cfg.NumWorkers = bot.Settings.SyncWorkersCount
-		}
-		if bot.Settings.Verbose {
-			cfg.Verbose = true
 		}
 		if s, err := setupSyncManager(
 			&cfg,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -491,21 +491,36 @@ func (bot *Engine) Start() error {
 	}
 
 	if bot.Settings.EnableExchangeSyncManager {
-		exchangeSyncCfg := &SyncManagerConfig{
-			SynchronizeTicker:       bot.Settings.EnableTickerSyncing,
-			SynchronizeOrderbook:    bot.Settings.EnableOrderbookSyncing,
-			SynchronizeTrades:       bot.Settings.EnableTradeSyncing,
-			SynchronizeContinuously: bot.Settings.SyncContinuously,
-			TimeoutREST:             bot.Settings.SyncTimeoutREST,
-			TimeoutWebsocket:        bot.Settings.SyncTimeoutWebsocket,
-			NumWorkers:              bot.Settings.SyncWorkersCount,
-			Verbose:                 bot.Settings.Verbose,
-			FiatDisplayCurrency:     bot.Config.Currency.FiatDisplayCurrency,
-			PairFormatDisplay:       bot.Config.Currency.CurrencyPairFormat,
+		cfg := bot.Config.SyncManagerConfig
+		if !bot.Settings.EnableTickerSyncing {
+			cfg.SynchronizeTicker = false
 		}
-
+		if !bot.Settings.EnableOrderbookSyncing {
+			cfg.SynchronizeOrderbook = false
+		}
+		if !bot.Settings.EnableTradeSyncing {
+			cfg.SynchronizeTrades = false
+		}
+		if !bot.Settings.SyncContinuously {
+			cfg.SynchronizeContinuously = false
+		}
+		if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&
+			bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {
+			cfg.TimeoutREST = bot.Settings.SyncTimeoutREST
+		}
+		if cfg.TimeoutWebsocket != bot.Settings.SyncTimeoutWebsocket &&
+			bot.Settings.SyncTimeoutWebsocket != config.DefaultSyncerTimeoutWebsocket {
+			cfg.TimeoutWebsocket = bot.Settings.SyncTimeoutWebsocket
+		}
+		if cfg.NumWorkers != bot.Settings.SyncWorkersCount &&
+			bot.Settings.SyncWorkersCount != config.DefaultSyncerWorkers {
+			cfg.NumWorkers = bot.Settings.SyncWorkersCount
+		}
+		if bot.Settings.Verbose {
+			cfg.Verbose = true
+		}
 		if s, err := setupSyncManager(
-			exchangeSyncCfg,
+			&cfg,
 			bot.ExchangeManager,
 			&bot.Config.RemoteControl,
 			bot.Settings.EnableWebsocketRoutine,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -496,7 +496,7 @@ func (bot *Engine) Start() error {
 		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
 		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
 		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
-		cfg.Verbose = bot.Settings.Verbose && cfg.Verbose
+		cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 		if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&
 			bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -490,7 +490,7 @@ func (bot *Engine) Start() error {
 		}
 	}
 
-	if bot.Settings.EnableExchangeSyncManager {
+	if bot.Config.SyncManagerConfig.Enabled && bot.Settings.EnableExchangeSyncManager {
 		cfg := bot.Config.SyncManagerConfig
 		if !bot.Settings.EnableTickerSyncing {
 			cfg.SynchronizeTicker = false

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -179,6 +179,12 @@ func validateSettings(b *Engine, s *Settings, flagSet FlagSet) {
 	flagSet.WithBool("currencystatemanager", &b.Settings.EnableCurrencyStateManager, b.Config.CurrencyStateManager.Enabled != nil && *b.Config.CurrencyStateManager.Enabled)
 	flagSet.WithBool("gctscriptmanager", &b.Settings.EnableGCTScriptManager, b.Config.GCTScript.Enabled)
 
+	flagSet.WithBool("tickersync", &b.Settings.EnableTickerSyncing, b.Config.SyncManagerConfig.SynchronizeTicker)
+	flagSet.WithBool("orderbooksync", &b.Settings.EnableOrderbookSyncing, b.Config.SyncManagerConfig.SynchronizeOrderbook)
+	flagSet.WithBool("tradesync", &b.Settings.EnableTradeSyncing, b.Config.SyncManagerConfig.SynchronizeTrades)
+	flagSet.WithBool("synccontinuously", &b.Settings.SyncContinuously, b.Config.SyncManagerConfig.SynchronizeContinuously)
+	flagSet.WithBool("syncmanager", &b.Settings.EnableExchangeSyncManager, b.Config.SyncManagerConfig.Enabled)
+
 	if b.Settings.EnablePortfolioManager &&
 		b.Settings.PortfolioManagerDelay <= 0 {
 		b.Settings.PortfolioManagerDelay = PortfolioSleepDelay
@@ -490,12 +496,12 @@ func (bot *Engine) Start() error {
 		}
 	}
 
-	if bot.Config.SyncManagerConfig.Enabled && bot.Settings.EnableExchangeSyncManager {
+	if bot.Settings.EnableExchangeSyncManager {
 		cfg := bot.Config.SyncManagerConfig
-		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing || cfg.SynchronizeTicker
-		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing || cfg.SynchronizeOrderbook
-		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously || cfg.SynchronizeContinuously
-		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
+		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing
+		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing
+		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously
+		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing
 		cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 		if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -494,8 +494,8 @@ func (bot *Engine) Start() error {
 		cfg := bot.Config.SyncManagerConfig
 		cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
 		cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
-		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
 		cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+		cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
 		cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 		if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -186,10 +186,10 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 		if enable {
 			if bot.currencyPairSyncer == nil {
 				cfg := bot.Config.SyncManagerConfig
-				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing || cfg.SynchronizeTicker
-				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing || cfg.SynchronizeOrderbook
-				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously || cfg.SynchronizeContinuously
-				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
+				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing
+				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing
+				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously
+				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing
 				cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -186,9 +186,9 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 		if enable {
 			if bot.currencyPairSyncer == nil {
 				cfg := bot.Config.SyncManagerConfig
-				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
-				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
-				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing || cfg.SynchronizeTicker
+				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing || cfg.SynchronizeOrderbook
+				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously || cfg.SynchronizeContinuously
 				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
 				cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -185,19 +185,33 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 	case SyncManagerName:
 		if enable {
 			if bot.currencyPairSyncer == nil {
-				exchangeSyncCfg := &SyncManagerConfig{
-					SynchronizeTicker:       bot.Settings.EnableTickerSyncing,
-					SynchronizeOrderbook:    bot.Settings.EnableOrderbookSyncing,
-					SynchronizeTrades:       bot.Settings.EnableTradeSyncing,
-					SynchronizeContinuously: bot.Settings.SyncContinuously,
-					TimeoutREST:             bot.Settings.SyncTimeoutREST,
-					TimeoutWebsocket:        bot.Settings.SyncTimeoutWebsocket,
-					NumWorkers:              bot.Settings.SyncWorkersCount,
-					FiatDisplayCurrency:     bot.Config.Currency.FiatDisplayCurrency,
-					Verbose:                 bot.Settings.Verbose,
+				cfg := bot.Config.SyncManagerConfig
+				if !bot.Settings.EnableTickerSyncing {
+					cfg.SynchronizeTicker = false
+				}
+				if !bot.Settings.EnableOrderbookSyncing {
+					cfg.SynchronizeOrderbook = false
+				}
+				if !bot.Settings.EnableTradeSyncing {
+					cfg.SynchronizeTrades = false
+				}
+				if !bot.Settings.SyncContinuously {
+					cfg.SynchronizeContinuously = false
+				}
+				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST && bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {
+					cfg.TimeoutREST = bot.Settings.SyncTimeoutREST
+				}
+				if cfg.TimeoutWebsocket != bot.Settings.SyncTimeoutWebsocket && bot.Settings.SyncTimeoutWebsocket != config.DefaultSyncerTimeoutWebsocket {
+					cfg.TimeoutWebsocket = bot.Settings.SyncTimeoutWebsocket
+				}
+				if cfg.NumWorkers != bot.Settings.SyncWorkersCount && bot.Settings.SyncWorkersCount != config.DefaultSyncerWorkers {
+					cfg.NumWorkers = bot.Settings.SyncWorkersCount
+				}
+				if bot.Settings.Verbose {
+					cfg.Verbose = true
 				}
 				bot.currencyPairSyncer, err = setupSyncManager(
-					exchangeSyncCfg,
+					&cfg,
 					bot.ExchangeManager,
 					&bot.Config.RemoteControl,
 					bot.Settings.EnableWebsocketRoutine)

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -188,8 +188,8 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 				cfg := bot.Config.SyncManagerConfig
 				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
 				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
-				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
 				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing || cfg.SynchronizeTrades
 				cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -190,7 +190,7 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
 				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
 				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
-				cfg.Verbose = bot.Settings.Verbose && cfg.Verbose
+				cfg.Verbose = bot.Settings.Verbose || cfg.Verbose
 
 				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&
 					bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -186,29 +186,23 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 		if enable {
 			if bot.currencyPairSyncer == nil {
 				cfg := bot.Config.SyncManagerConfig
-				if !bot.Settings.EnableTickerSyncing {
-					cfg.SynchronizeTicker = false
-				}
-				if !bot.Settings.EnableOrderbookSyncing {
-					cfg.SynchronizeOrderbook = false
-				}
-				if !bot.Settings.EnableTradeSyncing {
-					cfg.SynchronizeTrades = false
-				}
-				if !bot.Settings.SyncContinuously {
-					cfg.SynchronizeContinuously = false
-				}
-				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST && bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {
+				cfg.SynchronizeTicker = bot.Settings.EnableTickerSyncing && cfg.SynchronizeTicker
+				cfg.SynchronizeOrderbook = bot.Settings.EnableOrderbookSyncing && cfg.SynchronizeOrderbook
+				cfg.SynchronizeTrades = bot.Settings.EnableTradeSyncing && cfg.SynchronizeTrades
+				cfg.SynchronizeContinuously = bot.Settings.SyncContinuously && cfg.SynchronizeContinuously
+				cfg.Verbose = bot.Settings.Verbose && cfg.Verbose
+
+				if cfg.TimeoutREST != bot.Settings.SyncTimeoutREST &&
+					bot.Settings.SyncTimeoutREST != config.DefaultSyncerTimeoutREST {
 					cfg.TimeoutREST = bot.Settings.SyncTimeoutREST
 				}
-				if cfg.TimeoutWebsocket != bot.Settings.SyncTimeoutWebsocket && bot.Settings.SyncTimeoutWebsocket != config.DefaultSyncerTimeoutWebsocket {
+				if cfg.TimeoutWebsocket != bot.Settings.SyncTimeoutWebsocket &&
+					bot.Settings.SyncTimeoutWebsocket != config.DefaultSyncerTimeoutWebsocket {
 					cfg.TimeoutWebsocket = bot.Settings.SyncTimeoutWebsocket
 				}
-				if cfg.NumWorkers != bot.Settings.SyncWorkersCount && bot.Settings.SyncWorkersCount != config.DefaultSyncerWorkers {
+				if cfg.NumWorkers != bot.Settings.SyncWorkersCount &&
+					bot.Settings.SyncWorkersCount != config.DefaultSyncerWorkers {
 					cfg.NumWorkers = bot.Settings.SyncWorkersCount
-				}
-				if bot.Settings.Verbose {
-					cfg.Verbose = true
 				}
 				bot.currencyPairSyncer, err = setupSyncManager(
 					&cfg,

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -208,11 +208,8 @@ func (m *syncManager) Start() error {
 		if atomic.CompareAndSwapInt32(&m.initSyncCompleted, 0, 1) {
 			if m.config.LogInitialSyncEvents {
 				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync is complete.")
-			}
-			completedTime := time.Now()
-			if m.config.LogInitialSyncEvents {
 				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync took %v [%v sync items].",
-					completedTime.Sub(m.initSyncStartTime), createdCounter)
+					time.Since(m.initSyncStartTime), createdCounter)
 			}
 
 			if !m.config.SynchronizeContinuously {

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -32,21 +32,15 @@ const (
 )
 
 var (
-	createdCounter = 0
-	removedCounter = 0
-	// DefaultSyncerWorkers limits the number of sync workers
-	DefaultSyncerWorkers = 15
-	// DefaultSyncerTimeoutREST the default time to switch from REST to websocket protocols without a response
-	DefaultSyncerTimeoutREST = time.Second * 15
-	// DefaultSyncerTimeoutWebsocket the default time to switch from websocket to REST protocols without a response
-	DefaultSyncerTimeoutWebsocket = time.Minute
-	errNoSyncItemsEnabled         = errors.New("no sync items enabled")
-	errUnknownSyncItem            = errors.New("unknown sync item")
-	errCouldNotSyncNewData        = errors.New("could not sync new data")
+	createdCounter         = 0
+	removedCounter         = 0
+	errNoSyncItemsEnabled  = errors.New("no sync items enabled")
+	errUnknownSyncItem     = errors.New("unknown sync item")
+	errCouldNotSyncNewData = errors.New("could not sync new data")
 )
 
 // setupSyncManager starts a new CurrencyPairSyncer
-func setupSyncManager(c *SyncManagerConfig, exchangeManager iExchangeManager, remoteConfig *config.RemoteControlConfig, websocketRoutineManagerEnabled bool) (*syncManager, error) {
+func setupSyncManager(c *config.SyncManagerConfig, exchangeManager iExchangeManager, remoteConfig *config.RemoteControlConfig, websocketRoutineManagerEnabled bool) (*syncManager, error) {
 	if c == nil {
 		return nil, fmt.Errorf("%T %w", c, common.ErrNilPointer)
 	}
@@ -62,15 +56,15 @@ func setupSyncManager(c *SyncManagerConfig, exchangeManager iExchangeManager, re
 	}
 
 	if c.NumWorkers <= 0 {
-		c.NumWorkers = DefaultSyncerWorkers
+		c.NumWorkers = config.DefaultSyncerWorkers
 	}
 
 	if c.TimeoutREST <= time.Duration(0) {
-		c.TimeoutREST = DefaultSyncerTimeoutREST
+		c.TimeoutREST = config.DefaultSyncerTimeoutREST
 	}
 
 	if c.TimeoutWebsocket <= time.Duration(0) {
-		c.TimeoutWebsocket = DefaultSyncerTimeoutWebsocket
+		c.TimeoutWebsocket = config.DefaultSyncerTimeoutWebsocket
 	}
 
 	if c.FiatDisplayCurrency.IsEmpty() {
@@ -196,19 +190,25 @@ func (m *syncManager) Start() error {
 	}
 
 	if atomic.CompareAndSwapInt32(&m.initSyncStarted, 0, 1) {
-		log.Debugf(log.SyncMgr,
-			"Exchange CurrencyPairSyncer initial sync started. %d items to process.",
-			createdCounter)
+		if m.config.LogInitialSyncEvents {
+			log.Debugf(log.SyncMgr,
+				"Exchange CurrencyPairSyncer initial sync started. %d items to process.",
+				createdCounter)
+		}
 		m.initSyncStartTime = time.Now()
 	}
 
 	go func() {
 		m.initSyncWG.Wait()
 		if atomic.CompareAndSwapInt32(&m.initSyncCompleted, 0, 1) {
-			log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync is complete.")
+			if m.config.LogInitialSyncEvents {
+				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync is complete.")
+			}
 			completedTime := time.Now()
-			log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync took %v [%v sync items].",
-				completedTime.Sub(m.initSyncStartTime), createdCounter)
+			if m.config.LogInitialSyncEvents {
+				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync took %v [%v sync items].",
+					completedTime.Sub(m.initSyncStartTime), createdCounter)
+			}
 
 			if !m.config.SynchronizeContinuously {
 				log.Debugln(log.SyncMgr, "Exchange CurrencyPairSyncer stopping.")
@@ -382,13 +382,15 @@ func (m *syncManager) WebsocketUpdate(exchangeName string, p currency.Pair, a as
 	if !s.IsUsingWebsocket {
 		s.IsUsingWebsocket = true
 		s.IsUsingREST = false
-		log.Warnf(log.SyncMgr,
-			"%s %s %s: %s Websocket re-enabled, switching from rest to websocket",
-			c.Exchange,
-			m.FormatCurrency(c.Pair),
-			strings.ToUpper(c.AssetType.String()),
-			syncType,
-		)
+		if m.config.LogSwitchProtocolEvents {
+			log.Warnf(log.SyncMgr,
+				"%s %s %s: %s Websocket re-enabled, switching from rest to websocket",
+				c.Exchange,
+				m.FormatCurrency(c.Pair),
+				strings.ToUpper(c.AssetType.String()),
+				syncType,
+			)
+		}
 	}
 
 	return m.update(c, syncType, err)
@@ -410,12 +412,14 @@ func (m *syncManager) update(c *currencyPairSyncAgent, syncType syncItemType, er
 	s.HaveData = true
 	if atomic.LoadInt32(&m.initSyncCompleted) != 1 && !origHadData {
 		removedCounter++
-		log.Debugf(log.SyncMgr, "%s %s sync complete %v [%d/%d].",
-			c.Exchange,
-			syncType,
-			m.FormatCurrency(c.Pair),
-			removedCounter,
-			createdCounter)
+		if m.config.LogInitialSyncEvents {
+			log.Debugf(log.SyncMgr, "%s %s sync complete %v [%d/%d].",
+				c.Exchange,
+				syncType,
+				m.FormatCurrency(c.Pair),
+				removedCounter,
+				createdCounter)
+		}
 		m.initSyncWG.Done()
 	}
 
@@ -532,13 +536,15 @@ func (m *syncManager) syncTicker(c *currencyPairSyncAgent, e exchange.IBotExchan
 		// Downgrade to REST
 		s.IsUsingWebsocket = false
 		s.IsUsingREST = true
-		log.Warnf(log.SyncMgr,
-			"%s %s %s: No ticker update after %s, switching from websocket to rest",
-			c.Exchange,
-			m.FormatCurrency(c.Pair),
-			strings.ToUpper(c.AssetType.String()),
-			m.config.TimeoutWebsocket,
-		)
+		if m.config.LogSwitchProtocolEvents {
+			log.Warnf(log.SyncMgr,
+				"%s %s %s: No ticker update after %s, switching from websocket to rest",
+				c.Exchange,
+				m.FormatCurrency(c.Pair),
+				strings.ToUpper(c.AssetType.String()),
+				m.config.TimeoutWebsocket,
+			)
+		}
 	}
 
 	if s.IsUsingREST && time.Since(s.LastUpdated) > m.config.TimeoutREST {
@@ -605,13 +611,15 @@ func (m *syncManager) syncOrderbook(c *currencyPairSyncAgent, e exchange.IBotExc
 		// Downgrade to REST
 		s.IsUsingWebsocket = false
 		s.IsUsingREST = true
-		log.Warnf(log.SyncMgr,
-			"%s %s %s: No orderbook update after %s, switching from websocket to rest",
-			c.Exchange,
-			m.FormatCurrency(c.Pair).String(),
-			strings.ToUpper(c.AssetType.String()),
-			m.config.TimeoutWebsocket,
-		)
+		if m.config.LogSwitchProtocolEvents {
+			log.Warnf(log.SyncMgr,
+				"%s %s %s: No orderbook update after %s, switching from websocket to rest",
+				c.Exchange,
+				m.FormatCurrency(c.Pair).String(),
+				strings.ToUpper(c.AssetType.String()),
+				m.config.TimeoutWebsocket,
+			)
+		}
 	}
 
 	if s.IsUsingREST && time.Since(s.LastUpdated) > m.config.TimeoutREST {
@@ -706,6 +714,9 @@ func (m *syncManager) PrintTickerSummary(result *ticker.Price, protocol string, 
 
 	// ignoring error as not all tickers have volume populated and error is not actionable
 	_ = stats.Add(result.ExchangeName, result.Pair, result.AssetType, result.Last, result.Volume)
+	if !m.config.LogSyncUpdateEvents {
+		return
+	}
 
 	if result.Pair.Quote.IsFiatCurrency() &&
 		!result.Pair.Quote.Equal(m.fiatDisplayCurrency) &&
@@ -795,7 +806,9 @@ func (m *syncManager) PrintOrderbookSummary(result *orderbook.Base, protocol str
 			err)
 		return
 	}
-
+	if !m.config.LogSyncUpdateEvents {
+		return
+	}
 	bidsAmount, bidsValue := result.TotalBidsAmount()
 	asksAmount, asksValue := result.TotalAsksAmount()
 

--- a/engine/sync_manager_test.go
+++ b/engine/sync_manager_test.go
@@ -20,37 +20,37 @@ func TestSetupSyncManager(t *testing.T) {
 		t.Errorf("error '%v', expected '%v'", err, common.ErrNilPointer)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{}, nil, nil, false)
+	_, err = setupSyncManager(&config.SyncManagerConfig{}, nil, nil, false)
 	if !errors.Is(err, errNoSyncItemsEnabled) {
 		t.Errorf("error '%v', expected '%v'", err, errNoSyncItemsEnabled)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true}, nil, nil, false)
+	_, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true}, nil, nil, false)
 	if !errors.Is(err, errNilExchangeManager) {
 		t.Errorf("error '%v', expected '%v'", err, errNilExchangeManager)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true}, &ExchangeManager{}, nil, false)
+	_, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true}, &ExchangeManager{}, nil, false)
 	if !errors.Is(err, errNilConfig) {
 		t.Errorf("error '%v', expected '%v'", err, errNilConfig)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
+	_, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("error '%v', expected '%v'", err, currency.ErrCurrencyCodeEmpty)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.BTC}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
+	_, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.BTC}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, currency.ErrFiatDisplayCurrencyIsNotFiat) {
 		t.Errorf("error '%v', expected '%v'", err, currency.ErrFiatDisplayCurrencyIsNotFiat)
 	}
 
-	_, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
+	_, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("error '%v', expected '%v'", err, common.ErrNilPointer)
 	}
 
-	m, err := setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
+	m, err := setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -61,7 +61,7 @@ func TestSetupSyncManager(t *testing.T) {
 
 func TestSyncManagerStart(t *testing.T) {
 	t.Parallel()
-	m, err := setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
+	m, err := setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, &ExchangeManager{}, &config.RemoteControlConfig{}, true)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -112,7 +112,7 @@ func TestSyncManagerStop(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	m, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
+	m, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -163,7 +163,7 @@ func TestPrintTickerSummary(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	m, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
+	m, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
@@ -205,7 +205,7 @@ func TestPrintOrderbookSummary(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	m, err = setupSyncManager(&SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
+	m, err = setupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}

--- a/engine/sync_manager_types.go
+++ b/engine/sync_manager_types.go
@@ -33,20 +33,6 @@ type currencyPairSyncAgent struct {
 	locks    []sync.Mutex
 }
 
-// SyncManagerConfig stores the currency pair synchronization manager config
-type SyncManagerConfig struct {
-	SynchronizeTicker       bool
-	SynchronizeOrderbook    bool
-	SynchronizeTrades       bool
-	SynchronizeContinuously bool
-	TimeoutREST             time.Duration
-	TimeoutWebsocket        time.Duration
-	NumWorkers              int
-	FiatDisplayCurrency     currency.Code
-	PairFormatDisplay       *currency.PairFormat
-	Verbose                 bool
-}
-
 // syncManager stores the exchange currency pair syncer object
 type syncManager struct {
 	initSyncCompleted              int32
@@ -65,6 +51,6 @@ type syncManager struct {
 	tickerBatchLastRequested map[string]time.Time
 
 	remoteConfig    *config.RemoteControlConfig
-	config          SyncManagerConfig
+	config          config.SyncManagerConfig
 	exchangeManager iExchangeManager
 }

--- a/main.go
+++ b/main.go
@@ -63,11 +63,11 @@ func main() {
 	flag.IntVar(&settings.DispatchJobsLimit, "dispatchjobslimit", dispatch.DefaultJobsLimit, "sets the dispatch package max jobs limit")
 
 	// Exchange syncer settings
-	flag.BoolVar(&settings.EnableTickerSyncing, "tickersync", true, "enables ticker syncing for all enabled exchanges")
-	flag.BoolVar(&settings.EnableOrderbookSyncing, "orderbooksync", true, "enables orderbook syncing for all enabled exchanges")
-	flag.BoolVar(&settings.EnableTradeSyncing, "tradesync", false, "enables trade syncing for all enabled exchanges")
+	flag.BoolVar(&settings.EnableTickerSyncing, "tickersync", false, "enables ticker syncing for all enabled exchanges, overriding false config value")
+	flag.BoolVar(&settings.EnableOrderbookSyncing, "orderbooksync", false, "enables orderbook syncing for all enabled exchanges, overriding false config value")
+	flag.BoolVar(&settings.EnableTradeSyncing, "tradesync", false, "enables trade syncing for all enabled exchanges, overriding false config value")
 	flag.IntVar(&settings.SyncWorkersCount, "syncworkers", config.DefaultSyncerWorkers, "the amount of workers (goroutines) to use for syncing exchange data")
-	flag.BoolVar(&settings.SyncContinuously, "synccontinuously", true, "whether to sync exchange data continuously (ticker, orderbook and trade history info")
+	flag.BoolVar(&settings.SyncContinuously, "synccontinuously", false, "whether to sync exchange data continuously (ticker, orderbook and trade history info), overriding false config value")
 	flag.DurationVar(&settings.SyncTimeoutREST, "synctimeoutrest", config.DefaultSyncerTimeoutREST,
 		"the amount of time before the syncer will switch from rest protocol to the streaming protocol (e.g. from REST to websocket)")
 	flag.DurationVar(&settings.SyncTimeoutWebsocket, "synctimeoutwebsocket", config.DefaultSyncerTimeoutWebsocket,

--- a/main.go
+++ b/main.go
@@ -66,11 +66,11 @@ func main() {
 	flag.BoolVar(&settings.EnableTickerSyncing, "tickersync", true, "enables ticker syncing for all enabled exchanges")
 	flag.BoolVar(&settings.EnableOrderbookSyncing, "orderbooksync", true, "enables orderbook syncing for all enabled exchanges")
 	flag.BoolVar(&settings.EnableTradeSyncing, "tradesync", false, "enables trade syncing for all enabled exchanges")
-	flag.IntVar(&settings.SyncWorkersCount, "syncworkers", engine.DefaultSyncerWorkers, "the amount of workers (goroutines) to use for syncing exchange data")
+	flag.IntVar(&settings.SyncWorkersCount, "syncworkers", config.DefaultSyncerWorkers, "the amount of workers (goroutines) to use for syncing exchange data")
 	flag.BoolVar(&settings.SyncContinuously, "synccontinuously", true, "whether to sync exchange data continuously (ticker, orderbook and trade history info")
-	flag.DurationVar(&settings.SyncTimeoutREST, "synctimeoutrest", engine.DefaultSyncerTimeoutREST,
+	flag.DurationVar(&settings.SyncTimeoutREST, "synctimeoutrest", config.DefaultSyncerTimeoutREST,
 		"the amount of time before the syncer will switch from rest protocol to the streaming protocol (e.g. from REST to websocket)")
-	flag.DurationVar(&settings.SyncTimeoutWebsocket, "synctimeoutwebsocket", engine.DefaultSyncerTimeoutWebsocket,
+	flag.DurationVar(&settings.SyncTimeoutWebsocket, "synctimeoutwebsocket", config.DefaultSyncerTimeoutWebsocket,
 		"the amount of time before the syncer will switch from the websocket protocol to REST protocol (e.g. from websocket to REST)")
 
 	// Forex provider settings

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	flag.BoolVar(&settings.EnableCommsRelayer, "enablecommsrelayer", true, "enables available communications relayer")
 	flag.BoolVar(&settings.Verbose, "verbose", false, "increases logging verbosity for GoCryptoTrader")
 	flag.BoolVar(&settings.EnableFuturesTracking, "enablefuturestracking", true, "tracks futures orders PNL is supported by the exchange")
-	flag.BoolVar(&settings.EnableExchangeSyncManager, "syncmanager", true, "enables to exchange sync manager")
+	flag.BoolVar(&settings.EnableExchangeSyncManager, "syncmanager", false, "enables to exchange sync manager")
 	flag.BoolVar(&settings.EnableWebsocketRoutine, "websocketroutine", true, "enables the websocket routine for all loaded exchanges")
 	flag.BoolVar(&settings.EnableCoinmarketcapAnalysis, "coinmarketcap", false, "overrides config and runs currency analysis")
 	flag.BoolVar(&settings.EnableEventManager, "eventmanager", true, "enables the event manager")


### PR DESCRIPTION
# PR Description
This is a quick & basic QoL improvement which adds the sync manager config to our config file. No longer do you need to add so many params when running the application to change behaviour. You can still use the running params to override your config.

Also, the sync manager is a pretty trustworthy subsystem now, so I've added the ability to modify what logging events to output. You can toggle whether you want to see:
- Switch protocol updates
- Initial sync updates
- Event updates

Errors, default subsystem logs all still show and Verbose is still a thing. 

Please delete options that are not relevant and add an `x` in `[]` as item is complete.
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
- [x] go test ./... -race
- [x] golangci-lint run
- [x] `TestGetDefaultSyncManagerConfig()`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
