### PR TITLE
Websockets: Fix subscription failure on reconnect

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -270,6 +270,8 @@ func (w *Websocket) Connect() error {
 			w.exchangeName)
 	}
 
+	w.subscriptions = subscriptionMap{}
+
 	w.dataMonitor()
 	w.trafficMonitor()
 	w.setConnectingStatus(true)


### PR DESCRIPTION
If a websocket is disconnected then the subscription map was left with old subscriptions, causing:
`Okx websocket: subscription failure, channel already subscribed for ...`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run