### PR TITLE
Bitfinex: Fix UpdateTickers

### DIFF
--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -496,7 +496,7 @@ func TestUpdateTickers(t *testing.T) {
 		assert.NoError(t, err, "StorePairs should not error")
 
 		err = b.UpdateTickers(context.Background(), a)
-		assert.NoError(t, err, "UpdateTickers should not error")
+		assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 
 		// Bitfinex leaves delisted pairs in Available info/conf endpoints
 		// We want to assert that most pairs are valid, so we'll check that no more than 5% are erroring

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -366,15 +366,17 @@ func (b *Bitfinex) UpdateOrderExecutionLimits(ctx context.Context, a asset.Item)
 
 // UpdateTickers updates the ticker for all currency pairs of a given asset type
 func (b *Bitfinex) UpdateTickers(ctx context.Context, a asset.Item) error {
-	tickerNew, err := b.GetTickerBatch(ctx)
+	t, err := b.GetTickerBatch(ctx)
 	if err != nil {
 		return err
 	}
 
-	for key, val := range tickerNew {
+	var errs error
+	for key, val := range t {
 		pair, enabled, err := b.MatchSymbolCheckEnabled(key[1:], a, true)
 		if err != nil && !errors.Is(err, currency.ErrPairNotFound) {
-			return err
+			errs = common.AppendError(errs, err)
+			continue
 		}
 		if !enabled {
 			continue
@@ -391,10 +393,10 @@ func (b *Bitfinex) UpdateTickers(ctx context.Context, a asset.Item) error {
 			AssetType:    a,
 			ExchangeName: b.Name})
 		if err != nil {
-			return err
+			errs = common.AppendError(errs, err)
 		}
 	}
-	return nil
+	return errs
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair


### PR DESCRIPTION
* Fix UpdateTickes aborting on first failed ticker
On a cross or locked market error we should continue processing the other tickers.
BONK was locked today and as a result other tickers would not be processed

* Fix TestUpdateTickers failing on ICE
Accept 5% failure rate of available pairs not working as tickers.

When Bitfinex [delisted ICE](https://www.bitfinex.com/posts/990) it's still coming back in all pub:conf and pub:info listings:
```
❯ curl -s https://api.bitfinex.com/v2/conf/pub:info:pair | jq -c '.[0][] | select(.[0] | test("(BTC|ICE|ZIL)USD")) '                                                                   ["BTCUSD",[null,null,null,"0.00006","2000.0",null,null,null,0.1,0.05,null,null]]
["ICEUSD",[null,null,null,"4.0","25000.0",null,null,null,null,null,null,null]]
["ZILUSD",[null,null,null,"40.0","1500000.0",null,null,null,null,null,null,null]]
```
_( I included ZIL to show a tradable pair without Margin fields )_ There's absolutely no sign it's not a tradable pair _until_ you ask for a ticker for it:
```
❯ curl -s https://api.bitfinex.com/v2/ticker/tICEUSD                                                                                                                                   ["error",10020,"symbol: invalid"]⏎
❯ curl -s https://api.bitfinex.com/v2/ticker/tBTCUSD                                                                                                                                   [42854,11.8920918,42855,12.71095442,-290,-0.00672292,42846,725.08132142,43288,41850]⏎
```

## Type of change

- [x] Tests fix

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestUpdateTickers
