### PR TITLE
engine/syncer: Stop orderbook fallover to REST when websocket connection is active

### DIFF
--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -610,6 +610,13 @@ func (m *syncManager) syncOrderbook(c *currencyPairSyncAgent, e exchange.IBotExc
 		e.SupportsREST() &&
 		time.Since(s.LastUpdated) > m.config.TimeoutWebsocket &&
 		time.Since(c.Created) > m.config.TimeoutWebsocket {
+		if w, err := e.GetWebsocket(); err != nil && w.IsConnected() {
+			// With an active websocket connection, we can assume the orderbook
+			// is being updated via the websocket connection, It could be very
+			// illiquid. There is no need to fall over to rest.
+			s.LastUpdated = time.Now()
+			return
+		}
 		// Downgrade to REST
 		s.IsUsingWebsocket = false
 		s.IsUsingREST = true

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -610,11 +610,10 @@ func (m *syncManager) syncOrderbook(c *currencyPairSyncAgent, e exchange.IBotExc
 		e.SupportsREST() &&
 		time.Since(s.LastUpdated) > m.config.TimeoutWebsocket &&
 		time.Since(c.Created) > m.config.TimeoutWebsocket {
-		if w, err := e.GetWebsocket(); err != nil && w.IsConnected() {
+		if w, err := e.GetWebsocket(); err == nil && w.IsConnected() {
 			// With an active websocket connection, we can assume the orderbook
 			// is being updated via the websocket connection, It could be very
 			// illiquid. There is no need to fall over to rest.
-			s.LastUpdated = time.Now()
 			return
 		}
 		// Downgrade to REST


### PR DESCRIPTION
# PR Description

* In the context of orderbook synchronisation via websocket this update aims to reduce the fallover to REST with illiquid assets. There could be big stretches of time between updates (🧸 market) and as long as there is an active connection it's probable that the orderbook state has not been compromised. 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions/AppVeyor with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
