### PR TITLE
Websocket: Various refactors and test improvements

### DIFF
--- a/cmd/exchange_template/wrapper_file.tmpl
+++ b/cmd/exchange_template/wrapper_file.tmpl
@@ -125,7 +125,7 @@ func ({{.Variable}} *{{.CapitalName}}) SetDefaults() {
 		exchange.RestSpot:  {{.Name}}APIURL,
 		// exchange.WebsocketSpot: {{.Name}}WSAPIURL,
 	})
-	{{.Variable}}.Websocket = stream.New()
+	{{.Variable}}.Websocket = stream.NewWebsocket()
 	{{.Variable}}.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	{{.Variable}}.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	{{.Variable}}.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -293,7 +293,7 @@ func TestRegisterWebsocketDataHandlerWithFunctionality(t *testing.T) {
 		t.Fatal("unexpected data handlers registered")
 	}
 
-	mock := stream.New()
+	mock := stream.NewWebsocket()
 	mock.ToRoutine = make(chan interface{})
 	m.state = readyState
 	err = m.websocketDataReceiver(mock)

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -50,7 +50,7 @@ var (
 // WsConnect initiates a websocket connection
 func (b *Binance) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 
 	var dialer websocket.Dialer

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -238,7 +238,7 @@ func (b *Binance) SetDefaults() {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 }

--- a/exchanges/binanceus/binanceus_websocket.go
+++ b/exchanges/binanceus/binanceus_websocket.go
@@ -45,7 +45,7 @@ var (
 // WsConnect initiates a websocket connection
 func (bi *Binanceus) WsConnect() error {
 	if !bi.Websocket.IsEnabled() || !bi.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	dialer.HandshakeTimeout = bi.Config.HTTPTimeout

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -162,7 +162,7 @@ func (bi *Binanceus) SetDefaults() {
 			"%s setting default endpoints error %v",
 			bi.Name, err)
 	}
-	bi.Websocket = stream.New()
+	bi.Websocket = stream.NewWebsocket()
 	bi.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	bi.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	bi.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1128,7 +1128,7 @@ func TestGetDepositAddress(t *testing.T) {
 // TestWsAuth dials websocket, sends login request.
 func TestWsAuth(t *testing.T) {
 	if !b.Websocket.IsEnabled() {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	if !b.API.AuthenticatedWebsocketSupport {

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -43,7 +43,7 @@ var cMtx sync.Mutex
 // WsConnect starts a new websocket connection
 func (b *Bitfinex) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -198,7 +198,7 @@ func (b *Bitfinex) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/bithumb/bithumb_websocket.go
+++ b/exchanges/bithumb/bithumb_websocket.go
@@ -2,7 +2,6 @@ package bithumb
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -29,7 +28,7 @@ var (
 // WsConnect initiates a websocket connection
 func (b *Bithumb) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 
 	var dialer websocket.Dialer

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -150,7 +150,7 @@ func (b *Bithumb) SetDefaults() {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 }

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -789,7 +789,7 @@ func TestGetDepositAddress(t *testing.T) {
 func TestWsAuth(t *testing.T) {
 	t.Parallel()
 	if !b.Websocket.IsEnabled() && !b.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(b) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -68,7 +68,7 @@ const (
 // WsConnect initiates a new websocket connection
 func (b *Bitmex) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -175,7 +175,7 @@ func (b *Bitmex) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -45,7 +45,7 @@ var (
 // WsConnect connects to a websocket feed
 func (b *Bitstamp) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -146,7 +146,7 @@ func (b *Bitstamp) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -39,7 +39,7 @@ var (
 // WsConnect connects to a websocket feed
 func (b *BTCMarkets) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -150,7 +150,7 @@ func (b *BTCMarkets) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -30,7 +30,7 @@ const (
 // WsConnect connects the websocket client
 func (b *BTSE) WsConnect() error {
 	if !b.Websocket.IsEnabled() || !b.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := b.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -176,7 +176,7 @@ func (b *BTSE) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	b.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	b.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -21,7 +21,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
-	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
 )
 
 // Bybit is the overarching type across this package
@@ -90,7 +89,6 @@ var (
 	errAPIKeyIsNotUnified                      = errors.New("api key is not unified")
 	errEndpointAvailableForNormalAPIKeyHolders = errors.New("endpoint available for normal API key holders only")
 	errInvalidContractLength                   = errors.New("contract length cannot be less than or equal to zero")
-	errWebsocketNotEnabled                     = errors.New(stream.WebsocketNotEnabled)
 )
 
 var (

--- a/exchanges/bybit/bybit_inverse_websocket.go
+++ b/exchanges/bybit/bybit_inverse_websocket.go
@@ -12,7 +12,7 @@ import (
 // WsInverseConnect connects to inverse websocket feed
 func (by *Bybit) WsInverseConnect() error {
 	if !by.Websocket.IsEnabled() || !by.IsEnabled() || !by.IsAssetWebsocketSupported(asset.CoinMarginedFutures) {
-		return errWebsocketNotEnabled
+		return stream.ErrWebsocketNotEnabled
 	}
 	by.Websocket.Conn.SetURL(inversePublic)
 	var dialer websocket.Dialer

--- a/exchanges/bybit/bybit_linear_websocket.go
+++ b/exchanges/bybit/bybit_linear_websocket.go
@@ -14,7 +14,7 @@ import (
 // WsLinearConnect connects to linear a websocket feed
 func (by *Bybit) WsLinearConnect() error {
 	if !by.Websocket.IsEnabled() || !by.IsEnabled() || !by.IsAssetWebsocketSupported(asset.LinearContract) {
-		return errWebsocketNotEnabled
+		return stream.ErrWebsocketNotEnabled
 	}
 	by.Websocket.Conn.SetURL(linearPublic)
 	var dialer websocket.Dialer

--- a/exchanges/bybit/bybit_options_websocket.go
+++ b/exchanges/bybit/bybit_options_websocket.go
@@ -14,7 +14,7 @@ import (
 // WsOptionsConnect connects to options a websocket feed
 func (by *Bybit) WsOptionsConnect() error {
 	if !by.Websocket.IsEnabled() || !by.IsEnabled() || !by.IsAssetWebsocketSupported(asset.Options) {
-		return errWebsocketNotEnabled
+		return stream.ErrWebsocketNotEnabled
 	}
 	by.Websocket.Conn.SetURL(optionPublic)
 	var dialer websocket.Dialer

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/margin"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
 )
 
@@ -3064,7 +3065,7 @@ func TestWsLinearConnect(t *testing.T) {
 		t.Skip(skippingWebsocketFunctionsForMockTesting)
 	}
 	err := b.WsLinearConnect()
-	if err != nil && !errors.Is(err, errWebsocketNotEnabled) {
+	if err != nil && !errors.Is(err, stream.ErrWebsocketNotEnabled) {
 		t.Error(err)
 	}
 }
@@ -3074,7 +3075,7 @@ func TestWsInverseConnect(t *testing.T) {
 		t.Skip(skippingWebsocketFunctionsForMockTesting)
 	}
 	err := b.WsInverseConnect()
-	if err != nil && !errors.Is(err, errWebsocketNotEnabled) {
+	if err != nil && !errors.Is(err, stream.ErrWebsocketNotEnabled) {
 		t.Error(err)
 	}
 }
@@ -3084,7 +3085,7 @@ func TestWsOptionsConnect(t *testing.T) {
 		t.Skip(skippingWebsocketFunctionsForMockTesting)
 	}
 	err := b.WsOptionsConnect()
-	if err != nil && !errors.Is(err, errWebsocketNotEnabled) {
+	if err != nil && !errors.Is(err, stream.ErrWebsocketNotEnabled) {
 		t.Error(err)
 	}
 }

--- a/exchanges/bybit/bybit_websocket.go
+++ b/exchanges/bybit/bybit_websocket.go
@@ -57,7 +57,7 @@ const (
 // WsConnect connects to a websocket feed
 func (by *Bybit) WsConnect() error {
 	if !by.Websocket.IsEnabled() || !by.IsEnabled() || !by.IsAssetWebsocketSupported(asset.Spot) {
-		return errWebsocketNotEnabled
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := by.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -216,7 +216,7 @@ func (by *Bybit) SetDefaults() {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
-	by.Websocket = stream.New()
+	by.Websocket = stream.NewWebsocket()
 	by.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	by.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	by.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -681,7 +681,7 @@ func TestGetDepositAddress(t *testing.T) {
 // TestWsAuth dials websocket, sends login request.
 func TestWsAuth(t *testing.T) {
 	if !c.Websocket.IsEnabled() && !c.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(c) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	var dialer websocket.Dialer
 	err := c.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -31,7 +31,7 @@ const (
 // WsConnect initiates a websocket connection
 func (c *CoinbasePro) WsConnect() error {
 	if !c.Websocket.IsEnabled() || !c.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := c.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -145,7 +145,7 @@ func (c *CoinbasePro) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	c.Websocket = stream.New()
+	c.Websocket = stream.NewWebsocket()
 	c.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	c.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	c.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -66,7 +66,7 @@ func setupWSTestAuth(t *testing.T) {
 	}
 
 	if !c.Websocket.IsEnabled() && !c.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(c) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	if sharedtestvalues.AreAPICredentialsSet(c) {
 		c.Websocket.SetCanUseAuthenticatedEndpoints(true)

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -41,7 +41,7 @@ var (
 // WsConnect initiates a websocket connection
 func (c *COINUT) WsConnect() error {
 	if !c.Websocket.IsEnabled() || !c.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := c.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -127,7 +127,7 @@ func (c *COINUT) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	c.Websocket = stream.New()
+	c.Websocket = stream.NewWebsocket()
 	c.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	c.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	c.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -198,7 +198,7 @@ func TestSetClientProxyAddress(t *testing.T) {
 		Name:      "rawr",
 		Requester: requester}
 
-	newBase.Websocket = stream.New()
+	newBase.Websocket = stream.NewWebsocket()
 	err = newBase.SetClientProxyAddress("")
 	if err != nil {
 		t.Error(err)
@@ -1251,7 +1251,7 @@ func TestSetupDefaults(t *testing.T) {
 	}
 
 	// Test websocket support
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	b.Features.Supports.Websocket = true
 	err = b.Websocket.Setup(&stream.WebsocketSetup{
 		ExchangeConfig: &config.Exchange{
@@ -1596,7 +1596,7 @@ func TestIsWebsocketEnabled(t *testing.T) {
 		t.Error("exchange doesn't support websocket")
 	}
 
-	b.Websocket = stream.New()
+	b.Websocket = stream.NewWebsocket()
 	err := b.Websocket.Setup(&stream.WebsocketSetup{
 		ExchangeConfig: &config.Exchange{
 			Enabled:                 true,

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -60,7 +60,7 @@ var fetchedCurrencyPairSnapshotOrderbook = make(map[string]bool)
 // WsConnect initiates a websocket connection
 func (g *Gateio) WsConnect() error {
 	if !g.Websocket.IsEnabled() || !g.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	err := g.CurrencyPairs.IsAssetEnabled(asset.Spot)
 	if err != nil {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -194,7 +194,7 @@ func (g *Gateio) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	g.Websocket = stream.New()
+	g.Websocket = stream.NewWebsocket()
 	g.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	g.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	g.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/gateio/gateio_ws_delivery_futures.go
+++ b/exchanges/gateio/gateio_ws_delivery_futures.go
@@ -45,7 +45,7 @@ var fetchedFuturesCurrencyPairSnapshotOrderbook = make(map[string]bool)
 // WsDeliveryFuturesConnect initiates a websocket connection for delivery futures account
 func (g *Gateio) WsDeliveryFuturesConnect() error {
 	if !g.Websocket.IsEnabled() || !g.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	err := g.CurrencyPairs.IsAssetEnabled(asset.DeliveryFutures)
 	if err != nil {

--- a/exchanges/gateio/gateio_ws_futures.go
+++ b/exchanges/gateio/gateio_ws_futures.go
@@ -64,7 +64,7 @@ var responseFuturesStream = make(chan stream.Response)
 // WsFuturesConnect initiates a websocket connection for futures account
 func (g *Gateio) WsFuturesConnect() error {
 	if !g.Websocket.IsEnabled() || !g.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	err := g.CurrencyPairs.IsAssetEnabled(asset.Futures)
 	if err != nil {

--- a/exchanges/gateio/gateio_ws_option.go
+++ b/exchanges/gateio/gateio_ws_option.go
@@ -70,7 +70,7 @@ var fetchedOptionsCurrencyPairSnapshotOrderbook = make(map[string]bool)
 // WsOptionsConnect initiates a websocket connection to options websocket endpoints.
 func (g *Gateio) WsOptionsConnect() error {
 	if !g.Websocket.IsEnabled() || !g.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	err := g.CurrencyPairs.IsAssetEnabled(asset.Options)
 	if err != nil {

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -556,7 +556,7 @@ func TestWsAuth(t *testing.T) {
 	if !g.Websocket.IsEnabled() &&
 		!g.API.AuthenticatedWebsocketSupport ||
 		!sharedtestvalues.AreAPICredentialsSet(g) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	var dialer websocket.Dialer
 	go g.wsReadData()

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -39,7 +39,7 @@ var comms = make(chan stream.Response)
 // WsConnect initiates a websocket connection
 func (g *Gemini) WsConnect() error {
 	if !g.Websocket.IsEnabled() || !g.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 
 	var dialer websocket.Dialer

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -128,7 +128,7 @@ func (g *Gemini) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	g.Websocket = stream.New()
+	g.Websocket = stream.NewWebsocket()
 	g.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	g.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	g.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -466,7 +466,7 @@ func setupWsAuth(t *testing.T) {
 		return
 	}
 	if !h.Websocket.IsEnabled() && !h.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(h) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 
 	var dialer websocket.Dialer

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -34,7 +34,7 @@ const (
 // WsConnect starts a new connection with the websocket API
 func (h *HitBTC) WsConnect() error {
 	if !h.Websocket.IsEnabled() || !h.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := h.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -147,7 +147,7 @@ func (h *HitBTC) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	h.Websocket = stream.New()
+	h.Websocket = stream.NewWebsocket()
 	h.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	h.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	h.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -78,7 +78,7 @@ func setupWsTests(t *testing.T) {
 		return
 	}
 	if !h.Websocket.IsEnabled() && !h.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(h) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	comms = make(chan WsMessage, sharedtestvalues.WebsocketChannelOverrideCapacity)
 	go h.wsReadData()

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -62,7 +62,7 @@ var comms = make(chan WsMessage)
 // WsConnect initiates a new websocket connection
 func (h *HUOBI) WsConnect() error {
 	if !h.Websocket.IsEnabled() || !h.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := h.wsDial(&dialer)

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -202,7 +202,7 @@ func (h *HUOBI) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	h.Websocket = stream.New()
+	h.Websocket = stream.NewWebsocket()
 	h.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	h.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	h.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1215,7 +1215,7 @@ func setupWsTests(t *testing.T) {
 		return
 	}
 	if !k.Websocket.IsEnabled() && !k.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(k) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	var dialer websocket.Dialer
 	err := k.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -87,7 +87,7 @@ var cancelOrdersStatus = make(map[int64]*struct {
 // WsConnect initiates a websocket connection
 func (k *Kraken) WsConnect() error {
 	if !k.Websocket.IsEnabled() || !k.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 
 	var dialer websocket.Dialer

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -209,7 +209,7 @@ func (k *Kraken) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	k.Websocket = stream.New()
+	k.Websocket = stream.NewWebsocket()
 	k.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	k.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	k.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -97,7 +97,7 @@ var (
 // WsConnect creates a new websocket connection.
 func (ku *Kucoin) WsConnect() error {
 	if !ku.Websocket.IsEnabled() || !ku.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	fetchedFuturesSnapshotOrderbook = map[string]bool{}
 	var dialer websocket.Dialer

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -195,7 +195,7 @@ func (ku *Kucoin) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	ku.Websocket = stream.New()
+	ku.Websocket = stream.NewWebsocket()
 	ku.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	ku.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	ku.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/okcoin/okcoin_websocket.go
+++ b/exchanges/okcoin/okcoin_websocket.go
@@ -74,7 +74,7 @@ func isAuthenticatedChannel(channel string) bool {
 // WsConnect initiates a websocket connection
 func (o *Okcoin) WsConnect() error {
 	if !o.Websocket.IsEnabled() || !o.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	dialer.ReadBufferSize = 8192

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -150,7 +150,7 @@ func (o *Okcoin) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	o.Websocket = stream.New()
+	o.Websocket = stream.NewWebsocket()
 	o.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	o.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	o.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/okcoin/okcoin_ws_trade.go
+++ b/exchanges/okcoin/okcoin_ws_trade.go
@@ -130,7 +130,7 @@ func (o *Okcoin) WsAmendMultipleOrder(args []AmendTradeOrderRequestParam) ([]Ame
 func (o *Okcoin) SendWebsocketRequest(operation string, data, result interface{}, authenticated bool) error {
 	switch {
 	case !o.Websocket.IsEnabled():
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	case !o.Websocket.IsConnected():
 		return stream.ErrNotConnected
 	case !o.Websocket.CanUseAuthenticatedEndpoints() && authenticated:

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -216,7 +216,7 @@ const (
 // WsConnect initiates a websocket connection
 func (ok *Okx) WsConnect() error {
 	if !ok.Websocket.IsEnabled() || !ok.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	dialer.ReadBufferSize = 8192

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -190,7 +190,7 @@ func (ok *Okx) SetDefaults() {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
-	ok.Websocket = stream.New()
+	ok.Websocket = stream.NewWebsocket()
 	ok.WebsocketResponseMaxLimit = okxWebsocketResponseMaxLimit
 	ok.WebsocketResponseCheckTimeout = okxWebsocketResponseMaxLimit
 	ok.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -548,7 +548,7 @@ func TestGenerateNewAddress(t *testing.T) {
 func TestWsAuth(t *testing.T) {
 	t.Parallel()
 	if !p.Websocket.IsEnabled() && !p.API.AuthenticatedWebsocketSupport || !sharedtestvalues.AreAPICredentialsSet(p) {
-		t.Skip(stream.WebsocketNotEnabled)
+		t.Skip(stream.ErrWebsocketNotEnabled.Error())
 	}
 	var dialer websocket.Dialer
 	err := p.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -55,7 +55,7 @@ var (
 // WsConnect initiates a websocket connection
 func (p *Poloniex) WsConnect() error {
 	if !p.Websocket.IsEnabled() || !p.IsEnabled() {
-		return errors.New(stream.WebsocketNotEnabled)
+		return stream.ErrWebsocketNotEnabled
 	}
 	var dialer websocket.Dialer
 	err := p.Websocket.Conn.Dial(&dialer, http.Header{})

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -159,7 +159,7 @@ func (p *Poloniex) SetDefaults() {
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}
-	p.Websocket = stream.New()
+	p.Websocket = stream.NewWebsocket()
 	p.WebsocketResponseMaxLimit = exchange.DefaultWebsocketResponseMaxLimit
 	p.WebsocketResponseCheckTimeout = exchange.DefaultWebsocketResponseCheckTimeout
 	p.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit

--- a/exchanges/sharedtestvalues/sharedtestvalues.go
+++ b/exchanges/sharedtestvalues/sharedtestvalues.go
@@ -57,7 +57,6 @@ func GetWebsocketStructChannelOverride() chan struct{} {
 // NewTestWebsocket returns a test websocket object
 func NewTestWebsocket() *stream.Websocket {
 	return &stream.Websocket{
-		Init:              true,
 		DataHandler:       make(chan interface{}, WebsocketChannelOverrideCapacity),
 		ToRoutine:         make(chan interface{}, 1000),
 		TrafficAlert:      make(chan struct{}),

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -477,10 +477,11 @@ func (w *Websocket) Shutdown() error {
 	w.subscriptions = subscriptionMap{}
 	w.subscriptionMutex.Unlock()
 
+	w.setState(disconnected)
+
 	close(w.ShutdownC)
 	w.Wg.Wait()
 	w.ShutdownC = make(chan struct{})
-	w.setState(disconnected)
 	if w.verbose {
 		log.Debugf(log.WebsocketMgr, "%v websocket: completed websocket shutdown", w.exchangeName)
 	}

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -24,24 +24,20 @@ const (
 	defaultTrafficPeriod = time.Second
 )
 
+// Public websocket errors
 var (
-	// ErrSubscriptionNotFound defines an error when a subscription is not found
-	ErrSubscriptionNotFound = errors.New("subscription not found")
-	// ErrSubscribedAlready defines an error when a channel is already subscribed
-	ErrSubscribedAlready = errors.New("duplicate subscription")
-	// ErrSubscriptionFailure defines an error when a subscription fails
-	ErrSubscriptionFailure = errors.New("subscription failure")
-	// ErrSubscriptionNotSupported defines an error when a subscription channel is not supported by an exchange
+	ErrWebsocketNotEnabled      = errors.New("websocket not enabled")
+	ErrSubscriptionNotFound     = errors.New("subscription not found")
+	ErrSubscribedAlready        = errors.New("duplicate subscription")
+	ErrSubscriptionFailure      = errors.New("subscription failure")
 	ErrSubscriptionNotSupported = errors.New("subscription channel not supported ")
-	// ErrUnsubscribeFailure defines an error when a unsubscribe fails
-	ErrUnsubscribeFailure = errors.New("unsubscribe failure")
-	// ErrChannelInStateAlready defines an error when a subscription channel is already in a new state
-	ErrChannelInStateAlready = errors.New("channel already in state")
-	// ErrAlreadyDisabled is returned when you double-disable the websocket
-	ErrAlreadyDisabled = errors.New("websocket already disabled")
-	// ErrNotConnected defines an error when websocket is not connected
-	ErrNotConnected = errors.New("websocket is not connected")
+	ErrUnsubscribeFailure       = errors.New("unsubscribe failure")
+	ErrChannelInStateAlready    = errors.New("channel already in state")
+	ErrAlreadyDisabled          = errors.New("websocket already disabled")
+	ErrNotConnected             = errors.New("websocket is not connected")
+)
 
+var (
 	errAlreadyRunning                       = errors.New("connection monitor is already running")
 	errExchangeConfigIsNil                  = errors.New("exchange config is nil")
 	errWebsocketIsNil                       = errors.New("websocket is nil")
@@ -265,7 +261,7 @@ func (w *Websocket) Connect() error {
 	defer w.m.Unlock()
 
 	if !w.IsEnabled() {
-		return errors.New(WebsocketNotEnabled)
+		return ErrWebsocketNotEnabled
 	}
 	if w.IsConnecting() {
 		return fmt.Errorf("%v %w", w.exchangeName, errAlreadyReconnecting)
@@ -490,7 +486,7 @@ func (w *Websocket) Shutdown() error {
 // FlushChannels flushes channel subscriptions when there is a pair/asset change
 func (w *Websocket) FlushChannels() error {
 	if !w.IsEnabled() {
-		return fmt.Errorf("%s websocket: service not enabled", w.exchangeName)
+		return fmt.Errorf("%s %w", w.exchangeName, ErrWebsocketNotEnabled)
 	}
 
 	if !w.IsConnected() {

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -78,7 +78,6 @@ func SetupGlobalReporter(r Reporter) {
 // New initialises the websocket struct
 func New() *Websocket {
 	return &Websocket{
-		Init:              true,
 		DataHandler:       make(chan interface{}, defaultJobBuffer),
 		ToRoutine:         make(chan interface{}, defaultJobBuffer),
 		TrafficAlert:      make(chan struct{}),
@@ -99,7 +98,7 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 		return errWebsocketSetupIsNil
 	}
 
-	if !w.Init {
+	if w.state != uninitialised {
 		return fmt.Errorf("%s %w", w.exchangeName, errWebsocketAlreadyInitialised)
 	}
 
@@ -613,7 +612,7 @@ func (w *Websocket) trafficMonitor() {
 
 func (w *Websocket) setConnectedStatus(b bool) {
 	w.fieldMutex.Lock()
-	w.connected = b
+	w.state = connected
 	w.fieldMutex.Unlock()
 }
 
@@ -621,12 +620,12 @@ func (w *Websocket) setConnectedStatus(b bool) {
 func (w *Websocket) IsConnected() bool {
 	w.fieldMutex.RLock()
 	defer w.fieldMutex.RUnlock()
-	return w.connected
+	return w.state == connected
 }
 
 func (w *Websocket) setConnectingStatus(b bool) {
 	w.fieldMutex.Lock()
-	w.connecting = b
+	w.state = connecting
 	w.fieldMutex.Unlock()
 }
 

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -103,6 +103,9 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 		return errWebsocketSetupIsNil
 	}
 
+	w.m.Lock()
+	defer w.m.Unlock()
+
 	if w.IsInitialised() {
 		return fmt.Errorf("%s %w", w.exchangeName, errWebsocketAlreadyInitialised)
 	}

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -272,7 +272,7 @@ func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
 	return standardMessage, reader.Close()
 }
 
-// GenerateMessageID Creates a messageID to checkout
+// GenerateMessageID Creates a random message ID
 func (w *WebsocketConnection) GenerateMessageID(highPrec bool) int64 {
 	var min int64 = 1e8
 	var max int64 = 2e8

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -50,9 +50,7 @@ func (w *WebsocketConnection) SendMessageReturnResponse(signature, request inter
 		return payload, nil
 	case <-timer.C:
 		timer.Stop()
-		return nil, fmt.Errorf("%s websocket connection: timeout waiting for response with signature: %v",
-			w.ExchangeName,
-			signature)
+		return nil, fmt.Errorf("%s websocket connection: timeout waiting for response with signature: %v", w.ExchangeName, signature)
 	}
 }
 
@@ -72,25 +70,14 @@ func (w *WebsocketConnection) Dial(dialer *websocket.Dialer, headers http.Header
 	w.Connection, conStatus, err = dialer.Dial(w.URL, headers)
 	if err != nil {
 		if conStatus != nil {
-			return fmt.Errorf("%s websocket connection: %v %v %v Error: %v",
-				w.ExchangeName,
-				w.URL,
-				conStatus,
-				conStatus.StatusCode,
-				err)
+			return fmt.Errorf("%s websocket connection: %v %v %v Error: %w", w.ExchangeName, w.URL, conStatus, conStatus.StatusCode, err)
 		}
-		return fmt.Errorf("%s websocket connection: %v Error: %v",
-			w.ExchangeName,
-			w.URL,
-			err)
+		return fmt.Errorf("%s websocket connection: %v Error: %w", w.ExchangeName, w.URL, err)
 	}
 	defer conStatus.Body.Close()
 
 	if w.Verbose {
-		log.Infof(log.WebsocketMgr,
-			"%v Websocket connected to %s\n",
-			w.ExchangeName,
-			w.URL)
+		log.Infof(log.WebsocketMgr, "%v Websocket connected to %s\n", w.ExchangeName, w.URL)
 	}
 	select {
 	case w.Traffic <- struct{}{}:

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -227,7 +227,7 @@ func (w *WebsocketConnection) ReadMessage() Response {
 
 	select {
 	case w.Traffic <- struct{}{}:
-	default: // causes contention, just bypass if there is no receiver.
+	default: // Non-Blocking write ensures 1 buffered signal per trafficCheckInterval to avoid flooding
 	}
 
 	var standardMessage []byte

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -801,13 +801,12 @@ func TestCanUseAuthenticatedWebsocketForWrapper(t *testing.T) {
 func TestGenerateMessageID(t *testing.T) {
 	t.Parallel()
 	wc := WebsocketConnection{}
-	var id int64
-	for i := 0; i < 10; i++ {
-		newID := wc.GenerateMessageID(true)
-		if id == newID {
-			t.Fatal("ID generation is not unique")
-		}
-		id = newID
+	const spins = 1000
+	ids := make([]int64, spins)
+	for i := 0; i < spins; i++ {
+		id := wc.GenerateMessageID(true)
+		assert.NotContains(t, ids, id, "GenerateMessageID must not generate the same ID twice")
+		ids[i] = id
 	}
 }
 

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -122,7 +122,7 @@ func TestSetup(t *testing.T) {
 
 	websocketSetup.ExchangeConfig = &config.Exchange{}
 	err = w.Setup(websocketSetup)
-	assert.ErrorIs(t, err, errExchangeConfigNameUnset, "Setup should error correctly")
+	assert.ErrorIs(t, err, errExchangeConfigNameEmpty, "Setup should error correctly")
 
 	websocketSetup.ExchangeConfig.Name = "testname"
 	err = w.Setup(websocketSetup)
@@ -480,16 +480,10 @@ func TestConnectionMonitorNoConnection(t *testing.T) {
 	ws.Wg = &sync.WaitGroup{}
 	ws.enabled = true
 	err := ws.connectionMonitor()
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: %v, but expected: %v", err, nil)
-	}
-	if !ws.IsConnectionMonitorRunning() {
-		t.Fatal("Should not have exited")
-	}
+	require.NoError(t, err, "connectionMonitor must not error")
+	assert.True(t, ws.IsConnectionMonitorRunning(), "IsConnectionMonitorRunning should return true")
 	err = ws.connectionMonitor()
-	if !errors.Is(err, errAlreadyRunning) {
-		t.Fatalf("received: %v, but expected: %v", err, errAlreadyRunning)
-	}
+	assert.ErrorIs(t, err, errAlreadyRunning, "connectionMonitor should error correctly")
 }
 
 // TestGetSubscription logic test
@@ -528,15 +522,9 @@ func TestGetSubscriptions(t *testing.T) {
 func TestSetCanUseAuthenticatedEndpoints(t *testing.T) {
 	t.Parallel()
 	ws := NewWebsocket()
-	result := ws.CanUseAuthenticatedEndpoints()
-	if result {
-		t.Error("expected `canUseAuthenticatedEndpoints` to be false")
-	}
+	assert.False(t, ws.CanUseAuthenticatedEndpoints(), "CanUseAuthenticatedEndpoints should return false")
 	ws.SetCanUseAuthenticatedEndpoints(true)
-	result = ws.CanUseAuthenticatedEndpoints()
-	if !result {
-		t.Error("expected `canUseAuthenticatedEndpoints` to be true")
-	}
+	assert.True(t, ws.CanUseAuthenticatedEndpoints(), "CanUseAuthenticatedEndpoints should return true")
 }
 
 // TestDial logic test
@@ -773,69 +761,41 @@ func TestParseBinaryResponse(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	w := gzip.NewWriter(&b)
-	_, err := w.Write([]byte("hello"))
-	if err != nil {
-		t.Error(err)
-	}
-	err = w.Close()
-	if err != nil {
-		t.Error(err)
-	}
-	var resp []byte
+	g := gzip.NewWriter(&b)
+	_, err := g.Write([]byte("hello"))
+	require.NoError(t, err, "gzip.Write must not error")
+	assert.NoError(t, g.Close(), "Close should not error")
+
+	resp, err := wc.parseBinaryResponse(b.Bytes())
+	assert.NoError(t, err, "parseBinaryResponse should not error parsing gzip")
+	assert.EqualValues(t, "hello", resp, "parseBinaryResponse should decode gzip")
+
+	b.Reset()
+	f, err := flate.NewWriter(&b, 1)
+	require.NoError(t, err, "flate.NewWriter must not error")
+	_, err = f.Write([]byte("goodbye"))
+	require.NoError(t, err, "flate.Write must not error")
+	assert.NoError(t, f.Close(), "Close should not error")
+
 	resp, err = wc.parseBinaryResponse(b.Bytes())
-	if err != nil {
-		t.Error(err)
-	}
-	if !strings.EqualFold(string(resp), "hello") {
-		t.Errorf("GZip conversion failed. Received: '%v', Expected: 'hello'", string(resp))
-	}
+	assert.NoError(t, err, "parseBinaryResponse should not error parsing inflate")
+	assert.EqualValues(t, "goodbye", resp, "parseBinaryResponse should deflate")
 
-	var b2 bytes.Buffer
-	w2, err2 := flate.NewWriter(&b2, 1)
-	if err2 != nil {
-		t.Error(err2)
-	}
-	_, err2 = w2.Write([]byte("hello"))
-	if err2 != nil {
-		t.Error(err)
-	}
-	err2 = w2.Close()
-	if err2 != nil {
-		t.Error(err)
-	}
-	resp2, err3 := wc.parseBinaryResponse(b2.Bytes())
-	if err3 != nil {
-		t.Error(err3)
-	}
-	if !strings.EqualFold(string(resp2), "hello") {
-		t.Errorf("Deflate conversion failed. Received: '%v', Expected: 'hello'", string(resp2))
-	}
-
-	_, err4 := wc.parseBinaryResponse([]byte{})
-	if err4 == nil || err4.Error() != "unexpected EOF" {
-		t.Error("Expected error 'unexpected EOF'")
-	}
+	_, err = wc.parseBinaryResponse([]byte{})
+	assert.ErrorContains(t, err, "unexpected EOF", "parseBinaryResponse should error on empty input")
 }
 
 // TestCanUseAuthenticatedWebsocketForWrapper logic test
 func TestCanUseAuthenticatedWebsocketForWrapper(t *testing.T) {
 	t.Parallel()
 	ws := &Websocket{}
-	resp := ws.CanUseAuthenticatedWebsocketForWrapper()
-	if resp {
-		t.Error("Expected false, `connected` is false")
-	}
+	assert.False(t, ws.CanUseAuthenticatedWebsocketForWrapper(), "CanUseAuthenticatedWebsocketForWrapper should return false")
+
 	ws.setState(connected)
-	resp = ws.CanUseAuthenticatedWebsocketForWrapper()
-	if resp {
-		t.Error("Expected false, `connected` is true and `CanUseAuthenticatedEndpoints` is false")
-	}
+	assert.False(t, ws.CanUseAuthenticatedWebsocketForWrapper(), "CanUseAuthenticatedWebsocketForWrapper should return false")
+
 	ws.canUseAuthenticatedEndpoints = true
-	resp = ws.CanUseAuthenticatedWebsocketForWrapper()
-	if !resp {
-		t.Error("Expected true, `connected` and `CanUseAuthenticatedEndpoints` is true")
-	}
+	assert.True(t, ws.CanUseAuthenticatedWebsocketForWrapper(), "CanUseAuthenticatedWebsocketForWrapper should return true")
 }
 
 func TestGenerateMessageID(t *testing.T) {
@@ -869,34 +829,22 @@ func BenchmarkGenerateMessageID_Low(b *testing.B) {
 
 func TestCheckWebsocketURL(t *testing.T) {
 	err := checkWebsocketURL("")
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errInvalidWebsocketURL, "checkWebsocketURL should error correctly on empty string")
 
 	err = checkWebsocketURL("wowowow:wowowowo")
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errInvalidWebsocketURL, "checkWebsocketURL should error correctly on bad format")
 
 	err = checkWebsocketURL("://")
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorContains(t, err, "missing protocol scheme", "checkWebsocketURL should error correctly on bad proto")
 
 	err = checkWebsocketURL("http://www.google.com")
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errInvalidWebsocketURL, "checkWebsocketURL should error correctly on wrong proto")
 
 	err = checkWebsocketURL("wss://websocketconnection.place")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "checkWebsocketURL should not error")
 
 	err = checkWebsocketURL("ws://websocketconnection.place")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "checkWebsocketURL should not error")
 }
 
 func TestGetChannelDifference(t *testing.T) {
@@ -1002,9 +950,7 @@ func TestFlushChannels(t *testing.T) {
 
 	dodgyWs.setEnabled(true)
 	err = dodgyWs.FlushChannels()
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, ErrNotConnected, "FlushChannels should error correctly")
 
 	web := Websocket{
 		enabled:      true,
@@ -1023,7 +969,7 @@ func TestFlushChannels(t *testing.T) {
 	}
 
 	problemFunc := func() ([]subscription.Subscription, error) {
-		return nil, errors.New("problems")
+		return nil, errDastardlyReason
 	}
 
 	noSub := func() ([]subscription.Subscription, error) {
@@ -1037,47 +983,34 @@ func TestFlushChannels(t *testing.T) {
 		return []subscription.Subscription{{Channel: "test"}}, nil
 	}
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 
 	web.features.FullPayloadSubscribe = true
 	web.GenerateSubs = problemFunc
 	err = web.FlushChannels() // error on full subscribeToChannels
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errDastardlyReason, "FlushChannels should error correctly")
 
 	web.GenerateSubs = noSub
-	err = web.FlushChannels() // No subs to sub
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = web.FlushChannels() // No subs to unsub
+	assert.NoError(t, err, "FlushChannels should not error")
 
 	web.GenerateSubs = newgen.generateSubs
 	subs, err := web.GenerateSubs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "GenerateSubs must not error")
+
 	web.AddSuccessfulSubscriptions(subs...)
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 	web.features.FullPayloadSubscribe = false
 	web.features.Subscribe = true
 
 	web.GenerateSubs = problemFunc
 	err = web.FlushChannels()
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errDastardlyReason, "FlushChannels should error correctly")
 
 	web.GenerateSubs = newgen.generateSubs
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 	web.subscriptionMutex.Lock()
 	web.subscriptions = subscriptionMap{
 		41: {
@@ -1094,21 +1027,15 @@ func TestFlushChannels(t *testing.T) {
 	web.subscriptionMutex.Unlock()
 
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 
 	web.setState(connected)
 	web.features.Unsubscribe = true
 	err = web.FlushChannels()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "FlushChannels should not error")
 }
 
 func TestDisable(t *testing.T) {
@@ -1118,14 +1045,8 @@ func TestDisable(t *testing.T) {
 		state:     connected,
 		ShutdownC: make(chan struct{}),
 	}
-	err := web.Disable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = web.Disable()
-	if err == nil {
-		t.Fatal("should already be disabled")
-	}
+	require.NoError(t, web.Disable(), "Disable must not error")
+	assert.ErrorIs(t, web.Disable(), ErrAlreadyDisabled, "Disable should error correctly")
 }
 
 func TestEnable(t *testing.T) {
@@ -1140,98 +1061,66 @@ func TestEnable(t *testing.T) {
 		Subscriber: func([]subscription.Subscription) error { return nil },
 	}
 
-	err := web.Enable()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = web.Enable()
-	if err == nil {
-		t.Fatal("should already be enabled")
-	}
-
-	fmt.Print()
+	require.NoError(t, web.Enable(), "Enable must not error")
+	assert.ErrorIs(t, web.Enable(), errWebsocketAlreadyEnabled, "Enable should error correctly")
 }
 
 func TestSetupNewConnection(t *testing.T) {
 	t.Parallel()
 	var nonsenseWebsock *Websocket
 	err := nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errWebsocketIsNil, "SetupNewConnection should error correctly")
 
 	nonsenseWebsock = &Websocket{}
 	err = nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errExchangeConfigNameEmpty, "SetupNewConnection should error correctly")
 
 	nonsenseWebsock = &Websocket{exchangeName: "test"}
 	err = nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errTrafficAlertNil, "SetupNewConnection should error correctly")
 
 	nonsenseWebsock.TrafficAlert = make(chan struct{})
 	err = nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errReadMessageErrorsNil, "SetupNewConnection should error correctly")
 
 	web := Websocket{
 		connector:         connect,
 		Wg:                new(sync.WaitGroup),
 		ShutdownC:         make(chan struct{}),
-		state:             disconnected,
 		TrafficAlert:      make(chan struct{}),
 		ReadMessageErrors: make(chan error),
 		DataHandler:       make(chan interface{}),
 	}
 
 	err = web.Setup(defaultSetup)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "Setup should not error")
+
 	err = web.SetupNewConnection(ConnectionSetup{})
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorIs(t, err, errExchangeConfigEmpty, "SetupNewConnection should error correctly")
+
 	err = web.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = web.SetupNewConnection(ConnectionSetup{URL: "urlstring",
-		Authenticated: true})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "SetupNewConnection should not error")
+
+	err = web.SetupNewConnection(ConnectionSetup{URL: "urlstring", Authenticated: true})
+	assert.NoError(t, err, "SetupNewConnection should not error")
 }
 
 func TestWebsocketConnectionShutdown(t *testing.T) {
 	t.Parallel()
 	wc := WebsocketConnection{}
 	err := wc.Shutdown()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "Shutdown should not error")
 
 	err = wc.Dial(&websocket.Dialer{}, nil)
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
+	assert.ErrorContains(t, err, "malformed ws or wss URL", "Dial must error correctly")
 
 	wc.URL = websocketTestURL
 
 	err = wc.Dial(&websocket.Dialer{}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Dial must not error")
 
 	err = wc.Shutdown()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Shutdown must not error")
 }
 
 // TestLatency logic test
@@ -1285,27 +1174,19 @@ func TestCheckSubscriptions(t *testing.T) {
 	t.Parallel()
 	ws := Websocket{}
 	err := ws.checkSubscriptions(nil)
-	if !errors.Is(err, errNoSubscriptionsSupplied) {
-		t.Fatalf("received: %v, but expected: %v", err, errNoSubscriptionsSupplied)
-	}
+	assert.ErrorIs(t, err, errNoSubscriptionsSupplied, "checkSubscriptions should error correctly")
 
 	ws.MaxSubscriptionsPerConnection = 1
 
 	err = ws.checkSubscriptions([]subscription.Subscription{{}, {}})
-	if !errors.Is(err, errSubscriptionsExceedsLimit) {
-		t.Fatalf("received: %v, but expected: %v", err, errSubscriptionsExceedsLimit)
-	}
+	assert.ErrorIs(t, err, errSubscriptionsExceedsLimit, "checkSubscriptions should error correctly")
 
 	ws.MaxSubscriptionsPerConnection = 2
 
 	ws.subscriptions = subscriptionMap{42: {Key: 42, Channel: "test"}}
 	err = ws.checkSubscriptions([]subscription.Subscription{{Key: 42, Channel: "test"}})
-	if !errors.Is(err, errChannelAlreadySubscribed) {
-		t.Fatalf("received: %v, but expected: %v", err, errChannelAlreadySubscribed)
-	}
+	assert.ErrorIs(t, err, errChannelAlreadySubscribed, "checkSubscriptions should error correctly")
 
 	err = ws.checkSubscriptions([]subscription.Subscription{{}})
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: %v, but expected: %v", err, nil)
-	}
+	assert.NoError(t, err, "checkSubscriptions should not error")
 }

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -221,7 +221,7 @@ func TestTrafficMonitorTrafficAlerts(t *testing.T) {
 			}
 		}
 
-		require.Eventuallyf(t, func() bool { return len(ws.TrafficAlert) == 0 }, 6*trafficCheckInterval, patience, "trafficAlert should be drained; Check #%d", i)
+		require.Eventuallyf(t, func() bool { return len(ws.TrafficAlert) == 0 }, 5*time.Second, patience, "trafficAlert should be drained; Check #%d", i)
 		assert.Truef(t, ws.IsConnected(), "state should still be connected; Check #%d", i)
 	}
 

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -105,6 +106,12 @@ func (d *dodgyConnection) Connect() error {
 	return fmt.Errorf("cannot connect: %w", errDastardlyReason)
 }
 
+func TestMain(m *testing.M) {
+	// Change trafficCheckInterval for TestTrafficMonitorTimeout before parallel tests to avoid racing
+	trafficCheckInterval = 50 * time.Millisecond
+	os.Exit(m.Run())
+}
+
 func TestSetup(t *testing.T) {
 	t.Parallel()
 	var w *Websocket
@@ -181,22 +188,90 @@ func TestTrafficMonitorTimeout(t *testing.T) {
 	err := ws.Setup(defaultSetup)
 	require.NoError(t, err, "Setup must not error")
 
-	ws.trafficTimeout = time.Millisecond * 42
+	signal := struct{}{}
+	patience := 10 * time.Millisecond
+	// trafficCheckInterval is changed in TestMain to avoid racing
+	ws.trafficTimeout = 200 * time.Millisecond
 	ws.ShutdownC = make(chan struct{})
+
+	thenish := time.Now()
+	ws.trafficMonitor()
+
+	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
+	require.Equal(t, disconnected, ws.state.Load(), "websocket must be disconnected")
+
+	// Behaviour: Test multiple traffic alerts work and only process one trafficAlert per interval
+	for i := 0; i < 2; i++ {
+		ws.state.Store(disconnected)
+
+		select {
+		case ws.TrafficAlert <- signal:
+			if i == 0 {
+				require.WithinDurationf(t, time.Now(), thenish, trafficCheckInterval, "First Non-blocking test must happen before the traffic is checked")
+			}
+		default:
+			require.Failf(t, "", "TrafficAlert should not block; Check #%d", i)
+		}
+
+		select {
+		case ws.TrafficAlert <- signal:
+			require.Failf(t, "", "TrafficAlert should block after first slot used; Check #%d", i)
+		default:
+			if i == 0 {
+				require.WithinDuration(t, time.Now(), thenish, trafficCheckInterval, "First Blocking test must happen before the traffic is checked")
+			}
+		}
+
+		require.Eventuallyf(t, func() bool { return len(ws.TrafficAlert) == 0 }, 6*trafficCheckInterval, patience, "trafficAlert should be drained; Check #%d", i)
+		assert.Truef(t, ws.IsConnected(), "state should still be connected; Check #%d", i)
+	}
+
+	// Behaviour: Shuts down websocket and exits on timeout
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, disconnected, ws.state.Load(), "websocket must be disconnected")
+		assert.False(c, ws.IsTrafficMonitorRunning(), "trafficMonitor should be shut down")
+	}, 2*ws.trafficTimeout, patience, "trafficTimeout should trigger a shutdown")
+
+	// Behaviour: connecting status doesn't trigger shutdown
+	ws.state.Store(connecting)
+	ws.trafficTimeout = 50 * time.Millisecond
+	ws.trafficMonitor()
+	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
+	require.Equal(t, connecting, ws.state.Load(), "websocket must be connecting")
+	<-time.After(4 * ws.trafficTimeout)
+	require.Equal(t, connecting, ws.state.Load(), "websocket must still be connecting after several checks")
+	ws.state.Store(connected)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, disconnected, ws.state.Load(), "websocket must be disconnected")
+		assert.False(c, ws.IsTrafficMonitorRunning(), "trafficMonitor should be shut down")
+	}, 4*ws.trafficTimeout, patience, "trafficTimeout should trigger a shutdown after connecting status changes")
+
+	// Behaviour: shutdown is processed and waitgroup is cleared
+	ws.state.Store(connected)
+	ws.trafficTimeout = time.Minute
 	ws.trafficMonitor()
 	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
 
-	// Deploy traffic alert
-	ws.TrafficAlert <- struct{}{}
-	// try to add another traffic monitor
-	ws.trafficMonitor()
-	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
+	wgReady := make(chan bool)
+	go func() {
+		ws.Wg.Wait()
+		close(wgReady)
+	}()
+	select {
+	case <-wgReady:
+		require.Failf(t, "", "WaitGroup should be blocking still")
+	case <-time.After(trafficCheckInterval):
+	}
 
-	// prevent shutdown routine
-	ws.setState(disconnected)
-	// await timeout closure
-	ws.Wg.Wait()
-	assert.False(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be not be running")
+	close(ws.ShutdownC)
+
+	<-time.After(2 * trafficCheckInterval)
+	assert.False(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be shutdown")
+	select {
+	case <-wgReady:
+	default:
+		require.Failf(t, "", "WaitGroup should be freed now")
+	}
 }
 
 func TestIsDisconnectionError(t *testing.T) {
@@ -1079,18 +1154,11 @@ func TestSetupNewConnection(t *testing.T) {
 	err = nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
 	assert.ErrorIs(t, err, errTrafficAlertNil, "SetupNewConnection should error correctly")
 
-	nonsenseWebsock.TrafficAlert = make(chan struct{})
+	nonsenseWebsock.TrafficAlert = make(chan struct{}, 1)
 	err = nonsenseWebsock.SetupNewConnection(ConnectionSetup{URL: "urlstring"})
 	assert.ErrorIs(t, err, errReadMessageErrorsNil, "SetupNewConnection should error correctly")
 
-	web := Websocket{
-		connector:         connect,
-		Wg:                new(sync.WaitGroup),
-		ShutdownC:         make(chan struct{}),
-		TrafficAlert:      make(chan struct{}),
-		ReadMessageErrors: make(chan error),
-		DataHandler:       make(chan interface{}),
-	}
+	web := NewWebsocket()
 
 	err = web.Setup(defaultSetup)
 	assert.NoError(t, err, "Setup should not error")

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -15,8 +15,6 @@ import (
 
 // Websocket functionality list and state consts
 const (
-	// WebsocketNotEnabled alerts of a disabled websocket
-	WebsocketNotEnabled                = "exchange_websocket_not_enabled"
 	WebsocketNotAuthenticatedUsingRest = "%v - Websocket not authenticated, using REST\n"
 	Ping                               = "ping"
 	Pong                               = "pong"

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -25,10 +25,10 @@ const (
 
 type subscriptionMap map[any]*subscription.Subscription
 
-type State int
+type state int
 
 const (
-	uninitialised State = iota
+	uninitialised state = iota
 	disconnected
 	connecting
 	connected

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -23,10 +24,8 @@ const (
 
 type subscriptionMap map[any]*subscription.Subscription
 
-type state int
-
 const (
-	uninitialised state = iota
+	uninitialised uint32 = iota
 	disconnected
 	connecting
 	connected
@@ -35,13 +34,13 @@ const (
 // Websocket defines a return type for websocket connections via the interface
 // wrapper for routine processing
 type Websocket struct {
-	canUseAuthenticatedEndpoints bool
-	enabled                      bool
-	state                        state
+	canUseAuthenticatedEndpoints atomic.Bool
+	enabled                      atomic.Bool
+	state                        atomic.Uint32
 	verbose                      bool
-	connectionMonitorRunning     bool
-	trafficMonitorRunning        bool
-	dataMonitorRunning           bool
+	connectionMonitorRunning     atomic.Bool
+	trafficMonitorRunning        atomic.Bool
+	dataMonitorRunning           atomic.Bool
 	trafficTimeout               time.Duration
 	connectionMonitorDelay       time.Duration
 	proxyAddr                    string
@@ -51,7 +50,6 @@ type Websocket struct {
 	runningURLAuth               string
 	exchangeName                 string
 	m                            sync.Mutex
-	fieldMutex                   sync.RWMutex
 	connector                    func() error
 
 	subscriptionMutex sync.RWMutex

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -25,14 +25,21 @@ const (
 
 type subscriptionMap map[any]*subscription.Subscription
 
+type State int
+
+const (
+	uninitialised State = iota
+	disconnected
+	connecting
+	connected
+)
+
 // Websocket defines a return type for websocket connections via the interface
 // wrapper for routine processing
 type Websocket struct {
 	canUseAuthenticatedEndpoints bool
 	enabled                      bool
-	Init                         bool
-	connected                    bool
-	connecting                   bool
+	state                        state
 	verbose                      bool
 	connectionMonitorRunning     bool
 	trafficMonitorRunning        bool


### PR DESCRIPTION
* Websocket: Remove IsInit
IsInit was basically the same as IsConnected.
Any time Connect was called both would be set to true.
Any time we had a disconnect they'd both be set to false
Shutdown() incorrectly didn't setInit(false)
* SetProxyAddress simplified to only reconnect a connected Websocket.
Any other state means it hasn't been Connected, or it's about to
reconnect anyway.
There was no handling for IsConnecting previously, either, so I've wrapped
SetProxyAddress behind the main mutex.
* Websocket: Improve and simplify tests
* Simplify state (init, disc, connecting, connected) to a single state field
* Move WebsocketNotEnabled to a real ErrWebsocketNotEnabled

This PR started because of inconsistencies noticed with IsInit and state from a okx panic bug.
It kinda broke out containment at that point and went native. KSozThx.

## Type of change

- [x] Refactoring (non-breaking change)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run