### PR TITLE
Bitstamp: Add websocket heartbeat

### DIFF
--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -22,7 +22,10 @@ import (
 
 const (
 	bitstampWSURL = "wss://ws.bitstamp.net" //nolint // gosec false positive
+	hbInterval    = 8 * time.Second         // Connection monitor defaults to 10s inactivity
 )
+
+var hbMsg = []byte(`{"event":"bts:heartbeat"}`)
 
 // WsConnect connects to a websocket feed
 func (b *Bitstamp) WsConnect() error {
@@ -37,6 +40,11 @@ func (b *Bitstamp) WsConnect() error {
 	if b.Verbose {
 		log.Debugf(log.ExchangeSys, "%s Connected to Websocket.\n", b.Name)
 	}
+	b.Websocket.Conn.SetupPingHandler(stream.PingHandler{
+		MessageType: websocket.TextMessage,
+		Message:     hbMsg,
+		Delay:       hbInterval,
+	})
 	err = b.seedOrderBook(context.TODO())
 	if err != nil {
 		b.Websocket.DataHandler <- err
@@ -72,6 +80,8 @@ func (b *Bitstamp) wsHandleData(respRaw []byte) error {
 	}
 
 	switch wsResponse.Event {
+	case "bts:heartbeat":
+		return nil
 	case "bts:subscribe", "bts:subscription_succeeded":
 		if b.Verbose {
 			log.Debugf(log.ExchangeSys, "%v - Websocket subscription acknowledgement", b.Name)


### PR DESCRIPTION
This prevents the frequent (5x / hour) disconn/reconns we're seeing with a 10s or even 20s traffic timeout.
I'd like to base the interval on the traffic timeout / 2, but that's non-trivial right now, and 8s isn't an excessive default

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run