### PR TITLE
Orderbook: Add GetDepth to Base

### DIFF
--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -201,9 +201,7 @@ func (s *Service) Retrieve(exchange string, p currency.Pair, a asset.Item) (*Bas
 	return book.Retrieve()
 }
 
-// GetDepth returns the concrete book of which Base is a copy
-// This is probably useful for immutably monitoring orderbook health and state
-// whereas FetchOrderbook would trigger a refresh.
+// GetDepth returns the concrete book allowing the caller to stream orderbook changes
 func (b *Base) GetDepth() (*Depth, error) {
 	return service.GetDepth(b.Exchange, b.Pair, b.Asset)
 }

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -17,8 +17,7 @@ func Get(exchange string, p currency.Pair, a asset.Item) (*Base, error) {
 	return service.Retrieve(exchange, p, a)
 }
 
-// GetDepth returns a Depth pointer allowing the caller to stream orderbook
-// changes
+// GetDepth returns a Depth pointer allowing the caller to stream orderbook changes
 func GetDepth(exchange string, p currency.Pair, a asset.Item) (*Depth, error) {
 	return service.GetDepth(exchange, p, a)
 }
@@ -200,6 +199,13 @@ func (s *Service) Retrieve(exchange string, p currency.Pair, a asset.Item) (*Bas
 			p.Quote)
 	}
 	return book.Retrieve()
+}
+
+// GetDepth returns the concrete book of which Base is a copy
+// This is probably useful for immutably monitoring orderbook health and state
+// whereas FetchOrderbook would trigger a refresh.
+func (b *Base) GetDepth() (*Depth, error) {
+	return service.GetDepth(b.Exchange, b.Pair, b.Asset)
 }
 
 // TotalBidsAmount returns the total amount of bids and the total orderbook

--- a/exchanges/orderbook/orderbook_test.go
+++ b/exchanges/orderbook/orderbook_test.go
@@ -294,6 +294,34 @@ func TestGetDepth(t *testing.T) {
 	}
 }
 
+func TestBaseGetDepth(t *testing.T) {
+	c, err := currency.NewPairFromStrings("BTC", "UST")
+	if err != nil {
+		t.Error(err)
+	}
+	base := &Base{
+		Pair:     c,
+		Asks:     []Item{{Price: 100, Amount: 10}},
+		Bids:     []Item{{Price: 200, Amount: 10}},
+		Exchange: "Exchange",
+		Asset:    asset.Spot,
+	}
+
+	if _, err = base.GetDepth(); !errors.Is(err, errCannotFindOrderbook) {
+		t.Errorf("expecting %s error but received %v", errCannotFindOrderbook, err)
+	}
+
+	if err = base.Process(); err != nil {
+		t.Error(err)
+	}
+
+	if result, err := base.GetDepth(); err != nil {
+		t.Errorf("failed to get orderbook. Error %s", err)
+	} else if !result.pair.Equal(c) {
+		t.Errorf("Mismatched pairs: %v %v", result.pair, c)
+	}
+}
+
 func TestDeployDepth(t *testing.T) {
 	c, err := currency.NewPairFromStrings("BTC", "USD")
 	if err != nil {


### PR DESCRIPTION
Base.GetDepth returns the concrete book of which Base is a copy This is probably useful for immutably monitoring orderbook health and state whereas FetchOrderbook would trigger a refresh.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
