### PR TITLE
dispatch: Fix intermittent TestMuxPublish issue

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -180,11 +180,9 @@ func (d *Dispatcher) relayer() {
 				continue
 			}
 			for i := range pipes {
-				select {
-				case pipes[i] <- j.Data:
-				default:
-					// no receiver; don't wait. This limits complexity.
-				}
+				go func(p chan any) {
+					p <- j.Data
+				}(pipes[i])
 			}
 			d.rMtx.RUnlock()
 		case <-d.shutdown:


### PR DESCRIPTION
The existing behaviour was not consistently testable. Publishing to only listening Subscribers has no guarantees at all, and I'm not clear on when we'd be able to use it.

TestMuxPublish would fail intermittently when the jobs queue drained quickly
enough, and we could never guarantee a subscriber would receive a message even when synchronising the pools.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run