### PR TITLE
backtester: Fix ensureOrderFitsWithinHLV

### DIFF
--- a/backtester/eventhandlers/exchange/exchange.go
+++ b/backtester/eventhandlers/exchange/exchange.go
@@ -439,20 +439,16 @@ func ensureOrderFitsWithinHLV(price, amount, high, low, volume decimal.Decimal) 
 	if adjustedPrice.GreaterThan(high) {
 		adjustedPrice = high
 	}
-	orderVolume := amount.Mul(adjustedPrice)
-	if volume.LessThanOrEqual(decimal.Zero) || orderVolume.LessThanOrEqual(volume) {
+	if volume.LessThanOrEqual(decimal.Zero) || amount.LessThanOrEqual(volume) {
 		return adjustedPrice, amount
 	}
-	if orderVolume.GreaterThan(volume) {
+	if amount.GreaterThan(volume) {
 		// reduce the volume to not exceed the total volume of the candle
 		// it is slightly less than the total to still allow for the illusion
 		// that open high low close values are valid with the remaining volume
 		// this is very opinionated
-		orderVolume = volume.Mul(decimal.NewFromFloat(0.99999999))
+		adjustedAmount = volume.Mul(decimal.NewFromFloat(0.99999999))
 	}
-	// extract the amount from the adjusted volume
-	adjustedAmount = orderVolume.Div(adjustedPrice)
-
 	return adjustedPrice, adjustedAmount
 }
 

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -152,7 +152,7 @@ func TestSetCurrency(t *testing.T) {
 
 func TestEnsureOrderFitsWithinHLV(t *testing.T) {
 	t.Parallel()
-	adjustedPrice, adjustedAmount := ensureOrderFitsWithinHLV(decimal.NewFromInt(123), decimal.NewFromInt(1), decimal.NewFromInt(100), decimal.NewFromInt(99), decimal.NewFromInt(100))
+	adjustedPrice, adjustedAmount := ensureOrderFitsWithinHLV(decimal.NewFromInt(123), decimal.NewFromInt(1), decimal.NewFromInt(100), decimal.NewFromInt(99), decimal.NewFromInt(10))
 	if !adjustedAmount.Equal(decimal.NewFromInt(1)) {
 		t.Error("expected 1")
 	}
@@ -160,7 +160,7 @@ func TestEnsureOrderFitsWithinHLV(t *testing.T) {
 		t.Error("expected 100")
 	}
 
-	adjustedPrice, adjustedAmount = ensureOrderFitsWithinHLV(decimal.NewFromInt(123), decimal.NewFromInt(1), decimal.NewFromInt(100), decimal.NewFromInt(99), decimal.NewFromInt(80))
+	adjustedPrice, adjustedAmount = ensureOrderFitsWithinHLV(decimal.NewFromInt(123), decimal.NewFromInt(1), decimal.NewFromInt(100), decimal.NewFromInt(99), decimal.NewFromFloat(0.8))
 	if !adjustedAmount.Equal(decimal.NewFromFloat(0.799999992)) {
 		t.Errorf("received: %v, expected: %v", adjustedAmount, decimal.NewFromFloat(0.799999992))
 	}


### PR DESCRIPTION
# PR Description

Compare volume directly as the current implementation passes candle volume in base currency.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x ] Bug fix (non-breaking change which fixes an issue)


## How has this been tested

I updated the relavant test.

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [x ] Any dependent changes have been merged and published in downstream modules
