### PR TITLE
Types: Switch convert.StringToFloat64 to types.Number

### DIFF
--- a/common/convert/convert_test.go
+++ b/common/convert/convert_test.go
@@ -2,7 +2,6 @@ package convert
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -315,89 +314,6 @@ func TestInterfaceToStringOrZeroValue(t *testing.T) {
 	x = string("meow")
 	if r := InterfaceToStringOrZeroValue(x); r != "meow" {
 		t.Errorf("expected meow, got: %v", x)
-	}
-}
-
-func TestStringToFloat64(t *testing.T) {
-	t.Parallel()
-	resp := struct {
-		Data StringToFloat64 `json:"data"`
-	}{}
-
-	err := json.Unmarshal([]byte(`{"data":"0.00000001"}`), &resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.Data.Float64() != 1e-8 {
-		t.Fatalf("expected 1e-8, got %v", resp.Data.Float64())
-	}
-
-	err = json.Unmarshal([]byte(`{"data":""}`), &resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = json.Unmarshal([]byte(`{"data":1337.37}`), &resp)
-	if !errors.Is(err, errUnhandledType) {
-		t.Fatalf("received %v but expected %v", err, errUnhandledType)
-	}
-
-	// Demonstrates that a suffix check is not needed.
-	err = json.Unmarshal([]byte(`{"data":"1337.37}`), &resp)
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
-
-	err = json.Unmarshal([]byte(`{"data":"MEOW"}`), &resp)
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
-
-	data, err := json.Marshal(StringToFloat64(0))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(data) != `""` {
-		t.Fatalf("expected empty string, got %v", string(data))
-	}
-
-	data, err = json.Marshal(StringToFloat64(1337.1337))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(data) != `"1337.1337"` {
-		t.Fatalf("expected \"1337.1337\" string, got %v", string(data))
-	}
-}
-
-func TestStringToFloat64Decimal(t *testing.T) {
-	t.Parallel()
-	resp := struct {
-		Data StringToFloat64 `json:"data"`
-	}{}
-	err := json.Unmarshal([]byte(`{"data":"0.00000001"}`), &resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !resp.Data.Decimal().Equal(decimal.NewFromFloat(0.00000001)) {
-		t.Errorf("received '%v' expected '%v'", resp.Data.Decimal(), 0.00000001)
-	}
-}
-
-// 2677173	       428.9 ns/op	     240 B/op	       5 allocs/op
-func BenchmarkStringToFloat64(b *testing.B) {
-	resp := struct {
-		Data StringToFloat64 `json:"data"`
-	}{}
-
-	for i := 0; i < b.N; i++ {
-		err := json.Unmarshal([]byte(`{"data":"0.00000001"}`), &resp)
-		if err != nil {
-			b.Fatal(err)
-		}
 	}
 }
 

--- a/contrib/spellcheck/exclude_lines.txt
+++ b/contrib/spellcheck/exclude_lines.txt
@@ -5,7 +5,6 @@
 	if errOt != nil {
 		return order.Detail{}, fmt.Errorf("error parsing order type: %s", errOt)
 	currency.CANN:       0.2,
-	InstrumentID  string  `json:"insId"`
 	currency.DOTA:       0.01,
 	currency.SCRPT:      0.01,
 	currency.NOO:        0.002,
@@ -22,4 +21,3 @@
 	currency.MIS:        0.002,
 	SHFT             = NewCode("SHFT")
 	currency.SHFT:     84,
-	InstrumentID  string                  `json:"insId"`

--- a/contrib/spellcheck/ignore_words.txt
+++ b/contrib/spellcheck/ignore_words.txt
@@ -4,3 +4,4 @@ prevend
 flate
 freez
 zar
+insid

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const wsRateLimitMilliseconds = 250
@@ -295,14 +295,14 @@ type AggregatedTrade struct {
 
 // IndexMarkPrice stores data for index and mark prices
 type IndexMarkPrice struct {
-	Symbol               string                  `json:"symbol"`
-	Pair                 string                  `json:"pair"`
-	MarkPrice            convert.StringToFloat64 `json:"markPrice"`
-	IndexPrice           convert.StringToFloat64 `json:"indexPrice"`
-	EstimatedSettlePrice convert.StringToFloat64 `json:"estimatedSettlePrice"`
-	LastFundingRate      convert.StringToFloat64 `json:"lastFundingRate"`
-	NextFundingTime      int64                   `json:"nextFundingTime"`
-	Time                 int64                   `json:"time"`
+	Symbol               string       `json:"symbol"`
+	Pair                 string       `json:"pair"`
+	MarkPrice            types.Number `json:"markPrice"`
+	IndexPrice           types.Number `json:"indexPrice"`
+	EstimatedSettlePrice types.Number `json:"estimatedSettlePrice"`
+	LastFundingRate      types.Number `json:"lastFundingRate"`
+	NextFundingTime      int64        `json:"nextFundingTime"`
+	Time                 int64        `json:"time"`
 }
 
 // CandleStick holds kline data

--- a/exchanges/binance/ufutures_types.go
+++ b/exchanges/binance/ufutures_types.go
@@ -3,8 +3,8 @@ package binance
 import (
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 var (
@@ -84,11 +84,11 @@ type UMarkPrice struct {
 
 // FundingRateInfoResponse stores funding rate info
 type FundingRateInfoResponse struct {
-	Symbol                   string                  `json:"symbol"`
-	AdjustedFundingRateCap   convert.StringToFloat64 `json:"adjustedFundingRateCap"`
-	AdjustedFundingRateFloor convert.StringToFloat64 `json:"adjustedFundingRateFloor"`
-	FundingIntervalHours     int64                   `json:"fundingIntervalHours"`
-	Disclaimer               bool                    `json:"disclaimer"`
+	Symbol                   string       `json:"symbol"`
+	AdjustedFundingRateCap   types.Number `json:"adjustedFundingRateCap"`
+	AdjustedFundingRateFloor types.Number `json:"adjustedFundingRateFloor"`
+	FundingIntervalHours     int64        `json:"fundingIntervalHours"`
+	Disclaimer               bool         `json:"disclaimer"`
 }
 
 // FundingRateHistory stores funding rate history

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -14,12 +14,12 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Bybit is the overarching type across this package
@@ -164,10 +164,10 @@ func (by *Bybit) GetMergedOrderBook(ctx context.Context, symbol string, scale, d
 func (by *Bybit) GetTrades(ctx context.Context, symbol string, limit int64) ([]TradeItem, error) {
 	resp := struct {
 		Data []struct {
-			Price        convert.StringToFloat64 `json:"price"`
-			Time         bybitTimeMilliSec       `json:"time"`
-			Quantity     convert.StringToFloat64 `json:"qty"`
-			IsBuyerMaker bool                    `json:"isBuyerMaker"`
+			Price        types.Number      `json:"price"`
+			Time         bybitTimeMilliSec `json:"time"`
+			Quantity     types.Number      `json:"qty"`
+			IsBuyerMaker bool              `json:"isBuyerMaker"`
 		} `json:"result"`
 		Error
 	}{}

--- a/exchanges/bybit/bybit_cfutures.go
+++ b/exchanges/bybit/bybit_cfutures.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -394,7 +394,7 @@ func (by *Bybit) GetLastFundingRate(ctx context.Context, symbol currency.Pair) (
 // GetFuturesServerTime returns Bybit server time in seconds
 func (by *Bybit) GetFuturesServerTime(ctx context.Context) (time.Time, error) {
 	resp := struct {
-		TimeNow convert.StringToFloat64 `json:"time_now"`
+		TimeNow types.Number `json:"time_now"`
 		Error
 	}{}
 

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -3480,7 +3480,7 @@ func TestForceFileStandard(t *testing.T) {
 		t.Error(err)
 	}
 	if t.Failed() {
-		t.Fatal("Please use convert.StringToFloat64 type instead of `float64` and remove `,string` as strings can be empty in unmarshal process. Then call the Float64() method.")
+		t.Fatal("Please use types.Number type instead of `float64` and remove `,string` as strings can be empty in unmarshal process. Then call the Float64() method.")
 	}
 }
 

--- a/exchanges/bybit/bybit_types.go
+++ b/exchanges/bybit/bybit_types.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 var (
@@ -158,19 +158,19 @@ type UnmarshalTo interface {
 
 // PairData stores pair data
 type PairData struct {
-	Name              string                  `json:"name"`
-	Alias             string                  `json:"alias"`
-	BaseCurrency      string                  `json:"baseCurrency"`
-	QuoteCurrency     string                  `json:"quoteCurrency"`
-	BasePrecision     convert.StringToFloat64 `json:"basePrecision"`
-	QuotePrecision    convert.StringToFloat64 `json:"quotePrecision"`
-	MinTradeQuantity  convert.StringToFloat64 `json:"minTradeQuantity"`
-	MinTradeAmount    convert.StringToFloat64 `json:"minTradeAmount"`
-	MinPricePrecision convert.StringToFloat64 `json:"minPricePrecision"`
-	MaxTradeQuantity  convert.StringToFloat64 `json:"maxTradeQuantity"`
-	MaxTradeAmount    convert.StringToFloat64 `json:"maxTradeAmount"`
-	Category          int64                   `json:"category"`
-	ShowStatus        bool                    `json:"showStatus"`
+	Name              string       `json:"name"`
+	Alias             string       `json:"alias"`
+	BaseCurrency      string       `json:"baseCurrency"`
+	QuoteCurrency     string       `json:"quoteCurrency"`
+	BasePrecision     types.Number `json:"basePrecision"`
+	QuotePrecision    types.Number `json:"quotePrecision"`
+	MinTradeQuantity  types.Number `json:"minTradeQuantity"`
+	MinTradeAmount    types.Number `json:"minTradeAmount"`
+	MinPricePrecision types.Number `json:"minPricePrecision"`
+	MaxTradeQuantity  types.Number `json:"maxTradeQuantity"`
+	MaxTradeAmount    types.Number `json:"maxTradeAmount"`
+	Category          int64        `json:"category"`
+	ShowStatus        bool         `json:"showStatus"`
 }
 
 // Orderbook stores the orderbook data
@@ -207,32 +207,32 @@ type KlineItem struct {
 
 // PriceChangeStats contains statistics for the last 24 hours trade
 type PriceChangeStats struct {
-	Time         bybitTimeMilliSec       `json:"time"`
-	Symbol       string                  `json:"symbol"`
-	BestBidPrice convert.StringToFloat64 `json:"bestBidPrice"`
-	BestAskPrice convert.StringToFloat64 `json:"bestAskPrice"`
-	LastPrice    convert.StringToFloat64 `json:"lastPrice"`
-	OpenPrice    convert.StringToFloat64 `json:"openPrice"`
-	HighPrice    convert.StringToFloat64 `json:"highPrice"`
-	LowPrice     convert.StringToFloat64 `json:"lowPrice"`
-	Volume       convert.StringToFloat64 `json:"volume"`
-	QuoteVolume  convert.StringToFloat64 `json:"quoteVolume"`
+	Time         bybitTimeMilliSec `json:"time"`
+	Symbol       string            `json:"symbol"`
+	BestBidPrice types.Number      `json:"bestBidPrice"`
+	BestAskPrice types.Number      `json:"bestAskPrice"`
+	LastPrice    types.Number      `json:"lastPrice"`
+	OpenPrice    types.Number      `json:"openPrice"`
+	HighPrice    types.Number      `json:"highPrice"`
+	LowPrice     types.Number      `json:"lowPrice"`
+	Volume       types.Number      `json:"volume"`
+	QuoteVolume  types.Number      `json:"quoteVolume"`
 }
 
 // LastTradePrice contains price for last trade
 type LastTradePrice struct {
-	Symbol string                  `json:"symbol"`
-	Price  convert.StringToFloat64 `json:"price"`
+	Symbol string       `json:"symbol"`
+	Price  types.Number `json:"price"`
 }
 
 // TickerData stores ticker data
 type TickerData struct {
-	Symbol      string                  `json:"symbol"`
-	BidPrice    convert.StringToFloat64 `json:"bidPrice"`
-	BidQuantity convert.StringToFloat64 `json:"bidQty"`
-	AskPrice    convert.StringToFloat64 `json:"askPrice"`
-	AskQuantity convert.StringToFloat64 `json:"askQty"`
-	Time        bybitTimeMilliSec       `json:"time"`
+	Symbol      string            `json:"symbol"`
+	BidPrice    types.Number      `json:"bidPrice"`
+	BidQuantity types.Number      `json:"bidQty"`
+	AskPrice    types.Number      `json:"askPrice"`
+	AskQuantity types.Number      `json:"askQty"`
+	Time        bybitTimeMilliSec `json:"time"`
 }
 
 var (
@@ -270,97 +270,97 @@ type PlaceOrderRequest struct {
 
 // PlaceOrderResponse store new order response type
 type PlaceOrderResponse struct {
-	OrderID     string                  `json:"orderId"`
-	OrderLinkID string                  `json:"orderLinkId"`
-	Symbol      string                  `json:"symbol"`
-	Time        bybitTimeMilliSecStr    `json:"transactTime"`
-	Price       convert.StringToFloat64 `json:"price"`
-	Quantity    convert.StringToFloat64 `json:"origQty"`
-	TradeType   string                  `json:"type"`
-	Side        string                  `json:"side"`
-	Status      string                  `json:"status"`
-	TimeInForce string                  `json:"timeInForce"`
-	AccountID   string                  `json:"accountId"`
-	SymbolName  string                  `json:"symbolName"`
-	ExecutedQty convert.StringToFloat64 `json:"executedQty"`
+	OrderID     string               `json:"orderId"`
+	OrderLinkID string               `json:"orderLinkId"`
+	Symbol      string               `json:"symbol"`
+	Time        bybitTimeMilliSecStr `json:"transactTime"`
+	Price       types.Number         `json:"price"`
+	Quantity    types.Number         `json:"origQty"`
+	TradeType   string               `json:"type"`
+	Side        string               `json:"side"`
+	Status      string               `json:"status"`
+	TimeInForce string               `json:"timeInForce"`
+	AccountID   string               `json:"accountId"`
+	SymbolName  string               `json:"symbolName"`
+	ExecutedQty types.Number         `json:"executedQty"`
 }
 
 // QueryOrderResponse holds query order data
 type QueryOrderResponse struct {
-	AccountID           string                  `json:"accountId"`
-	ExchangeID          string                  `json:"exchangeId"`
-	Symbol              string                  `json:"symbol"`
-	SymbolName          string                  `json:"symbolName"`
-	OrderLinkID         string                  `json:"orderLinkId"`
-	OrderID             string                  `json:"orderId"`
-	Price               convert.StringToFloat64 `json:"price"`
-	Quantity            convert.StringToFloat64 `json:"origQty"`
-	ExecutedQty         convert.StringToFloat64 `json:"executedQty"`
-	CummulativeQuoteQty convert.StringToFloat64 `json:"cummulativeQuoteQty"`
-	AveragePrice        convert.StringToFloat64 `json:"avgPrice"`
-	Status              string                  `json:"status"`
-	TimeInForce         string                  `json:"timeInForce"`
-	TradeType           string                  `json:"type"`
-	Side                string                  `json:"side"`
-	StopPrice           convert.StringToFloat64 `json:"stopPrice"`
-	IcebergQty          convert.StringToFloat64 `json:"icebergQty"`
-	Time                bybitTimeMilliSecStr    `json:"time"`
-	UpdateTime          bybitTimeMilliSecStr    `json:"updateTime"`
-	IsWorking           bool                    `json:"isWorking"`
+	AccountID           string               `json:"accountId"`
+	ExchangeID          string               `json:"exchangeId"`
+	Symbol              string               `json:"symbol"`
+	SymbolName          string               `json:"symbolName"`
+	OrderLinkID         string               `json:"orderLinkId"`
+	OrderID             string               `json:"orderId"`
+	Price               types.Number         `json:"price"`
+	Quantity            types.Number         `json:"origQty"`
+	ExecutedQty         types.Number         `json:"executedQty"`
+	CummulativeQuoteQty types.Number         `json:"cummulativeQuoteQty"`
+	AveragePrice        types.Number         `json:"avgPrice"`
+	Status              string               `json:"status"`
+	TimeInForce         string               `json:"timeInForce"`
+	TradeType           string               `json:"type"`
+	Side                string               `json:"side"`
+	StopPrice           types.Number         `json:"stopPrice"`
+	IcebergQty          types.Number         `json:"icebergQty"`
+	Time                bybitTimeMilliSecStr `json:"time"`
+	UpdateTime          bybitTimeMilliSecStr `json:"updateTime"`
+	IsWorking           bool                 `json:"isWorking"`
 }
 
 // CancelOrderResponse is the return structured response from the exchange
 type CancelOrderResponse struct {
-	OrderID     string                  `json:"orderId"`
-	OrderLinkID string                  `json:"orderLinkId"`
-	Symbol      string                  `json:"symbol"`
-	Status      string                  `json:"status"`
-	AccountID   string                  `json:"accountId"`
-	Time        bybitTimeMilliSecStr    `json:"transactTime"`
-	Price       convert.StringToFloat64 `json:"price"`
-	Quantity    convert.StringToFloat64 `json:"origQty"`
-	ExecutedQty convert.StringToFloat64 `json:"executedQty"`
-	TimeInForce string                  `json:"timeInForce"`
-	TradeType   string                  `json:"type"`
-	Side        string                  `json:"side"`
+	OrderID     string               `json:"orderId"`
+	OrderLinkID string               `json:"orderLinkId"`
+	Symbol      string               `json:"symbol"`
+	Status      string               `json:"status"`
+	AccountID   string               `json:"accountId"`
+	Time        bybitTimeMilliSecStr `json:"transactTime"`
+	Price       types.Number         `json:"price"`
+	Quantity    types.Number         `json:"origQty"`
+	ExecutedQty types.Number         `json:"executedQty"`
+	TimeInForce string               `json:"timeInForce"`
+	TradeType   string               `json:"type"`
+	Side        string               `json:"side"`
 }
 
 // HistoricalTrade holds recent trade data
 type HistoricalTrade struct {
-	Symbol          string                  `json:"symbol"`
-	ID              string                  `json:"id"`
-	OrderID         string                  `json:"orderId"`
-	TicketID        string                  `json:"ticketId"`
-	Price           convert.StringToFloat64 `json:"price"`
-	Quantity        convert.StringToFloat64 `json:"qty"`
-	Commission      convert.StringToFloat64 `json:"commission"`
-	CommissionAsset convert.StringToFloat64 `json:"commissionAsset"`
-	Time            bybitTimeMilliSecStr    `json:"time"`
-	IsBuyer         bool                    `json:"isBuyer"`
-	IsMaker         bool                    `json:"isMaker"`
-	SymbolName      string                  `json:"symbolName"`
-	MatchOrderID    string                  `json:"matchOrderId"`
-	Fee             FeeData                 `json:"fee"`
-	FeeTokenID      string                  `json:"feeTokenId"`
-	FeeAmount       convert.StringToFloat64 `json:"feeAmount"`
-	MakerRebate     convert.StringToFloat64 `json:"makerRebate"`
+	Symbol          string               `json:"symbol"`
+	ID              string               `json:"id"`
+	OrderID         string               `json:"orderId"`
+	TicketID        string               `json:"ticketId"`
+	Price           types.Number         `json:"price"`
+	Quantity        types.Number         `json:"qty"`
+	Commission      types.Number         `json:"commission"`
+	CommissionAsset types.Number         `json:"commissionAsset"`
+	Time            bybitTimeMilliSecStr `json:"time"`
+	IsBuyer         bool                 `json:"isBuyer"`
+	IsMaker         bool                 `json:"isMaker"`
+	SymbolName      string               `json:"symbolName"`
+	MatchOrderID    string               `json:"matchOrderId"`
+	Fee             FeeData              `json:"fee"`
+	FeeTokenID      string               `json:"feeTokenId"`
+	FeeAmount       types.Number         `json:"feeAmount"`
+	MakerRebate     types.Number         `json:"makerRebate"`
 }
 
 // FeeData store fees data
 type FeeData struct {
-	FeeTokenID   int64                   `json:"feeTokenId"`
-	FeeTokenName string                  `json:"feeTokenName"`
-	Fee          convert.StringToFloat64 `json:"fee"`
+	FeeTokenID   int64        `json:"feeTokenId"`
+	FeeTokenName string       `json:"feeTokenName"`
+	Fee          types.Number `json:"fee"`
 }
 
 // Balance holds wallet balance
 type Balance struct {
-	Coin     string                  `json:"coin"`
-	CoinID   string                  `json:"coinId"`
-	CoinName string                  `json:"coinName"`
-	Total    convert.StringToFloat64 `json:"total"`
-	Free     convert.StringToFloat64 `json:"free"`
-	Locked   convert.StringToFloat64 `json:"locked"`
+	Coin     string       `json:"coin"`
+	CoinID   string       `json:"coinId"`
+	CoinName string       `json:"coinName"`
+	Total    types.Number `json:"total"`
+	Free     types.Number `json:"free"`
+	Locked   types.Number `json:"locked"`
 }
 
 type orderbookResponse struct {
@@ -417,12 +417,12 @@ type WsParams struct {
 
 // WsSpotTickerData stores ws ticker data
 type WsSpotTickerData struct {
-	Symbol  string                  `json:"symbol"`
-	Bid     convert.StringToFloat64 `json:"bidPrice"`
-	Ask     convert.StringToFloat64 `json:"askPrice"`
-	BidSize convert.StringToFloat64 `json:"bidQty"`
-	AskSize convert.StringToFloat64 `json:"askQty"`
-	Time    bybitTimeMilliSec       `json:"time"`
+	Symbol  string            `json:"symbol"`
+	Bid     types.Number      `json:"bidPrice"`
+	Ask     types.Number      `json:"askPrice"`
+	BidSize types.Number      `json:"bidQty"`
+	AskSize types.Number      `json:"askQty"`
+	Time    bybitTimeMilliSec `json:"time"`
 }
 
 // WsSpotTicker stores ws ticker data
@@ -434,13 +434,13 @@ type WsSpotTicker struct {
 
 // KlineStreamData stores ws kline stream data
 type KlineStreamData struct {
-	StartTime  bybitTimeMilliSec       `json:"t"`
-	Symbol     string                  `json:"s"`
-	ClosePrice convert.StringToFloat64 `json:"c"`
-	HighPrice  convert.StringToFloat64 `json:"h"`
-	LowPrice   convert.StringToFloat64 `json:"l"`
-	OpenPrice  convert.StringToFloat64 `json:"o"`
-	Volume     convert.StringToFloat64 `json:"v"`
+	StartTime  bybitTimeMilliSec `json:"t"`
+	Symbol     string            `json:"s"`
+	ClosePrice types.Number      `json:"c"`
+	HighPrice  types.Number      `json:"h"`
+	LowPrice   types.Number      `json:"l"`
+	OpenPrice  types.Number      `json:"o"`
+	Volume     types.Number      `json:"v"`
 }
 
 // KlineStream holds the kline stream data
@@ -468,11 +468,11 @@ type WsOrderbook struct {
 
 // WsTradeData stores ws trade data
 type WsTradeData struct {
-	Time  bybitTimeMilliSec       `json:"t"`
-	ID    string                  `json:"v"`
-	Price convert.StringToFloat64 `json:"p"`
-	Size  convert.StringToFloat64 `json:"q"`
-	Side  bool                    `json:"m"`
+	Time  bybitTimeMilliSec `json:"t"`
+	ID    string            `json:"v"`
+	Price types.Number      `json:"p"`
+	Size  types.Number      `json:"q"`
+	Side  bool              `json:"m"`
 }
 
 // WsTrade stores ws trades data
@@ -494,65 +494,65 @@ type wsAccount struct {
 
 // Currencies stores currencies data
 type Currencies struct {
-	Asset     string                  `json:"a"`
-	Available convert.StringToFloat64 `json:"f"`
-	Locked    convert.StringToFloat64 `json:"l"`
+	Asset     string       `json:"a"`
+	Available types.Number `json:"f"`
+	Locked    types.Number `json:"l"`
 }
 
 // wsOrderUpdate defines websocket account order update data
 type wsOrderUpdate struct {
-	EventType                         string                  `json:"e"`
-	EventTime                         string                  `json:"E"`
-	Symbol                            string                  `json:"s"`
-	ClientOrderID                     string                  `json:"c"`
-	Side                              string                  `json:"S"`
-	OrderType                         string                  `json:"o"`
-	TimeInForce                       string                  `json:"f"`
-	Quantity                          convert.StringToFloat64 `json:"q"`
-	Price                             convert.StringToFloat64 `json:"p"`
-	OrderStatus                       string                  `json:"X"`
-	OrderID                           string                  `json:"i"`
-	OpponentOrderID                   string                  `json:"M"`
-	LastExecutedQuantity              convert.StringToFloat64 `json:"l"`
-	CumulativeFilledQuantity          convert.StringToFloat64 `json:"z"`
-	LastExecutedPrice                 convert.StringToFloat64 `json:"L"`
-	Commission                        convert.StringToFloat64 `json:"n"`
-	CommissionAsset                   string                  `json:"N"`
-	IsNormal                          bool                    `json:"u"`
-	IsOnOrderBook                     bool                    `json:"w"`
-	IsLimitMaker                      bool                    `json:"m"`
-	OrderCreationTime                 bybitTimeMilliSecStr    `json:"O"`
-	CumulativeQuoteTransactedQuantity convert.StringToFloat64 `json:"Z"`
-	AccountID                         string                  `json:"A"`
-	IsClose                           bool                    `json:"C"`
-	Leverage                          convert.StringToFloat64 `json:"v"`
+	EventType                         string               `json:"e"`
+	EventTime                         string               `json:"E"`
+	Symbol                            string               `json:"s"`
+	ClientOrderID                     string               `json:"c"`
+	Side                              string               `json:"S"`
+	OrderType                         string               `json:"o"`
+	TimeInForce                       string               `json:"f"`
+	Quantity                          types.Number         `json:"q"`
+	Price                             types.Number         `json:"p"`
+	OrderStatus                       string               `json:"X"`
+	OrderID                           string               `json:"i"`
+	OpponentOrderID                   string               `json:"M"`
+	LastExecutedQuantity              types.Number         `json:"l"`
+	CumulativeFilledQuantity          types.Number         `json:"z"`
+	LastExecutedPrice                 types.Number         `json:"L"`
+	Commission                        types.Number         `json:"n"`
+	CommissionAsset                   string               `json:"N"`
+	IsNormal                          bool                 `json:"u"`
+	IsOnOrderBook                     bool                 `json:"w"`
+	IsLimitMaker                      bool                 `json:"m"`
+	OrderCreationTime                 bybitTimeMilliSecStr `json:"O"`
+	CumulativeQuoteTransactedQuantity types.Number         `json:"Z"`
+	AccountID                         string               `json:"A"`
+	IsClose                           bool                 `json:"C"`
+	Leverage                          types.Number         `json:"v"`
 }
 
 // wsOrderFilled defines websocket account order filled data
 type wsOrderFilled struct {
-	EventType         string                  `json:"e"`
-	EventTime         string                  `json:"E"`
-	Symbol            string                  `json:"s"`
-	Quantity          convert.StringToFloat64 `json:"q"`
-	Timestamp         bybitTimeMilliSecStr    `json:"t"`
-	Price             convert.StringToFloat64 `json:"p"`
-	TradeID           string                  `json:"T"`
-	OrderID           string                  `json:"o"`
-	UserGenOrderID    string                  `json:"c"`
-	OpponentOrderID   string                  `json:"O"`
-	AccountID         string                  `json:"a"`
-	OpponentAccountID string                  `json:"A"`
-	IsMaker           bool                    `json:"m"`
-	Side              string                  `json:"S"`
+	EventType         string               `json:"e"`
+	EventTime         string               `json:"E"`
+	Symbol            string               `json:"s"`
+	Quantity          types.Number         `json:"q"`
+	Timestamp         bybitTimeMilliSecStr `json:"t"`
+	Price             types.Number         `json:"p"`
+	TradeID           string               `json:"T"`
+	OrderID           string               `json:"o"`
+	UserGenOrderID    string               `json:"c"`
+	OpponentOrderID   string               `json:"O"`
+	AccountID         string               `json:"a"`
+	OpponentAccountID string               `json:"A"`
+	IsMaker           bool                 `json:"m"`
+	Side              string               `json:"S"`
 }
 
 // WsFuturesOrderbookData stores ws futures orderbook data
 type WsFuturesOrderbookData struct {
-	Price  convert.StringToFloat64 `json:"price"`
-	Symbol string                  `json:"symbol"`
-	ID     int64                   `json:"id"`
-	Side   string                  `json:"side"`
-	Size   float64                 `json:"size"`
+	Price  types.Number `json:"price"`
+	Symbol string       `json:"symbol"`
+	ID     int64        `json:"id"`
+	Side   string       `json:"side"`
+	Size   float64      `json:"size"`
 }
 
 // WsFuturesOrderbook stores ws futures orderbook
@@ -635,32 +635,32 @@ type WsInsurance struct {
 
 // WsTickerData stores ws ticker data
 type WsTickerData struct {
-	ID                    string                  `json:"id"`
-	Symbol                string                  `json:"symbol"`
-	LastPrice             convert.StringToFloat64 `json:"last_price"`
-	BidPrice              float64                 `json:"bid1_price"`
-	AskPrice              float64                 `json:"ask1_price"`
-	LastDirection         string                  `json:"last_tick_direction"`
-	PrevPrice24h          convert.StringToFloat64 `json:"prev_price_24h"`
-	Price24hPercentChange float64                 `json:"price_24h_pcnt_e6"`
-	Price1hPercentChange  float64                 `json:"price_1h_pcnt_e6"`
-	HighPrice24h          convert.StringToFloat64 `json:"high_price_24h"`
-	LowPrice24h           convert.StringToFloat64 `json:"low_price_24h"`
-	PrevPrice1h           convert.StringToFloat64 `json:"prev_price_1h"`
-	MarkPrice             convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice            convert.StringToFloat64 `json:"index_price"`
-	OpenInterest          float64                 `json:"open_interest"`
-	OpenValue             float64                 `json:"open_value_e8"`
-	TotalTurnOver         float64                 `json:"total_turnover_e8"`
-	TurnOver24h           float64                 `json:"turnover_24h_e8"`
-	TotalVolume           float64                 `json:"total_volume"`
-	Volume24h             float64                 `json:"volume_24h"`
-	FundingRate           int64                   `json:"funding_rate_e6"`
-	PredictedFundingRate  float64                 `json:"predicted_funding_rate_e6"`
-	CreatedAt             time.Time               `json:"created_at"`
-	UpdateAt              time.Time               `json:"updated_at"`
-	NextFundingAt         time.Time               `json:"next_funding_time"`
-	CountDownHour         int64                   `json:"countdown_hour"`
+	ID                    string       `json:"id"`
+	Symbol                string       `json:"symbol"`
+	LastPrice             types.Number `json:"last_price"`
+	BidPrice              float64      `json:"bid1_price"`
+	AskPrice              float64      `json:"ask1_price"`
+	LastDirection         string       `json:"last_tick_direction"`
+	PrevPrice24h          types.Number `json:"prev_price_24h"`
+	Price24hPercentChange float64      `json:"price_24h_pcnt_e6"`
+	Price1hPercentChange  float64      `json:"price_1h_pcnt_e6"`
+	HighPrice24h          types.Number `json:"high_price_24h"`
+	LowPrice24h           types.Number `json:"low_price_24h"`
+	PrevPrice1h           types.Number `json:"prev_price_1h"`
+	MarkPrice             types.Number `json:"mark_price"`
+	IndexPrice            types.Number `json:"index_price"`
+	OpenInterest          float64      `json:"open_interest"`
+	OpenValue             float64      `json:"open_value_e8"`
+	TotalTurnOver         float64      `json:"total_turnover_e8"`
+	TurnOver24h           float64      `json:"turnover_24h_e8"`
+	TotalVolume           float64      `json:"total_volume"`
+	Volume24h             float64      `json:"volume_24h"`
+	FundingRate           int64        `json:"funding_rate_e6"`
+	PredictedFundingRate  float64      `json:"predicted_funding_rate_e6"`
+	CreatedAt             time.Time    `json:"created_at"`
+	UpdateAt              time.Time    `json:"updated_at"`
+	NextFundingAt         time.Time    `json:"next_funding_time"`
+	CountDownHour         int64        `json:"countdown_hour"`
 }
 
 // WsTicker stores ws ticker
@@ -682,45 +682,45 @@ type WsDeltaTicker struct {
 
 // WsFuturesTickerData stores ws future ticker data
 type WsFuturesTickerData struct {
-	ID                    string                  `json:"id"`
-	Symbol                string                  `json:"symbol"`
-	SymbolName            string                  `json:"symbol_name"`
-	SymbolYear            int64                   `json:"symbol_year"`
-	ContractType          string                  `json:"contract_type"`
-	Coin                  string                  `json:"coin"`
-	QuoteSymbol           string                  `json:"quote_symbol"`
-	Mode                  string                  `json:"mode"`
-	IsUpBorrowable        int64                   `json:"is_up_borrowable"`
-	ImportTime            bybitTimeNanoSec        `json:"import_time_e9"`
-	StartTradingTime      bybitTimeNanoSec        `json:"start_trading_time_e9"`
-	TimeToSettle          bybitTimeNanoSec        `json:"settle_time_e9"`
-	SettleFeeRate         int64                   `json:"settle_fee_rate_e8"`
-	ContractStatus        string                  `json:"contract_status"`
-	SystemSubsidy         int64                   `json:"system_subsidy_e8"`
-	LastPrice             convert.StringToFloat64 `json:"last_price"`
-	BidPrice              float64                 `json:"bid1_price"`
-	AskPrice              float64                 `json:"ask1_price"`
-	LastDirection         string                  `json:"last_tick_direction"`
-	PrevPrice24h          convert.StringToFloat64 `json:"prev_price_24h"`
-	Price24hPercentChange float64                 `json:"price_24h_pcnt_e6"`
-	Price1hPercentChange  float64                 `json:"price_1h_pcnt_e6"`
-	HighPrice24h          convert.StringToFloat64 `json:"high_price_24h"`
-	LowPrice24h           convert.StringToFloat64 `json:"low_price_24h"`
-	PrevPrice1h           convert.StringToFloat64 `json:"prev_price_1h"`
-	MarkPrice             convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice            convert.StringToFloat64 `json:"index_price"`
-	OpenInterest          float64                 `json:"open_interest"`
-	OpenValue             float64                 `json:"open_value_e8"`
-	TotalTurnOver         float64                 `json:"total_turnover_e8"`
-	TurnOver24h           float64                 `json:"turnover_24h_e8"`
-	TotalVolume           float64                 `json:"total_volume"`
-	Volume24h             float64                 `json:"volume_24h"`
-	FairBasis             float64                 `json:"fair_basis_e8"`
-	FairBasisRate         float64                 `json:"fair_basis_rate_e8"`
-	BasisInYear           float64                 `json:"basis_in_year_e8"`
-	ExpectPrice           convert.StringToFloat64 `json:"expect_price"`
-	CreatedAt             time.Time               `json:"created_at"`
-	UpdateAt              time.Time               `json:"updated_at"`
+	ID                    string           `json:"id"`
+	Symbol                string           `json:"symbol"`
+	SymbolName            string           `json:"symbol_name"`
+	SymbolYear            int64            `json:"symbol_year"`
+	ContractType          string           `json:"contract_type"`
+	Coin                  string           `json:"coin"`
+	QuoteSymbol           string           `json:"quote_symbol"`
+	Mode                  string           `json:"mode"`
+	IsUpBorrowable        int64            `json:"is_up_borrowable"`
+	ImportTime            bybitTimeNanoSec `json:"import_time_e9"`
+	StartTradingTime      bybitTimeNanoSec `json:"start_trading_time_e9"`
+	TimeToSettle          bybitTimeNanoSec `json:"settle_time_e9"`
+	SettleFeeRate         int64            `json:"settle_fee_rate_e8"`
+	ContractStatus        string           `json:"contract_status"`
+	SystemSubsidy         int64            `json:"system_subsidy_e8"`
+	LastPrice             types.Number     `json:"last_price"`
+	BidPrice              float64          `json:"bid1_price"`
+	AskPrice              float64          `json:"ask1_price"`
+	LastDirection         string           `json:"last_tick_direction"`
+	PrevPrice24h          types.Number     `json:"prev_price_24h"`
+	Price24hPercentChange float64          `json:"price_24h_pcnt_e6"`
+	Price1hPercentChange  float64          `json:"price_1h_pcnt_e6"`
+	HighPrice24h          types.Number     `json:"high_price_24h"`
+	LowPrice24h           types.Number     `json:"low_price_24h"`
+	PrevPrice1h           types.Number     `json:"prev_price_1h"`
+	MarkPrice             types.Number     `json:"mark_price"`
+	IndexPrice            types.Number     `json:"index_price"`
+	OpenInterest          float64          `json:"open_interest"`
+	OpenValue             float64          `json:"open_value_e8"`
+	TotalTurnOver         float64          `json:"total_turnover_e8"`
+	TurnOver24h           float64          `json:"turnover_24h_e8"`
+	TotalVolume           float64          `json:"total_volume"`
+	Volume24h             float64          `json:"volume_24h"`
+	FairBasis             float64          `json:"fair_basis_e8"`
+	FairBasisRate         float64          `json:"fair_basis_rate_e8"`
+	BasisInYear           float64          `json:"basis_in_year_e8"`
+	ExpectPrice           types.Number     `json:"expect_price"`
+	CreatedAt             time.Time        `json:"created_at"`
+	UpdateAt              time.Time        `json:"updated_at"`
 }
 
 // WsFuturesTicker stores ws future ticker
@@ -742,11 +742,11 @@ type WsDeltaFuturesTicker struct {
 
 // WsLiquidationData stores ws liquidation data
 type WsLiquidationData struct {
-	Symbol    string                  `json:"symbol"`
-	Side      string                  `json:"side"`
-	Price     convert.StringToFloat64 `json:"price"`
-	Qty       float64                 `json:"qty"`
-	Timestamp bybitTimeMilliSec       `json:"time"`
+	Symbol    string            `json:"symbol"`
+	Side      string            `json:"side"`
+	Price     types.Number      `json:"price"`
+	Qty       float64           `json:"qty"`
+	Timestamp bybitTimeMilliSec `json:"time"`
 }
 
 // WsFuturesLiquidation stores ws future liquidation
@@ -757,36 +757,36 @@ type WsFuturesLiquidation struct {
 
 // WsFuturesPositionData stores ws future position data
 type WsFuturesPositionData struct {
-	UserID              int64                   `json:"user_id"`
-	Symbol              string                  `json:"symbol"`
-	Side                string                  `json:"side"`
-	Size                float64                 `json:"size"`
-	PositionID          int64                   `json:"position_idx"` // present in Futures position struct only
-	Mode                int64                   `json:"mode"`         // present in Futures position struct only
-	Isolated            bool                    `json:"isolated"`     // present in Futures position struct only
-	PositionValue       convert.StringToFloat64 `json:"position_value"`
-	EntryPrice          convert.StringToFloat64 `json:"entry_price"`
-	LiquidPrice         convert.StringToFloat64 `json:"liq_price"`
-	BustPrice           convert.StringToFloat64 `json:"bust_price"`
-	Leverage            convert.StringToFloat64 `json:"leverage"`
-	OrderMargin         convert.StringToFloat64 `json:"order_margin"`
-	PositionMargin      convert.StringToFloat64 `json:"position_margin"`
-	AvailableBalance    convert.StringToFloat64 `json:"available_balance"`
-	TakeProfit          convert.StringToFloat64 `json:"take_profit"`
-	TakeProfitTriggerBy string                  `json:"tp_trigger_by"`
-	StopLoss            convert.StringToFloat64 `json:"stop_loss"`
-	StopLossTriggerBy   string                  `json:"sl_trigger_by"`
-	RealisedPNL         convert.StringToFloat64 `json:"realised_pnl"`
-	TrailingStop        convert.StringToFloat64 `json:"trailing_stop"`
-	TrailingActive      convert.StringToFloat64 `json:"trailing_active"`
-	WalletBalance       convert.StringToFloat64 `json:"wallet_balance"`
-	RiskID              int64                   `json:"risk_id"`
-	ClosingFee          convert.StringToFloat64 `json:"occ_closing_fee"`
-	FundingFee          convert.StringToFloat64 `json:"occ_funding_fee"`
-	AutoAddMargin       int64                   `json:"auto_add_margin"`
-	TotalPNL            convert.StringToFloat64 `json:"cum_realised_pnl"`
-	Status              string                  `json:"position_status"`
-	Version             int64                   `json:"position_seq"`
+	UserID              int64        `json:"user_id"`
+	Symbol              string       `json:"symbol"`
+	Side                string       `json:"side"`
+	Size                float64      `json:"size"`
+	PositionID          int64        `json:"position_idx"` // present in Futures position struct only
+	Mode                int64        `json:"mode"`         // present in Futures position struct only
+	Isolated            bool         `json:"isolated"`     // present in Futures position struct only
+	PositionValue       types.Number `json:"position_value"`
+	EntryPrice          types.Number `json:"entry_price"`
+	LiquidPrice         types.Number `json:"liq_price"`
+	BustPrice           types.Number `json:"bust_price"`
+	Leverage            types.Number `json:"leverage"`
+	OrderMargin         types.Number `json:"order_margin"`
+	PositionMargin      types.Number `json:"position_margin"`
+	AvailableBalance    types.Number `json:"available_balance"`
+	TakeProfit          types.Number `json:"take_profit"`
+	TakeProfitTriggerBy string       `json:"tp_trigger_by"`
+	StopLoss            types.Number `json:"stop_loss"`
+	StopLossTriggerBy   string       `json:"sl_trigger_by"`
+	RealisedPNL         types.Number `json:"realised_pnl"`
+	TrailingStop        types.Number `json:"trailing_stop"`
+	TrailingActive      types.Number `json:"trailing_active"`
+	WalletBalance       types.Number `json:"wallet_balance"`
+	RiskID              int64        `json:"risk_id"`
+	ClosingFee          types.Number `json:"occ_closing_fee"`
+	FundingFee          types.Number `json:"occ_funding_fee"`
+	AutoAddMargin       int64        `json:"auto_add_margin"`
+	TotalPNL            types.Number `json:"cum_realised_pnl"`
+	Status              string       `json:"position_status"`
+	Version             int64        `json:"position_seq"`
 }
 
 // WsFuturesPosition stores ws future position
@@ -798,19 +798,19 @@ type WsFuturesPosition struct {
 
 // WsFuturesExecutionData stores ws future execution data
 type WsFuturesExecutionData struct {
-	Symbol        string                  `json:"symbol"`
-	Side          string                  `json:"side"`
-	OrderID       string                  `json:"order_id"`
-	ExecutionID   string                  `json:"exec_id"`
-	OrderLinkID   string                  `json:"order_link_id"`
-	Price         convert.StringToFloat64 `json:"price"`
-	OrderQty      float64                 `json:"order_qty"`
-	ExecutionType string                  `json:"exec_type"`
-	ExecutionQty  float64                 `json:"exec_qty"`
-	ExecutionFee  convert.StringToFloat64 `json:"exec_fee"`
-	LeavesQty     float64                 `json:"leaves_qty"`
-	IsMaker       bool                    `json:"is_maker"`
-	Time          time.Time               `json:"trade_time"`
+	Symbol        string       `json:"symbol"`
+	Side          string       `json:"side"`
+	OrderID       string       `json:"order_id"`
+	ExecutionID   string       `json:"exec_id"`
+	OrderLinkID   string       `json:"order_link_id"`
+	Price         types.Number `json:"price"`
+	OrderQty      float64      `json:"order_qty"`
+	ExecutionType string       `json:"exec_type"`
+	ExecutionQty  float64      `json:"exec_qty"`
+	ExecutionFee  types.Number `json:"exec_fee"`
+	LeavesQty     float64      `json:"leaves_qty"`
+	IsMaker       bool         `json:"is_maker"`
+	Time          time.Time    `json:"trade_time"`
 }
 
 // WsFuturesExecution stores ws future execution
@@ -821,31 +821,31 @@ type WsFuturesExecution struct {
 
 // WsOrderData stores ws order data
 type WsOrderData struct {
-	OrderID              string                  `json:"order_id"`
-	OrderLinkID          string                  `json:"order_link_id"`
-	Symbol               string                  `json:"symbol"`
-	Side                 string                  `json:"side"`
-	OrderType            string                  `json:"order_type"`
-	Price                convert.StringToFloat64 `json:"price"`
-	OrderQty             float64                 `json:"qty"`
-	TimeInForce          string                  `json:"time_in_force"`
-	CreateType           string                  `json:"create_type"`
-	CancelType           string                  `json:"cancel_type"`
-	OrderStatus          string                  `json:"order_status"`
-	LeavesQty            float64                 `json:"leaves_qty"`
-	CummulativeExecQty   float64                 `json:"cum_exec_qty"`
-	CummulativeExecValue convert.StringToFloat64 `json:"cum_exec_value"`
-	CummulativeExecFee   convert.StringToFloat64 `json:"cum_exec_fee"`
-	TakeProfit           convert.StringToFloat64 `json:"take_profit"`
-	StopLoss             convert.StringToFloat64 `json:"stop_loss"`
-	TrailingStop         convert.StringToFloat64 `json:"trailing_stop"`
-	TrailingActive       convert.StringToFloat64 `json:"trailing_active"`
-	LastExecPrice        convert.StringToFloat64 `json:"last_exec_price"`
-	ReduceOnly           bool                    `json:"reduce_only"`
-	CloseOnTrigger       bool                    `json:"close_on_trigger"`
-	Time                 time.Time               `json:"timestamp"`   // present in CoinMarginedFutures and Futures only
-	CreateTime           time.Time               `json:"create_time"` // present in USDTMarginedFutures only
-	UpdateTime           time.Time               `json:"update_time"` // present in USDTMarginedFutures only
+	OrderID              string       `json:"order_id"`
+	OrderLinkID          string       `json:"order_link_id"`
+	Symbol               string       `json:"symbol"`
+	Side                 string       `json:"side"`
+	OrderType            string       `json:"order_type"`
+	Price                types.Number `json:"price"`
+	OrderQty             float64      `json:"qty"`
+	TimeInForce          string       `json:"time_in_force"`
+	CreateType           string       `json:"create_type"`
+	CancelType           string       `json:"cancel_type"`
+	OrderStatus          string       `json:"order_status"`
+	LeavesQty            float64      `json:"leaves_qty"`
+	CummulativeExecQty   float64      `json:"cum_exec_qty"`
+	CummulativeExecValue types.Number `json:"cum_exec_value"`
+	CummulativeExecFee   types.Number `json:"cum_exec_fee"`
+	TakeProfit           types.Number `json:"take_profit"`
+	StopLoss             types.Number `json:"stop_loss"`
+	TrailingStop         types.Number `json:"trailing_stop"`
+	TrailingActive       types.Number `json:"trailing_active"`
+	LastExecPrice        types.Number `json:"last_exec_price"`
+	ReduceOnly           bool         `json:"reduce_only"`
+	CloseOnTrigger       bool         `json:"close_on_trigger"`
+	Time                 time.Time    `json:"timestamp"`   // present in CoinMarginedFutures and Futures only
+	CreateTime           time.Time    `json:"create_time"` // present in USDTMarginedFutures only
+	UpdateTime           time.Time    `json:"update_time"` // present in USDTMarginedFutures only
 }
 
 // WsOrder stores ws order
@@ -856,23 +856,23 @@ type WsOrder struct {
 
 // WsStopOrderData stores ws stop order data
 type WsStopOrderData struct {
-	OrderID        string                  `json:"order_id"`
-	OrderLinkID    string                  `json:"order_link_id"`
-	UserID         int64                   `json:"user_id"`
-	Symbol         string                  `json:"symbol"`
-	Side           string                  `json:"side"`
-	OrderType      string                  `json:"order_type"`
-	Price          convert.StringToFloat64 `json:"price"`
-	OrderQty       float64                 `json:"qty"`
-	TimeInForce    string                  `json:"time_in_force"`
-	CreateType     string                  `json:"create_type"`
-	CancelType     string                  `json:"cancel_type"`
-	OrderStatus    string                  `json:"order_status"`
-	StopOrderType  string                  `json:"stop_order_type"`
-	TriggerBy      string                  `json:"trigger_by"`
-	TriggerPrice   convert.StringToFloat64 `json:"trigger_price"`
-	Time           time.Time               `json:"timestamp"`
-	CloseOnTrigger bool                    `json:"close_on_trigger"`
+	OrderID        string       `json:"order_id"`
+	OrderLinkID    string       `json:"order_link_id"`
+	UserID         int64        `json:"user_id"`
+	Symbol         string       `json:"symbol"`
+	Side           string       `json:"side"`
+	OrderType      string       `json:"order_type"`
+	Price          types.Number `json:"price"`
+	OrderQty       float64      `json:"qty"`
+	TimeInForce    string       `json:"time_in_force"`
+	CreateType     string       `json:"create_type"`
+	CancelType     string       `json:"cancel_type"`
+	OrderStatus    string       `json:"order_status"`
+	StopOrderType  string       `json:"stop_order_type"`
+	TriggerBy      string       `json:"trigger_by"`
+	TriggerPrice   types.Number `json:"trigger_price"`
+	Time           time.Time    `json:"timestamp"`
+	CloseOnTrigger bool         `json:"close_on_trigger"`
 }
 
 // WsFuturesStopOrder stores ws future stop order
@@ -883,23 +883,23 @@ type WsFuturesStopOrder struct {
 
 // WsUSDTStopOrderData stores ws USDT stop order data
 type WsUSDTStopOrderData struct {
-	OrderID        string                  `json:"stop_order_id"`
-	OrderLinkID    string                  `json:"order_link_id"`
-	UserID         int64                   `json:"user_id"`
-	Symbol         string                  `json:"symbol"`
-	Side           string                  `json:"side"`
-	OrderType      string                  `json:"order_type"`
-	Price          convert.StringToFloat64 `json:"price"`
-	OrderQty       float64                 `json:"qty"`
-	TimeInForce    string                  `json:"time_in_force"`
-	OrderStatus    string                  `json:"order_status"`
-	StopOrderType  string                  `json:"stop_order_type"`
-	TriggerBy      string                  `json:"trigger_by"`
-	TriggerPrice   convert.StringToFloat64 `json:"trigger_price"`
-	ReduceOnly     bool                    `json:"reduce_only"`
-	CloseOnTrigger bool                    `json:"close_on_trigger"`
-	CreateTime     time.Time               `json:"create_time"`
-	UpdateTime     time.Time               `json:"update_time"`
+	OrderID        string       `json:"stop_order_id"`
+	OrderLinkID    string       `json:"order_link_id"`
+	UserID         int64        `json:"user_id"`
+	Symbol         string       `json:"symbol"`
+	Side           string       `json:"side"`
+	OrderType      string       `json:"order_type"`
+	Price          types.Number `json:"price"`
+	OrderQty       float64      `json:"qty"`
+	TimeInForce    string       `json:"time_in_force"`
+	OrderStatus    string       `json:"order_status"`
+	StopOrderType  string       `json:"stop_order_type"`
+	TriggerBy      string       `json:"trigger_by"`
+	TriggerPrice   types.Number `json:"trigger_price"`
+	ReduceOnly     bool         `json:"reduce_only"`
+	CloseOnTrigger bool         `json:"close_on_trigger"`
+	CreateTime     time.Time    `json:"create_time"`
+	UpdateTime     time.Time    `json:"update_time"`
 }
 
 // WsUSDTFuturesStopOrder stores ws USDT stop order
@@ -923,54 +923,54 @@ type WsFuturesWallet struct {
 // Ticker holds ticker information
 type Ticker struct {
 	// Spot fields
-	Symbol            string                  `json:"symbol"`
-	TopBidPrice       convert.StringToFloat64 `json:"bid1Price"`
-	TopBidSize        convert.StringToFloat64 `json:"bid1Size"`
-	TopAskPrice       convert.StringToFloat64 `json:"ask1Price"`
-	TopAskSize        convert.StringToFloat64 `json:"ask1Size"`
-	LastPrice         convert.StringToFloat64 `json:"lastPrice"`
-	PreviousPrice24Hr convert.StringToFloat64 `json:"prevPrice24h"`
-	Price24HrPcnt     convert.StringToFloat64 `json:"price24hPcnt"`
-	HighPrice24Hr     convert.StringToFloat64 `json:"highPrice24h"`
-	LowPrice24Hr      convert.StringToFloat64 `json:"lowPrice24h"`
-	Turnover24Hr      convert.StringToFloat64 `json:"turnover24h"`
-	Volume24Hr        convert.StringToFloat64 `json:"volume24h"`
-	USDIndexPrice     convert.StringToFloat64 `json:"usdIndexPrice"`
+	Symbol            string       `json:"symbol"`
+	TopBidPrice       types.Number `json:"bid1Price"`
+	TopBidSize        types.Number `json:"bid1Size"`
+	TopAskPrice       types.Number `json:"ask1Price"`
+	TopAskSize        types.Number `json:"ask1Size"`
+	LastPrice         types.Number `json:"lastPrice"`
+	PreviousPrice24Hr types.Number `json:"prevPrice24h"`
+	Price24HrPcnt     types.Number `json:"price24hPcnt"`
+	HighPrice24Hr     types.Number `json:"highPrice24h"`
+	LowPrice24Hr      types.Number `json:"lowPrice24h"`
+	Turnover24Hr      types.Number `json:"turnover24h"`
+	Volume24Hr        types.Number `json:"volume24h"`
+	USDIndexPrice     types.Number `json:"usdIndexPrice"`
 
 	// Option fields
-	TopBidImpliedVolatility convert.StringToFloat64 `json:"bid1Iv"`
-	TopAskImpliedVolatility convert.StringToFloat64 `json:"ask1Iv"`
-	MarkPrice               convert.StringToFloat64 `json:"markPrice"`
-	IndexPrice              convert.StringToFloat64 `json:"indexPrice"`
-	MarkImpliedVolatility   convert.StringToFloat64 `json:"markIv"`
-	UnderlyingPrice         convert.StringToFloat64 `json:"underlyingPrice"`
-	OpenInterest            convert.StringToFloat64 `json:"openInterest"`
-	TotalVolume             convert.StringToFloat64 `json:"totalVolume"`
-	TotalTurnover           convert.StringToFloat64 `json:"totalTurnover"`
-	Delta                   convert.StringToFloat64 `json:"delta"`
-	Gamma                   convert.StringToFloat64 `json:"gamma"`
-	Vega                    convert.StringToFloat64 `json:"vega"`
-	Theta                   convert.StringToFloat64 `json:"theta"`
-	PredictedDeliveryPrice  convert.StringToFloat64 `json:"predictedDeliveryPrice"`
-	Change24h               convert.StringToFloat64 `json:"change24h"`
+	TopBidImpliedVolatility types.Number `json:"bid1Iv"`
+	TopAskImpliedVolatility types.Number `json:"ask1Iv"`
+	MarkPrice               types.Number `json:"markPrice"`
+	IndexPrice              types.Number `json:"indexPrice"`
+	MarkImpliedVolatility   types.Number `json:"markIv"`
+	UnderlyingPrice         types.Number `json:"underlyingPrice"`
+	OpenInterest            types.Number `json:"openInterest"`
+	TotalVolume             types.Number `json:"totalVolume"`
+	TotalTurnover           types.Number `json:"totalTurnover"`
+	Delta                   types.Number `json:"delta"`
+	Gamma                   types.Number `json:"gamma"`
+	Vega                    types.Number `json:"vega"`
+	Theta                   types.Number `json:"theta"`
+	PredictedDeliveryPrice  types.Number `json:"predictedDeliveryPrice"`
+	Change24h               types.Number `json:"change24h"`
 
 	// Inverse/linear  fields
-	PrevPrice1h       convert.StringToFloat64 `json:"prevPrice1h"`
-	OpenInterestValue convert.StringToFloat64 `json:"openInterestValue"`
-	FundingRate       convert.StringToFloat64 `json:"fundingRate"`
-	NextFundingTime   convert.StringToFloat64 `json:"nextFundingTime"`
-	BasisRate         convert.StringToFloat64 `json:"basisRate"`
-	DeliveryFeeRate   convert.StringToFloat64 `json:"deliveryFeeRate"`
-	DeliveryTime      convert.StringToFloat64 `json:"deliveryTime"`
-	Basis             convert.StringToFloat64 `json:"basis"`
+	PrevPrice1h       types.Number `json:"prevPrice1h"`
+	OpenInterestValue types.Number `json:"openInterestValue"`
+	FundingRate       types.Number `json:"fundingRate"`
+	NextFundingTime   types.Number `json:"nextFundingTime"`
+	BasisRate         types.Number `json:"basisRate"`
+	DeliveryFeeRate   types.Number `json:"deliveryFeeRate"`
+	DeliveryTime      types.Number `json:"deliveryTime"`
+	Basis             types.Number `json:"basis"`
 }
 
 // Fee holds fee information
 type Fee struct {
-	BaseCoin string                  `json:"baseCoin"`
-	Symbol   string                  `json:"symbol"`
-	Taker    convert.StringToFloat64 `json:"takerFeeRate"`
-	Maker    convert.StringToFloat64 `json:"makerFeeRate"`
+	BaseCoin string       `json:"baseCoin"`
+	Symbol   string       `json:"symbol"`
+	Taker    types.Number `json:"takerFeeRate"`
+	Maker    types.Number `json:"makerFeeRate"`
 }
 
 // AccountFee holds account fee information
@@ -995,37 +995,37 @@ type GetInstrumentInfoResponse struct {
 // InstrumentInfo holds all instrument info across
 // spot, linear, option types
 type InstrumentInfo struct {
-	Symbol          string                  `json:"symbol"`
-	ContractType    string                  `json:"contractType"`
-	Innovation      string                  `json:"innovation"`
-	MarginTrading   string                  `json:"marginTrading"`
-	Status          string                  `json:"status"`
-	BaseCoin        string                  `json:"baseCoin"`
-	QuoteCoin       string                  `json:"quoteCoin"`
-	OptionsType     string                  `json:"optionsType"`
-	LaunchTime      convert.StringToFloat64 `json:"launchTime"`
-	DeliveryTime    convert.StringToFloat64 `json:"deliveryTime"`
-	DeliveryFeeRate convert.StringToFloat64 `json:"deliveryFeeRate"`
-	PriceScale      convert.StringToFloat64 `json:"priceScale"`
+	Symbol          string       `json:"symbol"`
+	ContractType    string       `json:"contractType"`
+	Innovation      string       `json:"innovation"`
+	MarginTrading   string       `json:"marginTrading"`
+	Status          string       `json:"status"`
+	BaseCoin        string       `json:"baseCoin"`
+	QuoteCoin       string       `json:"quoteCoin"`
+	OptionsType     string       `json:"optionsType"`
+	LaunchTime      types.Number `json:"launchTime"`
+	DeliveryTime    types.Number `json:"deliveryTime"`
+	DeliveryFeeRate types.Number `json:"deliveryFeeRate"`
+	PriceScale      types.Number `json:"priceScale"`
 	LeverageFilter  struct {
-		MinLeverage  convert.StringToFloat64 `json:"minLeverage"`
-		MaxLeverage  convert.StringToFloat64 `json:"maxLeverage"`
-		LeverageStep convert.StringToFloat64 `json:"leverageStep"`
+		MinLeverage  types.Number `json:"minLeverage"`
+		MaxLeverage  types.Number `json:"maxLeverage"`
+		LeverageStep types.Number `json:"leverageStep"`
 	} `json:"leverageFilter"`
 	PriceFilter struct {
-		MinPrice convert.StringToFloat64 `json:"minPrice"`
-		MaxPrice convert.StringToFloat64 `json:"maxPrice"`
-		TickSize convert.StringToFloat64 `json:"tickSize"`
+		MinPrice types.Number `json:"minPrice"`
+		MaxPrice types.Number `json:"maxPrice"`
+		TickSize types.Number `json:"tickSize"`
 	} `json:"priceFilter"`
 	LotSizeFilter struct {
-		MaxOrderQty         convert.StringToFloat64 `json:"maxOrderQty"`
-		MinOrderQty         convert.StringToFloat64 `json:"minOrderQty"`
-		QtyStep             convert.StringToFloat64 `json:"qtyStep"`
-		PostOnlyMaxOrderQty convert.StringToFloat64 `json:"postOnlyMaxOrderQty"`
-		BasePrecision       convert.StringToFloat64 `json:"basePrecision"`
-		QuotePrecision      convert.StringToFloat64 `json:"quotePrecision"`
-		MinOrderAmt         convert.StringToFloat64 `json:"minOrderAmt"`
-		MaxOrderAmt         convert.StringToFloat64 `json:"maxOrderAmt"`
+		MaxOrderQty         types.Number `json:"maxOrderQty"`
+		MinOrderQty         types.Number `json:"minOrderQty"`
+		QtyStep             types.Number `json:"qtyStep"`
+		PostOnlyMaxOrderQty types.Number `json:"postOnlyMaxOrderQty"`
+		BasePrecision       types.Number `json:"basePrecision"`
+		QuotePrecision      types.Number `json:"quotePrecision"`
+		MinOrderAmt         types.Number `json:"minOrderAmt"`
+		MaxOrderAmt         types.Number `json:"maxOrderAmt"`
 	} `json:"lotSizeFilter"`
 	UnifiedMarginTrade bool   `json:"unifiedMarginTrade"`
 	FundingInterval    int64  `json:"fundingInterval"`

--- a/exchanges/bybit/bybit_usdcfutures.go
+++ b/exchanges/bybit/bybit_usdcfutures.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -888,7 +888,7 @@ func (by *Bybit) GetUSDCPosition(ctx context.Context, symbol currency.Pair, cate
 func (by *Bybit) SetUSDCLeverage(ctx context.Context, symbol currency.Pair, leverage float64) (float64, error) {
 	resp := struct {
 		Result struct {
-			Leverage convert.StringToFloat64 `json:"leverage"`
+			Leverage types.Number `json:"leverage"`
 		} `json:"result"`
 		USDCError
 	}{}
@@ -1019,8 +1019,8 @@ func (by *Bybit) GetUSDCLastFundingRate(ctx context.Context, symbol currency.Pai
 func (by *Bybit) GetUSDCPredictedFundingRate(ctx context.Context, symbol currency.Pair) (predictedFundingRate, predictedFundingFee float64, err error) {
 	resp := struct {
 		Result struct {
-			PredictedFundingRate convert.StringToFloat64 `json:"predictedFundingRate"`
-			PredictedFundingFee  convert.StringToFloat64 `json:"predictedFundingFee"`
+			PredictedFundingRate types.Number `json:"predictedFundingRate"`
+			PredictedFundingFee  types.Number `json:"predictedFundingFee"`
 		} `json:"result"`
 		USDCError
 	}{}

--- a/exchanges/bybit/futures_type.go
+++ b/exchanges/bybit/futures_type.go
@@ -3,7 +3,7 @@ package bybit
 import (
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 var (
@@ -19,10 +19,10 @@ var (
 
 // OrderbookData stores ob data for cmargined futures
 type OrderbookData struct {
-	Symbol string                  `json:"symbol"`
-	Price  convert.StringToFloat64 `json:"price"`
-	Size   float64                 `json:"size"`
-	Side   string                  `json:"side"`
+	Symbol string       `json:"symbol"`
+	Price  types.Number `json:"price"`
+	Size   float64      `json:"size"`
+	Side   string       `json:"side"`
 }
 
 // FuturesCandleStick holds kline data
@@ -41,46 +41,46 @@ type FuturesCandleStick struct {
 
 // FuturesCandleStickWithStringParam holds kline data
 type FuturesCandleStickWithStringParam struct {
-	ID       int64                   `json:"id"`
-	Symbol   string                  `json:"symbol"`
-	Interval string                  `json:"interval"`
-	OpenTime int64                   `json:"open_time"`
-	Open     convert.StringToFloat64 `json:"open"`
-	High     convert.StringToFloat64 `json:"high"`
-	Low      convert.StringToFloat64 `json:"low"`
-	Close    convert.StringToFloat64 `json:"close"`
-	Volume   convert.StringToFloat64 `json:"volume"`
-	TurnOver convert.StringToFloat64 `json:"turnover"`
+	ID       int64        `json:"id"`
+	Symbol   string       `json:"symbol"`
+	Interval string       `json:"interval"`
+	OpenTime int64        `json:"open_time"`
+	Open     types.Number `json:"open"`
+	High     types.Number `json:"high"`
+	Low      types.Number `json:"low"`
+	Close    types.Number `json:"close"`
+	Volume   types.Number `json:"volume"`
+	TurnOver types.Number `json:"turnover"`
 }
 
 // SymbolPriceTicker stores ticker price stats
 type SymbolPriceTicker struct {
-	Symbol                 string                  `json:"symbol"`
-	BidPrice               convert.StringToFloat64 `json:"bid_price"`
-	AskPrice               convert.StringToFloat64 `json:"ask_price"`
-	LastPrice              convert.StringToFloat64 `json:"last_price"`
-	LastTickDirection      string                  `json:"last_tick_direction"`
-	Price24hAgo            convert.StringToFloat64 `json:"prev_price_24h"`
-	PricePcntChange24h     convert.StringToFloat64 `json:"price_24h_pcnt"`
-	HighPrice24h           convert.StringToFloat64 `json:"high_price_24h"`
-	LowPrice24h            convert.StringToFloat64 `json:"low_price_24h"`
-	Price1hAgo             convert.StringToFloat64 `json:"prev_price_1h"`
-	PricePcntChange1h      convert.StringToFloat64 `json:"price_1h_pcnt"`
-	MarkPrice              convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice             convert.StringToFloat64 `json:"index_price"`
-	OpenInterest           float64                 `json:"open_interest"`
-	OpenValue              convert.StringToFloat64 `json:"open_value"`
-	TotalTurnover          convert.StringToFloat64 `json:"total_turnover"`
-	Turnover24h            convert.StringToFloat64 `json:"turnover_24h"`
-	TotalVolume            float64                 `json:"total_volume"`
-	Volume24h              float64                 `json:"volume_24h"`
-	FundingRate            convert.StringToFloat64 `json:"funding_rate"`
-	PredictedFundingRate   convert.StringToFloat64 `json:"predicted_funding_rate"`
-	NextFundingTime        string                  `json:"next_funding_time"`
-	CountdownHour          int64                   `json:"countdown_hour"`
-	DeliveryFeeRate        convert.StringToFloat64 `json:"delivery_fee_rate"`
-	PredictedDeliveryPrice convert.StringToFloat64 `json:"predicted_delivery_price"`
-	DeliveryTime           string                  `json:"delivery_time"`
+	Symbol                 string       `json:"symbol"`
+	BidPrice               types.Number `json:"bid_price"`
+	AskPrice               types.Number `json:"ask_price"`
+	LastPrice              types.Number `json:"last_price"`
+	LastTickDirection      string       `json:"last_tick_direction"`
+	Price24hAgo            types.Number `json:"prev_price_24h"`
+	PricePcntChange24h     types.Number `json:"price_24h_pcnt"`
+	HighPrice24h           types.Number `json:"high_price_24h"`
+	LowPrice24h            types.Number `json:"low_price_24h"`
+	Price1hAgo             types.Number `json:"prev_price_1h"`
+	PricePcntChange1h      types.Number `json:"price_1h_pcnt"`
+	MarkPrice              types.Number `json:"mark_price"`
+	IndexPrice             types.Number `json:"index_price"`
+	OpenInterest           float64      `json:"open_interest"`
+	OpenValue              types.Number `json:"open_value"`
+	TotalTurnover          types.Number `json:"total_turnover"`
+	Turnover24h            types.Number `json:"turnover_24h"`
+	TotalVolume            float64      `json:"total_volume"`
+	Volume24h              float64      `json:"volume_24h"`
+	FundingRate            types.Number `json:"funding_rate"`
+	PredictedFundingRate   types.Number `json:"predicted_funding_rate"`
+	NextFundingTime        string       `json:"next_funding_time"`
+	CountdownHour          int64        `json:"countdown_hour"`
+	DeliveryFeeRate        types.Number `json:"delivery_fee_rate"`
+	PredictedDeliveryPrice types.Number `json:"predicted_delivery_price"`
+	DeliveryTime           string       `json:"delivery_time"`
 }
 
 // FuturesPublicTradesData stores recent public trades for futures
@@ -105,14 +105,14 @@ type SymbolInfo struct {
 	MakerFee           string  `json:"maker_fee"`
 	FundingFeeInterval int64   `json:"funding_interval"`
 	LeverageFilter     struct {
-		MinLeverage  float64                 `json:"min_leverage"`
-		MaxLeverage  float64                 `json:"max_leverage"`
-		LeverageStep convert.StringToFloat64 `json:"leverage_step"`
+		MinLeverage  float64      `json:"min_leverage"`
+		MaxLeverage  float64      `json:"max_leverage"`
+		LeverageStep types.Number `json:"leverage_step"`
 	} `json:"leverage_filter"`
 	PriceFilter struct {
-		MinPrice convert.StringToFloat64 `json:"min_price"`
-		MaxPrice convert.StringToFloat64 `json:"max_price"`
-		TickSize convert.StringToFloat64 `json:"tick_size"`
+		MinPrice types.Number `json:"min_price"`
+		MaxPrice types.Number `json:"max_price"`
+		TickSize types.Number `json:"tick_size"`
 	} `json:"price_filter"`
 	LotSizeFilter struct {
 		MinTradeQty float64 `json:"min_trading_qty"`
@@ -135,13 +135,13 @@ type MarkPriceKlineData struct {
 
 // IndexPriceKlineData stores index price kline data
 type IndexPriceKlineData struct {
-	Symbol   string                  `json:"symbol"`
-	Interval string                  `json:"period"`
-	StartAt  int64                   `json:"open_time"`
-	Open     convert.StringToFloat64 `json:"open"`
-	High     convert.StringToFloat64 `json:"high"`
-	Low      convert.StringToFloat64 `json:"low"`
-	Close    convert.StringToFloat64 `json:"close"`
+	Symbol   string       `json:"symbol"`
+	Interval string       `json:"period"`
+	StartAt  int64        `json:"open_time"`
+	Open     types.Number `json:"open"`
+	High     types.Number `json:"high"`
+	Low      types.Number `json:"low"`
+	Close    types.Number `json:"close"`
 }
 
 // OpenInterestData stores open interest data
@@ -246,35 +246,35 @@ type FuturesRealtimeOrderData struct {
 // FuturesActiveRealtimeOrder stores future active realtime order
 type FuturesActiveRealtimeOrder struct {
 	FuturesRealtimeOrderData
-	ExtensionField     map[string]interface{}  `json:"ext_fields"`
-	LastExecutionTime  string                  `json:"last_exec_time"`
-	LastExecutionPrice float64                 `json:"last_exec_price"`
-	LeavesQty          float64                 `json:"leaves_qty"`
-	LeaveValue         convert.StringToFloat64 `json:"leaves_value"`
-	CumulativeQty      convert.StringToFloat64 `json:"cum_exec_qty"`
-	CumulativeValue    convert.StringToFloat64 `json:"cum_exec_value"`
-	CumulativeFee      convert.StringToFloat64 `json:"cum_exec_fee"`
-	RejectReason       string                  `json:"reject_reason"`
-	CancelType         string                  `json:"cancel_type"`
-	CreatedAt          time.Time               `json:"create_at"`
-	UpdatedAt          time.Time               `json:"updated_at"`
-	OrderID            string                  `json:"order_id"`
+	ExtensionField     map[string]interface{} `json:"ext_fields"`
+	LastExecutionTime  string                 `json:"last_exec_time"`
+	LastExecutionPrice float64                `json:"last_exec_price"`
+	LeavesQty          float64                `json:"leaves_qty"`
+	LeaveValue         types.Number           `json:"leaves_value"`
+	CumulativeQty      types.Number           `json:"cum_exec_qty"`
+	CumulativeValue    types.Number           `json:"cum_exec_value"`
+	CumulativeFee      types.Number           `json:"cum_exec_fee"`
+	RejectReason       string                 `json:"reject_reason"`
+	CancelType         string                 `json:"cancel_type"`
+	CreatedAt          time.Time              `json:"create_at"`
+	UpdatedAt          time.Time              `json:"updated_at"`
+	OrderID            string                 `json:"order_id"`
 }
 
 // CoinFuturesConditionalRealtimeOrder stores CMF future coinditional realtime order
 type CoinFuturesConditionalRealtimeOrder struct {
 	FuturesRealtimeOrderData
-	ExtensionField  map[string]interface{}  `json:"ext_fields"`
-	LeavesQty       float64                 `json:"leaves_qty"`
-	LeaveValue      convert.StringToFloat64 `json:"leaves_value"`
-	CumulativeQty   convert.StringToFloat64 `json:"cum_exec_qty"`
-	CumulativeValue convert.StringToFloat64 `json:"cum_exec_value"`
-	CumulativeFee   convert.StringToFloat64 `json:"cum_exec_fee"`
-	RejectReason    string                  `json:"reject_reason"`
-	CancelType      string                  `json:"cancel_type"`
-	CreatedAt       string                  `json:"create_at"`
-	UpdatedAt       string                  `json:"updated_at"`
-	OrderID         string                  `json:"order_id"`
+	ExtensionField  map[string]interface{} `json:"ext_fields"`
+	LeavesQty       float64                `json:"leaves_qty"`
+	LeaveValue      types.Number           `json:"leaves_value"`
+	CumulativeQty   types.Number           `json:"cum_exec_qty"`
+	CumulativeValue types.Number           `json:"cum_exec_value"`
+	CumulativeFee   types.Number           `json:"cum_exec_fee"`
+	RejectReason    string                 `json:"reject_reason"`
+	CancelType      string                 `json:"cancel_type"`
+	CreatedAt       string                 `json:"create_at"`
+	UpdatedAt       string                 `json:"updated_at"`
+	OrderID         string                 `json:"order_id"`
 }
 
 // FuturesConditionalRealtimeOrder stores future conditional realtime order
@@ -379,10 +379,10 @@ type FuturesCancelOrderData struct {
 // FuturesCancelOrderResp stores future cancel order response
 type FuturesCancelOrderResp struct {
 	FuturesCancelOrderData
-	StopOrderType     string                  `json:"stop_order_type"`
-	TriggerBy         string                  `json:"trigger_by"`
-	BasePrice         convert.StringToFloat64 `json:"base_price"`
-	ExpectedDirection string                  `json:"expected_direction"`
+	StopOrderType     string       `json:"stop_order_type"`
+	TriggerBy         string       `json:"trigger_by"`
+	BasePrice         types.Number `json:"base_price"`
+	ExpectedDirection string       `json:"expected_direction"`
 }
 
 // RiskInfo stores risk information
@@ -401,23 +401,23 @@ type RiskInfo struct {
 
 // RiskInfoWithStringParam stores risk information where string params
 type RiskInfoWithStringParam struct {
-	ID             int64                   `json:"id"`
-	Symbol         string                  `json:"symbol"`
-	Limit          int64                   `json:"limit"`
-	MaintainMargin convert.StringToFloat64 `json:"maintain_margin"`
-	StartingMargin convert.StringToFloat64 `json:"starting_margin"`
-	Section        []string                `json:"section"`
-	IsLowestRisk   int64                   `json:"is_lowest_risk"`
-	CreatedAt      string                  `json:"create_at"`
-	UpdateAt       string                  `json:"updated_at"`
-	MaxLeverage    convert.StringToFloat64 `json:"max_leverage"`
+	ID             int64        `json:"id"`
+	Symbol         string       `json:"symbol"`
+	Limit          int64        `json:"limit"`
+	MaintainMargin types.Number `json:"maintain_margin"`
+	StartingMargin types.Number `json:"starting_margin"`
+	Section        []string     `json:"section"`
+	IsLowestRisk   int64        `json:"is_lowest_risk"`
+	CreatedAt      string       `json:"create_at"`
+	UpdateAt       string       `json:"updated_at"`
+	MaxLeverage    types.Number `json:"max_leverage"`
 }
 
 // FundingInfo stores funding information
 type FundingInfo struct {
-	Symbol               string                  `json:"symbol"`
-	FundingRate          convert.StringToFloat64 `json:"funding_rate"`
-	FundingRateTimestamp int64                   `json:"funding_rate_timestamp"`
+	Symbol               string       `json:"symbol"`
+	FundingRate          types.Number `json:"funding_rate"`
+	FundingRateTimestamp int64        `json:"funding_rate_timestamp"`
 }
 
 // USDTFundingInfo stores USDT funding information
@@ -455,19 +455,19 @@ type Position struct {
 
 // PositionWithStringParam stores position with string params
 type PositionWithStringParam struct {
-	UserID                 int64                   `json:"user_id"`
-	Symbol                 string                  `json:"symbol"`
-	Side                   string                  `json:"side"`
-	Size                   float64                 `json:"size"`
-	PositionValue          convert.StringToFloat64 `json:"position_value"`
-	EntryPrice             convert.StringToFloat64 `json:"entry_price"`
-	LiquidationPrice       convert.StringToFloat64 `json:"liq_price"`
-	BankruptcyPrice        convert.StringToFloat64 `json:"bust_price"`
-	Leverage               convert.StringToFloat64 `json:"leverage"`
-	PositionMargin         convert.StringToFloat64 `json:"position_margin"`
-	OccupiedClosingFee     convert.StringToFloat64 `json:"occ_closing_fee"`
-	RealisedPNL            convert.StringToFloat64 `json:"realised_pnl"`
-	AccumulatedRealisedPNL convert.StringToFloat64 `json:"cum_realised_pnl"`
+	UserID                 int64        `json:"user_id"`
+	Symbol                 string       `json:"symbol"`
+	Side                   string       `json:"side"`
+	Size                   float64      `json:"size"`
+	PositionValue          types.Number `json:"position_value"`
+	EntryPrice             types.Number `json:"entry_price"`
+	LiquidationPrice       types.Number `json:"liq_price"`
+	BankruptcyPrice        types.Number `json:"bust_price"`
+	Leverage               types.Number `json:"leverage"`
+	PositionMargin         types.Number `json:"position_margin"`
+	OccupiedClosingFee     types.Number `json:"occ_closing_fee"`
+	RealisedPNL            types.Number `json:"realised_pnl"`
+	AccumulatedRealisedPNL types.Number `json:"cum_realised_pnl"`
 }
 
 // PositionData stores position data
@@ -486,54 +486,54 @@ type PositionData struct {
 // PositionDataWithStringParam stores position data with string params
 type PositionDataWithStringParam struct {
 	PositionWithStringParam
-	IsIsolated          bool                    `json:"is_isolated"`
-	AutoAddMargin       int64                   `json:"auto_add_margin"`
-	UnrealisedPNL       float64                 `json:"unrealised_pnl"`
-	DeleverageIndicator int64                   `json:"deleverage_indicator"`
-	RiskID              int64                   `json:"risk_id"`
-	TakeProfit          convert.StringToFloat64 `json:"take_profit"`
-	StopLoss            convert.StringToFloat64 `json:"stop_loss"`
-	TrailingStop        convert.StringToFloat64 `json:"trailing_stop"`
+	IsIsolated          bool         `json:"is_isolated"`
+	AutoAddMargin       int64        `json:"auto_add_margin"`
+	UnrealisedPNL       float64      `json:"unrealised_pnl"`
+	DeleverageIndicator int64        `json:"deleverage_indicator"`
+	RiskID              int64        `json:"risk_id"`
+	TakeProfit          types.Number `json:"take_profit"`
+	StopLoss            types.Number `json:"stop_loss"`
+	TrailingStop        types.Number `json:"trailing_stop"`
 }
 
 // PositionResp stores position response
 type PositionResp struct {
 	PositionDataWithStringParam
-	PositionID             int64                   `json:"position_idx"`
-	Mode                   int64                   `json:"mode"`
-	ID                     int64                   `json:"id"`
-	EffectiveLeverage      convert.StringToFloat64 `json:"effective_leverage"`
-	OccupiedFundingFee     convert.StringToFloat64 `json:"occ_funding_fee"`
-	PositionStatus         string                  `json:"position_status"`
-	CalculatedData         string                  `json:"oc_calc_data"`
-	OrderMargin            convert.StringToFloat64 `json:"order_margin"`
-	WalletBalance          convert.StringToFloat64 `json:"wallet_balance"`
-	CrossSequence          int64                   `json:"cross_seq"`
-	PositionSequence       int64                   `json:"position_seq"`
-	TakeProfitStopLossMode string                  `json:"tp_sl_mode"`
-	CreatedAt              string                  `json:"created_at"`
-	UpdateAt               string                  `json:"updated_at"`
+	PositionID             int64        `json:"position_idx"`
+	Mode                   int64        `json:"mode"`
+	ID                     int64        `json:"id"`
+	EffectiveLeverage      types.Number `json:"effective_leverage"`
+	OccupiedFundingFee     types.Number `json:"occ_funding_fee"`
+	PositionStatus         string       `json:"position_status"`
+	CalculatedData         string       `json:"oc_calc_data"`
+	OrderMargin            types.Number `json:"order_margin"`
+	WalletBalance          types.Number `json:"wallet_balance"`
+	CrossSequence          int64        `json:"cross_seq"`
+	PositionSequence       int64        `json:"position_seq"`
+	TakeProfitStopLossMode string       `json:"tp_sl_mode"`
+	CreatedAt              string       `json:"created_at"`
+	UpdateAt               string       `json:"updated_at"`
 }
 
 // SetTradingAndStopResp stores set trading and stop response
 type SetTradingAndStopResp struct {
 	PositionData
-	ID                  int64                   `json:"id"`
-	RiskID              int64                   `json:"risk_id"`
-	AutoAddMargin       int64                   `json:"auto_add_margin"`
-	OccupiedFundingFee  convert.StringToFloat64 `json:"occ_funding_fee"`
-	TakeProfit          convert.StringToFloat64 `json:"take_profit"`
-	StopLoss            convert.StringToFloat64 `json:"stop_loss"`
-	PositionStatus      string                  `json:"position_status"`
-	DeleverageIndicator int64                   `json:"deleverage_indicator"`
-	CalculatedData      string                  `json:"oc_calc_data"`
-	OrderMargin         convert.StringToFloat64 `json:"order_margin"`
-	WalletBalance       convert.StringToFloat64 `json:"wallet_balance"`
-	CrossSequence       int64                   `json:"cross_seq"`
-	PositionSequence    int64                   `json:"position_seq"`
-	CreatedAt           string                  `json:"created_at"`
-	UpdateAt            string                  `json:"updated_at"`
-	ExtensionField      map[string]interface{}  `json:"ext_fields"`
+	ID                  int64                  `json:"id"`
+	RiskID              int64                  `json:"risk_id"`
+	AutoAddMargin       int64                  `json:"auto_add_margin"`
+	OccupiedFundingFee  types.Number           `json:"occ_funding_fee"`
+	TakeProfit          types.Number           `json:"take_profit"`
+	StopLoss            types.Number           `json:"stop_loss"`
+	PositionStatus      string                 `json:"position_status"`
+	DeleverageIndicator int64                  `json:"deleverage_indicator"`
+	CalculatedData      string                 `json:"oc_calc_data"`
+	OrderMargin         types.Number           `json:"order_margin"`
+	WalletBalance       types.Number           `json:"wallet_balance"`
+	CrossSequence       int64                  `json:"cross_seq"`
+	PositionSequence    int64                  `json:"position_seq"`
+	CreatedAt           string                 `json:"created_at"`
+	UpdateAt            string                 `json:"updated_at"`
+	ExtensionField      map[string]interface{} `json:"ext_fields"`
 }
 
 // USDTPositionResp stores USDT position response
@@ -551,24 +551,24 @@ type UpdateMarginResp struct {
 
 // TradeData stores trade data
 type TradeData struct {
-	OrderID        string                  `json:"order_id"`
-	OrderLinkedID  string                  `json:"order_link_id"`
-	OrderSide      string                  `json:"side"`
-	Symbol         string                  `json:"symbol"`
-	ExecutionID    string                  `json:"exec_id"`
-	OrderPrice     float64                 `json:"order_price"`
-	OrderQty       float64                 `json:"order_qty"`
-	OrderType      string                  `json:"order_type"`
-	FeeRate        float64                 `json:"fee_rate"`
-	ExecutionFee   convert.StringToFloat64 `json:"exec_fee"`
-	ExecutionPrice convert.StringToFloat64 `json:"exec_price"`
-	ExecutionQty   float64                 `json:"exec_qty"`
-	ExecutionType  string                  `json:"exec_type"`
-	ExecutionValue convert.StringToFloat64 `json:"exec_value"`
-	LeavesQty      float64                 `json:"leaves_qty"`
-	ClosedSize     float64                 `json:"closed_size"`
-	LastLiquidity  string                  `json:"last_liquidity_ind"`
-	TradeTimeMs    int64                   `json:"trade_time_ms"`
+	OrderID        string       `json:"order_id"`
+	OrderLinkedID  string       `json:"order_link_id"`
+	OrderSide      string       `json:"side"`
+	Symbol         string       `json:"symbol"`
+	ExecutionID    string       `json:"exec_id"`
+	OrderPrice     float64      `json:"order_price"`
+	OrderQty       float64      `json:"order_qty"`
+	OrderType      string       `json:"order_type"`
+	FeeRate        float64      `json:"fee_rate"`
+	ExecutionFee   types.Number `json:"exec_fee"`
+	ExecutionPrice types.Number `json:"exec_price"`
+	ExecutionQty   float64      `json:"exec_qty"`
+	ExecutionType  string       `json:"exec_type"`
+	ExecutionValue types.Number `json:"exec_value"`
+	LeavesQty      float64      `json:"leaves_qty"`
+	ClosedSize     float64      `json:"closed_size"`
+	LastLiquidity  string       `json:"last_liquidity_ind"`
+	TradeTimeMs    int64        `json:"trade_time_ms"`
 }
 
 // TradeResp stores trade response
@@ -654,30 +654,30 @@ type WalletData struct {
 
 // FundRecord stores funding records
 type FundRecord struct {
-	ID            int64                   `json:"id"`
-	UserID        int64                   `json:"user_id"`
-	Coin          string                  `json:"coin"`
-	Type          string                  `json:"type"`
-	Amount        convert.StringToFloat64 `json:"amount"`
-	TxID          string                  `json:"tx_id"`
-	Address       string                  `json:"address"`
-	WalletBalance convert.StringToFloat64 `json:"wallet_balance"`
-	ExecutionTime string                  `json:"exec_time"`
-	CrossSequence int64                   `json:"cross_seq"`
+	ID            int64        `json:"id"`
+	UserID        int64        `json:"user_id"`
+	Coin          string       `json:"coin"`
+	Type          string       `json:"type"`
+	Amount        types.Number `json:"amount"`
+	TxID          string       `json:"tx_id"`
+	Address       string       `json:"address"`
+	WalletBalance types.Number `json:"wallet_balance"`
+	ExecutionTime string       `json:"exec_time"`
+	CrossSequence int64        `json:"cross_seq"`
 }
 
 // FundWithdrawalRecord stores funding withdrawal records
 type FundWithdrawalRecord struct {
-	ID          int64                   `json:"id"`
-	UserID      int64                   `json:"user_id"`
-	Coin        string                  `json:"coin"`
-	Status      string                  `json:"status"`
-	Amount      convert.StringToFloat64 `json:"amount"`
-	Fee         float64                 `json:"fee"`
-	Address     string                  `json:"address"`
-	TxID        string                  `json:"tx_id"`
-	SubmittedAt time.Time               `json:"submited_at"`
-	UpdatedAt   time.Time               `json:"updated_at"`
+	ID          int64        `json:"id"`
+	UserID      int64        `json:"user_id"`
+	Coin        string       `json:"coin"`
+	Status      string       `json:"status"`
+	Amount      types.Number `json:"amount"`
+	Fee         float64      `json:"fee"`
+	Address     string       `json:"address"`
+	TxID        string       `json:"tx_id"`
+	SubmittedAt time.Time    `json:"submited_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
 }
 
 // AssetExchangeRecord stores asset exchange records
@@ -694,79 +694,79 @@ type AssetExchangeRecord struct {
 
 // USDCOrderbookData stores orderbook data for USDCMarginedFutures
 type USDCOrderbookData struct {
-	Price convert.StringToFloat64 `json:"price"`
-	Size  convert.StringToFloat64 `json:"size"`
-	Side  string                  `json:"side"`
+	Price types.Number `json:"price"`
+	Size  types.Number `json:"size"`
+	Side  string       `json:"side"`
 }
 
 // USDCContract stores contract data
 type USDCContract struct {
-	Symbol        string                  `json:"symbol"`
-	Status        string                  `json:"status"`
-	BaseCoin      string                  `json:"baseCoin"`
-	QuoteCoin     string                  `json:"quoteCoin"`
-	TakerFeeRate  convert.StringToFloat64 `json:"takerFeeRate"`
-	MakerFeeRate  convert.StringToFloat64 `json:"makerFeeRate"`
-	MinLeverage   convert.StringToFloat64 `json:"minLeverage"`
-	MaxLeverage   convert.StringToFloat64 `json:"maxLeverage"`
-	LeverageStep  convert.StringToFloat64 `json:"leverageStep"`
-	MinPrice      convert.StringToFloat64 `json:"minPrice"`
-	MaxPrice      convert.StringToFloat64 `json:"maxPrice"`
-	TickSize      convert.StringToFloat64 `json:"tickSize"`
-	MaxTradingQty convert.StringToFloat64 `json:"maxTradingQty"`
-	MinTradingQty convert.StringToFloat64 `json:"minTradingQty"`
-	QtyStep       convert.StringToFloat64 `json:"qtyStep"`
-	DeliveryTime  bybitTimeMilliSecStr    `json:"deliveryTime"`
+	Symbol        string               `json:"symbol"`
+	Status        string               `json:"status"`
+	BaseCoin      string               `json:"baseCoin"`
+	QuoteCoin     string               `json:"quoteCoin"`
+	TakerFeeRate  types.Number         `json:"takerFeeRate"`
+	MakerFeeRate  types.Number         `json:"makerFeeRate"`
+	MinLeverage   types.Number         `json:"minLeverage"`
+	MaxLeverage   types.Number         `json:"maxLeverage"`
+	LeverageStep  types.Number         `json:"leverageStep"`
+	MinPrice      types.Number         `json:"minPrice"`
+	MaxPrice      types.Number         `json:"maxPrice"`
+	TickSize      types.Number         `json:"tickSize"`
+	MaxTradingQty types.Number         `json:"maxTradingQty"`
+	MinTradingQty types.Number         `json:"minTradingQty"`
+	QtyStep       types.Number         `json:"qtyStep"`
+	DeliveryTime  bybitTimeMilliSecStr `json:"deliveryTime"`
 }
 
 // USDCSymbol stores symbol data
 type USDCSymbol struct {
-	Symbol               string                  `json:"symbol"`
-	NextFundingTime      string                  `json:"nextFundingTime"`
-	Bid                  convert.StringToFloat64 `json:"bid"`
-	BidSize              convert.StringToFloat64 `json:"bidSize"`
-	Ask                  convert.StringToFloat64 `json:"ask"`
-	AskSize              convert.StringToFloat64 `json:"askSize"`
-	LastPrice            convert.StringToFloat64 `json:"lastPrice"`
-	OpenInterest         convert.StringToFloat64 `json:"openInterest"`
-	IndexPrice           convert.StringToFloat64 `json:"indexPrice"`
-	MarkPrice            convert.StringToFloat64 `json:"markPrice"`
-	Change24h            convert.StringToFloat64 `json:"change24h"`
-	High24h              convert.StringToFloat64 `json:"high24h"`
-	Low24h               convert.StringToFloat64 `json:"low24h"`
-	Volume24h            convert.StringToFloat64 `json:"volume24h"`
-	Turnover24h          convert.StringToFloat64 `json:"turnover24h"`
-	TotalVolume          convert.StringToFloat64 `json:"totalVolume"`
-	TotalTurnover        convert.StringToFloat64 `json:"totalTurnover"`
-	FundingRate          convert.StringToFloat64 `json:"fundingRate"`
-	PredictedFundingRate convert.StringToFloat64 `json:"predictedFundingRate"`
-	CountdownHour        convert.StringToFloat64 `json:"countdownHour"`
-	UnderlyingPrice      string                  `json:"underlyingPrice"`
+	Symbol               string       `json:"symbol"`
+	NextFundingTime      string       `json:"nextFundingTime"`
+	Bid                  types.Number `json:"bid"`
+	BidSize              types.Number `json:"bidSize"`
+	Ask                  types.Number `json:"ask"`
+	AskSize              types.Number `json:"askSize"`
+	LastPrice            types.Number `json:"lastPrice"`
+	OpenInterest         types.Number `json:"openInterest"`
+	IndexPrice           types.Number `json:"indexPrice"`
+	MarkPrice            types.Number `json:"markPrice"`
+	Change24h            types.Number `json:"change24h"`
+	High24h              types.Number `json:"high24h"`
+	Low24h               types.Number `json:"low24h"`
+	Volume24h            types.Number `json:"volume24h"`
+	Turnover24h          types.Number `json:"turnover24h"`
+	TotalVolume          types.Number `json:"totalVolume"`
+	TotalTurnover        types.Number `json:"totalTurnover"`
+	FundingRate          types.Number `json:"fundingRate"`
+	PredictedFundingRate types.Number `json:"predictedFundingRate"`
+	CountdownHour        types.Number `json:"countdownHour"`
+	UnderlyingPrice      string       `json:"underlyingPrice"`
 }
 
 // USDCKlineBase stores Kline Base
 type USDCKlineBase struct {
-	Symbol   string                  `json:"symbol"`
-	Period   string                  `json:"period"`
-	OpenTime bybitTimeSecStr         `json:"openTime"`
-	Open     convert.StringToFloat64 `json:"open"`
-	High     convert.StringToFloat64 `json:"high"`
-	Low      convert.StringToFloat64 `json:"low"`
-	Close    convert.StringToFloat64 `json:"close"`
+	Symbol   string          `json:"symbol"`
+	Period   string          `json:"period"`
+	OpenTime bybitTimeSecStr `json:"openTime"`
+	Open     types.Number    `json:"open"`
+	High     types.Number    `json:"high"`
+	Low      types.Number    `json:"low"`
+	Close    types.Number    `json:"close"`
 }
 
 // USDCKline stores kline data
 type USDCKline struct {
 	USDCKlineBase
-	Volume   convert.StringToFloat64 `json:"volume"`
-	Turnover convert.StringToFloat64 `json:"turnover"`
+	Volume   types.Number `json:"volume"`
+	Turnover types.Number `json:"turnover"`
 }
 
 // USDCOpenInterest stores open interest data
 type USDCOpenInterest struct {
-	Symbol       string                  `json:"symbol"`
-	Timestamp    bybitTimeMilliSecStr    `json:"timestamp"`
-	OpenInterest convert.StringToFloat64 `json:"openInterest"`
+	Symbol       string               `json:"symbol"`
+	Timestamp    bybitTimeMilliSecStr `json:"timestamp"`
+	OpenInterest types.Number         `json:"openInterest"`
 }
 
 // USDCLargeOrder stores large order data
@@ -787,191 +787,191 @@ type USDCAccountRatio struct {
 
 // USDCTrade stores trade data
 type USDCTrade struct {
-	ID         string                  `json:"id"`
-	Symbol     string                  `json:"symbol"`
-	OrderPrice convert.StringToFloat64 `json:"orderPrice"`
-	OrderQty   convert.StringToFloat64 `json:"orderQty"`
-	Side       string                  `json:"side"`
-	Timestamp  bybitTimeMilliSecStr    `json:"time"`
+	ID         string               `json:"id"`
+	Symbol     string               `json:"symbol"`
+	OrderPrice types.Number         `json:"orderPrice"`
+	OrderQty   types.Number         `json:"orderQty"`
+	Side       string               `json:"side"`
+	Timestamp  bybitTimeMilliSecStr `json:"time"`
 }
 
 // USDCCreateOrderResp stores create order response
 type USDCCreateOrderResp struct {
-	ID          string                  `json:"orderId"`
-	OrderLinkID string                  `json:"orderLinkId"`
-	Symbol      string                  `json:"symbol"`
-	OrderPrice  convert.StringToFloat64 `json:"orderPrice"`
-	OrderQty    convert.StringToFloat64 `json:"orderQty"`
-	OrderType   string                  `json:"orderType"`
-	Side        string                  `json:"side"`
+	ID          string       `json:"orderId"`
+	OrderLinkID string       `json:"orderLinkId"`
+	Symbol      string       `json:"symbol"`
+	OrderPrice  types.Number `json:"orderPrice"`
+	OrderQty    types.Number `json:"orderQty"`
+	OrderType   string       `json:"orderType"`
+	Side        string       `json:"side"`
 }
 
 // USDCOrder store order data
 type USDCOrder struct {
-	ID              string                  `json:"orderId"`
-	OrderLinkID     string                  `json:"orderLinkId"`
-	Symbol          string                  `json:"symbol"`
-	OrderType       string                  `json:"orderType"`
-	Side            string                  `json:"side"`
-	Qty             convert.StringToFloat64 `json:"qty"`
-	Price           convert.StringToFloat64 `json:"price"`
-	TimeInForce     string                  `json:"timeInForce"`
-	TotalOrderValue convert.StringToFloat64 `json:"cumExecValue"`
-	TotalFilledQty  convert.StringToFloat64 `json:"cumExecQty"`
-	TotalFee        convert.StringToFloat64 `json:"cumExecFee"`
-	InitialMargin   string                  `json:"orderIM"`
-	OrderStatus     string                  `json:"orderStatus"`
-	TakeProfit      convert.StringToFloat64 `json:"takeProfit"`
-	StopLoss        convert.StringToFloat64 `json:"stopLoss"`
-	TPTriggerBy     string                  `json:"tpTriggerBy"`
-	SLTriggerBy     string                  `json:"slTriggerBy"`
-	LastExecPrice   float64                 `json:"lastExecPrice"`
-	BasePrice       string                  `json:"basePrice"`
-	TriggerPrice    convert.StringToFloat64 `json:"triggerPrice"`
-	TriggerBy       string                  `json:"triggerBy"`
-	ReduceOnly      bool                    `json:"reduceOnly"`
-	StopOrderType   string                  `json:"stopOrderType"`
-	CloseOnTrigger  string                  `json:"closeOnTrigger"`
-	CreatedAt       bybitTimeMilliSecStr    `json:"createdAt"`
+	ID              string               `json:"orderId"`
+	OrderLinkID     string               `json:"orderLinkId"`
+	Symbol          string               `json:"symbol"`
+	OrderType       string               `json:"orderType"`
+	Side            string               `json:"side"`
+	Qty             types.Number         `json:"qty"`
+	Price           types.Number         `json:"price"`
+	TimeInForce     string               `json:"timeInForce"`
+	TotalOrderValue types.Number         `json:"cumExecValue"`
+	TotalFilledQty  types.Number         `json:"cumExecQty"`
+	TotalFee        types.Number         `json:"cumExecFee"`
+	InitialMargin   string               `json:"orderIM"`
+	OrderStatus     string               `json:"orderStatus"`
+	TakeProfit      types.Number         `json:"takeProfit"`
+	StopLoss        types.Number         `json:"stopLoss"`
+	TPTriggerBy     string               `json:"tpTriggerBy"`
+	SLTriggerBy     string               `json:"slTriggerBy"`
+	LastExecPrice   float64              `json:"lastExecPrice"`
+	BasePrice       string               `json:"basePrice"`
+	TriggerPrice    types.Number         `json:"triggerPrice"`
+	TriggerBy       string               `json:"triggerBy"`
+	ReduceOnly      bool                 `json:"reduceOnly"`
+	StopOrderType   string               `json:"stopOrderType"`
+	CloseOnTrigger  string               `json:"closeOnTrigger"`
+	CreatedAt       bybitTimeMilliSecStr `json:"createdAt"`
 }
 
 // USDCOrderHistory stores order history
 type USDCOrderHistory struct {
 	USDCOrder
-	LeavesQty   convert.StringToFloat64 `json:"leavesQty"` // Est. unfilled order qty
-	CashFlow    string                  `json:"cashFlow"`
-	RealisedPnl convert.StringToFloat64 `json:"realisedPnl"`
-	UpdatedAt   bybitTimeMilliSecStr    `json:"updatedAt"`
+	LeavesQty   types.Number         `json:"leavesQty"` // Est. unfilled order qty
+	CashFlow    string               `json:"cashFlow"`
+	RealisedPnl types.Number         `json:"realisedPnl"`
+	UpdatedAt   bybitTimeMilliSecStr `json:"updatedAt"`
 }
 
 // USDCTradeHistory stores trade history
 type USDCTradeHistory struct {
-	ID               string                  `json:"orderId"`
-	OrderLinkID      string                  `json:"orderLinkId"`
-	Symbol           string                  `json:"symbol"`
-	Side             string                  `json:"side"`
-	TradeID          string                  `json:"tradeId"`
-	ExecPrice        convert.StringToFloat64 `json:"execPrice"`
-	ExecQty          convert.StringToFloat64 `json:"execQty"`
-	ExecFee          convert.StringToFloat64 `json:"execFee"`
-	FeeRate          convert.StringToFloat64 `json:"feeRate"`
-	ExecType         string                  `json:"execType"`
-	ExecValue        convert.StringToFloat64 `json:"execValue"`
-	TradeTime        bybitTimeMilliSecStr    `json:"tradeTime"`
-	LastLiquidityInd string                  `json:"lastLiquidityInd"`
+	ID               string               `json:"orderId"`
+	OrderLinkID      string               `json:"orderLinkId"`
+	Symbol           string               `json:"symbol"`
+	Side             string               `json:"side"`
+	TradeID          string               `json:"tradeId"`
+	ExecPrice        types.Number         `json:"execPrice"`
+	ExecQty          types.Number         `json:"execQty"`
+	ExecFee          types.Number         `json:"execFee"`
+	FeeRate          types.Number         `json:"feeRate"`
+	ExecType         string               `json:"execType"`
+	ExecValue        types.Number         `json:"execValue"`
+	TradeTime        bybitTimeMilliSecStr `json:"tradeTime"`
+	LastLiquidityInd string               `json:"lastLiquidityInd"`
 }
 
 // USDCTxLog stores transaction log data
 type USDCTxLog struct {
-	TxTime        bybitTimeMilliSecStr    `json:"transactionTime"`
-	Symbol        string                  `json:"symbol"`
-	Type          string                  `json:"type"`
-	Side          string                  `json:"side"`
-	Quantity      convert.StringToFloat64 `json:"qty"`
-	Size          convert.StringToFloat64 `json:"size"`
-	TradePrice    convert.StringToFloat64 `json:"tradePrice"`
-	Funding       convert.StringToFloat64 `json:"funding"`
-	Fee           convert.StringToFloat64 `json:"fee"`
-	CashFlow      string                  `json:"cashFlow"`
-	Change        convert.StringToFloat64 `json:"change"`
-	WalletBalance convert.StringToFloat64 `json:"walletBalance"`
-	FeeRate       convert.StringToFloat64 `json:"feeRate"`
-	TradeID       string                  `json:"tradeId"`
-	OrderID       string                  `json:"orderId"`
-	OrderLinkID   string                  `json:"orderLinkId"`
-	Info          string                  `json:"info"`
+	TxTime        bybitTimeMilliSecStr `json:"transactionTime"`
+	Symbol        string               `json:"symbol"`
+	Type          string               `json:"type"`
+	Side          string               `json:"side"`
+	Quantity      types.Number         `json:"qty"`
+	Size          types.Number         `json:"size"`
+	TradePrice    types.Number         `json:"tradePrice"`
+	Funding       types.Number         `json:"funding"`
+	Fee           types.Number         `json:"fee"`
+	CashFlow      string               `json:"cashFlow"`
+	Change        types.Number         `json:"change"`
+	WalletBalance types.Number         `json:"walletBalance"`
+	FeeRate       types.Number         `json:"feeRate"`
+	TradeID       string               `json:"tradeId"`
+	OrderID       string               `json:"orderId"`
+	OrderLinkID   string               `json:"orderLinkId"`
+	Info          string               `json:"info"`
 }
 
 // USDCWalletBalance store USDC wallet balance
 type USDCWalletBalance struct {
-	Equity           convert.StringToFloat64 `json:"equity"`
-	WalletBalance    convert.StringToFloat64 `json:"walletBalance"`
-	AvailableBalance convert.StringToFloat64 `json:"availableBalance"`
-	AccountIM        convert.StringToFloat64 `json:"accountIM"`
-	AccountMM        convert.StringToFloat64 `json:"accountMM"`
-	TotalRPL         convert.StringToFloat64 `json:"totalRPL"`
-	TotalSessionUPL  convert.StringToFloat64 `json:"totalSessionUPL"`
-	TotalSessionRPL  convert.StringToFloat64 `json:"totalSessionRPL"`
+	Equity           types.Number `json:"equity"`
+	WalletBalance    types.Number `json:"walletBalance"`
+	AvailableBalance types.Number `json:"availableBalance"`
+	AccountIM        types.Number `json:"accountIM"`
+	AccountMM        types.Number `json:"accountMM"`
+	TotalRPL         types.Number `json:"totalRPL"`
+	TotalSessionUPL  types.Number `json:"totalSessionUPL"`
+	TotalSessionRPL  types.Number `json:"totalSessionRPL"`
 }
 
 // USDCAssetInfo stores USDC asset data
 type USDCAssetInfo struct {
-	BaseCoin   string                  `json:"baseCoin"`
-	TotalDelta convert.StringToFloat64 `json:"totalDelta"`
-	TotalGamma convert.StringToFloat64 `json:"totalGamma"`
-	TotalVega  convert.StringToFloat64 `json:"totalVega"`
-	TotalTheta convert.StringToFloat64 `json:"totalTheta"`
-	TotalRPL   convert.StringToFloat64 `json:"totalRPL"`
-	SessionUPL convert.StringToFloat64 `json:"sessionUPL"`
-	SessionRPL convert.StringToFloat64 `json:"sessionRPL"`
-	IM         convert.StringToFloat64 `json:"im"`
-	MM         convert.StringToFloat64 `json:"mm"`
+	BaseCoin   string       `json:"baseCoin"`
+	TotalDelta types.Number `json:"totalDelta"`
+	TotalGamma types.Number `json:"totalGamma"`
+	TotalVega  types.Number `json:"totalVega"`
+	TotalTheta types.Number `json:"totalTheta"`
+	TotalRPL   types.Number `json:"totalRPL"`
+	SessionUPL types.Number `json:"sessionUPL"`
+	SessionRPL types.Number `json:"sessionRPL"`
+	IM         types.Number `json:"im"`
+	MM         types.Number `json:"mm"`
 }
 
 // USDCPosition store USDC position data
 type USDCPosition struct {
-	Symbol              string                  `json:"symbol"`
-	Leverage            convert.StringToFloat64 `json:"leverage"`
-	ClosingFee          convert.StringToFloat64 `json:"occClosingFee"`
-	LiquidPrice         string                  `json:"liqPrice"`
-	Position            float64                 `json:"positionValue"`
-	TakeProfit          convert.StringToFloat64 `json:"takeProfit"`
-	RiskID              string                  `json:"riskId"`
-	TrailingStop        convert.StringToFloat64 `json:"trailingStop"`
-	UnrealisedPnl       convert.StringToFloat64 `json:"unrealisedPnl"`
-	MarkPrice           convert.StringToFloat64 `json:"markPrice"`
-	CumRealisedPnl      convert.StringToFloat64 `json:"cumRealisedPnl"`
-	PositionMM          convert.StringToFloat64 `json:"positionMM"`
-	PositionIM          convert.StringToFloat64 `json:"positionIM"`
-	EntryPrice          convert.StringToFloat64 `json:"entryPrice"`
-	Size                convert.StringToFloat64 `json:"size"`
-	SessionRPL          convert.StringToFloat64 `json:"sessionRPL"`
-	SessionUPL          convert.StringToFloat64 `json:"sessionUPL"`
-	StopLoss            convert.StringToFloat64 `json:"stopLoss"`
-	OrderMargin         convert.StringToFloat64 `json:"orderMargin"`
-	SessionAvgPrice     convert.StringToFloat64 `json:"sessionAvgPrice"`
-	CreatedAt           bybitTimeMilliSecStr    `json:"createdAt"`
-	UpdatedAt           bybitTimeMilliSecStr    `json:"updatedAt"`
-	TpSLMode            string                  `json:"tpSLMode"`
-	Side                string                  `json:"side"`
-	BustPrice           string                  `json:"bustPrice"`
-	PositionStatus      string                  `json:"positionStatus"`
-	DeleverageIndicator int64                   `json:"deleverageIndicator"`
+	Symbol              string               `json:"symbol"`
+	Leverage            types.Number         `json:"leverage"`
+	ClosingFee          types.Number         `json:"occClosingFee"`
+	LiquidPrice         string               `json:"liqPrice"`
+	Position            float64              `json:"positionValue"`
+	TakeProfit          types.Number         `json:"takeProfit"`
+	RiskID              string               `json:"riskId"`
+	TrailingStop        types.Number         `json:"trailingStop"`
+	UnrealisedPnl       types.Number         `json:"unrealisedPnl"`
+	MarkPrice           types.Number         `json:"markPrice"`
+	CumRealisedPnl      types.Number         `json:"cumRealisedPnl"`
+	PositionMM          types.Number         `json:"positionMM"`
+	PositionIM          types.Number         `json:"positionIM"`
+	EntryPrice          types.Number         `json:"entryPrice"`
+	Size                types.Number         `json:"size"`
+	SessionRPL          types.Number         `json:"sessionRPL"`
+	SessionUPL          types.Number         `json:"sessionUPL"`
+	StopLoss            types.Number         `json:"stopLoss"`
+	OrderMargin         types.Number         `json:"orderMargin"`
+	SessionAvgPrice     types.Number         `json:"sessionAvgPrice"`
+	CreatedAt           bybitTimeMilliSecStr `json:"createdAt"`
+	UpdatedAt           bybitTimeMilliSecStr `json:"updatedAt"`
+	TpSLMode            string               `json:"tpSLMode"`
+	Side                string               `json:"side"`
+	BustPrice           string               `json:"bustPrice"`
+	PositionStatus      string               `json:"positionStatus"`
+	DeleverageIndicator int64                `json:"deleverageIndicator"`
 }
 
 // USDCSettlementHistory store USDC settlement history data
 type USDCSettlementHistory struct {
-	Symbol          string                  `json:"symbol"`
-	Side            string                  `json:"side"`
-	Time            bybitTimeMilliSecStr    `json:"time"`
-	Size            convert.StringToFloat64 `json:"size"`
-	SessionAvgPrice convert.StringToFloat64 `json:"sessionAvgPrice"`
-	MarkPrice       convert.StringToFloat64 `json:"markPrice"`
-	SessionRpl      convert.StringToFloat64 `json:"sessionRpl"`
+	Symbol          string               `json:"symbol"`
+	Side            string               `json:"side"`
+	Time            bybitTimeMilliSecStr `json:"time"`
+	Size            types.Number         `json:"size"`
+	SessionAvgPrice types.Number         `json:"sessionAvgPrice"`
+	MarkPrice       types.Number         `json:"markPrice"`
+	SessionRpl      types.Number         `json:"sessionRpl"`
 }
 
 // USDCRiskLimit store USDC risk limit data
 type USDCRiskLimit struct {
-	RiskID         string                  `json:"riskId"`
-	Symbol         string                  `json:"symbol"`
-	Limit          string                  `json:"limit"`
-	Section        []string                `json:"section"`
-	StartingMargin convert.StringToFloat64 `json:"startingMargin"`
-	MaintainMargin convert.StringToFloat64 `json:"maintainMargin"`
-	IsLowestRisk   bool                    `json:"isLowestRisk"`
-	MaxLeverage    convert.StringToFloat64 `json:"maxLeverage"`
+	RiskID         string       `json:"riskId"`
+	Symbol         string       `json:"symbol"`
+	Limit          string       `json:"limit"`
+	Section        []string     `json:"section"`
+	StartingMargin types.Number `json:"startingMargin"`
+	MaintainMargin types.Number `json:"maintainMargin"`
+	IsLowestRisk   bool         `json:"isLowestRisk"`
+	MaxLeverage    types.Number `json:"maxLeverage"`
 }
 
 // USDCFundingInfo store USDC funding data
 type USDCFundingInfo struct {
-	Symbol string                  `json:"symbol"`
-	Time   bybitTimeMilliSecStr    `json:"fundingRateTimestamp"`
-	Rate   convert.StringToFloat64 `json:"fundingRate"`
+	Symbol string               `json:"symbol"`
+	Time   bybitTimeMilliSecStr `json:"fundingRateTimestamp"`
+	Rate   types.Number         `json:"fundingRate"`
 }
 
 // CFuturesTradingFeeRate stores trading fee rate
 type CFuturesTradingFeeRate struct {
-	TakerFeeRate convert.StringToFloat64 `json:"taker_fee_rate"`
-	MakerFeeRate convert.StringToFloat64 `json:"maker_fee_rate"`
-	UserID       int64                   `json:"user_id"`
+	TakerFeeRate types.Number `json:"taker_fee_rate"`
+	MakerFeeRate types.Number `json:"maker_fee_rate"`
+	UserID       int64        `json:"user_id"`
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -3407,7 +3407,7 @@ func TestForceFileStandard(t *testing.T) {
 		t.Error(err)
 	}
 	if t.Failed() {
-		t.Fatal("Please use convert.StringToFloat64 type instead of `float64` and remove `,string` as strings can be empty in unmarshal process. Then call the Float64() method.")
+		t.Fatal("Please use types.Number type instead of `float64` and remove `,string` as strings can be empty in unmarshal process. Then call the Float64() method.")
 	}
 }
 

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -480,14 +480,14 @@ var WithdrawalFees = map[currency.Code]float64{
 
 // CurrencyInfo represents currency details with permission.
 type CurrencyInfo struct {
-	Currency         string                  `json:"currency"`
-	Delisted         bool                    `json:"delisted"`
-	WithdrawDisabled bool                    `json:"withdraw_disabled"`
-	WithdrawDelayed  bool                    `json:"withdraw_delayed"`
-	DepositDisabled  bool                    `json:"deposit_disabled"`
-	TradeDisabled    bool                    `json:"trade_disabled"`
-	FixedFeeRate     convert.StringToFloat64 `json:"fixed_rate,omitempty"`
-	Chain            string                  `json:"chain"`
+	Currency         string       `json:"currency"`
+	Delisted         bool         `json:"delisted"`
+	WithdrawDisabled bool         `json:"withdraw_disabled"`
+	WithdrawDelayed  bool         `json:"withdraw_delayed"`
+	DepositDisabled  bool         `json:"deposit_disabled"`
+	TradeDisabled    bool         `json:"trade_disabled"`
+	FixedFeeRate     types.Number `json:"fixed_rate,omitempty"`
+	Chain            string       `json:"chain"`
 }
 
 // CurrencyPairDetail represents a single currency pair detail.
@@ -590,18 +590,18 @@ type Orderbook struct {
 
 // Trade represents market trade.
 type Trade struct {
-	ID           int64                   `json:"id,string"`
-	TradingTime  gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	OrderID      string                  `json:"order_id"`
-	Side         string                  `json:"side"`
-	Role         string                  `json:"role"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Fee          convert.StringToFloat64 `json:"fee"`
-	FeeCurrency  string                  `json:"fee_currency"`
-	PointFee     string                  `json:"point_fee"`
-	GtFee        string                  `json:"gt_fee"`
+	ID           int64        `json:"id,string"`
+	TradingTime  gateioTime   `json:"create_time"`
+	CreateTimeMs gateioTime   `json:"create_time_ms"`
+	OrderID      string       `json:"order_id"`
+	Side         string       `json:"side"`
+	Role         string       `json:"role"`
+	Amount       types.Number `json:"amount"`
+	Price        types.Number `json:"price"`
+	Fee          types.Number `json:"fee"`
+	FeeCurrency  string       `json:"fee_currency"`
+	PointFee     string       `json:"point_fee"`
+	GtFee        string       `json:"gt_fee"`
 }
 
 // Candlestick represents candlestick data point detail.
@@ -627,87 +627,87 @@ type CurrencyChain struct {
 
 // MarginCurrencyPairInfo represents margin currency pair detailed info.
 type MarginCurrencyPairInfo struct {
-	ID             string                  `json:"id"`
-	Base           string                  `json:"base"`
-	Quote          string                  `json:"quote"`
-	Leverage       float64                 `json:"leverage"`
-	MinBaseAmount  convert.StringToFloat64 `json:"min_base_amount"`
-	MinQuoteAmount convert.StringToFloat64 `json:"min_quote_amount"`
-	MaxQuoteAmount convert.StringToFloat64 `json:"max_quote_amount"`
-	Status         int32                   `json:"status"`
+	ID             string       `json:"id"`
+	Base           string       `json:"base"`
+	Quote          string       `json:"quote"`
+	Leverage       float64      `json:"leverage"`
+	MinBaseAmount  types.Number `json:"min_base_amount"`
+	MinQuoteAmount types.Number `json:"min_quote_amount"`
+	MaxQuoteAmount types.Number `json:"max_quote_amount"`
+	Status         int32        `json:"status"`
 }
 
 // OrderbookOfLendingLoan represents order book of lending loans
 type OrderbookOfLendingLoan struct {
-	Rate   convert.StringToFloat64 `json:"rate"`
-	Amount convert.StringToFloat64 `json:"amount"`
-	Days   int64                   `json:"days"`
+	Rate   types.Number `json:"rate"`
+	Amount types.Number `json:"amount"`
+	Days   int64        `json:"days"`
 }
 
 // FuturesContract represents futures contract detailed data.
 type FuturesContract struct {
-	Name                  string                  `json:"name"`
-	Type                  string                  `json:"type"`
-	QuantoMultiplier      convert.StringToFloat64 `json:"quanto_multiplier"`
-	RefDiscountRate       convert.StringToFloat64 `json:"ref_discount_rate"`
-	OrderPriceDeviate     string                  `json:"order_price_deviate"`
-	MaintenanceRate       convert.StringToFloat64 `json:"maintenance_rate"`
-	MarkType              string                  `json:"mark_type"`
-	LastPrice             convert.StringToFloat64 `json:"last_price"`
-	MarkPrice             convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice            convert.StringToFloat64 `json:"index_price"`
-	FundingRateIndicative convert.StringToFloat64 `json:"funding_rate_indicative"`
-	MarkPriceRound        convert.StringToFloat64 `json:"mark_price_round"`
-	FundingOffset         int64                   `json:"funding_offset"`
-	InDelisting           bool                    `json:"in_delisting"`
-	RiskLimitBase         string                  `json:"risk_limit_base"`
-	InterestRate          string                  `json:"interest_rate"`
-	OrderPriceRound       string                  `json:"order_price_round"`
-	OrderSizeMin          int64                   `json:"order_size_min"`
-	RefRebateRate         string                  `json:"ref_rebate_rate"`
-	FundingInterval       int64                   `json:"funding_interval"`
-	RiskLimitStep         string                  `json:"risk_limit_step"`
-	LeverageMin           convert.StringToFloat64 `json:"leverage_min"`
-	LeverageMax           convert.StringToFloat64 `json:"leverage_max"`
-	RiskLimitMax          string                  `json:"risk_limit_max"`
-	MakerFeeRate          convert.StringToFloat64 `json:"maker_fee_rate"`
-	TakerFeeRate          convert.StringToFloat64 `json:"taker_fee_rate"`
-	FundingRate           convert.StringToFloat64 `json:"funding_rate"`
-	OrderSizeMax          int64                   `json:"order_size_max"`
-	FundingNextApply      gateioTime              `json:"funding_next_apply"`
-	ConfigChangeTime      gateioTime              `json:"config_change_time"`
-	ShortUsers            int64                   `json:"short_users"`
-	TradeSize             int64                   `json:"trade_size"`
-	PositionSize          int64                   `json:"position_size"`
-	LongUsers             int64                   `json:"long_users"`
-	FundingImpactValue    string                  `json:"funding_impact_value"`
-	OrdersLimit           int64                   `json:"orders_limit"`
-	TradeID               int64                   `json:"trade_id"`
-	OrderbookID           int64                   `json:"orderbook_id"`
+	Name                  string       `json:"name"`
+	Type                  string       `json:"type"`
+	QuantoMultiplier      types.Number `json:"quanto_multiplier"`
+	RefDiscountRate       types.Number `json:"ref_discount_rate"`
+	OrderPriceDeviate     string       `json:"order_price_deviate"`
+	MaintenanceRate       types.Number `json:"maintenance_rate"`
+	MarkType              string       `json:"mark_type"`
+	LastPrice             types.Number `json:"last_price"`
+	MarkPrice             types.Number `json:"mark_price"`
+	IndexPrice            types.Number `json:"index_price"`
+	FundingRateIndicative types.Number `json:"funding_rate_indicative"`
+	MarkPriceRound        types.Number `json:"mark_price_round"`
+	FundingOffset         int64        `json:"funding_offset"`
+	InDelisting           bool         `json:"in_delisting"`
+	RiskLimitBase         string       `json:"risk_limit_base"`
+	InterestRate          string       `json:"interest_rate"`
+	OrderPriceRound       string       `json:"order_price_round"`
+	OrderSizeMin          int64        `json:"order_size_min"`
+	RefRebateRate         string       `json:"ref_rebate_rate"`
+	FundingInterval       int64        `json:"funding_interval"`
+	RiskLimitStep         string       `json:"risk_limit_step"`
+	LeverageMin           types.Number `json:"leverage_min"`
+	LeverageMax           types.Number `json:"leverage_max"`
+	RiskLimitMax          string       `json:"risk_limit_max"`
+	MakerFeeRate          types.Number `json:"maker_fee_rate"`
+	TakerFeeRate          types.Number `json:"taker_fee_rate"`
+	FundingRate           types.Number `json:"funding_rate"`
+	OrderSizeMax          int64        `json:"order_size_max"`
+	FundingNextApply      gateioTime   `json:"funding_next_apply"`
+	ConfigChangeTime      gateioTime   `json:"config_change_time"`
+	ShortUsers            int64        `json:"short_users"`
+	TradeSize             int64        `json:"trade_size"`
+	PositionSize          int64        `json:"position_size"`
+	LongUsers             int64        `json:"long_users"`
+	FundingImpactValue    string       `json:"funding_impact_value"`
+	OrdersLimit           int64        `json:"orders_limit"`
+	TradeID               int64        `json:"trade_id"`
+	OrderbookID           int64        `json:"orderbook_id"`
 }
 
 // TradingHistoryItem represents futures trading history item.
 type TradingHistoryItem struct {
-	ID         int64                   `json:"id"`
-	CreateTime gateioTime              `json:"create_time"`
-	Contract   string                  `json:"contract"`
-	Text       string                  `json:"text"`
-	Size       float64                 `json:"size"`
-	Price      convert.StringToFloat64 `json:"price"`
+	ID         int64        `json:"id"`
+	CreateTime gateioTime   `json:"create_time"`
+	Contract   string       `json:"contract"`
+	Text       string       `json:"text"`
+	Size       float64      `json:"size"`
+	Price      types.Number `json:"price"`
 	// Added for Derived market trade history datas.
-	Fee      convert.StringToFloat64 `json:"fee"`
-	PointFee convert.StringToFloat64 `json:"point_fee"`
-	Role     string                  `json:"role"`
+	Fee      types.Number `json:"fee"`
+	PointFee types.Number `json:"point_fee"`
+	Role     string       `json:"role"`
 }
 
 // FuturesCandlestick represents futures candlestick data
 type FuturesCandlestick struct {
-	Timestamp    gateioTime              `json:"t"`
-	Volume       float64                 `json:"v"`
-	ClosePrice   convert.StringToFloat64 `json:"c"`
-	HighestPrice convert.StringToFloat64 `json:"h"`
-	LowestPrice  convert.StringToFloat64 `json:"l"`
-	OpenPrice    convert.StringToFloat64 `json:"o"`
+	Timestamp    gateioTime   `json:"t"`
+	Volume       float64      `json:"v"`
+	ClosePrice   types.Number `json:"c"`
+	HighestPrice types.Number `json:"h"`
+	LowestPrice  types.Number `json:"l"`
+	OpenPrice    types.Number `json:"o"`
 
 	// Added for websocket push data
 	Name string `json:"n,omitempty"`
@@ -715,31 +715,31 @@ type FuturesCandlestick struct {
 
 // FuturesPremiumIndexKLineResponse represents premium index K-Line information.
 type FuturesPremiumIndexKLineResponse struct {
-	UnixTimestamp gateioTime              `json:"t"`
-	ClosePrice    convert.StringToFloat64 `json:"c"`
-	HighestPrice  convert.StringToFloat64 `json:"h"`
-	LowestPrice   convert.StringToFloat64 `json:"l"`
-	OpenPrice     convert.StringToFloat64 `json:"o"`
+	UnixTimestamp gateioTime   `json:"t"`
+	ClosePrice    types.Number `json:"c"`
+	HighestPrice  types.Number `json:"h"`
+	LowestPrice   types.Number `json:"l"`
+	OpenPrice     types.Number `json:"o"`
 }
 
 // FuturesTicker represents futures ticker data.
 type FuturesTicker struct {
-	Contract              string                  `json:"contract"`
-	ChangePercentage      string                  `json:"change_percentage"`
-	Last                  convert.StringToFloat64 `json:"last"`
-	Low24H                convert.StringToFloat64 `json:"low_24h"`
-	High24H               convert.StringToFloat64 `json:"high_24h"`
-	TotalSize             convert.StringToFloat64 `json:"total_size"`
-	Volume24H             convert.StringToFloat64 `json:"volume_24h"`
-	Volume24HBtc          convert.StringToFloat64 `json:"volume_24h_btc"`
-	Volume24HUsd          convert.StringToFloat64 `json:"volume_24h_usd"`
-	Volume24HBase         convert.StringToFloat64 `json:"volume_24h_base"`
-	Volume24HQuote        convert.StringToFloat64 `json:"volume_24h_quote"`
-	Volume24HSettle       convert.StringToFloat64 `json:"volume_24h_settle"`
-	MarkPrice             convert.StringToFloat64 `json:"mark_price"`
-	FundingRate           convert.StringToFloat64 `json:"funding_rate"`
-	FundingRateIndicative string                  `json:"funding_rate_indicative"`
-	IndexPrice            convert.StringToFloat64 `json:"index_price"`
+	Contract              string       `json:"contract"`
+	ChangePercentage      string       `json:"change_percentage"`
+	Last                  types.Number `json:"last"`
+	Low24H                types.Number `json:"low_24h"`
+	High24H               types.Number `json:"high_24h"`
+	TotalSize             types.Number `json:"total_size"`
+	Volume24H             types.Number `json:"volume_24h"`
+	Volume24HBtc          types.Number `json:"volume_24h_btc"`
+	Volume24HUsd          types.Number `json:"volume_24h_usd"`
+	Volume24HBase         types.Number `json:"volume_24h_base"`
+	Volume24HQuote        types.Number `json:"volume_24h_quote"`
+	Volume24HSettle       types.Number `json:"volume_24h_settle"`
+	MarkPrice             types.Number `json:"mark_price"`
+	FundingRate           types.Number `json:"funding_rate"`
+	FundingRateIndicative string       `json:"funding_rate_indicative"`
+	IndexPrice            types.Number `json:"index_price"`
 }
 
 // FuturesFundingRate represents futures funding rate response.
@@ -783,159 +783,159 @@ type IndexConstituent struct {
 
 // LiquidationHistory represents  liquidation history for a specifies settle.
 type LiquidationHistory struct {
-	Time             gateioTime              `json:"time"`
-	Contract         string                  `json:"contract"`
-	Size             int64                   `json:"size"`
-	Leverage         string                  `json:"leverage"`
-	Margin           string                  `json:"margin"`
-	EntryPrice       convert.StringToFloat64 `json:"entry_price"`
-	LiquidationPrice gateioNumericalValue    `json:"liq_price"`
-	MarkPrice        convert.StringToFloat64 `json:"mark_price"`
-	OrderID          int64                   `json:"order_id"`
-	OrderPrice       convert.StringToFloat64 `json:"order_price"`
-	FillPrice        convert.StringToFloat64 `json:"fill_price"`
-	Left             int64                   `json:"left"`
+	Time             gateioTime           `json:"time"`
+	Contract         string               `json:"contract"`
+	Size             int64                `json:"size"`
+	Leverage         string               `json:"leverage"`
+	Margin           string               `json:"margin"`
+	EntryPrice       types.Number         `json:"entry_price"`
+	LiquidationPrice gateioNumericalValue `json:"liq_price"`
+	MarkPrice        types.Number         `json:"mark_price"`
+	OrderID          int64                `json:"order_id"`
+	OrderPrice       types.Number         `json:"order_price"`
+	FillPrice        types.Number         `json:"fill_price"`
+	Left             int64                `json:"left"`
 }
 
 // DeliveryContract represents a delivery contract instance detail.
 type DeliveryContract struct {
-	Name                string                  `json:"name"`
-	Underlying          string                  `json:"underlying"`
-	Cycle               string                  `json:"cycle"`
-	Type                string                  `json:"type"`
-	QuantoMultiplier    convert.StringToFloat64 `json:"quanto_multiplier"`
-	MarkType            string                  `json:"mark_type"`
-	LastPrice           convert.StringToFloat64 `json:"last_price"`
-	MarkPrice           convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice          convert.StringToFloat64 `json:"index_price"`
-	BasisRate           convert.StringToFloat64 `json:"basis_rate"`
-	BasisValue          convert.StringToFloat64 `json:"basis_value"`
-	BasisImpactValue    convert.StringToFloat64 `json:"basis_impact_value"`
-	SettlePrice         convert.StringToFloat64 `json:"settle_price"`
-	SettlePriceInterval int64                   `json:"settle_price_interval"`
-	SettlePriceDuration int64                   `json:"settle_price_duration"`
-	SettleFeeRate       convert.StringToFloat64 `json:"settle_fee_rate"`
-	OrderPriceRound     convert.StringToFloat64 `json:"order_price_round"`
-	MarkPriceRound      convert.StringToFloat64 `json:"mark_price_round"`
-	LeverageMin         convert.StringToFloat64 `json:"leverage_min"`
-	LeverageMax         convert.StringToFloat64 `json:"leverage_max"`
-	MaintenanceRate     convert.StringToFloat64 `json:"maintenance_rate"`
-	RiskLimitBase       convert.StringToFloat64 `json:"risk_limit_base"`
-	RiskLimitStep       convert.StringToFloat64 `json:"risk_limit_step"`
-	RiskLimitMax        convert.StringToFloat64 `json:"risk_limit_max"`
-	MakerFeeRate        convert.StringToFloat64 `json:"maker_fee_rate"`
-	TakerFeeRate        convert.StringToFloat64 `json:"taker_fee_rate"`
-	RefDiscountRate     convert.StringToFloat64 `json:"ref_discount_rate"`
-	RefRebateRate       convert.StringToFloat64 `json:"ref_rebate_rate"`
-	OrderPriceDeviate   convert.StringToFloat64 `json:"order_price_deviate"`
-	OrderSizeMin        int64                   `json:"order_size_min"`
-	OrderSizeMax        int64                   `json:"order_size_max"`
-	OrdersLimit         int64                   `json:"orders_limit"`
-	OrderbookID         int64                   `json:"orderbook_id"`
-	TradeID             int64                   `json:"trade_id"`
-	TradeSize           int64                   `json:"trade_size"`
-	PositionSize        int64                   `json:"position_size"`
-	ExpireTime          gateioTime              `json:"expire_time"`
-	ConfigChangeTime    gateioTime              `json:"config_change_time"`
-	InDelisting         bool                    `json:"in_delisting"`
+	Name                string       `json:"name"`
+	Underlying          string       `json:"underlying"`
+	Cycle               string       `json:"cycle"`
+	Type                string       `json:"type"`
+	QuantoMultiplier    types.Number `json:"quanto_multiplier"`
+	MarkType            string       `json:"mark_type"`
+	LastPrice           types.Number `json:"last_price"`
+	MarkPrice           types.Number `json:"mark_price"`
+	IndexPrice          types.Number `json:"index_price"`
+	BasisRate           types.Number `json:"basis_rate"`
+	BasisValue          types.Number `json:"basis_value"`
+	BasisImpactValue    types.Number `json:"basis_impact_value"`
+	SettlePrice         types.Number `json:"settle_price"`
+	SettlePriceInterval int64        `json:"settle_price_interval"`
+	SettlePriceDuration int64        `json:"settle_price_duration"`
+	SettleFeeRate       types.Number `json:"settle_fee_rate"`
+	OrderPriceRound     types.Number `json:"order_price_round"`
+	MarkPriceRound      types.Number `json:"mark_price_round"`
+	LeverageMin         types.Number `json:"leverage_min"`
+	LeverageMax         types.Number `json:"leverage_max"`
+	MaintenanceRate     types.Number `json:"maintenance_rate"`
+	RiskLimitBase       types.Number `json:"risk_limit_base"`
+	RiskLimitStep       types.Number `json:"risk_limit_step"`
+	RiskLimitMax        types.Number `json:"risk_limit_max"`
+	MakerFeeRate        types.Number `json:"maker_fee_rate"`
+	TakerFeeRate        types.Number `json:"taker_fee_rate"`
+	RefDiscountRate     types.Number `json:"ref_discount_rate"`
+	RefRebateRate       types.Number `json:"ref_rebate_rate"`
+	OrderPriceDeviate   types.Number `json:"order_price_deviate"`
+	OrderSizeMin        int64        `json:"order_size_min"`
+	OrderSizeMax        int64        `json:"order_size_max"`
+	OrdersLimit         int64        `json:"orders_limit"`
+	OrderbookID         int64        `json:"orderbook_id"`
+	TradeID             int64        `json:"trade_id"`
+	TradeSize           int64        `json:"trade_size"`
+	PositionSize        int64        `json:"position_size"`
+	ExpireTime          gateioTime   `json:"expire_time"`
+	ConfigChangeTime    gateioTime   `json:"config_change_time"`
+	InDelisting         bool         `json:"in_delisting"`
 }
 
 // DeliveryTradingHistory represents futures trading history
 type DeliveryTradingHistory struct {
-	ID         int64                   `json:"id"`
-	CreateTime gateioTime              `json:"create_time"`
-	Contract   string                  `json:"contract"`
-	Size       float64                 `json:"size"`
-	Price      convert.StringToFloat64 `json:"price"`
+	ID         int64        `json:"id"`
+	CreateTime gateioTime   `json:"create_time"`
+	Contract   string       `json:"contract"`
+	Size       float64      `json:"size"`
+	Price      types.Number `json:"price"`
 }
 
 // OptionUnderlying represents option underlying and it's index price.
 type OptionUnderlying struct {
-	Name       string                  `json:"name"`
-	IndexPrice convert.StringToFloat64 `json:"index_price"`
-	IndexTime  gateioTime              `json:"index_time"`
+	Name       string       `json:"name"`
+	IndexPrice types.Number `json:"index_price"`
+	IndexTime  gateioTime   `json:"index_time"`
 }
 
 // OptionContract represents an option contract detail.
 type OptionContract struct {
-	Name              string                  `json:"name"`
-	Tag               string                  `json:"tag"`
-	IsCall            bool                    `json:"is_call"`
-	StrikePrice       convert.StringToFloat64 `json:"strike_price"`
-	LastPrice         convert.StringToFloat64 `json:"last_price"`
-	MarkPrice         convert.StringToFloat64 `json:"mark_price"`
-	OrderbookID       int64                   `json:"orderbook_id"`
-	TradeID           int64                   `json:"trade_id"`
-	TradeSize         int64                   `json:"trade_size"`
-	PositionSize      int64                   `json:"position_size"`
-	Underlying        string                  `json:"underlying"`
-	UnderlyingPrice   convert.StringToFloat64 `json:"underlying_price"`
-	Multiplier        string                  `json:"multiplier"`
-	OrderPriceRound   string                  `json:"order_price_round"`
-	MarkPriceRound    string                  `json:"mark_price_round"`
-	MakerFeeRate      string                  `json:"maker_fee_rate"`
-	TakerFeeRate      string                  `json:"taker_fee_rate"`
-	PriceLimitFeeRate string                  `json:"price_limit_fee_rate"`
-	RefDiscountRate   string                  `json:"ref_discount_rate"`
-	RefRebateRate     string                  `json:"ref_rebate_rate"`
-	OrderPriceDeviate string                  `json:"order_price_deviate"`
-	OrderSizeMin      int64                   `json:"order_size_min"`
-	OrderSizeMax      int64                   `json:"order_size_max"`
-	OrdersLimit       int64                   `json:"orders_limit"`
-	CreateTime        gateioTime              `json:"create_time"`
-	ExpirationTime    gateioTime              `json:"expiration_time"`
+	Name              string       `json:"name"`
+	Tag               string       `json:"tag"`
+	IsCall            bool         `json:"is_call"`
+	StrikePrice       types.Number `json:"strike_price"`
+	LastPrice         types.Number `json:"last_price"`
+	MarkPrice         types.Number `json:"mark_price"`
+	OrderbookID       int64        `json:"orderbook_id"`
+	TradeID           int64        `json:"trade_id"`
+	TradeSize         int64        `json:"trade_size"`
+	PositionSize      int64        `json:"position_size"`
+	Underlying        string       `json:"underlying"`
+	UnderlyingPrice   types.Number `json:"underlying_price"`
+	Multiplier        string       `json:"multiplier"`
+	OrderPriceRound   string       `json:"order_price_round"`
+	MarkPriceRound    string       `json:"mark_price_round"`
+	MakerFeeRate      string       `json:"maker_fee_rate"`
+	TakerFeeRate      string       `json:"taker_fee_rate"`
+	PriceLimitFeeRate string       `json:"price_limit_fee_rate"`
+	RefDiscountRate   string       `json:"ref_discount_rate"`
+	RefRebateRate     string       `json:"ref_rebate_rate"`
+	OrderPriceDeviate string       `json:"order_price_deviate"`
+	OrderSizeMin      int64        `json:"order_size_min"`
+	OrderSizeMax      int64        `json:"order_size_max"`
+	OrdersLimit       int64        `json:"orders_limit"`
+	CreateTime        gateioTime   `json:"create_time"`
+	ExpirationTime    gateioTime   `json:"expiration_time"`
 }
 
 // OptionSettlement list settlement history
 type OptionSettlement struct {
-	Timestamp   gateioTime              `json:"time"`
-	Profit      gateioNumericalValue    `json:"profit"`
-	Fee         gateioNumericalValue    `json:"fee"`
-	SettlePrice convert.StringToFloat64 `json:"settle_price"`
-	Contract    string                  `json:"contract"`
-	StrikePrice convert.StringToFloat64 `json:"strike_price"`
+	Timestamp   gateioTime           `json:"time"`
+	Profit      gateioNumericalValue `json:"profit"`
+	Fee         gateioNumericalValue `json:"fee"`
+	SettlePrice types.Number         `json:"settle_price"`
+	Contract    string               `json:"contract"`
+	StrikePrice types.Number         `json:"strike_price"`
 }
 
 // SwapCurrencies represents Flash Swap supported currencies
 type SwapCurrencies struct {
-	Currency  string                  `json:"currency"`
-	MinAmount convert.StringToFloat64 `json:"min_amount"`
-	MaxAmount convert.StringToFloat64 `json:"max_amount"`
-	Swappable []string                `json:"swappable"`
+	Currency  string       `json:"currency"`
+	MinAmount types.Number `json:"min_amount"`
+	MaxAmount types.Number `json:"max_amount"`
+	Swappable []string     `json:"swappable"`
 }
 
 // MyOptionSettlement represents option private settlement
 type MyOptionSettlement struct {
-	Size         float64                 `json:"size"`
-	SettleProfit convert.StringToFloat64 `json:"settle_profit"`
-	Contract     string                  `json:"contract"`
-	StrikePrice  convert.StringToFloat64 `json:"strike_price"`
-	Time         gateioTime              `json:"time"`
-	SettlePrice  convert.StringToFloat64 `json:"settle_price"`
-	Underlying   string                  `json:"underlying"`
-	RealisedPnl  string                  `json:"realised_pnl"`
-	Fee          convert.StringToFloat64 `json:"fee"`
+	Size         float64      `json:"size"`
+	SettleProfit types.Number `json:"settle_profit"`
+	Contract     string       `json:"contract"`
+	StrikePrice  types.Number `json:"strike_price"`
+	Time         gateioTime   `json:"time"`
+	SettlePrice  types.Number `json:"settle_price"`
+	Underlying   string       `json:"underlying"`
+	RealisedPnl  string       `json:"realised_pnl"`
+	Fee          types.Number `json:"fee"`
 }
 
 // OptionsTicker represents  tickers of options contracts
 type OptionsTicker struct {
-	Name                  currency.Pair           `json:"name"`
-	LastPrice             gateioNumericalValue    `json:"last_price"`
-	MarkPrice             gateioNumericalValue    `json:"mark_price"`
-	PositionSize          float64                 `json:"position_size"`
-	Ask1Size              float64                 `json:"ask1_size"`
-	Ask1Price             convert.StringToFloat64 `json:"ask1_price"`
-	Bid1Size              float64                 `json:"bid1_size"`
-	Bid1Price             convert.StringToFloat64 `json:"bid1_price"`
-	Vega                  string                  `json:"vega"`
-	Theta                 string                  `json:"theta"`
-	Rho                   string                  `json:"rho"`
-	Gamma                 string                  `json:"gamma"`
-	Delta                 string                  `json:"delta"`
-	MarkImpliedVolatility gateioNumericalValue    `json:"mark_iv"`
-	BidImpliedVolatility  gateioNumericalValue    `json:"bid_iv"`
-	AskImpliedVolatility  gateioNumericalValue    `json:"ask_iv"`
-	Leverage              gateioNumericalValue    `json:"leverage"`
+	Name                  currency.Pair        `json:"name"`
+	LastPrice             gateioNumericalValue `json:"last_price"`
+	MarkPrice             gateioNumericalValue `json:"mark_price"`
+	PositionSize          float64              `json:"position_size"`
+	Ask1Size              float64              `json:"ask1_size"`
+	Ask1Price             types.Number         `json:"ask1_price"`
+	Bid1Size              float64              `json:"bid1_size"`
+	Bid1Price             types.Number         `json:"bid1_price"`
+	Vega                  string               `json:"vega"`
+	Theta                 string               `json:"theta"`
+	Rho                   string               `json:"rho"`
+	Gamma                 string               `json:"gamma"`
+	Delta                 string               `json:"delta"`
+	MarkImpliedVolatility gateioNumericalValue `json:"mark_iv"`
+	BidImpliedVolatility  gateioNumericalValue `json:"bid_iv"`
+	AskImpliedVolatility  gateioNumericalValue `json:"ask_iv"`
+	Leverage              gateioNumericalValue `json:"leverage"`
 
 	// Added fields for the websocket
 	IndexPrice gateioNumericalValue `json:"index_price"`
@@ -943,69 +943,69 @@ type OptionsTicker struct {
 
 // OptionsUnderlyingTicker represents underlying ticker
 type OptionsUnderlyingTicker struct {
-	TradePut   float64                 `json:"trade_put"`
-	TradeCall  float64                 `json:"trade_call"`
-	IndexPrice convert.StringToFloat64 `json:"index_price"`
+	TradePut   float64      `json:"trade_put"`
+	TradeCall  float64      `json:"trade_call"`
+	IndexPrice types.Number `json:"index_price"`
 }
 
 // OptionAccount represents option account.
 type OptionAccount struct {
-	User          int64                   `json:"user"`
-	Currency      string                  `json:"currency"`
-	ShortEnabled  bool                    `json:"short_enabled"`
-	Total         convert.StringToFloat64 `json:"total"`
-	UnrealisedPnl string                  `json:"unrealised_pnl"`
-	InitMargin    string                  `json:"init_margin"`
-	MaintMargin   string                  `json:"maint_margin"`
-	OrderMargin   string                  `json:"order_margin"`
-	Available     convert.StringToFloat64 `json:"available"`
-	Point         string                  `json:"point"`
+	User          int64        `json:"user"`
+	Currency      string       `json:"currency"`
+	ShortEnabled  bool         `json:"short_enabled"`
+	Total         types.Number `json:"total"`
+	UnrealisedPnl string       `json:"unrealised_pnl"`
+	InitMargin    string       `json:"init_margin"`
+	MaintMargin   string       `json:"maint_margin"`
+	OrderMargin   string       `json:"order_margin"`
+	Available     types.Number `json:"available"`
+	Point         string       `json:"point"`
 }
 
 // AccountBook represents account changing history item
 type AccountBook struct {
-	ChangeTime    gateioTime              `json:"time"`
-	AccountChange convert.StringToFloat64 `json:"change"`
-	Balance       convert.StringToFloat64 `json:"balance"`
-	CustomText    string                  `json:"text"`
-	ChangingType  string                  `json:"type"`
+	ChangeTime    gateioTime   `json:"time"`
+	AccountChange types.Number `json:"change"`
+	Balance       types.Number `json:"balance"`
+	CustomText    string       `json:"text"`
+	ChangingType  string       `json:"type"`
 }
 
 // UsersPositionForUnderlying represents user's position for specified underlying.
 type UsersPositionForUnderlying struct {
-	User          int64                   `json:"user"`
-	Contract      string                  `json:"contract"`
-	Size          int64                   `json:"size"`
-	EntryPrice    convert.StringToFloat64 `json:"entry_price"`
-	RealisedPnl   convert.StringToFloat64 `json:"realised_pnl"`
-	MarkPrice     convert.StringToFloat64 `json:"mark_price"`
-	UnrealisedPnl convert.StringToFloat64 `json:"unrealised_pnl"`
-	PendingOrders int64                   `json:"pending_orders"`
+	User          int64        `json:"user"`
+	Contract      string       `json:"contract"`
+	Size          int64        `json:"size"`
+	EntryPrice    types.Number `json:"entry_price"`
+	RealisedPnl   types.Number `json:"realised_pnl"`
+	MarkPrice     types.Number `json:"mark_price"`
+	UnrealisedPnl types.Number `json:"unrealised_pnl"`
+	PendingOrders int64        `json:"pending_orders"`
 	CloseOrder    struct {
-		ID    int64                   `json:"id"`
-		Price convert.StringToFloat64 `json:"price"`
-		IsLiq bool                    `json:"is_liq"`
+		ID    int64        `json:"id"`
+		Price types.Number `json:"price"`
+		IsLiq bool         `json:"is_liq"`
 	} `json:"close_order"`
 }
 
 // ContractClosePosition represents user's liquidation history
 type ContractClosePosition struct {
-	PositionCloseTime gateioTime              `json:"time"`
-	Pnl               convert.StringToFloat64 `json:"pnl"`
-	SettleSize        string                  `json:"settle_size"`
-	Side              string                  `json:"side"` // Position side, long or short
-	FuturesContract   string                  `json:"contract"`
-	CloseOrderText    string                  `json:"text"`
+	PositionCloseTime gateioTime   `json:"time"`
+	Pnl               types.Number `json:"pnl"`
+	SettleSize        string       `json:"settle_size"`
+	Side              string       `json:"side"` // Position side, long or short
+	FuturesContract   string       `json:"contract"`
+	CloseOrderText    string       `json:"text"`
 }
 
 // OptionOrderParam represents option order request body
 type OptionOrderParam struct {
-	OrderSize   float64                 `json:"size"`              // Order size. Specify positive number to make a bid, and negative number to ask
-	Iceberg     float64                 `json:"iceberg,omitempty"` // Display size for iceberg order. 0 for non-iceberg. Note that you will have to pay the taker fee for the hidden size
-	Contract    string                  `json:"contract"`
-	Text        string                  `json:"text,omitempty"`
-	TimeInForce string                  `json:"tif,omitempty"`
-	Price       convert.StringToFloat64 `json:"price,omitempty"`
+	OrderSize   float64      `json:"size"`              // Order size. Specify positive number to make a bid, and negative number to ask
+	Iceberg     float64      `json:"iceberg,omitempty"` // Display size for iceberg order. 0 for non-iceberg. Note that you will have to pay the taker fee for the hidden size
+	Contract    string       `json:"contract"`
+	Text        string       `json:"text,omitempty"`
+	TimeInForce string       `json:"tif,omitempty"`
+	Price       types.Number `json:"price,omitempty"`
 	// Close Set as true to close the position, with size set to 0
 	Close      bool `json:"close,omitempty"`
 	ReduceOnly bool `json:"reduce_only,omitempty"`
@@ -1013,59 +1013,59 @@ type OptionOrderParam struct {
 
 // OptionOrderResponse represents option order response detail
 type OptionOrderResponse struct {
-	Status               string                  `json:"status"`
-	Size                 float64                 `json:"size"`
-	OptionOrderID        int64                   `json:"id"`
-	Iceberg              int64                   `json:"iceberg"`
-	IsOrderLiquidation   bool                    `json:"is_liq"`
-	IsOrderPositionClose bool                    `json:"is_close"`
-	Contract             string                  `json:"contract"`
-	Text                 string                  `json:"text"`
-	FillPrice            convert.StringToFloat64 `json:"fill_price"`
-	FinishAs             string                  `json:"finish_as"` //  finish_as 	filled, cancelled, liquidated, ioc, auto_deleveraged, reduce_only, position_closed, reduce_out
-	Left                 float64                 `json:"left"`
-	TimeInForce          string                  `json:"tif"`
-	IsReduceOnly         bool                    `json:"is_reduce_only"`
-	CreateTime           gateioTime              `json:"create_time"`
-	FinishTime           gateioTime              `json:"finish_time"`
-	Price                convert.StringToFloat64 `json:"price"`
+	Status               string       `json:"status"`
+	Size                 float64      `json:"size"`
+	OptionOrderID        int64        `json:"id"`
+	Iceberg              int64        `json:"iceberg"`
+	IsOrderLiquidation   bool         `json:"is_liq"`
+	IsOrderPositionClose bool         `json:"is_close"`
+	Contract             string       `json:"contract"`
+	Text                 string       `json:"text"`
+	FillPrice            types.Number `json:"fill_price"`
+	FinishAs             string       `json:"finish_as"` //  finish_as 	filled, cancelled, liquidated, ioc, auto_deleveraged, reduce_only, position_closed, reduce_out
+	Left                 float64      `json:"left"`
+	TimeInForce          string       `json:"tif"`
+	IsReduceOnly         bool         `json:"is_reduce_only"`
+	CreateTime           gateioTime   `json:"create_time"`
+	FinishTime           gateioTime   `json:"finish_time"`
+	Price                types.Number `json:"price"`
 
-	TakerFee        convert.StringToFloat64 `json:"tkrf"`
-	MakerFee        convert.StringToFloat64 `json:"mkrf"`
-	ReferenceUserID string                  `json:"refu"`
+	TakerFee        types.Number `json:"tkrf"`
+	MakerFee        types.Number `json:"mkrf"`
+	ReferenceUserID string       `json:"refu"`
 }
 
 // OptionTradingHistory list personal trading history
 type OptionTradingHistory struct {
-	ID              int64                   `json:"id"`
-	UnderlyingPrice convert.StringToFloat64 `json:"underlying_price"`
-	Size            float64                 `json:"size"`
-	Contract        string                  `json:"contract"`
-	TradeRole       string                  `json:"role"`
-	CreateTime      gateioTime              `json:"create_time"`
-	OrderID         int64                   `json:"order_id"`
-	Price           convert.StringToFloat64 `json:"price"`
+	ID              int64        `json:"id"`
+	UnderlyingPrice types.Number `json:"underlying_price"`
+	Size            float64      `json:"size"`
+	Contract        string       `json:"contract"`
+	TradeRole       string       `json:"role"`
+	CreateTime      gateioTime   `json:"create_time"`
+	OrderID         int64        `json:"order_id"`
+	Price           types.Number `json:"price"`
 }
 
 // WithdrawalResponse represents withdrawal response
 type WithdrawalResponse struct {
-	ID                string                  `json:"id"`
-	Timestamp         gateioTime              `json:"timestamp"`
-	Currency          string                  `json:"currency"`
-	WithdrawalAddress string                  `json:"address"`
-	TransactionID     string                  `json:"txid"`
-	Amount            convert.StringToFloat64 `json:"amount"`
-	Memo              string                  `json:"memo"`
-	Status            string                  `json:"status"`
-	Chain             string                  `json:"chain"`
-	Fee               convert.StringToFloat64 `json:"fee"`
+	ID                string       `json:"id"`
+	Timestamp         gateioTime   `json:"timestamp"`
+	Currency          string       `json:"currency"`
+	WithdrawalAddress string       `json:"address"`
+	TransactionID     string       `json:"txid"`
+	Amount            types.Number `json:"amount"`
+	Memo              string       `json:"memo"`
+	Status            string       `json:"status"`
+	Chain             string       `json:"chain"`
+	Fee               types.Number `json:"fee"`
 }
 
 // WithdrawalRequestParam represents currency withdrawal request param.
 type WithdrawalRequestParam struct {
-	Currency currency.Code           `json:"currency"`
-	Amount   convert.StringToFloat64 `json:"amount"`
-	Chain    string                  `json:"chain,omitempty"`
+	Currency currency.Code `json:"currency"`
+	Amount   types.Number  `json:"amount"`
+	Chain    string        `json:"chain,omitempty"`
 
 	// Optional parameters
 	Address string `json:"address,omitempty"`
@@ -1090,26 +1090,26 @@ type MultiChainAddressItem struct {
 
 // DepositRecord represents deposit record item
 type DepositRecord struct {
-	ID            string                  `json:"id"`
-	Timestamp     gateioTime              `json:"timestamp"`
-	Currency      string                  `json:"currency"`
-	Address       string                  `json:"address"`
-	TransactionID string                  `json:"txid"`
-	Amount        convert.StringToFloat64 `json:"amount"`
-	Memo          string                  `json:"memo"`
-	Status        string                  `json:"status"`
-	Chain         string                  `json:"chain"`
-	Fee           convert.StringToFloat64 `json:"fee"`
+	ID            string       `json:"id"`
+	Timestamp     gateioTime   `json:"timestamp"`
+	Currency      string       `json:"currency"`
+	Address       string       `json:"address"`
+	TransactionID string       `json:"txid"`
+	Amount        types.Number `json:"amount"`
+	Memo          string       `json:"memo"`
+	Status        string       `json:"status"`
+	Chain         string       `json:"chain"`
+	Fee           types.Number `json:"fee"`
 }
 
 // TransferCurrencyParam represents currency transfer.
 type TransferCurrencyParam struct {
-	Currency     currency.Code           `json:"currency"`
-	From         string                  `json:"from"`
-	To           string                  `json:"to"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	CurrencyPair currency.Pair           `json:"currency_pair"`
-	Settle       string                  `json:"settle"`
+	Currency     currency.Code `json:"currency"`
+	From         string        `json:"from"`
+	To           string        `json:"to"`
+	Amount       types.Number  `json:"amount"`
+	CurrencyPair currency.Pair `json:"currency_pair"`
+	Settle       string        `json:"settle"`
 }
 
 // TransactionIDResponse represents transaction ID
@@ -1119,68 +1119,68 @@ type TransactionIDResponse struct {
 
 // SubAccountTransferParam represents currency subaccount transfer request param
 type SubAccountTransferParam struct {
-	Currency       currency.Code           `json:"currency"`
-	SubAccount     string                  `json:"sub_account"`
-	Direction      string                  `json:"direction"`
-	Amount         convert.StringToFloat64 `json:"amount"`
-	SubAccountType string                  `json:"sub_account_type"`
+	Currency       currency.Code `json:"currency"`
+	SubAccount     string        `json:"sub_account"`
+	Direction      string        `json:"direction"`
+	Amount         types.Number  `json:"amount"`
+	SubAccountType string        `json:"sub_account_type"`
 }
 
 // SubAccountTransferResponse represents transfer records between main and sub accounts
 type SubAccountTransferResponse struct {
-	MainAccountUserID string                  `json:"uid"`
-	Timestamp         gateioTime              `json:"timest"`
-	Source            string                  `json:"source"`
-	Currency          string                  `json:"currency"`
-	SubAccount        string                  `json:"sub_account"`
-	TransferDirection string                  `json:"direction"`
-	Amount            convert.StringToFloat64 `json:"amount"`
-	SubAccountType    string                  `json:"sub_account_type"`
+	MainAccountUserID string       `json:"uid"`
+	Timestamp         gateioTime   `json:"timest"`
+	Source            string       `json:"source"`
+	Currency          string       `json:"currency"`
+	SubAccount        string       `json:"sub_account"`
+	TransferDirection string       `json:"direction"`
+	Amount            types.Number `json:"amount"`
+	SubAccountType    string       `json:"sub_account_type"`
 }
 
 // WithdrawalStatus represents currency withdrawal status
 type WithdrawalStatus struct {
-	Currency               string                  `json:"currency"`
-	CurrencyName           string                  `json:"name"`
-	CurrencyNameChinese    string                  `json:"name_cn"`
-	Deposit                convert.StringToFloat64 `json:"deposit"`
-	WithdrawPercent        string                  `json:"withdraw_percent"`
-	FixedWithdrawalFee     convert.StringToFloat64 `json:"withdraw_fix"`
-	WithdrawDayLimit       convert.StringToFloat64 `json:"withdraw_day_limit"`
-	WithdrawDayLimitRemain convert.StringToFloat64 `json:"withdraw_day_limit_remain"`
-	WithdrawAmountMini     convert.StringToFloat64 `json:"withdraw_amount_mini"`
-	WithdrawEachTimeLimit  convert.StringToFloat64 `json:"withdraw_eachtime_limit"`
-	WithdrawFixOnChains    map[string]string       `json:"withdraw_fix_on_chains"`
-	AdditionalProperties   string                  `json:"additionalProperties"`
+	Currency               string            `json:"currency"`
+	CurrencyName           string            `json:"name"`
+	CurrencyNameChinese    string            `json:"name_cn"`
+	Deposit                types.Number      `json:"deposit"`
+	WithdrawPercent        string            `json:"withdraw_percent"`
+	FixedWithdrawalFee     types.Number      `json:"withdraw_fix"`
+	WithdrawDayLimit       types.Number      `json:"withdraw_day_limit"`
+	WithdrawDayLimitRemain types.Number      `json:"withdraw_day_limit_remain"`
+	WithdrawAmountMini     types.Number      `json:"withdraw_amount_mini"`
+	WithdrawEachTimeLimit  types.Number      `json:"withdraw_eachtime_limit"`
+	WithdrawFixOnChains    map[string]string `json:"withdraw_fix_on_chains"`
+	AdditionalProperties   string            `json:"additionalProperties"`
 }
 
 // FuturesSubAccountBalance represents sub account balance for specific sub account and several currencies
 type FuturesSubAccountBalance struct {
 	UserID    int64 `json:"uid,string"`
 	Available struct {
-		Total                     convert.StringToFloat64 `json:"total"`
-		UnrealisedProfitAndLoss   string                  `json:"unrealised_pnl"`
-		PositionMargin            string                  `json:"position_margin"`
-		OrderMargin               string                  `json:"order_margin"`
-		TotalAvailable            convert.StringToFloat64 `json:"available"`
-		PointAmount               float64                 `json:"point"`
-		SettleCurrency            string                  `json:"currency"`
-		InDualMode                bool                    `json:"in_dual_mode"`
-		EnableCredit              bool                    `json:"enable_credit"`
-		PositionInitialMargin     string                  `json:"position_initial_margin"` // applicable to the portfolio margin account model
-		MaintenanceMarginPosition string                  `json:"maintenance_margin"`
-		PerpetualContractBonus    string                  `json:"bonus"`
+		Total                     types.Number `json:"total"`
+		UnrealisedProfitAndLoss   string       `json:"unrealised_pnl"`
+		PositionMargin            string       `json:"position_margin"`
+		OrderMargin               string       `json:"order_margin"`
+		TotalAvailable            types.Number `json:"available"`
+		PointAmount               float64      `json:"point"`
+		SettleCurrency            string       `json:"currency"`
+		InDualMode                bool         `json:"in_dual_mode"`
+		EnableCredit              bool         `json:"enable_credit"`
+		PositionInitialMargin     string       `json:"position_initial_margin"` // applicable to the portfolio margin account model
+		MaintenanceMarginPosition string       `json:"maintenance_margin"`
+		PerpetualContractBonus    string       `json:"bonus"`
 		StatisticalData           struct {
-			TotalDNW         convert.StringToFloat64 `json:"dnw"` // total amount of deposit and withdraw
-			ProfitAndLoss    convert.StringToFloat64 `json:"pnl"` // total amount of trading profit and loss
-			TotalAmountOfFee convert.StringToFloat64 `json:"fee"`
-			ReferrerRebates  convert.StringToFloat64 `json:"refr"` // total amount of referrer rebates
-			Fund             convert.StringToFloat64 `json:"fund"` // total amount of funding costs
-			PointDNW         convert.StringToFloat64 `json:"point_dnw"`
-			PoointFee        convert.StringToFloat64 `json:"point_fee"`
-			PointRefr        convert.StringToFloat64 `json:"point_refr"`
-			BonusDNW         convert.StringToFloat64 `json:"bonus_dnw"`
-			BonusOffset      convert.StringToFloat64 `json:"bonus_offset"`
+			TotalDNW         types.Number `json:"dnw"` // total amount of deposit and withdraw
+			ProfitAndLoss    types.Number `json:"pnl"` // total amount of trading profit and loss
+			TotalAmountOfFee types.Number `json:"fee"`
+			ReferrerRebates  types.Number `json:"refr"` // total amount of referrer rebates
+			Fund             types.Number `json:"fund"` // total amount of funding costs
+			PointDNW         types.Number `json:"point_dnw"`
+			PoointFee        types.Number `json:"point_fee"`
+			PointRefr        types.Number `json:"point_refr"`
+			BonusDNW         types.Number `json:"bonus_dnw"`
+			BonusOffset      types.Number `json:"bonus_offset"`
 		} `json:"history"`
 	} `json:"available"`
 }
@@ -1199,11 +1199,11 @@ type SubAccountMarginBalance struct {
 
 // MarginCurrencyBalance represents a currency balance detail information.
 type MarginCurrencyBalance struct {
-	Currency       string                  `json:"currency"`
-	Available      convert.StringToFloat64 `json:"available"`
-	Locked         convert.StringToFloat64 `json:"locked"`
-	BorrowedAmount convert.StringToFloat64 `json:"borrowed"`
-	UnpairInterest convert.StringToFloat64 `json:"interest"`
+	Currency       string       `json:"currency"`
+	Available      types.Number `json:"available"`
+	Locked         types.Number `json:"locked"`
+	BorrowedAmount types.Number `json:"borrowed"`
+	UnpairInterest types.Number `json:"interest"`
 }
 
 // MarginAccountItem margin account item
@@ -1217,11 +1217,11 @@ type MarginAccountItem struct {
 
 // AccountBalanceInformation represents currency account balance information.
 type AccountBalanceInformation struct {
-	Available    convert.StringToFloat64 `json:"available"`
-	Borrowed     convert.StringToFloat64 `json:"borrowed"`
-	Interest     convert.StringToFloat64 `json:"interest"`
-	Currency     string                  `json:"currency"`
-	LockedAmount convert.StringToFloat64 `json:"locked"`
+	Available    types.Number `json:"available"`
+	Borrowed     types.Number `json:"borrowed"`
+	Interest     types.Number `json:"interest"`
+	Currency     string       `json:"currency"`
+	LockedAmount types.Number `json:"locked"`
 }
 
 // MarginAccountBalanceChangeInfo represents margin account balance
@@ -1237,47 +1237,47 @@ type MarginAccountBalanceChangeInfo struct {
 
 // MarginFundingAccountItem represents funding account list item.
 type MarginFundingAccountItem struct {
-	Currency     string                  `json:"currency"`
-	Available    convert.StringToFloat64 `json:"available"`
-	LockedAmount convert.StringToFloat64 `json:"locked"`
-	Lent         string                  `json:"lent"`       // Outstanding loan amount yet to be repaid
-	TotalLent    string                  `json:"total_lent"` // Amount used for lending. total_lent = lent + locked
+	Currency     string       `json:"currency"`
+	Available    types.Number `json:"available"`
+	LockedAmount types.Number `json:"locked"`
+	Lent         string       `json:"lent"`       // Outstanding loan amount yet to be repaid
+	TotalLent    string       `json:"total_lent"` // Amount used for lending. total_lent = lent + locked
 }
 
 // MarginLoanRequestParam represents margin lend or borrow request param
 type MarginLoanRequestParam struct {
-	Side         string                  `json:"side"`
-	Currency     currency.Code           `json:"currency"`
-	Rate         convert.StringToFloat64 `json:"rate,omitempty"`
-	Amount       convert.StringToFloat64 `json:"amount,omitempty"`
-	Days         int64                   `json:"days,omitempty"`
-	AutoRenew    bool                    `json:"auto_renew,omitempty"`
-	CurrencyPair currency.Pair           `json:"currency_pair,omitempty"`
-	FeeRate      convert.StringToFloat64 `json:"fee_rate,omitempty"`
-	OrigID       string                  `json:"orig_id,omitempty"`
-	Text         string                  `json:"text,omitempty"`
+	Side         string        `json:"side"`
+	Currency     currency.Code `json:"currency"`
+	Rate         types.Number  `json:"rate,omitempty"`
+	Amount       types.Number  `json:"amount,omitempty"`
+	Days         int64         `json:"days,omitempty"`
+	AutoRenew    bool          `json:"auto_renew,omitempty"`
+	CurrencyPair currency.Pair `json:"currency_pair,omitempty"`
+	FeeRate      types.Number  `json:"fee_rate,omitempty"`
+	OrigID       string        `json:"orig_id,omitempty"`
+	Text         string        `json:"text,omitempty"`
 }
 
 // MarginLoanResponse represents lending or borrow response.
 type MarginLoanResponse struct {
-	ID             string                  `json:"id"`
-	OrigID         string                  `json:"orig_id,omitempty"`
-	Side           string                  `json:"side"`
-	Currency       string                  `json:"currency"`
-	Amount         convert.StringToFloat64 `json:"amount"`
-	Rate           convert.StringToFloat64 `json:"rate"`
-	Days           int64                   `json:"days,omitempty"`
-	AutoRenew      bool                    `json:"auto_renew,omitempty"`
-	CurrencyPair   string                  `json:"currency_pair,omitempty"`
-	FeeRate        convert.StringToFloat64 `json:"fee_rate"`
-	Text           string                  `json:"text,omitempty"`
-	CreateTime     gateioTime              `json:"create_time"`
-	ExpireTime     gateioTime              `json:"expire_time"`
-	Status         string                  `json:"status"`
-	Left           convert.StringToFloat64 `json:"left"`
-	Repaid         convert.StringToFloat64 `json:"repaid"`
-	PaidInterest   convert.StringToFloat64 `json:"paid_interest"`
-	UnpaidInterest convert.StringToFloat64 `json:"unpaid_interest"`
+	ID             string       `json:"id"`
+	OrigID         string       `json:"orig_id,omitempty"`
+	Side           string       `json:"side"`
+	Currency       string       `json:"currency"`
+	Amount         types.Number `json:"amount"`
+	Rate           types.Number `json:"rate"`
+	Days           int64        `json:"days,omitempty"`
+	AutoRenew      bool         `json:"auto_renew,omitempty"`
+	CurrencyPair   string       `json:"currency_pair,omitempty"`
+	FeeRate        types.Number `json:"fee_rate"`
+	Text           string       `json:"text,omitempty"`
+	CreateTime     gateioTime   `json:"create_time"`
+	ExpireTime     gateioTime   `json:"expire_time"`
+	Status         string       `json:"status"`
+	Left           types.Number `json:"left"`
+	Repaid         types.Number `json:"repaid"`
+	PaidInterest   types.Number `json:"paid_interest"`
+	UnpaidInterest types.Number `json:"unpaid_interest"`
 }
 
 // SubAccountCrossMarginInfo represents subaccount's cross_margin account info
@@ -1286,34 +1286,34 @@ type SubAccountCrossMarginInfo struct {
 	Available struct {
 		UserID                     int64                         `json:"user_id"`
 		Locked                     bool                          `json:"locked"`
-		Total                      convert.StringToFloat64       `json:"total"`
-		Borrowed                   convert.StringToFloat64       `json:"borrowed"`
-		Interest                   convert.StringToFloat64       `json:"interest"` // Total unpaid interests in USDT, i.e., the sum of all currencies' interest*price*discount
+		Total                      types.Number                  `json:"total"`
+		Borrowed                   types.Number                  `json:"borrowed"`
+		Interest                   types.Number                  `json:"interest"` // Total unpaid interests in USDT, i.e., the sum of all currencies' interest*price*discount
 		BorrowedNet                string                        `json:"borrowed_net"`
-		TotalNetAssets             convert.StringToFloat64       `json:"net"`
-		Leverage                   convert.StringToFloat64       `json:"leverage"`
+		TotalNetAssets             types.Number                  `json:"net"`
+		Leverage                   types.Number                  `json:"leverage"`
 		Risk                       string                        `json:"risk"`
-		TotalInitialMargin         convert.StringToFloat64       `json:"total_initial_margin"`
-		TotalMarginBalance         convert.StringToFloat64       `json:"total_margin_balance"`
-		TotalMaintenanceMargin     convert.StringToFloat64       `json:"total_maintenance_margin"`
-		TotalInitialMarginRate     convert.StringToFloat64       `json:"total_initial_margin_rate"`
-		TotalMaintenanceMarginRate convert.StringToFloat64       `json:"total_maintenance_margin_rate"`
-		TotalAvailableMargin       convert.StringToFloat64       `json:"total_available_margin"`
+		TotalInitialMargin         types.Number                  `json:"total_initial_margin"`
+		TotalMarginBalance         types.Number                  `json:"total_margin_balance"`
+		TotalMaintenanceMargin     types.Number                  `json:"total_maintenance_margin"`
+		TotalInitialMarginRate     types.Number                  `json:"total_initial_margin_rate"`
+		TotalMaintenanceMarginRate types.Number                  `json:"total_maintenance_margin_rate"`
+		TotalAvailableMargin       types.Number                  `json:"total_available_margin"`
 		CurrencyBalances           map[string]CrossMarginBalance `json:"balances"`
 	} `json:"available"`
 }
 
 // CrossMarginBalance represents cross-margin currency balance detail
 type CrossMarginBalance struct {
-	Available           convert.StringToFloat64 `json:"available"`
-	Freeze              convert.StringToFloat64 `json:"freeze"`
-	Borrowed            convert.StringToFloat64 `json:"borrowed"`
-	Interest            convert.StringToFloat64 `json:"interest"`
-	Total               string                  `json:"total"`
-	BorrowedNet         string                  `json:"borrowed_net"`
-	TotalNetAssetInUSDT string                  `json:"net"`
-	PositionLeverage    string                  `json:"leverage"`
-	Risk                string                  `json:"risk"` // Risk rate. When it belows 110%, liquidation will be triggered. Calculation formula: total / (borrowed+interest)
+	Available           types.Number `json:"available"`
+	Freeze              types.Number `json:"freeze"`
+	Borrowed            types.Number `json:"borrowed"`
+	Interest            types.Number `json:"interest"`
+	Total               string       `json:"total"`
+	BorrowedNet         string       `json:"borrowed_net"`
+	TotalNetAssetInUSDT string       `json:"net"`
+	PositionLeverage    string       `json:"leverage"`
+	Risk                string       `json:"risk"` // Risk rate. When it belows 110%, liquidation will be triggered. Calculation formula: total / (borrowed+interest)
 }
 
 // WalletSavedAddress represents currency saved address
@@ -1328,16 +1328,16 @@ type WalletSavedAddress struct {
 
 // PersonalTradingFee represents personal trading fee for specific currency pair
 type PersonalTradingFee struct {
-	UserID          int64                   `json:"user_id"`
-	TakerFee        convert.StringToFloat64 `json:"taker_fee"`
-	MakerFee        convert.StringToFloat64 `json:"maker_fee"`
-	GtDiscount      bool                    `json:"gt_discount"`
-	GtTakerFee      convert.StringToFloat64 `json:"gt_taker_fee"`
-	GtMakerFee      convert.StringToFloat64 `json:"gt_maker_fee"`
-	LoanFee         convert.StringToFloat64 `json:"loan_fee"`
-	PointType       string                  `json:"point_type"`
-	FuturesTakerFee convert.StringToFloat64 `json:"futures_taker_fee"`
-	FuturesMakerFee convert.StringToFloat64 `json:"futures_maker_fee"`
+	UserID          int64        `json:"user_id"`
+	TakerFee        types.Number `json:"taker_fee"`
+	MakerFee        types.Number `json:"maker_fee"`
+	GtDiscount      bool         `json:"gt_discount"`
+	GtTakerFee      types.Number `json:"gt_taker_fee"`
+	GtMakerFee      types.Number `json:"gt_maker_fee"`
+	LoanFee         types.Number `json:"loan_fee"`
+	PointType       string       `json:"point_type"`
+	FuturesTakerFee types.Number `json:"futures_taker_fee"`
+	FuturesMakerFee types.Number `json:"futures_maker_fee"`
 }
 
 // UsersAllAccountBalance represents user all account balances.
@@ -1354,74 +1354,74 @@ type CurrencyBalanceAmount struct {
 
 // SpotTradingFeeRate user trading fee rates
 type SpotTradingFeeRate struct {
-	UserID          int64                   `json:"user_id"`
-	TakerFee        convert.StringToFloat64 `json:"taker_fee"`
-	MakerFee        convert.StringToFloat64 `json:"maker_fee"`
-	GtDiscount      bool                    `json:"gt_discount"`
-	GtTakerFee      convert.StringToFloat64 `json:"gt_taker_fee"`
-	GtMakerFee      convert.StringToFloat64 `json:"gt_maker_fee"`
-	FuturesTakerFee convert.StringToFloat64 `json:"futures_taker_fee"`
-	FuturesMakerFee convert.StringToFloat64 `json:"futures_maker_fee"`
-	LoanFee         convert.StringToFloat64 `json:"loan_fee"`
-	PointType       string                  `json:"point_type"`
+	UserID          int64        `json:"user_id"`
+	TakerFee        types.Number `json:"taker_fee"`
+	MakerFee        types.Number `json:"maker_fee"`
+	GtDiscount      bool         `json:"gt_discount"`
+	GtTakerFee      types.Number `json:"gt_taker_fee"`
+	GtMakerFee      types.Number `json:"gt_maker_fee"`
+	FuturesTakerFee types.Number `json:"futures_taker_fee"`
+	FuturesMakerFee types.Number `json:"futures_maker_fee"`
+	LoanFee         types.Number `json:"loan_fee"`
+	PointType       string       `json:"point_type"`
 }
 
 // SpotAccount represents spot account
 type SpotAccount struct {
-	Currency  string                  `json:"currency"`
-	Available convert.StringToFloat64 `json:"available"`
-	Locked    convert.StringToFloat64 `json:"locked"`
+	Currency  string       `json:"currency"`
+	Available types.Number `json:"available"`
+	Locked    types.Number `json:"locked"`
 }
 
 // CreateOrderRequestData represents a single order creation param.
 type CreateOrderRequestData struct {
-	Text         string                  `json:"text,omitempty"`
-	CurrencyPair currency.Pair           `json:"currency_pair,omitempty"`
-	Type         string                  `json:"type,omitempty"`
-	Account      string                  `json:"account,omitempty"`
-	Side         string                  `json:"side,omitempty"`
-	Iceberg      string                  `json:"iceberg,omitempty"`
-	Amount       convert.StringToFloat64 `json:"amount,omitempty"`
-	Price        convert.StringToFloat64 `json:"price,omitempty"`
-	TimeInForce  string                  `json:"time_in_force,omitempty"`
-	AutoBorrow   bool                    `json:"auto_borrow,omitempty"`
+	Text         string        `json:"text,omitempty"`
+	CurrencyPair currency.Pair `json:"currency_pair,omitempty"`
+	Type         string        `json:"type,omitempty"`
+	Account      string        `json:"account,omitempty"`
+	Side         string        `json:"side,omitempty"`
+	Iceberg      string        `json:"iceberg,omitempty"`
+	Amount       types.Number  `json:"amount,omitempty"`
+	Price        types.Number  `json:"price,omitempty"`
+	TimeInForce  string        `json:"time_in_force,omitempty"`
+	AutoBorrow   bool          `json:"auto_borrow,omitempty"`
 }
 
 // SpotOrder represents create order response.
 type SpotOrder struct {
-	OrderID            string                  `json:"id,omitempty"`
-	Text               string                  `json:"text,omitempty"`
-	Succeeded          bool                    `json:"succeeded"`
-	ErrorLabel         string                  `json:"label,omitempty"`
-	Message            string                  `json:"message,omitempty"`
-	CreateTime         gateioTime              `json:"create_time,omitempty"`
-	CreateTimeMs       gateioTime              `json:"create_time_ms,omitempty"`
-	UpdateTime         gateioTime              `json:"update_time,omitempty"`
-	UpdateTimeMs       gateioTime              `json:"update_time_ms,omitempty"`
-	CurrencyPair       string                  `json:"currency_pair,omitempty"`
-	Status             string                  `json:"status,omitempty"`
-	Type               string                  `json:"type,omitempty"`
-	Account            string                  `json:"account,omitempty"`
-	Side               string                  `json:"side,omitempty"`
-	Amount             convert.StringToFloat64 `json:"amount,omitempty"`
-	Price              convert.StringToFloat64 `json:"price,omitempty"`
-	TimeInForce        string                  `json:"time_in_force,omitempty"`
-	Iceberg            string                  `json:"iceberg,omitempty"`
-	AutoRepay          bool                    `json:"auto_repay"`
-	AutoBorrow         bool                    `json:"auto_borrow"`
-	Left               gateioNumericalValue    `json:"left"`
-	AverageFillPrice   convert.StringToFloat64 `json:"avg_deal_price"`
-	FeeDeducted        convert.StringToFloat64 `json:"fee"`
-	FeeCurrency        string                  `json:"fee_currency"`
-	FillPrice          convert.StringToFloat64 `json:"fill_price"`   // Total filled in quote currency. Deprecated in favor of filled_total
-	FilledTotal        convert.StringToFloat64 `json:"filled_total"` // Total filled in quote currency
-	PointFee           convert.StringToFloat64 `json:"point_fee"`
-	GtFee              string                  `json:"gt_fee,omitempty"`
-	GtDiscount         bool                    `json:"gt_discount"`
-	GtMakerFee         convert.StringToFloat64 `json:"gt_maker_fee"`
-	GtTakerFee         convert.StringToFloat64 `json:"gt_taker_fee"`
-	RebatedFee         convert.StringToFloat64 `json:"rebated_fee"`
-	RebatedFeeCurrency string                  `json:"rebated_fee_currency"`
+	OrderID            string               `json:"id,omitempty"`
+	Text               string               `json:"text,omitempty"`
+	Succeeded          bool                 `json:"succeeded"`
+	ErrorLabel         string               `json:"label,omitempty"`
+	Message            string               `json:"message,omitempty"`
+	CreateTime         gateioTime           `json:"create_time,omitempty"`
+	CreateTimeMs       gateioTime           `json:"create_time_ms,omitempty"`
+	UpdateTime         gateioTime           `json:"update_time,omitempty"`
+	UpdateTimeMs       gateioTime           `json:"update_time_ms,omitempty"`
+	CurrencyPair       string               `json:"currency_pair,omitempty"`
+	Status             string               `json:"status,omitempty"`
+	Type               string               `json:"type,omitempty"`
+	Account            string               `json:"account,omitempty"`
+	Side               string               `json:"side,omitempty"`
+	Amount             types.Number         `json:"amount,omitempty"`
+	Price              types.Number         `json:"price,omitempty"`
+	TimeInForce        string               `json:"time_in_force,omitempty"`
+	Iceberg            string               `json:"iceberg,omitempty"`
+	AutoRepay          bool                 `json:"auto_repay"`
+	AutoBorrow         bool                 `json:"auto_borrow"`
+	Left               gateioNumericalValue `json:"left"`
+	AverageFillPrice   types.Number         `json:"avg_deal_price"`
+	FeeDeducted        types.Number         `json:"fee"`
+	FeeCurrency        string               `json:"fee_currency"`
+	FillPrice          types.Number         `json:"fill_price"`   // Total filled in quote currency. Deprecated in favor of filled_total
+	FilledTotal        types.Number         `json:"filled_total"` // Total filled in quote currency
+	PointFee           types.Number         `json:"point_fee"`
+	GtFee              string               `json:"gt_fee,omitempty"`
+	GtDiscount         bool                 `json:"gt_discount"`
+	GtMakerFee         types.Number         `json:"gt_maker_fee"`
+	GtTakerFee         types.Number         `json:"gt_taker_fee"`
+	RebatedFee         types.Number         `json:"rebated_fee"`
+	RebatedFeeCurrency string               `json:"rebated_fee_currency"`
 }
 
 // SpotOrdersDetail represents list of orders for specific currency pair
@@ -1433,10 +1433,10 @@ type SpotOrdersDetail struct {
 
 // ClosePositionRequestParam represents close position when cross currency is disable.
 type ClosePositionRequestParam struct {
-	Text         string                  `json:"text"`
-	CurrencyPair currency.Pair           `json:"currency_pair"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	Price        convert.StringToFloat64 `json:"price"`
+	Text         string        `json:"text"`
+	CurrencyPair currency.Pair `json:"currency_pair"`
+	Amount       types.Number  `json:"amount"`
+	Price        types.Number  `json:"price"`
 }
 
 // CancelOrderByIDParam represents cancel order by id request param.
@@ -1457,19 +1457,19 @@ type CancelOrderByIDResponse struct {
 
 // SpotPersonalTradeHistory represents personal trading history.
 type SpotPersonalTradeHistory struct {
-	TradeID      string                  `json:"id"`
-	CreateTime   gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	CurrencyPair string                  `json:"currency_pair"`
-	OrderID      string                  `json:"order_id"`
-	Side         string                  `json:"side"`
-	Role         string                  `json:"role"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Fee          convert.StringToFloat64 `json:"fee"`
-	FeeCurrency  string                  `json:"fee_currency"`
-	PointFee     string                  `json:"point_fee"`
-	GtFee        string                  `json:"gt_fee"`
+	TradeID      string       `json:"id"`
+	CreateTime   gateioTime   `json:"create_time"`
+	CreateTimeMs gateioTime   `json:"create_time_ms"`
+	CurrencyPair string       `json:"currency_pair"`
+	OrderID      string       `json:"order_id"`
+	Side         string       `json:"side"`
+	Role         string       `json:"role"`
+	Amount       types.Number `json:"amount"`
+	Price        types.Number `json:"price"`
+	Fee          types.Number `json:"fee"`
+	FeeCurrency  string       `json:"fee_currency"`
+	PointFee     string       `json:"point_fee"`
+	GtFee        string       `json:"gt_fee"`
 }
 
 // CountdownCancelOrderParam represents countdown cancel order params
@@ -1492,19 +1492,19 @@ type PriceTriggeredOrderParam struct {
 
 // TriggerPriceInfo represents a trigger price and related information for Price triggered order
 type TriggerPriceInfo struct {
-	Price      convert.StringToFloat64 `json:"price"`
-	Rule       string                  `json:"rule"`
-	Expiration int64                   `json:"expiration"`
+	Price      types.Number `json:"price"`
+	Rule       string       `json:"rule"`
+	Expiration int64        `json:"expiration"`
 }
 
 // PutOrderData represents order detail for price triggered order request
 type PutOrderData struct {
-	Type        string                  `json:"type"`
-	Side        string                  `json:"side"`
-	Price       convert.StringToFloat64 `json:"price"`
-	Amount      convert.StringToFloat64 `json:"amount"`
-	Account     string                  `json:"account"`
-	TimeInForce string                  `json:"time_in_force,omitempty"`
+	Type        string       `json:"type"`
+	Side        string       `json:"side"`
+	Price       types.Number `json:"price"`
+	Amount      types.Number `json:"amount"`
+	Account     string       `json:"account"`
+	TimeInForce string       `json:"time_in_force,omitempty"`
 }
 
 // OrderID represents order creation ID response.
@@ -1537,10 +1537,10 @@ type ModifyLoanRequestParam struct {
 
 // RepayLoanRequestParam represents loan repay request parameters
 type RepayLoanRequestParam struct {
-	CurrencyPair currency.Pair           `json:"currency_pair"`
-	Currency     currency.Code           `json:"currency"`
-	Mode         string                  `json:"mode"`
-	Amount       convert.StringToFloat64 `json:"amount"`
+	CurrencyPair currency.Pair `json:"currency_pair"`
+	Currency     currency.Code `json:"currency"`
+	Mode         string        `json:"mode"`
+	Amount       types.Number  `json:"amount"`
 }
 
 // LoanRepaymentRecord represents loan repayment history record item.
@@ -1553,20 +1553,20 @@ type LoanRepaymentRecord struct {
 
 // LoanRecord represents loan repayment specific record
 type LoanRecord struct {
-	ID             string                  `json:"id"`
-	LoanID         string                  `json:"loan_id"`
-	CreateTime     gateioTime              `json:"create_time"`
-	ExpireTime     gateioTime              `json:"expire_time"`
-	Status         string                  `json:"status"`
-	BorrowUserID   string                  `json:"borrow_user_id"`
-	Currency       string                  `json:"currency"`
-	Rate           convert.StringToFloat64 `json:"rate"`
-	Amount         convert.StringToFloat64 `json:"amount"`
-	Days           int64                   `json:"days"`
-	AutoRenew      bool                    `json:"auto_renew"`
-	Repaid         convert.StringToFloat64 `json:"repaid"`
-	PaidInterest   convert.StringToFloat64 `json:"paid_interest"`
-	UnpaidInterest convert.StringToFloat64 `json:"unpaid_interest"`
+	ID             string       `json:"id"`
+	LoanID         string       `json:"loan_id"`
+	CreateTime     gateioTime   `json:"create_time"`
+	ExpireTime     gateioTime   `json:"expire_time"`
+	Status         string       `json:"status"`
+	BorrowUserID   string       `json:"borrow_user_id"`
+	Currency       string       `json:"currency"`
+	Rate           types.Number `json:"rate"`
+	Amount         types.Number `json:"amount"`
+	Days           int64        `json:"days"`
+	AutoRenew      bool         `json:"auto_renew"`
+	Repaid         types.Number `json:"repaid"`
+	PaidInterest   types.Number `json:"paid_interest"`
+	UnpaidInterest types.Number `json:"unpaid_interest"`
 }
 
 // OnOffStatus represents on or off status response status
@@ -1576,30 +1576,30 @@ type OnOffStatus struct {
 
 // MaxTransferAndLoanAmount represents the maximum amount to transfer, borrow, or lend for specific currency and currency pair
 type MaxTransferAndLoanAmount struct {
-	Currency     string                  `json:"currency"`
-	CurrencyPair string                  `json:"currency_pair"`
-	Amount       convert.StringToFloat64 `json:"amount"`
+	Currency     string       `json:"currency"`
+	CurrencyPair string       `json:"currency_pair"`
+	Amount       types.Number `json:"amount"`
 }
 
 // CrossMarginCurrencies represents a currency supported by cross margin
 type CrossMarginCurrencies struct {
-	Name                 string                  `json:"name"`
-	Rate                 convert.StringToFloat64 `json:"rate"`
-	CurrencyPrecision    convert.StringToFloat64 `json:"prec"`
-	Discount             string                  `json:"discount"`
-	MinBorrowAmount      convert.StringToFloat64 `json:"min_borrow_amount"`
-	UserMaxBorrowAmount  convert.StringToFloat64 `json:"user_max_borrow_amount"`
-	TotalMaxBorrowAmount convert.StringToFloat64 `json:"total_max_borrow_amount"`
-	Price                convert.StringToFloat64 `json:"price"` // Price change between this currency and USDT
-	Status               int64                   `json:"status"`
+	Name                 string       `json:"name"`
+	Rate                 types.Number `json:"rate"`
+	CurrencyPrecision    types.Number `json:"prec"`
+	Discount             string       `json:"discount"`
+	MinBorrowAmount      types.Number `json:"min_borrow_amount"`
+	UserMaxBorrowAmount  types.Number `json:"user_max_borrow_amount"`
+	TotalMaxBorrowAmount types.Number `json:"total_max_borrow_amount"`
+	Price                types.Number `json:"price"` // Price change between this currency and USDT
+	Status               int64        `json:"status"`
 }
 
 // CrossMarginCurrencyBalance represents the currency detailed balance information for cross margin
 type CrossMarginCurrencyBalance struct {
-	Available convert.StringToFloat64 `json:"available"`
-	Freeze    convert.StringToFloat64 `json:"freeze"`
-	Borrowed  convert.StringToFloat64 `json:"borrowed"`
-	Interest  convert.StringToFloat64 `json:"interest"`
+	Available types.Number `json:"available"`
+	Freeze    types.Number `json:"freeze"`
+	Borrowed  types.Number `json:"borrowed"`
+	Interest  types.Number `json:"interest"`
 }
 
 // CrossMarginAccount represents the account detail for cross margin account balance
@@ -1607,160 +1607,160 @@ type CrossMarginAccount struct {
 	UserID                      int64                                 `json:"user_id"`
 	Locked                      bool                                  `json:"locked"`
 	Balances                    map[string]CrossMarginCurrencyBalance `json:"balances"`
-	Total                       convert.StringToFloat64               `json:"total"`
-	Borrowed                    convert.StringToFloat64               `json:"borrowed"`
-	Interest                    convert.StringToFloat64               `json:"interest"`
-	Risk                        convert.StringToFloat64               `json:"risk"`
+	Total                       types.Number                          `json:"total"`
+	Borrowed                    types.Number                          `json:"borrowed"`
+	Interest                    types.Number                          `json:"interest"`
+	Risk                        types.Number                          `json:"risk"`
 	TotalInitialMargin          string                                `json:"total_initial_margin"`
-	TotalMarginBalance          convert.StringToFloat64               `json:"total_margin_balance"`
-	TotalMaintenanceMargin      convert.StringToFloat64               `json:"total_maintenance_margin"`
-	TotalInitialMarginRate      convert.StringToFloat64               `json:"total_initial_margin_rate"`
-	TotalMaintenanceMarginRate  convert.StringToFloat64               `json:"total_maintenance_margin_rate"`
-	TotalAvailableMargin        convert.StringToFloat64               `json:"total_available_margin"`
-	TotalPortfolioMarginAccount convert.StringToFloat64               `json:"portfolio_margin_total"`
+	TotalMarginBalance          types.Number                          `json:"total_margin_balance"`
+	TotalMaintenanceMargin      types.Number                          `json:"total_maintenance_margin"`
+	TotalInitialMarginRate      types.Number                          `json:"total_initial_margin_rate"`
+	TotalMaintenanceMarginRate  types.Number                          `json:"total_maintenance_margin_rate"`
+	TotalAvailableMargin        types.Number                          `json:"total_available_margin"`
+	TotalPortfolioMarginAccount types.Number                          `json:"portfolio_margin_total"`
 }
 
 // CrossMarginAccountHistoryItem represents a cross margin account change history item
 type CrossMarginAccountHistoryItem struct {
-	ID       string                  `json:"id"`
-	Time     gateioTime              `json:"time"`
-	Currency string                  `json:"currency"` // Currency changed
-	Change   string                  `json:"change"`
-	Balance  convert.StringToFloat64 `json:"balance"`
-	Type     string                  `json:"type"`
+	ID       string       `json:"id"`
+	Time     gateioTime   `json:"time"`
+	Currency string       `json:"currency"` // Currency changed
+	Change   string       `json:"change"`
+	Balance  types.Number `json:"balance"`
+	Type     string       `json:"type"`
 }
 
 // CrossMarginBorrowLoanParams represents a cross margin borrow loan parameters
 type CrossMarginBorrowLoanParams struct {
-	Currency currency.Code           `json:"currency"`
-	Amount   convert.StringToFloat64 `json:"amount"`
-	Text     string                  `json:"text"`
+	Currency currency.Code `json:"currency"`
+	Amount   types.Number  `json:"amount"`
+	Text     string        `json:"text"`
 }
 
 // CrossMarginLoanResponse represents a cross margin borrow loan response
 type CrossMarginLoanResponse struct {
-	ID             string                  `json:"id"`
-	CreateTime     gateioTime              `json:"create_time"`
-	UpdateTime     gateioTime              `json:"update_time"`
-	Currency       string                  `json:"currency"`
-	Amount         convert.StringToFloat64 `json:"amount"`
-	Text           string                  `json:"text"`
-	Status         int64                   `json:"status"`
-	Repaid         string                  `json:"repaid"`
-	RepaidInterest convert.StringToFloat64 `json:"repaid_interest"`
-	UnpaidInterest convert.StringToFloat64 `json:"unpaid_interest"`
+	ID             string       `json:"id"`
+	CreateTime     gateioTime   `json:"create_time"`
+	UpdateTime     gateioTime   `json:"update_time"`
+	Currency       string       `json:"currency"`
+	Amount         types.Number `json:"amount"`
+	Text           string       `json:"text"`
+	Status         int64        `json:"status"`
+	Repaid         string       `json:"repaid"`
+	RepaidInterest types.Number `json:"repaid_interest"`
+	UnpaidInterest types.Number `json:"unpaid_interest"`
 }
 
 // CurrencyAndAmount represents request parameters for repayment
 type CurrencyAndAmount struct {
-	Currency currency.Code           `json:"currency"`
-	Amount   convert.StringToFloat64 `json:"amount"`
+	Currency currency.Code `json:"currency"`
+	Amount   types.Number  `json:"amount"`
 }
 
 // RepaymentHistoryItem represents an item in a repayment history.
 type RepaymentHistoryItem struct {
-	ID         string                  `json:"id"`
-	CreateTime gateioTime              `json:"create_time"`
-	LoanID     string                  `json:"loan_id"`
-	Currency   string                  `json:"currency"`
-	Principal  convert.StringToFloat64 `json:"principal"`
-	Interest   convert.StringToFloat64 `json:"interest"`
+	ID         string       `json:"id"`
+	CreateTime gateioTime   `json:"create_time"`
+	LoanID     string       `json:"loan_id"`
+	Currency   string       `json:"currency"`
+	Principal  types.Number `json:"principal"`
+	Interest   types.Number `json:"interest"`
 }
 
 // FlashSwapOrderParams represents create flash swap order request parameters.
 type FlashSwapOrderParams struct {
-	PreviewID    string                  `json:"preview_id"`
-	SellCurrency currency.Code           `json:"sell_currency"`
-	SellAmount   convert.StringToFloat64 `json:"sell_amount,omitempty"`
-	BuyCurrency  currency.Code           `json:"buy_currency"`
-	BuyAmount    convert.StringToFloat64 `json:"buy_amount,omitempty"`
+	PreviewID    string        `json:"preview_id"`
+	SellCurrency currency.Code `json:"sell_currency"`
+	SellAmount   types.Number  `json:"sell_amount,omitempty"`
+	BuyCurrency  currency.Code `json:"buy_currency"`
+	BuyAmount    types.Number  `json:"buy_amount,omitempty"`
 }
 
 // FlashSwapOrderResponse represents create flash swap order response
 type FlashSwapOrderResponse struct {
-	ID           int64                   `json:"id"`
-	CreateTime   gateioTime              `json:"create_time"`
-	UpdateTime   gateioTime              `json:"update_time"`
-	UserID       int64                   `json:"user_id"`
-	SellCurrency string                  `json:"sell_currency"`
-	SellAmount   convert.StringToFloat64 `json:"sell_amount"`
-	BuyCurrency  string                  `json:"buy_currency"`
-	BuyAmount    convert.StringToFloat64 `json:"buy_amount"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Status       int64                   `json:"status"`
+	ID           int64        `json:"id"`
+	CreateTime   gateioTime   `json:"create_time"`
+	UpdateTime   gateioTime   `json:"update_time"`
+	UserID       int64        `json:"user_id"`
+	SellCurrency string       `json:"sell_currency"`
+	SellAmount   types.Number `json:"sell_amount"`
+	BuyCurrency  string       `json:"buy_currency"`
+	BuyAmount    types.Number `json:"buy_amount"`
+	Price        types.Number `json:"price"`
+	Status       int64        `json:"status"`
 }
 
 // InitFlashSwapOrderPreviewResponse represents the order preview for flash order
 type InitFlashSwapOrderPreviewResponse struct {
-	PreviewID    string                  `json:"preview_id"`
-	SellCurrency string                  `json:"sell_currency"`
-	SellAmount   convert.StringToFloat64 `json:"sell_amount"`
-	BuyCurrency  string                  `json:"buy_currency"`
-	BuyAmount    convert.StringToFloat64 `json:"buy_amount"`
-	Price        convert.StringToFloat64 `json:"price"`
+	PreviewID    string       `json:"preview_id"`
+	SellCurrency string       `json:"sell_currency"`
+	SellAmount   types.Number `json:"sell_amount"`
+	BuyCurrency  string       `json:"buy_currency"`
+	BuyAmount    types.Number `json:"buy_amount"`
+	Price        types.Number `json:"price"`
 }
 
 // FuturesAccount represents futures account detail
 type FuturesAccount struct {
-	User           int64                   `json:"user"`
-	Currency       string                  `json:"currency"`
-	Total          convert.StringToFloat64 `json:"total"` // total = position_margin + order_margin + available
-	UnrealisedPnl  string                  `json:"unrealised_pnl"`
-	PositionMargin string                  `json:"position_margin"`
-	OrderMargin    string                  `json:"order_margin"` // Order margin of unfinished orders
-	Available      convert.StringToFloat64 `json:"available"`    // The available balance for transferring or trading
-	Point          string                  `json:"point"`
-	Bonus          string                  `json:"bonus"`
-	InDualMode     bool                    `json:"in_dual_mode"` // Whether dual mode is enabled
+	User           int64        `json:"user"`
+	Currency       string       `json:"currency"`
+	Total          types.Number `json:"total"` // total = position_margin + order_margin + available
+	UnrealisedPnl  string       `json:"unrealised_pnl"`
+	PositionMargin string       `json:"position_margin"`
+	OrderMargin    string       `json:"order_margin"` // Order margin of unfinished orders
+	Available      types.Number `json:"available"`    // The available balance for transferring or trading
+	Point          string       `json:"point"`
+	Bonus          string       `json:"bonus"`
+	InDualMode     bool         `json:"in_dual_mode"` // Whether dual mode is enabled
 	History        struct {
-		DepositAndWithdrawal string                  `json:"dnw"`  // total amount of deposit and withdraw
-		ProfitAndLoss        convert.StringToFloat64 `json:"pnl"`  // total amount of trading profit and loss
-		Fee                  string                  `json:"fee"`  // total amount of fee
-		Refr                 string                  `json:"refr"` // total amount of referrer rebates
-		Fund                 string                  `json:"fund"`
-		PointDnw             string                  `json:"point_dnw"` // total amount of point deposit and withdraw
-		PointFee             string                  `json:"point_fee"` // total amount of point fee
-		PointRefr            string                  `json:"point_refr"`
-		BonusDnw             string                  `json:"bonus_dnw"`    // total amount of perpetual contract bonus transfer
-		BonusOffset          string                  `json:"bonus_offset"` // total amount of perpetual contract bonus deduction
+		DepositAndWithdrawal string       `json:"dnw"`  // total amount of deposit and withdraw
+		ProfitAndLoss        types.Number `json:"pnl"`  // total amount of trading profit and loss
+		Fee                  string       `json:"fee"`  // total amount of fee
+		Refr                 string       `json:"refr"` // total amount of referrer rebates
+		Fund                 string       `json:"fund"`
+		PointDnw             string       `json:"point_dnw"` // total amount of point deposit and withdraw
+		PointFee             string       `json:"point_fee"` // total amount of point fee
+		PointRefr            string       `json:"point_refr"`
+		BonusDnw             string       `json:"bonus_dnw"`    // total amount of perpetual contract bonus transfer
+		BonusOffset          string       `json:"bonus_offset"` // total amount of perpetual contract bonus deduction
 	} `json:"history"`
 }
 
 // AccountBookItem represents account book item
 type AccountBookItem struct {
-	Time    gateioTime              `json:"time"`
-	Change  convert.StringToFloat64 `json:"change"`
-	Balance convert.StringToFloat64 `json:"balance"`
-	Text    string                  `json:"text"`
-	Type    string                  `json:"type"`
+	Time    gateioTime   `json:"time"`
+	Change  types.Number `json:"change"`
+	Balance types.Number `json:"balance"`
+	Text    string       `json:"text"`
+	Type    string       `json:"type"`
 }
 
 // Position represents futures position
 type Position struct {
-	User            int64                   `json:"user"`
-	Contract        string                  `json:"contract"`
-	Size            int64                   `json:"size"`
-	Leverage        convert.StringToFloat64 `json:"leverage"`
-	RiskLimit       convert.StringToFloat64 `json:"risk_limit"`
-	LeverageMax     string                  `json:"leverage_max"`
-	MaintenanceRate convert.StringToFloat64 `json:"maintenance_rate"`
-	Value           convert.StringToFloat64 `json:"value"`
-	Margin          convert.StringToFloat64 `json:"margin"`
-	EntryPrice      convert.StringToFloat64 `json:"entry_price"`
-	LiqPrice        convert.StringToFloat64 `json:"liq_price"`
-	MarkPrice       convert.StringToFloat64 `json:"mark_price"`
-	UnrealisedPnl   string                  `json:"unrealised_pnl"`
-	RealisedPnl     string                  `json:"realised_pnl"`
-	HistoryPnl      string                  `json:"history_pnl"`
-	LastClosePnl    string                  `json:"last_close_pnl"`
-	RealisedPoint   string                  `json:"realised_point"`
-	HistoryPoint    string                  `json:"history_point"`
-	AdlRanking      int64                   `json:"adl_ranking"`
-	PendingOrders   int64                   `json:"pending_orders"`
+	User            int64        `json:"user"`
+	Contract        string       `json:"contract"`
+	Size            int64        `json:"size"`
+	Leverage        types.Number `json:"leverage"`
+	RiskLimit       types.Number `json:"risk_limit"`
+	LeverageMax     string       `json:"leverage_max"`
+	MaintenanceRate types.Number `json:"maintenance_rate"`
+	Value           types.Number `json:"value"`
+	Margin          types.Number `json:"margin"`
+	EntryPrice      types.Number `json:"entry_price"`
+	LiqPrice        types.Number `json:"liq_price"`
+	MarkPrice       types.Number `json:"mark_price"`
+	UnrealisedPnl   string       `json:"unrealised_pnl"`
+	RealisedPnl     string       `json:"realised_pnl"`
+	HistoryPnl      string       `json:"history_pnl"`
+	LastClosePnl    string       `json:"last_close_pnl"`
+	RealisedPoint   string       `json:"realised_point"`
+	HistoryPoint    string       `json:"history_point"`
+	AdlRanking      int64        `json:"adl_ranking"`
+	PendingOrders   int64        `json:"pending_orders"`
 	CloseOrder      struct {
-		ID    int64                   `json:"id"`
-		Price convert.StringToFloat64 `json:"price"`
-		IsLiq bool                    `json:"is_liq"`
+		ID    int64        `json:"id"`
+		Price types.Number `json:"price"`
+		IsLiq bool         `json:"is_liq"`
 	} `json:"close_order"`
 	Mode               string `json:"mode"`
 	CrossLeverageLimit string `json:"cross_leverage_limit"`
@@ -1768,38 +1768,38 @@ type Position struct {
 
 // DualModeResponse represents  dual mode enable or disable
 type DualModeResponse struct {
-	User           int64                   `json:"user"`
-	Currency       string                  `json:"currency"`
-	Total          string                  `json:"total"`
-	UnrealisedPnl  convert.StringToFloat64 `json:"unrealised_pnl"`
-	PositionMargin convert.StringToFloat64 `json:"position_margin"`
-	OrderMargin    string                  `json:"order_margin"`
-	Available      string                  `json:"available"`
-	Point          string                  `json:"point"`
-	Bonus          string                  `json:"bonus"`
-	InDualMode     bool                    `json:"in_dual_mode"`
+	User           int64        `json:"user"`
+	Currency       string       `json:"currency"`
+	Total          string       `json:"total"`
+	UnrealisedPnl  types.Number `json:"unrealised_pnl"`
+	PositionMargin types.Number `json:"position_margin"`
+	OrderMargin    string       `json:"order_margin"`
+	Available      string       `json:"available"`
+	Point          string       `json:"point"`
+	Bonus          string       `json:"bonus"`
+	InDualMode     bool         `json:"in_dual_mode"`
 	History        struct {
-		DepositAndWithdrawal convert.StringToFloat64 `json:"dnw"` // total amount of deposit and withdraw
-		ProfitAndLoss        convert.StringToFloat64 `json:"pnl"` // total amount of trading profit and loss
-		Fee                  convert.StringToFloat64 `json:"fee"`
-		Refr                 convert.StringToFloat64 `json:"refr"`
-		Fund                 convert.StringToFloat64 `json:"fund"`
-		PointDnw             convert.StringToFloat64 `json:"point_dnw"`
-		PointFee             convert.StringToFloat64 `json:"point_fee"`
-		PointRefr            convert.StringToFloat64 `json:"point_refr"`
-		BonusDnw             convert.StringToFloat64 `json:"bonus_dnw"`
-		BonusOffset          convert.StringToFloat64 `json:"bonus_offset"`
+		DepositAndWithdrawal types.Number `json:"dnw"` // total amount of deposit and withdraw
+		ProfitAndLoss        types.Number `json:"pnl"` // total amount of trading profit and loss
+		Fee                  types.Number `json:"fee"`
+		Refr                 types.Number `json:"refr"`
+		Fund                 types.Number `json:"fund"`
+		PointDnw             types.Number `json:"point_dnw"`
+		PointFee             types.Number `json:"point_fee"`
+		PointRefr            types.Number `json:"point_refr"`
+		BonusDnw             types.Number `json:"bonus_dnw"`
+		BonusOffset          types.Number `json:"bonus_offset"`
 	} `json:"history"`
 }
 
 // OrderCreateParams represents future order creation parameters
 type OrderCreateParams struct {
-	Contract    currency.Pair           `json:"contract"`
-	Size        float64                 `json:"size"`
-	Iceberg     int64                   `json:"iceberg"`
-	Price       convert.StringToFloat64 `json:"price"`
-	TimeInForce string                  `json:"tif"`
-	Text        string                  `json:"text"`
+	Contract    currency.Pair `json:"contract"`
+	Size        float64       `json:"size"`
+	Iceberg     int64         `json:"iceberg"`
+	Price       types.Number  `json:"price"`
+	TimeInForce string        `json:"tif"`
+	Text        string        `json:"text"`
 
 	// Optional Parameters
 	ClosePosition bool   `json:"close,omitempty"`
@@ -1810,57 +1810,57 @@ type OrderCreateParams struct {
 
 // Order represents future order response
 type Order struct {
-	ID                    int64                   `json:"id"`
-	User                  int64                   `json:"user"`
-	Contract              string                  `json:"contract"`
-	CreateTime            gateioTime              `json:"create_time"`
-	Size                  float64                 `json:"size"`
-	Iceberg               int64                   `json:"iceberg"`
-	RemainingAmount       float64                 `json:"left"` // Size left to be traded
-	OrderPrice            convert.StringToFloat64 `json:"price"`
-	FillPrice             convert.StringToFloat64 `json:"fill_price"` // Fill price of the order. total filled in quote currency.
-	MakerFee              string                  `json:"mkfr"`
-	TakerFee              string                  `json:"tkfr"`
-	TimeInForce           string                  `json:"tif"`
-	ReferenceUserID       int64                   `json:"refu"`
-	IsReduceOnly          bool                    `json:"is_reduce_only"`
-	IsClose               bool                    `json:"is_close"`
-	IsOrderForLiquidation bool                    `json:"is_liq"`
-	Text                  string                  `json:"text"`
-	Status                string                  `json:"status"`
-	FinishTime            gateioTime              `json:"finish_time"`
-	FinishAs              string                  `json:"finish_as"`
+	ID                    int64        `json:"id"`
+	User                  int64        `json:"user"`
+	Contract              string       `json:"contract"`
+	CreateTime            gateioTime   `json:"create_time"`
+	Size                  float64      `json:"size"`
+	Iceberg               int64        `json:"iceberg"`
+	RemainingAmount       float64      `json:"left"` // Size left to be traded
+	OrderPrice            types.Number `json:"price"`
+	FillPrice             types.Number `json:"fill_price"` // Fill price of the order. total filled in quote currency.
+	MakerFee              string       `json:"mkfr"`
+	TakerFee              string       `json:"tkfr"`
+	TimeInForce           string       `json:"tif"`
+	ReferenceUserID       int64        `json:"refu"`
+	IsReduceOnly          bool         `json:"is_reduce_only"`
+	IsClose               bool         `json:"is_close"`
+	IsOrderForLiquidation bool         `json:"is_liq"`
+	Text                  string       `json:"text"`
+	Status                string       `json:"status"`
+	FinishTime            gateioTime   `json:"finish_time"`
+	FinishAs              string       `json:"finish_as"`
 }
 
 // AmendFuturesOrderParam represents amend futures order parameter
 type AmendFuturesOrderParam struct {
-	Size  convert.StringToFloat64 `json:"size"`
-	Price convert.StringToFloat64 `json:"price"`
+	Size  types.Number `json:"size"`
+	Price types.Number `json:"price"`
 }
 
 // PositionCloseHistoryResponse represents a close position history detail
 type PositionCloseHistoryResponse struct {
-	Time          gateioTime              `json:"time"`
-	ProfitAndLoss convert.StringToFloat64 `json:"pnl"`
-	Side          string                  `json:"side"`
-	Contract      string                  `json:"contract"`
-	Text          string                  `json:"text"`
+	Time          gateioTime   `json:"time"`
+	ProfitAndLoss types.Number `json:"pnl"`
+	Side          string       `json:"side"`
+	Contract      string       `json:"contract"`
+	Text          string       `json:"text"`
 }
 
 // LiquidationHistoryItem liquidation history item
 type LiquidationHistoryItem struct {
-	Time       gateioTime              `json:"time"`
-	Contract   string                  `json:"contract"`
-	Size       int64                   `json:"size"`
-	Leverage   convert.StringToFloat64 `json:"leverage"`
-	Margin     string                  `json:"margin"`
-	EntryPrice convert.StringToFloat64 `json:"entry_price"`
-	MarkPrice  convert.StringToFloat64 `json:"mark_price"`
-	OrderPrice convert.StringToFloat64 `json:"order_price"`
-	FillPrice  convert.StringToFloat64 `json:"fill_price"`
-	LiqPrice   convert.StringToFloat64 `json:"liq_price"`
-	OrderID    int64                   `json:"order_id"`
-	Left       int64                   `json:"left"`
+	Time       gateioTime   `json:"time"`
+	Contract   string       `json:"contract"`
+	Size       int64        `json:"size"`
+	Leverage   types.Number `json:"leverage"`
+	Margin     string       `json:"margin"`
+	EntryPrice types.Number `json:"entry_price"`
+	MarkPrice  types.Number `json:"mark_price"`
+	OrderPrice types.Number `json:"order_price"`
+	FillPrice  types.Number `json:"fill_price"`
+	LiqPrice   types.Number `json:"liq_price"`
+	OrderID    int64        `json:"order_id"`
+	Left       int64        `json:"left"`
 }
 
 // CountdownParams represents query parameters for countdown cancel order
@@ -1878,39 +1878,39 @@ type FuturesPriceTriggeredOrderParam struct {
 
 // FuturesInitial represents a price triggered order initial parameters
 type FuturesInitial struct {
-	Contract    currency.Pair           `json:"contract"`
-	Size        int64                   `json:"size"`  // Order size. Positive size means to buy, while negative one means to sell. Set to 0 to close the position
-	Price       convert.StringToFloat64 `json:"price"` // Order price. Set to 0 to use market price
-	Close       bool                    `json:"close,omitempty"`
-	TimeInForce string                  `json:"tif,omitempty"`
-	Text        string                  `json:"text,omitempty"`
-	ReduceOnly  bool                    `json:"reduce_only,omitempty"`
-	AutoSize    string                  `json:"auto_size,omitempty"`
+	Contract    currency.Pair `json:"contract"`
+	Size        int64         `json:"size"`  // Order size. Positive size means to buy, while negative one means to sell. Set to 0 to close the position
+	Price       types.Number  `json:"price"` // Order price. Set to 0 to use market price
+	Close       bool          `json:"close,omitempty"`
+	TimeInForce string        `json:"tif,omitempty"`
+	Text        string        `json:"text,omitempty"`
+	ReduceOnly  bool          `json:"reduce_only,omitempty"`
+	AutoSize    string        `json:"auto_size,omitempty"`
 }
 
 // FuturesTrigger represents a price triggered order trigger parameter
 type FuturesTrigger struct {
-	StrategyType int64                   `json:"strategy_type,omitempty"` // How the order will be triggered 0: by price, which means the order will be triggered if price condition is satisfied 1: by price gap, which means the order will be triggered if gap of recent two prices of specified price_type are satisfied. Only 0 is supported currently
-	PriceType    int64                   `json:"price_type,omitempty"`
-	Price        convert.StringToFloat64 `json:"price,omitempty"`
-	Rule         int64                   `json:"rule,omitempty"`
-	Expiration   int64                   `json:"expiration,omitempty"` // how long(in seconds) to wait for the condition to be triggered before cancelling the order
-	OrderType    string                  `json:"order_type,omitempty"`
+	StrategyType int64        `json:"strategy_type,omitempty"` // How the order will be triggered 0: by price, which means the order will be triggered if price condition is satisfied 1: by price gap, which means the order will be triggered if gap of recent two prices of specified price_type are satisfied. Only 0 is supported currently
+	PriceType    int64        `json:"price_type,omitempty"`
+	Price        types.Number `json:"price,omitempty"`
+	Rule         int64        `json:"rule,omitempty"`
+	Expiration   int64        `json:"expiration,omitempty"` // how long(in seconds) to wait for the condition to be triggered before cancelling the order
+	OrderType    string       `json:"order_type,omitempty"`
 }
 
 // PriceTriggeredOrder represents a future triggered price order response
 type PriceTriggeredOrder struct {
 	Initial struct {
-		Contract string                  `json:"contract"`
-		Size     float64                 `json:"size"`
-		Price    convert.StringToFloat64 `json:"price"`
+		Contract string       `json:"contract"`
+		Size     float64      `json:"size"`
+		Price    types.Number `json:"price"`
 	} `json:"initial"`
 	Trigger struct {
-		StrategyType int64                   `json:"strategy_type"`
-		PriceType    int64                   `json:"price_type"`
-		Price        convert.StringToFloat64 `json:"price"`
-		Rule         int64                   `json:"rule"`
-		Expiration   int64                   `json:"expiration"`
+		StrategyType int64        `json:"strategy_type"`
+		PriceType    int64        `json:"price_type"`
+		Price        types.Number `json:"price"`
+		Rule         int64        `json:"rule"`
+		Expiration   int64        `json:"expiration"`
 	} `json:"trigger"`
 	ID         int64      `json:"id"`
 	User       int64      `json:"user"`
@@ -1925,15 +1925,15 @@ type PriceTriggeredOrder struct {
 
 // SettlementHistoryItem represents a settlement history item
 type SettlementHistoryItem struct {
-	Time        gateioTime              `json:"time"`
-	Contract    string                  `json:"contract"`
-	Size        int64                   `json:"size"`
-	Leverage    string                  `json:"leverage"`
-	Margin      string                  `json:"margin"`
-	EntryPrice  convert.StringToFloat64 `json:"entry_price"`
-	SettlePrice convert.StringToFloat64 `json:"settle_price"`
-	Profit      convert.StringToFloat64 `json:"profit"`
-	Fee         convert.StringToFloat64 `json:"fee"`
+	Time        gateioTime   `json:"time"`
+	Contract    string       `json:"contract"`
+	Size        int64        `json:"size"`
+	Leverage    string       `json:"leverage"`
+	Margin      string       `json:"margin"`
+	EntryPrice  types.Number `json:"entry_price"`
+	SettlePrice types.Number `json:"settle_price"`
+	Profit      types.Number `json:"profit"`
+	Fee         types.Number `json:"fee"`
 }
 
 // SubAccountParams represents subaccount creation parameters
@@ -2000,48 +2000,48 @@ type WsResponse struct {
 
 // WsTicker websocket ticker information.
 type WsTicker struct {
-	CurrencyPair     currency.Pair           `json:"currency_pair"`
-	Last             convert.StringToFloat64 `json:"last"`
-	LowestAsk        convert.StringToFloat64 `json:"lowest_ask"`
-	HighestBid       convert.StringToFloat64 `json:"highest_bid"`
-	ChangePercentage convert.StringToFloat64 `json:"change_percentage"`
-	BaseVolume       convert.StringToFloat64 `json:"base_volume"`
-	QuoteVolume      convert.StringToFloat64 `json:"quote_volume"`
-	High24H          convert.StringToFloat64 `json:"high_24h"`
-	Low24H           convert.StringToFloat64 `json:"low_24h"`
+	CurrencyPair     currency.Pair `json:"currency_pair"`
+	Last             types.Number  `json:"last"`
+	LowestAsk        types.Number  `json:"lowest_ask"`
+	HighestBid       types.Number  `json:"highest_bid"`
+	ChangePercentage types.Number  `json:"change_percentage"`
+	BaseVolume       types.Number  `json:"base_volume"`
+	QuoteVolume      types.Number  `json:"quote_volume"`
+	High24H          types.Number  `json:"high_24h"`
+	Low24H           types.Number  `json:"low_24h"`
 }
 
 // WsTrade represents a websocket push data response for a trade
 type WsTrade struct {
-	ID           int64                   `json:"id"`
-	CreateTime   gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	Side         string                  `json:"side"`
-	CurrencyPair currency.Pair           `json:"currency_pair"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	Price        convert.StringToFloat64 `json:"price"`
+	ID           int64         `json:"id"`
+	CreateTime   gateioTime    `json:"create_time"`
+	CreateTimeMs gateioTime    `json:"create_time_ms"`
+	Side         string        `json:"side"`
+	CurrencyPair currency.Pair `json:"currency_pair"`
+	Amount       types.Number  `json:"amount"`
+	Price        types.Number  `json:"price"`
 }
 
 // WsCandlesticks represents the candlestick data for spot, margin and cross margin trades pushed through the websocket channel.
 type WsCandlesticks struct {
-	Timestamp          int64                   `json:"t,string"`
-	TotalVolume        convert.StringToFloat64 `json:"v"`
-	ClosePrice         convert.StringToFloat64 `json:"c"`
-	HighestPrice       convert.StringToFloat64 `json:"h"`
-	LowestPrice        convert.StringToFloat64 `json:"l"`
-	OpenPrice          convert.StringToFloat64 `json:"o"`
-	NameOfSubscription string                  `json:"n"`
+	Timestamp          int64        `json:"t,string"`
+	TotalVolume        types.Number `json:"v"`
+	ClosePrice         types.Number `json:"c"`
+	HighestPrice       types.Number `json:"h"`
+	LowestPrice        types.Number `json:"l"`
+	OpenPrice          types.Number `json:"o"`
+	NameOfSubscription string       `json:"n"`
 }
 
 // WsOrderbookTickerData represents the websocket orderbook best bid or best ask push data
 type WsOrderbookTickerData struct {
-	UpdateTimeMS  int64                   `json:"t"`
-	UpdateOrderID int64                   `json:"u"`
-	CurrencyPair  currency.Pair           `json:"s"`
-	BestBidPrice  convert.StringToFloat64 `json:"b"`
-	BestBidAmount convert.StringToFloat64 `json:"B"`
-	BestAskPrice  convert.StringToFloat64 `json:"a"`
-	BestAskAmount convert.StringToFloat64 `json:"A"`
+	UpdateTimeMS  int64         `json:"t"`
+	UpdateOrderID int64         `json:"u"`
+	CurrencyPair  currency.Pair `json:"s"`
+	BestBidPrice  types.Number  `json:"b"`
+	BestBidAmount types.Number  `json:"B"`
+	BestAskPrice  types.Number  `json:"a"`
+	BestAskAmount types.Number  `json:"A"`
 }
 
 // WsOrderbookUpdate represents websocket orderbook update push data
@@ -2067,153 +2067,153 @@ type WsOrderbookSnapshot struct {
 
 // WsSpotOrder represents an order push data through the websocket channel.
 type WsSpotOrder struct {
-	ID                 string                  `json:"id,omitempty"`
-	User               int64                   `json:"user"`
-	Text               string                  `json:"text,omitempty"`
-	Succeeded          bool                    `json:"succeeded,omitempty"`
-	Label              string                  `json:"label,omitempty"`
-	Message            string                  `json:"message,omitempty"`
-	CurrencyPair       currency.Pair           `json:"currency_pair,omitempty"`
-	Type               string                  `json:"type,omitempty"`
-	Account            string                  `json:"account,omitempty"`
-	Side               string                  `json:"side,omitempty"`
-	Amount             convert.StringToFloat64 `json:"amount,omitempty"`
-	Price              convert.StringToFloat64 `json:"price,omitempty"`
-	TimeInForce        string                  `json:"time_in_force,omitempty"`
-	Iceberg            string                  `json:"iceberg,omitempty"`
-	Left               gateioNumericalValue    `json:"left,omitempty"`
-	FilledTotal        convert.StringToFloat64 `json:"filled_total,omitempty"`
-	Fee                convert.StringToFloat64 `json:"fee,omitempty"`
-	FeeCurrency        string                  `json:"fee_currency,omitempty"`
-	PointFee           string                  `json:"point_fee,omitempty"`
-	GtFee              string                  `json:"gt_fee,omitempty"`
-	GtDiscount         bool                    `json:"gt_discount,omitempty"`
-	RebatedFee         string                  `json:"rebated_fee,omitempty"`
-	RebatedFeeCurrency string                  `json:"rebated_fee_currency,omitempty"`
-	Event              string                  `json:"event"`
-	CreateTime         gateioTime              `json:"create_time,omitempty"`
-	CreateTimeMs       gateioTime              `json:"create_time_ms,omitempty"`
-	UpdateTime         gateioTime              `json:"update_time,omitempty"`
-	UpdateTimeMs       gateioTime              `json:"update_time_ms,omitempty"`
+	ID                 string               `json:"id,omitempty"`
+	User               int64                `json:"user"`
+	Text               string               `json:"text,omitempty"`
+	Succeeded          bool                 `json:"succeeded,omitempty"`
+	Label              string               `json:"label,omitempty"`
+	Message            string               `json:"message,omitempty"`
+	CurrencyPair       currency.Pair        `json:"currency_pair,omitempty"`
+	Type               string               `json:"type,omitempty"`
+	Account            string               `json:"account,omitempty"`
+	Side               string               `json:"side,omitempty"`
+	Amount             types.Number         `json:"amount,omitempty"`
+	Price              types.Number         `json:"price,omitempty"`
+	TimeInForce        string               `json:"time_in_force,omitempty"`
+	Iceberg            string               `json:"iceberg,omitempty"`
+	Left               gateioNumericalValue `json:"left,omitempty"`
+	FilledTotal        types.Number         `json:"filled_total,omitempty"`
+	Fee                types.Number         `json:"fee,omitempty"`
+	FeeCurrency        string               `json:"fee_currency,omitempty"`
+	PointFee           string               `json:"point_fee,omitempty"`
+	GtFee              string               `json:"gt_fee,omitempty"`
+	GtDiscount         bool                 `json:"gt_discount,omitempty"`
+	RebatedFee         string               `json:"rebated_fee,omitempty"`
+	RebatedFeeCurrency string               `json:"rebated_fee_currency,omitempty"`
+	Event              string               `json:"event"`
+	CreateTime         gateioTime           `json:"create_time,omitempty"`
+	CreateTimeMs       gateioTime           `json:"create_time_ms,omitempty"`
+	UpdateTime         gateioTime           `json:"update_time,omitempty"`
+	UpdateTimeMs       gateioTime           `json:"update_time_ms,omitempty"`
 }
 
 // WsUserPersonalTrade represents a user's personal trade pushed through the websocket connection.
 type WsUserPersonalTrade struct {
-	ID           int64                   `json:"id"`
-	UserID       int64                   `json:"user_id"`
-	OrderID      string                  `json:"order_id"`
-	CurrencyPair currency.Pair           `json:"currency_pair"`
-	CreateTime   int64                   `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	Side         string                  `json:"side"`
-	Amount       convert.StringToFloat64 `json:"amount"`
-	Role         string                  `json:"role"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Fee          convert.StringToFloat64 `json:"fee"`
-	PointFee     convert.StringToFloat64 `json:"point_fee"`
-	GtFee        string                  `json:"gt_fee"`
-	Text         string                  `json:"text"`
+	ID           int64         `json:"id"`
+	UserID       int64         `json:"user_id"`
+	OrderID      string        `json:"order_id"`
+	CurrencyPair currency.Pair `json:"currency_pair"`
+	CreateTime   int64         `json:"create_time"`
+	CreateTimeMs gateioTime    `json:"create_time_ms"`
+	Side         string        `json:"side"`
+	Amount       types.Number  `json:"amount"`
+	Role         string        `json:"role"`
+	Price        types.Number  `json:"price"`
+	Fee          types.Number  `json:"fee"`
+	PointFee     types.Number  `json:"point_fee"`
+	GtFee        string        `json:"gt_fee"`
+	Text         string        `json:"text"`
 }
 
 // WsSpotBalance represents a spot balance.
 type WsSpotBalance struct {
-	Timestamp   convert.StringToFloat64 `json:"timestamp"`
-	TimestampMs convert.StringToFloat64 `json:"timestamp_ms"`
-	User        string                  `json:"user"`
-	Currency    string                  `json:"currency"`
-	Change      convert.StringToFloat64 `json:"change"`
-	Total       convert.StringToFloat64 `json:"total"`
-	Available   convert.StringToFloat64 `json:"available"`
+	Timestamp   types.Number `json:"timestamp"`
+	TimestampMs types.Number `json:"timestamp_ms"`
+	User        string       `json:"user"`
+	Currency    string       `json:"currency"`
+	Change      types.Number `json:"change"`
+	Total       types.Number `json:"total"`
+	Available   types.Number `json:"available"`
 }
 
 // WsMarginBalance represents margin account balance push data
 type WsMarginBalance struct {
-	Timestamp    convert.StringToFloat64 `json:"timestamp"`
-	TimestampMs  convert.StringToFloat64 `json:"timestamp_ms"`
-	User         string                  `json:"user"`
-	CurrencyPair string                  `json:"currency_pair"`
-	Currency     string                  `json:"currency"`
-	Change       convert.StringToFloat64 `json:"change"`
-	Available    convert.StringToFloat64 `json:"available"`
-	Freeze       convert.StringToFloat64 `json:"freeze"`
-	Borrowed     string                  `json:"borrowed"`
-	Interest     string                  `json:"interest"`
+	Timestamp    types.Number `json:"timestamp"`
+	TimestampMs  types.Number `json:"timestamp_ms"`
+	User         string       `json:"user"`
+	CurrencyPair string       `json:"currency_pair"`
+	Currency     string       `json:"currency"`
+	Change       types.Number `json:"change"`
+	Available    types.Number `json:"available"`
+	Freeze       types.Number `json:"freeze"`
+	Borrowed     string       `json:"borrowed"`
+	Interest     string       `json:"interest"`
 }
 
 // WsFundingBalance represents funding balance push data.
 type WsFundingBalance struct {
-	Timestamp   int64                   `json:"timestamp,string"`
-	TimestampMs convert.StringToFloat64 `json:"timestamp_ms"`
-	User        string                  `json:"user"`
-	Currency    string                  `json:"currency"`
-	Change      string                  `json:"change"`
-	Freeze      string                  `json:"freeze"`
-	Lent        string                  `json:"lent"`
+	Timestamp   int64        `json:"timestamp,string"`
+	TimestampMs types.Number `json:"timestamp_ms"`
+	User        string       `json:"user"`
+	Currency    string       `json:"currency"`
+	Change      string       `json:"change"`
+	Freeze      string       `json:"freeze"`
+	Lent        string       `json:"lent"`
 }
 
 // WsCrossMarginBalance represents a cross margin balance detail
 type WsCrossMarginBalance struct {
-	Timestamp   int64                   `json:"timestamp,string"`
-	TimestampMs convert.StringToFloat64 `json:"timestamp_ms"`
-	User        string                  `json:"user"`
-	Currency    string                  `json:"currency"`
-	Change      string                  `json:"change"`
-	Total       convert.StringToFloat64 `json:"total"`
-	Available   convert.StringToFloat64 `json:"available"`
+	Timestamp   int64        `json:"timestamp,string"`
+	TimestampMs types.Number `json:"timestamp_ms"`
+	User        string       `json:"user"`
+	Currency    string       `json:"currency"`
+	Change      string       `json:"change"`
+	Total       types.Number `json:"total"`
+	Available   types.Number `json:"available"`
 }
 
 // WsCrossMarginLoan represents a cross margin loan push data
 type WsCrossMarginLoan struct {
-	Timestamp gateioTime              `json:"timestamp"`
-	User      string                  `json:"user"`
-	Currency  string                  `json:"currency"`
-	Change    string                  `json:"change"`
-	Total     convert.StringToFloat64 `json:"total"`
-	Available convert.StringToFloat64 `json:"available"`
-	Borrowed  string                  `json:"borrowed"`
-	Interest  string                  `json:"interest"`
+	Timestamp gateioTime   `json:"timestamp"`
+	User      string       `json:"user"`
+	Currency  string       `json:"currency"`
+	Change    string       `json:"change"`
+	Total     types.Number `json:"total"`
+	Available types.Number `json:"available"`
+	Borrowed  string       `json:"borrowed"`
+	Interest  string       `json:"interest"`
 }
 
 // WsFutureTicker represents a futures push data.
 type WsFutureTicker struct {
-	Contract              currency.Pair           `json:"contract"`
-	Last                  convert.StringToFloat64 `json:"last"`
-	ChangePercentage      string                  `json:"change_percentage"`
-	FundingRate           string                  `json:"funding_rate"`
-	FundingRateIndicative string                  `json:"funding_rate_indicative"`
-	MarkPrice             convert.StringToFloat64 `json:"mark_price"`
-	IndexPrice            convert.StringToFloat64 `json:"index_price"`
-	TotalSize             convert.StringToFloat64 `json:"total_size"`
-	Volume24H             convert.StringToFloat64 `json:"volume_24h"`
-	Volume24HBtc          convert.StringToFloat64 `json:"volume_24h_btc"`
-	Volume24HUsd          convert.StringToFloat64 `json:"volume_24h_usd"`
-	QuantoBaseRate        string                  `json:"quanto_base_rate"`
-	Volume24HQuote        convert.StringToFloat64 `json:"volume_24h_quote"`
-	Volume24HSettle       string                  `json:"volume_24h_settle"`
-	Volume24HBase         convert.StringToFloat64 `json:"volume_24h_base"`
-	Low24H                convert.StringToFloat64 `json:"low_24h"`
-	High24H               convert.StringToFloat64 `json:"high_24h"`
+	Contract              currency.Pair `json:"contract"`
+	Last                  types.Number  `json:"last"`
+	ChangePercentage      string        `json:"change_percentage"`
+	FundingRate           string        `json:"funding_rate"`
+	FundingRateIndicative string        `json:"funding_rate_indicative"`
+	MarkPrice             types.Number  `json:"mark_price"`
+	IndexPrice            types.Number  `json:"index_price"`
+	TotalSize             types.Number  `json:"total_size"`
+	Volume24H             types.Number  `json:"volume_24h"`
+	Volume24HBtc          types.Number  `json:"volume_24h_btc"`
+	Volume24HUsd          types.Number  `json:"volume_24h_usd"`
+	QuantoBaseRate        string        `json:"quanto_base_rate"`
+	Volume24HQuote        types.Number  `json:"volume_24h_quote"`
+	Volume24HSettle       string        `json:"volume_24h_settle"`
+	Volume24HBase         types.Number  `json:"volume_24h_base"`
+	Low24H                types.Number  `json:"low_24h"`
+	High24H               types.Number  `json:"high_24h"`
 }
 
 // WsFuturesTrades represents  a list of trades push data
 type WsFuturesTrades struct {
-	Size         float64                 `json:"size"`
-	ID           int64                   `json:"id"`
-	CreateTime   gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Contract     currency.Pair           `json:"contract"`
+	Size         float64       `json:"size"`
+	ID           int64         `json:"id"`
+	CreateTime   gateioTime    `json:"create_time"`
+	CreateTimeMs gateioTime    `json:"create_time_ms"`
+	Price        types.Number  `json:"price"`
+	Contract     currency.Pair `json:"contract"`
 }
 
 // WsFuturesOrderbookTicker represents the orderbook ticker push data
 type WsFuturesOrderbookTicker struct {
-	TimestampMs   gateioTime              `json:"t"`
-	UpdateID      int64                   `json:"u"`
-	CurrencyPair  string                  `json:"s"`
-	BestBidPrice  convert.StringToFloat64 `json:"b"`
-	BestBidAmount float64                 `json:"B"`
-	BestAskPrice  convert.StringToFloat64 `json:"a"`
-	BestAskAmount float64                 `json:"A"`
+	TimestampMs   gateioTime   `json:"t"`
+	UpdateID      int64        `json:"u"`
+	CurrencyPair  string       `json:"s"`
+	BestBidPrice  types.Number `json:"b"`
+	BestBidAmount float64      `json:"B"`
+	BestAskPrice  types.Number `json:"a"`
+	BestAskAmount float64      `json:"A"`
 }
 
 // WsFuturesAndOptionsOrderbookUpdate represents futures and options account orderbook update push data
@@ -2223,12 +2223,12 @@ type WsFuturesAndOptionsOrderbookUpdate struct {
 	FirstUpdatedID int64         `json:"U"`
 	LastUpdatedID  int64         `json:"u"`
 	Bids           []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"b"`
 	Asks []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"a"`
 }
 
@@ -2238,21 +2238,21 @@ type WsFuturesOrderbookSnapshot struct {
 	Contract      currency.Pair `json:"contract"`
 	OrderbookID   int64         `json:"id"`
 	Asks          []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"asks"`
 	Bids []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"bids"`
 }
 
 // WsFuturesOrderbookUpdateEvent represents futures orderbook push data with the event 'update'
 type WsFuturesOrderbookUpdateEvent struct {
-	Price        convert.StringToFloat64 `json:"p"`
-	Amount       float64                 `json:"s"`
-	CurrencyPair string                  `json:"c"`
-	ID           int64                   `json:"id"`
+	Price        types.Number `json:"p"`
+	Amount       float64      `json:"s"`
+	CurrencyPair string       `json:"c"`
+	ID           int64        `json:"id"`
 }
 
 // WsFuturesOrder represents futures order
@@ -2284,17 +2284,17 @@ type WsFuturesOrder struct {
 
 // WsFuturesUserTrade represents a futures account user trade push data
 type WsFuturesUserTrade struct {
-	ID           string                  `json:"id"`
-	CreateTime   gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	Contract     currency.Pair           `json:"contract"`
-	OrderID      string                  `json:"order_id"`
-	Size         float64                 `json:"size"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Role         string                  `json:"role"`
-	Text         string                  `json:"text"`
-	Fee          float64                 `json:"fee"`
-	PointFee     int64                   `json:"point_fee"`
+	ID           string        `json:"id"`
+	CreateTime   gateioTime    `json:"create_time"`
+	CreateTimeMs gateioTime    `json:"create_time_ms"`
+	Contract     currency.Pair `json:"contract"`
+	OrderID      string        `json:"order_id"`
+	Size         float64       `json:"size"`
+	Price        types.Number  `json:"price"`
+	Role         string        `json:"role"`
+	Text         string        `json:"text"`
+	Fee          float64       `json:"fee"`
+	PointFee     int64         `json:"point_fee"`
 }
 
 // WsFuturesLiquidationNotification represents a liquidation notification push data
@@ -2400,14 +2400,14 @@ type WsFuturesAutoOrder struct {
 		Expiration   int64  `json:"expiration"`
 	} `json:"trigger"`
 	Initial struct {
-		Contract     string                  `json:"contract"`
-		Size         int64                   `json:"size"`
-		Price        convert.StringToFloat64 `json:"price"`
-		TimeInForce  string                  `json:"tif"`
-		Text         string                  `json:"text"`
-		Iceberg      int64                   `json:"iceberg"`
-		IsClose      bool                    `json:"is_close"`
-		IsReduceOnly bool                    `json:"is_reduce_only"`
+		Contract     string       `json:"contract"`
+		Size         int64        `json:"size"`
+		Price        types.Number `json:"price"`
+		TimeInForce  string       `json:"tif"`
+		Text         string       `json:"text"`
+		Iceberg      int64        `json:"iceberg"`
+		IsClose      bool         `json:"is_close"`
+		IsReduceOnly bool         `json:"is_reduce_only"`
 	} `json:"initial"`
 	ID          int64      `json:"id"`
 	TradeID     int64      `json:"trade_id"`
@@ -2508,25 +2508,25 @@ type WsOptionsContract struct {
 
 // WsOptionsContractCandlestick represents an options contract candlestick push data.
 type WsOptionsContractCandlestick struct {
-	Timestamp          int64                   `json:"t"`
-	TotalVolume        float64                 `json:"v"`
-	ClosePrice         convert.StringToFloat64 `json:"c"`
-	HighestPrice       convert.StringToFloat64 `json:"h"`
-	LowestPrice        convert.StringToFloat64 `json:"l"`
-	OpenPrice          convert.StringToFloat64 `json:"o"`
-	Amount             convert.StringToFloat64 `json:"a"`
-	NameOfSubscription string                  `json:"n"` // the format of <interval string>_<currency pair>
+	Timestamp          int64        `json:"t"`
+	TotalVolume        float64      `json:"v"`
+	ClosePrice         types.Number `json:"c"`
+	HighestPrice       types.Number `json:"h"`
+	LowestPrice        types.Number `json:"l"`
+	OpenPrice          types.Number `json:"o"`
+	Amount             types.Number `json:"a"`
+	NameOfSubscription string       `json:"n"` // the format of <interval string>_<currency pair>
 }
 
 // WsOptionsOrderbookTicker represents options orderbook ticker push data.
 type WsOptionsOrderbookTicker struct {
-	UpdateTimestamp gateioTime              `json:"t"`
-	UpdateID        int64                   `json:"u"`
-	ContractName    string                  `json:"s"`
-	BidPrice        convert.StringToFloat64 `json:"b"`
-	BidSize         float64                 `json:"B"`
-	AskPrice        convert.StringToFloat64 `json:"a"`
-	AskSize         float64                 `json:"A"`
+	UpdateTimestamp gateioTime   `json:"t"`
+	UpdateID        int64        `json:"u"`
+	ContractName    string       `json:"s"`
+	BidPrice        types.Number `json:"b"`
+	BidSize         float64      `json:"B"`
+	AskPrice        types.Number `json:"a"`
+	AskSize         float64      `json:"A"`
 }
 
 // WsOptionsOrderbookSnapshot represents the options orderbook snapshot push data.
@@ -2535,12 +2535,12 @@ type WsOptionsOrderbookSnapshot struct {
 	Contract  currency.Pair `json:"contract"`
 	ID        int64         `json:"id"`
 	Asks      []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"asks"`
 	Bids []struct {
-		Price convert.StringToFloat64 `json:"p"`
-		Size  float64                 `json:"s"`
+		Price types.Number `json:"p"`
+		Size  float64      `json:"s"`
 	} `json:"bids"`
 }
 
@@ -2573,15 +2573,15 @@ type WsOptionsOrder struct {
 
 // WsOptionsUserTrade represents user's personal trades of option account.
 type WsOptionsUserTrade struct {
-	ID           string                  `json:"id"`
-	Underlying   string                  `json:"underlying"`
-	OrderID      string                  `json:"order"`
-	Contract     currency.Pair           `json:"contract"`
-	CreateTime   gateioTime              `json:"create_time"`
-	CreateTimeMs gateioTime              `json:"create_time_ms"`
-	Price        convert.StringToFloat64 `json:"price"`
-	Role         string                  `json:"role"`
-	Size         float64                 `json:"size"`
+	ID           string        `json:"id"`
+	Underlying   string        `json:"underlying"`
+	OrderID      string        `json:"order"`
+	Contract     currency.Pair `json:"contract"`
+	CreateTime   gateioTime    `json:"create_time"`
+	CreateTimeMs gateioTime    `json:"create_time_ms"`
+	Price        types.Number  `json:"price"`
+	Role         string        `json:"role"`
+	Size         float64       `json:"size"`
 }
 
 // WsOptionsLiquidates represents the liquidates push data of option account.
@@ -2621,13 +2621,13 @@ type WsOptionsPosition struct {
 
 // InterSubAccountTransferParams represents parameters to transfer funds between sub-accounts.
 type InterSubAccountTransferParams struct {
-	Currency                currency.Code           `json:"currency"` // Required
-	SubAccountType          string                  `json:"sub_account_type"`
-	SubAccountFromUserID    string                  `json:"sub_account_from"`      // Required
-	SubAccountFromAssetType asset.Item              `json:"sub_account_from_type"` // Required
-	SubAccountToUserID      string                  `json:"sub_account_to"`        // Required
-	SubAccountToAssetType   asset.Item              `json:"sub_account_to_type"`   // Required
-	Amount                  convert.StringToFloat64 `json:"amount"`                // Required
+	Currency                currency.Code `json:"currency"` // Required
+	SubAccountType          string        `json:"sub_account_type"`
+	SubAccountFromUserID    string        `json:"sub_account_from"`      // Required
+	SubAccountFromAssetType asset.Item    `json:"sub_account_from_type"` // Required
+	SubAccountToUserID      string        `json:"sub_account_to"`        // Required
+	SubAccountToAssetType   asset.Item    `json:"sub_account_to_type"`   // Required
+	Amount                  types.Number  `json:"amount"`                // Required
 }
 
 // CreateAPIKeySubAccountParams represents subaccount new API key creation parameters.
@@ -2665,6 +2665,6 @@ type CreateAPIKeyResponse struct {
 
 // PriceAndAmount used in updating an order
 type PriceAndAmount struct {
-	Amount convert.StringToFloat64 `json:"amount,omitempty"`
-	Price  convert.StringToFloat64 `json:"price,omitempty"`
+	Amount types.Number `json:"amount,omitempty"`
+	Price  types.Number `json:"price,omitempty"`
 }

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -32,6 +31,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // GetDefaultConfig returns a default exchange config
@@ -1048,8 +1048,8 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 			Side:         orderTypeFormat,
 			Type:         s.Type.Lower(),
 			Account:      g.assetTypeToString(s.AssetType),
-			Amount:       convert.StringToFloat64(s.Amount),
-			Price:        convert.StringToFloat64(s.Price),
+			Amount:       types.Number(s.Amount),
+			Price:        types.Number(s.Price),
 			CurrencyPair: s.Pair,
 			Text:         s.ClientOrderID,
 		})
@@ -1091,7 +1091,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		fOrder, err := g.PlaceFuturesOrder(ctx, &OrderCreateParams{
 			Contract:    s.Pair,
 			Size:        s.Amount,
-			Price:       convert.StringToFloat64(s.Price),
+			Price:       types.Number(s.Price),
 			Settle:      settle,
 			ReduceOnly:  s.ReduceOnly,
 			TimeInForce: "gtc",
@@ -1128,7 +1128,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		newOrder, err := g.PlaceDeliveryOrder(ctx, &OrderCreateParams{
 			Contract:    s.Pair,
 			Size:        s.Amount,
-			Price:       convert.StringToFloat64(s.Price),
+			Price:       types.Number(s.Price),
 			Settle:      settle,
 			ReduceOnly:  s.ReduceOnly,
 			TimeInForce: "gtc",
@@ -1156,7 +1156,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		optionOrder, err := g.PlaceOptionOrder(ctx, OptionOrderParam{
 			Contract:   s.Pair.String(),
 			OrderSize:  s.Amount,
-			Price:      convert.StringToFloat64(s.Price),
+			Price:      types.Number(s.Price),
 			ReduceOnly: s.ReduceOnly,
 			Text:       s.ClientOrderID,
 		})
@@ -1544,7 +1544,7 @@ func (g *Gateio) WithdrawCryptocurrencyFunds(ctx context.Context, withdrawReques
 	}
 	response, err := g.WithdrawCurrency(ctx,
 		WithdrawalRequestParam{
-			Amount:   convert.StringToFloat64(withdrawRequest.Amount),
+			Amount:   types.Number(withdrawRequest.Amount),
 			Currency: withdrawRequest.Currency,
 			Address:  withdrawRequest.Crypto.Address,
 			Chain:    withdrawRequest.Crypto.Chain,

--- a/exchanges/gemini/gemini_types.go
+++ b/exchanges/gemini/gemini_types.go
@@ -1,8 +1,8 @@
 package gemini
 
 import (
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -32,17 +32,17 @@ type Ticker struct {
 
 // SymbolDetails contains additional symbol details
 type SymbolDetails struct {
-	Symbol                string                  `json:"symbol"`
-	BaseCurrency          string                  `json:"base_currency"`
-	QuoteCurrency         string                  `json:"quote_currency"`
-	TickSize              float64                 `json:"tick_size"`
-	QuoteIncrement        float64                 `json:"quote_increment"`
-	MinOrderSize          convert.StringToFloat64 `json:"min_order_size"`
-	Status                string                  `json:"status"`
-	WrapEnabled           bool                    `json:"wrap_enabled"`
-	ProductType           string                  `json:"product_type"`
-	ContractType          string                  `json:"contract_type"`
-	ContractPriceCurrency string                  `json:"contract_price_currency"`
+	Symbol                string       `json:"symbol"`
+	BaseCurrency          string       `json:"base_currency"`
+	QuoteCurrency         string       `json:"quote_currency"`
+	TickSize              float64      `json:"tick_size"`
+	QuoteIncrement        float64      `json:"quote_increment"`
+	MinOrderSize          types.Number `json:"min_order_size"`
+	Status                string       `json:"status"`
+	WrapEnabled           bool         `json:"wrap_enabled"`
+	ProductType           string       `json:"product_type"`
+	ContractType          string       `json:"contract_type"`
+	ContractPriceCurrency string       `json:"contract_price_currency"`
 }
 
 // TickerV2 holds returned ticker data from the exchange

--- a/exchanges/kucoin/kucoin_futures_types.go
+++ b/exchanges/kucoin/kucoin_futures_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 var (
@@ -74,17 +75,17 @@ type Contract struct {
 
 // FuturesTicker stores ticker data
 type FuturesTicker struct {
-	Sequence     int64                   `json:"sequence"`
-	Symbol       string                  `json:"symbol"`
-	Side         order.Side              `json:"side"`
-	Size         float64                 `json:"size"`
-	Price        convert.StringToFloat64 `json:"price"`
-	BestBidSize  float64                 `json:"bestBidSize"`
-	BestBidPrice convert.StringToFloat64 `json:"bestBidPrice"`
-	BestAskSize  float64                 `json:"bestAskSize"`
-	BestAskPrice convert.StringToFloat64 `json:"bestAskPrice"`
-	TradeID      string                  `json:"tradeId"`
-	FilledTime   convert.ExchangeTime    `json:"ts"`
+	Sequence     int64                `json:"sequence"`
+	Symbol       string               `json:"symbol"`
+	Side         order.Side           `json:"side"`
+	Size         float64              `json:"size"`
+	Price        types.Number         `json:"price"`
+	BestBidSize  float64              `json:"bestBidSize"`
+	BestBidPrice types.Number         `json:"bestBidPrice"`
+	BestAskSize  float64              `json:"bestAskSize"`
+	BestAskPrice types.Number         `json:"bestAskPrice"`
+	TradeID      string               `json:"tradeId"`
+	FilledTime   convert.ExchangeTime `json:"ts"`
 }
 
 type futuresOrderbookResponse struct {

--- a/exchanges/okcoin/okcoin_types.go
+++ b/exchanges/okcoin/okcoin_types.go
@@ -3,8 +3,8 @@ package okcoin
 import (
 	"strconv"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 var withdrawalFeeMaps = map[currency.Code]float64{
@@ -108,22 +108,22 @@ var withdrawalFeeMaps = map[currency.Code]float64{
 
 // TickerData stores ticker data
 type TickerData struct {
-	InstType        string                  `json:"instType"`
-	InstrumentID    string                  `json:"instId"`
-	LastTradedPrice convert.StringToFloat64 `json:"last"`
-	LastTradedSize  convert.StringToFloat64 `json:"lastSz"`
-	BestAskPrice    convert.StringToFloat64 `json:"askPx"`
-	BestAskSize     convert.StringToFloat64 `json:"askSz"`
-	BestBidPrice    convert.StringToFloat64 `json:"bidPx"`
-	BestBidSize     convert.StringToFloat64 `json:"bidSz"`
-	Open24H         convert.StringToFloat64 `json:"open24h"`   // Open price in the past 24 hours
-	High24H         convert.StringToFloat64 `json:"high24h"`   // Highest price in the past 24 hours
-	Low24H          convert.StringToFloat64 `json:"low24h"`    // Lowest price in the past 24 hours
-	VolCcy24H       convert.StringToFloat64 `json:"volCcy24h"` // 24h trading volume, with a unit of currency. The value is the quantity in quote currency.
-	Vol24H          convert.StringToFloat64 `json:"vol24h"`    // 24h trading volume, with a unit of contract. The value is the quantity in base currency.
-	Timestamp       okcoinTime              `json:"ts"`
-	OpenPriceInUtc0 convert.StringToFloat64 `json:"sodUtc0"`
-	OpenPriceInUtc8 convert.StringToFloat64 `json:"sodUtc8"`
+	InstType        string       `json:"instType"`
+	InstrumentID    string       `json:"instId"`
+	LastTradedPrice types.Number `json:"last"`
+	LastTradedSize  types.Number `json:"lastSz"`
+	BestAskPrice    types.Number `json:"askPx"`
+	BestAskSize     types.Number `json:"askSz"`
+	BestBidPrice    types.Number `json:"bidPx"`
+	BestBidSize     types.Number `json:"bidSz"`
+	Open24H         types.Number `json:"open24h"`   // Open price in the past 24 hours
+	High24H         types.Number `json:"high24h"`   // Highest price in the past 24 hours
+	Low24H          types.Number `json:"low24h"`    // Lowest price in the past 24 hours
+	VolCcy24H       types.Number `json:"volCcy24h"` // 24h trading volume, with a unit of currency. The value is the quantity in quote currency.
+	Vol24H          types.Number `json:"vol24h"`    // 24h trading volume, with a unit of contract. The value is the quantity in base currency.
+	Timestamp       okcoinTime   `json:"ts"`
+	OpenPriceInUtc0 types.Number `json:"sodUtc0"`
+	OpenPriceInUtc8 types.Number `json:"sodUtc8"`
 }
 
 // GetOrderBookResponse response data
@@ -248,40 +248,40 @@ type WebsocketAccount struct {
 	Data []struct {
 		AdjustedEquity string `json:"adjEq"`
 		Details        []struct {
-			AvailableBalance   okcoinNumber            `json:"availBal"`
-			AvailableEquity    convert.StringToFloat64 `json:"availEq"`
-			CashBalance        convert.StringToFloat64 `json:"cashBal"`
-			Currency           string                  `json:"ccy"`
-			CoinUsdPrice       convert.StringToFloat64 `json:"coinUsdPrice"`
-			CrossLiab          string                  `json:"crossLiab"`
-			DiscountEquity     string                  `json:"disEq"`
-			Equity             string                  `json:"eq"`
-			EquityUsd          string                  `json:"eqUsd"`
-			FixedBalance       convert.StringToFloat64 `json:"fixedBal"`
-			FrozenBalance      convert.StringToFloat64 `json:"frozenBal"`
-			Interest           convert.StringToFloat64 `json:"interest"`
-			IsoEquity          string                  `json:"isoEq"`
-			IsoLiability       string                  `json:"isoLiab"`
-			IsoUpl             string                  `json:"isoUpl"`
-			Liability          convert.StringToFloat64 `json:"liab"`
-			MaxLoan            convert.StringToFloat64 `json:"maxLoan"`
-			MgnRatio           convert.StringToFloat64 `json:"mgnRatio"`
-			NotionalLeverage   string                  `json:"notionalLever"`
-			MarginFrozenOrders string                  `json:"ordFrozen"`
-			SpotInUseAmount    string                  `json:"spotInUseAmt"`
-			StrategyEquity     string                  `json:"stgyEq"`
-			Twap               string                  `json:"twap"`
-			UPL                string                  `json:"upl"` // Unrealized profit and loss
-			UpdateTime         okcoinTime              `json:"uTime"`
+			AvailableBalance   okcoinNumber `json:"availBal"`
+			AvailableEquity    types.Number `json:"availEq"`
+			CashBalance        types.Number `json:"cashBal"`
+			Currency           string       `json:"ccy"`
+			CoinUsdPrice       types.Number `json:"coinUsdPrice"`
+			CrossLiab          string       `json:"crossLiab"`
+			DiscountEquity     string       `json:"disEq"`
+			Equity             string       `json:"eq"`
+			EquityUsd          string       `json:"eqUsd"`
+			FixedBalance       types.Number `json:"fixedBal"`
+			FrozenBalance      types.Number `json:"frozenBal"`
+			Interest           types.Number `json:"interest"`
+			IsoEquity          string       `json:"isoEq"`
+			IsoLiability       string       `json:"isoLiab"`
+			IsoUpl             string       `json:"isoUpl"`
+			Liability          types.Number `json:"liab"`
+			MaxLoan            types.Number `json:"maxLoan"`
+			MgnRatio           types.Number `json:"mgnRatio"`
+			NotionalLeverage   string       `json:"notionalLever"`
+			MarginFrozenOrders string       `json:"ordFrozen"`
+			SpotInUseAmount    string       `json:"spotInUseAmt"`
+			StrategyEquity     string       `json:"stgyEq"`
+			Twap               string       `json:"twap"`
+			UPL                string       `json:"upl"` // Unrealized profit and loss
+			UpdateTime         okcoinTime   `json:"uTime"`
 		} `json:"details"`
-		FrozenEquity                 string                  `json:"imr"`
-		IsoEquity                    string                  `json:"isoEq"`
-		MarginRatio                  string                  `json:"mgnRatio"`
-		MaintenanceMarginRequirement string                  `json:"mmr"`
-		NotionalUsd                  convert.StringToFloat64 `json:"notionalUsd"`
-		MarginOrderFrozen            string                  `json:"ordFroz"`
-		TotalEquity                  string                  `json:"totalEq"`
-		UpdateTime                   okcoinTime              `json:"uTime"`
+		FrozenEquity                 string       `json:"imr"`
+		IsoEquity                    string       `json:"isoEq"`
+		MarginRatio                  string       `json:"mgnRatio"`
+		MaintenanceMarginRequirement string       `json:"mmr"`
+		NotionalUsd                  types.Number `json:"notionalUsd"`
+		MarginOrderFrozen            string       `json:"ordFroz"`
+		TotalEquity                  string       `json:"totalEq"`
+		UpdateTime                   okcoinTime   `json:"uTime"`
 	} `json:"data"`
 }
 
@@ -294,52 +294,52 @@ type WebsocketOrder struct {
 		UID            string `json:"uid"`
 	} `json:"arg"`
 	Data []struct {
-		AccFillSize                convert.StringToFloat64 `json:"accFillSz"`
-		AmendResult                string                  `json:"amendResult"`
-		AveragePrice               convert.StringToFloat64 `json:"avgPx"`
-		CreateTime                 okcoinTime              `json:"cTime"`
-		Category                   string                  `json:"category"`
-		Currency                   string                  `json:"ccy"`
-		ClientOrdID                string                  `json:"clOrdId"`
-		Code                       string                  `json:"code"`
-		ExecType                   string                  `json:"execType"`
-		Fee                        convert.StringToFloat64 `json:"fee"`
-		FeeCurrency                string                  `json:"feeCcy"`
-		FillFee                    convert.StringToFloat64 `json:"fillFee"`
-		FillFeeCurrency            string                  `json:"fillFeeCcy"`
-		FillNotionalUsd            convert.StringToFloat64 `json:"fillNotionalUsd"`
-		FillPrice                  convert.StringToFloat64 `json:"fillPx"`
-		FillSize                   convert.StringToFloat64 `json:"fillSz"`
-		FillTime                   okcoinTime              `json:"fillTime"`
-		InstrumentID               string                  `json:"instId"`
-		InstrumentType             string                  `json:"instType"`
-		Leverage                   convert.StringToFloat64 `json:"lever"`
-		ErrorMessage               string                  `json:"msg"`
-		NotionalUsd                convert.StringToFloat64 `json:"notionalUsd"`
-		OrderID                    string                  `json:"ordId"`
-		OrderType                  string                  `json:"ordType"`
-		ProfitAndLoss              convert.StringToFloat64 `json:"pnl"`
-		PositionSide               string                  `json:"posSide"`
-		Price                      convert.StringToFloat64 `json:"px"`
-		Rebate                     string                  `json:"rebate"`
-		RebateCurrency             string                  `json:"rebateCcy"`
-		ReduceOnly                 bool                    `json:"reduceOnly,string"`
-		ClientRequestID            string                  `json:"reqId"`
-		Side                       string                  `json:"side"`
-		StopLossOrderPrice         convert.StringToFloat64 `json:"slOrdPx"`
-		StopLossTriggerPrice       convert.StringToFloat64 `json:"slTriggerPx"`
-		StopLossTriggerPriceType   string                  `json:"slTriggerPxType"`
-		Source                     string                  `json:"source"`
-		State                      string                  `json:"state"`
-		Size                       convert.StringToFloat64 `json:"sz"`
-		Tag                        string                  `json:"tag"`
-		TradeMode                  string                  `json:"tdMode"`
-		TargetCurrency             string                  `json:"tgtCcy"`
-		TakeProfitOrdPrice         convert.StringToFloat64 `json:"tpOrdPx"`
-		TakeProfitTriggerPrice     convert.StringToFloat64 `json:"tpTriggerPx"`
-		TakeProfitTriggerPriceType string                  `json:"tpTriggerPxType"`
-		TradeID                    string                  `json:"tradeId"`
-		UpdateTime                 okcoinTime              `json:"uTime"`
+		AccFillSize                types.Number `json:"accFillSz"`
+		AmendResult                string       `json:"amendResult"`
+		AveragePrice               types.Number `json:"avgPx"`
+		CreateTime                 okcoinTime   `json:"cTime"`
+		Category                   string       `json:"category"`
+		Currency                   string       `json:"ccy"`
+		ClientOrdID                string       `json:"clOrdId"`
+		Code                       string       `json:"code"`
+		ExecType                   string       `json:"execType"`
+		Fee                        types.Number `json:"fee"`
+		FeeCurrency                string       `json:"feeCcy"`
+		FillFee                    types.Number `json:"fillFee"`
+		FillFeeCurrency            string       `json:"fillFeeCcy"`
+		FillNotionalUsd            types.Number `json:"fillNotionalUsd"`
+		FillPrice                  types.Number `json:"fillPx"`
+		FillSize                   types.Number `json:"fillSz"`
+		FillTime                   okcoinTime   `json:"fillTime"`
+		InstrumentID               string       `json:"instId"`
+		InstrumentType             string       `json:"instType"`
+		Leverage                   types.Number `json:"lever"`
+		ErrorMessage               string       `json:"msg"`
+		NotionalUsd                types.Number `json:"notionalUsd"`
+		OrderID                    string       `json:"ordId"`
+		OrderType                  string       `json:"ordType"`
+		ProfitAndLoss              types.Number `json:"pnl"`
+		PositionSide               string       `json:"posSide"`
+		Price                      types.Number `json:"px"`
+		Rebate                     string       `json:"rebate"`
+		RebateCurrency             string       `json:"rebateCcy"`
+		ReduceOnly                 bool         `json:"reduceOnly,string"`
+		ClientRequestID            string       `json:"reqId"`
+		Side                       string       `json:"side"`
+		StopLossOrderPrice         types.Number `json:"slOrdPx"`
+		StopLossTriggerPrice       types.Number `json:"slTriggerPx"`
+		StopLossTriggerPriceType   string       `json:"slTriggerPxType"`
+		Source                     string       `json:"source"`
+		State                      string       `json:"state"`
+		Size                       types.Number `json:"sz"`
+		Tag                        string       `json:"tag"`
+		TradeMode                  string       `json:"tdMode"`
+		TargetCurrency             string       `json:"tgtCcy"`
+		TakeProfitOrdPrice         types.Number `json:"tpOrdPx"`
+		TakeProfitTriggerPrice     types.Number `json:"tpTriggerPx"`
+		TakeProfitTriggerPriceType string       `json:"tpTriggerPxType"`
+		TradeID                    string       `json:"tradeId"`
+		UpdateTime                 okcoinTime   `json:"uTime"`
 	} `json:"data"`
 }
 
@@ -352,36 +352,36 @@ type WebsocketAlgoOrder struct {
 		InstrumentID string `json:"instId"`
 	} `json:"arg"`
 	Data []struct {
-		InstrumentType             string                  `json:"instType"`
-		InstrumentID               string                  `json:"instId"`
-		OrderID                    string                  `json:"ordId"`
-		Currency                   string                  `json:"ccy"`
-		ClientOrderID              string                  `json:"clOrdId"`
-		AlgoID                     string                  `json:"algoId"`
-		Price                      convert.StringToFloat64 `json:"px"`
-		Size                       convert.StringToFloat64 `json:"sz"`
-		TradeMode                  string                  `json:"tdMode"`
-		TgtCurrency                string                  `json:"tgtCcy"`
-		NotionalUsd                convert.StringToFloat64 `json:"notionalUsd"`
-		OrderType                  string                  `json:"ordType"`
-		Side                       string                  `json:"side"`
-		PositionSide               string                  `json:"posSide"`
-		State                      string                  `json:"state"`
-		Leverage                   float64                 `json:"lever"`
-		TakeProfitTriggerPrice     convert.StringToFloat64 `json:"tpTriggerPx"`
-		TakeProfitTriggerPriceType string                  `json:"tpTriggerPxType"`
-		TakeProfitOrdPrice         convert.StringToFloat64 `json:"tpOrdPx"`
-		SlTriggerPrice             convert.StringToFloat64 `json:"slTriggerPx"`
-		SlTriggerPriceType         string                  `json:"slTriggerPxType"`
-		TriggerPxType              string                  `json:"triggerPxType"`
-		TriggerPrice               convert.StringToFloat64 `json:"triggerPx"`
-		OrderPrice                 convert.StringToFloat64 `json:"ordPx"`
-		Tag                        string                  `json:"tag"`
-		ActualSize                 convert.StringToFloat64 `json:"actualSz"`
-		ActualPrice                convert.StringToFloat64 `json:"actualPx"`
-		ActualSide                 string                  `json:"actualSide"`
-		TriggerTime                okcoinTime              `json:"triggerTime"`
-		CreateTime                 okcoinTime              `json:"cTime"`
+		InstrumentType             string       `json:"instType"`
+		InstrumentID               string       `json:"instId"`
+		OrderID                    string       `json:"ordId"`
+		Currency                   string       `json:"ccy"`
+		ClientOrderID              string       `json:"clOrdId"`
+		AlgoID                     string       `json:"algoId"`
+		Price                      types.Number `json:"px"`
+		Size                       types.Number `json:"sz"`
+		TradeMode                  string       `json:"tdMode"`
+		TgtCurrency                string       `json:"tgtCcy"`
+		NotionalUsd                types.Number `json:"notionalUsd"`
+		OrderType                  string       `json:"ordType"`
+		Side                       string       `json:"side"`
+		PositionSide               string       `json:"posSide"`
+		State                      string       `json:"state"`
+		Leverage                   float64      `json:"lever"`
+		TakeProfitTriggerPrice     types.Number `json:"tpTriggerPx"`
+		TakeProfitTriggerPriceType string       `json:"tpTriggerPxType"`
+		TakeProfitOrdPrice         types.Number `json:"tpOrdPx"`
+		SlTriggerPrice             types.Number `json:"slTriggerPx"`
+		SlTriggerPriceType         string       `json:"slTriggerPxType"`
+		TriggerPxType              string       `json:"triggerPxType"`
+		TriggerPrice               types.Number `json:"triggerPx"`
+		OrderPrice                 types.Number `json:"ordPx"`
+		Tag                        string       `json:"tag"`
+		ActualSize                 types.Number `json:"actualSz"`
+		ActualPrice                types.Number `json:"actualPx"`
+		ActualSide                 string       `json:"actualSide"`
+		TriggerTime                okcoinTime   `json:"triggerTime"`
+		CreateTime                 okcoinTime   `json:"cTime"`
 	} `json:"data"`
 }
 
@@ -394,95 +394,95 @@ type WebsocketAdvancedAlgoOrder struct {
 		InstrumentID string `json:"instId"`
 	} `json:"arg"`
 	Data []struct {
-		ActualPx             convert.StringToFloat64 `json:"actualPx"`
-		ActualSide           string                  `json:"actualSide"`
-		ActualSz             convert.StringToFloat64 `json:"actualSz"`
-		AlgoID               string                  `json:"algoId"`
-		CreationTime         okcoinTime              `json:"cTime"`
-		Ccy                  string                  `json:"ccy"`
-		ClOrdID              string                  `json:"clOrdId"`
-		Count                string                  `json:"count"`
-		InstrumentID         string                  `json:"instId"`
-		InstType             string                  `json:"instType"`
-		Lever                convert.StringToFloat64 `json:"lever"`
-		NotionalUsd          convert.StringToFloat64 `json:"notionalUsd"`
-		OrderPrice           convert.StringToFloat64 `json:"ordPx"`
-		OrderType            string                  `json:"ordType"`
-		PushTime             okcoinTime              `json:"pTime"`
-		PosSide              string                  `json:"posSide"`
-		PriceLimit           convert.StringToFloat64 `json:"pxLimit"`
-		PriceSpread          okcoinNumber            `json:"pxSpread"`
-		PriceVar             okcoinNumber            `json:"pxVar"`
-		Side                 string                  `json:"side"`
-		StopLossOrdPrice     string                  `json:"slOrdPx"`
-		StopLossTriggerPrice string                  `json:"slTriggerPx"`
-		State                string                  `json:"state"`
-		Size                 convert.StringToFloat64 `json:"sz"`
-		SizeLimit            convert.StringToFloat64 `json:"szLimit"`
-		TradeMode            string                  `json:"tdMode"`
-		TimeInterval         string                  `json:"timeInterval"`
-		TakeProfitOrdPx      convert.StringToFloat64 `json:"tpOrdPx"`
-		TakeProfitTriggerPx  convert.StringToFloat64 `json:"tpTriggerPx"`
-		Tag                  string                  `json:"tag"`
-		TriggerPrice         convert.StringToFloat64 `json:"triggerPx"`
-		TriggerTime          string                  `json:"triggerTime"`
-		CallbackRatio        string                  `json:"callbackRatio"`
-		CallbackSpread       string                  `json:"callbackSpread"`
-		ActivePrice          convert.StringToFloat64 `json:"activePx"`
-		MoveTriggerPrice     convert.StringToFloat64 `json:"moveTriggerPx"`
+		ActualPx             types.Number `json:"actualPx"`
+		ActualSide           string       `json:"actualSide"`
+		ActualSz             types.Number `json:"actualSz"`
+		AlgoID               string       `json:"algoId"`
+		CreationTime         okcoinTime   `json:"cTime"`
+		Ccy                  string       `json:"ccy"`
+		ClOrdID              string       `json:"clOrdId"`
+		Count                string       `json:"count"`
+		InstrumentID         string       `json:"instId"`
+		InstType             string       `json:"instType"`
+		Lever                types.Number `json:"lever"`
+		NotionalUsd          types.Number `json:"notionalUsd"`
+		OrderPrice           types.Number `json:"ordPx"`
+		OrderType            string       `json:"ordType"`
+		PushTime             okcoinTime   `json:"pTime"`
+		PosSide              string       `json:"posSide"`
+		PriceLimit           types.Number `json:"pxLimit"`
+		PriceSpread          okcoinNumber `json:"pxSpread"`
+		PriceVar             okcoinNumber `json:"pxVar"`
+		Side                 string       `json:"side"`
+		StopLossOrdPrice     string       `json:"slOrdPx"`
+		StopLossTriggerPrice string       `json:"slTriggerPx"`
+		State                string       `json:"state"`
+		Size                 types.Number `json:"sz"`
+		SizeLimit            types.Number `json:"szLimit"`
+		TradeMode            string       `json:"tdMode"`
+		TimeInterval         string       `json:"timeInterval"`
+		TakeProfitOrdPx      types.Number `json:"tpOrdPx"`
+		TakeProfitTriggerPx  types.Number `json:"tpTriggerPx"`
+		Tag                  string       `json:"tag"`
+		TriggerPrice         types.Number `json:"triggerPx"`
+		TriggerTime          string       `json:"triggerTime"`
+		CallbackRatio        string       `json:"callbackRatio"`
+		CallbackSpread       string       `json:"callbackSpread"`
+		ActivePrice          types.Number `json:"activePx"`
+		MoveTriggerPrice     types.Number `json:"moveTriggerPx"`
 	} `json:"data"`
 }
 
 // WebsocketInstrumentData contains formatted data for instruments related websocket responses
 type WebsocketInstrumentData struct {
-	Alias                 string                  `json:"alias"`
-	BaseCurrency          string                  `json:"baseCcy"`
-	Category              string                  `json:"category"`
-	ContractMultiplier    string                  `json:"ctMult"`
-	ContractType          string                  `json:"ctType"`
-	ContractValue         string                  `json:"ctVal"`
-	ContractValueCurrency string                  `json:"ctValCcy"`
-	ExpiryTime            okcoinTime              `json:"expTime"`
-	InstrumentFamily      string                  `json:"instFamily"`
-	InstrumentID          string                  `json:"instId"`
-	InstrumentType        string                  `json:"instType"`
-	Leverage              convert.StringToFloat64 `json:"lever"`
-	ListTime              okcoinTime              `json:"listTime"`
-	LotSize               convert.StringToFloat64 `json:"lotSz"`
-	MaxIcebergSize        convert.StringToFloat64 `json:"maxIcebergSz"`
-	MaxLimitSize          convert.StringToFloat64 `json:"maxLmtSz"`
-	MaxMarketSize         convert.StringToFloat64 `json:"maxMktSz"`
-	MaxStopSize           convert.StringToFloat64 `json:"maxStopSz"`
-	MaxTriggerSize        convert.StringToFloat64 `json:"maxTriggerSz"`
-	MaxTwapSize           convert.StringToFloat64 `json:"maxTwapSz"`
-	MinimumOrderSize      convert.StringToFloat64 `json:"minSz"`
-	OptionType            string                  `json:"optType"`
-	QuoteCurrency         string                  `json:"quoteCcy"`
-	SettleCurrency        string                  `json:"settleCcy"`
-	State                 string                  `json:"state"`
-	StrikePrice           convert.StringToFloat64 `json:"stk"`
-	TickSize              convert.StringToFloat64 `json:"tickSz"`
-	Underlying            string                  `json:"uly"`
+	Alias                 string       `json:"alias"`
+	BaseCurrency          string       `json:"baseCcy"`
+	Category              string       `json:"category"`
+	ContractMultiplier    string       `json:"ctMult"`
+	ContractType          string       `json:"ctType"`
+	ContractValue         string       `json:"ctVal"`
+	ContractValueCurrency string       `json:"ctValCcy"`
+	ExpiryTime            okcoinTime   `json:"expTime"`
+	InstrumentFamily      string       `json:"instFamily"`
+	InstrumentID          string       `json:"instId"`
+	InstrumentType        string       `json:"instType"`
+	Leverage              types.Number `json:"lever"`
+	ListTime              okcoinTime   `json:"listTime"`
+	LotSize               types.Number `json:"lotSz"`
+	MaxIcebergSize        types.Number `json:"maxIcebergSz"`
+	MaxLimitSize          types.Number `json:"maxLmtSz"`
+	MaxMarketSize         types.Number `json:"maxMktSz"`
+	MaxStopSize           types.Number `json:"maxStopSz"`
+	MaxTriggerSize        types.Number `json:"maxTriggerSz"`
+	MaxTwapSize           types.Number `json:"maxTwapSz"`
+	MinimumOrderSize      types.Number `json:"minSz"`
+	OptionType            string       `json:"optType"`
+	QuoteCurrency         string       `json:"quoteCcy"`
+	SettleCurrency        string       `json:"settleCcy"`
+	State                 string       `json:"state"`
+	StrikePrice           types.Number `json:"stk"`
+	TickSize              types.Number `json:"tickSz"`
+	Underlying            string       `json:"uly"`
 }
 
 // WsTickerData contains formatted data for ticker related websocket responses
 type WsTickerData struct {
-	InstrumentType string                  `json:"instType"`
-	InstrumentID   string                  `json:"instId"`
-	Last           convert.StringToFloat64 `json:"last"`
-	LastSize       convert.StringToFloat64 `json:"lastSz"`
-	AskPrice       convert.StringToFloat64 `json:"askPx"`
-	AskSize        convert.StringToFloat64 `json:"askSz"`
-	BidPrice       convert.StringToFloat64 `json:"bidPx"`
-	BidSize        convert.StringToFloat64 `json:"bidSz"`
-	Open24H        convert.StringToFloat64 `json:"open24h"`
-	High24H        convert.StringToFloat64 `json:"high24h"`
-	Low24H         convert.StringToFloat64 `json:"low24h"`
-	SodUtc0        string                  `json:"sodUtc0"`
-	SodUtc8        string                  `json:"sodUtc8"`
-	VolCcy24H      convert.StringToFloat64 `json:"volCcy24h"`
-	Vol24H         convert.StringToFloat64 `json:"vol24h"`
-	Timestamp      okcoinTime              `json:"ts"`
+	InstrumentType string       `json:"instType"`
+	InstrumentID   string       `json:"instId"`
+	Last           types.Number `json:"last"`
+	LastSize       types.Number `json:"lastSz"`
+	AskPrice       types.Number `json:"askPx"`
+	AskSize        types.Number `json:"askSz"`
+	BidPrice       types.Number `json:"bidPx"`
+	BidSize        types.Number `json:"bidSz"`
+	Open24H        types.Number `json:"open24h"`
+	High24H        types.Number `json:"high24h"`
+	Low24H         types.Number `json:"low24h"`
+	SodUtc0        string       `json:"sodUtc0"`
+	SodUtc8        string       `json:"sodUtc8"`
+	VolCcy24H      types.Number `json:"volCcy24h"`
+	Vol24H         types.Number `json:"vol24h"`
+	Timestamp      okcoinTime   `json:"ts"`
 }
 
 // WebsocketTradeResponse contains formatted data for trade related websocket responses
@@ -492,12 +492,12 @@ type WebsocketTradeResponse struct {
 		InstrumentID string `json:"instId"`
 	} `json:"arg"`
 	Data []struct {
-		InstrumentID string                  `json:"instId"`
-		TradeID      string                  `json:"tradeId"`
-		Price        convert.StringToFloat64 `json:"px"`
-		Size         convert.StringToFloat64 `json:"sz"`
-		Side         string                  `json:"side"`
-		Timestamp    okcoinTime              `json:"ts"`
+		InstrumentID string       `json:"instId"`
+		TradeID      string       `json:"tradeId"`
+		Price        types.Number `json:"px"`
+		Size         types.Number `json:"sz"`
+		Side         string       `json:"side"`
+		Timestamp    okcoinTime   `json:"ts"`
 	} `json:"data"`
 }
 
@@ -545,34 +545,34 @@ type SystemStatus struct {
 
 // Instrument represents an instrument in an open contract.
 type Instrument struct {
-	Alias          string                  `json:"alias"`
-	BaseCurrency   string                  `json:"baseCcy"`
-	Category       string                  `json:"category"`
-	CtMult         string                  `json:"ctMult"`
-	CtType         string                  `json:"ctType"`
-	CtVal          string                  `json:"ctVal"`
-	CtValCurrency  string                  `json:"ctValCcy"`
-	ExpTime        okcoinTime              `json:"expTime"`
-	InstFamily     string                  `json:"instFamily"`
-	InstrumentID   string                  `json:"instId"`
-	InstrumentType string                  `json:"instType"`
-	Leverage       convert.StringToFloat64 `json:"lever"`
-	ListTime       okcoinTime              `json:"listTime"`
-	LotSize        convert.StringToFloat64 `json:"lotSz"`
-	MaxIcebergSz   okcoinNumber            `json:"maxIcebergSz"`
-	MaxLimitSize   okcoinNumber            `json:"maxLmtSz"`
-	MaxMarketSize  okcoinNumber            `json:"maxMktSz"`
-	MaxStopSize    okcoinNumber            `json:"maxStopSz"`
-	MaxTwapSize    okcoinNumber            `json:"maxTwapSz"`
-	MaxTriggerSize okcoinNumber            `json:"maxTriggerSz"`
-	MinSize        okcoinNumber            `json:"minSz"` // Minimum order size
-	QuoteCurrency  string                  `json:"quoteCcy"`
-	OptionType     string                  `json:"optType"`
-	SettleCurrency string                  `json:"settleCcy"`
-	State          string                  `json:"state"`
-	StrikePrice    okcoinNumber            `json:"stk"`
-	TickSize       okcoinNumber            `json:"tickSz"`
-	Underlying     string                  `json:"uly"`
+	Alias          string       `json:"alias"`
+	BaseCurrency   string       `json:"baseCcy"`
+	Category       string       `json:"category"`
+	CtMult         string       `json:"ctMult"`
+	CtType         string       `json:"ctType"`
+	CtVal          string       `json:"ctVal"`
+	CtValCurrency  string       `json:"ctValCcy"`
+	ExpTime        okcoinTime   `json:"expTime"`
+	InstFamily     string       `json:"instFamily"`
+	InstrumentID   string       `json:"instId"`
+	InstrumentType string       `json:"instType"`
+	Leverage       types.Number `json:"lever"`
+	ListTime       okcoinTime   `json:"listTime"`
+	LotSize        types.Number `json:"lotSz"`
+	MaxIcebergSz   okcoinNumber `json:"maxIcebergSz"`
+	MaxLimitSize   okcoinNumber `json:"maxLmtSz"`
+	MaxMarketSize  okcoinNumber `json:"maxMktSz"`
+	MaxStopSize    okcoinNumber `json:"maxStopSz"`
+	MaxTwapSize    okcoinNumber `json:"maxTwapSz"`
+	MaxTriggerSize okcoinNumber `json:"maxTriggerSz"`
+	MinSize        okcoinNumber `json:"minSz"` // Minimum order size
+	QuoteCurrency  string       `json:"quoteCcy"`
+	OptionType     string       `json:"optType"`
+	SettleCurrency string       `json:"settleCcy"`
+	State          string       `json:"state"`
+	StrikePrice    okcoinNumber `json:"stk"`
+	TickSize       okcoinNumber `json:"tickSz"`
+	Underlying     string       `json:"uly"`
 }
 
 type candlestickItemResponse [9]string
@@ -592,19 +592,19 @@ type CandlestickData struct {
 
 // SpotTrade represents spot trades
 type SpotTrade struct {
-	InstrumentID string                  `json:"instId"`
-	Side         string                  `json:"side"`
-	TradeSize    convert.StringToFloat64 `json:"sz"`
-	TradePrice   convert.StringToFloat64 `json:"px"`
-	TradeID      string                  `json:"tradeId"`
-	Timestamp    okcoinTime              `json:"ts"`
+	InstrumentID string       `json:"instId"`
+	Side         string       `json:"side"`
+	TradeSize    types.Number `json:"sz"`
+	TradePrice   types.Number `json:"px"`
+	TradeID      string       `json:"tradeId"`
+	Timestamp    okcoinTime   `json:"ts"`
 }
 
 // TradingVolume represents the trading volume of the platform in 24 hours
 type TradingVolume struct {
-	VolCny    convert.StringToFloat64 `json:"volCny"`
-	VolUsd    convert.StringToFloat64 `json:"volUsd"`
-	Timestamp okcoinTime              `json:"ts"`
+	VolCny    types.Number `json:"volCny"`
+	VolUsd    types.Number `json:"volUsd"`
+	Timestamp okcoinTime   `json:"ts"`
 }
 
 // Oracle represents crypto price of signing using Open Oracle smart contract.
@@ -678,48 +678,48 @@ func ExtractCandlesticks(candles []candlestickItemResponse) ([]CandlestickData, 
 
 // CurrencyInfo represents a currency instance detailed information
 type CurrencyInfo struct {
-	CanDep                     bool                    `json:"canDep"`
-	CanInternal                bool                    `json:"canInternal"`
-	CanWd                      bool                    `json:"canWd"`
-	Currency                   string                  `json:"ccy"`
-	Chain                      string                  `json:"chain"`
-	DepQuotaFixed              string                  `json:"depQuotaFixed"`
-	DepQuoteDailyLayer2        string                  `json:"depQuoteDailyLayer2"`
-	LogoLink                   string                  `json:"logoLink"`
-	MainNet                    bool                    `json:"mainNet"`
-	MaxFee                     convert.StringToFloat64 `json:"maxFee"`
-	MaxWithdrawal              convert.StringToFloat64 `json:"maxWd"`
-	MinDeposit                 convert.StringToFloat64 `json:"minDep"`
-	MinDepArrivalConfirm       string                  `json:"minDepArrivalConfirm"`
-	MinFee                     convert.StringToFloat64 `json:"minFee"`
-	MinWithdrawal              convert.StringToFloat64 `json:"minWd"`
-	MinWithdrawalUnlockConfirm string                  `json:"minWdUnlockConfirm"`
-	Name                       string                  `json:"name"`
-	NeedTag                    bool                    `json:"needTag"`
-	UsedDepQuotaFixed          string                  `json:"usedDepQuotaFixed"`
-	UsedWdQuota                string                  `json:"usedWdQuota"`
-	WithdrawalQuota            string                  `json:"wdQuota"`
-	WithdrawalTickSize         convert.StringToFloat64 `json:"wdTickSz"`
+	CanDep                     bool         `json:"canDep"`
+	CanInternal                bool         `json:"canInternal"`
+	CanWd                      bool         `json:"canWd"`
+	Currency                   string       `json:"ccy"`
+	Chain                      string       `json:"chain"`
+	DepQuotaFixed              string       `json:"depQuotaFixed"`
+	DepQuoteDailyLayer2        string       `json:"depQuoteDailyLayer2"`
+	LogoLink                   string       `json:"logoLink"`
+	MainNet                    bool         `json:"mainNet"`
+	MaxFee                     types.Number `json:"maxFee"`
+	MaxWithdrawal              types.Number `json:"maxWd"`
+	MinDeposit                 types.Number `json:"minDep"`
+	MinDepArrivalConfirm       string       `json:"minDepArrivalConfirm"`
+	MinFee                     types.Number `json:"minFee"`
+	MinWithdrawal              types.Number `json:"minWd"`
+	MinWithdrawalUnlockConfirm string       `json:"minWdUnlockConfirm"`
+	Name                       string       `json:"name"`
+	NeedTag                    bool         `json:"needTag"`
+	UsedDepQuotaFixed          string       `json:"usedDepQuotaFixed"`
+	UsedWdQuota                string       `json:"usedWdQuota"`
+	WithdrawalQuota            string       `json:"wdQuota"`
+	WithdrawalTickSize         types.Number `json:"wdTickSz"`
 }
 
 // CurrencyBalance represents a currency balance information.
 type CurrencyBalance struct {
-	AvailableBalance convert.StringToFloat64 `json:"availBal"`
-	Balance          convert.StringToFloat64 `json:"bal"`
-	Currency         string                  `json:"ccy"`
-	FrozenBalance    convert.StringToFloat64 `json:"frozenBal"`
+	AvailableBalance types.Number `json:"availBal"`
+	Balance          types.Number `json:"bal"`
+	Currency         string       `json:"ccy"`
+	FrozenBalance    types.Number `json:"frozenBal"`
 }
 
 // AccountAssetValuation represents account asset valuation
 type AccountAssetValuation struct {
 	Details struct {
-		Classic convert.StringToFloat64 `json:"classic"`
-		Earn    convert.StringToFloat64 `json:"earn"`
-		Funding convert.StringToFloat64 `json:"funding"`
-		Trading convert.StringToFloat64 `json:"trading"`
+		Classic types.Number `json:"classic"`
+		Earn    types.Number `json:"earn"`
+		Funding types.Number `json:"funding"`
+		Trading types.Number `json:"trading"`
 	} `json:"details"`
-	TotalBalance convert.StringToFloat64 `json:"totalBal"`
-	Timestamp    okcoinTime              `json:"ts"`
+	TotalBalance types.Number `json:"totalBal"`
+	Timestamp    okcoinTime   `json:"ts"`
 }
 
 // FundingTransferRequest represents a transfer of funds between your funding account and trading account
@@ -741,28 +741,28 @@ type FundingTransferRequest struct {
 
 // FundingTransferItem represents a response for a transfer of funds between your funding account and trading account
 type FundingTransferItem struct {
-	TransferID     string                  `json:"transId"`
-	Currency       string                  `json:"ccy"`
-	ClientID       string                  `json:"clientId"`
-	From           string                  `json:"from"`
-	Amount         convert.StringToFloat64 `json:"amt"`
-	InstrumentID   string                  `json:"instId"`
-	State          string                  `json:"state"`
-	SubAcct        string                  `json:"subAcct"`
-	To             string                  `json:"to"`
-	ToInstrumentID string                  `json:"toInstId"`
-	Type           string                  `json:"type"`
+	TransferID     string       `json:"transId"`
+	Currency       string       `json:"ccy"`
+	ClientID       string       `json:"clientId"`
+	From           string       `json:"from"`
+	Amount         types.Number `json:"amt"`
+	InstrumentID   string       `json:"instId"`
+	State          string       `json:"state"`
+	SubAcct        string       `json:"subAcct"`
+	To             string       `json:"to"`
+	ToInstrumentID string       `json:"toInstId"`
+	Type           string       `json:"type"`
 }
 
 // AssetBillDetail represents the billing record.
 type AssetBillDetail struct {
-	BillID    string                  `json:"billId"`
-	Currency  string                  `json:"ccy"`
-	ClientID  string                  `json:"clientId"`
-	BalChange convert.StringToFloat64 `json:"balChg"`
-	Balance   convert.StringToFloat64 `json:"bal"`
-	Type      string                  `json:"type"`
-	Timestamp okcoinTime              `json:"ts"`
+	BillID    string       `json:"billId"`
+	Currency  string       `json:"ccy"`
+	ClientID  string       `json:"clientId"`
+	BalChange types.Number `json:"balChg"`
+	Balance   types.Number `json:"bal"`
+	Type      string       `json:"type"`
+	Timestamp okcoinTime   `json:"ts"`
 }
 
 // LightningDepositDetail represents a lightning deposit instance detail
@@ -787,16 +787,16 @@ type DepositAddress struct {
 
 // DepositHistoryItem represents deposit records according to the currency, deposit status, and time range in reverse chronological order.
 type DepositHistoryItem struct {
-	ActualDepBlkConfirm string                  `json:"actualDepBlkConfirm"` // ActualDepBlkConfirm actual amount of blockchain confirm in a single deposit
-	Amount              convert.StringToFloat64 `json:"amt"`
-	Currency            string                  `json:"ccy"`
-	Chain               string                  `json:"chain"`
-	DepositID           string                  `json:"depId"`
-	From                string                  `json:"from"`
-	State               string                  `json:"state"`
-	To                  string                  `json:"to"`
-	Timestamp           okcoinTime              `json:"ts"`
-	TransactionID       string                  `json:"txId"`
+	ActualDepBlkConfirm string       `json:"actualDepBlkConfirm"` // ActualDepBlkConfirm actual amount of blockchain confirm in a single deposit
+	Amount              types.Number `json:"amt"`
+	Currency            string       `json:"ccy"`
+	Chain               string       `json:"chain"`
+	DepositID           string       `json:"depId"`
+	From                string       `json:"from"`
+	State               string       `json:"state"`
+	To                  string       `json:"to"`
+	Timestamp           okcoinTime   `json:"ts"`
+	TransactionID       string       `json:"txId"`
 }
 
 // WithdrawalRequest represents withdrawal of tokens request.
@@ -839,85 +839,85 @@ type WithdrawalCancellation struct {
 
 // WithdrawalOrderItem represents a withdrawal instance item
 type WithdrawalOrderItem struct {
-	Ccy                         string                  `json:"ccy"`
-	Chain                       string                  `json:"chain"`
-	Amount                      convert.StringToFloat64 `json:"amt"`
-	Timestamp                   okcoinTime              `json:"ts"`
-	RemittingAddress            string                  `json:"from"`
-	ReceivingAddress            string                  `json:"to"`
-	Tag                         string                  `json:"tag"`
-	PaymentID                   string                  `json:"pmtId"`
-	Memo                        string                  `json:"memo"`
-	WithdrawalAddressAttachment string                  `json:"addrEx"`
-	TransactionID               string                  `json:"txId"`
-	Fee                         convert.StringToFloat64 `json:"fee"`
-	State                       string                  `json:"state"`
-	WithdrawalID                string                  `json:"wdId"`
-	ClientID                    string                  `json:"clientId"`
+	Ccy                         string       `json:"ccy"`
+	Chain                       string       `json:"chain"`
+	Amount                      types.Number `json:"amt"`
+	Timestamp                   okcoinTime   `json:"ts"`
+	RemittingAddress            string       `json:"from"`
+	ReceivingAddress            string       `json:"to"`
+	Tag                         string       `json:"tag"`
+	PaymentID                   string       `json:"pmtId"`
+	Memo                        string       `json:"memo"`
+	WithdrawalAddressAttachment string       `json:"addrEx"`
+	TransactionID               string       `json:"txId"`
+	Fee                         types.Number `json:"fee"`
+	State                       string       `json:"state"`
+	WithdrawalID                string       `json:"wdId"`
+	ClientID                    string       `json:"clientId"`
 }
 
 // AccountBalanceInformation represents currency balance information.
 type AccountBalanceInformation struct {
 	AdjustedEquity string `json:"adjEq"` // Adjusted / Effective equity in USD . Not enabled. Please disregard.
 	Details        []struct {
-		AvailableBalance                 okcoinNumber            `json:"availBal"`
-		AvailableEquity                  convert.StringToFloat64 `json:"availEq"`
-		CashBalance                      convert.StringToFloat64 `json:"cashBal"`
-		Currency                         string                  `json:"ccy"`
-		CrossLiability                   string                  `json:"crossLiab"`
-		DiscountEquity                   string                  `json:"disEq"`
-		Equity                           okcoinNumber            `json:"eq"`
-		EquityUsd                        okcoinNumber            `json:"eqUsd"`
-		FixedBalance                     okcoinNumber            `json:"fixedBal"`
-		FrozenBalance                    okcoinNumber            `json:"frozenBal"`
-		Interest                         okcoinNumber            `json:"interest"`
-		IsolatedEquity                   okcoinNumber            `json:"isoEq"`
-		IsolatedLiability                okcoinNumber            `json:"isoLiab"`
-		IsolatedUpl                      string                  `json:"isoUpl"` // Isolated unrealized profit and loss of the currency. Not enabled. Please disregard.
-		Liability                        okcoinNumber            `json:"liab"`
-		MaxLoan                          okcoinNumber            `json:"maxLoan"`
-		MarginRatio                      okcoinNumber            `json:"mgnRatio"`
-		NotionalLever                    okcoinNumber            `json:"notionalLever"`
-		OrderFrozen                      okcoinNumber            `json:"ordFrozen"`
-		SpotInUseAmount                  okcoinNumber            `json:"spotInUseAmt"`
-		StrategyEquity                   string                  `json:"stgyEq"`
-		Twap                             string                  `json:"twap"`
-		UpdateTime                       okcoinTime              `json:"uTime"`
-		UnrealizedProfitAndLoss          convert.StringToFloat64 `json:"upl"`
-		UnrealizedProfitAndLossLiability string                  `json:"uplLiab"`
+		AvailableBalance                 okcoinNumber `json:"availBal"`
+		AvailableEquity                  types.Number `json:"availEq"`
+		CashBalance                      types.Number `json:"cashBal"`
+		Currency                         string       `json:"ccy"`
+		CrossLiability                   string       `json:"crossLiab"`
+		DiscountEquity                   string       `json:"disEq"`
+		Equity                           okcoinNumber `json:"eq"`
+		EquityUsd                        okcoinNumber `json:"eqUsd"`
+		FixedBalance                     okcoinNumber `json:"fixedBal"`
+		FrozenBalance                    okcoinNumber `json:"frozenBal"`
+		Interest                         okcoinNumber `json:"interest"`
+		IsolatedEquity                   okcoinNumber `json:"isoEq"`
+		IsolatedLiability                okcoinNumber `json:"isoLiab"`
+		IsolatedUpl                      string       `json:"isoUpl"` // Isolated unrealized profit and loss of the currency. Not enabled. Please disregard.
+		Liability                        okcoinNumber `json:"liab"`
+		MaxLoan                          okcoinNumber `json:"maxLoan"`
+		MarginRatio                      okcoinNumber `json:"mgnRatio"`
+		NotionalLever                    okcoinNumber `json:"notionalLever"`
+		OrderFrozen                      okcoinNumber `json:"ordFrozen"`
+		SpotInUseAmount                  okcoinNumber `json:"spotInUseAmt"`
+		StrategyEquity                   string       `json:"stgyEq"`
+		Twap                             string       `json:"twap"`
+		UpdateTime                       okcoinTime   `json:"uTime"`
+		UnrealizedProfitAndLoss          types.Number `json:"upl"`
+		UnrealizedProfitAndLossLiability string       `json:"uplLiab"`
 	} `json:"details"`
-	IMR            string                  `json:"imr"` // Frozen equity for open positions and pending orders in USD.
-	IsolatedEquity string                  `json:"isoEq"`
-	MarginRatio    okcoinNumber            `json:"mgnRatio"`
-	Mmr            string                  `json:"mmr"` // Maintenance margin requirement in USD.
-	NotionalUsd    convert.StringToFloat64 `json:"notionalUsd"`
-	OrdFroz        string                  `json:"ordFroz"`
-	TotalEq        string                  `json:"totalEq"`
-	UpdateTime     okcoinTime              `json:"uTime"`
+	IMR            string       `json:"imr"` // Frozen equity for open positions and pending orders in USD.
+	IsolatedEquity string       `json:"isoEq"`
+	MarginRatio    okcoinNumber `json:"mgnRatio"`
+	Mmr            string       `json:"mmr"` // Maintenance margin requirement in USD.
+	NotionalUsd    types.Number `json:"notionalUsd"`
+	OrdFroz        string       `json:"ordFroz"`
+	TotalEq        string       `json:"totalEq"`
+	UpdateTime     okcoinTime   `json:"uTime"`
 }
 
 // BillsDetail represents a bill
 type BillsDetail struct {
-	Balance          convert.StringToFloat64 `json:"bal"`
-	BalanceChange    convert.StringToFloat64 `json:"balChg"`
-	BillID           string                  `json:"billId"`
-	Currency         string                  `json:"ccy"`
-	ExecType         string                  `json:"execType"`
-	Fee              okcoinNumber            `json:"fee"`
-	From             string                  `json:"from"`
-	InstrumentID     string                  `json:"instId"`
-	InstrumentType   string                  `json:"instType"`
-	MarginMode       string                  `json:"mgnMode"`
-	Notes            string                  `json:"notes"`
-	OrderID          string                  `json:"ordId"`
-	ProfitAndLoss    convert.StringToFloat64 `json:"pnl"`
-	PosBalance       convert.StringToFloat64 `json:"posBal"`
-	PosBalanceChange convert.StringToFloat64 `json:"posBalChg"`
-	BillSubType      string                  `json:"subType"`
-	Size             convert.StringToFloat64 `json:"sz"`
-	To               string                  `json:"to"`
-	BillType         string                  `json:"type"`
-	Timestamp        okcoinTime              `json:"ts"`
+	Balance          types.Number `json:"bal"`
+	BalanceChange    types.Number `json:"balChg"`
+	BillID           string       `json:"billId"`
+	Currency         string       `json:"ccy"`
+	ExecType         string       `json:"execType"`
+	Fee              okcoinNumber `json:"fee"`
+	From             string       `json:"from"`
+	InstrumentID     string       `json:"instId"`
+	InstrumentType   string       `json:"instType"`
+	MarginMode       string       `json:"mgnMode"`
+	Notes            string       `json:"notes"`
+	OrderID          string       `json:"ordId"`
+	ProfitAndLoss    types.Number `json:"pnl"`
+	PosBalance       types.Number `json:"posBal"`
+	PosBalanceChange types.Number `json:"posBalChg"`
+	BillSubType      string       `json:"subType"`
+	Size             types.Number `json:"sz"`
+	To               string       `json:"to"`
+	BillType         string       `json:"type"`
+	Timestamp        okcoinTime   `json:"ts"`
 }
 
 // AccountConfiguration represents account configuration information.
@@ -936,33 +936,33 @@ type AccountConfiguration struct {
 
 // MaxBuySellResp represent a maximum buy sell or open amount information.
 type MaxBuySellResp struct {
-	Currency     string                  `json:"ccy"`
-	InstrumentID string                  `json:"instId"`
-	MaxBuy       convert.StringToFloat64 `json:"maxBuy"`
-	MaxSell      convert.StringToFloat64 `json:"maxSell"`
+	Currency     string       `json:"ccy"`
+	InstrumentID string       `json:"instId"`
+	MaxBuy       types.Number `json:"maxBuy"`
+	MaxSell      types.Number `json:"maxSell"`
 }
 
 // AvailableTradableAmount represents maximum available tradable amount information
 type AvailableTradableAmount struct {
-	AvailableBuy  convert.StringToFloat64 `json:"availBuy"`
-	AvailableSell convert.StringToFloat64 `json:"availSell"`
-	InstrumentID  string                  `json:"instId"`
+	AvailableBuy  types.Number `json:"availBuy"`
+	AvailableSell types.Number `json:"availSell"`
+	InstrumentID  string       `json:"instId"`
 }
 
 // FeeRate represents instrument trading fee information.
 type FeeRate struct {
-	Category       string                  `json:"category"`
-	Delivery       string                  `json:"delivery"`
-	Exercise       string                  `json:"exercise"`
-	InstrumentType string                  `json:"instType"`
-	Level          string                  `json:"level"`
-	MakerFeeRate   convert.StringToFloat64 `json:"maker"`
-	MakerU         convert.StringToFloat64 `json:"makerU"`
-	MakerUSDC      convert.StringToFloat64 `json:"makerUSDC"`
-	TakerFeeRate   convert.StringToFloat64 `json:"taker"`
-	TakerU         convert.StringToFloat64 `json:"takerU"`
-	TakerUSDC      convert.StringToFloat64 `json:"takerUSDC"`
-	Timestamp      okcoinTime              `json:"ts"`
+	Category       string       `json:"category"`
+	Delivery       string       `json:"delivery"`
+	Exercise       string       `json:"exercise"`
+	InstrumentType string       `json:"instType"`
+	Level          string       `json:"level"`
+	MakerFeeRate   types.Number `json:"maker"`
+	MakerU         types.Number `json:"makerU"`
+	MakerUSDC      types.Number `json:"makerUSDC"`
+	TakerFeeRate   types.Number `json:"taker"`
+	TakerU         types.Number `json:"takerU"`
+	TakerUSDC      types.Number `json:"takerUSDC"`
+	Timestamp      okcoinTime   `json:"ts"`
 }
 
 // MaximumWithdrawal represents maximum withdrawal information for currency.
@@ -1001,22 +1001,22 @@ type QuoteRequestArg struct {
 
 // RFQQuoteResponse query current market quotation information
 type RFQQuoteResponse struct {
-	QuoteTimestamp okcoinTime              `json:"quoteTs"`
-	TTLMs          string                  `json:"ttlMs"`
-	ClQReqID       string                  `json:"clQReqId"`
-	QuoteID        string                  `json:"quoteId"`
-	BaseCurrency   string                  `json:"baseCcy"`
-	QuoteCurrency  string                  `json:"quoteCcy"`
-	Side           string                  `json:"side"`
-	OrigRfqSize    float64                 `json:"origRfqSz"`
-	RfqSize        float64                 `json:"rfqSz"`
-	RfqSzCurrency  string                  `json:"rfqSzCcy"`
-	BidPrice       convert.StringToFloat64 `json:"bidPx"`
-	BidBaseSize    convert.StringToFloat64 `json:"bidBaseSz"`
-	BidQuoteSize   convert.StringToFloat64 `json:"bidQuoteSz"`
-	AskPx          convert.StringToFloat64 `json:"askPx"`
-	AskBaseSize    convert.StringToFloat64 `json:"askBaseSz"`
-	AskQuoteSize   convert.StringToFloat64 `json:"askQuoteSz"`
+	QuoteTimestamp okcoinTime   `json:"quoteTs"`
+	TTLMs          string       `json:"ttlMs"`
+	ClQReqID       string       `json:"clQReqId"`
+	QuoteID        string       `json:"quoteId"`
+	BaseCurrency   string       `json:"baseCcy"`
+	QuoteCurrency  string       `json:"quoteCcy"`
+	Side           string       `json:"side"`
+	OrigRfqSize    float64      `json:"origRfqSz"`
+	RfqSize        float64      `json:"rfqSz"`
+	RfqSzCurrency  string       `json:"rfqSzCcy"`
+	BidPrice       types.Number `json:"bidPx"`
+	BidBaseSize    types.Number `json:"bidBaseSz"`
+	BidQuoteSize   types.Number `json:"bidQuoteSz"`
+	AskPx          types.Number `json:"askPx"`
+	AskBaseSize    types.Number `json:"askBaseSz"`
+	AskQuoteSize   types.Number `json:"askQuoteSz"`
 }
 
 // PlaceRFQOrderRequest represents a place RFQ request order.
@@ -1033,34 +1033,34 @@ type PlaceRFQOrderRequest struct {
 
 // RFQOrderResponse represents an RFQ
 type RFQOrderResponse struct {
-	Timestamp      okcoinTime              `json:"ts"`
-	TradeID        string                  `json:"tradeId"`
-	QuoteID        string                  `json:"quoteId"`
-	ClTReqID       string                  `json:"clTReqId"` // user-defined ID
-	State          string                  `json:"state"`
-	InstrumentID   string                  `json:"instId"`
-	BaseCurrency   string                  `json:"baseCcy"`
-	QuoteCurrency  string                  `json:"quoteCcy"`
-	Side           string                  `json:"side"`
-	Price          convert.StringToFloat64 `json:"px"`
-	FilledBaseSize convert.StringToFloat64 `json:"filledBaseSz"`
-	FilledTermSize convert.StringToFloat64 `json:"filledTermSz"`
+	Timestamp      okcoinTime   `json:"ts"`
+	TradeID        string       `json:"tradeId"`
+	QuoteID        string       `json:"quoteId"`
+	ClTReqID       string       `json:"clTReqId"` // user-defined ID
+	State          string       `json:"state"`
+	InstrumentID   string       `json:"instId"`
+	BaseCurrency   string       `json:"baseCcy"`
+	QuoteCurrency  string       `json:"quoteCcy"`
+	Side           string       `json:"side"`
+	Price          types.Number `json:"px"`
+	FilledBaseSize types.Number `json:"filledBaseSz"`
+	FilledTermSize types.Number `json:"filledTermSz"`
 }
 
 // RFQOrderDetail represents an rfq order detail
 type RFQOrderDetail struct {
-	Timestamp      okcoinTime              `json:"ts"`
-	TradeID        string                  `json:"tradeId"`
-	QuoteID        string                  `json:"quoteId"`
-	ClTReqID       string                  `json:"clTReqId"`
-	State          string                  `json:"state"`
-	InstrumentID   string                  `json:"instId"`
-	BaseCurrency   string                  `json:"baseCcy"`
-	QuoteCurrency  string                  `json:"quoteCcy"`
-	Side           string                  `json:"side"`
-	Price          convert.StringToFloat64 `json:"px"`
-	FilledBaseSize convert.StringToFloat64 `json:"filledBaseSz"`
-	FilledTermSize convert.StringToFloat64 `json:"filledTermSz"`
+	Timestamp      okcoinTime   `json:"ts"`
+	TradeID        string       `json:"tradeId"`
+	QuoteID        string       `json:"quoteId"`
+	ClTReqID       string       `json:"clTReqId"`
+	State          string       `json:"state"`
+	InstrumentID   string       `json:"instId"`
+	BaseCurrency   string       `json:"baseCcy"`
+	QuoteCurrency  string       `json:"quoteCcy"`
+	Side           string       `json:"side"`
+	Price          types.Number `json:"px"`
+	FilledBaseSize types.Number `json:"filledBaseSz"`
+	FilledTermSize types.Number `json:"filledTermSz"`
 }
 
 // RFQOrderHistoryItem represents otc rfq order instance.
@@ -1070,17 +1070,17 @@ type RFQOrderHistoryItem struct {
 	TotalPageCount   int64      `json:"totalPageCnt,string"`
 	TotalRecordCount int64      `json:"totalRecordCnt,string"`
 	Trades           []struct {
-		Timestamp      okcoinTime              `json:"ts"`
-		TradeID        string                  `json:"tradeId"`
-		TradeTimestamp okcoinTime              `json:"tradeTs"`
-		ClTRequestID   string                  `json:"clTReqId"`
-		InstrumentID   string                  `json:"instId"`
-		Side           string                  `json:"side"`
-		Price          convert.StringToFloat64 `json:"px"`
-		BaseCurrency   string                  `json:"baseCcy"`
-		BaseSize       convert.StringToFloat64 `json:"baseSz"`
-		QuoteCurrency  string                  `json:"quoteCcy"`
-		QuoteSize      convert.StringToFloat64 `json:"quoteSz"`
+		Timestamp      okcoinTime   `json:"ts"`
+		TradeID        string       `json:"tradeId"`
+		TradeTimestamp okcoinTime   `json:"tradeTs"`
+		ClTRequestID   string       `json:"clTReqId"`
+		InstrumentID   string       `json:"instId"`
+		Side           string       `json:"side"`
+		Price          types.Number `json:"px"`
+		BaseCurrency   string       `json:"baseCcy"`
+		BaseSize       types.Number `json:"baseSz"`
+		QuoteCurrency  string       `json:"quoteCcy"`
+		QuoteSize      types.Number `json:"quoteSz"`
 	} `json:"trades"`
 }
 
@@ -1105,16 +1105,16 @@ type CancelDepositAddressResp struct {
 
 // DepositHistoryResponse represents a deposit history instance detail.
 type DepositHistoryResponse struct {
-	DepositID         string                  `json:"depId"`
-	ChannelID         string                  `json:"chanId"`
-	BillID            string                  `json:"billId"`
-	BankAccountName   string                  `json:"bankAcctName"`
-	BankAccountNumber string                  `json:"bankAcctNum"`
-	Amount            convert.StringToFloat64 `json:"amt"`
-	State             string                  `json:"state"`
-	Currency          string                  `json:"ccy"`
-	CreationTime      okcoinTime              `json:"cTime"`
-	UpdatedTime       okcoinTime              `json:"uTime"`
+	DepositID         string       `json:"depId"`
+	ChannelID         string       `json:"chanId"`
+	BillID            string       `json:"billId"`
+	BankAccountName   string       `json:"bankAcctName"`
+	BankAccountNumber string       `json:"bankAcctNum"`
+	Amount            types.Number `json:"amt"`
+	State             string       `json:"state"`
+	Currency          string       `json:"ccy"`
+	CreationTime      okcoinTime   `json:"cTime"`
+	UpdatedTime       okcoinTime   `json:"uTime"`
 }
 
 // FiatWithdrawalParam represents a fiat withdrawal parameters
@@ -1126,24 +1126,24 @@ type FiatWithdrawalParam struct {
 
 // FiatWithdrawalResponse represents a fiat withdrawal
 type FiatWithdrawalResponse struct {
-	DepositID    string                  `json:"depId"`
-	Fee          convert.StringToFloat64 `json:"fee"`
-	CreationTime okcoinTime              `json:"cTime"`
+	DepositID    string       `json:"depId"`
+	Fee          types.Number `json:"fee"`
+	CreationTime okcoinTime   `json:"cTime"`
 }
 
 // FiatWithdrawalHistoryItem represents fiat withdrawal history item.
 type FiatWithdrawalHistoryItem struct {
-	WithdrawalID    string                  `json:"wdId"`
-	ChannelID       string                  `json:"chanId"`
-	BillID          string                  `json:"billId"`
-	BankAccountName string                  `json:"bankAcctName"`
-	BankAcctNumber  string                  `json:"bankAcctNum"`
-	Amount          convert.StringToFloat64 `json:"amt"`
-	Fee             convert.StringToFloat64 `json:"fee"`
-	State           string                  `json:"state"`
-	Ccy             string                  `json:"ccy"`
-	CreationTime    okcoinTime              `json:"cTime"`
-	UpdateTime      okcoinTime              `json:"uTime"`
+	WithdrawalID    string       `json:"wdId"`
+	ChannelID       string       `json:"chanId"`
+	BillID          string       `json:"billId"`
+	BankAccountName string       `json:"bankAcctName"`
+	BankAcctNumber  string       `json:"bankAcctNum"`
+	Amount          types.Number `json:"amt"`
+	Fee             types.Number `json:"fee"`
+	State           string       `json:"state"`
+	Ccy             string       `json:"ccy"`
+	CreationTime    okcoinTime   `json:"cTime"`
+	UpdateTime      okcoinTime   `json:"uTime"`
 }
 
 // ChannelInfo represents a channel information
@@ -1231,62 +1231,62 @@ type AmendTradeOrderResponse struct {
 
 // TradeOrder represents a trade order detail
 type TradeOrder struct {
-	AccFillSize                convert.StringToFloat64 `json:"accFillSz"`
-	AveragePrice               convert.StringToFloat64 `json:"avgPx"`
-	CreationTime               okcoinTime              `json:"cTime"`
-	Category                   string                  `json:"category"`
-	Currency                   string                  `json:"ccy"`
-	ClientOrdID                string                  `json:"clOrdId"`
-	Fee                        okcoinNumber            `json:"fee"`
-	FeeCurrency                string                  `json:"feeCcy"`
-	FillPrice                  convert.StringToFloat64 `json:"fillPx"`
-	FillSize                   convert.StringToFloat64 `json:"fillSz"`
-	FillTime                   okcoinTime              `json:"fillTime"`
-	InstrumentID               string                  `json:"instId"`
-	InstrumentType             string                  `json:"instType"`
-	Leverage                   okcoinNumber            `json:"lever"`
-	OrderID                    string                  `json:"ordId"`
-	OrderType                  string                  `json:"ordType"`
-	ProfitAndLoss              convert.StringToFloat64 `json:"pnl"`
-	PosSide                    string                  `json:"posSide"`
-	Price                      convert.StringToFloat64 `json:"px"`
-	Rebate                     okcoinNumber            `json:"rebate"`
-	RebateCurrency             string                  `json:"rebateCcy"`
-	ReduceOnly                 bool                    `json:"reduceOnly,string"`
-	Side                       string                  `json:"side"`
-	StopLossOrdPrice           okcoinNumber            `json:"slOrdPx"`
-	StopLossTriggerPrice       okcoinNumber            `json:"slTriggerPx"`
-	StopLossTriggerPriceType   string                  `json:"slTriggerPxType"`
-	Source                     string                  `json:"source"`
-	State                      string                  `json:"state"`
-	Size                       convert.StringToFloat64 `json:"sz"`
-	Tag                        string                  `json:"tag"`
-	TradeMode                  string                  `json:"tdMode"`
-	TargetCurrency             string                  `json:"tgtCcy"`
-	TakeProfitOrderPrice       okcoinNumber            `json:"tpOrdPx"`
-	TakeProfitTriggerPrice     okcoinNumber            `json:"tpTriggerPx"`
-	TakeProfitTriggerPriceType string                  `json:"tpTriggerPxType"`
-	TradeID                    string                  `json:"tradeId"`
-	UpdateTime                 okcoinTime              `json:"uTime"`
+	AccFillSize                types.Number `json:"accFillSz"`
+	AveragePrice               types.Number `json:"avgPx"`
+	CreationTime               okcoinTime   `json:"cTime"`
+	Category                   string       `json:"category"`
+	Currency                   string       `json:"ccy"`
+	ClientOrdID                string       `json:"clOrdId"`
+	Fee                        okcoinNumber `json:"fee"`
+	FeeCurrency                string       `json:"feeCcy"`
+	FillPrice                  types.Number `json:"fillPx"`
+	FillSize                   types.Number `json:"fillSz"`
+	FillTime                   okcoinTime   `json:"fillTime"`
+	InstrumentID               string       `json:"instId"`
+	InstrumentType             string       `json:"instType"`
+	Leverage                   okcoinNumber `json:"lever"`
+	OrderID                    string       `json:"ordId"`
+	OrderType                  string       `json:"ordType"`
+	ProfitAndLoss              types.Number `json:"pnl"`
+	PosSide                    string       `json:"posSide"`
+	Price                      types.Number `json:"px"`
+	Rebate                     okcoinNumber `json:"rebate"`
+	RebateCurrency             string       `json:"rebateCcy"`
+	ReduceOnly                 bool         `json:"reduceOnly,string"`
+	Side                       string       `json:"side"`
+	StopLossOrdPrice           okcoinNumber `json:"slOrdPx"`
+	StopLossTriggerPrice       okcoinNumber `json:"slTriggerPx"`
+	StopLossTriggerPriceType   string       `json:"slTriggerPxType"`
+	Source                     string       `json:"source"`
+	State                      string       `json:"state"`
+	Size                       types.Number `json:"sz"`
+	Tag                        string       `json:"tag"`
+	TradeMode                  string       `json:"tdMode"`
+	TargetCurrency             string       `json:"tgtCcy"`
+	TakeProfitOrderPrice       okcoinNumber `json:"tpOrdPx"`
+	TakeProfitTriggerPrice     okcoinNumber `json:"tpTriggerPx"`
+	TakeProfitTriggerPriceType string       `json:"tpTriggerPxType"`
+	TradeID                    string       `json:"tradeId"`
+	UpdateTime                 okcoinTime   `json:"uTime"`
 }
 
 // TransactionFillItem represents recently filled transactions
 type TransactionFillItem struct {
-	InstrumentType string                  `json:"instType"`
-	InstrumentID   string                  `json:"instId"`
-	TradeID        string                  `json:"tradeId"`
-	OrderID        string                  `json:"ordId"`
-	ClientOrderID  string                  `json:"clOrdId"`
-	BillID         string                  `json:"billId"`
-	Tag            string                  `json:"tag"`
-	FillSize       convert.StringToFloat64 `json:"fillSz"`
-	FillPrice      convert.StringToFloat64 `json:"fillPx"`
-	Side           string                  `json:"side"`
-	PosSide        string                  `json:"posSide"`
-	ExecType       string                  `json:"execType"`
-	FeeCurrency    string                  `json:"feeCcy"`
-	Fee            okcoinNumber            `json:"fee"`
-	Timestamp      okcoinTime              `json:"ts"`
+	InstrumentType string       `json:"instType"`
+	InstrumentID   string       `json:"instId"`
+	TradeID        string       `json:"tradeId"`
+	OrderID        string       `json:"ordId"`
+	ClientOrderID  string       `json:"clOrdId"`
+	BillID         string       `json:"billId"`
+	Tag            string       `json:"tag"`
+	FillSize       types.Number `json:"fillSz"`
+	FillPrice      types.Number `json:"fillPx"`
+	Side           string       `json:"side"`
+	PosSide        string       `json:"posSide"`
+	ExecType       string       `json:"execType"`
+	FeeCurrency    string       `json:"feeCcy"`
+	Fee            okcoinNumber `json:"fee"`
+	Timestamp      okcoinTime   `json:"ts"`
 }
 
 // AlgoOrderRequestParam represents algo order request parameters.
@@ -1341,44 +1341,44 @@ type CancelAlgoOrderRequestParam struct {
 
 // AlgoOrderDetail represents an algo-order detailed information
 type AlgoOrderDetail struct {
-	ActivePrice              okcoinNumber            `json:"activePx"`
-	ActualPrice              okcoinNumber            `json:"actualPx"`
-	ActualSide               string                  `json:"actualSide"`
-	ActualSize               okcoinNumber            `json:"actualSz"`
-	AlgoID                   string                  `json:"algoId"`
-	CreateTime               okcoinTime              `json:"cTime"`
-	CallbackRatio            okcoinNumber            `json:"callbackRatio"`
-	CallbackSpread           string                  `json:"callbackSpread"`
-	Currency                 string                  `json:"ccy"`
-	ClientOrderID            string                  `json:"clOrdId"`
-	InstrumentID             string                  `json:"instId"`
-	InstrumentType           string                  `json:"instType"`
-	Leverage                 convert.StringToFloat64 `json:"lever"`
-	MoveTriggerPrice         okcoinNumber            `json:"moveTriggerPx"`
-	OrderID                  string                  `json:"ordId"`
-	OrdPrice                 okcoinNumber            `json:"ordPx"`
-	OrderType                string                  `json:"ordType"`
-	PosSide                  string                  `json:"posSide"`
-	PriceLimit               okcoinNumber            `json:"pxLimit"`
-	PriceSpread              okcoinNumber            `json:"pxSpread"`
-	PriceVar                 okcoinNumber            `json:"pxVar"`
-	Side                     string                  `json:"side"`
-	StopLossOrdPrice         okcoinNumber            `json:"slOrdPx"`
-	StopLossTriggerPrice     okcoinNumber            `json:"slTriggerPx"`
-	StopLossTriggerPriceType string                  `json:"slTriggerPxType"`
-	State                    string                  `json:"state"`
-	Size                     okcoinNumber            `json:"sz"`
-	SizeLimit                okcoinNumber            `json:"szLimit"`
-	Tag                      string                  `json:"tag"`
-	TdMode                   string                  `json:"tdMode"`
-	TgtCcy                   string                  `json:"tgtCcy"`
-	TimeInterval             string                  `json:"timeInterval"`
-	TpOrdPrice               okcoinNumber            `json:"tpOrdPx"`
-	TpTriggerPrice           okcoinNumber            `json:"tpTriggerPx"`
-	TpTriggerPriceType       string                  `json:"tpTriggerPxType"`
-	TriggerPrice             okcoinNumber            `json:"triggerPx"`
-	TriggerPriceType         string                  `json:"triggerPxType"`
-	TriggerTime              okcoinTime              `json:"triggerTime"`
+	ActivePrice              okcoinNumber `json:"activePx"`
+	ActualPrice              okcoinNumber `json:"actualPx"`
+	ActualSide               string       `json:"actualSide"`
+	ActualSize               okcoinNumber `json:"actualSz"`
+	AlgoID                   string       `json:"algoId"`
+	CreateTime               okcoinTime   `json:"cTime"`
+	CallbackRatio            okcoinNumber `json:"callbackRatio"`
+	CallbackSpread           string       `json:"callbackSpread"`
+	Currency                 string       `json:"ccy"`
+	ClientOrderID            string       `json:"clOrdId"`
+	InstrumentID             string       `json:"instId"`
+	InstrumentType           string       `json:"instType"`
+	Leverage                 types.Number `json:"lever"`
+	MoveTriggerPrice         okcoinNumber `json:"moveTriggerPx"`
+	OrderID                  string       `json:"ordId"`
+	OrdPrice                 okcoinNumber `json:"ordPx"`
+	OrderType                string       `json:"ordType"`
+	PosSide                  string       `json:"posSide"`
+	PriceLimit               okcoinNumber `json:"pxLimit"`
+	PriceSpread              okcoinNumber `json:"pxSpread"`
+	PriceVar                 okcoinNumber `json:"pxVar"`
+	Side                     string       `json:"side"`
+	StopLossOrdPrice         okcoinNumber `json:"slOrdPx"`
+	StopLossTriggerPrice     okcoinNumber `json:"slTriggerPx"`
+	StopLossTriggerPriceType string       `json:"slTriggerPxType"`
+	State                    string       `json:"state"`
+	Size                     okcoinNumber `json:"sz"`
+	SizeLimit                okcoinNumber `json:"szLimit"`
+	Tag                      string       `json:"tag"`
+	TdMode                   string       `json:"tdMode"`
+	TgtCcy                   string       `json:"tgtCcy"`
+	TimeInterval             string       `json:"timeInterval"`
+	TpOrdPrice               okcoinNumber `json:"tpOrdPx"`
+	TpTriggerPrice           okcoinNumber `json:"tpTriggerPx"`
+	TpTriggerPriceType       string       `json:"tpTriggerPxType"`
+	TriggerPrice             okcoinNumber `json:"triggerPx"`
+	TriggerPriceType         string       `json:"triggerPxType"`
+	TriggerTime              okcoinTime   `json:"triggerTime"`
 }
 
 // SubAccountAPIKey retrieves sub-account API key.
@@ -1392,56 +1392,56 @@ type SubAccountAPIKey struct {
 
 // SubAccountTradingBalance represents a sub-account trading detail.
 type SubAccountTradingBalance struct {
-	AdjEq   convert.StringToFloat64 `json:"adjEq"` // Adjusted / Effective equity in USD. Not enabled. Please disregard.
+	AdjEq   types.Number `json:"adjEq"` // Adjusted / Effective equity in USD. Not enabled. Please disregard.
 	Details []struct {
-		AvailableBal            convert.StringToFloat64 `json:"availBal"`
-		AvailableEquity         convert.StringToFloat64 `json:"availEq"`
-		CashBalance             convert.StringToFloat64 `json:"cashBal"`
-		Currency                string                  `json:"ccy"`
-		CrossLiab               convert.StringToFloat64 `json:"crossLiab"`
-		DiscountEquity          convert.StringToFloat64 `json:"disEq"`
-		Equity                  convert.StringToFloat64 `json:"eq"`
-		EquityUSD               convert.StringToFloat64 `json:"eqUsd"`
-		FrozenBalance           convert.StringToFloat64 `json:"frozenBal"`
-		Interest                convert.StringToFloat64 `json:"interest"`
-		IsolatedEquity          convert.StringToFloat64 `json:"isoEq"`
-		IsolatedLiability       convert.StringToFloat64 `json:"isoLiab"`
-		Liability               convert.StringToFloat64 `json:"liab"`
-		MaxLoan                 convert.StringToFloat64 `json:"maxLoan"`
-		MarginRatio             convert.StringToFloat64 `json:"mgnRatio"`
-		NotionalLeverage        convert.StringToFloat64 `json:"notionalLever"`
-		OrderMarginFrozen       convert.StringToFloat64 `json:"ordFrozen"`
-		Twap                    convert.StringToFloat64 `json:"twap"`
-		UTime                   convert.StringToFloat64 `json:"uTime"`
-		UnrealizedProfitAndLoss convert.StringToFloat64 `json:"upl"`
-		UPLLiability            convert.StringToFloat64 `json:"uplLiab"`
+		AvailableBal            types.Number `json:"availBal"`
+		AvailableEquity         types.Number `json:"availEq"`
+		CashBalance             types.Number `json:"cashBal"`
+		Currency                string       `json:"ccy"`
+		CrossLiab               types.Number `json:"crossLiab"`
+		DiscountEquity          types.Number `json:"disEq"`
+		Equity                  types.Number `json:"eq"`
+		EquityUSD               types.Number `json:"eqUsd"`
+		FrozenBalance           types.Number `json:"frozenBal"`
+		Interest                types.Number `json:"interest"`
+		IsolatedEquity          types.Number `json:"isoEq"`
+		IsolatedLiability       types.Number `json:"isoLiab"`
+		Liability               types.Number `json:"liab"`
+		MaxLoan                 types.Number `json:"maxLoan"`
+		MarginRatio             types.Number `json:"mgnRatio"`
+		NotionalLeverage        types.Number `json:"notionalLever"`
+		OrderMarginFrozen       types.Number `json:"ordFrozen"`
+		Twap                    types.Number `json:"twap"`
+		UTime                   types.Number `json:"uTime"`
+		UnrealizedProfitAndLoss types.Number `json:"upl"`
+		UPLLiability            types.Number `json:"uplLiab"`
 	} `json:"details"`
-	IMR            convert.StringToFloat64 `json:"imr"` // Frozen equity for open positions and pending orders in USD. Not enabled. Please disregard.
-	IsolatedEquity convert.StringToFloat64 `json:"isoEq"`
-	MarginRatio    convert.StringToFloat64 `json:"mgnRatio"`
-	MMR            convert.StringToFloat64 `json:"mmr"` // Maintenance margin requirement in USD. Not enabled. Please disregard
-	NotionalUsd    convert.StringToFloat64 `json:"notionalUsd"`
-	OrdFrozen      convert.StringToFloat64 `json:"ordFroz"`
-	TotalEquity    convert.StringToFloat64 `json:"totalEq"`
-	UpdatedTime    okcoinTime              `json:"uTime"`
+	IMR            types.Number `json:"imr"` // Frozen equity for open positions and pending orders in USD. Not enabled. Please disregard.
+	IsolatedEquity types.Number `json:"isoEq"`
+	MarginRatio    types.Number `json:"mgnRatio"`
+	MMR            types.Number `json:"mmr"` // Maintenance margin requirement in USD. Not enabled. Please disregard
+	NotionalUsd    types.Number `json:"notionalUsd"`
+	OrdFrozen      types.Number `json:"ordFroz"`
+	TotalEquity    types.Number `json:"totalEq"`
+	UpdatedTime    okcoinTime   `json:"uTime"`
 }
 
 // SubAccountFundingBalance represents a sub-account funding balance for a currency.
 type SubAccountFundingBalance struct {
-	AvailBal  convert.StringToFloat64 `json:"availBal"`
-	Bal       convert.StringToFloat64 `json:"bal"`
-	Currency  string                  `json:"ccy"`
-	FrozenBal convert.StringToFloat64 `json:"frozenBal"`
+	AvailBal  types.Number `json:"availBal"`
+	Bal       types.Number `json:"bal"`
+	Currency  string       `json:"ccy"`
+	FrozenBal types.Number `json:"frozenBal"`
 }
 
 // SubAccountTransferInfo represents a sub-account transfer information.
 type SubAccountTransferInfo struct {
-	BillID            string                  `json:"billId"`
-	Type              string                  `json:"type"`
-	Ccy               string                  `json:"ccy"`
-	Amount            convert.StringToFloat64 `json:"amt"`
-	SubAccount        string                  `json:"subAcct"`
-	CreationTimestamp okcoinTime              `json:"ts"`
+	BillID            string       `json:"billId"`
+	Type              string       `json:"type"`
+	Ccy               string       `json:"ccy"`
+	Amount            types.Number `json:"amt"`
+	SubAccount        string       `json:"subAcct"`
+	CreationTimestamp okcoinTime   `json:"ts"`
 }
 
 // SubAccountTransferResponse represents a transfer operation response.

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -5,11 +5,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -282,34 +282,34 @@ type InstrumentsFetchParams struct {
 
 // Instrument  representing an instrument with open contract.
 type Instrument struct {
-	InstrumentType                  string                  `json:"instType"`
-	InstrumentID                    string                  `json:"instId"`
-	InstrumentFamily                string                  `json:"instFamily"`
-	Underlying                      string                  `json:"uly"`
-	Category                        string                  `json:"category"`
-	BaseCurrency                    string                  `json:"baseCcy"`
-	QuoteCurrency                   string                  `json:"quoteCcy"`
-	SettlementCurrency              string                  `json:"settleCcy"`
-	ContractValue                   convert.StringToFloat64 `json:"ctVal"`
-	ContractMultiplier              convert.StringToFloat64 `json:"ctMult"`
-	ContractValueCurrency           string                  `json:"ctValCcy"`
-	OptionType                      string                  `json:"optType"`
-	StrikePrice                     string                  `json:"stk"`
-	ListTime                        okxTime                 `json:"listTime"`
-	ExpTime                         okxTime                 `json:"expTime"`
-	MaxLeverage                     convert.StringToFloat64 `json:"lever"`
-	TickSize                        convert.StringToFloat64 `json:"tickSz"`
-	LotSize                         convert.StringToFloat64 `json:"lotSz"`
-	MinimumOrderSize                convert.StringToFloat64 `json:"minSz"`
-	ContractType                    string                  `json:"ctType"`
-	Alias                           string                  `json:"alias"`
-	State                           string                  `json:"state"`
-	MaxQuantityOfSpotLimitOrder     convert.StringToFloat64 `json:"maxLmtSz"`
-	MaxQuantityOfMarketLimitOrder   convert.StringToFloat64 `json:"maxMktSz"`
-	MaxQuantityOfSpotTwapLimitOrder convert.StringToFloat64 `json:"maxTwapSz"`
-	MaxSpotIcebergSize              convert.StringToFloat64 `json:"maxIcebergSz"`
-	MaxTriggerSize                  convert.StringToFloat64 `json:"maxTriggerSz"`
-	MaxStopSize                     convert.StringToFloat64 `json:"maxStopSz"`
+	InstrumentType                  string       `json:"instType"`
+	InstrumentID                    string       `json:"instId"`
+	InstrumentFamily                string       `json:"instFamily"`
+	Underlying                      string       `json:"uly"`
+	Category                        string       `json:"category"`
+	BaseCurrency                    string       `json:"baseCcy"`
+	QuoteCurrency                   string       `json:"quoteCcy"`
+	SettlementCurrency              string       `json:"settleCcy"`
+	ContractValue                   types.Number `json:"ctVal"`
+	ContractMultiplier              types.Number `json:"ctMult"`
+	ContractValueCurrency           string       `json:"ctValCcy"`
+	OptionType                      string       `json:"optType"`
+	StrikePrice                     string       `json:"stk"`
+	ListTime                        okxTime      `json:"listTime"`
+	ExpTime                         okxTime      `json:"expTime"`
+	MaxLeverage                     types.Number `json:"lever"`
+	TickSize                        types.Number `json:"tickSz"`
+	LotSize                         types.Number `json:"lotSz"`
+	MinimumOrderSize                types.Number `json:"minSz"`
+	ContractType                    string       `json:"ctType"`
+	Alias                           string       `json:"alias"`
+	State                           string       `json:"state"`
+	MaxQuantityOfSpotLimitOrder     types.Number `json:"maxLmtSz"`
+	MaxQuantityOfMarketLimitOrder   types.Number `json:"maxMktSz"`
+	MaxQuantityOfSpotTwapLimitOrder types.Number `json:"maxTwapSz"`
+	MaxSpotIcebergSize              types.Number `json:"maxIcebergSz"`
+	MaxTriggerSize                  types.Number `json:"maxTriggerSz"`
+	MaxStopSize                     types.Number `json:"maxStopSz"`
 }
 
 // DeliveryHistoryDetail holds instrument id and delivery price information detail
@@ -336,13 +336,13 @@ type OpenInterest struct {
 
 // FundingRateResponse response data for the Funding Rate for an instruction type
 type FundingRateResponse struct {
-	FundingRate     convert.StringToFloat64 `json:"fundingRate"`
-	RealisedRate    convert.StringToFloat64 `json:"realizedRate"`
-	FundingTime     okxUnixMilliTime        `json:"fundingTime"`
-	InstrumentID    string                  `json:"instId"`
-	InstrumentType  string                  `json:"instType"`
-	NextFundingRate convert.StringToFloat64 `json:"nextFundingRate"`
-	NextFundingTime okxUnixMilliTime        `json:"nextFundingTime"`
+	FundingRate     types.Number     `json:"fundingRate"`
+	RealisedRate    types.Number     `json:"realizedRate"`
+	FundingTime     okxUnixMilliTime `json:"fundingTime"`
+	InstrumentID    string           `json:"instId"`
+	InstrumentType  string           `json:"instType"`
+	NextFundingRate types.Number     `json:"nextFundingRate"`
+	NextFundingTime okxUnixMilliTime `json:"nextFundingTime"`
 }
 
 // LimitPriceResponse hold an information for
@@ -505,11 +505,11 @@ type InsuranceFundInformation struct {
 // InsuranceFundInformationDetail represents an Insurance fund information item for a
 // single currency and type
 type InsuranceFundInformationDetail struct {
-	Amount    convert.StringToFloat64 `json:"amt"`
-	Balance   convert.StringToFloat64 `json:"balance"`
-	Currency  string                  `json:"ccy"`
-	Timestamp okxUnixMilliTime        `json:"ts"`
-	Type      string                  `json:"type"`
+	Amount    types.Number     `json:"amt"`
+	Balance   types.Number     `json:"balance"`
+	Currency  string           `json:"ccy"`
+	Timestamp okxUnixMilliTime `json:"ts"`
+	Type      string           `json:"type"`
 }
 
 // SupportedCoinsData holds information about currencies supported by the trading data endpoints.
@@ -717,42 +717,42 @@ type OrderHistoryRequestParams struct {
 
 // PendingOrderItem represents a pending order Item in pending orders list.
 type PendingOrderItem struct {
-	AccumulatedFillSize        convert.StringToFloat64 `json:"accFillSz"`
-	AveragePrice               convert.StringToFloat64 `json:"avgPx"`
-	CreationTime               okxUnixMilliTime        `json:"cTime"`
-	Category                   string                  `json:"category"`
-	Currency                   string                  `json:"ccy"`
-	ClientOrderID              string                  `json:"clOrdId"`
-	Fee                        convert.StringToFloat64 `json:"fee"`
-	FeeCurrency                currency.Code           `json:"feeCcy"`
-	LastFilledPrice            convert.StringToFloat64 `json:"fillPx"`
-	LastFilledSize             convert.StringToFloat64 `json:"fillSz"`
-	FillTime                   okxUnixMilliTime        `json:"fillTime"`
-	InstrumentID               string                  `json:"instId"`
-	InstrumentType             string                  `json:"instType"`
-	Leverage                   convert.StringToFloat64 `json:"lever"`
-	OrderID                    string                  `json:"ordId"`
-	OrderType                  string                  `json:"ordType"`
-	ProfitAndLoss              string                  `json:"pnl"`
-	PositionSide               string                  `json:"posSide"`
-	RebateAmount               convert.StringToFloat64 `json:"rebate"`
-	RebateCurrency             string                  `json:"rebateCcy"`
-	Side                       order.Side              `json:"side"`
-	StopLossOrdPrice           convert.StringToFloat64 `json:"slOrdPx"`
-	StopLossTriggerPrice       convert.StringToFloat64 `json:"slTriggerPx"`
-	StopLossTriggerPriceType   string                  `json:"slTriggerPxType"`
-	State                      string                  `json:"state"`
-	Price                      convert.StringToFloat64 `json:"px"`
-	Size                       convert.StringToFloat64 `json:"sz"`
-	Tag                        string                  `json:"tag"`
-	SizeType                   string                  `json:"tgtCcy"`
-	TradeMode                  string                  `json:"tdMode"`
-	Source                     string                  `json:"source"`
-	TakeProfitOrdPrice         convert.StringToFloat64 `json:"tpOrdPx"`
-	TakeProfitTriggerPrice     convert.StringToFloat64 `json:"tpTriggerPx"`
-	TakeProfitTriggerPriceType string                  `json:"tpTriggerPxType"`
-	TradeID                    string                  `json:"tradeId"`
-	UpdateTime                 okxUnixMilliTime        `json:"uTime"`
+	AccumulatedFillSize        types.Number     `json:"accFillSz"`
+	AveragePrice               types.Number     `json:"avgPx"`
+	CreationTime               okxUnixMilliTime `json:"cTime"`
+	Category                   string           `json:"category"`
+	Currency                   string           `json:"ccy"`
+	ClientOrderID              string           `json:"clOrdId"`
+	Fee                        types.Number     `json:"fee"`
+	FeeCurrency                currency.Code    `json:"feeCcy"`
+	LastFilledPrice            types.Number     `json:"fillPx"`
+	LastFilledSize             types.Number     `json:"fillSz"`
+	FillTime                   okxUnixMilliTime `json:"fillTime"`
+	InstrumentID               string           `json:"instId"`
+	InstrumentType             string           `json:"instType"`
+	Leverage                   types.Number     `json:"lever"`
+	OrderID                    string           `json:"ordId"`
+	OrderType                  string           `json:"ordType"`
+	ProfitAndLoss              string           `json:"pnl"`
+	PositionSide               string           `json:"posSide"`
+	RebateAmount               types.Number     `json:"rebate"`
+	RebateCurrency             string           `json:"rebateCcy"`
+	Side                       order.Side       `json:"side"`
+	StopLossOrdPrice           types.Number     `json:"slOrdPx"`
+	StopLossTriggerPrice       types.Number     `json:"slTriggerPx"`
+	StopLossTriggerPriceType   string           `json:"slTriggerPxType"`
+	State                      string           `json:"state"`
+	Price                      types.Number     `json:"px"`
+	Size                       types.Number     `json:"sz"`
+	Tag                        string           `json:"tag"`
+	SizeType                   string           `json:"tgtCcy"`
+	TradeMode                  string           `json:"tdMode"`
+	Source                     string           `json:"source"`
+	TakeProfitOrdPrice         types.Number     `json:"tpOrdPx"`
+	TakeProfitTriggerPrice     types.Number     `json:"tpTriggerPx"`
+	TakeProfitTriggerPriceType string           `json:"tpTriggerPxType"`
+	TradeID                    string           `json:"tradeId"`
+	UpdateTime                 okxUnixMilliTime `json:"uTime"`
 }
 
 // TransactionDetailRequestParams retrieve recently-filled transaction details in the last 3 day.
@@ -1237,72 +1237,72 @@ type Account struct {
 
 // AccountDetail account detail information.
 type AccountDetail struct {
-	AvailableBalance              convert.StringToFloat64 `json:"availBal"`
-	AvailableEquity               convert.StringToFloat64 `json:"availEq"`
-	CashBalance                   convert.StringToFloat64 `json:"cashBal"` // Cash Balance
-	Currency                      string                  `json:"ccy"`
-	CrossLiab                     convert.StringToFloat64 `json:"crossLiab"`
-	DiscountEquity                convert.StringToFloat64 `json:"disEq"`
-	EquityOfCurrency              convert.StringToFloat64 `json:"eq"`
-	EquityUsd                     convert.StringToFloat64 `json:"eqUsd"`
-	FrozenBalance                 convert.StringToFloat64 `json:"frozenBal"`
-	Interest                      convert.StringToFloat64 `json:"interest"`
-	IsoEquity                     convert.StringToFloat64 `json:"isoEq"`
-	IsolatedLiabilities           convert.StringToFloat64 `json:"isoLiab"`
-	IsoUpl                        convert.StringToFloat64 `json:"isoUpl"` // Isolated unrealized profit and loss of the currency applicable to Single-currency margin and Multi-currency margin and Portfolio margin
-	LiabilitiesOfCurrency         convert.StringToFloat64 `json:"liab"`
-	MaxLoan                       convert.StringToFloat64 `json:"maxLoan"`
-	MarginRatio                   convert.StringToFloat64 `json:"mgnRatio"`      // Equity of the currency
-	NotionalLever                 convert.StringToFloat64 `json:"notionalLever"` // Leverage of the currency applicable to Single-currency margin
-	OpenOrdersMarginFrozen        convert.StringToFloat64 `json:"ordFrozen"`
-	Twap                          convert.StringToFloat64 `json:"twap"`
-	UpdateTime                    okxUnixMilliTime        `json:"uTime"`
-	UnrealizedProfit              convert.StringToFloat64 `json:"upl"`
-	UnrealizedCurrencyLiabilities convert.StringToFloat64 `json:"uplLiab"`
-	StrategyEquity                convert.StringToFloat64 `json:"stgyEq"`  // strategy equity
-	TotalEquity                   convert.StringToFloat64 `json:"totalEq"` // Total equity in USD level. Appears unused
+	AvailableBalance              types.Number     `json:"availBal"`
+	AvailableEquity               types.Number     `json:"availEq"`
+	CashBalance                   types.Number     `json:"cashBal"` // Cash Balance
+	Currency                      string           `json:"ccy"`
+	CrossLiab                     types.Number     `json:"crossLiab"`
+	DiscountEquity                types.Number     `json:"disEq"`
+	EquityOfCurrency              types.Number     `json:"eq"`
+	EquityUsd                     types.Number     `json:"eqUsd"`
+	FrozenBalance                 types.Number     `json:"frozenBal"`
+	Interest                      types.Number     `json:"interest"`
+	IsoEquity                     types.Number     `json:"isoEq"`
+	IsolatedLiabilities           types.Number     `json:"isoLiab"`
+	IsoUpl                        types.Number     `json:"isoUpl"` // Isolated unrealized profit and loss of the currency applicable to Single-currency margin and Multi-currency margin and Portfolio margin
+	LiabilitiesOfCurrency         types.Number     `json:"liab"`
+	MaxLoan                       types.Number     `json:"maxLoan"`
+	MarginRatio                   types.Number     `json:"mgnRatio"`      // Equity of the currency
+	NotionalLever                 types.Number     `json:"notionalLever"` // Leverage of the currency applicable to Single-currency margin
+	OpenOrdersMarginFrozen        types.Number     `json:"ordFrozen"`
+	Twap                          types.Number     `json:"twap"`
+	UpdateTime                    okxUnixMilliTime `json:"uTime"`
+	UnrealizedProfit              types.Number     `json:"upl"`
+	UnrealizedCurrencyLiabilities types.Number     `json:"uplLiab"`
+	StrategyEquity                types.Number     `json:"stgyEq"`  // strategy equity
+	TotalEquity                   types.Number     `json:"totalEq"` // Total equity in USD level. Appears unused
 }
 
 // AccountPosition account position.
 type AccountPosition struct {
-	AutoDeleveraging             string                  `json:"adl"`      // Auto-deleveraging (ADL) indicator Divided into 5 levels, from 1 to 5, the smaller the number, the weaker the adl intensity.
-	AvailablePosition            string                  `json:"availPos"` // Position that can be closed Only applicable to MARGIN, FUTURES/SWAP in the long-short mode, OPTION in Simple and isolated OPTION in margin Account.
-	AveragePrice                 convert.StringToFloat64 `json:"avgPx"`
-	CreationTime                 okxUnixMilliTime        `json:"cTime"`
-	Currency                     string                  `json:"ccy"`
-	DeltaBS                      string                  `json:"deltaBS"` // delta：Black-Scholes Greeks in dollars,only applicable to OPTION
-	DeltaPA                      string                  `json:"deltaPA"` // delta：Greeks in coins,only applicable to OPTION
-	GammaBS                      string                  `json:"gammaBS"` // gamma：Black-Scholes Greeks in dollars,only applicable to OPTION
-	GammaPA                      string                  `json:"gammaPA"` // gamma：Greeks in coins,only applicable to OPTION
-	InitialMarginRequirement     convert.StringToFloat64 `json:"imr"`     // Initial margin requirement, only applicable to cross.
-	InstrumentID                 string                  `json:"instId"`
-	InstrumentType               asset.Item              `json:"instType"`
-	Interest                     convert.StringToFloat64 `json:"interest"`
-	USDPrice                     convert.StringToFloat64 `json:"usdPx"`
-	LastTradePrice               convert.StringToFloat64 `json:"last"`
-	Leverage                     convert.StringToFloat64 `json:"lever"`   // Leverage, not applicable to OPTION seller
-	Liabilities                  string                  `json:"liab"`    // Liabilities, only applicable to MARGIN.
-	LiabilitiesCurrency          string                  `json:"liabCcy"` // Liabilities currency, only applicable to MARGIN.
-	LiquidationPrice             convert.StringToFloat64 `json:"liqPx"`   // Estimated liquidation price Not applicable to OPTION
-	MarkPrice                    convert.StringToFloat64 `json:"markPx"`
-	Margin                       convert.StringToFloat64 `json:"margin"`
-	MarginMode                   string                  `json:"mgnMode"`
-	MarginRatio                  convert.StringToFloat64 `json:"mgnRatio"`
-	MaintenanceMarginRequirement convert.StringToFloat64 `json:"mmr"`         // Maintenance margin requirement in USD level Applicable to Multi-currency margin and Portfolio margin
-	NotionalUsd                  convert.StringToFloat64 `json:"notionalUsd"` // Quality of Positions -- usd
-	OptionValue                  convert.StringToFloat64 `json:"optVal"`      // Option Value, only application to position.
-	QuantityOfPosition           convert.StringToFloat64 `json:"pos"`         // Quantity of positions,In the mode of autonomous transfer from position to position, after the deposit is transferred, a position with pos of 0 will be generated
-	PositionCurrency             string                  `json:"posCcy"`
-	PositionID                   string                  `json:"posId"`
-	PositionSide                 string                  `json:"posSide"`
-	ThetaBS                      string                  `json:"thetaBS"` // theta：Black-Scholes Greeks in dollars,only applicable to OPTION
-	ThetaPA                      string                  `json:"thetaPA"` // theta：Greeks in coins,only applicable to OPTION
-	TradeID                      string                  `json:"tradeId"`
-	UpdatedTime                  okxUnixMilliTime        `json:"uTime"`    // Latest time position was adjusted,
-	UPNL                         convert.StringToFloat64 `json:"upl"`      // Unrealized profit and loss
-	UPLRatio                     convert.StringToFloat64 `json:"uplRatio"` // Unrealized profit and loss ratio
-	VegaBS                       string                  `json:"vegaBS"`   // vega：Black-Scholes Greeks in dollars,only applicable to OPTION
-	VegaPA                       string                  `json:"vegaPA"`   // vega：Greeks in coins,only applicable to OPTION
+	AutoDeleveraging             string           `json:"adl"`      // Auto-deleveraging (ADL) indicator Divided into 5 levels, from 1 to 5, the smaller the number, the weaker the adl intensity.
+	AvailablePosition            string           `json:"availPos"` // Position that can be closed Only applicable to MARGIN, FUTURES/SWAP in the long-short mode, OPTION in Simple and isolated OPTION in margin Account.
+	AveragePrice                 types.Number     `json:"avgPx"`
+	CreationTime                 okxUnixMilliTime `json:"cTime"`
+	Currency                     string           `json:"ccy"`
+	DeltaBS                      string           `json:"deltaBS"` // delta：Black-Scholes Greeks in dollars,only applicable to OPTION
+	DeltaPA                      string           `json:"deltaPA"` // delta：Greeks in coins,only applicable to OPTION
+	GammaBS                      string           `json:"gammaBS"` // gamma：Black-Scholes Greeks in dollars,only applicable to OPTION
+	GammaPA                      string           `json:"gammaPA"` // gamma：Greeks in coins,only applicable to OPTION
+	InitialMarginRequirement     types.Number     `json:"imr"`     // Initial margin requirement, only applicable to cross.
+	InstrumentID                 string           `json:"instId"`
+	InstrumentType               asset.Item       `json:"instType"`
+	Interest                     types.Number     `json:"interest"`
+	USDPrice                     types.Number     `json:"usdPx"`
+	LastTradePrice               types.Number     `json:"last"`
+	Leverage                     types.Number     `json:"lever"`   // Leverage, not applicable to OPTION seller
+	Liabilities                  string           `json:"liab"`    // Liabilities, only applicable to MARGIN.
+	LiabilitiesCurrency          string           `json:"liabCcy"` // Liabilities currency, only applicable to MARGIN.
+	LiquidationPrice             types.Number     `json:"liqPx"`   // Estimated liquidation price Not applicable to OPTION
+	MarkPrice                    types.Number     `json:"markPx"`
+	Margin                       types.Number     `json:"margin"`
+	MarginMode                   string           `json:"mgnMode"`
+	MarginRatio                  types.Number     `json:"mgnRatio"`
+	MaintenanceMarginRequirement types.Number     `json:"mmr"`         // Maintenance margin requirement in USD level Applicable to Multi-currency margin and Portfolio margin
+	NotionalUsd                  types.Number     `json:"notionalUsd"` // Quality of Positions -- usd
+	OptionValue                  types.Number     `json:"optVal"`      // Option Value, only application to position.
+	QuantityOfPosition           types.Number     `json:"pos"`         // Quantity of positions,In the mode of autonomous transfer from position to position, after the deposit is transferred, a position with pos of 0 will be generated
+	PositionCurrency             string           `json:"posCcy"`
+	PositionID                   string           `json:"posId"`
+	PositionSide                 string           `json:"posSide"`
+	ThetaBS                      string           `json:"thetaBS"` // theta：Black-Scholes Greeks in dollars,only applicable to OPTION
+	ThetaPA                      string           `json:"thetaPA"` // theta：Greeks in coins,only applicable to OPTION
+	TradeID                      string           `json:"tradeId"`
+	UpdatedTime                  okxUnixMilliTime `json:"uTime"`    // Latest time position was adjusted,
+	UPNL                         types.Number     `json:"upl"`      // Unrealized profit and loss
+	UPLRatio                     types.Number     `json:"uplRatio"` // Unrealized profit and loss ratio
+	VegaBS                       string           `json:"vegaBS"`   // vega：Black-Scholes Greeks in dollars,only applicable to OPTION
+	VegaPA                       string           `json:"vegaPA"`   // vega：Greeks in coins,only applicable to OPTION
 
 	// PushTime added feature in the websocket push data.
 
@@ -1379,26 +1379,26 @@ type BillsDetailQueryParameter struct {
 
 // BillsDetailResponse represents account bills information.
 type BillsDetailResponse struct {
-	Balance                    okxNumericalValue       `json:"bal"`
-	BalanceChange              string                  `json:"balChg"`
-	BillID                     string                  `json:"billId"`
-	Currency                   string                  `json:"ccy"`
-	ExecType                   string                  `json:"execType"` // Order flow type, T：taker M：maker
-	Fee                        convert.StringToFloat64 `json:"fee"`      // Fee Negative number represents the user transaction fee charged by the platform. Positive number represents rebate.
-	From                       string                  `json:"from"`     // The remitting account 6: FUNDING 18: Trading account When bill type is not transfer, the field returns "".
-	InstrumentID               string                  `json:"instId"`
-	InstrumentType             asset.Item              `json:"instType"`
-	MarginMode                 string                  `json:"mgnMode"`
-	Notes                      string                  `json:"notes"` // notes When bill type is not transfer, the field returns "".
-	OrderID                    string                  `json:"ordId"`
-	ProfitAndLoss              convert.StringToFloat64 `json:"pnl"`
-	PositionLevelBalance       convert.StringToFloat64 `json:"posBal"`
-	PositionLevelBalanceChange convert.StringToFloat64 `json:"posBalChg"`
-	SubType                    string                  `json:"subType"`
-	Size                       convert.StringToFloat64 `json:"sz"`
-	To                         string                  `json:"to"`
-	Timestamp                  okxUnixMilliTime        `json:"ts"`
-	Type                       string                  `json:"type"`
+	Balance                    okxNumericalValue `json:"bal"`
+	BalanceChange              string            `json:"balChg"`
+	BillID                     string            `json:"billId"`
+	Currency                   string            `json:"ccy"`
+	ExecType                   string            `json:"execType"` // Order flow type, T：taker M：maker
+	Fee                        types.Number      `json:"fee"`      // Fee Negative number represents the user transaction fee charged by the platform. Positive number represents rebate.
+	From                       string            `json:"from"`     // The remitting account 6: FUNDING 18: Trading account When bill type is not transfer, the field returns "".
+	InstrumentID               string            `json:"instId"`
+	InstrumentType             asset.Item        `json:"instType"`
+	MarginMode                 string            `json:"mgnMode"`
+	Notes                      string            `json:"notes"` // notes When bill type is not transfer, the field returns "".
+	OrderID                    string            `json:"ordId"`
+	ProfitAndLoss              types.Number      `json:"pnl"`
+	PositionLevelBalance       types.Number      `json:"posBal"`
+	PositionLevelBalanceChange types.Number      `json:"posBalChg"`
+	SubType                    string            `json:"subType"`
+	Size                       types.Number      `json:"sz"`
+	To                         string            `json:"to"`
+	Timestamp                  okxUnixMilliTime  `json:"ts"`
+	Type                       string            `json:"type"`
 }
 
 // AccountConfigurationResponse represents account configuration response.
@@ -1492,18 +1492,18 @@ type MaximumLoanInstrument struct {
 
 // TradeFeeRate holds trade fee rate information for a given instrument type.
 type TradeFeeRate struct {
-	Category         string                  `json:"category"`
-	DeliveryFeeRate  string                  `json:"delivery"`
-	Exercise         string                  `json:"exercise"`
-	InstrumentType   asset.Item              `json:"instType"`
-	FeeRateLevel     string                  `json:"level"`
-	FeeRateMaker     convert.StringToFloat64 `json:"maker"`
-	FeeRateMakerUSDT convert.StringToFloat64 `json:"makerU"`
-	FeeRateMakerUSDC convert.StringToFloat64 `json:"makerUSDC"`
-	FeeRateTaker     convert.StringToFloat64 `json:"taker"`
-	FeeRateTakerUSDT convert.StringToFloat64 `json:"takerU"`
-	FeeRateTakerUSDC convert.StringToFloat64 `json:"takerUSDC"`
-	Timestamp        okxUnixMilliTime        `json:"ts"`
+	Category         string           `json:"category"`
+	DeliveryFeeRate  string           `json:"delivery"`
+	Exercise         string           `json:"exercise"`
+	InstrumentType   asset.Item       `json:"instType"`
+	FeeRateLevel     string           `json:"level"`
+	FeeRateMaker     types.Number     `json:"maker"`
+	FeeRateMakerUSDT types.Number     `json:"makerU"`
+	FeeRateMakerUSDC types.Number     `json:"makerUSDC"`
+	FeeRateTaker     types.Number     `json:"taker"`
+	FeeRateTakerUSDT types.Number     `json:"takerU"`
+	FeeRateTakerUSDC types.Number     `json:"takerUSDC"`
+	Timestamp        okxUnixMilliTime `json:"ts"`
 }
 
 // InterestAccruedData represents interest rate accrued response
@@ -2503,16 +2503,16 @@ type WsBalanceAndPosition struct {
 // WsOrder represents a websocket order.
 type WsOrder struct {
 	PendingOrderItem
-	AmendResult     string                  `json:"amendResult"`
-	Code            string                  `json:"code"`
-	ExecType        string                  `json:"execType"`
-	FillFee         convert.StringToFloat64 `json:"fillFee"`
-	FillFeeCurrency string                  `json:"fillFeeCcy"`
-	FillNotionalUsd convert.StringToFloat64 `json:"fillNotionalUsd"`
-	Msg             string                  `json:"msg"`
-	NotionalUSD     convert.StringToFloat64 `json:"notionalUsd"`
-	ReduceOnly      bool                    `json:"reduceOnly,string"`
-	RequestID       string                  `json:"reqId"`
+	AmendResult     string       `json:"amendResult"`
+	Code            string       `json:"code"`
+	ExecType        string       `json:"execType"`
+	FillFee         types.Number `json:"fillFee"`
+	FillFeeCurrency string       `json:"fillFeeCcy"`
+	FillNotionalUsd types.Number `json:"fillNotionalUsd"`
+	Msg             string       `json:"msg"`
+	NotionalUSD     types.Number `json:"notionalUsd"`
+	ReduceOnly      bool         `json:"reduceOnly,string"`
+	RequestID       string       `json:"reqId"`
 }
 
 // WsOrderResponse holds order list push data through the websocket connection

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
@@ -96,14 +97,14 @@ type TickerResponse struct {
 
 // IndexTicker represents Index ticker data.
 type IndexTicker struct {
-	InstID    string                  `json:"instId"`
-	IdxPx     convert.StringToFloat64 `json:"idxPx"`
-	High24H   convert.StringToFloat64 `json:"high24h"`
-	SodUtc0   convert.StringToFloat64 `json:"sodUtc0"`
-	Open24H   convert.StringToFloat64 `json:"open24h"`
-	Low24H    convert.StringToFloat64 `json:"low24h"`
-	SodUtc8   convert.StringToFloat64 `json:"sodUtc8"`
-	Timestamp okxUnixMilliTime        `json:"ts"`
+	InstID    string           `json:"instId"`
+	IdxPx     types.Number     `json:"idxPx"`
+	High24H   types.Number     `json:"high24h"`
+	SodUtc0   types.Number     `json:"sodUtc0"`
+	Open24H   types.Number     `json:"open24h"`
+	Low24H    types.Number     `json:"low24h"`
+	SodUtc8   types.Number     `json:"sodUtc8"`
+	Timestamp okxUnixMilliTime `json:"ts"`
 }
 
 // OrderBookResponse holds the order asks and bids at a specific timestamp
@@ -226,21 +227,21 @@ type CandleStick struct {
 
 // TradeResponse represents the recent transaction instance.
 type TradeResponse struct {
-	InstrumentID string                  `json:"instId"`
-	TradeID      string                  `json:"tradeId"`
-	Price        convert.StringToFloat64 `json:"px"`
-	Quantity     convert.StringToFloat64 `json:"sz"`
-	Side         order.Side              `json:"side"`
-	Timestamp    okxUnixMilliTime        `json:"ts"`
+	InstrumentID string           `json:"instId"`
+	TradeID      string           `json:"tradeId"`
+	Price        types.Number     `json:"px"`
+	Quantity     types.Number     `json:"sz"`
+	Side         order.Side       `json:"side"`
+	Timestamp    okxUnixMilliTime `json:"ts"`
 }
 
 // TradingVolumeIn24HR response model.
 type TradingVolumeIn24HR struct {
-	BlockVolumeInCNY   okxNumericalValue       `json:"blockVolCny"`
-	BlockVolumeInUSD   okxNumericalValue       `json:"blockVolUsd"`
-	TradingVolumeInUSD convert.StringToFloat64 `json:"volUsd"`
-	TradingVolumeInCny convert.StringToFloat64 `json:"volCny"`
-	Timestamp          okxUnixMilliTime        `json:"ts"`
+	BlockVolumeInCNY   okxNumericalValue `json:"blockVolCny"`
+	BlockVolumeInUSD   okxNumericalValue `json:"blockVolUsd"`
+	TradingVolumeInUSD types.Number      `json:"volUsd"`
+	TradingVolumeInCny types.Number      `json:"volCny"`
+	Timestamp          okxUnixMilliTime  `json:"ts"`
 }
 
 // OracleSmartContractResponse returns the crypto price of signing using Open Oracle smart contract.
@@ -253,15 +254,15 @@ type OracleSmartContractResponse struct {
 
 // UsdCnyExchangeRate the exchange rate for converting from USD to CNV
 type UsdCnyExchangeRate struct {
-	UsdCny convert.StringToFloat64 `json:"usdCny"`
+	UsdCny types.Number `json:"usdCny"`
 }
 
 // IndexComponent represents index component data on the market
 type IndexComponent struct {
-	Components []IndexComponentItem    `json:"components"`
-	Last       convert.StringToFloat64 `json:"last"`
-	Index      string                  `json:"index"`
-	Timestamp  okxUnixMilliTime        `json:"ts"`
+	Components []IndexComponentItem `json:"components"`
+	Last       types.Number         `json:"last"`
+	Index      string               `json:"index"`
+	Timestamp  okxUnixMilliTime     `json:"ts"`
 }
 
 // IndexComponentItem an item representing the index component item
@@ -314,9 +315,9 @@ type Instrument struct {
 
 // DeliveryHistoryDetail holds instrument id and delivery price information detail
 type DeliveryHistoryDetail struct {
-	Type          string                  `json:"type"`
-	InstrumentID  string                  `json:"insId"`
-	DeliveryPrice convert.StringToFloat64 `json:"px"`
+	Type          string       `json:"type"`
+	InstrumentID  string       `json:"insId"`
+	DeliveryPrice types.Number `json:"px"`
 }
 
 // DeliveryHistory represents list of delivery history detail items and timestamp information
@@ -327,11 +328,11 @@ type DeliveryHistory struct {
 
 // OpenInterest Retrieve the total open interest for contracts on OKX.
 type OpenInterest struct {
-	InstrumentType       asset.Item              `json:"instType"`
-	InstrumentID         string                  `json:"instId"`
-	OpenInterest         convert.StringToFloat64 `json:"oi"`
-	OpenInterestCurrency convert.StringToFloat64 `json:"oiCcy"`
-	Timestamp            okxUnixMilliTime        `json:"ts"`
+	InstrumentType       asset.Item       `json:"instType"`
+	InstrumentID         string           `json:"instId"`
+	OpenInterest         types.Number     `json:"oi"`
+	OpenInterestCurrency types.Number     `json:"oiCcy"`
+	Timestamp            okxUnixMilliTime `json:"ts"`
 }
 
 // FundingRateResponse response data for the Funding Rate for an instruction type
@@ -347,33 +348,33 @@ type FundingRateResponse struct {
 
 // LimitPriceResponse hold an information for
 type LimitPriceResponse struct {
-	InstrumentType string                  `json:"instType"`
-	InstID         string                  `json:"instId"`
-	BuyLimit       convert.StringToFloat64 `json:"buyLmt"`
-	SellLimit      convert.StringToFloat64 `json:"sellLmt"`
-	Timestamp      okxUnixMilliTime        `json:"ts"`
+	InstrumentType string           `json:"instType"`
+	InstID         string           `json:"instId"`
+	BuyLimit       types.Number     `json:"buyLmt"`
+	SellLimit      types.Number     `json:"sellLmt"`
+	Timestamp      okxUnixMilliTime `json:"ts"`
 }
 
 // OptionMarketDataResponse holds response data for option market data
 type OptionMarketDataResponse struct {
-	InstrumentType string                  `json:"instType"`
-	InstrumentID   string                  `json:"instId"`
-	Underlying     string                  `json:"uly"`
-	Delta          convert.StringToFloat64 `json:"delta"`
-	Gamma          convert.StringToFloat64 `json:"gamma"`
-	Theta          convert.StringToFloat64 `json:"theta"`
-	Vega           convert.StringToFloat64 `json:"vega"`
-	DeltaBS        convert.StringToFloat64 `json:"deltaBS"`
-	GammaBS        convert.StringToFloat64 `json:"gammaBS"`
-	ThetaBS        convert.StringToFloat64 `json:"thetaBS"`
-	VegaBS         convert.StringToFloat64 `json:"vegaBS"`
-	RealVol        string                  `json:"realVol"`
-	BidVolatility  string                  `json:"bidVol"`
-	AskVolatility  convert.StringToFloat64 `json:"askVol"`
-	MarkVolatility convert.StringToFloat64 `json:"markVol"`
-	Leverage       convert.StringToFloat64 `json:"lever"`
-	ForwardPrice   string                  `json:"fwdPx"`
-	Timestamp      okxUnixMilliTime        `json:"ts"`
+	InstrumentType string           `json:"instType"`
+	InstrumentID   string           `json:"instId"`
+	Underlying     string           `json:"uly"`
+	Delta          types.Number     `json:"delta"`
+	Gamma          types.Number     `json:"gamma"`
+	Theta          types.Number     `json:"theta"`
+	Vega           types.Number     `json:"vega"`
+	DeltaBS        types.Number     `json:"deltaBS"`
+	GammaBS        types.Number     `json:"gammaBS"`
+	ThetaBS        types.Number     `json:"thetaBS"`
+	VegaBS         types.Number     `json:"vegaBS"`
+	RealVol        string           `json:"realVol"`
+	BidVolatility  string           `json:"bidVol"`
+	AskVolatility  types.Number     `json:"askVol"`
+	MarkVolatility types.Number     `json:"markVol"`
+	Leverage       types.Number     `json:"lever"`
+	ForwardPrice   string           `json:"fwdPx"`
+	Timestamp      okxUnixMilliTime `json:"ts"`
 }
 
 // DeliveryEstimatedPrice holds an estimated delivery or exercise price response.
@@ -429,13 +430,13 @@ type LiquidationOrder struct {
 
 // LiquidationOrderDetailItem represents the detail information of liquidation order
 type LiquidationOrderDetailItem struct {
-	BankruptcyLoss        string                  `json:"bkLoss"`
-	BankruptcyPx          string                  `json:"bkPx"`
-	Currency              string                  `json:"ccy"`
-	PosSide               string                  `json:"posSide"`
-	Side                  string                  `json:"side"` // May be empty
-	QuantityOfLiquidation convert.StringToFloat64 `json:"sz"`
-	Timestamp             okxUnixMilliTime        `json:"ts"`
+	BankruptcyLoss        string           `json:"bkLoss"`
+	BankruptcyPx          string           `json:"bkPx"`
+	Currency              string           `json:"ccy"`
+	PosSide               string           `json:"posSide"`
+	Side                  string           `json:"side"` // May be empty
+	QuantityOfLiquidation types.Number     `json:"sz"`
+	Timestamp             okxUnixMilliTime `json:"ts"`
 }
 
 // MarkPrice represents a mark price information for a single instrument id
@@ -448,40 +449,40 @@ type MarkPrice struct {
 
 // PositionTiers represents position tier detailed information.
 type PositionTiers struct {
-	BaseMaxLoan                  string                  `json:"baseMaxLoan"`
-	InitialMarginRequirement     string                  `json:"imr"`
-	InstrumentID                 string                  `json:"instId"`
-	MaximumLeverage              string                  `json:"maxLever"`
-	MaximumSize                  convert.StringToFloat64 `json:"maxSz"`
-	MinSize                      convert.StringToFloat64 `json:"minSz"`
-	MaintenanceMarginRequirement string                  `json:"mmr"`
-	OptionalMarginFactor         string                  `json:"optMgnFactor"`
-	QuoteMaxLoan                 string                  `json:"quoteMaxLoan"`
-	Tier                         string                  `json:"tier"`
-	Underlying                   string                  `json:"uly"`
+	BaseMaxLoan                  string       `json:"baseMaxLoan"`
+	InitialMarginRequirement     string       `json:"imr"`
+	InstrumentID                 string       `json:"instId"`
+	MaximumLeverage              string       `json:"maxLever"`
+	MaximumSize                  types.Number `json:"maxSz"`
+	MinSize                      types.Number `json:"minSz"`
+	MaintenanceMarginRequirement string       `json:"mmr"`
+	OptionalMarginFactor         string       `json:"optMgnFactor"`
+	QuoteMaxLoan                 string       `json:"quoteMaxLoan"`
+	Tier                         string       `json:"tier"`
+	Underlying                   string       `json:"uly"`
 }
 
 // InterestRateLoanQuotaBasic holds the basic Currency, loan,and interest rate information.
 type InterestRateLoanQuotaBasic struct {
-	Currency     string                  `json:"ccy"`
-	LoanQuota    string                  `json:"quota"`
-	InterestRate convert.StringToFloat64 `json:"rate"`
+	Currency     string       `json:"ccy"`
+	LoanQuota    string       `json:"quota"`
+	InterestRate types.Number `json:"rate"`
 }
 
 // InterestRateLoanQuotaItem holds the basic Currency, loan,interest rate, and other level and VIP related information.
 type InterestRateLoanQuotaItem struct {
 	InterestRateLoanQuotaBasic
-	InterestRateDiscount convert.StringToFloat64 `json:"0.7"`
-	LoanQuotaCoefficient convert.StringToFloat64 `json:"loanQuotaCoef"`
-	Level                string                  `json:"level"`
+	InterestRateDiscount types.Number `json:"0.7"`
+	LoanQuotaCoefficient types.Number `json:"loanQuotaCoef"`
+	Level                string       `json:"level"`
 }
 
 // VIPInterestRateAndLoanQuotaInformation holds interest rate and loan quoata information for VIP users.
 type VIPInterestRateAndLoanQuotaInformation struct {
 	InterestRateLoanQuotaBasic
 	LevelList []struct {
-		Level     string                  `json:"level"`
-		LoanQuota convert.StringToFloat64 `json:"loanQuota"`
+		Level     string       `json:"level"`
+		LoanQuota types.Number `json:"loanQuota"`
 	} `json:"levelList"`
 }
 
@@ -499,7 +500,7 @@ type InsuranceFundInformationRequestParams struct {
 // InsuranceFundInformation holds insurance fund information data.
 type InsuranceFundInformation struct {
 	Details []InsuranceFundInformationDetail `json:"details"`
-	Total   convert.StringToFloat64          `json:"total"`
+	Total   types.Number                     `json:"total"`
 }
 
 // InsuranceFundInformationDetail represents an Insurance fund information item for a
@@ -771,21 +772,21 @@ type TransactionDetailRequestParams struct {
 
 // TransactionDetail holds ecently-filled transaction detail data.
 type TransactionDetail struct {
-	InstrumentType string                  `json:"instType"`
-	InstrumentID   string                  `json:"instId"`
-	TradeID        string                  `json:"tradeId"`
-	OrderID        string                  `json:"ordId"`
-	ClientOrderID  string                  `json:"clOrdId"`
-	BillID         string                  `json:"billId"`
-	Tag            string                  `json:"tag"`
-	FillPrice      convert.StringToFloat64 `json:"fillPx"`
-	FillSize       convert.StringToFloat64 `json:"fillSz"`
-	Side           order.Side              `json:"side"`
-	PositionSide   string                  `json:"posSide"`
-	ExecType       string                  `json:"execType"`
-	FeeCurrency    string                  `json:"feeCcy"`
-	Fee            string                  `json:"fee"`
-	Timestamp      okxUnixMilliTime        `json:"ts"`
+	InstrumentType string           `json:"instType"`
+	InstrumentID   string           `json:"instId"`
+	TradeID        string           `json:"tradeId"`
+	OrderID        string           `json:"ordId"`
+	ClientOrderID  string           `json:"clOrdId"`
+	BillID         string           `json:"billId"`
+	Tag            string           `json:"tag"`
+	FillPrice      types.Number     `json:"fillPx"`
+	FillSize       types.Number     `json:"fillSz"`
+	Side           order.Side       `json:"side"`
+	PositionSide   string           `json:"posSide"`
+	ExecType       string           `json:"execType"`
+	FeeCurrency    string           `json:"feeCcy"`
+	Fee            string           `json:"fee"`
+	Timestamp      okxUnixMilliTime `json:"ts"`
 }
 
 // AlgoOrderParams holds algo order information.
@@ -894,41 +895,41 @@ type AlgoOrderResponse struct {
 
 // CurrencyResponse represents a currency item detail response data.
 type CurrencyResponse struct {
-	CanDeposit          bool                    `json:"canDep"`      // Availability to deposit from chain. false: not available true: available
-	CanInternalTransfer bool                    `json:"canInternal"` // Availability to internal transfer.
-	CanWithdraw         bool                    `json:"canWd"`       // Availability to withdraw to chain.
-	Currency            string                  `json:"ccy"`         //
-	Chain               string                  `json:"chain"`       //
-	LogoLink            string                  `json:"logoLink"`    // Logo link of currency
-	MainNet             bool                    `json:"mainNet"`     // If current chain is main net then return true, otherwise return false
-	MaxFee              convert.StringToFloat64 `json:"maxFee"`      // Minimum withdrawal fee
-	MaxWithdrawal       convert.StringToFloat64 `json:"maxWd"`       // Minimum amount of currency withdrawal in a single transaction
-	MinFee              convert.StringToFloat64 `json:"minFee"`      // Minimum withdrawal fee
-	MinWithdrawal       string                  `json:"minWd"`       // Minimum amount of currency withdrawal in a single transaction
-	Name                string                  `json:"name"`        // Chinese name of currency
-	UsedWithdrawalQuota string                  `json:"usedWdQuota"` // Amount of currency withdrawal used in the past 24 hours, unit in BTC
-	WithdrawalQuota     string                  `json:"wdQuota"`     // Minimum amount of currency withdrawal in a single transaction
-	WithdrawalTickSize  string                  `json:"wdTickSz"`    // Withdrawal precision, indicating the number of digits after the decimal point
+	CanDeposit          bool         `json:"canDep"`      // Availability to deposit from chain. false: not available true: available
+	CanInternalTransfer bool         `json:"canInternal"` // Availability to internal transfer.
+	CanWithdraw         bool         `json:"canWd"`       // Availability to withdraw to chain.
+	Currency            string       `json:"ccy"`         //
+	Chain               string       `json:"chain"`       //
+	LogoLink            string       `json:"logoLink"`    // Logo link of currency
+	MainNet             bool         `json:"mainNet"`     // If current chain is main net then return true, otherwise return false
+	MaxFee              types.Number `json:"maxFee"`      // Minimum withdrawal fee
+	MaxWithdrawal       types.Number `json:"maxWd"`       // Minimum amount of currency withdrawal in a single transaction
+	MinFee              types.Number `json:"minFee"`      // Minimum withdrawal fee
+	MinWithdrawal       string       `json:"minWd"`       // Minimum amount of currency withdrawal in a single transaction
+	Name                string       `json:"name"`        // Chinese name of currency
+	UsedWithdrawalQuota string       `json:"usedWdQuota"` // Amount of currency withdrawal used in the past 24 hours, unit in BTC
+	WithdrawalQuota     string       `json:"wdQuota"`     // Minimum amount of currency withdrawal in a single transaction
+	WithdrawalTickSize  string       `json:"wdTickSz"`    // Withdrawal precision, indicating the number of digits after the decimal point
 }
 
 // AssetBalance represents account owner asset balance
 type AssetBalance struct {
-	AvailBal      convert.StringToFloat64 `json:"availBal"`
-	Balance       convert.StringToFloat64 `json:"bal"`
-	Currency      string                  `json:"ccy"`
-	FrozenBalance convert.StringToFloat64 `json:"frozenBal"`
+	AvailBal      types.Number `json:"availBal"`
+	Balance       types.Number `json:"bal"`
+	Currency      string       `json:"ccy"`
+	FrozenBalance types.Number `json:"frozenBal"`
 }
 
 // AccountAssetValuation represents view account asset valuation data
 type AccountAssetValuation struct {
 	Details struct {
-		Classic convert.StringToFloat64 `json:"classic"`
-		Earn    convert.StringToFloat64 `json:"earn"`
-		Funding convert.StringToFloat64 `json:"funding"`
-		Trading convert.StringToFloat64 `json:"trading"`
+		Classic types.Number `json:"classic"`
+		Earn    types.Number `json:"earn"`
+		Funding types.Number `json:"funding"`
+		Trading types.Number `json:"trading"`
 	} `json:"details"`
-	TotalBalance convert.StringToFloat64 `json:"totalBal"`
-	Timestamp    okxUnixMilliTime        `json:"ts"`
+	TotalBalance types.Number     `json:"totalBal"`
+	Timestamp    okxUnixMilliTime `json:"ts"`
 }
 
 // FundingTransferRequestInput represents funding account request input.
@@ -945,27 +946,27 @@ type FundingTransferRequestInput struct {
 
 // FundingTransferResponse represents funding transfer and trading account transfer response.
 type FundingTransferResponse struct {
-	TransferID string                  `json:"transId"`
-	Currency   string                  `json:"ccy"`
-	ClientID   string                  `json:"clientId"`
-	From       int64                   `json:"from,string"`
-	Amount     convert.StringToFloat64 `json:"amt"`
-	To         int64                   `json:"to,string"`
+	TransferID string       `json:"transId"`
+	Currency   string       `json:"ccy"`
+	ClientID   string       `json:"clientId"`
+	From       int64        `json:"from,string"`
+	Amount     types.Number `json:"amt"`
+	To         int64        `json:"to,string"`
 }
 
 // TransferFundRateResponse represents funcing transfer rate response
 type TransferFundRateResponse struct {
-	Amount         convert.StringToFloat64 `json:"amt"`
-	Currency       string                  `json:"ccy"`
-	ClientID       string                  `json:"clientId"`
-	From           string                  `json:"from"`
-	InstrumentID   string                  `json:"instId"`
-	State          string                  `json:"state"`
-	SubAccount     string                  `json:"subAcct"`
-	To             string                  `json:"to"`
-	ToInstrumentID string                  `json:"toInstId"`
-	TransferID     string                  `json:"transId"`
-	Type           int                     `json:"type,string"`
+	Amount         types.Number `json:"amt"`
+	Currency       string       `json:"ccy"`
+	ClientID       string       `json:"clientId"`
+	From           string       `json:"from"`
+	InstrumentID   string       `json:"instId"`
+	State          string       `json:"state"`
+	SubAccount     string       `json:"subAcct"`
+	To             string       `json:"to"`
+	ToInstrumentID string       `json:"toInstId"`
+	TransferID     string       `json:"transId"`
+	Type           int          `json:"type,string"`
 }
 
 // AssetBillDetail represents  the billing record
@@ -1001,15 +1002,15 @@ type CurrencyDepositResponseItem struct {
 
 // DepositHistoryResponseItem deposit history response item.
 type DepositHistoryResponseItem struct {
-	Amount           convert.StringToFloat64 `json:"amt"`
-	TransactionID    string                  `json:"txId"` // Hash record of the deposit
-	Currency         string                  `json:"ccy"`
-	Chain            string                  `json:"chain"`
-	From             string                  `json:"from"`
-	ToDepositAddress string                  `json:"to"`
-	Timestamp        okxUnixMilliTime        `json:"ts"`
-	State            int                     `json:"state,string"`
-	DepositID        string                  `json:"depId"`
+	Amount           types.Number     `json:"amt"`
+	TransactionID    string           `json:"txId"` // Hash record of the deposit
+	Currency         string           `json:"ccy"`
+	Chain            string           `json:"chain"`
+	From             string           `json:"from"`
+	ToDepositAddress string           `json:"to"`
+	Timestamp        okxUnixMilliTime `json:"ts"`
+	State            int              `json:"state,string"`
+	DepositID        string           `json:"depId"`
 }
 
 // WithdrawalInput represents request parameters for cryptocurrency withdrawal
@@ -1025,11 +1026,11 @@ type WithdrawalInput struct {
 
 // WithdrawalResponse cryptocurrency withdrawal response
 type WithdrawalResponse struct {
-	Amount       convert.StringToFloat64 `json:"amt"`
-	WithdrawalID string                  `json:"wdId"`
-	Currency     string                  `json:"ccy"`
-	ClientID     string                  `json:"clientId"`
-	Chain        string                  `json:"chain"`
+	Amount       types.Number `json:"amt"`
+	WithdrawalID string       `json:"wdId"`
+	Currency     string       `json:"ccy"`
+	ClientID     string       `json:"clientId"`
+	Chain        string       `json:"chain"`
 }
 
 // LightningWithdrawalRequestInput to request Lightning Withdrawal requests.
@@ -1047,19 +1048,19 @@ type LightningWithdrawalResponse struct {
 
 // WithdrawalHistoryResponse represents the withdrawal response history.
 type WithdrawalHistoryResponse struct {
-	ChainName            string                  `json:"chain"`
-	WithdrawalFee        convert.StringToFloat64 `json:"fee"`
-	Currency             string                  `json:"ccy"`
-	ClientID             string                  `json:"clientId"`
-	Amount               convert.StringToFloat64 `json:"amt"`
-	TransactionID        string                  `json:"txId"` // Hash record of the withdrawal. This parameter will not be returned for internal transfers.
-	FromRemittingAddress string                  `json:"from"`
-	ToReceivingAddress   string                  `json:"to"`
-	StateOfWithdrawal    string                  `json:"state"`
-	Timestamp            okxUnixMilliTime        `json:"ts"`
-	WithdrawalID         string                  `json:"wdId"`
-	PaymentID            string                  `json:"pmtId,omitempty"`
-	Memo                 string                  `json:"memo"`
+	ChainName            string           `json:"chain"`
+	WithdrawalFee        types.Number     `json:"fee"`
+	Currency             string           `json:"ccy"`
+	ClientID             string           `json:"clientId"`
+	Amount               types.Number     `json:"amt"`
+	TransactionID        string           `json:"txId"` // Hash record of the withdrawal. This parameter will not be returned for internal transfers.
+	FromRemittingAddress string           `json:"from"`
+	ToReceivingAddress   string           `json:"to"`
+	StateOfWithdrawal    string           `json:"state"`
+	Timestamp            okxUnixMilliTime `json:"ts"`
+	WithdrawalID         string           `json:"wdId"`
+	PaymentID            string           `json:"pmtId,omitempty"`
+	Memo                 string           `json:"memo"`
 }
 
 // SmallAssetConvertResponse represents a response of converting a small asset to OKB.
@@ -1075,13 +1076,13 @@ type SmallAssetConvertResponse struct {
 
 // SavingBalanceResponse returns a saving response.
 type SavingBalanceResponse struct {
-	Earnings      convert.StringToFloat64 `json:"earnings"`
-	RedemptAmount convert.StringToFloat64 `json:"redemptAmt"`
-	Rate          convert.StringToFloat64 `json:"rate"`
-	Currency      string                  `json:"ccy"`
-	Amount        convert.StringToFloat64 `json:"amt"`
-	LoanAmount    convert.StringToFloat64 `json:"loanAmt"`
-	PendingAmount convert.StringToFloat64 `json:"pendingAmt"`
+	Earnings      types.Number `json:"earnings"`
+	RedemptAmount types.Number `json:"redemptAmt"`
+	Rate          types.Number `json:"rate"`
+	Currency      string       `json:"ccy"`
+	Amount        types.Number `json:"amt"`
+	LoanAmount    types.Number `json:"loanAmt"`
+	PendingAmount types.Number `json:"pendingAmt"`
 }
 
 // SavingsPurchaseRedemptionInput input json to SavingPurchase Post merthod.
@@ -1094,25 +1095,25 @@ type SavingsPurchaseRedemptionInput struct {
 
 // SavingsPurchaseRedemptionResponse response json to SavingPurchase or SavingRedemption Post method.
 type SavingsPurchaseRedemptionResponse struct {
-	Currency   string                  `json:"ccy"`
-	Amount     convert.StringToFloat64 `json:"amt"`
-	ActionType string                  `json:"side"`
-	Rate       convert.StringToFloat64 `json:"rate"`
+	Currency   string       `json:"ccy"`
+	Amount     types.Number `json:"amt"`
+	ActionType string       `json:"side"`
+	Rate       types.Number `json:"rate"`
 }
 
 // LendingRate represents lending rate response
 type LendingRate struct {
-	Currency string                  `json:"ccy"`
-	Rate     convert.StringToFloat64 `json:"rate"`
+	Currency string       `json:"ccy"`
+	Rate     types.Number `json:"rate"`
 }
 
 // LendingHistory holds lending history responses
 type LendingHistory struct {
-	Currency  string                  `json:"ccy"`
-	Amount    convert.StringToFloat64 `json:"amt"`
-	Earnings  convert.StringToFloat64 `json:"earnings,omitempty"`
-	Rate      convert.StringToFloat64 `json:"rate"`
-	Timestamp okxUnixMilliTime        `json:"ts"`
+	Currency  string           `json:"ccy"`
+	Amount    types.Number     `json:"amt"`
+	Earnings  types.Number     `json:"earnings,omitempty"`
+	Rate      types.Number     `json:"rate"`
+	Timestamp okxUnixMilliTime `json:"ts"`
 }
 
 // PublicBorrowInfo holds a currency's borrow info.
@@ -1127,10 +1128,10 @@ type PublicBorrowInfo struct {
 
 // PublicBorrowHistory holds a currencies borrow history.
 type PublicBorrowHistory struct {
-	Amount    convert.StringToFloat64 `json:"amt"`
-	Currency  string                  `json:"ccy"`
-	Rate      convert.StringToFloat64 `json:"rate"`
-	Timestamp okxUnixMilliTime        `json:"ts"`
+	Amount    types.Number     `json:"amt"`
+	Currency  string           `json:"ccy"`
+	Rate      types.Number     `json:"rate"`
+	Timestamp okxUnixMilliTime `json:"ts"`
 }
 
 // ConvertCurrency represents currency conversion detailed data.
@@ -1142,13 +1143,13 @@ type ConvertCurrency struct {
 
 // ConvertCurrencyPair holds information related to conversion between two pairs.
 type ConvertCurrencyPair struct {
-	InstrumentID     string                  `json:"instId"`
-	BaseCurrency     string                  `json:"baseCcy"`
-	BaseCurrencyMax  convert.StringToFloat64 `json:"baseCcyMax,omitempty"`
-	BaseCurrencyMin  convert.StringToFloat64 `json:"baseCcyMin,omitempty"`
-	QuoteCurrency    string                  `json:"quoteCcy,omitempty"`
-	QuoteCurrencyMax convert.StringToFloat64 `json:"quoteCcyMax,omitempty"`
-	QuoteCurrencyMin convert.StringToFloat64 `json:"quoteCcyMin,omitempty"`
+	InstrumentID     string       `json:"instId"`
+	BaseCurrency     string       `json:"baseCcy"`
+	BaseCurrencyMax  types.Number `json:"baseCcyMax,omitempty"`
+	BaseCurrencyMin  types.Number `json:"baseCcyMin,omitempty"`
+	QuoteCurrency    string       `json:"quoteCcy,omitempty"`
+	QuoteCurrencyMax types.Number `json:"quoteCcyMax,omitempty"`
+	QuoteCurrencyMin types.Number `json:"quoteCcyMin,omitempty"`
 }
 
 // EstimateQuoteRequestInput represents estimate quote request parameters
@@ -1193,32 +1194,32 @@ type ConvertTradeInput struct {
 
 // ConvertTradeResponse represents convert trade response
 type ConvertTradeResponse struct {
-	BaseCurrency  string                  `json:"baseCcy"`
-	ClientOrderID string                  `json:"clTReqId"`
-	FillBaseSize  convert.StringToFloat64 `json:"fillBaseSz"`
-	FillPrice     string                  `json:"fillPx"`
-	FillQuoteSize convert.StringToFloat64 `json:"fillQuoteSz"`
-	InstrumentID  string                  `json:"instId"`
-	QuoteCurrency string                  `json:"quoteCcy"`
-	QuoteID       string                  `json:"quoteId"`
-	Side          order.Side              `json:"side"`
-	State         string                  `json:"state"`
-	TradeID       string                  `json:"tradeId"`
-	Timestamp     okxUnixMilliTime        `json:"ts"`
+	BaseCurrency  string           `json:"baseCcy"`
+	ClientOrderID string           `json:"clTReqId"`
+	FillBaseSize  types.Number     `json:"fillBaseSz"`
+	FillPrice     string           `json:"fillPx"`
+	FillQuoteSize types.Number     `json:"fillQuoteSz"`
+	InstrumentID  string           `json:"instId"`
+	QuoteCurrency string           `json:"quoteCcy"`
+	QuoteID       string           `json:"quoteId"`
+	Side          order.Side       `json:"side"`
+	State         string           `json:"state"`
+	TradeID       string           `json:"tradeId"`
+	Timestamp     okxUnixMilliTime `json:"ts"`
 }
 
 // ConvertHistory holds convert trade history response
 type ConvertHistory struct {
-	InstrumentID  string                  `json:"instId"`
-	Side          order.Side              `json:"side"`
-	FillPrice     convert.StringToFloat64 `json:"fillPx"`
-	BaseCurrency  string                  `json:"baseCcy"`
-	QuoteCurrency string                  `json:"quoteCcy"`
-	FillBaseSize  convert.StringToFloat64 `json:"fillBaseSz"`
-	State         string                  `json:"state"`
-	TradeID       string                  `json:"tradeId"`
-	FillQuoteSize convert.StringToFloat64 `json:"fillQuoteSz"`
-	Timestamp     okxUnixMilliTime        `json:"ts"`
+	InstrumentID  string           `json:"instId"`
+	Side          order.Side       `json:"side"`
+	FillPrice     types.Number     `json:"fillPx"`
+	BaseCurrency  string           `json:"baseCcy"`
+	QuoteCurrency string           `json:"quoteCcy"`
+	FillBaseSize  types.Number     `json:"fillBaseSz"`
+	State         string           `json:"state"`
+	TradeID       string           `json:"tradeId"`
+	FillQuoteSize types.Number     `json:"fillQuoteSz"`
+	Timestamp     okxUnixMilliTime `json:"ts"`
 }
 
 // Account holds currency account balance and related information
@@ -1311,24 +1312,24 @@ type AccountPosition struct {
 
 // AccountPositionHistory hold account position history.
 type AccountPositionHistory struct {
-	CreationTime       okxUnixMilliTime        `json:"cTime"`
-	Currency           string                  `json:"ccy"`
-	CloseAveragePrice  convert.StringToFloat64 `json:"closeAvgPx,omitempty"`
-	CloseTotalPosition convert.StringToFloat64 `json:"closeTotalPos,omitempty"`
-	InstrumentID       string                  `json:"instId"`
-	InstrumentType     string                  `json:"instType"`
-	Leverage           string                  `json:"lever"`
-	ManagementMode     string                  `json:"mgnMode"`
-	OpenAveragePrice   string                  `json:"openAvgPx"`
-	OpenMaxPosition    string                  `json:"openMaxPos"`
-	ProfitAndLoss      convert.StringToFloat64 `json:"pnl,omitempty"`
-	ProfitAndLossRatio convert.StringToFloat64 `json:"pnlRatio,omitempty"`
-	PositionID         string                  `json:"posId"`
-	PositionSide       string                  `json:"posSide"`
-	TriggerPrice       string                  `json:"triggerPx"`
-	Type               string                  `json:"type"`
-	UpdateTime         okxUnixMilliTime        `json:"uTime"`
-	Underlying         string                  `json:"uly"`
+	CreationTime       okxUnixMilliTime `json:"cTime"`
+	Currency           string           `json:"ccy"`
+	CloseAveragePrice  types.Number     `json:"closeAvgPx,omitempty"`
+	CloseTotalPosition types.Number     `json:"closeTotalPos,omitempty"`
+	InstrumentID       string           `json:"instId"`
+	InstrumentType     string           `json:"instType"`
+	Leverage           string           `json:"lever"`
+	ManagementMode     string           `json:"mgnMode"`
+	OpenAveragePrice   string           `json:"openAvgPx"`
+	OpenMaxPosition    string           `json:"openMaxPos"`
+	ProfitAndLoss      types.Number     `json:"pnl,omitempty"`
+	ProfitAndLossRatio types.Number     `json:"pnlRatio,omitempty"`
+	PositionID         string           `json:"posId"`
+	PositionSide       string           `json:"posSide"`
+	TriggerPrice       string           `json:"triggerPx"`
+	Type               string           `json:"type"`
+	UpdateTime         okxUnixMilliTime `json:"uTime"`
+	Underlying         string           `json:"uly"`
 }
 
 // AccountBalanceData represents currency account balance.
@@ -1520,8 +1521,8 @@ type InterestAccruedData struct {
 
 // InterestRateResponse represents interest rate response.
 type InterestRateResponse struct {
-	InterestRate convert.StringToFloat64 `json:"interestRate"`
-	Currency     string                  `json:"ccy"`
+	InterestRate types.Number `json:"interestRate"`
+	Currency     string       `json:"ccy"`
 }
 
 // GreeksType represents for greeks type response
@@ -1552,9 +1553,9 @@ type AccountRiskState struct {
 
 // LoanBorrowAndReplayInput represents currency VIP borrow or repay request params.
 type LoanBorrowAndReplayInput struct {
-	Currency string                  `json:"ccy"`
-	Side     string                  `json:"side,omitempty"`
-	Amount   convert.StringToFloat64 `json:"amt,omitempty"`
+	Currency string       `json:"ccy"`
+	Side     string       `json:"side,omitempty"`
+	Amount   types.Number `json:"amt,omitempty"`
 }
 
 // LoanBorrowAndReplay loans borrow and repay
@@ -1729,9 +1730,9 @@ type OrderLeg struct {
 	TargetCurrency string `json:"tgtCcy"`
 
 	// available in REST only
-	Fee         convert.StringToFloat64 `json:"fee"`
-	FeeCurrency string                  `json:"feeCcy"`
-	TradeID     string                  `json:"tradeId"`
+	Fee         types.Number `json:"fee"`
+	FeeCurrency string       `json:"feeCcy"`
+	TradeID     string       `json:"tradeId"`
 }
 
 // CreateQuoteParams holds information related to create quote.
@@ -1744,10 +1745,10 @@ type CreateQuoteParams struct {
 
 // QuoteLeg the legs of the Quote.
 type QuoteLeg struct {
-	Price          convert.StringToFloat64 `json:"px"`
-	SizeOfQuoteLeg convert.StringToFloat64 `json:"sz"`
-	InstrumentID   string                  `json:"instId"`
-	Side           order.Side              `json:"side"`
+	Price          types.Number `json:"px"`
+	SizeOfQuoteLeg types.Number `json:"sz"`
+	InstrumentID   string       `json:"instId"`
+	Side           order.Side   `json:"side"`
 
 	// TargetCurrency represents target currency
 	TargetCurrency string `json:"tgtCcy,omitempty"`
@@ -1856,13 +1857,13 @@ type RfqTradeResponse struct {
 
 // BlockTradeLeg Rfq trade response leg.
 type BlockTradeLeg struct {
-	TradeID      string                  `json:"tradeId"`
-	InstrumentID string                  `json:"instId"`
-	Side         order.Side              `json:"side"`
-	Size         convert.StringToFloat64 `json:"sz"`
-	Price        convert.StringToFloat64 `json:"px"`
-	Fee          convert.StringToFloat64 `json:"fee,omitempty"`
-	FeeCurrency  string                  `json:"feeCcy,omitempty"`
+	TradeID      string       `json:"tradeId"`
+	InstrumentID string       `json:"instId"`
+	Side         order.Side   `json:"side"`
+	Size         types.Number `json:"sz"`
+	Price        types.Number `json:"px"`
+	Fee          types.Number `json:"fee,omitempty"`
+	FeeCurrency  string       `json:"feeCcy,omitempty"`
 }
 
 // PublicBlockTradesResponse represents data will be pushed whenever there is a block trade.
@@ -1971,22 +1972,22 @@ type SubaccountName struct {
 
 // GridAlgoOrder represents grid algo order.
 type GridAlgoOrder struct {
-	InstrumentID string                  `json:"instId"`
-	AlgoOrdType  string                  `json:"algoOrdType"`
-	MaxPrice     convert.StringToFloat64 `json:"maxPx"`
-	MinPrice     convert.StringToFloat64 `json:"minPx"`
-	GridQuantity convert.StringToFloat64 `json:"gridNum"`
-	GridType     string                  `json:"runType"` // "1": Arithmetic, "2": Geometric Default is Arithmetic
+	InstrumentID string       `json:"instId"`
+	AlgoOrdType  string       `json:"algoOrdType"`
+	MaxPrice     types.Number `json:"maxPx"`
+	MinPrice     types.Number `json:"minPx"`
+	GridQuantity types.Number `json:"gridNum"`
+	GridType     string       `json:"runType"` // "1": Arithmetic, "2": Geometric Default is Arithmetic
 
 	// Spot Grid Order
-	QuoteSize convert.StringToFloat64 `json:"quoteSz"` // Invest amount for quote currency Either "instId" or "ccy" is required
-	BaseSize  convert.StringToFloat64 `json:"baseSz"`  // Invest amount for base currency Either "instId" or "ccy" is required
+	QuoteSize types.Number `json:"quoteSz"` // Invest amount for quote currency Either "instId" or "ccy" is required
+	BaseSize  types.Number `json:"baseSz"`  // Invest amount for base currency Either "instId" or "ccy" is required
 
 	// Contract Grid Order
-	BasePosition bool                    `json:"basePos"` // Whether or not open a position when strategy actives Default is false Neutral contract grid should omit the parameter
-	Size         convert.StringToFloat64 `json:"sz"`
-	Direction    string                  `json:"direction"`
-	Lever        string                  `json:"lever"`
+	BasePosition bool         `json:"basePos"` // Whether or not open a position when strategy actives Default is false Neutral contract grid should omit the parameter
+	Size         types.Number `json:"sz"`
+	Direction    string       `json:"direction"`
+	Lever        string       `json:"lever"`
 }
 
 // GridAlgoOrderIDResponse represents grid algo order
@@ -2159,34 +2160,34 @@ type SystemStatusResponse struct {
 
 // BlockTicker holds block trading information.
 type BlockTicker struct {
-	InstrumentType           string                  `json:"instType"`
-	InstrumentID             string                  `json:"instId"`
-	TradingVolumeInCCY24Hour convert.StringToFloat64 `json:"volCcy24h"`
-	TradingVolumeInUSD24Hour convert.StringToFloat64 `json:"vol24h"`
-	Timestamp                okxUnixMilliTime        `json:"ts"`
+	InstrumentType           string           `json:"instType"`
+	InstrumentID             string           `json:"instId"`
+	TradingVolumeInCCY24Hour types.Number     `json:"volCcy24h"`
+	TradingVolumeInUSD24Hour types.Number     `json:"vol24h"`
+	Timestamp                okxUnixMilliTime `json:"ts"`
 }
 
 // BlockTrade represents a block trade.
 type BlockTrade struct {
-	InstrumentID   string                  `json:"instId"`
-	TradeID        string                  `json:"tradeId"`
-	Price          convert.StringToFloat64 `json:"px"`
-	Size           convert.StringToFloat64 `json:"sz"`
-	Side           order.Side              `json:"side"`
-	FillVolatility convert.StringToFloat64 `json:"fillVol"`
-	ForwardPrice   convert.StringToFloat64 `json:"fwdPx"`
-	IndexPrice     convert.StringToFloat64 `json:"idxPx"`
-	MarkPrice      convert.StringToFloat64 `json:"markPx"`
-	Timestamp      convert.ExchangeTime    `json:"ts"`
+	InstrumentID   string               `json:"instId"`
+	TradeID        string               `json:"tradeId"`
+	Price          types.Number         `json:"px"`
+	Size           types.Number         `json:"sz"`
+	Side           order.Side           `json:"side"`
+	FillVolatility types.Number         `json:"fillVol"`
+	ForwardPrice   types.Number         `json:"fwdPx"`
+	IndexPrice     types.Number         `json:"idxPx"`
+	MarkPrice      types.Number         `json:"markPx"`
+	Timestamp      convert.ExchangeTime `json:"ts"`
 }
 
 // UnitConvertResponse unit convert response.
 type UnitConvertResponse struct {
-	InstrumentID string                  `json:"instId"`
-	Price        convert.StringToFloat64 `json:"px"`
-	Size         convert.StringToFloat64 `json:"sz"`
-	ConvertType  uint64                  `json:"type"`
-	Unit         string                  `json:"unit"`
+	InstrumentID string       `json:"instId"`
+	Price        types.Number `json:"px"`
+	Size         types.Number `json:"sz"`
+	ConvertType  uint64       `json:"type"`
+	Unit         string       `json:"unit"`
 }
 
 // Websocket Models
@@ -2259,20 +2260,20 @@ type WSMarketDataResponse struct {
 
 // WSPlaceOrderData holds websocket order information.
 type WSPlaceOrderData struct {
-	ClientOrderID  string                  `json:"clOrdId,omitempty"`
-	Currency       string                  `json:"ccy,omitempty"`
-	Tag            string                  `json:"tag,omitempty"`
-	PositionSide   string                  `json:"posSide,omitempty"`
-	ExpiryTime     int64                   `json:"expTime,string,omitempty"`
-	BanAmend       bool                    `json:"banAmend,omitempty"`
-	Side           string                  `json:"side"`
-	InstrumentID   string                  `json:"instId"`
-	TradeMode      string                  `json:"tdMode"`
-	OrderType      string                  `json:"ordType"`
-	Size           float64                 `json:"sz"`
-	Price          convert.StringToFloat64 `json:"px,omitempty"`
-	ReduceOnly     bool                    `json:"reduceOnly,string,omitempty"`
-	TargetCurrency string                  `json:"tgtCurrency,omitempty"`
+	ClientOrderID  string       `json:"clOrdId,omitempty"`
+	Currency       string       `json:"ccy,omitempty"`
+	Tag            string       `json:"tag,omitempty"`
+	PositionSide   string       `json:"posSide,omitempty"`
+	ExpiryTime     int64        `json:"expTime,string,omitempty"`
+	BanAmend       bool         `json:"banAmend,omitempty"`
+	Side           string       `json:"side"`
+	InstrumentID   string       `json:"instId"`
+	TradeMode      string       `json:"tdMode"`
+	OrderType      string       `json:"ordType"`
+	Size           float64      `json:"sz"`
+	Price          types.Number `json:"px,omitempty"`
+	ReduceOnly     bool         `json:"reduceOnly,string,omitempty"`
+	TargetCurrency string       `json:"tgtCurrency,omitempty"`
 }
 
 // WSPlaceOrder holds the websocket place order input data.
@@ -2373,28 +2374,28 @@ type WSOpenInterestResponse struct {
 
 // WSTradeData websocket trade data response.
 type WSTradeData struct {
-	InstrumentID string                  `json:"instId"`
-	TradeID      string                  `json:"tradeId"`
-	Price        convert.StringToFloat64 `json:"px"`
-	Size         convert.StringToFloat64 `json:"sz"`
-	Side         order.Side              `json:"side"`
-	Timestamp    okxUnixMilliTime        `json:"ts"`
+	InstrumentID string           `json:"instId"`
+	TradeID      string           `json:"tradeId"`
+	Price        types.Number     `json:"px"`
+	Size         types.Number     `json:"sz"`
+	Side         order.Side       `json:"side"`
+	Timestamp    okxUnixMilliTime `json:"ts"`
 }
 
 // WSPlaceOrderInput place order input variables as a json.
 type WSPlaceOrderInput struct {
-	Side           order.Side              `json:"side"`
-	InstrumentID   string                  `json:"instId"`
-	TradeMode      string                  `json:"tdMode"`
-	OrderType      string                  `json:"ordType"`
-	Size           convert.StringToFloat64 `json:"sz"`
-	Currency       string                  `json:"ccy"`
-	ClientOrderID  string                  `json:"clOrdId,omitempty"`
-	Tag            string                  `json:"tag,omitempty"`
-	PositionSide   string                  `json:"posSide,omitempty"`
-	Price          convert.StringToFloat64 `json:"px,omitempty"`
-	ReduceOnly     bool                    `json:"reduceOnly,omitempty"`
-	TargetCurrency string                  `json:"tgtCcy"`
+	Side           order.Side   `json:"side"`
+	InstrumentID   string       `json:"instId"`
+	TradeMode      string       `json:"tdMode"`
+	OrderType      string       `json:"ordType"`
+	Size           types.Number `json:"sz"`
+	Currency       string       `json:"ccy"`
+	ClientOrderID  string       `json:"clOrdId,omitempty"`
+	Tag            string       `json:"tag,omitempty"`
+	PositionSide   string       `json:"posSide,omitempty"`
+	Price          types.Number `json:"px,omitempty"`
+	ReduceOnly     bool         `json:"reduceOnly,omitempty"`
+	TargetCurrency string       `json:"tgtCcy"`
 }
 
 // WsPlaceOrderInput for all websocket request inputs.
@@ -2529,35 +2530,35 @@ type WsAlgoOrder struct {
 
 // WsAlgoOrderDetail algo order response pushed through the websocket conn
 type WsAlgoOrderDetail struct {
-	InstrumentType             string                  `json:"instType"`
-	InstrumentID               string                  `json:"instId"`
-	OrderID                    string                  `json:"ordId"`
-	Currency                   string                  `json:"ccy"`
-	AlgoID                     string                  `json:"algoId"`
-	Price                      string                  `json:"px"`
-	Size                       string                  `json:"sz"`
-	TradeMode                  string                  `json:"tdMode"`
-	TargetCurrency             string                  `json:"tgtCcy"`
-	NotionalUsd                string                  `json:"notionalUsd"`
-	OrderType                  string                  `json:"ordType"`
-	Side                       order.Side              `json:"side"`
-	PositionSide               string                  `json:"posSide"`
-	State                      string                  `json:"state"`
-	Leverage                   string                  `json:"lever"`
-	TakeProfitTriggerPrice     string                  `json:"tpTriggerPx"`
-	TakeProfitTriggerPriceType string                  `json:"tpTriggerPxType"`
-	TakeProfitOrdPrice         string                  `json:"tpOrdPx"`
-	StopLossTriggerPrice       string                  `json:"slTriggerPx"`
-	StopLossTriggerPriceType   string                  `json:"slTriggerPxType"`
-	TriggerPrice               string                  `json:"triggerPx"`
-	TriggerPriceType           string                  `json:"triggerPxType"`
-	OrderPrice                 convert.StringToFloat64 `json:"ordPx"`
-	ActualSize                 string                  `json:"actualSz"`
-	ActualPrice                string                  `json:"actualPx"`
-	Tag                        string                  `json:"tag"`
-	ActualSide                 string                  `json:"actualSide"`
-	TriggerTime                okxUnixMilliTime        `json:"triggerTime"`
-	CreationTime               okxUnixMilliTime        `json:"cTime"`
+	InstrumentType             string           `json:"instType"`
+	InstrumentID               string           `json:"instId"`
+	OrderID                    string           `json:"ordId"`
+	Currency                   string           `json:"ccy"`
+	AlgoID                     string           `json:"algoId"`
+	Price                      string           `json:"px"`
+	Size                       string           `json:"sz"`
+	TradeMode                  string           `json:"tdMode"`
+	TargetCurrency             string           `json:"tgtCcy"`
+	NotionalUsd                string           `json:"notionalUsd"`
+	OrderType                  string           `json:"ordType"`
+	Side                       order.Side       `json:"side"`
+	PositionSide               string           `json:"posSide"`
+	State                      string           `json:"state"`
+	Leverage                   string           `json:"lever"`
+	TakeProfitTriggerPrice     string           `json:"tpTriggerPx"`
+	TakeProfitTriggerPriceType string           `json:"tpTriggerPxType"`
+	TakeProfitOrdPrice         string           `json:"tpOrdPx"`
+	StopLossTriggerPrice       string           `json:"slTriggerPx"`
+	StopLossTriggerPriceType   string           `json:"slTriggerPxType"`
+	TriggerPrice               string           `json:"triggerPx"`
+	TriggerPriceType           string           `json:"triggerPxType"`
+	OrderPrice                 types.Number     `json:"ordPx"`
+	ActualSize                 string           `json:"actualSz"`
+	ActualPrice                string           `json:"actualPx"`
+	Tag                        string           `json:"tag"`
+	ActualSide                 string           `json:"actualSide"`
+	TriggerTime                okxUnixMilliTime `json:"triggerTime"`
+	CreationTime               okxUnixMilliTime `json:"cTime"`
 }
 
 // WsAdvancedAlgoOrder advanced algo order response.
@@ -2930,9 +2931,9 @@ type WsBlockTicker struct {
 
 // PMLimitationResponse represents portfolio margin mode limitation for specific underlying
 type PMLimitationResponse struct {
-	MaximumSize  convert.StringToFloat64 `json:"maxSz"`
-	PositionType string                  `json:"postType"`
-	Underlying   string                  `json:"uly"`
+	MaximumSize  types.Number `json:"maxSz"`
+	PositionType string       `json:"postType"`
+	Underlying   string       `json:"uly"`
 }
 
 // EasyConvertDetail represents easy convert currencies list and their detail.
@@ -2943,8 +2944,8 @@ type EasyConvertDetail struct {
 
 // EasyConvertFromData represents convert currency from detail
 type EasyConvertFromData struct {
-	FromAmount   convert.StringToFloat64 `json:"fromAmt"`
-	FromCurrency string                  `json:"fromCcy"`
+	FromAmount   types.Number `json:"fromAmt"`
+	FromCurrency string       `json:"fromCcy"`
 }
 
 // PlaceEasyConvertParam represents easy convert request params
@@ -2955,12 +2956,12 @@ type PlaceEasyConvertParam struct {
 
 // EasyConvertItem represents easy convert place order response.
 type EasyConvertItem struct {
-	FilFromSize  convert.StringToFloat64 `json:"fillFromSz"`
-	FillToSize   convert.StringToFloat64 `json:"fillToSz"`
-	FromCurrency string                  `json:"fromCcy"`
-	Status       string                  `json:"status"`
-	ToCurrency   string                  `json:"toCcy"`
-	UpdateTime   okxUnixMilliTime        `json:"uTime"`
+	FilFromSize  types.Number     `json:"fillFromSz"`
+	FillToSize   types.Number     `json:"fillToSz"`
+	FromCurrency string           `json:"fromCcy"`
+	Status       string           `json:"status"`
+	ToCurrency   string           `json:"toCcy"`
+	UpdateTime   okxUnixMilliTime `json:"uTime"`
 }
 
 // OneClickRepayCurrencyItem represents debt currency data and repay currencies.
@@ -2972,14 +2973,14 @@ type OneClickRepayCurrencyItem struct {
 
 // CurrencyDebtAmount represents debt currency data
 type CurrencyDebtAmount struct {
-	DebtAmount   convert.StringToFloat64 `json:"debtAmt"`
-	DebtCurrency string                  `json:"debtCcy"`
+	DebtAmount   types.Number `json:"debtAmt"`
+	DebtCurrency string       `json:"debtCcy"`
 }
 
 // CurrencyRepayAmount represents rebat currency amount.
 type CurrencyRepayAmount struct {
-	RepayAmount   convert.StringToFloat64 `json:"repayAmt"`
-	RepayCurrency string                  `json:"repayCcy"`
+	RepayAmount   types.Number `json:"repayAmt"`
+	RepayCurrency string       `json:"repayCcy"`
 }
 
 // TradeOneClickRepayParam represents click one repay param
@@ -2990,13 +2991,13 @@ type TradeOneClickRepayParam struct {
 
 // CurrencyOneClickRepay represents one click repay currency
 type CurrencyOneClickRepay struct {
-	DebtCurrency  string                  `json:"debtCcy"`
-	FillFromSize  okxNumericalValue       `json:"fillFromSz"`
-	FillRepaySize okxNumericalValue       `json:"fillRepaySz"`
-	FillToSize    convert.StringToFloat64 `json:"fillToSz"`
-	RepayCurrency string                  `json:"repayCcy"`
-	Status        string                  `json:"status"`
-	UpdateTime    time.Time               `json:"uTime"`
+	DebtCurrency  string            `json:"debtCcy"`
+	FillFromSize  okxNumericalValue `json:"fillFromSz"`
+	FillRepaySize okxNumericalValue `json:"fillRepaySz"`
+	FillToSize    types.Number      `json:"fillToSz"`
+	RepayCurrency string            `json:"repayCcy"`
+	Status        string            `json:"status"`
+	UpdateTime    time.Time         `json:"uTime"`
 }
 
 // SetQuoteProductParam represents set quote product request param
@@ -3007,10 +3008,10 @@ type SetQuoteProductParam struct {
 
 // MakerInstrumentSetting represents set quote product setting info
 type MakerInstrumentSetting struct {
-	Underlying     string                  `json:"uly"`
-	InstrumentID   string                  `json:"instId"`
-	MaxBlockSize   convert.StringToFloat64 `json:"maxBlockSz"`
-	MakerPriceBand convert.StringToFloat64 `json:"makerPxBand"`
+	Underlying     string       `json:"uly"`
+	InstrumentID   string       `json:"instId"`
+	MaxBlockSize   types.Number `json:"maxBlockSz"`
+	MakerPriceBand types.Number `json:"makerPxBand"`
 }
 
 // SetQuoteProductsResult represents set quote products result
@@ -3048,8 +3049,8 @@ type MarginBalanceParam struct {
 
 // ComputeMarginBalance represents compute margin amount request response
 type ComputeMarginBalance struct {
-	Leverage      convert.StringToFloat64 `json:"lever"`
-	MaximumAmount convert.StringToFloat64 `json:"maxAmt"`
+	Leverage      types.Number `json:"lever"`
+	MaximumAmount types.Number `json:"maxAmt"`
 }
 
 // AdjustMarginBalanceResponse represents algo id for response for margin balance adjust request.
@@ -3059,20 +3060,20 @@ type AdjustMarginBalanceResponse struct {
 
 // GridAIParameterResponse represents gri AI parameter response.
 type GridAIParameterResponse struct {
-	AlgoOrderType        string                  `json:"algoOrdType"`
-	AnnualizedRate       string                  `json:"annualizedRate"`
-	Currency             string                  `json:"ccy"`
-	Direction            string                  `json:"direction"`
-	Duration             string                  `json:"duration"`
-	GridNum              string                  `json:"gridNum"`
-	InstrumentID         string                  `json:"instId"`
-	Leverage             convert.StringToFloat64 `json:"lever"`
-	MaximumPrice         convert.StringToFloat64 `json:"maxPx"`
-	MinimumInvestment    convert.StringToFloat64 `json:"minInvestment"`
-	MinimumPrice         convert.StringToFloat64 `json:"minPx"`
-	PerMaximumProfitRate convert.StringToFloat64 `json:"perMaxProfitRate"`
-	PerMinimumProfitRate convert.StringToFloat64 `json:"perMinProfitRate"`
-	RunType              string                  `json:"runType"`
+	AlgoOrderType        string       `json:"algoOrdType"`
+	AnnualizedRate       string       `json:"annualizedRate"`
+	Currency             string       `json:"ccy"`
+	Direction            string       `json:"direction"`
+	Duration             string       `json:"duration"`
+	GridNum              string       `json:"gridNum"`
+	InstrumentID         string       `json:"instId"`
+	Leverage             types.Number `json:"lever"`
+	MaximumPrice         types.Number `json:"maxPx"`
+	MinimumInvestment    types.Number `json:"minInvestment"`
+	MinimumPrice         types.Number `json:"minPx"`
+	PerMaximumProfitRate types.Number `json:"perMaxProfitRate"`
+	PerMinimumProfitRate types.Number `json:"perMinProfitRate"`
+	RunType              string       `json:"runType"`
 }
 
 // Offer represents an investment offer information for different 'staking' and 'defi' protocols
@@ -3109,8 +3110,8 @@ type PurchaseRequestParam struct {
 
 // PurchaseInvestDataItem represents purchase invest data information having the currency and amount information
 type PurchaseInvestDataItem struct {
-	Currency string                  `json:"ccy"`
-	Amount   convert.StringToFloat64 `json:"amt"`
+	Currency string       `json:"ccy"`
+	Amount   types.Number `json:"amt"`
 }
 
 // OrderIDResponse represents purchase order ID
@@ -3141,34 +3142,34 @@ type ActiveFundingOrder struct {
 	Term         string `json:"term"`
 	Apy          string `json:"apy"`
 	InvestData   []struct {
-		Currency string                  `json:"ccy"`
-		Amount   convert.StringToFloat64 `json:"amt"`
+		Currency string       `json:"ccy"`
+		Amount   types.Number `json:"amt"`
 	} `json:"investData"`
 	EarningData []struct {
-		Ccy         string                  `json:"ccy"`
-		EarningType string                  `json:"earningType"`
-		Earnings    convert.StringToFloat64 `json:"earnings"`
+		Ccy         string       `json:"ccy"`
+		EarningType string       `json:"earningType"`
+		Earnings    types.Number `json:"earnings"`
 	} `json:"earningData"`
 	PurchasedTime okxUnixMilliTime `json:"purchasedTime"`
 }
 
 // FundingOrder represents orders of earning, purchase, and redeem
 type FundingOrder struct {
-	OrderID      string                  `json:"ordId"`
-	State        string                  `json:"state"`
-	Currency     string                  `json:"ccy"`
-	Protocol     string                  `json:"protocol"`
-	ProtocolType string                  `json:"protocolType"`
-	Term         string                  `json:"term"`
-	Apy          convert.StringToFloat64 `json:"apy"`
+	OrderID      string       `json:"ordId"`
+	State        string       `json:"state"`
+	Currency     string       `json:"ccy"`
+	Protocol     string       `json:"protocol"`
+	ProtocolType string       `json:"protocolType"`
+	Term         string       `json:"term"`
+	Apy          types.Number `json:"apy"`
 	InvestData   []struct {
-		Currency string                  `json:"ccy"`
-		Amount   convert.StringToFloat64 `json:"amt"`
+		Currency string       `json:"ccy"`
+		Amount   types.Number `json:"amt"`
 	} `json:"investData"`
 	EarningData []struct {
-		Currency         string                  `json:"ccy"`
-		EarningType      string                  `json:"earningType"`
-		RealizedEarnings convert.StringToFloat64 `json:"realizedEarnings"`
+		Currency         string       `json:"ccy"`
+		EarningType      string       `json:"earningType"`
+		RealizedEarnings types.Number `json:"realizedEarnings"`
 	} `json:"earningData"`
 	PurchasedTime okxUnixMilliTime `json:"purchasedTime"`
 	RedeemedTime  okxUnixMilliTime `json:"redeemedTime"`

--- a/types/number.go
+++ b/types/number.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+)
+
+var errInvalidNumberValue = errors.New("invalid value for Number type")
+
+// Number represents a floating point number, and implements json.Unmarshaller and json.Marshaller
+type Number float64
+
+// UnmarshalJSON implements json.Unmarshaler
+func (f *Number) UnmarshalJSON(data []byte) error {
+	switch c := data[0]; c { // From json.decode literalInterface
+	case 'n', 't', 'f': // null, true, false
+		return fmt.Errorf("%w: %s", errInvalidNumberValue, data)
+	case '"': // string
+		if len(data) < 2 || data[len(data)-1] != '"' {
+			return fmt.Errorf("%w: %s", errInvalidNumberValue, data)
+		}
+		data = data[1 : len(data)-1] // Naive Unquote
+	default: // Should be a number
+		if c != '-' && (c < '0' || c > '9') { // Invalid json syntax
+			return fmt.Errorf("%w: %s", errInvalidNumberValue, data)
+		}
+	}
+
+	if len(data) == 0 {
+		*f = Number(0)
+		return nil
+	}
+
+	val, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errInvalidNumberValue, data) // We don't use err; We know it's not valid and errInvalidNumberValue is clearer
+	}
+
+	*f = Number(val)
+
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler by formatting to a json string
+// 1337.37 will marshal to "1337.37"
+// 0 will marshal to an empty string: ""
+func (f Number) MarshalJSON() ([]byte, error) {
+	if f == 0 {
+		return []byte(`""`), nil
+	}
+	val := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	return []byte(`"` + val + `"`), nil
+}
+
+// Float64 returns the underlying float64
+func (f Number) Float64() float64 {
+	return float64(f)
+}
+
+// Int64 returns the truncated integer component of the number
+func (f Number) Int64() int64 {
+	// It's likely this is sufficient, since Numbers probably have not had floating point math performed on them
+	// However if issues arise then we can switch to math.Round
+	return int64(f)
+}
+
+// Decimal returns a decimal.Decimal
+func (f Number) Decimal() decimal.Decimal {
+	return decimal.NewFromFloat(float64(f))
+}

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNumberUnmarshalJSON asserts the following behaviour:
+// * Literal numbers and quoted are valid
+// * Anything else returns errInvalidNumberValue
+func TestNumberUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	var n Number
+
+	err := n.UnmarshalJSON([]byte(`"0.00000001"`))
+	assert.NoError(t, err, "Unmarshal should not error")
+	assert.Equal(t, 1e-8, n.Float64(), "Float64() should return the correct value")
+
+	err = n.UnmarshalJSON([]byte(`""`))
+	assert.NoError(t, err, "Unmarshal should not error")
+	assert.Zero(t, n.Float64(), "UnmarshalJSON should parse empty as 0")
+
+	err = n.UnmarshalJSON([]byte(`1337.37`))
+	assert.NoError(t, err, "Unmarshal should not error on number types")
+	assert.Equal(t, 1337.37, n.Float64(), "UnmarshalJSON should handle raw numerics")
+
+	// Invalid value checking
+	for _, i := range []string{`"MEOW"`, `null`, `false`, `true`, `"1337.37`} {
+		err = n.UnmarshalJSON([]byte(i))
+		assert.ErrorIsf(t, err, errInvalidNumberValue, "UnmarshalJSON should error with invalid Value for `%s`", i)
+	}
+}
+
+// TestNumberMarshalJSON asserts the following behaviour:
+// 0 marshalls to quoted empty string
+// Anything else marshalls as a quoted number
+func TestNumberMarshalJSON(t *testing.T) {
+	data, err := new(Number).MarshalJSON()
+	assert.NoError(t, err, "MarshalJSON should not error")
+	assert.Equal(t, `""`, string(data), "MarshalJSON should return the correct value")
+
+	data, err = Number(1337.1337).MarshalJSON()
+	assert.NoError(t, err, "MarshalJSON should not error")
+	assert.Equal(t, `"1337.1337"`, string(data), "MarshalJSON should return the correct value")
+}
+
+// TestNumberFloat64 asserts Float64() returns a valid float64
+func TestNumberFloat64(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0.04200064, Number(0.04200064).Float64(), "Float64() should return the correct value")
+}
+
+// TestNumberDecimal asserts Decimal() returns a valid decimal.Decimal
+func TestNumberDecimal(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, decimal.NewFromFloat(0.04200064), Number(0.04200064).Decimal(), "Decimal() should return the correct value")
+}
+
+// TestNumberInt64 asserts Int64() returns a valid truncated int64
+func TestNumberInt64(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, int64(42), Number(42.00000064).Int64(), "Int64() should return the correct truncated value")
+	assert.Equal(t, int64(43), Number(43.99999964).Int64(), "Int64() should not round the number")
+}
+
+// BenchmarkNumberUnmarshalJSON provides a barebones benchmark of Unmarshaling a string value
+// Ballpark: 42.78 ns/op        16 B/op          1 allocs/op
+func BenchmarkNumberUnmarshalJSON(b *testing.B) {
+	var n Number
+	for i := 0; i < b.N; i++ {
+		_ = n.UnmarshalJSON([]byte(`"0.04200074"`))
+	}
+}
+
+// BenchmarkNumberMarshalJSON provides a barebones benchmark of Marshaling a string value
+// Ballpark: 118.2 ns/op            56 B/op          3 allocs/op
+func BenchmarkNumberMarshalJSON(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = Number(1337.1337).MarshalJSON()
+	}
+}


### PR DESCRIPTION
This change mostly just renames the type.

convert package and StringToFloat64 represent actions, not types,
and make it misleading to use outside of the API context,
especially when using it for a Float64ToString operation.

This is intended as a first step towards unified type helpers appropriate across GCT in general, not just in exchange APIs.

## Type of change

- [x] Non-Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
