### PR TITLE
websocket: Relay disconnect errors to subscribers

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -391,16 +391,15 @@ func (w *Websocket) connectionMonitor() error {
 			}
 			select {
 			case err := <-w.ReadMessageErrors:
-				if isDisconnectionError(err) {
+				if IsDisconnectionError(err) {
 					w.setInit(false)
 					log.Warnf(log.WebsocketMgr,
 						"%v websocket has been disconnected. Reason: %v",
 						w.exchangeName, err)
 					w.setConnectedStatus(false)
-				} else {
-					// pass off non disconnect errors to datahandler to manage
-					w.DataHandler <- err
 				}
+
+				w.DataHandler <- err
 			case <-timer.C:
 				if !w.IsConnecting() && !w.IsConnected() {
 					err := w.Connect()
@@ -984,7 +983,7 @@ func (w *Websocket) CanUseAuthenticatedEndpoints() bool {
 }
 
 // isDisconnectionError Determines if the error sent over chan ReadMessageErrors is a disconnection error
-func isDisconnectionError(err error) bool {
+func IsDisconnectionError(err error) bool {
 	if websocket.IsUnexpectedCloseError(err) {
 		return true
 	}

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -982,7 +982,7 @@ func (w *Websocket) CanUseAuthenticatedEndpoints() bool {
 	return w.canUseAuthenticatedEndpoints
 }
 
-// isDisconnectionError Determines if the error sent over chan ReadMessageErrors is a disconnection error
+// IsDisconnectionError Determines if the error sent over chan ReadMessageErrors is a disconnection error
 func IsDisconnectionError(err error) bool {
 	if websocket.IsUnexpectedCloseError(err) {
 		return true

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -216,7 +216,7 @@ func (w *WebsocketConnection) IsConnected() bool {
 func (w *WebsocketConnection) ReadMessage() Response {
 	mType, resp, err := w.Connection.ReadMessage()
 	if err != nil {
-		if isDisconnectionError(err) {
+		if IsDisconnectionError(err) {
 			if w.setConnectedStatus(false) {
 				// NOTE: When w.setConnectedStatus() returns true the underlying
 				// state was changed and this infers that the connection was


### PR DESCRIPTION
Subscribers probably care when the WS got disconncted. Tell them and expose a method to test the error for matching

## Type of change

- [x] New micro 🐖 feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestConnectionMessageErrors