### PR TITLE
Deps: Require go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thrasher-corp/gocryptotrader
 
-go 1.20
+go 1.21
 
 require (
 	github.com/buger/jsonparser v1.1.1


### PR DESCRIPTION
Our build toolchain is using 1.21 since #1313
This hides issues on 1.20 from go.mod
Notably uses of implied Generics and slices package seem okay, but would fail for anyone running 1.20 locally

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run