### PR TITLE
OrderManager: Fix race condition in submit with ws

### DIFF
--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -593,7 +593,7 @@ func (m *OrderManager) processSubmittedOrder(newOrderResp *order.SubmitResponse)
 		// Streamed by ws before we got here. Details from ws supersede since they are more recent.
 		detail = m.orderStore.getByDetail(detail)
 	} else if err != nil {
-		// Non-fatal error. OrderStore doesn't mean it wasn't submitted and consumers shouldn't get an error
+		// Non-fatal error: Unable to store order, but error does not need to be returned to caller
 		log.Errorf(log.OrderMgr, "unable to add %v order %v to orderStore: %s", detail.Exchange, detail.OrderID, err)
 	}
 

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -590,7 +590,7 @@ func (m *OrderManager) processSubmittedOrder(newOrderResp *order.SubmitResponse)
 	}
 
 	if err := m.orderStore.add(detail.CopyToPointer()); errors.Is(err, ErrOrdersAlreadyExists) {
-		// Streamed by ws before we got here. Details from ws supecede since they are more recent.
+		// Streamed by ws before we got here. Details from ws supersede since they are more recent.
 		detail = m.orderStore.getByDetail(detail)
 	} else if err != nil {
 		// Non-fatal error. OrderStore doesn't mean it wasn't submitted and consumers shouldn't get an error

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -1062,7 +1062,7 @@ func (s *store) getByDetail(det *order.Detail) *order.Detail {
 	exchangeOrders := s.Orders[strings.ToLower(det.Exchange)]
 	for _, o := range exchangeOrders {
 		if o.OrderID == det.OrderID {
-			return o
+			return o.CopyToPointer()
 		}
 	}
 	return nil

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -594,7 +594,7 @@ func (m *OrderManager) processSubmittedOrder(newOrderResp *order.SubmitResponse)
 		detail = m.orderStore.getByDetail(detail)
 	} else if err != nil {
 		// Non-fatal error: Unable to store order, but error does not need to be returned to caller
-		log.Errorf(log.OrderMgr, "unable to add %v order %v to orderStore: %s", detail.Exchange, detail.OrderID, err)
+		log.Errorf(log.OrderMgr, "Unable to add %v order %v to orderStore: %s", detail.Exchange, detail.OrderID, err)
 	}
 
 	msg := fmt.Sprintf("Exchange %s submitted order ID=%v [Ours: %v] pair=%v price=%v amount=%v quoteAmount=%v side=%v type=%v for time %v.",

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -589,7 +589,7 @@ func (m *OrderManager) processSubmittedOrder(newOrderResp *order.SubmitResponse)
 		return nil, err
 	}
 
-	if err := m.orderStore.add(detail.CopyToPointer()); err == ErrOrdersAlreadyExists {
+	if err := m.orderStore.add(detail.CopyToPointer()); errors.Is(err, ErrOrdersAlreadyExists) {
 		// Streamed by ws before we got here. Details from ws supecede since they are more recent.
 		detail = m.orderStore.getByDetail(detail)
 	} else if err != nil {

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -3,8 +3,6 @@ package engine
 import (
 	"context"
 	"errors"
-	"log"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -30,16 +28,7 @@ type omfExchange struct {
 	exchange.IBotExchange
 }
 
-var btcusdPair currency.Pair
-
-func TestMain(m *testing.M) {
-	var err error
-	btcusdPair, err = currency.NewPairFromString("BTCUSD")
-	if err != nil {
-		log.Fatal(err)
-	}
-	os.Exit(m.Run())
-}
+var btcusdPair = currency.NewPair(currency.BTC, currency.USD)
 
 // CancelOrder overrides testExchange's cancel order function
 // to do the bare minimum required with no API calls or credentials required

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -1683,3 +1683,24 @@ func TestProcessFuturesPositions(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
 }
+
+// TestGetByDetail tests orderstore.getByDetail
+func TestGetByDetail(t *testing.T) {
+	t.Parallel()
+	m := OrdersSetup(t)
+	assert.Nil(t, m.orderStore.getByDetail(nil), "Fetching a nil order should return nil")
+	od := &order.Detail{
+		Exchange:      testExchange,
+		AssetType:     asset.Spot,
+		OrderID:       "AdmiralHarold",
+		ClientOrderID: "DuskyLeafMonkey",
+	}
+	concise := &order.Detail{
+		Exchange: od.Exchange,
+		OrderID:  od.OrderID,
+	}
+	assert.Nil(t, m.orderStore.getByDetail(od), "Fetching a non-stored order should return nil")
+	assert.Nil(t, m.orderStore.add(od), "Adding the details should not error")
+	assert.Same(t, m.orderStore.getByDetail(od), od, "Retrieve by full details should return the same pointer")
+	assert.Same(t, m.orderStore.getByDetail(concise), od, "Retrieve by other details should return the original pointer")
+}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -639,7 +639,7 @@ func TestSubmit(t *testing.T) {
 }
 
 // TestSubmitOrderAlreadyInStore ensures that if an order is submitted, but the WS sees the conf before processSubmittedOrder
-// then we don't error that it was there already, and we merge together the details
+// then we don't error that it was there already
 func TestSubmitOrderAlreadyInStore(t *testing.T) {
 	m := OrdersSetup(t)
 	submitReq := &order.Submit{

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -1695,12 +1695,25 @@ func TestGetByDetail(t *testing.T) {
 		OrderID:       "AdmiralHarold",
 		ClientOrderID: "DuskyLeafMonkey",
 	}
-	concise := &order.Detail{
+	id := &order.Detail{
 		Exchange: od.Exchange,
 		OrderID:  od.OrderID,
 	}
+
 	assert.Nil(t, m.orderStore.getByDetail(od), "Fetching a non-stored order should return nil")
 	assert.Nil(t, m.orderStore.add(od), "Adding the details should not error")
-	assert.Same(t, m.orderStore.getByDetail(od), od, "Retrieve by full details should return the same pointer")
-	assert.Same(t, m.orderStore.getByDetail(concise), od, "Retrieve by other details should return the original pointer")
+
+	byOrig := m.orderStore.getByDetail(od)
+	byID := m.orderStore.getByDetail(id)
+
+	if assert.NotNil(t, byOrig, od, "Retrieve by orig pointer should find a record") {
+		assert.NotSame(t, byOrig, od, "Retrieve by orig pointer should return a new pointer")
+		assert.Equal(t, od.ClientOrderID, byOrig.ClientOrderID, "Retrieve by orig pointer should contain the correct ClientOrderID")
+	}
+
+	if assert.NotNil(t, byID, od, "Retrieve by new pointer should find a record") {
+		assert.NotSame(t, byID, id, "Retrieve by new pointer should return a different new pointer than we passed in")
+		assert.NotSame(t, byID, od, "Retrieve by new pointer should return a different new pointer than the original object")
+		assert.Equal(t, od.ClientOrderID, byID.ClientOrderID, "Retrieve by id pointer should contain the correct ClientOrderID")
+	}
 }

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -660,7 +660,8 @@ func TestSubmitOrderAlreadyInStore(t *testing.T) {
 	assert.Nil(t, err, "Derive Detail should not error")
 
 	d.ClientOrderID = "SecretSquirrelSauce"
-	assert.Nil(t, m.orderStore.add(d), "Adding an order should not error")
+	err = m.orderStore.add(d)
+	assert.Nil(t, err, "Adding an order should not error")
 
 	resp, err := m.SubmitFakeOrder(submitReq, submitResp, false)
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -35,7 +35,7 @@ const (
 
 var b = &Bitfinex{}
 var wsAuthExecuted bool
-var btcusdPair currency.Pair
+var btcusdPair = currency.NewPair(currency.BTC, currency.USD)
 
 func TestMain(m *testing.M) {
 	b.SetDefaults()
@@ -64,11 +64,6 @@ func TestMain(m *testing.M) {
 		b.API.AuthenticatedWebsocketSupport = true
 	}
 	b.WebsocketSubdChannels = make(map[int]*stream.ChannelSubscription)
-
-	btcusdPair, err = currency.NewPairFromString("BTCUSD")
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
If the ws sees the order before processSubmittedOrder then it will have assigned it an internal order id already and added it to the store. Don't treat that as an error. Instead just use the newer ws details

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestSubmitOrderAlreadyInStore