### PR TITLE
Kraken: Fix WS Auth endpoints not re-enabled

### DIFF
--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -117,6 +117,7 @@ func (k *Kraken) WsConnect() error {
 					k.Name,
 					err)
 			} else {
+				k.Websocket.SetCanUseAuthenticatedEndpoints(true)
 				k.Websocket.Wg.Add(1)
 				go k.wsFunnelConnectionData(k.Websocket.AuthConn, comms)
 				err = k.wsAuthPingHandler()


### PR DESCRIPTION
When Kraken has a disconnect or failure that sets SetCanUseAuthenticatedEndpoints(false), it's never re-enabled when the websocket is reconnected That means all subsequent requests would fall back to rest

Can't see a low hanging fruit test for this so just doing a driveby on it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run