### PR TITLE
Bitfinex: Fix panic on TestUpdateTickers

### DIFF
--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -748,86 +748,86 @@ func (b *Bitfinex) GetTicker(ctx context.Context, symbol string) (*Ticker, error
 	if len(response) > 10 {
 		var ok bool
 		if t.FlashReturnRate, ok = response[0].(float64); !ok {
-			return nil, errors.New("unable to type assert flashReturnRate")
+			return nil, common.GetTypeAssertError("float64", response[0], "Ticker.Data.FlashReturnRate")
 		}
 		if t.Bid, ok = response[1].(float64); !ok {
-			return nil, errors.New("unable to type assert bid")
+			return nil, common.GetTypeAssertError("float64", response[1], "Ticker.Data.Bid")
 		}
-		var bidPeriod float64
-		bidPeriod, ok = response[2].(float64)
+		var bidPeriodF float64
+		bidPeriodF, ok = response[2].(float64)
 		if !ok {
-			return nil, errors.New("unable to type assert bidPeriod")
+			return nil, common.GetTypeAssertError("float64", response[2], "Ticker.Data.BidPeriod")
 		}
-		t.BidPeriod = int64(bidPeriod)
+		t.BidPeriod = int64(bidPeriodF)
 		if t.BidSize, ok = response[3].(float64); !ok {
-			return nil, errors.New("unable to type assert bidSize")
+			return nil, common.GetTypeAssertError("float64", response[3], "Ticker.Data.BidSize")
 		}
 		if t.Ask, ok = response[4].(float64); !ok {
-			return nil, errors.New("unable to type assert ask")
+			return nil, common.GetTypeAssertError("float64", response[4], "Ticker.Data.Ask")
 		}
-		var askPeriod float64
-		askPeriod, ok = response[5].(float64)
+		var askPeriodF float64
+		askPeriodF, ok = response[5].(float64)
 		if !ok {
-			return nil, errors.New("unable to type assert askPeriod")
+			return nil, common.GetTypeAssertError("float64", response[5], "Ticker.Data.AskPeriod")
 		}
-		t.AskPeriod = int64(askPeriod)
+		t.AskPeriod = int64(askPeriodF)
 		if t.AskSize, ok = response[6].(float64); !ok {
-			return nil, errors.New("unable to type assert askSize")
+			return nil, common.GetTypeAssertError("float64", response[6], "Ticker.Data.AskSize")
 		}
 		if t.DailyChange, ok = response[7].(float64); !ok {
-			return nil, errors.New("unable to type assert dailyChange")
+			return nil, common.GetTypeAssertError("float64", response[7], "Ticker.Data.DailyChange")
 		}
 		if t.DailyChangePerc, ok = response[8].(float64); !ok {
-			return nil, errors.New("unable to type assert dailyChangePerc")
+			return nil, common.GetTypeAssertError("float64", response[8], "Ticker.Data.DailyChangePerc")
 		}
 		if t.Last, ok = response[9].(float64); !ok {
-			return nil, errors.New("unable to type assert last")
+			return nil, common.GetTypeAssertError("float64", response[9], "Ticker.Data.Last")
 		}
 		if t.Volume, ok = response[10].(float64); !ok {
-			return nil, errors.New("unable to type assert volume")
+			return nil, common.GetTypeAssertError("float64", response[10], "Ticker.Data.Volume")
 		}
 		if t.High, ok = response[11].(float64); !ok {
-			return nil, errors.New("unable to type assert high")
+			return nil, common.GetTypeAssertError("float64", response[11], "Ticker.Data.High")
 		}
 		if t.Low, ok = response[12].(float64); !ok {
-			return nil, errors.New("unable to type assert low")
+			return nil, common.GetTypeAssertError("float64", response[12], "Ticker.Data.Low")
 		}
 		if t.FFRAmountAvailable, ok = response[15].(float64); !ok {
-			return nil, errors.New("unable to type assert FFRAmountAvailable")
+			return nil, common.GetTypeAssertError("float64", response[15], "Ticker.Data.FFRAmountAvailable")
 		}
 		return &t, nil
 	}
 
 	var ok bool
 	if t.Bid, ok = response[0].(float64); !ok {
-		return nil, errors.New("unable to type assert bid")
+		return nil, common.GetTypeAssertError("float64", response[0], "Ticker.Data.Bid")
 	}
 	if t.BidSize, ok = response[1].(float64); !ok {
-		return nil, errors.New("unable to type assert bidSize")
+		return nil, common.GetTypeAssertError("float64", response[1], "Ticker.Data.BidSize")
 	}
 	if t.Ask, ok = response[2].(float64); !ok {
-		return nil, errors.New("unable to type assert ask")
+		return nil, common.GetTypeAssertError("float64", response[2], "Ticker.Data.Ask")
 	}
 	if t.AskSize, ok = response[3].(float64); !ok {
-		return nil, errors.New("unable to type assert askSize")
+		return nil, common.GetTypeAssertError("float64", response[3], "Ticker.Data.AskSize")
 	}
 	if t.DailyChange, ok = response[4].(float64); !ok {
-		return nil, errors.New("unable to type assert dailyChange")
+		return nil, common.GetTypeAssertError("float64", response[4], "Ticker.Data.DailyChange")
 	}
 	if t.DailyChangePerc, ok = response[5].(float64); !ok {
-		return nil, errors.New("unable to type assert dailyChangePerc")
+		return nil, common.GetTypeAssertError("float64", response[5], "Ticker.Data.DailyChangePerc")
 	}
 	if t.Last, ok = response[6].(float64); !ok {
-		return nil, errors.New("unable to type assert last")
+		return nil, common.GetTypeAssertError("float64", response[6], "Ticker.Data.Last")
 	}
 	if t.Volume, ok = response[7].(float64); !ok {
-		return nil, errors.New("unable to type assert volume")
+		return nil, common.GetTypeAssertError("float64", response[7], "Ticker.Data.Volume")
 	}
 	if t.High, ok = response[8].(float64); !ok {
-		return nil, errors.New("unable to type assert high")
+		return nil, common.GetTypeAssertError("float64", response[8], "Ticker.Data.High")
 	}
 	if t.Low, ok = response[9].(float64); !ok {
-		return nil, errors.New("unable to type assert low")
+		return nil, common.GetTypeAssertError("float64", response[9], "Ticker.Data.Low")
 	}
 	return &t, nil
 }

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -645,7 +645,10 @@ func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]*Ticker, erro
 			continue
 		}
 		if t, err := tickerFromResp(symbol, tickResp[1:]); err != nil {
-			tickErrs = common.AppendError(tickErrs, err)
+			// We get too frequent intermittent formatting errors from tALT2612:USD to treat them as errors
+			if !errors.Is(err, errTickerInvalidResp) {
+				tickErrs = common.AppendError(tickErrs, err)
+			}
 		} else {
 			tickers[symbol] = t
 		}

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -625,8 +625,8 @@ func (b *Bitfinex) GetDerivativeStatusInfo(ctx context.Context, keys, startTime,
 }
 
 // GetTickerBatch returns all supported ticker information
-func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]Ticker, error) {
-	var response [][]interface{}
+func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]*Ticker, error) {
+	var response [][]any
 
 	path := bitfinexAPIVersion2 + bitfinexTickerBatch +
 		"?symbols=ALL"
@@ -636,106 +636,26 @@ func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]Ticker, error
 		return nil, err
 	}
 
-	var tickers = make(map[string]Ticker)
-	for x := range response {
-		symbol, ok := response[x][0].(string)
+	var tickErrs error
+	var tickers = make(map[string]*Ticker)
+	for _, tickResp := range response {
+		symbol, ok := tickResp[0].(string)
 		if !ok {
-			return nil, common.GetTypeAssertError("string", response[x][0], "Ticker.Symbol")
-		}
-
-		var t Ticker
-		if len(response[x]) > 11 {
-			if t.FlashReturnRate, ok = response[x][1].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][1], "Ticker.Data.FlashReturnRate")
-			}
-			if t.Bid, ok = response[x][2].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][2], "Ticker.Data.Bid")
-			}
-			var bidPeriod float64
-			bidPeriod, ok = response[x][3].(float64)
-			if !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][3], "Ticker.Data.BidPeriod")
-			}
-			t.BidPeriod = int64(bidPeriod)
-			if t.BidSize, ok = response[x][4].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][4], "Ticker.Data.BidSize")
-			}
-			if t.Ask, ok = response[x][5].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][5], "Ticker.Data.Ask")
-			}
-			var askPeriod float64
-			askPeriod, ok = response[x][6].(float64)
-			if !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][6], "Ticker.Data.AskPeriod")
-			}
-			t.AskPeriod = int64(askPeriod)
-			if t.AskSize, ok = response[x][7].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][7], "Ticker.Data.AskSize")
-			}
-			if t.DailyChange, ok = response[x][8].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][8], "Ticker.Data.DailyChange")
-			}
-			if t.DailyChangePerc, ok = response[x][9].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][9], "Ticker.Data.DailyChangePercentage")
-			}
-			if t.Last, ok = response[x][10].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][10], "Ticker.Data.LastPrice")
-			}
-			if t.Volume, ok = response[x][11].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][11], "Ticker.Data.DailyVolume")
-			}
-			if t.High, ok = response[x][12].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][12], "Ticker.Data.DailyHigh")
-			}
-			if t.Low, ok = response[x][13].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][13], "Ticker.Data.DailyLow")
-			}
-			if t.FFRAmountAvailable, ok = response[x][16].(float64); !ok {
-				return nil, common.GetTypeAssertError("float64", response[x][16], "Ticker.Data.FFRAmountAvailable")
-			}
-
-			tickers[symbol] = t
+			tickErrs = common.AppendError(tickErrs, fmt.Errorf("%w: %v", errTickerInvalidSymbol, symbol))
 			continue
 		}
-
-		if t.Bid, ok = response[x][1].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][1], "Tickers.Symbol.Bid")
+		if t, err := tickerFromResp(symbol, tickResp[1:]); err != nil {
+			tickErrs = common.AppendError(tickErrs, err)
+		} else {
+			tickers[symbol] = t
 		}
-		if t.BidSize, ok = response[x][2].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][2], "Tickers.Symbol.BidSize")
-		}
-		if t.Ask, ok = response[x][3].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][3], "Tickers.Symbol.Ask")
-		}
-		if t.AskSize, ok = response[x][4].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][4], "Tickers.Symbol.AskSize")
-		}
-		if t.DailyChange, ok = response[x][5].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][5], "Tickers.Symbol.DailyChange")
-		}
-		if t.DailyChangePerc, ok = response[x][6].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][6], "Tickers.Symbol.DailyChangeRelative")
-		}
-		if t.Last, ok = response[x][7].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][7], "Tickers.Symbol.LastPrice")
-		}
-		if t.Volume, ok = response[x][8].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][8], "Tickers.Symbol.DailyVolume")
-		}
-		if t.High, ok = response[x][9].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][9], "Tickers.Symbol.DailyHigh")
-		}
-		if t.Low, ok = response[x][10].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[x][10], "Tickers.Symbol.DailyLow")
-		}
-		tickers[symbol] = t
 	}
-	return tickers, nil
+	return tickers, tickErrs
 }
 
 // GetTicker returns ticker information for one symbol
 func (b *Bitfinex) GetTicker(ctx context.Context, symbol string) (*Ticker, error) {
-	var response []interface{}
+	var response []any
 
 	path := bitfinexAPIVersion2 + bitfinexTicker + symbol
 
@@ -744,92 +664,77 @@ func (b *Bitfinex) GetTicker(ctx context.Context, symbol string) (*Ticker, error
 		return nil, err
 	}
 
-	var t Ticker
-	if len(response) > 10 {
-		var ok bool
-		if t.FlashReturnRate, ok = response[0].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[0], "Ticker.Data.FlashReturnRate")
-		}
-		if t.Bid, ok = response[1].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[1], "Ticker.Data.Bid")
-		}
-		var bidPeriodF float64
-		bidPeriodF, ok = response[2].(float64)
-		if !ok {
-			return nil, common.GetTypeAssertError("float64", response[2], "Ticker.Data.BidPeriod")
-		}
-		t.BidPeriod = int64(bidPeriodF)
-		if t.BidSize, ok = response[3].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[3], "Ticker.Data.BidSize")
-		}
-		if t.Ask, ok = response[4].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[4], "Ticker.Data.Ask")
-		}
-		var askPeriodF float64
-		askPeriodF, ok = response[5].(float64)
-		if !ok {
-			return nil, common.GetTypeAssertError("float64", response[5], "Ticker.Data.AskPeriod")
-		}
-		t.AskPeriod = int64(askPeriodF)
-		if t.AskSize, ok = response[6].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[6], "Ticker.Data.AskSize")
-		}
-		if t.DailyChange, ok = response[7].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[7], "Ticker.Data.DailyChange")
-		}
-		if t.DailyChangePerc, ok = response[8].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[8], "Ticker.Data.DailyChangePerc")
-		}
-		if t.Last, ok = response[9].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[9], "Ticker.Data.Last")
-		}
-		if t.Volume, ok = response[10].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[10], "Ticker.Data.Volume")
-		}
-		if t.High, ok = response[11].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[11], "Ticker.Data.High")
-		}
-		if t.Low, ok = response[12].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[12], "Ticker.Data.Low")
-		}
-		if t.FFRAmountAvailable, ok = response[15].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", response[15], "Ticker.Data.FFRAmountAvailable")
-		}
-		return &t, nil
+	t, err := tickerFromResp(symbol, response)
+	if err != nil {
+		return nil, err
 	}
+	return t, nil
+}
 
-	var ok bool
-	if t.Bid, ok = response[0].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[0], "Ticker.Data.Bid")
+var tickerFields = []string{"Bid", "BidSize", "Ask", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow"}
+
+func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
+	if strings.HasPrefix(symbol, "f") {
+		return tickerFromFundingResp(symbol, respAny)
 	}
-	if t.BidSize, ok = response[1].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[1], "Ticker.Data.BidSize")
+	if len(respAny) != 10 {
+		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
 	}
-	if t.Ask, ok = response[2].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[2], "Ticker.Data.Ask")
+	resp := make([]float64, 10)
+	for i := range respAny {
+		f, ok := respAny[i].(float64)
+		if !ok {
+			return nil, fmt.Errorf("%w for %s field %s from %v", errTickerInvalidResp, symbol, tickerFields[i], respAny)
+		}
+		resp[i] = f
 	}
-	if t.AskSize, ok = response[3].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[3], "Ticker.Data.AskSize")
+	return &Ticker{
+		Bid:             resp[0],
+		BidSize:         resp[1],
+		Ask:             resp[2],
+		AskSize:         resp[3],
+		DailyChange:     resp[4],
+		DailyChangePerc: resp[5],
+		Last:            resp[6],
+		Volume:          resp[7],
+		High:            resp[8],
+		Low:             resp[9],
+	}, nil
+}
+
+var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FFRAmountAvailable"}
+
+func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
+	if len(respAny) != 16 {
+		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
 	}
-	if t.DailyChange, ok = response[4].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[4], "Ticker.Data.DailyChange")
+	resp := make([]float64, 16)
+	for i := range respAny {
+		if fundingTickerFields[i] == "" { // Unused nil fields
+			continue
+		}
+		f, ok := respAny[i].(float64)
+		if !ok {
+			return nil, fmt.Errorf("%w for %s field %s from %v", errTickerInvalidResp, symbol, fundingTickerFields[i], respAny)
+		}
+		resp[i] = f
 	}
-	if t.DailyChangePerc, ok = response[5].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[5], "Ticker.Data.DailyChangePerc")
-	}
-	if t.Last, ok = response[6].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[6], "Ticker.Data.Last")
-	}
-	if t.Volume, ok = response[7].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[7], "Ticker.Data.Volume")
-	}
-	if t.High, ok = response[8].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[8], "Ticker.Data.High")
-	}
-	if t.Low, ok = response[9].(float64); !ok {
-		return nil, common.GetTypeAssertError("float64", response[9], "Ticker.Data.Low")
-	}
-	return &t, nil
+	return &Ticker{
+		FlashReturnRate:    resp[0],
+		Bid:                resp[1],
+		BidPeriod:          int64(resp[2]),
+		BidSize:            resp[3],
+		Ask:                resp[4],
+		AskPeriod:          int64(resp[5]),
+		AskSize:            resp[6],
+		DailyChange:        resp[7],
+		DailyChangePerc:    resp[8],
+		Last:               resp[9],
+		Volume:             resp[10],
+		High:               resp[11],
+		Low:                resp[12],
+		FFRAmountAvailable: resp[15],
+	}, nil
 }
 
 // GetTrades gets historic trades that occurred on the exchange

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -243,10 +243,7 @@ func TestGetPlatformStatus(t *testing.T) {
 func TestGetTickerBatch(t *testing.T) {
 	t.Parallel()
 	ticks, err := b.GetTickerBatch(context.Background())
-	// Exclude TickerInvalidResp because Bitfinex is intermittently sending invalid formats for tALT2612:USD
-	// Error handling for that is covered in TestTickerFromResp
-	// Ensuring that in general the tickers are sane is handled below by specifically testing tBTCUSD and fUSD
-	require.NoError(t, common.ExcludeError(err, errTickerInvalidResp), "GetTickerBatch may only error about bad response formats")
+	require.NoError(t, err, "GetTickerBatch should not error")
 	require.NotEmpty(t, ticks, "GetTickerBatch should return some ticks")
 	require.Contains(t, ticks, "tBTCUSD", "Ticker batch must contain tBTCUSD")
 	checkTradeTick(t, ticks["tBTCUSD"])

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/core"
@@ -242,22 +243,16 @@ func TestGetPlatformStatus(t *testing.T) {
 func TestGetTickerBatch(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetTickerBatch(context.Background())
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "GetTickerBatch should not error")
 }
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetTicker(context.Background(), "tBTCUSD")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "GetTicker should not error")
 
 	_, err = b.GetTicker(context.Background(), "fUSD")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "GetTicker should not error")
 }
 
 func TestGetTrades(t *testing.T) {
@@ -478,9 +473,8 @@ func TestNewOrder(t *testing.T) {
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 
-	if _, err := b.UpdateTicker(context.Background(), btcusdPair, asset.Spot); err != nil {
-		t.Error(err)
-	}
+	_, err := b.UpdateTicker(context.Background(), btcusdPair, asset.Spot)
+	assert.NoError(t, err, "UpdateTicker should not error")
 }
 
 func TestUpdateTickers(t *testing.T) {
@@ -491,13 +485,13 @@ func TestUpdateTickers(t *testing.T) {
 	assets := b.GetAssetTypes(false)
 	for _, a := range assets {
 		avail, err := b.GetAvailablePairs(a)
-		assert.NoError(t, err, "GetAvailablePairs should not error")
+		require.NoError(t, err, "GetAvailablePairs should not error")
 
 		err = b.CurrencyPairs.StorePairs(a, avail, true)
-		assert.NoError(t, err, "StorePairs should not error")
+		require.NoError(t, err, "StorePairs should not error")
 
 		err = b.UpdateTickers(context.Background(), a)
-		assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
+		require.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 
 		// Bitfinex leaves delisted pairs in Available info/conf endpoints
 		// We want to assert that most pairs are valid, so we'll check that no more than 5% are erroring
@@ -512,7 +506,7 @@ func TestUpdateTickers(t *testing.T) {
 			}
 		}
 		if !assert.Greater(t, okay/float64(len(avail))*100.0, acceptableThreshold, "At least %.f%% of %s tickers should not error", acceptableThreshold, a) {
-			t.Log(errs.Error())
+			assert.NoError(t, errs, "Collection of all the ticker errors")
 		}
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -565,7 +565,7 @@ func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 
 	_, err := b.UpdateTicker(context.Background(), btcusdPair, asset.Spot)
-	assert.NoError(t, err, "UpdateTicker should not error")
+	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTicker may only error about locked markets")
 }
 
 func TestUpdateTickers(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -11,12 +11,14 @@ import (
 )
 
 var (
-	errSetCannotBeEmpty = errors.New("set cannot be empty")
-	errTypeAssert       = errors.New("type assertion failed")
-	errNoSeqNo          = errors.New("no sequence number")
-	errUnknownError     = errors.New("unknown error")
-	errParamNotAllowed  = errors.New("param not allowed")
-	errParsingWSField   = errors.New("error parsing WS field")
+	errSetCannotBeEmpty        = errors.New("set cannot be empty")
+	errNoSeqNo                 = errors.New("no sequence number")
+	errUnknownError            = errors.New("unknown error")
+	errParamNotAllowed         = errors.New("param not allowed")
+	errParsingWSField          = errors.New("error parsing WS field")
+	errTickerInvalidSymbol     = errors.New("invalid ticker symbol")
+	errTickerInvalidResp       = errors.New("invalid ticker response format")
+	errTickerInvalidFieldCount = errors.New("invalid ticker response field count")
 )
 
 // AccountV2Data stores account v2 data


### PR DESCRIPTION
* Handle Errors in tickers without panic
* Refactor and improve ticker handling
* Unify Ticker response handling
* Simplify/Humanify errors in parsing ticker responses
* Remove polymorphic response handling for < 10 fields, seems [antiquated according to docs](https://docs.bitfinex.com/reference/rest-public-ticker)
* Add test coverage for tickers

Panic was on using `err.Error()` when no errors were collected:
```
=== NAME  TestUpdateTickers
    bitfinex_test.go:508:
                Error Trace:    /Users/gbjk/go/src/github.com/gbjk/gocryptotrader/exchanges/bitfinex/bitfinex_test.go:508
                Error:          Can not compare type "float64"
                Test:           TestUpdateTickers
                Messages:       At least 95% of marginfunding tickers should not error
--- FAIL: TestUpdateTickers (15.08s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1011c0d84]

goroutine 68 [running]:
testing.tRunner.func1.2({0x1013f90e0, 0x1018ed2a0})
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1545 +0x274
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1548 +0x448
panic({0x1013f90e0?, 0x1018ed2a0?})
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/runtime/panic.go:920 +0x26c
github.com/thrasher-corp/gocryptotrader/exchanges/bitfinex.TestUpdateTickers(0xc0002b8d00)
        /Users/gbjk/go/src/github.com/gbjk/gocryptotrader/exchanges/bitfinex/bitfinex_test.go:509 +0x314
testing.tRunner(0xc0002b8d00, 0x1014a2d88)
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0x198
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x5dc
FAIL    github.com/thrasher-corp/gocryptotrader/exchanges/bitfinex      21.009s
FAIL
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
