### PR TITLE
engine/gRPC proxy: Fix mux regression and add test coverage

### DIFF
--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -108,7 +108,7 @@ func (bot *Engine) GetRPCEndpoints() (map[string]RPCEndpoint, error) {
 		},
 		grpcProxyName: {
 			Started:    bot.Settings.EnableGRPCProxy,
-			ListenAddr: "http://" + bot.Config.RemoteControl.GRPC.GRPCProxyListenAddress,
+			ListenAddr: "https://" + bot.Config.RemoteControl.GRPC.GRPCProxyListenAddress,
 		},
 		DeprecatedName: {
 			Started:    bot.Settings.EnableDeprecatedRPC,

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -220,6 +220,7 @@ func (s *RPCServer) authClient(handler http.Handler) http.Handler {
 		if !ok || username != s.Config.RemoteControl.Username || password != s.Config.RemoteControl.Password {
 			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
 			http.Error(w, "Access denied", http.StatusUnauthorized)
+			log.Warnf(log.GRPCSys, "gRPC proxy server unauthorised access attempt. IP: %s Path: %s\n", r.RemoteAddr, r.URL.Path)
 			return
 		}
 		handler.ServeHTTP(w, r)

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -172,12 +172,14 @@ func StartRPCServer(engine *Engine) {
 
 // StartRPCRESTProxy starts a gRPC proxy
 func (s *RPCServer) StartRPCRESTProxy() {
-	log.Debugf(log.GRPCSys, "gRPC proxy server support enabled. Starting gRPC proxy server on http://%v.\n", s.Config.RemoteControl.GRPC.GRPCProxyListenAddress)
+	log.Debugf(log.GRPCSys, "gRPC proxy server support enabled. Starting gRPC proxy server on https://%v.\n", s.Config.RemoteControl.GRPC.GRPCProxyListenAddress)
 
 	targetDir := utils.GetTLSDir(s.Settings.DataDir)
-	creds, err := credentials.NewClientTLSFromFile(filepath.Join(targetDir, "cert.pem"), "")
+	certFile := filepath.Join(targetDir, "cert.pem")
+	keyFile := filepath.Join(targetDir, "key.pem")
+	creds, err := credentials.NewClientTLSFromFile(certFile, "")
 	if err != nil {
-		log.Errorf(log.GRPCSys, "Unabled to start gRPC proxy. Err: %s\n", err)
+		log.Errorf(log.GRPCSys, "Unable to start gRPC proxy. Err: %s\n", err)
 		return
 	}
 
@@ -200,14 +202,28 @@ func (s *RPCServer) StartRPCRESTProxy() {
 			Addr:              s.Config.RemoteControl.GRPC.GRPCProxyListenAddress,
 			ReadHeaderTimeout: time.Minute,
 			ReadTimeout:       time.Minute,
+			Handler:           s.authClient(mux),
 		}
 
-		if err = server.ListenAndServe(); err != nil {
-			log.Errorf(log.GRPCSys, "GRPC proxy failed to server: %s\n", err)
+		if err = server.ListenAndServeTLS(certFile, keyFile); err != nil {
+			log.Errorf(log.GRPCSys, "gRPC proxy server failed to serve: %s\n", err)
+			return
 		}
 	}()
 
 	log.Debugln(log.GRPCSys, "gRPC proxy server started!")
+}
+
+func (s *RPCServer) authClient(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != s.Config.RemoteControl.Username || password != s.Config.RemoteControl.Password {
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
+			http.Error(w, "Access denied", http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
 }
 
 // GetInfo returns info about the current GoCryptoTrader session

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -51,7 +52,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/gctrpc"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/banking"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
-	"github.com/thrasher-corp/gocryptotrader/utils"
 	"github.com/thrasher-corp/goose"
 	"google.golang.org/grpc/metadata"
 )
@@ -4152,6 +4152,17 @@ func TestGetOpenInterest(t *testing.T) {
 func TestStartRPCRESTProxy(t *testing.T) {
 	t.Parallel()
 
+	tempDir := filepath.Join(os.TempDir(), "gct-grpc-proxy-test")
+	tempDirTLS := filepath.Join(tempDir, "tls")
+
+	t.Cleanup(func() {
+		assert.NoErrorf(t, os.RemoveAll(tempDir), "RemoveAll should not error, manual directory deletion required for TempDir: %s", tempDir)
+	})
+
+	if !assert.NoError(t, genCert(tempDirTLS), "genCert should not error") {
+		t.FailNow()
+	}
+
 	gRPCPort := rand.Intn(65535-42069) + 42069 //nolint:gosec // Don't require crypto/rand usage here
 	gRPCProxyPort := gRPCPort + 1
 
@@ -4168,7 +4179,7 @@ func TestStartRPCRESTProxy(t *testing.T) {
 			},
 		},
 		Settings: Settings{
-			DataDir:      common.GetDefaultDataDir(""),
+			DataDir:      tempDir,
 			CoreSettings: CoreSettings{EnableGRPCProxy: true},
 		},
 	}
@@ -4181,9 +4192,7 @@ func TestStartRPCRESTProxy(t *testing.T) {
 	// Give the proxy time to start
 	time.Sleep(time.Millisecond * 500)
 
-	targetDir := utils.GetTLSDir(common.GetDefaultDataDir(""))
-	certFile := filepath.Join(targetDir, "cert.pem")
-
+	certFile := filepath.Join(tempDirTLS, "cert.pem")
 	caCert, err := os.ReadFile(certFile)
 	require.NoError(t, err, "ReadFile should not error")
 	caCertPool := x509.NewCertPool()
@@ -4191,20 +4200,43 @@ func TestStartRPCRESTProxy(t *testing.T) {
 	require.True(t, ok, "AppendCertsFromPEM should return true")
 	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12}}}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost:"+strconv.Itoa(gRPCProxyPort)+"/v1/getinfo", http.NoBody)
-	require.NoError(t, err, "NewRequestWithContext should not error")
-	req.SetBasicAuth("bobmarley", "Sup3rdup3rS3cr3t")
-	resp, err := client.Do(req)
-	require.NoError(t, err, "Do should not error")
-	defer resp.Body.Close()
+	for _, creds := range []struct {
+		testDescription string
+		username        string
+		password        string
+	}{
+		{"Valid credentials", "bobmarley", "Sup3rdup3rS3cr3t"},
+		{"Valid username but invalid password", "bobmarley", "wrongpass"},
+		{"Invalid username but valid password", "bonk", "Sup3rdup3rS3cr3t"},
+		{"Invalid username and password despite glorious credentials", "bonk", "wif"},
+	} {
+		creds := creds
+		t.Run(creds.testDescription, func(t *testing.T) {
+			t.Parallel()
 
-	var info gctrpc.GetInfoResponse
-	err = json.NewDecoder(resp.Body).Decode(&info)
-	require.NoError(t, err, "Decode should not error")
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost:"+strconv.Itoa(gRPCProxyPort)+"/v1/getinfo", http.NoBody)
+			require.NoError(t, err, "NewRequestWithContext should not error")
+			req.SetBasicAuth(creds.username, creds.password)
+			resp, err := client.Do(req)
+			require.NoError(t, err, "Do should not error")
+			defer resp.Body.Close()
 
-	uptimeDuration, err := time.ParseDuration(info.Uptime)
-	require.NoError(t, err, "ParseDuration should not error")
-	assert.InDelta(t, time.Since(fakeTime).Seconds(), uptimeDuration.Seconds(), 1.0, "Uptime should be within 1 second of the expected duration")
+			if creds.username == "bobmarley" && creds.password == "Sup3rdup3rS3cr3t" {
+				var info gctrpc.GetInfoResponse
+				err = json.NewDecoder(resp.Body).Decode(&info)
+				require.NoError(t, err, "Decode should not error")
+
+				uptimeDuration, err := time.ParseDuration(info.Uptime)
+				require.NoError(t, err, "ParseDuration should not error")
+				assert.InDelta(t, time.Since(fakeTime).Seconds(), uptimeDuration.Seconds(), 1.0, "Uptime should be within 1 second of the expected duration")
+			} else {
+				respBody, err := io.ReadAll(resp.Body)
+				require.NoError(t, err, "ReadAll should not error")
+				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "HTTP status code should be 401")
+				assert.Equal(t, "Access denied\n", string(respBody), "Response body should be 'Access denied\n'")
+			}
+		})
+	}
 }
 
 func TestRPCProxyAuthClient(t *testing.T) {
@@ -4226,21 +4258,35 @@ func TestRPCProxyAuthClient(t *testing.T) {
 		require.NoError(t, err, "Write should not error")
 	})
 
-	rr := httptest.NewRecorder()
 	handler := s.authClient(dummyHandler)
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	require.NoError(t, err, "NewRequestWithContext should not error")
 
-	// Test with valid credentials
-	req.SetBasicAuth("bobmarley", "Sup3rdup3rS3cr3t")
-	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusOK, rr.Code, "HTTP status code should be 200")
-	assert.Equal(t, "MEOW", rr.Body.String(), "Response body should be 'MEOW'")
+	for _, creds := range []struct {
+		testDescription string
+		username        string
+		password        string
+	}{
+		{"Valid credentials", "bobmarley", "Sup3rdup3rS3cr3t"},
+		{"Valid username but invalid password", "bobmarley", "wrongpass"},
+		{"Invalid username but valid password", "bonk", "Sup3rdup3rS3cr3t"},
+		{"Invalid username and password despite glorious credentials", "bonk", "wif"},
+	} {
+		creds := creds
+		t.Run(creds.testDescription, func(t *testing.T) {
+			t.Parallel()
 
-	// Test with wrong credentials
-	req.SetBasicAuth("wronguser", "wrongpass")
-	rr = httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusUnauthorized, rr.Code, "HTTP status code should be 401")
-	assert.Equal(t, "Access denied\n", rr.Body.String(), "Response body should be 'Access denied\n'")
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+			require.NoError(t, err, "NewRequestWithContext should not error")
+			req.SetBasicAuth(creds.username, creds.password)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if creds.username == "bobmarley" && creds.password == "Sup3rdup3rS3cr3t" {
+				assert.Equal(t, http.StatusOK, rr.Code, "HTTP status code should be 200")
+				assert.Equal(t, "MEOW", rr.Body.String(), "Response body should be 'MEOW'")
+			} else {
+				assert.Equal(t, http.StatusUnauthorized, rr.Code, "HTTP status code should be 401")
+				assert.Equal(t, "Access denied\n", rr.Body.String(), "Response body should be 'Access denied\n'")
+			}
+		})
+	}
 }


### PR DESCRIPTION
# PR Description

A user spotted a regression in Slack that the mux wasn't set for the gRPC proxy handler. This PR adds it back and adds test coverage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
