### PR TITLE
Exchanges: Remove bespoke pair upgrade handling and abstract Start/Run

### DIFF
--- a/cmd/config_builder/builder.go
+++ b/cmd/config_builder/builder.go
@@ -20,13 +20,14 @@ func main() {
 
 	log.Printf("Loading exchanges..")
 	var wg sync.WaitGroup
-	for x := range exchange.Exchanges {
-		name := exchange.Exchanges[x]
-		err = engine.Bot.LoadExchange(name, &wg)
-		if err != nil {
-			log.Printf("Failed to load exchange %s. Err: %s", name, err)
-			continue
-		}
+	for i := range exchange.Exchanges {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			if err = engine.Bot.LoadExchange(name); err != nil {
+				log.Printf("Failed to load exchange %s. Err: %s", name, err)
+			}
+		}(exchange.Exchanges[i])
 	}
 	wg.Wait()
 	log.Println("Done.")

--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -3,8 +3,6 @@ package {{.Name}}
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -180,42 +178,6 @@ func ({{.Variable}} *{{.CapitalName}}) Setup(exch *config.Exchange) error {
 	}
 	*/
 	return nil
-}
-
-// Start starts the {{.CapitalName}} go routine
-func ({{.Variable}} *{{.CapitalName}}) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		{{.Variable}}.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the {{.CapitalName}} wrapper
-func ({{.Variable}} *{{.CapitalName}}) Run(ctx context.Context) {
-	if {{.Variable}}.Verbose {
-	{{ if .WS }} log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s.",
-			{{.Variable}}.Name,
-			common.IsEnabled({{.Variable}}.Websocket.IsEnabled())) {{ end }}
-		{{.Variable}}.PrintEnabledPairs()
-	}
-
-	if !{{.Variable}}.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := {{.Variable}}.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			{{.Variable}}.Name,
-			err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/cmd/exchange_wrapper_coverage/main.go
+++ b/cmd/exchange_wrapper_coverage/main.go
@@ -32,18 +32,19 @@ func main() {
 
 	log.Printf("Loading exchanges..")
 	var wg sync.WaitGroup
-	for x := range exchange.Exchanges {
-		if exchange.Exchanges[x] == "ftx" {
+	for i := range exchange.Exchanges {
+		name := exchange.Exchanges[i]
+		if name == "ftx" {
 			log.Println("Skipping exchange FTX...")
 			continue
 		}
-		err = engine.Bot.LoadExchange(exchange.Exchanges[x], &wg)
-		if err != nil {
-			log.Printf("Failed to load exchange %s. Err: %s",
-				exchange.Exchanges[x],
-				err)
-			continue
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := engine.Bot.LoadExchange(name); err != nil {
+				log.Printf("Failed to load exchange %s. Err: %s", name, err)
+			}
+		}()
 	}
 	wg.Wait()
 	log.Println("Done.")

--- a/cmd/exchange_wrapper_issues/main.go
+++ b/cmd/exchange_wrapper_issues/main.go
@@ -68,17 +68,19 @@ func main() {
 	log.Println("Loading exchanges..")
 
 	var wg sync.WaitGroup
-	for x := range exchange.Exchanges {
-		name := exchange.Exchanges[x]
+	for i := range exchange.Exchanges {
+		name := exchange.Exchanges[i]
 		if _, ok := wrapperConfig.Exchanges[name]; !ok {
 			wrapperConfig.Exchanges[strings.ToLower(name)] = &config.APICredentialsConfig{}
 		}
 		if shouldLoadExchange(name) {
-			err = bot.LoadExchange(name, &wg)
-			if err != nil {
-				log.Printf("Failed to load exchange %s. Err: %s", name, err)
-				continue
-			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err = bot.LoadExchange(name); err != nil {
+					log.Printf("Failed to load exchange %s. Err: %s", name, err)
+				}
+			}()
 		}
 	}
 	wg.Wait()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -846,9 +846,7 @@ func (bot *Engine) LoadExchange(name string) error {
 		}
 	}
 
-	exchange.Bootstrap(context.TODO(), exch)
-
-	return nil
+	return exchange.Bootstrap(context.TODO(), exch)
 }
 
 func (bot *Engine) dryRunParamInteraction(param string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -850,7 +850,7 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 		wg = &sync.WaitGroup{}
 		defer wg.Wait()
 	}
-	return exch.Start(context.TODO(), wg)
+	return exchange.Start(context.TODO(), exch, wg)
 }
 
 func (bot *Engine) dryRunParamInteraction(param string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -722,7 +722,7 @@ func (bot *Engine) GetExchanges() []exchange.IBotExchange {
 
 // LoadExchange loads an exchange by name. Optional wait group can be added for
 // external synchronization.
-func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
+func (bot *Engine) LoadExchange(name string) error {
 	exch, err := bot.ExchangeManager.NewExchangeByName(name)
 	if err != nil {
 		return err
@@ -846,11 +846,9 @@ func (bot *Engine) LoadExchange(name string, wg *sync.WaitGroup) error {
 		}
 	}
 
-	if wg == nil {
-		wg = &sync.WaitGroup{}
-		defer wg.Wait()
-	}
-	return exchange.Start(context.TODO(), exch, wg)
+	exchange.Bootstrap(context.TODO(), exch)
+
+	return nil
 }
 
 func (bot *Engine) dryRunParamInteraction(param string) {
@@ -869,7 +867,6 @@ func (bot *Engine) dryRunParamInteraction(param string) {
 
 // SetupExchanges sets up the exchanges used by the Bot
 func (bot *Engine) SetupExchanges() error {
-	var wg sync.WaitGroup
 	configs := bot.Config.GetAllExchangeConfigs()
 	if bot.Settings.EnableAllPairs {
 		bot.dryRunParamInteraction("enableallpairs")
@@ -902,6 +899,7 @@ func (bot *Engine) SetupExchanges() error {
 		bot.dryRunParamInteraction("exchangehttpdebugging")
 	}
 
+	var wg sync.WaitGroup
 	for x := range configs {
 		if !configs[x].Enabled && !bot.Settings.EnableAllExchanges {
 			gctlog.Debugf(gctlog.ExchangeSys, "%s: Exchange support: Disabled\n", configs[x].Name)
@@ -910,17 +908,16 @@ func (bot *Engine) SetupExchanges() error {
 		wg.Add(1)
 		go func(c config.Exchange) {
 			defer wg.Done()
-			err := bot.LoadExchange(c.Name, &wg)
-			if err != nil {
+			if err := bot.LoadExchange(c.Name); err != nil {
 				gctlog.Errorf(gctlog.ExchangeSys, "LoadExchange %s failed: %s\n", c.Name, err)
-				return
+			} else {
+				gctlog.Debugf(gctlog.ExchangeSys,
+					"%s: Exchange support: Enabled (Authenticated API support: %s - Verbose mode: %s).\n",
+					c.Name,
+					common.IsEnabled(c.API.AuthenticatedSupport),
+					common.IsEnabled(c.Verbose),
+				)
 			}
-			gctlog.Debugf(gctlog.ExchangeSys,
-				"%s: Exchange support: Enabled (Authenticated API support: %s - Verbose mode: %s).\n",
-				c.Name,
-				common.IsEnabled(c.API.AuthenticatedSupport),
-				common.IsEnabled(c.Verbose),
-			)
 		}(configs[x])
 	}
 	wg.Wait()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -242,9 +243,9 @@ func TestDryRunParamInteraction(t *testing.T) {
 			},
 		},
 	}
-	if err := bot.LoadExchange(testExchange, nil); err != nil {
-		t.Error(err)
-	}
+	err := bot.LoadExchange(testExchange)
+	assert.NoError(t, err, "LoadExchange should not error")
+
 	exchCfg, err := bot.Config.GetExchangeConfig(testExchange)
 	if err != nil {
 		t.Error(err)
@@ -262,9 +263,9 @@ func TestDryRunParamInteraction(t *testing.T) {
 	bot.Settings.EnableDryRun = true
 	bot.Settings.CheckParamInteraction = true
 	bot.Settings.EnableExchangeVerbose = true
-	if err = bot.LoadExchange(testExchange, nil); err != nil {
-		t.Error(err)
-	}
+
+	err = bot.LoadExchange(testExchange)
+	assert.NoError(t, err, "LoadExchange should not error")
 
 	exchCfg, err = bot.Config.GetExchangeConfig(testExchange)
 	if err != nil {

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -40,8 +40,8 @@ import (
 
 var testExchange = "Bitstamp"
 
-func CreateTestBot(t *testing.T) *Engine {
-	t.Helper()
+func CreateTestBot(tb testing.TB) *Engine {
+	tb.Helper()
 	cFormat := &currency.PairFormat{Uppercase: true}
 	cp1 := currency.NewPair(currency.BTC, currency.USD)
 	cp2 := currency.NewPair(currency.BTC, currency.USDT)
@@ -92,9 +92,9 @@ func CreateTestBot(t *testing.T) *Engine {
 				},
 			},
 		}}}
-	if err := bot.LoadExchange(testExchange, nil); err != nil {
-		t.Fatalf("SetupTest: Failed to load exchange: %s", err)
-	}
+	err := bot.LoadExchange(testExchange)
+	assert.NoError(tb, err, "LoadExchange should not error")
+
 	return bot
 }
 

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -310,7 +310,7 @@ func (s *RPCServer) DisableExchange(_ context.Context, r *gctrpc.GenericExchange
 
 // EnableExchange enables an exchange
 func (s *RPCServer) EnableExchange(_ context.Context, r *gctrpc.GenericExchangeNameRequest) (*gctrpc.GenericResponse, error) {
-	err := s.LoadExchange(r.Exchange, nil)
+	err := s.LoadExchange(r.Exchange)
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -32,9 +31,9 @@ func (a *Alphapoint) GetDefaultConfig(_ context.Context) (*config.Exchange, erro
 	return nil, common.ErrFunctionNotSupported
 }
 
-// Start starts the Aplhapoint go routine
-func (a *Alphapoint) Start(_ context.Context, _ *sync.WaitGroup) error {
-	return common.ErrNotYetImplemented
+// Bootstrap loads the exchange and performs initialisation tasks
+func (a *Alphapoint) Bootstrap(_ context.Context) (continueBootstrap bool, err error) {
+	return false, common.ErrNotYetImplemented
 }
 
 // SetDefaults sets current default settings

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -67,21 +67,6 @@ func getTime() (start, end time.Time) {
 	return tn.Add(-offset), tn
 }
 
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testWg.Wait()
-}
-
 func TestUServerTime(t *testing.T) {
 	t.Parallel()
 	_, err := b.UServerTime(context.Background())

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -304,81 +304,21 @@ func (b *Binance) Start(ctx context.Context, wg *sync.WaitGroup) error {
 // Run implements the Binance wrapper
 func (b *Binance) Run(ctx context.Context) {
 	if b.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s. (url: %s).\n",
-			b.Name,
-			common.IsEnabled(b.Websocket.IsEnabled()),
-			b.Websocket.GetWebsocketURL())
+		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", b.Name, common.IsEnabled(b.Websocket.IsEnabled()), b.Websocket.GetWebsocketURL())
 		b.PrintEnabledPairs()
 	}
 
-	forceUpdate := false
 	a := b.GetAssetTypes(true)
 	for x := range a {
 		if err := b.UpdateOrderExecutionLimits(ctx, a[x]); err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s failed to set exchange order execution limits. Err: %v",
-				b.Name,
-				err)
-		}
-		if a[x] == asset.USDTMarginedFutures && !b.BypassConfigFormatUpgrades {
-			format, err := b.GetPairFormat(asset.USDTMarginedFutures, false)
-			if err != nil {
-				log.Errorf(log.ExchangeSys, "%s failed to get enabled currencies. Err %s\n",
-					b.Name,
-					err)
-				return
-			}
-			var enabled, avail currency.Pairs
-			enabled, err = b.CurrencyPairs.GetPairs(asset.USDTMarginedFutures, true)
-			if err != nil {
-				log.Errorf(log.ExchangeSys, "%s failed to get enabled currencies. Err %s\n",
-					b.Name,
-					err)
-				return
-			}
-
-			avail, err = b.CurrencyPairs.GetPairs(asset.USDTMarginedFutures, false)
-			if err != nil {
-				log.Errorf(log.ExchangeSys, "%s failed to get available currencies. Err %s\n",
-					b.Name,
-					err)
-				return
-			}
-			if !common.StringDataContains(enabled.Strings(), format.Delimiter) ||
-				!common.StringDataContains(avail.Strings(), format.Delimiter) {
-				var enabledPairs currency.Pairs
-				enabledPairs, err = currency.NewPairsFromStrings([]string{
-					currency.BTC.String() + format.Delimiter + currency.USDT.String(),
-				})
-				if err != nil {
-					log.Errorf(log.ExchangeSys, "%s failed to update currencies. Err %s\n",
-						b.Name,
-						err)
-				} else {
-					log.Warnf(log.ExchangeSys, exchange.ResetConfigPairsWarningMessage, b.Name, a[x], enabledPairs)
-					forceUpdate = true
-					err = b.UpdatePairs(enabledPairs, a[x], true, true)
-					if err != nil {
-						log.Errorf(log.ExchangeSys,
-							"%s failed to update currencies. Err: %s\n",
-							b.Name,
-							err)
-					}
-				}
-			}
+			log.Errorf(log.ExchangeSys, "%s failed to set exchange order execution limits. Err: %v", b.Name, err)
 		}
 	}
 
-	if !b.GetEnabledFeatures().AutoPairUpdates && !forceUpdate {
-		return
-	}
-
-	if err := b.UpdateTradablePairs(ctx, forceUpdate); err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			b.Name,
-			err)
+	if b.GetEnabledFeatures().AutoPairUpdates {
+		if err := b.UpdateTradablePairs(ctx, false); err != nil {
+			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
+		}
 	}
 }
 

--- a/exchanges/binanceus/binanceus_test.go
+++ b/exchanges/binanceus/binanceus_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -61,15 +60,6 @@ func TestMain(m *testing.M) {
 		log.Fatal("Binanceus TestMain()", err)
 	}
 	bi.setupOrderbookManager()
-	err = bi.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		log.Fatalf("%s received: '%v' but expected: '%v'", bi.Name, err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = bi.Start(context.Background(), &testWg)
-	if err != nil {
-		log.Fatal("Binanceus Starting error ", err)
-	}
 	os.Exit(m.Run())
 }
 

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -213,42 +212,6 @@ func (bi *Binanceus) Setup(exch *config.Exchange) error {
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 		RateLimit:            wsRateLimitMilliseconds,
 	})
-}
-
-// Start starts the Binanceus go routine
-func (bi *Binanceus) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		bi.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Binanceus wrapper
-func (bi *Binanceus) Run(ctx context.Context) {
-	if bi.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s.",
-			bi.Name,
-			common.IsEnabled(bi.Websocket.IsEnabled()))
-		bi.PrintEnabledPairs()
-	}
-
-	if !bi.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := bi.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			bi.Name,
-			err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -72,20 +72,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
-}
-
 func TestGetV2MarginFunding(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -257,52 +256,6 @@ func (b *Bitfinex) Setup(exch *config.Exchange) error {
 		URL:                  authenticatedBitfinexWebsocketEndpoint,
 		Authenticated:        true,
 	})
-}
-
-// Start starts the Bitfinex go routine
-func (b *Bitfinex) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bitfinex wrapper
-func (b *Bitfinex) Run(ctx context.Context) {
-	if b.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s.",
-			b.Name,
-			common.IsEnabled(b.Websocket.IsEnabled()))
-		b.PrintEnabledPairs()
-	}
-
-	if b.GetEnabledFeatures().AutoPairUpdates {
-		if err := b.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s failed to update tradable pairs. Err: %s",
-				b.Name,
-				err)
-		}
-	}
-	for _, a := range b.GetAssetTypes(true) {
-		if err := b.UpdateOrderExecutionLimits(ctx, a); err != nil && err != common.ErrNotYetImplemented {
-			log.Errorln(log.ExchangeSys, err.Error())
-		}
-	}
-
-	err := b.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			b.Name,
-			err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -2,10 +2,8 @@ package bitflyer
 
 import (
 	"context"
-	"errors"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -50,20 +48,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetLatestBlockCA(t *testing.T) {

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -122,35 +121,6 @@ func (b *Bitflyer) Setup(exch *config.Exchange) error {
 		return nil
 	}
 	return b.SetupDefaults(exch)
-}
-
-// Start starts the Bitflyer go routine
-func (b *Bitflyer) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bitflyer wrapper
-func (b *Bitflyer) Run(ctx context.Context) {
-	if b.Verbose {
-		b.PrintEnabledPairs()
-	}
-
-	if !b.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := b.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -58,20 +57,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetTradablePairs(t *testing.T) {

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -198,43 +197,6 @@ func (b *Bithumb) Setup(exch *config.Exchange) error {
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 		RateLimit:            wsRateLimitMillisecond,
 	})
-}
-
-// Start starts the Bithumb go routine
-func (b *Bithumb) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bithumb wrapper
-func (b *Bithumb) Run(ctx context.Context) {
-	if b.Verbose {
-		b.PrintEnabledPairs()
-	}
-
-	err := b.UpdateOrderExecutionLimits(ctx, asset.Empty)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to set exchange order execution limits. Err: %v",
-			b.Name,
-			err)
-	}
-
-	if !b.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err = b.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -59,20 +58,6 @@ func TestMain(m *testing.M) {
 		log.Fatal("Bitmex setup error", err)
 	}
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetFullFundingHistory(t *testing.T) {

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -223,44 +222,6 @@ func (b *Bitmex) Setup(exch *config.Exchange) error {
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 		URL:                  bitmexWSURL,
 	})
-}
-
-// Start starts the Bitmex go routine
-func (b *Bitmex) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bitmex wrapper
-func (b *Bitmex) Run(ctx context.Context) {
-	if b.Verbose {
-		wsEndpoint, err := b.API.Endpoints.GetURL(exchange.WebsocketSpot)
-		if err != nil {
-			log.Errorln(log.ExchangeSys, err)
-		}
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s. (url: %s).\n",
-			b.Name,
-			common.IsEnabled(b.Websocket.IsEnabled()),
-			wsEndpoint)
-		b.PrintEnabledPairs()
-	}
-
-	if !b.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := b.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -3,7 +3,6 @@ package bitstamp
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
@@ -38,20 +37,6 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		Pair:          currency.NewPair(currency.LTC, currency.BTC),
 		PurchasePrice: 1800,
 	}
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 // TestGetFeeByTypeOfflineTradeFee logic test

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -192,39 +191,6 @@ func (b *Bitstamp) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the Bitstamp go routine
-func (b *Bitstamp) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bitstamp wrapper
-func (b *Bitstamp) Run(ctx context.Context) {
-	if b.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s.", b.Name, common.IsEnabled(b.Websocket.IsEnabled()))
-		b.PrintEnabledPairs()
-	}
-
-	if b.GetEnabledFeatures().AutoPairUpdates {
-		if err := b.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
-		}
-	}
-
-	for _, a := range b.GetAssetTypes(true) {
-		if err := b.UpdateOrderExecutionLimits(ctx, a); err != nil && err != common.ErrNotYetImplemented {
-			log.Errorln(log.ExchangeSys, err.Error())
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -210,71 +210,13 @@ func (b *Bitstamp) Start(ctx context.Context, wg *sync.WaitGroup) error {
 // Run implements the Bitstamp wrapper
 func (b *Bitstamp) Run(ctx context.Context) {
 	if b.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s.",
-			b.Name,
-			common.IsEnabled(b.Websocket.IsEnabled()))
+		log.Debugf(log.ExchangeSys, "%s Websocket: %s.", b.Name, common.IsEnabled(b.Websocket.IsEnabled()))
 		b.PrintEnabledPairs()
 	}
 
-	forceUpdate := false
-	if !b.BypassConfigFormatUpgrades {
-		format, err := b.GetPairFormat(asset.Spot, false)
-		if err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to get pair format. Err %s\n",
-				b.Name,
-				err)
-			return
-		}
-
-		enabled, err := b.CurrencyPairs.GetPairs(asset.Spot, true)
-		if err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to get enabled currencies. Err %s\n",
-				b.Name,
-				err)
-			return
-		}
-
-		avail, err := b.CurrencyPairs.GetPairs(asset.Spot, false)
-		if err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to get available currencies. Err %s\n",
-				b.Name,
-				err)
-			return
-		}
-
-		if !common.StringDataContains(enabled.Strings(), format.Delimiter) ||
-			!common.StringDataContains(avail.Strings(), format.Delimiter) {
-			var enabledPairs currency.Pairs
-			enabledPairs, err = currency.NewPairsFromStrings([]string{
-				currency.BTC.String() + format.Delimiter + currency.USD.String(),
-			})
-			if err != nil {
-				log.Errorf(log.ExchangeSys, "%s failed to update currencies. Err %s\n",
-					b.Name,
-					err)
-			} else {
-				log.Warnf(log.ExchangeSys,
-					exchange.ResetConfigPairsWarningMessage, b.Name, asset.Spot, enabledPairs)
-				forceUpdate = true
-
-				err = b.UpdatePairs(enabledPairs, asset.Spot, true, true)
-				if err != nil {
-					log.Errorf(log.ExchangeSys,
-						"%s failed to update currencies. Err: %s\n",
-						b.Name,
-						err)
-				}
-			}
-		}
-	}
-
-	if b.GetEnabledFeatures().AutoPairUpdates || forceUpdate {
-		if err := b.UpdateTradablePairs(ctx, forceUpdate); err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s failed to update tradable pairs. Err: %s",
-				b.Name,
-				err)
+	if b.GetEnabledFeatures().AutoPairUpdates {
+		if err := b.UpdateTradablePairs(ctx, false); err != nil {
+			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
 		}
 	}
 

--- a/exchanges/blackbox_test.go
+++ b/exchanges/blackbox_test.go
@@ -2,9 +2,7 @@ package exchange_test
 
 import (
 	"context"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -21,20 +19,13 @@ func (m *mockEx) UpdateTradablePairs(_ context.Context, _ bool) error {
 	return nil
 }
 
-func TestStart(t *testing.T) {
+func TestBootstrap(t *testing.T) {
 	m := &mockEx{
 		shared.CustomEx{},
 		make(chan int, 1),
 	}
 	m.Features.Enabled.AutoPairUpdates = true
-	wg := sync.WaitGroup{}
-	err := exchange.Start(context.TODO(), m, &wg)
-	assert.NoError(t, err, "Start should not error")
-	done := make(chan bool, 1)
-	go func() {
-		wg.Wait()
-		done <- true
-	}()
-	assert.Eventually(t, func() bool { return len(done) == 1 }, time.Second, 100*time.Millisecond, "Start should resolve the waitgroup eventually")
+	err := exchange.Bootstrap(context.TODO(), m)
+	assert.NoError(t, err, "Bootstrap should not error")
 	assert.Equal(t, 42, <-m.flow, "UpdateTradablePairs should be called on the exchange")
 }

--- a/exchanges/blackbox_test.go
+++ b/exchanges/blackbox_test.go
@@ -1,0 +1,40 @@
+package exchange_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
+	shared "github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
+)
+
+type mockEx struct {
+	shared.CustomEx
+	flow chan int
+}
+
+func (m *mockEx) UpdateTradablePairs(_ context.Context, _ bool) error {
+	m.flow <- 42
+	return nil
+}
+
+func TestStart(t *testing.T) {
+	m := &mockEx{
+		shared.CustomEx{},
+		make(chan int, 1),
+	}
+	m.Features.Enabled.AutoPairUpdates = true
+	wg := sync.WaitGroup{}
+	err := exchange.Start(context.TODO(), m, &wg)
+	assert.NoError(t, err, "Start should not error")
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+	assert.Eventually(t, func() bool { return len(done) == 1 }, time.Second, 100*time.Millisecond, "Start should resolve the waitgroup eventually")
+	assert.Equal(t, 42, <-m.flow, "UpdateTradablePairs should be called on the exchange")
+}

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -60,20 +59,6 @@ func TestMain(m *testing.M) {
 		b.API.AuthenticatedWebsocketSupport = false
 	}
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetMarkets(t *testing.T) {

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -200,33 +199,6 @@ func (b *BTCMarkets) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the BTC Markets go routine
-func (b *BTCMarkets) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the BTC Markets wrapper
-func (b *BTCMarkets) Run(ctx context.Context) {
-	if b.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s (url: %s).\n", b.Name, common.IsEnabled(b.Websocket.IsEnabled()), btcMarketsWSURL)
-		b.PrintEnabledPairs()
-	}
-
-	if b.GetEnabledFeatures().AutoPairUpdates {
-		if err := b.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", b.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -73,22 +73,6 @@ func TestUpdateTradablePairs(t *testing.T) {
 	}
 }
 
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	assert.ErrorIs(t, err, common.ErrNilPointer, "Start with no WG should error correctly")
-
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	assert.NoError(t, err, "Start should not error")
-	done := make(chan struct{}, 1)
-	go func() {
-		testWg.Wait()
-		done <- struct{}{}
-	}()
-	assert.Eventually(t, func() bool { return len(done) > 0 }, 10*time.Second, 100*time.Millisecond, "Start should complete")
-}
-
 func TestFetchFundingHistory(t *testing.T) {
 	_, err := b.FetchFundingHistory(context.Background(), "")
 	assert.NoError(t, err, "FetchFundingHistory should not error")

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -226,36 +225,6 @@ func (b *BTSE) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the BTSE go routine
-func (b *BTSE) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		b.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the BTSE wrapper
-func (b *BTSE) Run(ctx context.Context) {
-	if b.Verbose {
-		b.PrintEnabledPairs()
-	}
-
-	if !b.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := b.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s Failed to update tradable pairs. Error: %s", b.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/key"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -40,20 +38,6 @@ var (
 
 	spotTradablePair, usdcMarginedTradablePair, usdtMarginedTradablePair, inverseTradablePair, optionsTradablePair currency.Pair
 )
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := b.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = b.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
-}
 
 func TestGetInstrumentInfo(t *testing.T) {
 	t.Parallel()

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -284,42 +283,6 @@ func (by *Bybit) Setup(exch *config.Exchange) error {
 // AuthenticateWebsocket sends an authentication message to the websocket
 func (by *Bybit) AuthenticateWebsocket(ctx context.Context) error {
 	return by.WsAuth(ctx)
-}
-
-// Start starts the Bybit go routine
-func (by *Bybit) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		by.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Bybit wrapper
-func (by *Bybit) Run(ctx context.Context) {
-	if by.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s.",
-			by.Name,
-			common.IsEnabled(by.Websocket.IsEnabled()))
-		by.PrintEnabledPairs()
-	}
-
-	if !by.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := by.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			by.Name,
-			err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -62,20 +61,6 @@ func TestMain(m *testing.M) {
 		log.Fatal("CoinbasePro setup error", err)
 	}
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := c.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = c.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetProducts(t *testing.T) {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -194,33 +193,6 @@ func (c *CoinbasePro) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the coinbasepro go routine
-func (c *CoinbasePro) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		c.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the coinbasepro wrapper
-func (c *CoinbasePro) Run(ctx context.Context) {
-	if c.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", c.Name, common.IsEnabled(c.Websocket.IsEnabled()), coinbaseproWebsocketURL)
-		c.PrintEnabledPairs()
-	}
-
-	if c.GetEnabledFeatures().AutoPairUpdates {
-		if err := c.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", c.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -2,11 +2,9 @@ package coinut
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -89,20 +87,6 @@ func setupWSTestAuth(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := c.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = c.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetInstruments(t *testing.T) {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -177,33 +176,6 @@ func (c *COINUT) Setup(exch *config.Exchange) error {
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 		RateLimit:            wsRateLimitInMilliseconds,
 	})
-}
-
-// Start starts the COINUT go routine
-func (c *COINUT) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		c.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the COINUT wrapper
-func (c *COINUT) Run(ctx context.Context) {
-	if c.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", c.Name, common.IsEnabled(c.Websocket.IsEnabled()), coinutWebsocketURL)
-		c.PrintEnabledPairs()
-	}
-
-	if c.GetEnabledFeatures().AutoPairUpdates {
-		if err := c.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", c.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -46,8 +46,6 @@ const (
 	DefaultWebsocketResponseMaxLimit = time.Second * 7
 	// DefaultWebsocketOrderbookBufferLimit is the maximum number of orderbook updates that get stored before being applied
 	DefaultWebsocketOrderbookBufferLimit = 5
-	// ResetConfigPairsWarningMessage is displayed when a currency pair format in the config needs to be updated
-	ResetConfigPairsWarningMessage = "%s Enabled and available pairs for %s reset due to config upgrade, please enable the ones you would like to use again. Defaulting to %v"
 )
 
 var (

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -2,10 +2,8 @@ package exmo
 
 import (
 	"context"
-	"errors"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -49,20 +47,6 @@ func TestMain(m *testing.M) {
 	e.API.AuthenticatedSupport = true
 	e.SetCredentials(APIKey, APISecret, "", "", "", "")
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := e.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = e.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetTrades(t *testing.T) {

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -137,35 +136,6 @@ func (e *EXMO) Setup(exch *config.Exchange) error {
 		return nil
 	}
 	return e.SetupDefaults(exch)
-}
-
-// Start starts the EXMO go routine
-func (e *EXMO) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		e.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the EXMO wrapper
-func (e *EXMO) Run(ctx context.Context) {
-	if e.Verbose {
-		e.PrintEnabledPairs()
-	}
-
-	if !e.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := e.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", e.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -58,7 +58,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal("GateIO setup error", err)
 	}
-	g.Run(context.Background())
 	getFirstTradablePairOfAssets()
 	os.Exit(m.Run())
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,7 +35,6 @@ const (
 )
 
 var g = &Gateio{}
-var spotTradablePair, marginTradablePair, crossMarginTradablePair, futuresTradablePair, optionsTradablePair, deliveryFuturesTradablePair currency.Pair
 
 func TestMain(m *testing.M) {
 	g.SetDefaults()
@@ -58,8 +58,12 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal("GateIO setup error", err)
 	}
-	getFirstTradablePairOfAssets()
 	os.Exit(m.Run())
+}
+
+func TestUpdateTradablePairs(t *testing.T) {
+	t.Parallel()
+	updatePairsOnce(t)
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {
@@ -73,7 +77,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
-		Pair:          optionsTradablePair,
+		Pair:          getPair(t, asset.Options),
 		AssetType:     asset.Options,
 	}
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
@@ -81,7 +85,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		t.Error(err)
 	}
 	orderCancellation.AssetType = asset.Spot
-	orderCancellation.Pair = spotTradablePair
+	orderCancellation.Pair = getPair(t, asset.Spot)
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
 	if err != nil {
 		t.Error(err)
@@ -92,7 +96,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
-	orderCancellation.Pair = marginTradablePair
+	orderCancellation.Pair = getPair(t, asset.Margin)
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
 	if err != nil {
 		t.Error(err)
@@ -103,7 +107,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
-	orderCancellation.Pair = crossMarginTradablePair
+	orderCancellation.Pair = getPair(t, asset.CrossMargin)
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
 	if err != nil {
 		t.Error(err)
@@ -114,7 +118,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
-	orderCancellation.Pair = futuresTradablePair
+	orderCancellation.Pair = getPair(t, asset.Futures)
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
 	if err != nil {
 		t.Error(err)
@@ -125,7 +129,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
-	orderCancellation.Pair = deliveryFuturesTradablePair
+	orderCancellation.Pair = getPair(t, asset.DeliveryFutures)
 	_, err = g.CancelAllOrders(context.Background(), orderCancellation)
 	if err != nil {
 		t.Error(err)
@@ -183,27 +187,27 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
 	_, err := g.GetOrderInfo(context.Background(),
-		"917591554", spotTradablePair, asset.Spot)
+		"917591554", getPair(t, asset.Spot), asset.Spot)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
-	_, err = g.GetOrderInfo(context.Background(), "917591554", optionsTradablePair, asset.Options)
+	_, err = g.GetOrderInfo(context.Background(), "917591554", getPair(t, asset.Options), asset.Options)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
-	_, err = g.GetOrderInfo(context.Background(), "917591554", marginTradablePair, asset.Margin)
+	_, err = g.GetOrderInfo(context.Background(), "917591554", getPair(t, asset.Margin), asset.Margin)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
-	_, err = g.GetOrderInfo(context.Background(), "917591554", crossMarginTradablePair, asset.CrossMargin)
+	_, err = g.GetOrderInfo(context.Background(), "917591554", getPair(t, asset.CrossMargin), asset.CrossMargin)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
-	_, err = g.GetOrderInfo(context.Background(), "917591554", futuresTradablePair, asset.Futures)
+	_, err = g.GetOrderInfo(context.Background(), "917591554", getPair(t, asset.Futures), asset.Futures)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
-	_, err = g.GetOrderInfo(context.Background(), "917591554", deliveryFuturesTradablePair, asset.DeliveryFutures)
+	_, err = g.GetOrderInfo(context.Background(), "917591554", getPair(t, asset.DeliveryFutures), asset.DeliveryFutures)
 	if err != nil {
 		t.Errorf("GetOrderInfo() %v", err)
 	}
@@ -211,29 +215,9 @@ func TestGetOrderInfo(t *testing.T) {
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	_, err := g.UpdateTicker(context.Background(), optionsTradablePair, asset.Options)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = g.UpdateTicker(context.Background(), spotTradablePair, asset.Spot)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = g.UpdateTicker(context.Background(), marginTradablePair, asset.Margin)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = g.UpdateTicker(context.Background(), crossMarginTradablePair, asset.CrossMargin)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = g.UpdateTicker(context.Background(), futuresTradablePair, asset.Futures)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = g.UpdateTicker(context.Background(), deliveryFuturesTradablePair, asset.DeliveryFutures)
-	if err != nil {
-		t.Error(err)
+	for _, a := range g.GetAssetTypes(false) {
+		_, err := g.UpdateTicker(context.Background(), getPair(t, a), a)
+		assert.NoError(t, err, "UpdateTicker should not error for %s", a)
 	}
 }
 
@@ -281,39 +265,39 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetOrderbook(context.Background(), spotTradablePair.String(), "0.1", 10, false)
+	_, err := g.GetOrderbook(context.Background(), getPair(t, asset.Spot).String(), "0.1", 10, false)
 	if err != nil {
 		t.Errorf("%s GetOrderbook() error %v", g.Name, err)
 	}
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err = g.GetFuturesOrderbook(context.Background(), settle, futuresTradablePair.String(), "", 10, false); err != nil {
-		t.Errorf("%s GetOrderbook() error %v", g.Name, err)
-	}
-	settle, err = g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.GetDeliveryOrderbook(context.Background(), settle, "0.1", deliveryFuturesTradablePair, 10, false); err != nil {
+	if _, err = g.GetFuturesOrderbook(context.Background(), settle, getPair(t, asset.Futures).String(), "", 10, false); err != nil {
 		t.Errorf("%s GetOrderbook() error %v", g.Name, err)
 	}
-	if _, err = g.GetOptionsOrderbook(context.Background(), optionsTradablePair, "0.1", 10, false); err != nil {
+	settle, err = g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = g.GetDeliveryOrderbook(context.Background(), settle, "0.1", getPair(t, asset.DeliveryFutures), 10, false); err != nil {
+		t.Errorf("%s GetOrderbook() error %v", g.Name, err)
+	}
+	if _, err = g.GetOptionsOrderbook(context.Background(), getPair(t, asset.Options), "0.1", 10, false); err != nil {
 		t.Errorf("%s GetOrderbook() error %v", g.Name, err)
 	}
 }
 
 func TestGetMarketTrades(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetMarketTrades(context.Background(), spotTradablePair, 0, "", true, time.Time{}, time.Time{}, 1); err != nil {
+	if _, err := g.GetMarketTrades(context.Background(), getPair(t, asset.Spot), 0, "", true, time.Time{}, time.Time{}, 1); err != nil {
 		t.Errorf("%s GetMarketTrades() error %v", g.Name, err)
 	}
 }
 
 func TestGetCandlesticks(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetCandlesticks(context.Background(), spotTradablePair, 0, time.Time{}, time.Time{}, kline.OneDay); err != nil {
+	if _, err := g.GetCandlesticks(context.Background(), getPair(t, asset.Spot), 0, time.Time{}, time.Time{}, kline.OneDay); err != nil {
 		t.Errorf("%s GetCandlesticks() error %v", g.Name, err)
 	}
 }
@@ -338,7 +322,7 @@ func TestCreateBatchOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	if _, err := g.CreateBatchOrders(context.Background(), []CreateOrderRequestData{
 		{
-			CurrencyPair: spotTradablePair,
+			CurrencyPair: getPair(t, asset.Spot),
 			Side:         "sell",
 			Amount:       0.001,
 			Price:        12349,
@@ -372,7 +356,7 @@ func TestSpotClosePositionWhenCrossCurrencyDisabled(t *testing.T) {
 	if _, err := g.SpotClosePositionWhenCrossCurrencyDisabled(context.Background(), &ClosePositionRequestParam{
 		Amount:       0.1,
 		Price:        1234567384,
-		CurrencyPair: spotTradablePair,
+		CurrencyPair: getPair(t, asset.Spot),
 	}); err != nil {
 		t.Errorf("%s SpotClosePositionWhenCrossCurrencyDisabled() error %v", g.Name, err)
 	}
@@ -382,7 +366,7 @@ func TestCreateSpotOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	if _, err := g.PlaceSpotOrder(context.Background(), &CreateOrderRequestData{
-		CurrencyPair: spotTradablePair,
+		CurrencyPair: getPair(t, asset.Spot),
 		Side:         "buy",
 		Amount:       1,
 		Price:        900000,
@@ -404,7 +388,7 @@ func TestGetSpotOrders(t *testing.T) {
 func TestCancelAllOpenOrdersSpecifiedCurrencyPair(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	if _, err := g.CancelAllOpenOrdersSpecifiedCurrencyPair(context.Background(), spotTradablePair, order.Sell, asset.Empty); err != nil {
+	if _, err := g.CancelAllOpenOrdersSpecifiedCurrencyPair(context.Background(), getPair(t, asset.Spot), order.Sell, asset.Empty); err != nil {
 		t.Errorf("%s CancelAllOpenOrdersSpecifiedCurrencyPair() error %v", g.Name, err)
 	}
 }
@@ -414,7 +398,7 @@ func TestCancelBatchOrdersWithIDList(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	if _, err := g.CancelBatchOrdersWithIDList(context.Background(), []CancelOrderByIDParam{
 		{
-			CurrencyPair: spotTradablePair,
+			CurrencyPair: getPair(t, asset.Spot),
 			ID:           "1234567",
 		},
 		{
@@ -438,7 +422,7 @@ func TestGetSpotOrder(t *testing.T) {
 }
 func TestAmendSpotOrder(t *testing.T) {
 	t.Parallel()
-	_, err := g.AmendSpotOrder(context.Background(), "", spotTradablePair, false, &PriceAndAmount{
+	_, err := g.AmendSpotOrder(context.Background(), "", getPair(t, asset.Spot), false, &PriceAndAmount{
 		Price: 1000,
 	})
 	if !errors.Is(err, errInvalidOrderID) {
@@ -451,7 +435,7 @@ func TestAmendSpotOrder(t *testing.T) {
 		t.Errorf("expecting %v, but found %v", currency.ErrCurrencyPairEmpty, err)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	_, err = g.AmendSpotOrder(context.Background(), "123", spotTradablePair, false, &PriceAndAmount{
+	_, err = g.AmendSpotOrder(context.Background(), "123", getPair(t, asset.Spot), false, &PriceAndAmount{
 		Price: 1000,
 	})
 	if err != nil {
@@ -462,7 +446,7 @@ func TestCancelSingleSpotOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	if _, err := g.CancelSingleSpotOrder(context.Background(), "1234",
-		spotTradablePair.String(), false); err != nil {
+		getPair(t, asset.Spot).String(), false); err != nil {
 		t.Errorf("%s CancelSingleSpotOrder() error %v", g.Name, err)
 	}
 }
@@ -862,7 +846,7 @@ func TestTransferCurrency(t *testing.T) {
 		From:         g.assetTypeToString(asset.Spot),
 		To:           g.assetTypeToString(asset.Margin),
 		Amount:       1202.000,
-		CurrencyPair: spotTradablePair,
+		CurrencyPair: getPair(t, asset.Spot),
 	}); err != nil {
 		t.Errorf("%s TransferCurrency() error %v", g.Name, err)
 	}
@@ -977,7 +961,7 @@ func TestGetMarginSupportedCurrencyPairs(t *testing.T) {
 
 func TestGetMarginSupportedCurrencyPair(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetSingleMarginSupportedCurrencyPair(context.Background(), marginTradablePair); err != nil {
+	if _, err := g.GetSingleMarginSupportedCurrencyPair(context.Background(), getPair(t, asset.Margin)); err != nil {
 		t.Errorf("%s GetMarginSupportedCurrencyPair() error %v", g.Name, err)
 	}
 }
@@ -1004,76 +988,76 @@ func TestGetAllFutureContracts(t *testing.T) {
 }
 func TestGetSingleContract(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.GetSingleContract(context.Background(), settle, futuresTradablePair.String()); err != nil {
+	if _, err = g.GetSingleContract(context.Background(), settle, getPair(t, asset.Futures).String()); err != nil {
 		t.Errorf("%s GetSingleContract() error %s", g.Name, err)
 	}
 }
 
 func TestGetFuturesOrderbook(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetFuturesOrderbook(context.Background(), settle, futuresTradablePair.String(), "", 0, false); err != nil {
+	if _, err := g.GetFuturesOrderbook(context.Background(), settle, getPair(t, asset.Futures).String(), "", 0, false); err != nil {
 		t.Errorf("%s GetFuturesOrderbook() error %v", g.Name, err)
 	}
 }
 func TestGetFuturesTradingHistory(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetFuturesTradingHistory(context.Background(), settle, futuresTradablePair, 0, 0, "", time.Time{}, time.Time{}); err != nil {
+	if _, err := g.GetFuturesTradingHistory(context.Background(), settle, getPair(t, asset.Futures), 0, 0, "", time.Time{}, time.Time{}); err != nil {
 		t.Errorf("%s GetFuturesTradingHistory() error %v", g.Name, err)
 	}
 }
 
 func TestGetFuturesCandlesticks(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetFuturesCandlesticks(context.Background(), settle, futuresTradablePair.String(), time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
+	if _, err := g.GetFuturesCandlesticks(context.Background(), settle, getPair(t, asset.Futures).String(), time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
 		t.Errorf("%s GetFuturesCandlesticks() error %v", g.Name, err)
 	}
 }
 
 func TestPremiumIndexKLine(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Error(err)
 	}
-	if _, err := g.PremiumIndexKLine(context.Background(), settle, futuresTradablePair, time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
+	if _, err := g.PremiumIndexKLine(context.Background(), settle, getPair(t, asset.Futures), time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
 		t.Errorf("%s PremiumIndexKLine() error %v", g.Name, err)
 	}
 }
 
 func TestGetFutureTickers(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetFuturesTickers(context.Background(), settle, futuresTradablePair); err != nil {
+	if _, err := g.GetFuturesTickers(context.Background(), settle, getPair(t, asset.Futures)); err != nil {
 		t.Errorf("%s GetFuturesTickers() error %v", g.Name, err)
 	}
 }
 
 func TestGetFutureFundingRates(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetFutureFundingRates(context.Background(), settle, futuresTradablePair, 0); err != nil {
+	if _, err := g.GetFutureFundingRates(context.Background(), settle, getPair(t, asset.Futures), 0); err != nil {
 		t.Errorf("%s GetFutureFundingRates() error %v", g.Name, err)
 	}
 }
@@ -1087,11 +1071,11 @@ func TestGetFuturesInsuranceBalanceHistory(t *testing.T) {
 
 func TestGetFutureStats(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetFutureStats(context.Background(), settle, futuresTradablePair, time.Time{}, 0, 0)
+	_, err = g.GetFutureStats(context.Background(), settle, getPair(t, asset.Futures), time.Time{}, 0, 0)
 	if err != nil {
 		t.Errorf("%s GetFutureStats() error %v", g.Name, err)
 	}
@@ -1106,11 +1090,11 @@ func TestGetIndexConstituent(t *testing.T) {
 
 func TestGetLiquidationHistory(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Error(err)
 	}
-	if _, err := g.GetLiquidationHistory(context.Background(), settle, futuresTradablePair, time.Time{}, time.Time{}, 0); err != nil {
+	if _, err := g.GetLiquidationHistory(context.Background(), settle, getPair(t, asset.Futures), time.Time{}, time.Time{}, 0); err != nil {
 		t.Errorf("%s GetLiquidationHistory() error %v", g.Name, err)
 	}
 }
@@ -1149,11 +1133,11 @@ func TestGetSinglePosition(t *testing.T) {
 func TestUpdatePositionMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.UpdateFuturesPositionMargin(context.Background(), settle, 0.01, futuresTradablePair); err != nil {
+	if _, err := g.UpdateFuturesPositionMargin(context.Background(), settle, 0.01, getPair(t, asset.Futures)); err != nil {
 		t.Errorf("%s UpdatePositionMargin() error %v", g.Name, err)
 	}
 }
@@ -1161,11 +1145,11 @@ func TestUpdatePositionMargin(t *testing.T) {
 func TestUpdatePositionLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.UpdateFuturesPositionLeverage(context.Background(), settle, futuresTradablePair, 1, 0); err != nil {
+	if _, err := g.UpdateFuturesPositionLeverage(context.Background(), settle, getPair(t, asset.Futures), 1, 0); err != nil {
 		t.Errorf("%s UpdatePositionLeverage() error %v", g.Name, err)
 	}
 }
@@ -1173,11 +1157,11 @@ func TestUpdatePositionLeverage(t *testing.T) {
 func TestUpdatePositionRiskLimit(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.UpdateFuturesPositionRiskLimit(context.Background(), settle, futuresTradablePair, 10); err != nil {
+	if _, err := g.UpdateFuturesPositionRiskLimit(context.Background(), settle, getPair(t, asset.Futures), 10); err != nil {
 		t.Errorf("%s UpdatePositionRiskLimit() error %v", g.Name, err)
 	}
 }
@@ -1185,12 +1169,12 @@ func TestUpdatePositionRiskLimit(t *testing.T) {
 func TestCreateDeliveryOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := g.PlaceDeliveryOrder(context.Background(), &OrderCreateParams{
-		Contract:    deliveryFuturesTradablePair,
+		Contract:    getPair(t, asset.DeliveryFutures),
 		Size:        6024,
 		Iceberg:     0,
 		Price:       3765,
@@ -1205,11 +1189,11 @@ func TestCreateDeliveryOrder(t *testing.T) {
 func TestGetDeliveryOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.GetDeliveryOrders(context.Background(), deliveryFuturesTradablePair, "open", settle, "", 0, 0, 1); err != nil {
+	if _, err := g.GetDeliveryOrders(context.Background(), getPair(t, asset.DeliveryFutures), "open", settle, "", 0, 0, 1); err != nil {
 		t.Errorf("%s GetDeliveryOrders() error %v", g.Name, err)
 	}
 }
@@ -1217,11 +1201,11 @@ func TestGetDeliveryOrders(t *testing.T) {
 func TestCancelAllDeliveryOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.CancelMultipleDeliveryOrders(context.Background(), deliveryFuturesTradablePair, "ask", settle); err != nil {
+	if _, err := g.CancelMultipleDeliveryOrders(context.Background(), getPair(t, asset.DeliveryFutures), "ask", settle); err != nil {
 		t.Errorf("%s CancelAllDeliveryOrders() error %v", g.Name, err)
 	}
 }
@@ -1254,7 +1238,7 @@ func TestCancelSingleDeliveryOrder(t *testing.T) {
 func TestGetDeliveryPersonalTradingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetDeliveryPersonalTradingHistory(context.Background(), settleUSDT, "", deliveryFuturesTradablePair, 0, 0, 1, ""); err != nil {
+	if _, err := g.GetDeliveryPersonalTradingHistory(context.Background(), settleUSDT, "", getPair(t, asset.DeliveryFutures), 0, 0, 1, ""); err != nil {
 		t.Errorf("%s GetDeliveryPersonalTradingHistory() error %v", g.Name, err)
 	}
 }
@@ -1262,7 +1246,7 @@ func TestGetDeliveryPersonalTradingHistory(t *testing.T) {
 func TestGetDeliveryPositionCloseHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetDeliveryPositionCloseHistory(context.Background(), settleUSDT, deliveryFuturesTradablePair, 0, 0, time.Time{}, time.Time{}); err != nil {
+	if _, err := g.GetDeliveryPositionCloseHistory(context.Background(), settleUSDT, getPair(t, asset.DeliveryFutures), 0, 0, time.Time{}, time.Time{}); err != nil {
 		t.Errorf("%s GetDeliveryPositionCloseHistory() error %v", g.Name, err)
 	}
 }
@@ -1270,7 +1254,7 @@ func TestGetDeliveryPositionCloseHistory(t *testing.T) {
 func TestGetDeliveryLiquidationHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetDeliveryLiquidationHistory(context.Background(), settleUSDT, deliveryFuturesTradablePair, 0, time.Now()); err != nil {
+	if _, err := g.GetDeliveryLiquidationHistory(context.Background(), settleUSDT, getPair(t, asset.DeliveryFutures), 0, time.Now()); err != nil {
 		t.Errorf("%s GetDeliveryLiquidationHistory() error %v", g.Name, err)
 	}
 }
@@ -1278,7 +1262,7 @@ func TestGetDeliveryLiquidationHistory(t *testing.T) {
 func TestGetDeliverySettlementHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetDeliverySettlementHistory(context.Background(), settleUSDT, deliveryFuturesTradablePair, 0, time.Now()); err != nil {
+	if _, err := g.GetDeliverySettlementHistory(context.Background(), settleUSDT, getPair(t, asset.DeliveryFutures), 0, time.Now()); err != nil {
 		t.Errorf("%s GetDeliverySettlementHistory() error %v", g.Name, err)
 	}
 }
@@ -1290,7 +1274,7 @@ func TestGetDeliveryPriceTriggeredOrder(t *testing.T) {
 		Initial: FuturesInitial{
 			Price:    1234.,
 			Size:     12,
-			Contract: deliveryFuturesTradablePair,
+			Contract: getPair(t, asset.DeliveryFutures),
 		},
 		Trigger: FuturesTrigger{
 			Rule:      1,
@@ -1305,7 +1289,7 @@ func TestGetDeliveryPriceTriggeredOrder(t *testing.T) {
 func TestGetDeliveryAllAutoOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetDeliveryAllAutoOrder(context.Background(), "open", settleUSDT, deliveryFuturesTradablePair, 0, 1); err != nil {
+	if _, err := g.GetDeliveryAllAutoOrder(context.Background(), "open", settleUSDT, getPair(t, asset.DeliveryFutures), 0, 1); err != nil {
 		t.Errorf("%s GetDeliveryAllAutoOrder() error %v", g.Name, err)
 	}
 }
@@ -1313,11 +1297,11 @@ func TestGetDeliveryAllAutoOrder(t *testing.T) {
 func TestCancelAllDeliveryPriceTriggeredOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.CancelAllDeliveryPriceTriggeredOrder(context.Background(), settle, deliveryFuturesTradablePair); err != nil {
+	if _, err := g.CancelAllDeliveryPriceTriggeredOrder(context.Background(), settle, getPair(t, asset.DeliveryFutures)); err != nil {
 		t.Errorf("%s CancelAllDeliveryPriceTriggeredOrder() error %v", g.Name, err)
 	}
 }
@@ -1349,11 +1333,11 @@ func TestEnableOrDisableDualMode(t *testing.T) {
 func TestRetrivePositionDetailInDualMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.RetrivePositionDetailInDualMode(context.Background(), settle, futuresTradablePair); err != nil {
+	if _, err = g.RetrivePositionDetailInDualMode(context.Background(), settle, getPair(t, asset.Futures)); err != nil {
 		t.Errorf("%s RetrivePositionDetailInDualMode() error %v", g.Name, err)
 	}
 }
@@ -1361,22 +1345,22 @@ func TestRetrivePositionDetailInDualMode(t *testing.T) {
 func TestUpdatePositionMarginInDualMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.UpdatePositionMarginInDualMode(context.Background(), settle, futuresTradablePair, 0.001, "dual_long"); err != nil {
+	if _, err = g.UpdatePositionMarginInDualMode(context.Background(), settle, getPair(t, asset.Futures), 0.001, "dual_long"); err != nil {
 		t.Errorf("%s UpdatePositionMarginInDualMode() error %v", g.Name, err)
 	}
 }
 func TestUpdatePositionLeverageInDualMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.UpdatePositionLeverageInDualMode(context.Background(), settle, futuresTradablePair, 0.001, 0.001); err != nil {
+	if _, err = g.UpdatePositionLeverageInDualMode(context.Background(), settle, getPair(t, asset.Futures), 0.001, 0.001); err != nil {
 		t.Errorf("%s UpdatePositionLeverageInDualMode() error %v", g.Name, err)
 	}
 }
@@ -1384,11 +1368,11 @@ func TestUpdatePositionLeverageInDualMode(t *testing.T) {
 func TestUpdatePositionRiskLimitinDualMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = g.UpdatePositionRiskLimitInDualMode(context.Background(), settle, futuresTradablePair, 10); err != nil {
+	if _, err = g.UpdatePositionRiskLimitInDualMode(context.Background(), settle, getPair(t, asset.Futures), 10); err != nil {
 		t.Errorf("%s UpdatePositionRiskLimitinDualMode() error %v", g.Name, err)
 	}
 }
@@ -1396,12 +1380,12 @@ func TestUpdatePositionRiskLimitinDualMode(t *testing.T) {
 func TestCreateFuturesOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := g.PlaceFuturesOrder(context.Background(), &OrderCreateParams{
-		Contract:    futuresTradablePair,
+		Contract:    getPair(t, asset.Futures),
 		Size:        6024,
 		Iceberg:     0,
 		Price:       3765,
@@ -1424,7 +1408,7 @@ func TestGetFuturesOrders(t *testing.T) {
 func TestCancelMultipleFuturesOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	if _, err := g.CancelMultipleFuturesOpenOrders(context.Background(), futuresTradablePair, "ask", settleUSDT); err != nil {
+	if _, err := g.CancelMultipleFuturesOpenOrders(context.Background(), getPair(t, asset.Futures), "ask", settleUSDT); err != nil {
 		t.Errorf("%s CancelAllOpenOrdersMatched() error %v", g.Name, err)
 	}
 }
@@ -1448,13 +1432,13 @@ func TestCancelFuturesPriceTriggeredOrder(t *testing.T) {
 func TestCreateBatchFuturesOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, true)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := g.PlaceBatchFuturesOrders(context.Background(), settleBTC, []OrderCreateParams{
 		{
-			Contract:    futuresTradablePair,
+			Contract:    getPair(t, asset.Futures),
 			Size:        6024,
 			Iceberg:     0,
 			Price:       3765,
@@ -1503,7 +1487,7 @@ func TestAmendFuturesOrder(t *testing.T) {
 func TestGetMyPersonalTradingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetMyPersonalTradingHistory(context.Background(), settleBTC, "", "", futuresTradablePair, 0, 0, 0); err != nil {
+	if _, err := g.GetMyPersonalTradingHistory(context.Background(), settleBTC, "", "", getPair(t, asset.Futures), 0, 0, 0); err != nil {
 		t.Errorf("%s GetMyPersonalTradingHistory() error %v", g.Name, err)
 	}
 }
@@ -1511,7 +1495,7 @@ func TestGetMyPersonalTradingHistory(t *testing.T) {
 func TestGetPositionCloseHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetFuturesPositionCloseHistory(context.Background(), settleBTC, futuresTradablePair, 0, 0, time.Time{}, time.Time{}); err != nil {
+	if _, err := g.GetFuturesPositionCloseHistory(context.Background(), settleBTC, getPair(t, asset.Futures), 0, 0, time.Time{}, time.Time{}); err != nil {
 		t.Errorf("%s GetPositionCloseHistory() error %v", g.Name, err)
 	}
 }
@@ -1519,7 +1503,7 @@ func TestGetPositionCloseHistory(t *testing.T) {
 func TestGetFuturesLiquidationHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetFuturesLiquidationHistory(context.Background(), settleBTC, futuresTradablePair, 0, time.Time{}); err != nil {
+	if _, err := g.GetFuturesLiquidationHistory(context.Background(), settleBTC, getPair(t, asset.Futures), 0, time.Time{}); err != nil {
 		t.Errorf("%s GetFuturesLiquidationHistory() error %v", g.Name, err)
 	}
 }
@@ -1537,7 +1521,7 @@ func TestCountdownCancelOrders(t *testing.T) {
 func TestCreatePriceTriggeredFuturesOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1545,7 +1529,7 @@ func TestCreatePriceTriggeredFuturesOrder(t *testing.T) {
 		Initial: FuturesInitial{
 			Price:    1234.,
 			Size:     2,
-			Contract: futuresTradablePair,
+			Contract: getPair(t, asset.Futures),
 		},
 		Trigger: FuturesTrigger{
 			Rule:      1,
@@ -1558,7 +1542,7 @@ func TestCreatePriceTriggeredFuturesOrder(t *testing.T) {
 		Initial: FuturesInitial{
 			Price:    1234.,
 			Size:     1,
-			Contract: futuresTradablePair,
+			Contract: getPair(t, asset.Futures),
 		},
 		Trigger: FuturesTrigger{
 			Rule: 1,
@@ -1579,11 +1563,11 @@ func TestListAllFuturesAutoOrders(t *testing.T) {
 func TestCancelAllFuturesOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(futuresTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.Futures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.CancelAllFuturesOpenOrders(context.Background(), settle, futuresTradablePair); err != nil {
+	if _, err := g.CancelAllFuturesOpenOrders(context.Background(), settle, getPair(t, asset.Futures)); err != nil {
 		t.Errorf("%s CancelAllFuturesOpenOrders() error %v", g.Name, err)
 	}
 }
@@ -1597,50 +1581,50 @@ func TestGetAllDeliveryContracts(t *testing.T) {
 
 func TestGetSingleDeliveryContracts(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Skip(err)
 	}
-	if _, err := g.GetSingleDeliveryContracts(context.Background(), settle, deliveryFuturesTradablePair); err != nil {
+	if _, err := g.GetSingleDeliveryContracts(context.Background(), settle, getPair(t, asset.DeliveryFutures)); err != nil {
 		t.Errorf("%s GetSingleDeliveryContracts() error %v", g.Name, err)
 	}
 }
 
 func TestGetDeliveryOrderbook(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetDeliveryOrderbook(context.Background(), settleUSDT, "0", deliveryFuturesTradablePair, 0, false); err != nil {
+	if _, err := g.GetDeliveryOrderbook(context.Background(), settleUSDT, "0", getPair(t, asset.DeliveryFutures), 0, false); err != nil {
 		t.Errorf("%s GetDeliveryOrderbook() error %v", g.Name, err)
 	}
 }
 
 func TestGetDeliveryTradingHistory(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Skip(err)
 	}
-	if _, err := g.GetDeliveryTradingHistory(context.Background(), settle, "", deliveryFuturesTradablePair, 0, time.Time{}, time.Time{}); err != nil {
+	if _, err := g.GetDeliveryTradingHistory(context.Background(), settle, "", getPair(t, asset.DeliveryFutures), 0, time.Time{}, time.Time{}); err != nil {
 		t.Errorf("%s GetDeliveryTradingHistory() error %v", g.Name, err)
 	}
 }
 func TestGetDeliveryFuturesCandlesticks(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Skip(err)
 	}
-	if _, err := g.GetDeliveryFuturesCandlesticks(context.Background(), settle, deliveryFuturesTradablePair, time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
+	if _, err := g.GetDeliveryFuturesCandlesticks(context.Background(), settle, getPair(t, asset.DeliveryFutures), time.Time{}, time.Time{}, 0, kline.OneWeek); err != nil {
 		t.Errorf("%s GetFuturesCandlesticks() error %v", g.Name, err)
 	}
 }
 
 func TestGetDeliveryFutureTickers(t *testing.T) {
 	t.Parallel()
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Skip(err)
 	}
-	if _, err := g.GetDeliveryFutureTickers(context.Background(), settle, deliveryFuturesTradablePair); err != nil {
+	if _, err := g.GetDeliveryFutureTickers(context.Background(), settle, getPair(t, asset.DeliveryFutures)); err != nil {
 		t.Errorf("%s GetDeliveryFutureTickers() error %v", g.Name, err)
 	}
 }
@@ -1678,7 +1662,7 @@ func TestGetAllDeliveryPositionsOfUser(t *testing.T) {
 func TestGetSingleDeliveryPosition(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	if _, err := g.GetSingleDeliveryPosition(context.Background(), settleUSDT, deliveryFuturesTradablePair); err != nil {
+	if _, err := g.GetSingleDeliveryPosition(context.Background(), settleUSDT, getPair(t, asset.DeliveryFutures)); err != nil {
 		t.Errorf("%s GetSingleDeliveryPosition() error %v", g.Name, err)
 	}
 }
@@ -1686,11 +1670,11 @@ func TestGetSingleDeliveryPosition(t *testing.T) {
 func TestUpdateDeliveryPositionMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	settle, err := g.getSettlementFromCurrency(deliveryFuturesTradablePair, false)
+	settle, err := g.getSettlementFromCurrency(getPair(t, asset.DeliveryFutures), false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := g.UpdateDeliveryPositionMargin(context.Background(), settle, 0.001, deliveryFuturesTradablePair); err != nil {
+	if _, err := g.UpdateDeliveryPositionMargin(context.Background(), settle, 0.001, getPair(t, asset.DeliveryFutures)); err != nil {
 		t.Errorf("%s UpdateDeliveryPositionMargin() error %v", g.Name, err)
 	}
 }
@@ -1698,7 +1682,7 @@ func TestUpdateDeliveryPositionMargin(t *testing.T) {
 func TestUpdateDeliveryPositionLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	if _, err := g.UpdateDeliveryPositionLeverage(context.Background(), "usdt", deliveryFuturesTradablePair, 0.001); err != nil {
+	if _, err := g.UpdateDeliveryPositionLeverage(context.Background(), "usdt", getPair(t, asset.DeliveryFutures), 0.001); err != nil {
 		t.Errorf("%s UpdateDeliveryPositionLeverage() error %v", g.Name, err)
 	}
 }
@@ -1706,7 +1690,7 @@ func TestUpdateDeliveryPositionLeverage(t *testing.T) {
 func TestUpdateDeliveryPositionRiskLimit(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	if _, err := g.UpdateDeliveryPositionRiskLimit(context.Background(), "usdt", deliveryFuturesTradablePair, 30); err != nil {
+	if _, err := g.UpdateDeliveryPositionRiskLimit(context.Background(), "usdt", getPair(t, asset.DeliveryFutures), 30); err != nil {
 		t.Errorf("%s UpdateDeliveryPositionRiskLimit() error %v", g.Name, err)
 	}
 }
@@ -1734,7 +1718,7 @@ func TestGetAllContractOfUnderlyingWithinExpiryDate(t *testing.T) {
 
 func TestGetOptionsSpecifiedContractDetail(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetOptionsSpecifiedContractDetail(context.Background(), optionsTradablePair); err != nil {
+	if _, err := g.GetOptionsSpecifiedContractDetail(context.Background(), getPair(t, asset.Options)); err != nil {
 		t.Errorf("%s GetOptionsSpecifiedContractDetail() error %v", g.Name, err)
 	}
 }
@@ -1857,7 +1841,7 @@ func TestGetSpecifiedContractPosition(t *testing.T) {
 	if err != nil && !errors.Is(err, errInvalidOrMissingContractParam) {
 		t.Errorf("%s GetSpecifiedContractPosition() error expecting %v, but found %v", g.Name, errInvalidOrMissingContractParam, err)
 	}
-	_, err = g.GetSpecifiedContractPosition(context.Background(), optionsTradablePair)
+	_, err = g.GetSpecifiedContractPosition(context.Background(), getPair(t, asset.Options))
 	if err != nil {
 		t.Errorf("%s GetSpecifiedContractPosition() error expecting %v, but found %v", g.Name, errInvalidOrMissingContractParam, err)
 	}
@@ -1875,7 +1859,7 @@ func TestPlaceOptionOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	_, err := g.PlaceOptionOrder(context.Background(), OptionOrderParam{
-		Contract:    optionsTradablePair.String(),
+		Contract:    getPair(t, asset.Options).String(),
 		OrderSize:   -1,
 		Iceberg:     0,
 		Text:        "-",
@@ -1898,7 +1882,7 @@ func TestGetOptionFuturesOrders(t *testing.T) {
 func TestCancelOptionOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	if _, err := g.CancelMultipleOptionOpenOrders(context.Background(), optionsTradablePair, "", ""); err != nil {
+	if _, err := g.CancelMultipleOptionOpenOrders(context.Background(), getPair(t, asset.Options), "", ""); err != nil {
 		t.Errorf("%s CancelOptionOpenOrders() error %v", g.Name, err)
 	}
 }
@@ -1957,7 +1941,7 @@ func TestCancelWithdrawalWithSpecifiedID(t *testing.T) {
 
 func TestGetOptionsOrderbook(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetOptionsOrderbook(context.Background(), optionsTradablePair, "0.1", 9, true); err != nil {
+	if _, err := g.GetOptionsOrderbook(context.Background(), getPair(t, asset.Options), "0.1", 9, true); err != nil {
 		t.Errorf("%s GetOptionsFuturesOrderbooks() error %v", g.Name, err)
 	}
 }
@@ -1978,7 +1962,7 @@ func TestGetOptionUnderlyingTickers(t *testing.T) {
 
 func TestGetOptionFuturesCandlesticks(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetOptionFuturesCandlesticks(context.Background(), optionsTradablePair, 0, time.Now().Add(-time.Hour*10), time.Time{}, kline.ThirtyMin); err != nil {
+	if _, err := g.GetOptionFuturesCandlesticks(context.Background(), getPair(t, asset.Options), 0, time.Now().Add(-time.Hour*10), time.Time{}, kline.ThirtyMin); err != nil {
 		t.Error(err)
 	}
 }
@@ -1992,7 +1976,7 @@ func TestGetOptionFuturesMarkPriceCandlesticks(t *testing.T) {
 
 func TestGetOptionsTradeHistory(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetOptionsTradeHistory(context.Background(), optionsTradablePair, "C", 0, 0, time.Time{}, time.Time{}); err != nil {
+	if _, err := g.GetOptionsTradeHistory(context.Background(), getPair(t, asset.Options), "C", 0, 0, time.Time{}, time.Time{}); err != nil {
 		t.Errorf("%s GetOptionsTradeHistory() error %v", g.Name, err)
 	}
 }
@@ -2053,13 +2037,6 @@ func TestFetchTradablePairs(t *testing.T) {
 	}
 }
 
-func TestUpdateTradablePairs(t *testing.T) {
-	t.Parallel()
-	if err := g.UpdateTradablePairs(context.Background(), true); err != nil {
-		t.Errorf("%s UpdateTradablePairs() error %v", g.Name, err)
-	}
-}
-
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 	if err := g.UpdateTickers(context.Background(), asset.DeliveryFutures); err != nil {
@@ -2084,26 +2061,26 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := g.UpdateOrderbook(context.Background(), spotTradablePair, asset.Spot)
+	_, err := g.UpdateOrderbook(context.Background(), getPair(t, asset.Spot), asset.Spot)
 	if err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
-	_, err = g.UpdateOrderbook(context.Background(), marginTradablePair, asset.Margin)
+	_, err = g.UpdateOrderbook(context.Background(), getPair(t, asset.Margin), asset.Margin)
 	if err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
-	_, err = g.UpdateOrderbook(context.Background(), crossMarginTradablePair, asset.CrossMargin)
+	_, err = g.UpdateOrderbook(context.Background(), getPair(t, asset.CrossMargin), asset.CrossMargin)
 	if err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
-	_, err = g.UpdateOrderbook(context.Background(), futuresTradablePair, asset.Futures)
+	_, err = g.UpdateOrderbook(context.Background(), getPair(t, asset.Futures), asset.Futures)
 	if err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
-	if _, err = g.UpdateOrderbook(context.Background(), deliveryFuturesTradablePair, asset.DeliveryFutures); err != nil {
+	if _, err = g.UpdateOrderbook(context.Background(), getPair(t, asset.DeliveryFutures), asset.DeliveryFutures); err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
-	if _, err = g.UpdateOrderbook(context.Background(), optionsTradablePair, asset.Options); err != nil {
+	if _, err = g.UpdateOrderbook(context.Background(), getPair(t, asset.Options), asset.Options); err != nil {
 		t.Errorf("%s UpdateOrderbook() error %v", g.Name, err)
 	}
 }
@@ -2117,27 +2094,27 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 }
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetRecentTrades(context.Background(), spotTradablePair, asset.Spot)
+	_, err := g.GetRecentTrades(context.Background(), getPair(t, asset.Spot), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), marginTradablePair, asset.Margin)
+	_, err = g.GetRecentTrades(context.Background(), getPair(t, asset.Margin), asset.Margin)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), crossMarginTradablePair, asset.CrossMargin)
+	_, err = g.GetRecentTrades(context.Background(), getPair(t, asset.CrossMargin), asset.CrossMargin)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), deliveryFuturesTradablePair, asset.DeliveryFutures)
+	_, err = g.GetRecentTrades(context.Background(), getPair(t, asset.DeliveryFutures), asset.DeliveryFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), futuresTradablePair, asset.Futures)
+	_, err = g.GetRecentTrades(context.Background(), getPair(t, asset.Futures), asset.Futures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), optionsTradablePair, asset.Options)
+	_, err = g.GetRecentTrades(context.Background(), getPair(t, asset.Options), asset.Options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2147,7 +2124,7 @@ func TestSubmitOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	_, err := g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      crossMarginTradablePair,
+		Pair:      getPair(t, asset.CrossMargin),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2159,7 +2136,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	_, err = g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      spotTradablePair,
+		Pair:      getPair(t, asset.Spot),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2171,7 +2148,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	_, err = g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      optionsTradablePair,
+		Pair:      getPair(t, asset.Options),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2183,7 +2160,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	_, err = g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      deliveryFuturesTradablePair,
+		Pair:      getPair(t, asset.DeliveryFutures),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2195,7 +2172,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	_, err = g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      futuresTradablePair,
+		Pair:      getPair(t, asset.Futures),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2207,7 +2184,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	_, err = g.SubmitOrder(context.Background(), &order.Submit{
 		Exchange:  g.Name,
-		Pair:      marginTradablePair,
+		Pair:      getPair(t, asset.Margin),
 		Side:      order.Buy,
 		Type:      order.Limit,
 		Price:     1,
@@ -2266,13 +2243,13 @@ func TestCancelBatchOrders(t *testing.T) {
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          spotTradablePair,
+			Pair:          getPair(t, asset.Spot),
 			AssetType:     asset.Spot,
 		}, {
 			OrderID:       "2",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          spotTradablePair,
+			Pair:          getPair(t, asset.Spot),
 			AssetType:     asset.Spot,
 		}})
 	if err != nil {
@@ -2283,13 +2260,13 @@ func TestCancelBatchOrders(t *testing.T) {
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          futuresTradablePair,
+			Pair:          getPair(t, asset.Futures),
 			AssetType:     asset.Futures,
 		}, {
 			OrderID:       "2",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          futuresTradablePair,
+			Pair:          getPair(t, asset.Futures),
 			AssetType:     asset.Futures,
 		}})
 	if err != nil {
@@ -2300,13 +2277,13 @@ func TestCancelBatchOrders(t *testing.T) {
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          deliveryFuturesTradablePair,
+			Pair:          getPair(t, asset.DeliveryFutures),
 			AssetType:     asset.DeliveryFutures,
 		}, {
 			OrderID:       "2",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          deliveryFuturesTradablePair,
+			Pair:          getPair(t, asset.DeliveryFutures),
 			AssetType:     asset.DeliveryFutures,
 		}})
 	if err != nil {
@@ -2317,13 +2294,13 @@ func TestCancelBatchOrders(t *testing.T) {
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          optionsTradablePair,
+			Pair:          getPair(t, asset.Options),
 			AssetType:     asset.Options,
 		}, {
 			OrderID:       "2",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          optionsTradablePair,
+			Pair:          getPair(t, asset.Options),
 			AssetType:     asset.Options,
 		}})
 	if err != nil {
@@ -2334,13 +2311,13 @@ func TestCancelBatchOrders(t *testing.T) {
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          marginTradablePair,
+			Pair:          getPair(t, asset.Margin),
 			AssetType:     asset.Margin,
 		}, {
 			OrderID:       "2",
 			WalletAddress: core.BitcoinDonationAddress,
 			AccountID:     "1",
-			Pair:          marginTradablePair,
+			Pair:          getPair(t, asset.Margin),
 			AssetType:     asset.Margin,
 		}})
 	if err != nil {
@@ -2409,7 +2386,7 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Errorf(" %s GetActiveOrders() error: %v", g.Name, err)
 	}
 	_, err = g.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
-		Pairs:     currency.Pairs{futuresTradablePair},
+		Pairs:     currency.Pairs{getPair(t, asset.Futures)},
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 		AssetType: asset.Futures,
@@ -2418,7 +2395,7 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Errorf(" %s GetActiveOrders() error: %v", g.Name, err)
 	}
 	_, err = g.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
-		Pairs:     currency.Pairs{deliveryFuturesTradablePair},
+		Pairs:     currency.Pairs{getPair(t, asset.DeliveryFutures)},
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 		AssetType: asset.DeliveryFutures,
@@ -2427,7 +2404,7 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Errorf(" %s GetActiveOrders() error: %v", g.Name, err)
 	}
 	_, err = g.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
-		Pairs:     currency.Pairs{optionsTradablePair},
+		Pairs:     currency.Pairs{getPair(t, asset.Options)},
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 		AssetType: asset.Options,
@@ -2494,25 +2471,25 @@ func TestGetOrderHistory(t *testing.T) {
 func TestGetHistoricCandles(t *testing.T) {
 	t.Parallel()
 	startTime := time.Now().Add(-time.Hour * 10)
-	if _, err := g.GetHistoricCandles(context.Background(), spotTradablePair, asset.Spot, kline.OneDay, startTime, time.Now()); err != nil {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.Spot), asset.Spot, kline.OneDay, startTime, time.Now()); err != nil {
 		t.Errorf("%s GetHistoricCandles() error: %v", g.Name, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), marginTradablePair, asset.Margin, kline.OneDay, startTime, time.Now()); err != nil {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.Margin), asset.Margin, kline.OneDay, startTime, time.Now()); err != nil {
 		t.Errorf("%s GetHistoricCandles() error: %v", g.Name, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), crossMarginTradablePair, asset.CrossMargin, kline.OneDay, startTime, time.Now()); err != nil {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.CrossMargin), asset.CrossMargin, kline.OneDay, startTime, time.Now()); err != nil {
 		t.Errorf("%s GetHistoricCandles() error: %v", g.Name, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), futuresTradablePair, asset.Futures, kline.OneDay, startTime, time.Now()); err != nil {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.Futures), asset.Futures, kline.OneDay, startTime, time.Now()); err != nil {
 		t.Errorf("%s GetHistoricCandles() error: %v", g.Name, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), deliveryFuturesTradablePair, asset.DeliveryFutures, kline.OneDay, startTime, time.Now()); err != nil {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.DeliveryFutures), asset.DeliveryFutures, kline.OneDay, startTime, time.Now()); err != nil {
 		t.Errorf("%s GetHistoricCandles() error: %v", g.Name, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), optionsTradablePair, asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.Options), asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("%s GetHistoricCandles() expecting: %v, but found %v", g.Name, asset.ErrNotSupported, err)
 	}
-	if _, err := g.GetHistoricCandles(context.Background(), optionsTradablePair, asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
+	if _, err := g.GetHistoricCandles(context.Background(), getPair(t, asset.Options), asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("%s GetHistoricCandles() expecting: %v, but found %v", g.Name, asset.ErrNotSupported, err)
 	}
 }
@@ -2521,30 +2498,30 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	t.Parallel()
 	startTime := time.Now().Add(-time.Hour * 5)
 	_, err := g.GetHistoricCandlesExtended(context.Background(),
-		spotTradablePair, asset.Spot, kline.OneMin, startTime, time.Now())
+		getPair(t, asset.Spot), asset.Spot, kline.OneMin, startTime, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = g.GetHistoricCandlesExtended(context.Background(),
-		marginTradablePair, asset.Margin, kline.OneMin, startTime, time.Now())
+		getPair(t, asset.Margin), asset.Margin, kline.OneMin, startTime, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = g.GetHistoricCandlesExtended(context.Background(),
-		deliveryFuturesTradablePair, asset.DeliveryFutures, kline.OneMin, time.Now().Add(-time.Hour*5), time.Now())
+		getPair(t, asset.DeliveryFutures), asset.DeliveryFutures, kline.OneMin, time.Now().Add(-time.Hour*5), time.Now())
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetHistoricCandlesExtended(context.Background(), futuresTradablePair, asset.Futures, kline.OneMin, startTime, time.Now())
+	_, err = g.GetHistoricCandlesExtended(context.Background(), getPair(t, asset.Futures), asset.Futures, kline.OneMin, startTime, time.Now())
 	if err != nil {
 		t.Error(err)
 	}
 	_, err = g.GetHistoricCandlesExtended(context.Background(),
-		crossMarginTradablePair, asset.CrossMargin, kline.OneMin, startTime, time.Now())
+		getPair(t, asset.CrossMargin), asset.CrossMargin, kline.OneMin, startTime, time.Now())
 	if err != nil {
 		t.Error(err)
 	}
-	if _, err = g.GetHistoricCandlesExtended(context.Background(), optionsTradablePair, asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
+	if _, err = g.GetHistoricCandlesExtended(context.Background(), getPair(t, asset.Options), asset.Options, kline.OneDay, startTime, time.Now()); !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("%s GetHistoricCandlesExtended() expecting: %v, but found %v", g.Name, asset.ErrNotSupported, err)
 	}
 }
@@ -3121,49 +3098,6 @@ func TestUnlockSubAccount(t *testing.T) {
 	}
 }
 
-func getFirstTradablePairOfAssets() {
-	enabledPairs, err := g.GetEnabledPairs(asset.Spot)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.Spot)
-	}
-	spotTradablePair = enabledPairs[0]
-	enabledPairs, err = g.GetEnabledPairs(asset.Margin)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.Margin)
-	}
-	marginTradablePair = enabledPairs[0]
-	enabledPairs, err = g.GetEnabledPairs(asset.CrossMargin)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.CrossMargin)
-	}
-	crossMarginTradablePair = enabledPairs[0]
-	enabledPairs, err = g.GetEnabledPairs(asset.Futures)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.Futures)
-	}
-
-	if len(enabledPairs) == 0 {
-		var availPairs currency.Pairs
-		availPairs, err = g.GetAvailablePairs(asset.Futures)
-		if err != nil {
-			log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.Futures)
-		}
-		futuresTradablePair = availPairs[len(availPairs)-1]
-	} else {
-		futuresTradablePair = enabledPairs[len(enabledPairs)-1]
-	}
-	enabledPairs, err = g.GetEnabledPairs(asset.Options)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.Options)
-	}
-	optionsTradablePair = enabledPairs[0]
-	enabledPairs, err = g.GetEnabledPairs(asset.DeliveryFutures)
-	if err != nil {
-		log.Fatalf("GateIO %v, trying to get %v enabled pairs error", err, asset.DeliveryFutures)
-	}
-	deliveryFuturesTradablePair = enabledPairs[0]
-}
-
 func TestSettlement(t *testing.T) {
 	availablePairs, err := g.GetAvailablePairs(asset.Futures)
 	if err != nil {
@@ -3294,13 +3228,9 @@ func TestParseGateioTimeUnmarshal(t *testing.T) {
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
+	updatePairsOnce(t)
 
-	err := g.UpdateTradablePairs(context.Background(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = g.UpdateOrderExecutionLimits(context.Background(), 1336)
+	err := g.UpdateOrderExecutionLimits(context.Background(), 1336)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received %v, expected %v", err, asset.ErrNotSupported)
 	}
@@ -3492,25 +3422,63 @@ func TestGetOpenInterest(t *testing.T) {
 		Quote: currency.USDT.Item,
 		Asset: asset.USDTMarginedFutures,
 	})
-	assert.ErrorIs(t, err, asset.ErrNotSupported)
+	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetOpenInterest should error correctly")
 
-	resp, err := g.GetOpenInterest(context.Background(), key.PairAsset{
-		Base:  futuresTradablePair.Base.Item,
-		Quote: futuresTradablePair.Quote.Item,
-		Asset: asset.Futures,
+	for _, a := range []asset.Item{asset.Futures, asset.DeliveryFutures} {
+		p := getPair(t, a)
+		resp, err := g.GetOpenInterest(context.Background(), key.PairAsset{
+			Base:  p.Base.Item,
+			Quote: p.Quote.Item,
+			Asset: a,
+		})
+		assert.NoErrorf(t, err, "GetOpenInterest should not error for %s asset", a)
+		assert.Lenf(t, resp, 1, "GetOpenInterest should return 1 item for %s asset", a)
+	}
+
+	resp, err := g.GetOpenInterest(context.Background())
+	assert.NoError(t, err, "GetOpenInterest should not error")
+	assert.NotEmpty(t, resp, "GetOpenInterest should return some items")
+}
+
+var updatePairsGuard sync.Once
+
+func updatePairsOnce(tb testing.TB) {
+	tb.Helper()
+	updatePairsGuard.Do(func() {
+		err := g.UpdateTradablePairs(context.Background(), true)
+		assert.NoError(tb, err, "UpdateTradablePairs should not error")
 	})
-	assert.NoError(t, err)
-	assert.Len(t, resp, 1)
+}
 
-	resp, err = g.GetOpenInterest(context.Background(), key.PairAsset{
-		Base:  deliveryFuturesTradablePair.Base.Item,
-		Quote: deliveryFuturesTradablePair.Quote.Item,
-		Asset: asset.DeliveryFutures,
-	})
-	assert.NoError(t, err)
-	assert.Len(t, resp, 1)
+var pairs = map[asset.Item]currency.Pair{
+	asset.Spot: currency.NewPairWithDelimiter("BTC", "USDT", "_"),
+}
 
-	resp, err = g.GetOpenInterest(context.Background())
-	assert.NoError(t, err)
-	assert.NotEmpty(t, resp)
+var pairsGuard sync.RWMutex
+
+func getPair(tb testing.TB, a asset.Item) currency.Pair {
+	tb.Helper()
+	pairsGuard.RLock()
+	p, ok := pairs[a]
+	pairsGuard.RUnlock()
+	if ok {
+		return p
+	}
+	pairsGuard.Lock()
+	defer pairsGuard.Unlock()
+	p, ok = pairs[a] // Protect Race if we blocked on Lock and another RW populated
+	if ok {
+		return p
+	}
+
+	updatePairsOnce(tb)
+	enabledPairs, err := g.GetEnabledPairs(a)
+	assert.NoErrorf(tb, err, "%s GetEnabledPairs should not error", a)
+	if !assert.NotEmpty(tb, enabledPairs, "%s GetEnabledPairs should not be empty", a) {
+		tb.Fatalf("No pair available for asset %s", a)
+		return currency.EMPTYPAIR
+	}
+	pairs[a] = enabledPairs[0]
+
+	return pairs[a]
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -3424,9 +3424,10 @@ func TestGetOpenInterest(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetOpenInterest should error correctly")
 
+	var resp []futures.OpenInterest
 	for _, a := range []asset.Item{asset.Futures, asset.DeliveryFutures} {
 		p := getPair(t, a)
-		resp, err := g.GetOpenInterest(context.Background(), key.PairAsset{
+		resp, err = g.GetOpenInterest(context.Background(), key.PairAsset{
 			Base:  p.Base.Item,
 			Quote: p.Quote.Item,
 			Asset: a,
@@ -3435,7 +3436,7 @@ func TestGetOpenInterest(t *testing.T) {
 		assert.Lenf(t, resp, 1, "GetOpenInterest should return 1 item for %s asset", a)
 	}
 
-	resp, err := g.GetOpenInterest(context.Background())
+	resp, err = g.GetOpenInterest(context.Background())
 	assert.NoError(t, err, "GetOpenInterest should not error")
 	assert.NotEmpty(t, resp, "GetOpenInterest should return some items")
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -62,19 +61,6 @@ func TestMain(m *testing.M) {
 	g.Run(context.Background())
 	getFirstTradablePairOfAssets()
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	err := g.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = g.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestCancelAllExchangeOrders(t *testing.T) {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -242,33 +241,6 @@ func (g *Gateio) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the GateIO go routine
-func (g *Gateio) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		g.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the GateIO wrapper
-func (g *Gateio) Run(ctx context.Context) {
-	if g.Verbose {
-		g.PrintEnabledPairs()
-	}
-	if !g.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-	err := g.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", g.Name, err)
-	}
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/url"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -31,20 +30,6 @@ const (
 const testCurrency = "btcusd"
 
 var g = &Gemini{}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := g.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = g.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
-}
 
 func TestGetSymbols(t *testing.T) {
 	t.Parallel()

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -191,36 +190,6 @@ func (g *Gemini) Setup(exch *config.Exchange) error {
 		URL:                  geminiWebsocketEndpoint + "/v1/" + geminiWsOrderEvents,
 		Authenticated:        true,
 	})
-}
-
-// Start starts the Gemini go routine
-func (g *Gemini) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		g.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Gemini wrapper
-func (g *Gemini) Run(ctx context.Context) {
-	if g.Verbose {
-		g.PrintEnabledPairs()
-	}
-
-	if err := g.UpdateOrderExecutionLimits(ctx, asset.Spot); err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to set exchange order execution limits. Err: %v", g.Name, err)
-	}
-
-	if g.GetEnabledFeatures().AutoPairUpdates {
-		if err := g.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", g.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -2,11 +2,9 @@ package hitbtc
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -63,20 +61,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := h.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = h.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetOrderbook(t *testing.T) {

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -197,33 +196,6 @@ func (h *HitBTC) Setup(exch *config.Exchange) error {
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 		ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 	})
-}
-
-// Start starts the HitBTC go routine
-func (h *HitBTC) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		h.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the HitBTC wrapper
-func (h *HitBTC) Run(ctx context.Context) {
-	if h.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s (url: %s).\n", h.Name, common.IsEnabled(h.Websocket.IsEnabled()), hitbtcWebsocketAddress)
-		h.PrintEnabledPairs()
-	}
-
-	if h.GetEnabledFeatures().AutoPairUpdates {
-		if err := h.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", h.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -94,20 +93,6 @@ func setupWsTests(t *testing.T) {
 	}
 
 	wsSetupRan = true
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := h.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Errorf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = h.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Error(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetCurrenciesIncludingChains(t *testing.T) {

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -259,33 +258,6 @@ func (h *HUOBI) Setup(exch *config.Exchange) error {
 		URL:                  wsAccountsOrdersURL,
 		Authenticated:        true,
 	})
-}
-
-// Start starts the HUOBI go routine
-func (h *HUOBI) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		h.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the HUOBI wrapper
-func (h *HUOBI) Run(ctx context.Context) {
-	if h.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s (url: %s).\n", h.Name, common.IsEnabled(h.Websocket.IsEnabled()), wsMarketURL)
-		h.PrintEnabledPairs()
-	}
-
-	if h.GetEnabledFeatures().AutoPairUpdates {
-		if err := h.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", h.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -277,88 +277,14 @@ func (h *HUOBI) Start(ctx context.Context, wg *sync.WaitGroup) error {
 // Run implements the HUOBI wrapper
 func (h *HUOBI) Run(ctx context.Context) {
 	if h.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%s Websocket: %s (url: %s).\n",
-			h.Name,
-			common.IsEnabled(h.Websocket.IsEnabled()),
-			wsMarketURL)
+		log.Debugf(log.ExchangeSys, "%s Websocket: %s (url: %s).\n", h.Name, common.IsEnabled(h.Websocket.IsEnabled()), wsMarketURL)
 		h.PrintEnabledPairs()
 	}
 
-	var forceUpdate bool
-	enabled, err := h.GetEnabledPairs(asset.Spot)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s Failed to update enabled currencies. Err:%s\n",
-			h.Name,
-			err)
-	}
-
-	avail, err := h.GetAvailablePairs(asset.Spot)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s Failed to update enabled currencies. Err:%s\n",
-			h.Name,
-			err)
-	}
-
-	if common.StringDataContains(enabled.Strings(), currency.CNY.String()) ||
-		common.StringDataContains(avail.Strings(), currency.CNY.String()) {
-		forceUpdate = true
-	}
-
-	if common.StringDataContains(h.BaseCurrencies.Strings(), currency.CNY.String()) {
-		cfg := config.GetConfig()
-		var exchCfg *config.Exchange
-		exchCfg, err = cfg.GetExchangeConfig(h.Name)
-		if err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s failed to get exchange config. %s\n",
-				h.Name,
-				err)
-			return
+	if h.GetEnabledFeatures().AutoPairUpdates {
+		if err := h.UpdateTradablePairs(ctx, false); err != nil {
+			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", h.Name, err)
 		}
-		exchCfg.BaseCurrencies = currency.Currencies{currency.USD}
-		h.BaseCurrencies = currency.Currencies{currency.USD}
-	}
-
-	if forceUpdate {
-		var format currency.PairFormat
-		format, err = h.GetPairFormat(asset.Spot, false)
-		if err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s failed to get exchange config. %s\n",
-				h.Name,
-				err)
-			return
-		}
-		enabledPairs := currency.Pairs{
-			currency.Pair{
-				Base:      currency.BTC.Lower(),
-				Quote:     currency.USDT.Lower(),
-				Delimiter: format.Delimiter,
-			},
-		}
-		log.Warnf(log.ExchangeSys, exchange.ResetConfigPairsWarningMessage, h.Name, asset.Spot, enabledPairs)
-		err = h.UpdatePairs(enabledPairs, asset.Spot, true, true)
-		if err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s Failed to update enabled currencies. Err:%s\n",
-				h.Name,
-				err)
-		}
-	}
-
-	if !h.GetEnabledFeatures().AutoPairUpdates && !forceUpdate {
-		return
-	}
-
-	err = h.UpdateTradablePairs(ctx, forceUpdate)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			h.Name,
-			err)
 	}
 }
 

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -29,7 +29,7 @@ import (
 // GoCryptoTrader
 type IBotExchange interface {
 	Setup(exch *config.Exchange) error
-	Bootstrap(context.Context) (continueBootstrap bool)
+	Bootstrap(context.Context) (continueBootstrap bool, err error)
 	SetDefaults()
 	Shutdown() error
 	GetName() string

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common/key"
@@ -30,7 +29,6 @@ import (
 // GoCryptoTrader
 type IBotExchange interface {
 	Setup(exch *config.Exchange) error
-	Start(ctx context.Context, wg *sync.WaitGroup) error
 	SetDefaults()
 	Shutdown() error
 	GetName() string
@@ -81,6 +79,9 @@ type IBotExchange interface {
 	CheckOrderExecutionLimits(a asset.Item, cp currency.Pair, price, amount float64, orderType order.Type) error
 	UpdateOrderExecutionLimits(ctx context.Context, a asset.Item) error
 	GetCredentials(ctx context.Context) (*account.Credentials, error)
+	EnsureOnePairEnabled() error
+	PrintEnabledPairs()
+	IsVerbose() bool
 
 	// ValidateAPICredentials function validates the API keys by sending an
 	// authenticated REST request. See exchange specific wrapper implementation.

--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -29,6 +29,7 @@ import (
 // GoCryptoTrader
 type IBotExchange interface {
 	Setup(exch *config.Exchange) error
+	Bootstrap(context.Context) (continueBootstrap bool)
 	SetDefaults()
 	Shutdown() error
 	GetName() string

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -2,10 +2,8 @@ package itbit
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
@@ -31,20 +29,6 @@ const (
 
 func TestMain(_ *testing.M) {
 	fmt.Println("ItBit API deprecated, skipping tests")
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := i.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = i.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetTicker(t *testing.T) {

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -115,26 +114,6 @@ func (i *ItBit) Setup(exch *config.Exchange) error {
 		return nil
 	}
 	return i.SetupDefaults(exch)
-}
-
-// Start starts the ItBit go routine
-func (i *ItBit) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		i.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the ItBit wrapper
-func (i *ItBit) Run(_ context.Context) {
-	if i.Verbose {
-		i.PrintEnabledPairs()
-	}
 }
 
 // GetServerTime returns the current exchange server time.

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -31,7 +31,7 @@ const (
 	krakenFuturesVersion          = "3"
 )
 
-// Kraken is the overarching type across the alphapoint package
+// Kraken is the overarching type across the kraken package
 type Kraken struct {
 	exchange.Base
 	wsRequestMtx sync.Mutex

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -70,20 +69,6 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := k.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = k.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetCurrentServerTime(t *testing.T) {

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -272,39 +271,6 @@ func (k *Kraken) Setup(exch *config.Exchange) error {
 		URL:                  krakenAuthWSURL,
 		Authenticated:        true,
 	})
-}
-
-// Start starts the Kraken go routine
-func (k *Kraken) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		k.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Kraken wrapper
-func (k *Kraken) Run(ctx context.Context) {
-	if k.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s. (url: %s).\n", k.Name, common.IsEnabled(k.Websocket.IsEnabled()), k.Websocket.GetWebsocketURL())
-		k.PrintEnabledPairs()
-	}
-
-	if k.GetEnabledFeatures().AutoPairUpdates {
-		if err := k.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", k.Name, err)
-		}
-	}
-
-	for _, a := range k.GetAssetTypes(true) {
-		if err := k.UpdateOrderExecutionLimits(ctx, a); err != nil && err != common.ErrNotYetImplemented {
-			log.Errorln(log.ExchangeSys, err.Error())
-		}
-	}
 }
 
 // UpdateOrderExecutionLimits sets exchange execution order limits for an asset type

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -2,15 +2,12 @@ package lbank
 
 import (
 	"context"
-	"errors"
 	"log"
 	"os"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -62,20 +59,6 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := l.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = l.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestGetTicker(t *testing.T) {

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -153,35 +152,6 @@ func (l *Lbank) Setup(exch *config.Exchange) error {
 		}
 	}
 	return nil
-}
-
-// Start starts the Lbank go routine
-func (l *Lbank) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		l.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Lbank wrapper
-func (l *Lbank) Run(ctx context.Context) {
-	if l.Verbose {
-		l.PrintEnabledPairs()
-	}
-
-	if !l.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := l.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", l.Name, err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -63,20 +61,6 @@ func TestMain(m *testing.M) {
 	}
 	setupWS()
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := o.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = o.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestFetchTradablePair(t *testing.T) {

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -205,33 +204,6 @@ func (o *Okcoin) Setup(exch *config.Exchange) error {
 		RateLimit:            okcoinWsRateLimit,
 		Authenticated:        true,
 	})
-}
-
-// Start starts the Okcoin go routine
-func (o *Okcoin) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		o.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Okcoin wrapper
-func (o *Okcoin) Run(ctx context.Context) {
-	if o.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Websocket: %s.", o.Name, common.IsEnabled(o.Websocket.IsEnabled()))
-		o.PrintEnabledPairs()
-	}
-
-	if o.GetEnabledFeatures().AutoPairUpdates {
-		if err := o.UpdateTradablePairs(ctx, false); err != nil {
-			log.Errorf(log.ExchangeSys, "%s failed to update tradable pairs. Err: %s", o.Name, err)
-		}
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -85,20 +85,6 @@ func contextGenerate() context.Context {
 	return ctx
 }
 
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := ok.Start(contextGenerate(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = ok.Start(contextGenerate(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
-}
-
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
 	_, err := ok.GetTickers(contextGenerate(), "OPTION", "", "SOL-USD")

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,20 +29,6 @@ const (
 )
 
 var p = &Poloniex{}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := p.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = p.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
-}
 
 func TestTimestamp(t *testing.T) {
 	t.Parallel()

--- a/exchanges/sharedtestvalues/customex.go
+++ b/exchanges/sharedtestvalues/customex.go
@@ -2,7 +2,6 @@ package sharedtestvalues
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -31,11 +30,6 @@ type CustomEx struct {
 
 // Setup is a mock method for CustomEx
 func (c *CustomEx) Setup(_ *config.Exchange) error {
-	return nil
-}
-
-// Start is a mock method for CustomEx
-func (c *CustomEx) Start(_ context.Context, _ *sync.WaitGroup) error {
 	return nil
 }
 

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -51,20 +50,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-func TestStart(t *testing.T) {
-	t.Parallel()
-	err := y.Start(context.Background(), nil)
-	if !errors.Is(err, common.ErrNilPointer) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
-	}
-	var testWg sync.WaitGroup
-	err = y.Start(context.Background(), &testWg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testWg.Wait()
 }
 
 func TestFetchTradablePairs(t *testing.T) {

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -125,38 +124,6 @@ func (y *Yobit) Setup(exch *config.Exchange) error {
 		return nil
 	}
 	return y.SetupDefaults(exch)
-}
-
-// Start starts the WEX go routine
-func (y *Yobit) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	if wg == nil {
-		return fmt.Errorf("%T %w", wg, common.ErrNilPointer)
-	}
-	wg.Add(1)
-	go func() {
-		y.Run(ctx)
-		wg.Done()
-	}()
-	return nil
-}
-
-// Run implements the Yobit wrapper
-func (y *Yobit) Run(ctx context.Context) {
-	if y.Verbose {
-		y.PrintEnabledPairs()
-	}
-
-	if !y.GetEnabledFeatures().AutoPairUpdates {
-		return
-	}
-
-	err := y.UpdateTradablePairs(ctx, false)
-	if err != nil {
-		log.Errorf(log.ExchangeSys,
-			"%s failed to update tradable pairs. Err: %s",
-			y.Name,
-			err)
-	}
 }
 
 // FetchTradablePairs returns a list of the exchanges tradable pairs

--- a/gctscript/wrappers/gct/exchange/exchange_test.go
+++ b/gctscript/wrappers/gct/exchange/exchange_test.go
@@ -204,7 +204,7 @@ func setupEngine() (err error) {
 	em := engine.NewExchangeManager()
 	engine.Bot.ExchangeManager = em
 
-	return engine.Bot.LoadExchange(exchName, nil)
+	return engine.Bot.LoadExchange(exchName)
 }
 
 func cleanup() {


### PR DESCRIPTION
## Remove bespoke pair upgrade handling
Now redundant behind #1401. These paths should never be met.
Several legacy coin upgrade paths being deprecated as well: ZUSD and CNY
Expecting any users with bad config from 3+ years ago would have to reset anyway.

Also: At the time the intention of this was to upgrade the config format.
However now, instead, it'd mostly serve to reset enabled pairs if there's a config mistake, which doesn't feel right.

## Abstract Start and Run

Both Start and Run were pretty much cargo culted across the exchanges.
The bespoke pair upgrade handling masked this, as well as inconsistencies, but when whittled down the only time there was a difference it was a missing behaviour that should be added.

For clarity about this design pattern:
* If we had a `*Base.Run` then any methods called inside it would not call `*exchange.UpdateOrderExecutionLimits` but always only call `*Base.UpdateOrderExecutionLimits`. Because once Run has been dispatched to the embedded field Base, there's no way back to the containing struct.
* By calling functions which receive interface arguments, we get to dispatch first to `exchange.Method`, if it exists, otherwise `base.Method`
* Run is not currently a method, because we wanted to have the behaviour above ☝️ Any option that would end up calling methods on a `*Base` would lose the method inheritence
* We might consider renaming exchange.Run to `CommonBootstrap` and then calling `Bootstrap` on b to allow it to do anything else
* We could also consider a type switch on an interface, and calling the exchange `Bootstrap` if it can do it, otherwise calling `CommonBootstrap`

All of this is simply to say: We're not penned in or inflexible as a result of this abstraction.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Non-Breaking change

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run