### PR TITLE
Websocket: Prevent panic on Disconnect/Connect

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -415,7 +415,11 @@ func (w *Websocket) connectionMonitor() error {
 			case err := <-w.ReadMessageErrors:
 				if IsDisconnectionError(err) {
 					log.Warnf(log.WebsocketMgr, "%v websocket has been disconnected. Reason: %v", w.exchangeName, err)
-					w.setState(disconnected)
+					if w.IsConnected() {
+						if shutdownErr := w.Shutdown(); shutdownErr != nil {
+							log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor shutdown err: %s", w.exchangeName, shutdownErr)
+						}
+					}
 				}
 
 				w.DataHandler <- err

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -330,22 +330,26 @@ func TestConnectionMessageErrors(t *testing.T) {
 
 	c := func(tb *assert.CollectT) {
 		select {
-		case v := <-ws.ToRoutine:
+		case v, ok := <-ws.ToRoutine:
+			require.True(tb, ok, "ToRoutine should not be closed on us")
 			switch err := v.(type) {
 			case *websocket.CloseError:
 				assert.Equal(tb, "SpecialText", err.Text, "Should get correct Close Error")
 			case error:
 				assert.ErrorIs(tb, err, errDastardlyReason, "Should get the correct error")
+			default:
+				assert.Failf(tb, "Wrong data type sent to ToRoutine", "Got type: %T", err)
 			}
 		default:
+			assert.Fail(tb, "Nothing available on ToRoutine")
 		}
 	}
 
 	ws.ReadMessageErrors <- errDastardlyReason
-	assert.EventuallyWithT(t, c, 900*time.Millisecond, 10*time.Millisecond, "Should get an error down the routine")
+	assert.EventuallyWithT(t, c, 2*time.Second, 10*time.Millisecond, "Should get an error down the routine")
 
 	ws.ReadMessageErrors <- &websocket.CloseError{Code: 1006, Text: "SpecialText"}
-	assert.EventuallyWithT(t, c, 900*time.Millisecond, 10*time.Millisecond, "Should get an error down the routine")
+	assert.EventuallyWithT(t, c, 2*time.Second, 10*time.Millisecond, "Should get an error down the routine")
 }
 
 func TestWebsocket(t *testing.T) {

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -326,8 +326,6 @@ func TestConnectionMessageErrors(t *testing.T) {
 	err = ws.Connect()
 	require.NoError(t, err, "Connect must not error")
 
-	ws.TrafficAlert <- struct{}{}
-
 	c := func(tb *assert.CollectT) {
 		select {
 		case v, ok := <-ws.ToRoutine:
@@ -345,6 +343,7 @@ func TestConnectionMessageErrors(t *testing.T) {
 		}
 	}
 
+	ws.TrafficAlert <- struct{}{}
 	ws.ReadMessageErrors <- errDastardlyReason
 	assert.EventuallyWithT(t, c, 2*time.Second, 10*time.Millisecond, "Should get an error down the routine")
 


### PR DESCRIPTION
Previously we'd set the websocket to disconnected when *either* of the
Conn/AuthConn got a disconnect message.

This meant that:
* The other connection was still functioning
* A user would be free to call Connect()
* wsReadData() may not have exited

Any call to Connect would be acceptable, and we'd probably get a panic
from the underlying shared/re-used gorilla websocket:
`panic: runtime error: slice bounds out of range [:13501] with capacity 8192`
when a new wsReadData goro is started and the old tries to ReadMessage
as well, overallocating the buffer.

This wouldn't normally occur because trafficMonitor would see traffic
(on either connection) and then set the websocket to being connected
again.

The solution is to treat a Disconnect on either websocket as a call to
Shutdown the whole websocket, and then trafficMonitor can reconnect it
properly.

Unit Testing for this has been difficult. So far I've had to rely on a
disruption inside websocket's connectionMonitor itself to reproduce the
panic, but from there it's been very consistent.

Depends on merge of #1466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run