### PR TITLE
websocket: configurable subscriptions concept

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -184,6 +184,7 @@ type Exchange struct {
 	WebsocketResponseCheckTimeout time.Duration          `json:"websocketResponseCheckTimeout"`
 	WebsocketResponseMaxLimit     time.Duration          `json:"websocketResponseMaxLimit"`
 	WebsocketTrafficTimeout       time.Duration          `json:"websocketTrafficTimeout"`
+	WebsocketSubscriptions        WebsocketSubscriptions `json:"websocketSubscriptions"`
 	ConnectionMonitorDelay        time.Duration          `json:"connectionMonitorDelay"`
 	ProxyAddress                  string                 `json:"proxyAddress,omitempty"`
 	BaseCurrencies                currency.Currencies    `json:"baseCurrencies"`
@@ -212,6 +213,12 @@ type Exchange struct {
 	SupportsAutoPairUpdates          *bool                `json:"supportsAutoPairUpdates,omitempty"`
 	Websocket                        *bool                `json:"websocket,omitempty"`
 	WebsocketURL                     *string              `json:"websocketUrl,omitempty"`
+}
+
+// WebsocketSubscriptions holds the websocket subscriptions for an exchange
+type WebsocketSubscriptions struct {
+	Authenticated   map[string][]string `json:"authenticatedSubscriptions"`
+	Unauthenticated map[string][]string `json:"unauthenticatedSubscriptions"`
 }
 
 // Profiler defines the profiler configuration to enable pprof

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -829,6 +829,36 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 	}
 
 	base := exch.GetBase()
+	if len(base.WebsocketSubscriptions.Unauthenticated) > 0 {
+		if exchCfg.WebsocketSubscriptions.Unauthenticated == nil {
+			exchCfg.WebsocketSubscriptions.Unauthenticated = make(map[string][]string)
+		}
+		for k, v := range base.WebsocketSubscriptions.Unauthenticated {
+			base.WebsocketSubscriptions.Unauthenticated[k] = v
+		}
+		for k, v := range base.DefaultWebsocketSubscriptions.Unauthenticated {
+			if len(base.WebsocketSubscriptions.Unauthenticated[k]) == 0 {
+				exchCfg.WebsocketSubscriptions.Unauthenticated[k.String()] = v
+			}
+		}
+
+	}
+
+	if len(base.WebsocketSubscriptions.Authenticated) > 0 {
+		if exchCfg.WebsocketSubscriptions.Authenticated == nil {
+			exchCfg.WebsocketSubscriptions.Authenticated = make(map[string][]string)
+		}
+		for k, v := range base.WebsocketSubscriptions.Authenticated {
+			base.WebsocketSubscriptions.Authenticated[k] = v
+		}
+		for k, v := range base.DefaultWebsocketSubscriptions.Authenticated {
+			if len(base.WebsocketSubscriptions.Authenticated[k]) == 0 {
+				exchCfg.WebsocketSubscriptions.Authenticated[k.String()] = v
+			} else {
+				exchCfg.WebsocketSubscriptions.Authenticated[k.String()] = v
+			}
+		}
+	}
 	if base.API.AuthenticatedSupport ||
 		base.API.AuthenticatedWebsocketSupport {
 		assetTypes := base.GetAssetTypes(false)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -834,7 +834,7 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 			exchCfg.WebsocketSubscriptions.Unauthenticated = make(map[string][]string)
 		}
 		for k, v := range base.WebsocketSubscriptions.Unauthenticated {
-			base.WebsocketSubscriptions.Unauthenticated[k] = v
+			exchCfg.WebsocketSubscriptions.Unauthenticated[k.String()] = v
 		}
 		for k, v := range base.DefaultWebsocketSubscriptions.Unauthenticated {
 			if len(base.WebsocketSubscriptions.Unauthenticated[k]) == 0 {
@@ -849,7 +849,7 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 			exchCfg.WebsocketSubscriptions.Authenticated = make(map[string][]string)
 		}
 		for k, v := range base.WebsocketSubscriptions.Authenticated {
-			base.WebsocketSubscriptions.Authenticated[k] = v
+			exchCfg.WebsocketSubscriptions.Authenticated[k.String()] = v
 		}
 		for k, v := range base.DefaultWebsocketSubscriptions.Authenticated {
 			if len(base.WebsocketSubscriptions.Authenticated[k]) == 0 {

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -578,6 +578,31 @@ func (b *Base) SetupDefaults(exch *config.Exchange) error {
 		}
 	}
 
+	if len(exch.WebsocketSubscriptions.Unauthenticated) > 0 {
+		if b.WebsocketSubscriptions.Unauthenticated == nil {
+			b.WebsocketSubscriptions.Unauthenticated = make(map[asset.Item][]string)
+		}
+		for k, v := range exch.WebsocketSubscriptions.Unauthenticated {
+			item, err := asset.New(k)
+			if err != nil {
+				return err
+			}
+			b.WebsocketSubscriptions.Unauthenticated[item] = v
+		}
+	}
+	if len(exch.WebsocketSubscriptions.Authenticated) > 0 {
+		if b.WebsocketSubscriptions.Authenticated == nil {
+			b.WebsocketSubscriptions.Authenticated = make(map[asset.Item][]string)
+		}
+		for k, v := range exch.WebsocketSubscriptions.Authenticated {
+			item, err := asset.New(k)
+			if err != nil {
+				return err
+			}
+			b.WebsocketSubscriptions.Authenticated[item] = v
+		}
+	}
+
 	b.HTTPDebugging = exch.HTTPDebugging
 	b.BypassConfigFormatUpgrades = exch.CurrencyPairs.BypassConfigFormatUpgrades
 	err = b.SetHTTPClientUserAgent(exch.HTTPUserAgent)

--- a/exchanges/exchange_types.go
+++ b/exchanges/exchange_types.go
@@ -234,6 +234,8 @@ type Base struct {
 	WebsocketResponseMaxLimit     time.Duration
 	WebsocketOrderbookBufferLimit int64
 	Websocket                     *stream.Websocket
+	WebsocketSubscriptions        WebsocketSubscriptions
+	DefaultWebsocketSubscriptions WebsocketSubscriptions
 	*request.Requester
 	Config        *config.Exchange
 	settingsMutex sync.RWMutex
@@ -245,6 +247,12 @@ type Base struct {
 
 	AssetWebsocketSupport
 	*currencystate.States
+}
+
+// WebsocketSubscriptions holds the websocket subscriptions for an exchange
+type WebsocketSubscriptions struct {
+	Authenticated   map[asset.Item][]string
+	Unauthenticated map[asset.Item][]string
 }
 
 // url lookup consts

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -163,6 +163,38 @@ func (ku *Kucoin) SetDefaults() {
 	ku.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	ku.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	ku.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit
+	ku.DefaultWebsocketSubscriptions.Unauthenticated = map[asset.Item][]string{
+		asset.Spot: {
+			marketTickerChannel,
+			marketMatchChannel,
+			marketOrderbookLevel2Channels,
+		},
+		asset.Margin: {
+			marketTickerChannel,
+			marketMatchChannel,
+			marketOrderbookLevel2Channels,
+			marginFundingbookChangeChannel,
+		},
+		asset.Futures: {
+			futuresTickerV2Channel,
+			futuresOrderbookLevel2Depth50Channel,
+		},
+	}
+	ku.DefaultWebsocketSubscriptions.Authenticated = map[asset.Item][]string{
+		asset.Spot: {
+			accountBalanceChannel,
+		},
+		asset.Margin: {
+			marginPositionChannel,
+			marginLoanChannel,
+		},
+		asset.Futures: {
+			futuresTradeOrdersBySymbolChannel,
+			futuresTradeOrderChannel,
+			futuresStopOrdersLifecycleEventChannel,
+			futuresAccountBalanceEventChannel,
+		},
+	}
 }
 
 // Setup takes in the supplied exchange configuration details and sets params
@@ -204,6 +236,14 @@ func (ku *Kucoin) Setup(exch *config.Exchange) error {
 	if err != nil {
 		return err
 	}
+
+	if len(ku.WebsocketSubscriptions.Unauthenticated) == 0 {
+		ku.WebsocketSubscriptions.Unauthenticated = ku.DefaultWebsocketSubscriptions.Unauthenticated
+	}
+	if len(ku.WebsocketSubscriptions.Authenticated) == 0 {
+		ku.WebsocketSubscriptions.Authenticated = ku.DefaultWebsocketSubscriptions.Authenticated
+	}
+
 	return ku.Websocket.SetupNewConnection(stream.ConnectionSetup{
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,


### PR DESCRIPTION
# PR Description
This is a design for having customisable websocket subscriptions. Its only implemented on Binance and Kucoin and I want feedback on it before I do it for all exchanges. I think the two exchanges show the flexibility of the design, they are applied quite differently

If this design is fine, I'll be adding
- Readme updates (some channels like ` "/market/ticker:%s"` might need explaining)
- Testing
- All exchange support
- If necessary for external users, a way to set subs on setup without a config


Another aspect of this is that it is trying to change things minimally. There are certainly extra features I'd desire, but I feel like the important part of this is to _stop subscribing to candles_ because I don't want to

## Type of change


- [x] New feature (non-breaking change which adds functionality)
