### PR TITLE
Binance: Fix UpdateOrderExecutionLimits margin test

### DIFF
--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -44,13 +44,13 @@ type ExchangeInfo struct {
 	Msg        string    `json:"msg"`
 	Timezone   string    `json:"timezone"`
 	ServerTime time.Time `json:"serverTime"`
-	RateLimits []struct {
+	RateLimits []*struct {
 		RateLimitType string `json:"rateLimitType"`
 		Interval      string `json:"interval"`
 		Limit         int    `json:"limit"`
 	} `json:"rateLimits"`
 	ExchangeFilters interface{} `json:"exchangeFilters"`
-	Symbols         []struct {
+	Symbols         []*struct {
 		Symbol                     string        `json:"symbol"`
 		Status                     string        `json:"status"`
 		BaseAsset                  string        `json:"baseAsset"`

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1894,17 +1894,13 @@ func (b *Binance) UpdateOrderExecutionLimits(ctx context.Context, a asset.Item) 
 	var err error
 	switch a {
 	case asset.Spot:
-		limits, err = b.FetchSpotExchangeLimits(ctx)
+		limits, err = b.FetchExchangeLimits(ctx, asset.Spot)
 	case asset.USDTMarginedFutures:
 		limits, err = b.FetchUSDTMarginExchangeLimits(ctx)
 	case asset.CoinMarginedFutures:
 		limits, err = b.FetchCoinMarginExchangeLimits(ctx)
 	case asset.Margin:
-		if err = b.CurrencyPairs.IsAssetEnabled(asset.Spot); err != nil {
-			limits, err = b.FetchSpotExchangeLimits(ctx)
-		} else {
-			return nil
-		}
+		limits, err = b.FetchExchangeLimits(ctx, asset.Margin)
 	default:
 		err = fmt.Errorf("%w %v", asset.ErrNotSupported, a)
 	}

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -204,7 +204,7 @@ func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
 	st, err := b.GetServerTime(context.Background(), asset.Spot)
 	assert.NoError(t, err, "GetServerTime should not error")
-	assert.WithinRange(t, st, time.Now().Add(-24*time.Hour), time.Now().Add(24*time.Hour), "Time should be within a day of what now")
+	assert.WithinRange(t, st, time.Now().Add(-24*time.Hour), time.Now().Add(24*time.Hour), "Time should be within a day of now")
 }
 
 func TestGetWalletInformation(t *testing.T) {


### PR DESCRIPTION
Calls for limits for margin asset were not doing anything if spot is enabled.
This caused intermittent test failures when the sequence meant margin was tested before spot, since the limits wouldn't be loaded.

But it also highlighted that API users calling Update Limits for margin outside the context of a loop on all assets would not get an update. Also intermittently when the loop of UpdateLimits on assets puts margin first

The unfortunate side to this is that we can't avoid having to hit the API twice, because UpdateOrderExecutionLimits can never know if it's being called in isolation or not. Caching could fix that, but it'd be a new paradigm in this context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run