### PR TITLE
gctcli: Add colourful exchange-style rendering to orderbook fetching commands (optional)

### DIFF
--- a/cmd/gctcli/helpers.go
+++ b/cmd/gctcli/helpers.go
@@ -10,6 +10,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+var (
+	// use these to change text colours in CMD output
+	redText     = "\033[38;5;203m"
+	greenText   = "\033[38;5;157m"
+	whiteText   = "\033[38;5;255m"
+	grayText    = "\033[38;5;243m"
+	defaultText = "\u001b[0m"
+)
+
 func clearScreen() error {
 	switch runtime.GOOS {
 	case "windows":

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -679,6 +679,7 @@ func getOrderbookStream(c *cli.Context) error {
 }
 
 func renderOrderbookExchangeStyle(resp *gctrpc.OrderbookResponse, exchangeName, assetType string, maxLen, askLen, bidLen int64) {
+	maxLen-- // ensure we get the 0 index at the correct max length
 	upperBase := strings.ToUpper(resp.Pair.Base)
 	upperQuote := strings.ToUpper(resp.Pair.Quote)
 	printFmt := "%s%.8f\t\t%.8f\n"
@@ -687,7 +688,7 @@ func renderOrderbookExchangeStyle(resp *gctrpc.OrderbookResponse, exchangeName, 
 
 	fmt.Printf("%sPrice(%v)\t\tAmount(%s)\n",
 		grayText, upperQuote, upperBase)
-	for i := maxLen; i > 0; i-- {
+	for i := maxLen; i >= 0; i-- {
 		var askAmount, askPrice float64
 		if i <= askLen {
 			askAmount = resp.Asks[i].Amount
@@ -696,7 +697,7 @@ func renderOrderbookExchangeStyle(resp *gctrpc.OrderbookResponse, exchangeName, 
 		fmt.Printf(printFmt, redText, askPrice, askAmount)
 	}
 	fmt.Println()
-	for i := int64(0); i < maxLen; i++ {
+	for i := int64(0); i <= maxLen; i++ {
 		var bidAmount, bidPrice float64
 		if i <= bidLen {
 			bidAmount = resp.Bids[i].Amount

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -15,16 +15,19 @@ import (
 
 var orderbookCommonFlags = []cli.Flag{
 	&cli.StringFlag{
-		Name:  "exchange",
-		Usage: "the exchange to get the orderbook for",
+		Name:     "exchange",
+		Usage:    "the exchange to get the orderbook for",
+		Required: true,
 	},
 	&cli.StringFlag{
-		Name:  "pair",
-		Usage: "the currency pair to get the orderbook for",
+		Name:     "pair",
+		Usage:    "the currency pair to get the orderbook for",
+		Required: true,
 	},
 	&cli.StringFlag{
-		Name:  "asset",
-		Usage: "the asset type of the currency pair to get the orderbook for",
+		Name:     "asset",
+		Usage:    "the asset type of the currency pair to get the orderbook for",
+		Required: true,
 	},
 }
 
@@ -356,28 +359,15 @@ var getOrderbookCommand = &cli.Command{
 	Usage:     "gets the orderbook for a specific currency pair and exchange",
 	ArgsUsage: "<exchange> <pair> <asset> <exchangestyle> <depthlimit>",
 	Action:    getOrderbook,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "exchange",
-			Usage: "the exchange to get the orderbook for",
-		},
-		&cli.StringFlag{
-			Name:  "pair",
-			Usage: "the currency pair to get the orderbook for",
-		},
-		&cli.StringFlag{
-			Name:  "asset",
-			Usage: "the asset type of the currency pair to get the orderbook for",
-		},
+	Flags: append(orderbookCommonFlags,
 		&cli.BoolFlag{
 			Name:  "exchangestyle",
-			Usage: "renders the books like on an exchange website",
+			Usage: "optional - renders the books like on an exchange website",
 		},
 		&cli.Int64Flag{
 			Name:  "depthlimit",
-			Usage: "limit how deep the book rendering is, max 100 - only works if exchangestyle is true",
-		},
-	},
+			Usage: "optional - limit how deep the book rendering is, max 100 - only works if exchangestyle is true",
+		}),
 }
 
 func getOrderbook(c *cli.Context) error {
@@ -416,7 +406,7 @@ func getOrderbook(c *cli.Context) error {
 
 	if c.IsSet("exchangestyle") {
 		exchangeStyle = c.Bool("exchangestyle")
-	} else {
+	} else if c.Args().Get(3) != "" {
 		exchangeStyle, err = strconv.ParseBool(c.Args().Get(3))
 		if err != nil {
 			return err
@@ -425,7 +415,7 @@ func getOrderbook(c *cli.Context) error {
 
 	if c.IsSet("depthlimit") {
 		depthLimit = c.Int64("depthlimit")
-	} else {
+	} else if c.Args().Get(4) != "" {
 		depthLimit, err = strconv.ParseInt(c.Args().Get(4), 10, 64)
 		if err != nil {
 			return err
@@ -518,11 +508,11 @@ var getOrderbookStreamCommand = &cli.Command{
 	Flags: append(orderbookCommonFlags,
 		&cli.BoolFlag{
 			Name:  "exchangestyle",
-			Usage: "renders the books like on an exchange website",
+			Usage: "optional - renders the books like on an exchange website",
 		},
 		&cli.Int64Flag{
 			Name:  "depthlimit",
-			Usage: "limit how deep the book rendering is, max 50",
+			Usage: "optional - limit how deep the book rendering is, max 50",
 		}),
 }
 
@@ -562,7 +552,7 @@ func getOrderbookStream(c *cli.Context) error {
 
 	if c.IsSet("exchangestyle") {
 		exchangeStyle = c.Bool("exchangestyle")
-	} else {
+	} else if c.Args().Get(3) != "" {
 		exchangeStyle, err = strconv.ParseBool(c.Args().Get(3))
 		if err != nil {
 			return err
@@ -571,7 +561,7 @@ func getOrderbookStream(c *cli.Context) error {
 
 	if c.IsSet("depthlimit") {
 		depthLimit = c.Int64("depthlimit")
-	} else {
+	} else if c.Args().Get(4) != "" {
 		depthLimit, err = strconv.ParseInt(c.Args().Get(4), 10, 64)
 		if err != nil {
 			return err

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -15,19 +15,16 @@ import (
 
 var orderbookCommonFlags = []cli.Flag{
 	&cli.StringFlag{
-		Name:     "exchange",
-		Usage:    "the exchange to get the orderbook for",
-		Required: true,
+		Name:  "exchange",
+		Usage: "the exchange to get the orderbook for",
 	},
 	&cli.StringFlag{
-		Name:     "pair",
-		Usage:    "the currency pair to get the orderbook for",
-		Required: true,
+		Name:  "pair",
+		Usage: "the currency pair to get the orderbook for",
 	},
 	&cli.StringFlag{
-		Name:     "asset",
-		Usage:    "the asset type of the currency pair to get the orderbook for",
-		Required: true,
+		Name:  "asset",
+		Usage: "the asset type of the currency pair to get the orderbook for",
 	},
 }
 

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -2141,8 +2141,9 @@ func (s *RPCServer) GetOrderbookStream(r *gctrpc.GetOrderbookStreamRequest, stre
 		base, err := depth.Retrieve()
 		if err != nil {
 			resp.Error = err.Error()
-			resp.LastUpdated = time.Now().Unix()
+			resp.LastUpdated = time.Now().UnixMicro()
 		} else {
+			resp.LastUpdated = base.LastUpdated.UnixMicro()
 			resp.Bids = make([]*gctrpc.OrderbookItem, len(base.Bids))
 			for i := range base.Bids {
 				resp.Bids[i] = &gctrpc.OrderbookItem{
@@ -2204,8 +2205,9 @@ func (s *RPCServer) GetExchangeOrderbookStream(r *gctrpc.GetExchangeOrderbookStr
 		ob, err := d.Retrieve()
 		if err != nil {
 			resp.Error = err.Error()
-			resp.LastUpdated = time.Now().Unix()
+			resp.LastUpdated = time.Now().UnixMicro()
 		} else {
+			resp.LastUpdated = ob.LastUpdated.UnixMicro()
 			resp.Pair = &gctrpc.CurrencyPair{
 				Base:  ob.Pair.Base.String(),
 				Quote: ob.Pair.Quote.String(),


### PR DESCRIPTION
# PR Description
I have difficulty looking at the CLI way of rendering orderbooks and checking them against exchanges to find faults in our books. So I've added an option to allow it to render like an exchange

From CLI use:
`go run . --it  orderbook getorderbookstream --exchange="binance" --pair="btc-usdt" --asset="spot" --depthlimit=25 --exchangestyle=true`


https://github.com/thrasher-corp/gocryptotrader/assets/9261323/92b2df0c-d926-43e5-9a13-1e5a0c60cd81

Fixes: my eyes

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How has this been tested
- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
