### PR TITLE
gRPC GW: bug fix http server Handler not set mux

### DIFF
--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -200,6 +200,7 @@ func (s *RPCServer) StartRPCRESTProxy() {
 			Addr:              s.Config.RemoteControl.GRPC.GRPCProxyListenAddress,
 			ReadHeaderTimeout: time.Minute,
 			ReadTimeout:       time.Minute,
+			Handler:           mux,
 		}
 
 		if err = server.ListenAndServe(); err != nil {


### PR DESCRIPTION
# PR Description
// engine/rpcserver.go
```go
199: server := &http.Server{
          Addr:              s.Config.RemoteControl.GRPC.GRPCProxyListenAddress,
          ReadHeaderTimeout: time.Minute,
          ReadTimeout:       time.Minute,
          Handler:           mux,
        }
```