### PR TITLE
orderbook: fix race condition when function scope is in error.

### DIFF
--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -94,6 +94,8 @@ func (d *Depth) Retrieve() (*Base, error) {
 
 // LoadSnapshot flushes the bids and asks with a snapshot
 func (d *Depth) LoadSnapshot(bids, asks []Item, lastUpdateID int64, lastUpdated time.Time, updateByREST bool) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if lastUpdated.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -101,7 +103,6 @@ func (d *Depth) LoadSnapshot(bids, asks []Item, lastUpdateID int64, lastUpdated 
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
 	d.lastUpdateID = lastUpdateID
 	d.lastUpdated = lastUpdated
 	d.restSnapshot = updateByREST
@@ -109,7 +110,6 @@ func (d *Depth) LoadSnapshot(bids, asks []Item, lastUpdateID int64, lastUpdated 
 	d.asks.load(asks, d.stack, lastUpdated)
 	d.validationError = nil
 	d.Alert()
-	d.m.Unlock()
 	return nil
 }
 
@@ -149,6 +149,8 @@ func (d *Depth) IsValid() bool {
 // UpdateBidAskByPrice updates the bid and ask spread by supplied updates, this
 // will trim total length of depth level to a specified supplied number
 func (d *Depth) UpdateBidAskByPrice(update *Update) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if update.UpdateTime.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -156,7 +158,6 @@ func (d *Depth) UpdateBidAskByPrice(update *Update) error {
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
 	if len(update.Bids) != 0 {
 		d.bids.updateInsertByPrice(update.Bids, d.stack, d.options.maxDepth, update.UpdateTime)
 	}
@@ -170,6 +171,9 @@ func (d *Depth) UpdateBidAskByPrice(update *Update) error {
 
 // UpdateBidAskByID amends details by ID
 func (d *Depth) UpdateBidAskByID(update *Update) error {
+	d.m.Lock()
+	defer d.m.Unlock()
+
 	if update.UpdateTime.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -177,8 +181,7 @@ func (d *Depth) UpdateBidAskByID(update *Update) error {
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
-	defer d.m.Unlock()
+
 	if len(update.Bids) != 0 {
 		err := d.bids.updateByID(update.Bids)
 		if err != nil {
@@ -197,6 +200,8 @@ func (d *Depth) UpdateBidAskByID(update *Update) error {
 
 // DeleteBidAskByID deletes a price level by ID
 func (d *Depth) DeleteBidAskByID(update *Update, bypassErr bool) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if update.UpdateTime.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -204,8 +209,6 @@ func (d *Depth) DeleteBidAskByID(update *Update, bypassErr bool) error {
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
-	defer d.m.Unlock()
 	if len(update.Bids) != 0 {
 		err := d.bids.deleteByID(update.Bids, d.stack, bypassErr, update.UpdateTime)
 		if err != nil {
@@ -224,6 +227,8 @@ func (d *Depth) DeleteBidAskByID(update *Update, bypassErr bool) error {
 
 // InsertBidAskByID inserts new updates
 func (d *Depth) InsertBidAskByID(update *Update) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if update.UpdateTime.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -231,8 +236,6 @@ func (d *Depth) InsertBidAskByID(update *Update) error {
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
-	defer d.m.Unlock()
 	if len(update.Bids) != 0 {
 		err := d.bids.insertUpdates(update.Bids, d.stack)
 		if err != nil {
@@ -251,6 +254,8 @@ func (d *Depth) InsertBidAskByID(update *Update) error {
 
 // UpdateInsertByID updates or inserts by ID at current price level.
 func (d *Depth) UpdateInsertByID(update *Update) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if update.UpdateTime.IsZero() {
 		return fmt.Errorf("%s %s %s %w",
 			d.exchange,
@@ -258,8 +263,6 @@ func (d *Depth) UpdateInsertByID(update *Update) error {
 			d.asset,
 			errLastUpdatedNotSet)
 	}
-	d.m.Lock()
-	defer d.m.Unlock()
 	if len(update.Bids) != 0 {
 		err := d.bids.updateInsertByID(update.Bids, d.stack)
 		if err != nil {

--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -165,7 +165,6 @@ func (d *Depth) UpdateBidAskByPrice(update *Update) error {
 		d.asks.updateInsertByPrice(update.Asks, d.stack, d.options.maxDepth, update.UpdateTime)
 	}
 	d.updateAndAlert(update)
-	d.m.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
# PR Description

* orderbook fields were exposed beyond a mutex gate this fix closes them in and makes them super safe and snug.
![th-2272636053](https://github.com/thrasher-corp/gocryptotrader/assets/9391715/05b5f45d-38c5-45a2-8446-6d1dfb514e2a)


Fixes # (issue)

https://trello.com/c/ZOTO4BCP/195-rare-orderbook-data-race

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
