### PR TITLE
CI/build: Update Go version, linters and fix minor issues

### DIFF
--- a/.github/workflows/arm64.Dockerfile
+++ b/.github/workflows/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21
+FROM arm64v8/golang:1.22
 
 WORKDIR /app
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,9 +8,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: '1.22.x'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.0
+          version: v1.56.0

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Setup build depends
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.22.x
 jobs:
   backend-psql:
     name: GoCryptoTrader back-end

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
 #   - unused
 
 # disabled by default linters
@@ -51,6 +50,7 @@ linters:
     - gocheckcompilerdirectives
 #   - gochecknoglobals
 #   - gochecknoinits
+    - gochecksumtype
 #   - gocognit
     - goconst
     - gocritic
@@ -72,6 +72,7 @@ linters:
     - grouper
 #   - ifshort // deprecated by its owner
 #   - importas
+#   - inamedparam
 #   - interfacebloat
 #   - interfacer // deprecated by its owner
 #   - ireturn
@@ -94,9 +95,11 @@ linters:
 #   - nosnakecase // deprecated by its owner, replaced by revive 'var-naming'
     - nosprintfhostport
 #   - paralleltest
+    - perfsprint
     - prealloc
     - predeclared
 #   - promlinter
+#   - protogetter
     - reassign
     - revive
     - rowserrcheck
@@ -104,9 +107,11 @@ linters:
     - sqlclosecheck
 #   - structcheck // abandoned by its owner, replaced by unused
     - stylecheck
+    - tagalign
 #   - tagliatelle
     - tenv
     - testableexamples
+    - testifylint
 #   - testpackage
     - thelper
     - tparallel
@@ -136,6 +141,11 @@ linters-settings:
       - importShadow
       - methodExprCall
       - evalOrder
+  testifylint:
+    enable-all: true
+    disable:
+      - require-error
+      - float-compare
 
 issues:
   max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as build
+FROM golang:1.22 as build
 WORKDIR /go/src/github.com/thrasher-corp/gocryptotrader
 COPY . .
 RUN GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/backtester/common/common.go
+++ b/backtester/common/common.go
@@ -206,10 +206,10 @@ func Logo() string {
 	sb := strings.Builder{}
 	sb.WriteString("                                                                                \n")
 	sb.WriteString("                               " + CMDColours.White + "@@@@@@@@@@@@@@@@@                                \n")
-	sb.WriteString("                            " + CMDColours.White + "@@@@@@@@@@@@@@@@@@@@@@@    " + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n")
+	sb.WriteString("                            " + CMDColours.White + "@@@@@@@@@@@@@@@@@@@@@@@    " + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n") //nolint:goconst // not needed for this glorious logo
 	sb.WriteString("                           " + CMDColours.White + "@@@@@@@@" + CMDColours.Grey + ",,,,,    " + CMDColours.White + "@@@@@@@@@" + CMDColours.Grey + ",,,,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                         " + CMDColours.White + "@@@@@@@@" + CMDColours.Grey + ",,,,,,,       " + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,,," + CMDColours.White + "                   \n")
-	sb.WriteString("                         " + CMDColours.White + "@@@@@@" + CMDColours.Grey + "(,,,,,,,,      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n")
+	sb.WriteString("                         " + CMDColours.White + "@@@@@@" + CMDColours.Grey + "(,,,,,,,,      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n") //nolint:goconst // not needed for this glorious logo
 	sb.WriteString("                      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,   #,,,,,,,,,,,,,,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                   " + CMDColours.Grey + ",,,,*" + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,,,,,,,,,,,,,,,,,," + CMDColours.Green + "%%%%%%%" + CMDColours.White + "                \n")
 	sb.WriteString("                " + CMDColours.Grey + ",,,,,,,*" + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,,,,,," + CMDColours.Green + "%%%%%" + CMDColours.Grey + " ,,,,,," + CMDColours.Grey + "%" + CMDColours.Green + "%%%%%%" + CMDColours.White + "                 \n")

--- a/backtester/engine/grpcserver.go
+++ b/backtester/engine/grpcserver.go
@@ -141,21 +141,21 @@ func (s *GRPCServer) StartRPCRESTProxy() error {
 func (s *GRPCServer) authenticateClient(ctx context.Context) (context.Context, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return ctx, fmt.Errorf("unable to extract metadata")
+		return ctx, errors.New("unable to extract metadata")
 	}
 
 	authStr, ok := md["authorization"]
 	if !ok {
-		return ctx, fmt.Errorf("authorization header missing")
+		return ctx, errors.New("authorization header missing")
 	}
 
 	if !strings.Contains(authStr[0], "Basic") {
-		return ctx, fmt.Errorf("basic not found in authorization header")
+		return ctx, errors.New("basic not found in authorization header")
 	}
 
 	decoded, err := crypto.Base64Decode(strings.Split(authStr[0], " ")[1])
 	if err != nil {
-		return ctx, fmt.Errorf("unable to base64 decode authorization header")
+		return ctx, errors.New("unable to base64 decode authorization header")
 	}
 
 	creds := strings.Split(string(decoded), ":")
@@ -164,7 +164,7 @@ func (s *GRPCServer) authenticateClient(ctx context.Context) (context.Context, e
 
 	if username != s.config.GRPC.Username ||
 		password != s.config.GRPC.Password {
-		return ctx, fmt.Errorf("username/password mismatch")
+		return ctx, errors.New("username/password mismatch")
 	}
 	return ctx, nil
 }

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -858,7 +858,7 @@ func (bt *BackTest) loadData(cfg *config.Config, exch gctexchange.IBotExchange, 
 		return nil, err
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("processing error, response returned nil")
+		return nil, errors.New("processing error, response returned nil")
 	}
 
 	resp.Item.UnderlyingPair = underlyingPair

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -550,7 +550,7 @@ func addExch(exchName, checkType string, data interface{}, isUpdate bool) error 
 	}
 	if canUpdateTrello() {
 		if !isUpdate {
-			err := trelloCreateNewCheck(fmt.Sprintf("%s 1", exchName))
+			err := trelloCreateNewCheck(exchName + " 1")
 			if err != nil {
 				return err
 			}
@@ -1187,7 +1187,7 @@ func nameStateChanges(currentName, currentState string) (string, error) {
 		}
 		name = fmt.Sprintf("%s %s", strings.Split(currentName, " ")[0], strings.Split(currentName, " ")[1])
 		if !exists {
-			return fmt.Sprintf("%s 1", name), nil
+			return name + " 1", nil
 		}
 		num, err = strconv.ParseInt(strings.Split(currentName, " ")[2], 10, 64)
 		if err != nil {
@@ -1198,7 +1198,7 @@ func nameStateChanges(currentName, currentState string) (string, error) {
 			exists = true
 			name = strings.Split(currentName, " ")[0]
 			if !exists {
-				return fmt.Sprintf("%s 1", name), nil
+				return name + " 1", nil
 			}
 			num, err = strconv.ParseInt(strings.Split(currentName, " ")[1], 10, 64)
 			if err != nil {
@@ -1206,7 +1206,7 @@ func nameStateChanges(currentName, currentState string) (string, error) {
 			}
 		}
 		if !exists {
-			return fmt.Sprintf("%s 1", name), nil
+			return name + " 1", nil
 		}
 	}
 

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -1775,7 +1775,7 @@ func cancelOrder(c *cli.Context) error {
 
 	// pair is optional, but if it's set, do a validity check
 	var p currency.Pair
-	if len(currencyPair) > 0 {
+	if currencyPair != "" {
 		if !validPair(currencyPair) {
 			return errInvalidPair
 		}
@@ -1917,7 +1917,7 @@ func cancelBatchOrders(c *cli.Context) error {
 
 	// pair is optional, but if it's set, do a validity check
 	var p currency.Pair
-	if len(currencyPair) > 0 {
+	if currencyPair != "" {
 		if !validPair(currencyPair) {
 			return errInvalidPair
 		}
@@ -2208,19 +2208,19 @@ func addEvent(c *cli.Context) error {
 	if c.IsSet("exchange") {
 		exchangeName = c.String("exchange")
 	} else {
-		return fmt.Errorf("exchange name is required")
+		return errors.New("exchange name is required")
 	}
 
 	if c.IsSet("item") {
 		item = c.String("item")
 	} else {
-		return fmt.Errorf("item is required")
+		return errors.New("item is required")
 	}
 
 	if c.IsSet("condition") {
 		condition = c.String("condition")
 	} else {
-		return fmt.Errorf("condition is required")
+		return errors.New("condition is required")
 	}
 
 	if c.IsSet("price") {
@@ -2242,7 +2242,7 @@ func addEvent(c *cli.Context) error {
 	if c.IsSet("pair") {
 		currencyPair = c.String("pair")
 	} else {
-		return fmt.Errorf("currency pair is required")
+		return errors.New("currency pair is required")
 	}
 
 	if !validPair(currencyPair) {
@@ -2261,7 +2261,7 @@ func addEvent(c *cli.Context) error {
 	if c.IsSet("action") {
 		action = c.String("action")
 	} else {
-		return fmt.Errorf("action is required")
+		return errors.New("action is required")
 	}
 
 	p, err := currency.NewPairDelimiter(currencyPair, pairDelimiter)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -664,7 +664,7 @@ func TestErrors(t *testing.T) {
 	e5 := errors.New("add vodka")
 
 	// Nil tests
-	assert.Nil(t, AppendError(nil, nil), "Append nil to nil should nil")
+	assert.NoError(t, AppendError(nil, nil), "Append nil to nil should nil")
 	assert.Same(t, AppendError(e1, nil), e1, "Append nil to e1 should e1")
 	assert.Same(t, AppendError(nil, e2), e2, "Append e2 to nil should e2")
 
@@ -676,7 +676,7 @@ func TestErrors(t *testing.T) {
 
 	err = ExcludeError(err, e2)
 	assert.ErrorIs(t, err, e1, "Should still be bored")
-	assert.False(t, errors.Is(err, e2), "Should not be an e2")
+	assert.NotErrorIs(t, err, e2, "Should not be an e2")
 	me, ok := err.(*multiError)
 	if assert.True(t, ok, "Should be a multiError") {
 		assert.Len(t, me.errs, 2, "Should only have 2 errors")
@@ -690,19 +690,19 @@ func TestErrors(t *testing.T) {
 	err = fmt.Errorf("%w: %w", e3, fmt.Errorf("%w: %w", e4, e5))
 	assert.ErrorIs(t, ExcludeError(err, e4), e3, "Excluding e4 should retain e3")
 	assert.ErrorIs(t, ExcludeError(err, e4), e5, "Excluding e4 should retain the vanilla co-wrapped e5")
-	assert.False(t, errors.Is(ExcludeError(err, e4), e4), "e4 should be excluded")
+	assert.NotErrorIs(t, ExcludeError(err, e4), e4, "e4 should be excluded")
 	assert.ErrorIs(t, ExcludeError(err, e5), e3, "Excluding e5 should retain e3")
 	assert.ErrorIs(t, ExcludeError(err, e5), e4, "Excluding e5 should retain the vanilla co-wrapped e4")
-	assert.False(t, errors.Is(ExcludeError(err, e5), e5), "e5 should be excluded")
+	assert.NotErrorIs(t, ExcludeError(err, e5), e5, "e5 should be excluded")
 
 	// Hybrid tests
 	err = AppendError(fmt.Errorf("%w: %w", e4, e5), e3)
 	assert.ErrorIs(t, ExcludeError(err, e4), e3, "Excluding e4 should retain e3")
 	assert.ErrorIs(t, ExcludeError(err, e4), e5, "Excluding e4 should retain the vanilla co-wrapped e5")
-	assert.False(t, errors.Is(ExcludeError(err, e4), e4), "e4 should be excluded")
+	assert.NotErrorIs(t, ExcludeError(err, e4), e4, "e4 should be excluded")
 	assert.ErrorIs(t, ExcludeError(err, e5), e3, "Excluding e5 should retain e3")
 	assert.ErrorIs(t, ExcludeError(err, e5), e4, "Excluding e5 should retain the vanilla co-wrapped e4")
-	assert.False(t, errors.Is(ExcludeError(err, e5), e5), "e4 should be excluded")
+	assert.NotErrorIs(t, ExcludeError(err, e5), e5, "e4 should be excluded")
 }
 
 func TestParseStartEndDate(t *testing.T) {

--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -94,8 +94,7 @@ func IntToHumanFriendlyString(number int64, thousandsSep string) string {
 		number = -number
 		neg = true
 	}
-	str := fmt.Sprintf("%v", number)
-	return numberToHumanFriendlyString(str, 0, "", thousandsSep, neg)
+	return numberToHumanFriendlyString(strconv.FormatInt(number, 10), 0, "", thousandsSep, neg)
 }
 
 // FloatToHumanFriendlyString converts a float to a comma separated string at the thousand point

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -1,7 +1,7 @@
 package file
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -70,7 +70,7 @@ func TestMove(t *testing.T) {
 		}
 
 		if !strings.Contains(string(contents), "GoCryptoTrader") {
-			return fmt.Errorf("unable to find previously written data")
+			return errors.New("unable to find previously written data")
 		}
 
 		return os.Remove(out)

--- a/communications/telegram/telegram.go
+++ b/communications/telegram/telegram.go
@@ -203,7 +203,7 @@ func (t *Telegram) HandleMessages(text string, chatID int64) error {
 		return t.SendMessage(fmt.Sprintf("%s: %s", talkRoot, cmdHelpReply), chatID)
 
 	case strings.Contains(text, cmdStart):
-		return t.SendMessage(fmt.Sprintf("%s: START COMMANDS HERE", talkRoot), chatID)
+		return t.SendMessage(talkRoot+": START COMMANDS HERE", chatID)
 
 	case strings.Contains(text, cmdStatus):
 		return t.SendMessage(fmt.Sprintf("%s: %s", talkRoot, t.GetStatus()), chatID)

--- a/currency/forexprovider/currencylayer/currencylayer_test.go
+++ b/currency/forexprovider/currencylayer/currencylayer_test.go
@@ -89,7 +89,7 @@ func TestGetHistoricalData(t *testing.T) {
 	r, err := c.GetHistoricalData("2022-09-26", []string{"USD"}, "EUR")
 	if assert.NoError(t, err, "GetHistoricalData should not error") {
 		assert.Contains(t, r, "EURUSD", "Should find rate")
-		assert.Equal(t, r["EURUSD"], 0.962232, "Rate should be exactly correct")
+		assert.Equal(t, 0.962232, r["EURUSD"], "Rate should be exactly correct")
 	}
 }
 
@@ -110,7 +110,7 @@ func TestQueryTimeFrame(t *testing.T) {
 		assert.Len(t, r, 5, "Should get correct number of days")
 		a, ok := r["2020-03-16"].(map[string]any)
 		assert.True(t, ok, "Has final date entry")
-		assert.Equal(t, a["USDAUD"], 1.6397, "And it was a bad week")
+		assert.Equal(t, 1.6397, a["USDAUD"], "And it was a bad week")
 	}
 }
 

--- a/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
+++ b/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
@@ -91,13 +91,13 @@ func (e *ExchangeRates) GetSymbols() (map[string]string, error) {
 // all supported currencies
 func (e *ExchangeRates) GetLatestRates(baseCurrency, symbols string) (*Rates, error) {
 	vals := url.Values{}
-	if len(baseCurrency) > 0 && e.APIKeyLvl <= apiKeyFree && !strings.EqualFold("EUR", baseCurrency) {
+	if baseCurrency != "" && e.APIKeyLvl <= apiKeyFree && !strings.EqualFold("EUR", baseCurrency) {
 		return nil, errCannotSetBaseCurrencyOnFreePlan
-	} else if len(baseCurrency) > 0 {
+	} else if baseCurrency != "" {
 		vals.Set("base", baseCurrency)
 	}
 
-	if len(symbols) > 0 {
+	if symbols != "" {
 		symbols = e.cleanCurrencies(baseCurrency, symbols)
 		vals.Set("symbols", symbols)
 	}
@@ -120,9 +120,9 @@ func (e *ExchangeRates) GetHistoricalRates(date time.Time, baseCurrency string, 
 	var resp HistoricalRates
 	v := url.Values{}
 
-	if len(baseCurrency) > 0 && e.APIKeyLvl <= apiKeyFree && !strings.EqualFold("EUR", baseCurrency) {
+	if baseCurrency != "" && e.APIKeyLvl <= apiKeyFree && !strings.EqualFold("EUR", baseCurrency) {
 		return nil, errCannotSetBaseCurrencyOnFreePlan
-	} else if len(baseCurrency) > 0 {
+	} else if baseCurrency != "" {
 		v.Set("base", baseCurrency)
 	}
 

--- a/currency/forexprovider/fixer.io/fixer_test.go
+++ b/currency/forexprovider/fixer.io/fixer_test.go
@@ -13,7 +13,6 @@ var f Fixer
 
 var isSetup bool
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func setup(t *testing.T) {
 	t.Helper()
 	if !isSetup {

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -3,7 +3,7 @@ package currency
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -965,7 +965,7 @@ func TestGetOrderParameters(t *testing.T) {
 
 	for i, tc := range testCases {
 		tc := tc
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			var resp *OrderParameters
 			var err error
@@ -1032,7 +1032,7 @@ func TestIsAssociated(t *testing.T) {
 
 	for x := range testCases {
 		x := x
-		t.Run(fmt.Sprintf("%d", x), func(t *testing.T) {
+		t.Run(strconv.Itoa(x), func(t *testing.T) {
 			t.Parallel()
 			if testCases[x].Pair.IsAssociated(testCases[x].associate) != testCases[x].expectedResult {
 				t.Fatalf("Test %d failed. Expected %v, received %v", x, testCases[x].expectedResult, testCases[x].Pair.IsAssociated(testCases[x].associate))

--- a/database/repository/audit/audit_test.go
+++ b/database/repository/audit/audit_test.go
@@ -99,7 +99,6 @@ func TestAudit(t *testing.T) {
 	}
 }
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func writeAudit(t *testing.T) {
 	t.Helper()
 	var wg sync.WaitGroup
@@ -117,7 +116,6 @@ func writeAudit(t *testing.T) {
 	wg.Wait()
 }
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func readHelper(t *testing.T) {
 	t.Helper()
 

--- a/database/repository/trade/trade_test.go
+++ b/database/repository/trade/trade_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -120,7 +121,7 @@ func tradeSQLTester(t *testing.T) {
 			Price:     float64(i * (i + 3)),
 			Amount:    float64(i * (i + 2)),
 			Side:      order.Buy.String(),
-			TID:       fmt.Sprintf("%v", i),
+			TID:       strconv.Itoa(i),
 		})
 	}
 	err := Insert(trades...)
@@ -140,7 +141,7 @@ func tradeSQLTester(t *testing.T) {
 			Price:     float64(i * (i + 3)),
 			Amount:    float64(i * (i + 2)),
 			Side:      order.Buy.String(),
-			TID:       fmt.Sprintf("%v", i),
+			TID:       strconv.Itoa(i),
 		})
 	}
 	err = Insert(trades2...)

--- a/database/repository/withdraw/withdraw_test.go
+++ b/database/repository/withdraw/withdraw_test.go
@@ -154,7 +154,6 @@ func seedWithdrawData() {
 	}
 }
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func withdrawHelper(t *testing.T) {
 	t.Helper()
 	seedWithdrawData()

--- a/engine/database_connection_test.go
+++ b/engine/database_connection_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/database/drivers"
 )
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func CreateDatabase(t *testing.T) {
 	t.Helper()
 	// fun workarounds to globals ruining testing

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -639,7 +639,7 @@ func GetCollatedExchangeAccountInfoByCoin(accounts []account.Holdings) map[curre
 func GetExchangeHighestPriceByCurrencyPair(p currency.Pair, a asset.Item) (string, error) {
 	result := stats.SortExchangesByPrice(p, a, true)
 	if len(result) == 0 {
-		return "", fmt.Errorf("no stats for supplied currency pair and asset type")
+		return "", errors.New("no stats for supplied currency pair and asset type")
 	}
 
 	return result[0].Exchange, nil
@@ -650,7 +650,7 @@ func GetExchangeHighestPriceByCurrencyPair(p currency.Pair, a asset.Item) (strin
 func GetExchangeLowestPriceByCurrencyPair(p currency.Pair, assetType asset.Item) (string, error) {
 	result := stats.SortExchangesByPrice(p, assetType, false)
 	if len(result) == 0 {
-		return "", fmt.Errorf("no stats for supplied currency pair and asset type")
+		return "", errors.New("no stats for supplied currency pair and asset type")
 	}
 
 	return result[0].Exchange, nil
@@ -962,7 +962,7 @@ func genCert(targetDir string) error {
 
 	certData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	if certData == nil {
-		return fmt.Errorf("cert data is nil")
+		return errors.New("cert data is nil")
 	}
 
 	b, err := x509.MarshalECPrivateKey(privKey)
@@ -972,7 +972,7 @@ func genCert(targetDir string) error {
 
 	keyData := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
 	if keyData == nil {
-		return fmt.Errorf("key pem data is nil")
+		return errors.New("key pem data is nil")
 	}
 
 	err = file.Write(filepath.Join(targetDir, "key.pem"), keyData)

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -653,20 +653,20 @@ func TestSubmitOrderAlreadyInStore(t *testing.T) {
 		Exchange:  testExchange,
 	}
 	submitResp, err := submitReq.DeriveSubmitResponse("batman.obvs")
-	assert.Nil(t, err, "Deriving a SubmitResp should not error")
+	assert.NoError(t, err, "Deriving a SubmitResp should not error")
 
 	id, err := uuid.NewV4()
-	assert.Nil(t, err, "uuid should not error")
+	assert.NoError(t, err, "uuid should not error")
 	d, err := submitResp.DeriveDetail(id)
-	assert.Nil(t, err, "Derive Detail should not error")
+	assert.NoError(t, err, "Derive Detail should not error")
 
 	d.ClientOrderID = "SecretSquirrelSauce"
 	err = m.orderStore.add(d)
-	assert.Nil(t, err, "Adding an order should not error")
+	assert.NoError(t, err, "Adding an order should not error")
 
 	resp, err := m.SubmitFakeOrder(submitReq, submitResp, false)
 
-	if assert.Nil(t, err, "SumbitFakeOrder should not error that the order is already in the store") {
+	if assert.NoError(t, err, "SumbitFakeOrder should not error that the order is already in the store") {
 		assert.Equal(t, d.ClientOrderID, resp.ClientOrderID, "resp should contain the ClientOrderID from the store")
 	}
 }
@@ -1712,7 +1712,7 @@ func TestGetByDetail(t *testing.T) {
 	}
 
 	assert.Nil(t, m.orderStore.getByDetail(od), "Fetching a non-stored order should return nil")
-	assert.Nil(t, m.orderStore.add(od), "Adding the details should not error")
+	assert.NoError(t, m.orderStore.add(od), "Adding the details should not error")
 
 	byOrig := m.orderStore.getByDetail(od)
 	byID := m.orderStore.getByDetail(id)

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -91,21 +91,21 @@ type RPCServer struct {
 func (s *RPCServer) authenticateClient(ctx context.Context) (context.Context, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return ctx, fmt.Errorf("unable to extract metadata")
+		return ctx, errors.New("unable to extract metadata")
 	}
 
 	authStr, ok := md["authorization"]
 	if !ok {
-		return ctx, fmt.Errorf("authorization header missing")
+		return ctx, errors.New("authorization header missing")
 	}
 
 	if !strings.Contains(authStr[0], "Basic") {
-		return ctx, fmt.Errorf("basic not found in authorization header")
+		return ctx, errors.New("basic not found in authorization header")
 	}
 
 	decoded, err := crypto.Base64Decode(strings.Split(authStr[0], " ")[1])
 	if err != nil {
-		return ctx, fmt.Errorf("unable to base64 decode authorization header")
+		return ctx, errors.New("unable to base64 decode authorization header")
 	}
 
 	cred := strings.Split(string(decoded), ":")
@@ -114,7 +114,7 @@ func (s *RPCServer) authenticateClient(ctx context.Context) (context.Context, er
 
 	if username != s.Config.RemoteControl.Username ||
 		password != s.Config.RemoteControl.Password {
-		return ctx, fmt.Errorf("username/password mismatch")
+		return ctx, errors.New("username/password mismatch")
 	}
 	ctx, err = account.ParseCredentialsMetadata(ctx, md)
 	if err != nil {
@@ -878,7 +878,7 @@ func (s *RPCServer) RemovePortfolioAddress(_ context.Context, r *gctrpc.RemovePo
 func (s *RPCServer) GetForexProviders(_ context.Context, _ *gctrpc.GetForexProvidersRequest) (*gctrpc.GetForexProvidersResponse, error) {
 	providers := s.Config.GetForexProviders()
 	if len(providers) == 0 {
-		return nil, fmt.Errorf("forex providers is empty")
+		return nil, errors.New("forex providers is empty")
 	}
 
 	forexProviders := make([]*gctrpc.ForexProvider, len(providers))
@@ -904,7 +904,7 @@ func (s *RPCServer) GetForexRates(_ context.Context, _ *gctrpc.GetForexRatesRequ
 	}
 
 	if len(rates) == 0 {
-		return nil, fmt.Errorf("forex rates is empty")
+		return nil, errors.New("forex rates is empty")
 	}
 
 	forexRates := make([]*gctrpc.ForexRatesConversion, 0, len(rates))
@@ -3290,7 +3290,7 @@ func (s *RPCServer) ConvertTradesToCandles(_ context.Context, r *gctrpc.ConvertT
 		return nil, err
 	}
 	if len(klineItem.Candles) == 0 {
-		return nil, fmt.Errorf("no candles generated from trades")
+		return nil, errors.New("no candles generated from trades")
 	}
 
 	resp := &gctrpc.GetHistoricCandlesResponse{

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -143,7 +143,7 @@ func TestGetTradesByDate(t *testing.T) {
 	if !trades.IsAccepted {
 		t.Error("Alphapoint trades.IsAccepted value is true")
 	}
-	if len(trades.RejectReason) > 0 {
+	if trades.RejectReason != "" {
 		t.Error("Alphapoint trades.IsAccepted value has been returned")
 	}
 	if trades.StartDate < 0 {

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -139,7 +139,7 @@ func (b *Binance) GetOrderBook(ctx context.Context, obd OrderBookDataRequestPara
 		return nil, err
 	}
 	params.Set("symbol", symbol)
-	params.Set("limit", fmt.Sprintf("%d", obd.Limit))
+	params.Set("limit", strconv.Itoa(obd.Limit))
 
 	var resp OrderBookData
 	if err := b.SendHTTPRequest(ctx,
@@ -200,7 +200,7 @@ func (b *Binance) GetMostRecentTrades(ctx context.Context, rtr RecentTradeReques
 		return nil, err
 	}
 	params.Set("symbol", symbol)
-	params.Set("limit", fmt.Sprintf("%d", rtr.Limit))
+	params.Set("limit", strconv.Itoa(rtr.Limit))
 
 	path := recentTrades + "?" + params.Encode()
 
@@ -219,10 +219,10 @@ func (b *Binance) GetHistoricalTrades(ctx context.Context, symbol string, limit 
 	params := url.Values{}
 
 	params.Set("symbol", symbol)
-	params.Set("limit", fmt.Sprintf("%d", limit))
+	params.Set("limit", strconv.Itoa(limit))
 	// else return most recent trades
 	if fromID > 0 {
-		params.Set("fromId", fmt.Sprintf("%d", fromID))
+		params.Set("fromId", strconv.FormatInt(fromID, 10))
 	}
 
 	path := historicalTrades + "?" + params.Encode()

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1464,7 +1464,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if mockTests {
 		expected = 1002
 	}
-	assert.Equal(t, expected, len(result), "GetHistoricTrades should return correct number of entries") // assert.Len doesn't produce clear messages on result
+	assert.Equal(t, expected, len(result), "GetHistoricTrades should return correct number of entries") //nolint:testifylint // assert.Len doesn't produce clear messages on result
 	for _, r := range result {
 		if !assert.WithinRange(t, r.Timestamp, start, end, "All trades should be within time range") {
 			break

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -965,7 +965,7 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 		case order.Sell:
 			reqSide = "SELL"
 		default:
-			return nil, fmt.Errorf("invalid side")
+			return nil, errors.New("invalid side")
 		}
 
 		var (
@@ -1018,7 +1018,7 @@ func (b *Binance) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Subm
 		case order.Sell:
 			reqSide = "SELL"
 		default:
-			return nil, fmt.Errorf("invalid side")
+			return nil, errors.New("invalid side")
 		}
 		var oType string
 		switch s.Type {
@@ -1549,7 +1549,7 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequ
 					return nil, errors.New("endTime cannot be before startTime")
 				}
 				if time.Since(req.StartTime) > time.Hour*24*30 {
-					return nil, fmt.Errorf("can only fetch orders 30 days out")
+					return nil, errors.New("can only fetch orders 30 days out")
 				}
 				orderHistory, err = b.GetAllFuturesOrders(ctx,
 					req.Pairs[i], currency.EMPTYPAIR, req.StartTime, req.EndTime, 0, 0)
@@ -1567,7 +1567,7 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequ
 					return nil, err
 				}
 			default:
-				return nil, fmt.Errorf("invalid combination of input params")
+				return nil, errors.New("invalid combination of input params")
 			}
 			for y := range orderHistory {
 				var feeBuilder exchange.FeeBuilder
@@ -1607,7 +1607,7 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequ
 					return nil, errors.New("endTime cannot be before startTime")
 				}
 				if time.Since(req.StartTime) > time.Hour*24*7 {
-					return nil, fmt.Errorf("can only fetch orders 7 days out")
+					return nil, errors.New("can only fetch orders 7 days out")
 				}
 				orderHistory, err = b.UAllAccountOrders(ctx,
 					req.Pairs[i], 0, 0, req.StartTime, req.EndTime)
@@ -1625,7 +1625,7 @@ func (b *Binance) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequ
 					return nil, err
 				}
 			default:
-				return nil, fmt.Errorf("invalid combination of input params")
+				return nil, errors.New("invalid combination of input params")
 			}
 			for y := range orderHistory {
 				var feeBuilder exchange.FeeBuilder

--- a/exchanges/binanceus/binanceus.go
+++ b/exchanges/binanceus/binanceus.go
@@ -348,7 +348,7 @@ func (bi *Binanceus) GetOrderBookDepth(ctx context.Context, arg *OrderBookDataRe
 		return nil, err
 	}
 	params.Set("symbol", symbol)
-	params.Set("limit", fmt.Sprintf("%d", arg.Limit))
+	params.Set("limit", strconv.FormatInt(arg.Limit, 10))
 	var resp OrderBookData
 	if err := bi.SendHTTPRequest(ctx,
 		exchange.RestSpotSupplementary,
@@ -955,7 +955,7 @@ func (bi *Binanceus) GetSubaccountAssets(ctx context.Context, email string) (*Su
 	}
 	params := url.Values{}
 	timestamp := time.Now().UnixMilli()
-	params.Set("timestamp", fmt.Sprintf("%d", timestamp))
+	params.Set("timestamp", strconv.FormatInt(timestamp, 10))
 	params.Set("email", email)
 	//
 	return &resp, bi.SendAuthHTTPRequest(ctx,
@@ -1184,7 +1184,7 @@ func (bi *Binanceus) GetTrades(ctx context.Context, arg *GetTradesParams) ([]Tra
 		params.Set("fromId", strconv.Itoa(int(arg.FromID)))
 	}
 	if arg.Limit > 0 && arg.Limit < 1000 {
-		params.Set("limit", fmt.Sprint(arg.Limit))
+		params.Set("limit", strconv.FormatUint(arg.Limit, 10))
 	} else if arg.Limit > 1000 {
 		params.Set("limit", strconv.Itoa(1000))
 	}
@@ -1244,7 +1244,7 @@ func (bi *Binanceus) CreateNewOCOOrder(ctx context.Context, arg *OCOOrderInputPa
 // GetOCOOrder to retrieve a specific OCO order based on provided optional parameters.
 func (bi *Binanceus) GetOCOOrder(ctx context.Context, arg *GetOCOOrderRequestParams) (*OCOOrderResponse, error) {
 	params := url.Values{}
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	switch {
 	case arg.OrderListID != "":
 		params.Set("orderListId", arg.OrderListID)
@@ -1261,23 +1261,23 @@ func (bi *Binanceus) GetOCOOrder(ctx context.Context, arg *GetOCOOrderRequestPar
 // GetAllOCOOrder to retrieve all OCO orders based on provided optional parameters. Please note the maximum limit is 1,000 orders.
 func (bi *Binanceus) GetAllOCOOrder(ctx context.Context, arg *OCOOrdersRequestParams) ([]OCOOrderResponse, error) {
 	params := url.Values{}
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	var response []OCOOrderResponse
 	if arg.FromID > 0 {
-		params.Set("fromId", fmt.Sprint(arg.FromID))
+		params.Set("fromId", strconv.FormatUint(arg.FromID, 10))
 	} else {
 		if arg.StartTime.Unix() > 0 && arg.StartTime.Before(arg.EndTime) {
-			params.Set("startTime", fmt.Sprint(arg.StartTime.UnixMilli()))
-			params.Set("endTime", fmt.Sprint(arg.EndTime.UnixMilli()))
+			params.Set("startTime", strconv.FormatInt(arg.StartTime.UnixMilli(), 10))
+			params.Set("endTime", strconv.FormatInt(arg.EndTime.UnixMilli(), 10))
 		} else if arg.StartTime.Unix() > 0 {
-			params.Set("startTime", fmt.Sprint(arg.StartTime.UnixMilli()))
+			params.Set("startTime", strconv.FormatInt(arg.StartTime.UnixMilli(), 10))
 		}
 	}
 	if arg.Limit > 0 {
-		params.Set("limit", fmt.Sprint(arg.Limit))
+		params.Set("limit", strconv.FormatUint(arg.Limit, 10))
 	}
 	if arg.RecvWindow > 0 {
-		params.Set("recvWindow", fmt.Sprint(arg.RecvWindow))
+		params.Set("recvWindow", strconv.FormatUint(arg.RecvWindow, 10))
 	}
 	return response, bi.SendAuthHTTPRequest(ctx, exchange.RestSpotSupplementary,
 		http.MethodGet, ocoAllOrderList,
@@ -1286,11 +1286,11 @@ func (bi *Binanceus) GetAllOCOOrder(ctx context.Context, arg *OCOOrdersRequestPa
 }
 
 // GetOpenOCOOrders to query open OCO orders.
-func (bi *Binanceus) GetOpenOCOOrders(ctx context.Context, recvWindow uint) ([]OCOOrderResponse, error) {
+func (bi *Binanceus) GetOpenOCOOrders(ctx context.Context, recvWindow uint64) ([]OCOOrderResponse, error) {
 	params := url.Values{}
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	if recvWindow > 0 {
-		params.Set("recvWindow", fmt.Sprint(recvWindow))
+		params.Set("recvWindow", strconv.FormatUint(recvWindow, 10))
 	} else {
 		params.Set("recvWindow", "30000")
 	}
@@ -1304,7 +1304,7 @@ func (bi *Binanceus) GetOpenOCOOrders(ctx context.Context, recvWindow uint) ([]O
 func (bi *Binanceus) CancelOCOOrder(ctx context.Context, arg *OCOOrdersDeleteRequestParams) (*OCOFullOrderResponse, error) {
 	var response OCOFullOrderResponse
 	params := url.Values{}
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	switch {
 	case arg.OrderListID > 0:
 		params.Set("orderListId", strconv.Itoa(int(arg.OrderListID)))
@@ -1314,7 +1314,7 @@ func (bi *Binanceus) CancelOCOOrder(ctx context.Context, arg *OCOOrdersDeleteReq
 		return nil, errIncompleteArguments
 	}
 	if arg.RecvWindow > 0 {
-		params.Set("recvWindow", fmt.Sprint(arg.RecvWindow))
+		params.Set("recvWindow", strconv.FormatUint(arg.RecvWindow, 10))
 	}
 	return &response, bi.SendAuthHTTPRequest(ctx, exchange.RestSpotSupplementary,
 		http.MethodGet, ocoOrderList,
@@ -1389,7 +1389,7 @@ func (bi *Binanceus) GetOTCTradeOrder(ctx context.Context, orderID uint64) (*OTC
 	}
 	orderIDStr := strconv.FormatUint(orderID, 10)
 	params.Set("orderId", orderIDStr)
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	path := otcTradeOrders + orderIDStr
 	return &response, bi.SendAuthHTTPRequest(ctx,
 		exchange.RestSpotSupplementary,
@@ -1679,16 +1679,16 @@ func (bi *Binanceus) DepositHistory(ctx context.Context, c currency.Code, status
 func (bi *Binanceus) FiatDepositHistory(ctx context.Context, arg *FiatWithdrawalRequestParams) (FiatAssetsHistory, error) {
 	params := url.Values{}
 	if !(arg.EndTime.IsZero()) && !(arg.EndTime.Before(time.Now())) {
-		params.Set("endTime", fmt.Sprint(arg.EndTime.UnixMilli()))
+		params.Set("endTime", strconv.FormatInt(arg.EndTime.UnixMilli(), 10))
 	}
 	if !(arg.StartTime.IsZero()) && !(arg.StartTime.After(time.Now())) {
-		params.Set("startTime", fmt.Sprint(arg.StartTime.UnixMilli()))
+		params.Set("startTime", strconv.FormatInt(arg.StartTime.UnixMilli(), 10))
 	}
 	if arg.FiatCurrency != "" {
 		params.Set("fiatCurrency", arg.FiatCurrency)
 	}
 	if arg.Offset > 0 {
-		params.Set("offset", fmt.Sprint(arg.Offset))
+		params.Set("offset", strconv.FormatInt(arg.Offset, 10))
 	}
 	if arg.PaymentChannel != "" {
 		params.Set("paymentChannel", arg.PaymentChannel)
@@ -1696,7 +1696,7 @@ func (bi *Binanceus) FiatDepositHistory(ctx context.Context, arg *FiatWithdrawal
 	if arg.PaymentMethod != "" {
 		params.Set("paymentMethod", arg.PaymentMethod)
 	}
-	params.Set("timestamp", fmt.Sprint(time.Now().UnixMilli()))
+	params.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
 	var response FiatAssetsHistory
 	return response, bi.SendAuthHTTPRequest(ctx,
 		exchange.RestSpotSupplementary, http.MethodGet,

--- a/exchanges/binanceus/binanceus_types.go
+++ b/exchanges/binanceus/binanceus_types.go
@@ -524,8 +524,8 @@ type GetTradesParams struct {
 	StartTime  *time.Time `json:"startTime"`
 	EndTime    *time.Time `json:"endTime"`
 	FromID     uint64     `json:"fromId"`
-	Limit      uint       `json:"limit"`
-	RecvWindow uint       `json:"recvWindow"`
+	Limit      uint64     `json:"limit"`
+	RecvWindow uint64     `json:"recvWindow"`
 }
 
 // Trade this struct represents a trade response.
@@ -599,8 +599,8 @@ type OCOOrdersRequestParams struct {
 	FromID     uint64
 	StartTime  time.Time
 	EndTime    time.Time
-	Limit      uint
-	RecvWindow uint
+	Limit      uint64
+	RecvWindow uint64
 }
 
 // OCOOrdersDeleteRequestParams holds the params to delete a new order
@@ -609,7 +609,7 @@ type OCOOrdersDeleteRequestParams struct {
 	OrderListID       uint64
 	ListClientOrderID string
 	NewClientOrderID  string
-	RecvWindow        uint
+	RecvWindow        uint64
 }
 
 // OTC endpoints

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -471,7 +471,7 @@ func (bi *Binanceus) GetWithdrawalsHistory(ctx context.Context, c currency.Code,
 			return nil, err
 		}
 		resp[i] = exchange.WithdrawalHistory{
-			Status:          fmt.Sprint(withdrawals[i].Status),
+			Status:          strconv.FormatInt(withdrawals[i].Status, 10),
 			TransferID:      withdrawals[i].ID,
 			Currency:        withdrawals[i].Coin,
 			Amount:          withdrawals[i].Amount,
@@ -501,7 +501,7 @@ func (bi *Binanceus) GetRecentTrades(ctx context.Context, p currency.Pair, asset
 	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
 		resp[i] = trade.Data{
-			TID:          fmt.Sprint(tradeData[i].ID),
+			TID:          strconv.FormatInt(tradeData[i].ID, 10),
 			Exchange:     bi.Name,
 			AssetType:    assetType,
 			CurrencyPair: p,

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1814,7 +1814,7 @@ func (b *Bitfinex) GetBalanceHistory(ctx context.Context, symbol string, timeSin
 	if limit > 0 {
 		req["limit"] = limit
 	}
-	if len(wallet) > 0 {
+	if wallet != "" {
 		req["wallet"] = wallet
 	}
 
@@ -1831,7 +1831,7 @@ func (b *Bitfinex) GetMovementHistory(ctx context.Context, symbol, method string
 	req := make(map[string]interface{})
 	req["currency"] = symbol
 
-	if len(method) > 0 {
+	if method != "" {
 		req["method"] = method
 	}
 	if !timeSince.IsZero() {
@@ -2301,22 +2301,22 @@ func (b *Bitfinex) PopulateAcceptableMethods(ctx context.Context) error {
 	storeData := make(map[string][]string)
 	for x := range data {
 		if len(data[x]) == 0 {
-			return fmt.Errorf("data should not be empty")
+			return errors.New("data should not be empty")
 		}
 		name, ok := data[x][0].(string)
 		if !ok {
-			return fmt.Errorf("unable to type assert name")
+			return errors.New("unable to type assert name")
 		}
 
 		var availOptions []string
 		options, ok := data[x][1].([]interface{})
 		if !ok {
-			return fmt.Errorf("unable to type assert options")
+			return errors.New("unable to type assert options")
 		}
 		for x := range options {
 			o, ok := options[x].(string)
 			if !ok {
-				return fmt.Errorf("unable to type assert option to string")
+				return errors.New("unable to type assert option to string")
 			}
 			availOptions = append(availOptions, o)
 		}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -1082,7 +1082,7 @@ func (b *Bitfinex) AuthenticateWebsocket(ctx context.Context) error {
 
 // appendOptionalDelimiter ensures that a delimiter is present for long character currencies
 func (b *Bitfinex) appendOptionalDelimiter(p *currency.Pair) {
-	if (len(p.Base.String()) > 3 && len(p.Quote.String()) > 0) ||
+	if (len(p.Base.String()) > 3 && !p.Quote.IsEmpty()) ||
 		len(p.Quote.String()) > 3 {
 		p.Delimiter = ":"
 	}
@@ -1247,7 +1247,7 @@ func (b *Bitfinex) GetAvailableTransferChains(ctx context.Context, cryptocurrenc
 
 	availChains := acceptableMethods.lookup(cryptocurrency)
 	if len(availChains) == 0 {
-		return nil, fmt.Errorf("unable to find any available chains")
+		return nil, errors.New("unable to find any available chains")
 	}
 	return availChains, nil
 }

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -342,11 +342,11 @@ func (b *Bithumb) GetOrders(ctx context.Context, orderID, transactionType string
 
 	params.Set("order_currency", orderCurrency.Upper().String())
 
-	if len(orderID) > 0 {
+	if orderID != "" {
 		params.Set("order_id", orderID)
 	}
 
-	if len(transactionType) > 0 {
+	if transactionType != "" {
 		params.Set("type", transactionType)
 	}
 
@@ -454,7 +454,7 @@ func (b *Bithumb) WithdrawCrypto(ctx context.Context, address, destination, curr
 
 	params := url.Values{}
 	params.Set("address", address)
-	if len(destination) > 0 {
+	if destination != "" {
 		params.Set("destination", destination)
 	}
 	params.Set("currency", strings.ToUpper(currency))

--- a/exchanges/bithumb/bithumb_websocket.go
+++ b/exchanges/bithumb/bithumb_websocket.go
@@ -78,7 +78,7 @@ func (b *Bithumb) wsHandleData(respRaw []byte) error {
 		return err
 	}
 
-	if len(resp.Status) > 0 {
+	if resp.Status != "" {
 		if resp.Status == "0000" {
 			return nil
 		}

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -142,7 +142,7 @@ func TestGetAccountTradingFee(t *testing.T) {
 			assert.Positive(t, fee.Fees.Taker, "Taker should be positive")
 		}
 		assert.NotEmpty(t, fee.Symbol, "Symbol should not be empty")
-		assert.Equal(t, fee.Symbol, "ltcbtc", "Symbol should be correct")
+		assert.Equal(t, "ltcbtc", fee.Symbol, "Symbol should be correct")
 	}
 
 	_, err = b.GetAccountTradingFee(context.Background(), currency.EMPTYPAIR)

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -211,13 +211,13 @@ func (c *CoinbasePro) GetTrades(ctx context.Context, currencyPair string) ([]Tra
 func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start, end string, granularity int64) ([]History, error) {
 	values := url.Values{}
 
-	if len(start) > 0 {
+	if start != "" {
 		values.Set("start", start)
 	} else {
 		values.Set("start", "")
 	}
 
-	if len(end) > 0 {
+	if end != "" {
 		values.Set("end", end)
 	} else {
 		values.Set("end", "")
@@ -469,7 +469,7 @@ func (c *CoinbasePro) CancelAllExistingOrders(ctx context.Context, currencyPair 
 	var resp []string
 	req := make(map[string]interface{})
 
-	if len(currencyPair) > 0 {
+	if currencyPair != "" {
 		req["product_id"] = currencyPair
 	}
 	return resp, c.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, http.MethodDelete, coinbaseproOrders, req, &resp)

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -2275,7 +2275,7 @@ func (g *Gateio) UpdatePositionMarginInDualMode(ctx context.Context, settle stri
 	params := url.Values{}
 	params.Set("change", strconv.FormatFloat(change, 'f', -1, 64))
 	if dualSide != "dual_long" && dualSide != "dual_short" {
-		return nil, fmt.Errorf("invalid 'dual_side' should be 'dual_short' or 'dual_long'")
+		return nil, errors.New("invalid 'dual_side' should be 'dual_short' or 'dual_long'")
 	}
 	params.Set("dual_side", dualSide)
 	var response []Position
@@ -3204,13 +3204,13 @@ func (g *Gateio) GetDeliveryPriceTriggeredOrder(ctx context.Context, settle stri
 		return nil, fmt.Errorf("%w, only time in force value 'gtc' and 'ioc' are supported", errInvalidTimeInForce)
 	}
 	if arg.Trigger.StrategyType != 0 && arg.Trigger.StrategyType != 1 {
-		return nil, fmt.Errorf("strategy type must be 0 or 1, 0: by price, and 1: by price gap")
+		return nil, errors.New("strategy type must be 0 or 1, 0: by price, and 1: by price gap")
 	}
 	if arg.Trigger.Rule != 1 && arg.Trigger.Rule != 2 {
-		return nil, fmt.Errorf("invalid trigger condition('rule') value, rule must be 1 or 2")
+		return nil, errors.New("invalid trigger condition('rule') value, rule must be 1 or 2")
 	}
 	if arg.Trigger.PriceType != 0 && arg.Trigger.PriceType != 1 && arg.Trigger.PriceType != 2 {
-		return nil, fmt.Errorf("price type must be 0 or 1 or 2")
+		return nil, errors.New("price type must be 0 or 1 or 2")
 	}
 	if arg.Trigger.Price <= 0 {
 		return nil, errors.New("invalid argument: trigger.price")
@@ -3482,7 +3482,7 @@ func (g *Gateio) GetUsersLiquidationHistoryForSpecifiedUnderlying(ctx context.Co
 }
 
 // PlaceOptionOrder creates an options order
-func (g *Gateio) PlaceOptionOrder(ctx context.Context, arg OptionOrderParam) (*OptionOrderResponse, error) {
+func (g *Gateio) PlaceOptionOrder(ctx context.Context, arg *OptionOrderParam) (*OptionOrderResponse, error) {
 	if arg.Contract == "" {
 		return nil, errInvalidOrMissingContractParam
 	}

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -1858,7 +1858,7 @@ func TestGetUsersLiquidationHistoryForSpecifiedUnderlying(t *testing.T) {
 func TestPlaceOptionOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	_, err := g.PlaceOptionOrder(context.Background(), OptionOrderParam{
+	_, err := g.PlaceOptionOrder(context.Background(), &OptionOrderParam{
 		Contract:    getPair(t, asset.Options).String(),
 		OrderSize:   -1,
 		Iceberg:     0,

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -1938,7 +1938,7 @@ type SettlementHistoryItem struct {
 
 // SubAccountParams represents subaccount creation parameters
 type SubAccountParams struct {
-	LoginName string `json:"login_name,"`
+	LoginName string `json:"login_name"`
 	Remark    string `json:"remark,omitempty"`
 	Email     string `json:"email,omitempty"`    // The sub-account's password.
 	Password  string `json:"password,omitempty"` // The sub-account's email address.

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -1130,7 +1130,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		response.Price = newOrder.OrderPrice.Float64()
 		return response, nil
 	case asset.Options:
-		optionOrder, err := g.PlaceOptionOrder(ctx, OptionOrderParam{
+		optionOrder, err := g.PlaceOptionOrder(ctx, &OptionOrderParam{
 			Contract:   s.Pair.String(),
 			OrderSize:  s.Amount,
 			Price:      types.Number(s.Price),

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -80,7 +80,7 @@ func (g *Gemini) GetSymbolDetails(ctx context.Context, symbol string) ([]SymbolD
 // GetTicker returns information about recent trading activity for the symbol
 func (g *Gemini) GetTicker(ctx context.Context, currencyPair string) (TickerV2, error) {
 	ticker := TickerV2{}
-	path := fmt.Sprintf("/v2/ticker/%s", currencyPair)
+	path := "/v2/ticker/" + currencyPair
 	err := g.SendHTTPRequest(ctx, exchange.RestSpot, path, &ticker)
 	if err != nil {
 		return ticker, err
@@ -334,7 +334,7 @@ func (g *Gemini) GetCryptoDepositAddress(ctx context.Context, depositAddlabel, c
 	response := DepositAddress{}
 	req := make(map[string]interface{})
 
-	if len(depositAddlabel) > 0 {
+	if depositAddlabel != "" {
 		req["label"] = depositAddlabel
 	}
 

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -21,12 +22,12 @@ const (
 	apiURL = "https://api.hitbtc.com"
 
 	// Public
-	apiV2Trades    = "api/2/public/trades"
-	apiV2Currency  = "api/2/public/currency"
-	apiV2Symbol    = "api/2/public/symbol"
-	apiV2Ticker    = "api/2/public/ticker"
-	apiV2Orderbook = "api/2/public/orderbook"
-	apiV2Candles   = "api/2/public/candles"
+	apiV2Trades    = "/api/2/public/trades"
+	apiV2Currency  = "/api/2/public/currency"
+	apiV2Symbol    = "/api/2/public/symbol"
+	apiV2Ticker    = "/api/2/public/ticker"
+	apiV2Orderbook = "/api/2/public/orderbook"
+	apiV2Candles   = "/api/2/public/candles"
 
 	// Authenticated
 	apiV2Balance        = "api/2/trading/balance"
@@ -58,10 +59,8 @@ func (h *HitBTC) GetCurrencies(ctx context.Context) (map[string]Currencies, erro
 		Data []Currencies
 	}
 	resp := Response{}
-	path := fmt.Sprintf("/%s", apiV2Currency)
-
 	ret := make(map[string]Currencies)
-	err := h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp.Data)
+	err := h.SendHTTPRequest(ctx, exchange.RestSpot, apiV2Currency, &resp.Data)
 	if err != nil {
 		return ret, err
 	}
@@ -79,7 +78,7 @@ func (h *HitBTC) GetCurrency(ctx context.Context, currency string) (Currencies, 
 		Data Currencies
 	}
 	resp := Response{}
-	path := fmt.Sprintf("/%s/%s", apiV2Currency, currency)
+	path := apiV2Currency + "/" + currency
 
 	return resp.Data, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp.Data)
 }
@@ -91,7 +90,7 @@ func (h *HitBTC) GetCurrency(ctx context.Context, currency string) (Currencies, 
 // of the base currency.
 func (h *HitBTC) GetSymbols(ctx context.Context, symbol string) ([]string, error) {
 	var resp []Symbol
-	path := fmt.Sprintf("/%s/%s", apiV2Symbol, symbol)
+	path := apiV2Symbol + "/" + symbol
 
 	ret := make([]string, 0, len(resp))
 	err := h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
@@ -109,22 +108,20 @@ func (h *HitBTC) GetSymbols(ctx context.Context, symbol string) ([]string, error
 // all their details.
 func (h *HitBTC) GetSymbolsDetailed(ctx context.Context) ([]Symbol, error) {
 	var resp []Symbol
-	path := fmt.Sprintf("/%s", apiV2Symbol)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
+	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, apiV2Symbol, &resp)
 }
 
 // GetTicker returns ticker information
 func (h *HitBTC) GetTicker(ctx context.Context, symbol string) (TickerResponse, error) {
 	var resp TickerResponse
-	path := fmt.Sprintf("/%s/%s", apiV2Ticker, symbol)
+	path := apiV2Ticker + "/" + symbol
 	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
 // GetTickers returns ticker information
 func (h *HitBTC) GetTickers(ctx context.Context) ([]TickerResponse, error) {
 	var resp []TickerResponse
-	path := fmt.Sprintf("/%s/", apiV2Ticker)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
+	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, apiV2Ticker, &resp)
 }
 
 // GetTrades returns trades from hitbtc
@@ -150,10 +147,7 @@ func (h *HitBTC) GetTrades(ctx context.Context, currencyPair, by, sort string, f
 	}
 
 	var resp []TradeHistory
-	path := fmt.Sprintf("/%s/%s?%s",
-		apiV2Trades,
-		currencyPair,
-		urlValues.Encode())
+	path := common.EncodeURLValues(apiV2Trades+"/"+currencyPair, urlValues)
 	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -168,10 +162,7 @@ func (h *HitBTC) GetOrderbook(ctx context.Context, currencyPair string, limit in
 	}
 
 	var resp Orderbook
-	path := fmt.Sprintf("/%s/%s?%s",
-		apiV2Orderbook,
-		currencyPair,
-		vals.Encode())
+	path := common.EncodeURLValues(apiV2Orderbook+"/"+currencyPair, vals)
 	err := h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 	if err != nil {
 		return nil, err
@@ -206,7 +197,7 @@ func (h *HitBTC) GetCandles(ctx context.Context, currencyPair, limit, period str
 	}
 
 	var resp []ChartData
-	path := "/" + apiV2Candles + "/" + currencyPair + "?" + vals.Encode()
+	path := common.EncodeURLValues(apiV2Candles+"/"+currencyPair, vals)
 	return resp, h.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -460,7 +460,6 @@ func TestGetDepositAddress(t *testing.T) {
 	}
 }
 
-//nolint:gocritic // Only used as a testing helper function in this package
 func setupWsAuth(t *testing.T) {
 	t.Helper()
 	if wsSetupRan {

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -583,7 +583,7 @@ func (h *HUOBI) GetOpenOrders(ctx context.Context, symbol currency.Pair, account
 	}
 	vals.Set("symbol", symbolValue)
 	vals.Set("accountID", accountID)
-	if len(side) > 0 {
+	if side != "" {
 		vals.Set("side", side)
 	}
 	vals.Set("size", strconv.FormatInt(size, 10))

--- a/exchanges/huobi/huobi_cfutures.go
+++ b/exchanges/huobi/huobi_cfutures.go
@@ -3,7 +3,6 @@ package huobi
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -138,7 +137,7 @@ func (h *HUOBI) GetSwapKlineData(ctx context.Context, code currency.Pair, period
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -250,14 +249,14 @@ func (h *HUOBI) GetOpenInterestInfo(ctx context.Context, code currency.Pair, per
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
-		return resp, fmt.Errorf("invalid size provided, only values between 1-1200 are supported")
+		return resp, errors.New("invalid size provided, only values between 1-1200 are supported")
 	}
 	aType, ok := validAmountType[amountType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trade type")
+		return resp, errors.New("invalid trade type")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -289,7 +288,7 @@ func (h *HUOBI) GetTraderSentimentIndexAccount(ctx context.Context, code currenc
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -307,7 +306,7 @@ func (h *HUOBI) GetTraderSentimentIndexPosition(ctx context.Context, code curren
 	}
 
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -325,7 +324,7 @@ func (h *HUOBI) GetLiquidationOrders(ctx context.Context, contract currency.Pair
 	}
 	tType, ok := validTradeTypes[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trade type")
+		return resp, errors.New("invalid trade type")
 	}
 	params := url.Values{}
 	params.Set("contract", formattedContract)
@@ -374,10 +373,10 @@ func (h *HUOBI) GetPremiumIndexKlineData(ctx context.Context, code currency.Pair
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
-		return resp, fmt.Errorf("invalid size provided, only values between 1-1200 are supported")
+		return resp, errors.New("invalid size provided, only values between 1-1200 are supported")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -395,10 +394,10 @@ func (h *HUOBI) GetEstimatedFundingRates(ctx context.Context, code currency.Pair
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
-		return resp, fmt.Errorf("invalid size provided, only values between 1-1200 are supported")
+		return resp, errors.New("invalid size provided, only values between 1-1200 are supported")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -416,13 +415,13 @@ func (h *HUOBI) GetBasisData(ctx context.Context, code currency.Pair, period, ba
 		return resp, err
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
-		return resp, fmt.Errorf("invalid size provided, only values between 1-1200 are supported")
+		return resp, errors.New("invalid size provided, only values between 1-1200 are supported")
 	}
 	if !common.StringDataCompareInsensitive(validBasisPriceTypes, basisPriceType) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
 	params.Set("contract_code", codeValue)
@@ -583,7 +582,7 @@ func (h *HUOBI) GetSwapOrderLimitInfo(ctx context.Context, code currency.Pair, o
 	}
 	req["contract_code"] = codeValue
 	if !common.StringDataCompareInsensitive(validOrderTypes, orderType) {
-		return resp, fmt.Errorf("invalid ordertype provided")
+		return resp, errors.New("invalid ordertype provided")
 	}
 	req["order_price_type"] = orderType
 	return resp, h.FuturesAuthenticatedHTTPRequest(ctx, exchange.RestFutures, http.MethodPost, huobiSwapOrderLimitInfo, nil, req, &resp)
@@ -637,7 +636,7 @@ func (h *HUOBI) AccountTransferData(ctx context.Context, code currency.Pair, sub
 	req["subUid"] = subUID
 	req["amount"] = amount
 	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
-		return resp, fmt.Errorf("invalid transferType received")
+		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
 	return resp, h.FuturesAuthenticatedHTTPRequest(ctx, exchange.RestFutures, http.MethodPost, huobiSwapInternalTransferData, nil, req, &resp)
@@ -653,11 +652,11 @@ func (h *HUOBI) AccountTransferRecords(ctx context.Context, code currency.Pair, 
 	}
 	req["contract_code"] = codeValue
 	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
-		return resp, fmt.Errorf("invalid transferType received")
+		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
 	if createDate > 90 {
-		return resp, fmt.Errorf("invalid create date value: only supports up to 90 days")
+		return resp, errors.New("invalid create date value: only supports up to 90 days")
 	}
 	req["create_date"] = strconv.FormatInt(createDate, 10)
 	if pageIndex != 0 {
@@ -684,7 +683,7 @@ func (h *HUOBI) PlaceSwapOrders(ctx context.Context, code currency.Pair, clientO
 	req["direction"] = direction
 	req["offset"] = offset
 	if !common.StringDataCompareInsensitive(validOrderTypes, orderPriceType) {
-		return resp, fmt.Errorf("invalid ordertype provided")
+		return resp, errors.New("invalid ordertype provided")
 	}
 	req["order_price_type"] = orderPriceType
 	req["price"] = price
@@ -698,7 +697,7 @@ func (h *HUOBI) PlaceSwapBatchOrders(ctx context.Context, data BatchOrderRequest
 	var resp BatchOrderData
 	req := make(map[string]interface{})
 	if len(data.Data) > 10 || len(data.Data) == 0 {
-		return resp, fmt.Errorf("invalid data provided: maximum of 10 batch orders supported")
+		return resp, errors.New("invalid data provided: maximum of 10 batch orders supported")
 	}
 	for x := range data.Data {
 		if data.Data[x].ContractCode == "" {
@@ -752,7 +751,7 @@ func (h *HUOBI) PlaceLightningCloseOrder(ctx context.Context, contractCode curre
 	}
 	if orderPriceType != "" {
 		if !common.StringDataCompareInsensitive(validLightningOrderPriceType, orderPriceType) {
-			return resp, fmt.Errorf("invalid orderPriceType")
+			return resp, errors.New("invalid orderPriceType")
 		}
 		req["order_price_type"] = orderPriceType
 	}
@@ -768,7 +767,7 @@ func (h *HUOBI) GetSwapOrderDetails(ctx context.Context, contractCode currency.P
 	req["created_at"] = createdAt
 	oType, ok := validOrderType[orderType]
 	if !ok {
-		return resp, fmt.Errorf("invalid ordertype")
+		return resp, errors.New("invalid ordertype")
 	}
 	req["order_type"] = oType
 	if pageIndex != 0 {
@@ -829,12 +828,12 @@ func (h *HUOBI) GetSwapOrderHistory(ctx context.Context, contractCode currency.P
 	req["contract_code"] = codeValue
 	tType, ok := validFuturesTradeType[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid tradeType")
+		return resp, errors.New("invalid tradeType")
 	}
 	req["trade_type"] = tType
 	rType, ok := validFuturesReqType[reqType]
 	if !ok {
-		return resp, fmt.Errorf("invalid reqType")
+		return resp, errors.New("invalid reqType")
 	}
 	req["type"] = rType
 	reqStatus := "0"
@@ -843,7 +842,7 @@ func (h *HUOBI) GetSwapOrderHistory(ctx context.Context, contractCode currency.P
 		for x := range status {
 			sType, ok := validOrderStatus[status[x]]
 			if !ok {
-				return resp, fmt.Errorf("invalid status")
+				return resp, errors.New("invalid status")
 			}
 			if firstTime {
 				firstTime = false
@@ -855,7 +854,7 @@ func (h *HUOBI) GetSwapOrderHistory(ctx context.Context, contractCode currency.P
 	}
 	req["status"] = reqStatus
 	if createDate < 0 || createDate > 90 {
-		return resp, fmt.Errorf("invalid createDate")
+		return resp, errors.New("invalid createDate")
 	}
 	req["create_date"] = createDate
 	if pageIndex != 0 {
@@ -877,11 +876,11 @@ func (h *HUOBI) GetSwapTradeHistory(ctx context.Context, contractCode currency.P
 	}
 	req["contract_code"] = codeValue
 	if createDate > 90 {
-		return resp, fmt.Errorf("invalid create date value: only supports up to 90 days")
+		return resp, errors.New("invalid create date value: only supports up to 90 days")
 	}
 	tType, ok := validTradeType[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trade type")
+		return resp, errors.New("invalid trade type")
 	}
 	req["trade_type"] = tType
 	req["create_date"] = strconv.FormatInt(createDate, 10)
@@ -905,7 +904,7 @@ func (h *HUOBI) PlaceSwapTriggerOrder(ctx context.Context, contractCode currency
 	req["contract_code"] = codeValue
 	tType, ok := validTriggerType[triggerType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trigger type")
+		return resp, errors.New("invalid trigger type")
 	}
 	req["trigger_type"] = tType
 	req["direction"] = direction
@@ -915,7 +914,7 @@ func (h *HUOBI) PlaceSwapTriggerOrder(ctx context.Context, contractCode currency
 	req["lever_rate"] = leverageRate
 	req["order_price"] = orderPrice
 	if !common.StringDataCompareInsensitive(validOrderPriceType, orderPriceType) {
-		return resp, fmt.Errorf("invalid order price type")
+		return resp, errors.New("invalid order price type")
 	}
 	req["order_price_type"] = orderPriceType
 	return resp, h.FuturesAuthenticatedHTTPRequest(ctx, exchange.RestFutures, http.MethodPost, huobiSwapTriggerOrder, nil, req, &resp)
@@ -954,11 +953,11 @@ func (h *HUOBI) GetSwapTriggerOrderHistory(ctx context.Context, contractCode cur
 	req["status"] = status
 	tType, ok := validTradeType[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trade type")
+		return resp, errors.New("invalid trade type")
 	}
 	req["trade_type"] = tType
 	if createDate > 90 {
-		return resp, fmt.Errorf("invalid create date value: only supports up to 90 days")
+		return resp, errors.New("invalid create date value: only supports up to 90 days")
 	}
 	req["create_date"] = strconv.FormatInt(createDate, 10)
 	if pageIndex != 0 {

--- a/exchanges/huobi/huobi_futures.go
+++ b/exchanges/huobi/huobi_futures.go
@@ -92,7 +92,7 @@ func (h *HUOBI) FGetContractInfo(ctx context.Context, symbol, contractType strin
 	}
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return resp, fmt.Errorf("invalid contractType")
+			return resp, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
 	}
@@ -165,7 +165,7 @@ func (h *HUOBI) ContractOpenInterestUSDT(ctx context.Context, contractCode, pair
 	}
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return nil, fmt.Errorf("invalid contractType")
+			return nil, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
 	}
@@ -188,7 +188,7 @@ func (h *HUOBI) FContractOpenInterest(ctx context.Context, symbol, contractType 
 	}
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return resp, fmt.Errorf("invalid contractType")
+			return resp, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
 	}
@@ -264,7 +264,7 @@ func (h *HUOBI) FGetKlineData(ctx context.Context, symbol currency.Pair, period 
 	}
 	params.Set("symbol", symbolValue)
 	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
 	if size > 0 {
@@ -380,7 +380,7 @@ func (h *HUOBI) FQueryHisOpenInterest(ctx context.Context, symbol, contractType,
 	}
 	params.Set("contract_type", contractType)
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period")
+		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
 	if size > 0 || size <= 200 {
@@ -388,7 +388,7 @@ func (h *HUOBI) FQueryHisOpenInterest(ctx context.Context, symbol, contractType,
 	}
 	validAmount, ok := validAmountType[amountType]
 	if !ok {
-		return resp, fmt.Errorf("invalid amountType")
+		return resp, errors.New("invalid amountType")
 	}
 	params.Set("amount_type", strconv.FormatInt(validAmount, 10))
 	path := common.EncodeURLValues(fHisContractOpenInterest, params)
@@ -418,7 +418,7 @@ func (h *HUOBI) FQueryTopAccountsRatio(ctx context.Context, symbol, period strin
 		params.Set("symbol", symbol)
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period")
+		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
 	path := common.EncodeURLValues(fTopAccountsSentiment, params)
@@ -433,7 +433,7 @@ func (h *HUOBI) FQueryTopPositionsRatio(ctx context.Context, symbol, period stri
 		params.Set("symbol", symbol)
 	}
 	if !common.StringDataCompareInsensitive(validPeriods, period) {
-		return resp, fmt.Errorf("invalid period")
+		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
 	path := common.EncodeURLValues(fTopPositionsSentiment, params)
@@ -445,7 +445,7 @@ func (h *HUOBI) FLiquidationOrders(ctx context.Context, symbol currency.Code, tr
 	var resp LiquidationOrdersData
 	tType, ok := validTradeTypes[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trade type")
+		return resp, errors.New("invalid trade type")
 	}
 	params := url.Values{}
 	params.Set("symbol", symbol.String())
@@ -477,11 +477,11 @@ func (h *HUOBI) FIndexKline(ctx context.Context, symbol currency.Pair, period st
 	}
 	params.Set("symbol", symbolValue)
 	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
 	if size <= 0 || size > 2000 {
-		return resp, fmt.Errorf("invalid size")
+		return resp, errors.New("invalid size")
 	}
 	params.Set("size", strconv.FormatInt(size, 10))
 	path := common.EncodeURLValues(fIndexKline, params)
@@ -498,7 +498,7 @@ func (h *HUOBI) FGetBasisData(ctx context.Context, symbol currency.Pair, period,
 	}
 	params.Set("symbol", symbolValue)
 	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
-		return resp, fmt.Errorf("invalid period value received")
+		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
 	if basisPriceType != "" {
@@ -587,7 +587,7 @@ func (h *HUOBI) FGetFinancialRecords(ctx context.Context, symbol, recordType str
 	if recordType != "" {
 		rType, ok := validFuturesRecordTypes[recordType]
 		if !ok {
-			return resp, fmt.Errorf("invalid recordType")
+			return resp, errors.New("invalid recordType")
 		}
 		req["type"] = rType
 	}
@@ -633,7 +633,7 @@ func (h *HUOBI) FGetOrderLimits(ctx context.Context, symbol, orderPriceType stri
 	}
 	if orderPriceType != "" {
 		if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
-			return resp, fmt.Errorf("invalid orderPriceType")
+			return resp, errors.New("invalid orderPriceType")
 		}
 		req["order_price_type"] = orderPriceType
 	}
@@ -698,7 +698,7 @@ func (h *HUOBI) FTransfer(ctx context.Context, subUID, symbol, transferType stri
 	req["subUid"] = subUID
 	req["amount"] = amount
 	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
-		return resp, fmt.Errorf("invalid transferType received")
+		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
 	return resp, h.FuturesAuthenticatedHTTPRequest(ctx, exchange.RestFutures, http.MethodPost, fTransfer, nil, req, &resp)
@@ -712,11 +712,11 @@ func (h *HUOBI) FGetTransferRecords(ctx context.Context, symbol, transferType st
 		req["symbol"] = symbol
 	}
 	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
-		return resp, fmt.Errorf("invalid transferType received")
+		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
 	if createDate < 0 || createDate > 90 {
-		return resp, fmt.Errorf("invalid create date value: only supports up to 90 days")
+		return resp, errors.New("invalid create date value: only supports up to 90 days")
 	}
 	req["create_date"] = strconv.FormatInt(createDate, 10)
 	if pageIndex != 0 {
@@ -751,7 +751,7 @@ func (h *HUOBI) FOrder(ctx context.Context, contractCode currency.Pair, symbol, 
 	}
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return resp, fmt.Errorf("invalid contractType")
+			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
 	}
@@ -774,10 +774,10 @@ func (h *HUOBI) FOrder(ctx context.Context, contractCode currency.Pair, symbol, 
 	}
 	req["direction"] = direction
 	if !common.StringDataCompareInsensitive(validOffsetTypes, offset) {
-		return resp, fmt.Errorf("invalid offset amounts")
+		return resp, errors.New("invalid offset amounts")
 	}
 	if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
-		return resp, fmt.Errorf("invalid orderPriceType")
+		return resp, errors.New("invalid orderPriceType")
 	}
 	req["order_price_type"] = orderPriceType
 	req["lever_rate"] = leverageRate
@@ -792,7 +792,7 @@ func (h *HUOBI) FPlaceBatchOrder(ctx context.Context, data []fBatchOrderData) (F
 	var resp FBatchOrderResponse
 	req := make(map[string]interface{})
 	if len(data) > 10 || len(data) == 0 {
-		return resp, fmt.Errorf("invalid data provided: maximum of 10 batch orders supported")
+		return resp, errors.New("invalid data provided: maximum of 10 batch orders supported")
 	}
 	for x := range data {
 		if data[x].ContractCode != "" {
@@ -808,14 +808,14 @@ func (h *HUOBI) FPlaceBatchOrder(ctx context.Context, data []fBatchOrderData) (F
 		}
 		if data[x].ContractType != "" {
 			if !common.StringDataCompareInsensitive(validContractTypes, data[x].ContractType) {
-				return resp, fmt.Errorf("invalid contractType")
+				return resp, errors.New("invalid contractType")
 			}
 		}
 		if !common.StringDataCompareInsensitive(validOffsetTypes, data[x].Offset) {
-			return resp, fmt.Errorf("invalid offset amounts")
+			return resp, errors.New("invalid offset amounts")
 		}
 		if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, data[x].OrderPriceType) {
-			return resp, fmt.Errorf("invalid orderPriceType")
+			return resp, errors.New("invalid orderPriceType")
 		}
 	}
 	req["orders_data"] = data
@@ -848,7 +848,7 @@ func (h *HUOBI) FCancelAllOrders(ctx context.Context, contractCode currency.Pair
 	}
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return resp, fmt.Errorf("invalid contractType")
+			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
 	}
@@ -869,7 +869,7 @@ func (h *HUOBI) FFlashCloseOrder(ctx context.Context, contractCode currency.Pair
 	req["symbol"] = symbol
 	if contractType != "" {
 		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
-			return resp, fmt.Errorf("invalid contractType")
+			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
 	}
@@ -887,7 +887,7 @@ func (h *HUOBI) FFlashCloseOrder(ctx context.Context, contractCode currency.Pair
 	}
 	if orderPriceType != "" {
 		if !common.StringDataCompareInsensitive(validOPTypes, orderPriceType) {
-			return resp, fmt.Errorf("invalid orderPriceType")
+			return resp, errors.New("invalid orderPriceType")
 		}
 		req["orderPriceType"] = orderPriceType
 	}
@@ -917,7 +917,7 @@ func (h *HUOBI) FOrderDetails(ctx context.Context, symbol, orderID, orderType st
 	req["created_at"] = strconv.FormatInt(createdAt.Unix(), 10)
 	oType, ok := validOrderType[orderType]
 	if !ok {
-		return resp, fmt.Errorf("invalid orderType")
+		return resp, errors.New("invalid orderType")
 	}
 	req["order_type"] = oType
 	if pageIndex != 0 {
@@ -950,12 +950,12 @@ func (h *HUOBI) FGetOrderHistory(ctx context.Context, contractCode currency.Pair
 	req["symbol"] = symbol
 	tType, ok := validFuturesTradeType[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid tradeType")
+		return resp, errors.New("invalid tradeType")
 	}
 	req["trade_type"] = tType
 	rType, ok := validFuturesReqType[reqType]
 	if !ok {
-		return resp, fmt.Errorf("invalid reqType")
+		return resp, errors.New("invalid reqType")
 	}
 	req["type"] = rType
 	reqStatus := "0"
@@ -964,7 +964,7 @@ func (h *HUOBI) FGetOrderHistory(ctx context.Context, contractCode currency.Pair
 		for x := range status {
 			sType, ok := validOrderStatus[status[x]]
 			if !ok {
-				return resp, fmt.Errorf("invalid status")
+				return resp, errors.New("invalid status")
 			}
 			if firstTime {
 				firstTime = false
@@ -976,7 +976,7 @@ func (h *HUOBI) FGetOrderHistory(ctx context.Context, contractCode currency.Pair
 	}
 	req["status"] = reqStatus
 	if createDate < 0 || createDate > 90 {
-		return resp, fmt.Errorf("invalid createDate")
+		return resp, errors.New("invalid createDate")
 	}
 	req["create_date"] = createDate
 	if !contractCode.IsEmpty() {
@@ -989,7 +989,7 @@ func (h *HUOBI) FGetOrderHistory(ctx context.Context, contractCode currency.Pair
 	if orderType != "" {
 		oType, ok := validFuturesOrderTypes[orderType]
 		if !ok {
-			return resp, fmt.Errorf("invalid orderType")
+			return resp, errors.New("invalid orderType")
 		}
 		req["order_type"] = oType
 	}
@@ -1009,7 +1009,7 @@ func (h *HUOBI) FTradeHistory(ctx context.Context, contractCode currency.Pair, s
 	req["symbol"] = symbol
 	tType, ok := validTradeType[tradeType]
 	if !ok {
-		return resp, fmt.Errorf("invalid tradeType")
+		return resp, errors.New("invalid tradeType")
 	}
 	req["trade_type"] = tType
 	if !contractCode.IsEmpty() {
@@ -1020,7 +1020,7 @@ func (h *HUOBI) FTradeHistory(ctx context.Context, contractCode currency.Pair, s
 		req["contract_code"] = codeValue
 	}
 	if createDate <= 0 || createDate > 90 {
-		return resp, fmt.Errorf("invalid createDate")
+		return resp, errors.New("invalid createDate")
 	}
 	req["create_date"] = createDate
 	if pageIndex != 0 {
@@ -1054,12 +1054,12 @@ func (h *HUOBI) FPlaceTriggerOrder(ctx context.Context, contractCode currency.Pa
 	}
 	tType, ok := validTriggerType[triggerType]
 	if !ok {
-		return resp, fmt.Errorf("invalid trigger type")
+		return resp, errors.New("invalid trigger type")
 	}
 	req["trigger_type"] = tType
 	req["direction"] = direction
 	if !common.StringDataCompareInsensitive(validOffsetTypes, offset) {
-		return resp, fmt.Errorf("invalid offset")
+		return resp, errors.New("invalid offset")
 	}
 	req["offset"] = offset
 	req["trigger_price"] = triggerPrice
@@ -1067,7 +1067,7 @@ func (h *HUOBI) FPlaceTriggerOrder(ctx context.Context, contractCode currency.Pa
 	req["lever_rate"] = leverageRate
 	req["order_price"] = orderPrice
 	if !common.StringDataCompareInsensitive(validOrderPriceType, orderPriceType) {
-		return resp, fmt.Errorf("invalid order price type")
+		return resp, errors.New("invalid order price type")
 	}
 	req["order_price_type"] = orderPriceType
 	return resp, h.FuturesAuthenticatedHTTPRequest(ctx, exchange.RestFutures, http.MethodPost, fTriggerOrder, nil, req, &resp)
@@ -1139,17 +1139,17 @@ func (h *HUOBI) FQueryTriggerOrderHistory(ctx context.Context, contractCode curr
 	if tradeType != "" {
 		tType, ok := validTradeType[tradeType]
 		if !ok {
-			return resp, fmt.Errorf("invalid tradeType")
+			return resp, errors.New("invalid tradeType")
 		}
 		req["trade_type"] = tType
 	}
 	validStatus, ok := validStatusTypes[status]
 	if !ok {
-		return resp, fmt.Errorf("invalid status")
+		return resp, errors.New("invalid status")
 	}
 	req["status"] = validStatus
 	if createDate <= 0 || createDate > 90 {
-		return resp, fmt.Errorf("invalid createDate")
+		return resp, errors.New("invalid createDate")
 	}
 	req["create_date"] = createDate
 	if pageIndex != 0 {

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -2886,7 +2886,7 @@ func TestConvertContractShortHandToExpiry(t *testing.T) {
 	cp := currency.NewPair(currency.BTC, currency.NewCode("CW"))
 	cp, err := h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.NotEqual(t, cp.Quote.String(), "CW")
+	assert.NotEqual(t, "CW", cp.Quote.String())
 	tick, err := h.FetchTicker(context.Background(), cp, asset.Futures)
 	if assert.NoError(t, err) {
 		assert.NotZero(t, tick.Close)
@@ -2895,7 +2895,7 @@ func TestConvertContractShortHandToExpiry(t *testing.T) {
 	cp = currency.NewPair(currency.BTC, currency.NewCode("NW"))
 	cp, err = h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.NotEqual(t, cp.Quote.String(), "NW")
+	assert.NotEqual(t, "NW", cp.Quote.String())
 	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
 	if assert.NoError(t, err) {
 		assert.NotZero(t, tick.Close)
@@ -2904,7 +2904,7 @@ func TestConvertContractShortHandToExpiry(t *testing.T) {
 	cp = currency.NewPair(currency.BTC, currency.NewCode("CQ"))
 	cp, err = h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.NotEqual(t, cp.Quote.String(), "CQ")
+	assert.NotEqual(t, "CQ", cp.Quote.String())
 	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
 	if assert.NoError(t, err) {
 		assert.NotZero(t, tick.Close)
@@ -2915,12 +2915,12 @@ func TestConvertContractShortHandToExpiry(t *testing.T) {
 	tt = time.Date(2021, 6, 3, 0, 0, 0, 0, time.UTC)
 	cp, err = h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.Equal(t, cp.Quote.String(), "210625")
+	assert.Equal(t, "210625", cp.Quote.String())
 
 	cp = currency.NewPair(currency.BTC, currency.NewCode("CW"))
 	cp, err = h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.Equal(t, cp.Quote.String(), "210604")
+	assert.Equal(t, "210604", cp.Quote.String())
 
 	cp = currency.NewPair(currency.BTC, currency.NewCode("CWif hat"))
 	_, err = h.convertContractShortHandToExpiry(cp, tt)
@@ -2930,7 +2930,7 @@ func TestConvertContractShortHandToExpiry(t *testing.T) {
 	cp = currency.NewPair(currency.BTC, currency.NewCode("NQ"))
 	cp, err = h.convertContractShortHandToExpiry(cp, tt)
 	assert.NoError(t, err)
-	assert.NotEqual(t, cp.Quote.String(), "NQ")
+	assert.NotEqual(t, "NQ", cp.Quote.String())
 	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
 	if err != nil {
 		// Huobi doesn't always have a next-quarter contract, return if no data found

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -514,10 +514,10 @@ func (h *HUOBI) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item)
 		}
 
 		if len(marketData.Tick.Bid) == 0 {
-			return nil, fmt.Errorf("invalid data for bid")
+			return nil, errors.New("invalid data for bid")
 		}
 		if len(marketData.Tick.Ask) == 0 {
-			return nil, fmt.Errorf("invalid data for Ask")
+			return nil, errors.New("invalid data for Ask")
 		}
 
 		err = ticker.ProcessTicker(&ticker.Price{
@@ -1252,7 +1252,7 @@ func (h *HUOBI) CancelAllOrders(ctx context.Context, orderCancellation *order.Ca
 					cancelAllOrdersResponse.Status[split[x]] = "success"
 				}
 				for y := range a.Errors {
-					cancelAllOrdersResponse.Status[a.Errors[y].OrderID] = fmt.Sprintf("fail: %s", a.Errors[y].ErrMsg)
+					cancelAllOrdersResponse.Status[a.Errors[y].OrderID] = "fail: " + a.Errors[y].ErrMsg
 				}
 			}
 		} else {
@@ -1265,7 +1265,7 @@ func (h *HUOBI) CancelAllOrders(ctx context.Context, orderCancellation *order.Ca
 				cancelAllOrdersResponse.Status[split[x]] = "success"
 			}
 			for y := range a.Errors {
-				cancelAllOrdersResponse.Status[a.Errors[y].OrderID] = fmt.Sprintf("fail: %s", a.Errors[y].ErrMsg)
+				cancelAllOrdersResponse.Status[a.Errors[y].OrderID] = "fail: " + a.Errors[y].ErrMsg
 			}
 		}
 	case asset.Futures:
@@ -1284,7 +1284,7 @@ func (h *HUOBI) CancelAllOrders(ctx context.Context, orderCancellation *order.Ca
 					cancelAllOrdersResponse.Status[split[x]] = "success"
 				}
 				for y := range a.Data.Errors {
-					cancelAllOrdersResponse.Status[strconv.FormatInt(a.Data.Errors[y].OrderID, 10)] = fmt.Sprintf("fail: %s", a.Data.Errors[y].ErrMsg)
+					cancelAllOrdersResponse.Status[strconv.FormatInt(a.Data.Errors[y].OrderID, 10)] = "fail: " + a.Data.Errors[y].ErrMsg
 				}
 			}
 		} else {
@@ -1297,7 +1297,7 @@ func (h *HUOBI) CancelAllOrders(ctx context.Context, orderCancellation *order.Ca
 				cancelAllOrdersResponse.Status[split[x]] = "success"
 			}
 			for y := range a.Data.Errors {
-				cancelAllOrdersResponse.Status[strconv.FormatInt(a.Data.Errors[y].OrderID, 10)] = fmt.Sprintf("fail: %s", a.Data.Errors[y].ErrMsg)
+				cancelAllOrdersResponse.Status[strconv.FormatInt(a.Data.Errors[y].OrderID, 10)] = "fail: " + a.Data.Errors[y].ErrMsg
 			}
 		}
 	}
@@ -1479,7 +1479,7 @@ func (h *HUOBI) GetDepositAddress(ctx context.Context, cryptocurrency currency.C
 			}, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to match deposit address currency or chain")
+	return nil, errors.New("unable to match deposit address currency or chain")
 }
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
@@ -2085,7 +2085,7 @@ func compatibleVars(side, orderPriceType string, status int64) (OrderVars, error
 	case "sell":
 		resp.Side = order.Sell
 	default:
-		return resp, fmt.Errorf("invalid orderSide")
+		return resp, errors.New("invalid orderSide")
 	}
 	switch orderPriceType {
 	case "limit":
@@ -2095,7 +2095,7 @@ func compatibleVars(side, orderPriceType string, status int64) (OrderVars, error
 	case "post_only":
 		resp.OrderType = order.PostOnly
 	default:
-		return resp, fmt.Errorf("invalid orderPriceType")
+		return resp, errors.New("invalid orderPriceType")
 	}
 	switch status {
 	case 1, 2, 11:
@@ -2111,7 +2111,7 @@ func compatibleVars(side, orderPriceType string, status int64) (OrderVars, error
 	case 7:
 		resp.Status = order.Cancelled
 	default:
-		return resp, fmt.Errorf("invalid orderStatus")
+		return resp, errors.New("invalid orderStatus")
 	}
 	return resp, nil
 }

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -569,11 +569,11 @@ func (k *Kraken) GetTradeBalance(ctx context.Context, args ...TradeBalanceOption
 	params := url.Values{}
 
 	if args != nil {
-		if len(args[0].Aclass) > 0 {
+		if args[0].Aclass != "" {
 			params.Set("aclass", args[0].Aclass)
 		}
 
-		if len(args[0].Asset) > 0 {
+		if args[0].Asset != "" {
 			params.Set("asset", args[0].Asset)
 		}
 	}
@@ -626,11 +626,11 @@ func (k *Kraken) GetClosedOrders(ctx context.Context, args GetClosedOrdersOption
 		params.Set("userref", strconv.FormatInt(int64(args.UserRef), 10))
 	}
 
-	if len(args.Start) > 0 {
+	if args.Start != "" {
 		params.Set("start", args.Start)
 	}
 
-	if len(args.End) > 0 {
+	if args.End != "" {
 		params.Set("end", args.End)
 	}
 
@@ -638,7 +638,7 @@ func (k *Kraken) GetClosedOrders(ctx context.Context, args GetClosedOrdersOption
 		params.Set("ofs", strconv.FormatInt(args.Ofs, 10))
 	}
 
-	if len(args.CloseTime) > 0 {
+	if args.CloseTime != "" {
 		params.Set("closetime", args.CloseTime)
 	}
 
@@ -689,7 +689,7 @@ func (k *Kraken) GetTradesHistory(ctx context.Context, args ...GetTradesHistoryO
 	params := url.Values{}
 
 	if args != nil {
-		if len(args[0].Type) > 0 {
+		if args[0].Type != "" {
 			params.Set("type", args[0].Type)
 		}
 
@@ -697,11 +697,11 @@ func (k *Kraken) GetTradesHistory(ctx context.Context, args ...GetTradesHistoryO
 			params.Set("trades", "true")
 		}
 
-		if len(args[0].Start) > 0 {
+		if args[0].Start != "" {
 			params.Set("start", args[0].Start)
 		}
 
-		if len(args[0].End) > 0 {
+		if args[0].End != "" {
 			params.Set("end", args[0].End)
 		}
 

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -838,7 +838,7 @@ func (k *Kraken) wsProcessOrderBook(channelData *WebsocketChannelData, data map[
 	if asksExist || bidsExist {
 		checksum, ok := data["c"].(string)
 		if !ok {
-			return fmt.Errorf("could not process orderbook update checksum not found")
+			return errors.New("could not process orderbook update checksum not found")
 		}
 
 		k.wsRequestMtx.Lock()
@@ -1414,7 +1414,7 @@ func (k *Kraken) wsCancelOrders(orderIDs []string) error {
 	if cancelOrdersStatus[id].Error != "" || len(orderIDs) != successful { // strange Kraken logic ...
 		var reason string
 		if cancelOrdersStatus[id].Error != "" {
-			reason = fmt.Sprintf(" Reason: %s", cancelOrdersStatus[id].Error)
+			reason = " Reason: " + cancelOrdersStatus[id].Error
 		}
 		return fmt.Errorf("%s cancelled %d out of %d orders.%s",
 			k.Name, successful, len(orderIDs), reason)

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -1474,7 +1474,7 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 						Pair:      pairs[p],
 					})
 				default:
-					return orders, fmt.Errorf("invalid orderHistory data")
+					return orders, errors.New("invalid orderHistory data")
 				}
 			}
 		}
@@ -1566,7 +1566,7 @@ func compatibleOrderSide(side string) (order.Side, error) {
 	case strings.EqualFold(order.Sell.String(), side):
 		return order.Sell, nil
 	}
-	return order.AnySide, fmt.Errorf("invalid side received")
+	return order.AnySide, errors.New("invalid side received")
 }
 
 func compatibleOrderType(orderType string) (order.Type, error) {
@@ -1579,7 +1579,7 @@ func compatibleOrderType(orderType string) (order.Type, error) {
 	case "take_profit":
 		resp = order.TakeProfit
 	default:
-		return resp, fmt.Errorf("invalid orderType")
+		return resp, errors.New("invalid orderType")
 	}
 	return resp, nil
 }
@@ -1594,7 +1594,7 @@ func compatibleFillOrderType(fillType string) (order.Type, error) {
 	case "liquidation":
 		resp = order.Liquidation
 	default:
-		return resp, fmt.Errorf("invalid orderPriceType")
+		return resp, errors.New("invalid orderPriceType")
 	}
 	return resp, nil
 }

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -1995,7 +1995,7 @@ func TestPushData(t *testing.T) {
 func verifySubs(tb testing.TB, subs []subscription.Subscription, a asset.Item, prefix string, expected ...string) {
 	tb.Helper()
 	var sub *subscription.Subscription
-	for i, s := range subs {
+	for i, s := range subs { //nolint:gocritic // prefer convenience over performance here for tests
 		if s.Asset == a && strings.HasPrefix(s.Channel, prefix) {
 			if len(expected) == 1 && !strings.Contains(s.Channel, expected[0]) {
 				continue
@@ -2510,7 +2510,7 @@ func TestProcessMarketSnapshot(t *testing.T) {
 					assert.Equal(t, time.UnixMilli(1700555340197), v.LastUpdated, "datetime")
 					assert.Contains(t, []asset.Item{asset.Spot, asset.Margin}, v.AssetType, "AssetType is Spot or Margin")
 					seenAssetTypes[v.AssetType]++
-					assert.Equal(t, seenAssetTypes[v.AssetType], 1, "Each Asset Type is sent only once per unique snapshot")
+					assert.Equal(t, 1, seenAssetTypes[v.AssetType], "Each Asset Type is sent only once per unique snapshot")
 					assert.Equal(t, 0.054846, v.High, "high")
 					assert.Equal(t, 0.053778, v.Last, "lastTradedPrice")
 					assert.Equal(t, 0.05364, v.Low, "low")
@@ -2640,7 +2640,7 @@ func TestChangePositionMargin(t *testing.T) {
 
 	req.NewAllocatedMargin = 1337
 	_, err = ku.ChangePositionMargin(context.Background(), req)
-	assert.ErrorIs(t, err, nil)
+	assert.NoError(t, err)
 }
 
 func TestGetFuturesPositionSummary(t *testing.T) {
@@ -2659,7 +2659,7 @@ func TestGetFuturesPositionSummary(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	req.Pair = currency.NewPair(currency.XBT, currency.USDTM)
 	_, err = ku.GetFuturesPositionSummary(context.Background(), req)
-	assert.ErrorIs(t, err, nil)
+	assert.NoError(t, err)
 }
 
 func TestGetFuturesPositionOrders(t *testing.T) {
@@ -2685,7 +2685,7 @@ func TestGetFuturesPositionOrders(t *testing.T) {
 	req.EndDate = time.Now()
 	req.StartDate = req.EndDate.Add(-time.Hour * 24 * 7)
 	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
-	assert.ErrorIs(t, err, nil)
+	assert.NoError(t, err)
 
 	req.StartDate = req.EndDate.Add(-time.Hour * 24 * 30)
 	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
@@ -2693,7 +2693,7 @@ func TestGetFuturesPositionOrders(t *testing.T) {
 
 	req.RespectOrderHistoryLimits = true
 	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
-	assert.ErrorIs(t, err, nil)
+	assert.NoError(t, err)
 }
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -1350,7 +1350,7 @@ func (ku *Kucoin) GetFeeByType(ctx context.Context, feeBuilder *exchange.FeeBuil
 			}
 			return feeBuilder.Amount * fee.TakerFeeRate, nil
 		}
-		return 0, fmt.Errorf("can't construct fee")
+		return 0, errors.New("can't construct fee")
 	}
 }
 

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -484,7 +484,7 @@ func (ok *Okx) CancelSingleOrder(ctx context.Context, arg CancelOrderRequestPara
 		return nil, errMissingInstrumentID
 	}
 	if arg.OrderID == "" && arg.ClientOrderID == "" {
-		return nil, fmt.Errorf("either order id or client id is required")
+		return nil, errors.New("either order id or client id is required")
 	}
 	var resp []OrderData
 	err := ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelOrderEPL, http.MethodPost, cancelTradeOrder, &arg, &resp, true)
@@ -509,7 +509,7 @@ func (ok *Okx) CancelMultipleOrders(ctx context.Context, args []CancelOrderReque
 			return nil, errMissingInstrumentID
 		}
 		if arg.OrderID == "" && arg.ClientOrderID == "" {
-			return nil, fmt.Errorf("either order id or client id is required")
+			return nil, errors.New("either order id or client id is required")
 		}
 	}
 	var resp []OrderData
@@ -2079,7 +2079,7 @@ func (ok *Okx) GetMaximumAvailableTradableAmount(ctx context.Context, instrument
 }
 
 // IncreaseDecreaseMargin Increase or decrease the margin of the isolated position. Margin reduction may result in the change of the actual leverage.
-func (ok *Okx) IncreaseDecreaseMargin(ctx context.Context, arg IncreaseDecreaseMarginInput) (*IncreaseDecreaseMargin, error) {
+func (ok *Okx) IncreaseDecreaseMargin(ctx context.Context, arg *IncreaseDecreaseMarginInput) (*IncreaseDecreaseMargin, error) {
 	if arg.InstrumentID == "" {
 		return nil, errMissingInstrumentID
 	}
@@ -2499,7 +2499,7 @@ func (ok *Okx) HistoryOfSubaccountTransfer(ctx context.Context, currency, subacc
 }
 
 // MasterAccountsManageTransfersBetweenSubaccounts master accounts manage the transfers between sub-accounts applies to master accounts only
-func (ok *Okx) MasterAccountsManageTransfersBetweenSubaccounts(ctx context.Context, arg SubAccountAssetTransferParams) ([]TransferIDInfo, error) {
+func (ok *Okx) MasterAccountsManageTransfersBetweenSubaccounts(ctx context.Context, arg *SubAccountAssetTransferParams) ([]TransferIDInfo, error) {
 	if arg.Currency == "" {
 		return nil, errInvalidCurrencyValue
 	}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -1405,7 +1405,7 @@ func TestIncreaseDecreaseMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
 
-	if _, err := ok.IncreaseDecreaseMargin(contextGenerate(), IncreaseDecreaseMarginInput{
+	if _, err := ok.IncreaseDecreaseMargin(contextGenerate(), &IncreaseDecreaseMarginInput{
 		InstrumentID: "BTC-USDT",
 		PositionSide: "long",
 		Type:         "add",
@@ -1620,13 +1620,13 @@ func TestMasterAccountsManageTransfersBetweenSubaccounts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
 
-	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 9, To: 9, FromSubAccount: "", ToSubAccount: "", LoanTransfer: true}); err != nil && !errors.Is(err, errInvalidSubaccount) {
+	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), &SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 9, To: 9, FromSubAccount: "", ToSubAccount: "", LoanTransfer: true}); err != nil && !errors.Is(err, errInvalidSubaccount) {
 		t.Error("Okx MasterAccountsManageTransfersBetweenSubaccounts() error", err)
 	}
-	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 8, To: 8, FromSubAccount: "", ToSubAccount: "", LoanTransfer: true}); err != nil && !errors.Is(err, errInvalidSubaccount) {
+	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), &SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 8, To: 8, FromSubAccount: "", ToSubAccount: "", LoanTransfer: true}); err != nil && !errors.Is(err, errInvalidSubaccount) {
 		t.Error("Okx MasterAccountsManageTransfersBetweenSubaccounts() error", err)
 	}
-	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 6, To: 6, FromSubAccount: "test1", ToSubAccount: "test2", LoanTransfer: true}); err != nil && !strings.Contains(err.Error(), "Sub-account test1 does not exists") {
+	if _, err := ok.MasterAccountsManageTransfersBetweenSubaccounts(contextGenerate(), &SubAccountAssetTransferParams{Currency: "BTC", Amount: 1200, From: 6, To: 6, FromSubAccount: "test1", ToSubAccount: "test2", LoanTransfer: true}); err != nil && !strings.Contains(err.Error(), "Sub-account test1 does not exists") {
 		t.Error("Okx MasterAccountsManageTransfersBetweenSubaccounts() error", err)
 	}
 }

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1485,7 +1485,7 @@ func (ok *Okx) WsCancelOrder(arg CancelOrderRequestParam) (*OrderData, error) {
 		return nil, errMissingInstrumentID
 	}
 	if arg.OrderID == "" && arg.ClientOrderID == "" {
-		return nil, fmt.Errorf("either order id or client supplier id is required")
+		return nil, errors.New("either order id or client supplier id is required")
 	}
 	randomID, err := common.GenerateRandomString(4, common.NumberCharacters)
 	if err != nil {
@@ -1544,7 +1544,7 @@ func (ok *Okx) WsCancelMultipleOrder(args []CancelOrderRequestParam) ([]OrderDat
 			return nil, errMissingInstrumentID
 		}
 		if arg.OrderID == "" && arg.ClientOrderID == "" {
-			return nil, fmt.Errorf("either order id or client supplier id is required")
+			return nil, errors.New("either order id or client supplier id is required")
 		}
 	}
 	randomID, err := common.GenerateRandomString(4, common.NumberCharacters)

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -737,7 +737,7 @@ func (ok *Okx) SubmitOrder(ctx context.Context, s *order.Submit) (*order.SubmitR
 		return nil, fmt.Errorf("%w: %v", asset.ErrNotSupported, s.AssetType)
 	}
 	if s.Amount <= 0 {
-		return nil, fmt.Errorf("amount, or size (sz) of quantity to buy or sell hast to be greater than zero ")
+		return nil, errors.New("amount, or size (sz) of quantity to buy or sell hast to be greater than zero")
 	}
 	pairFormat, err := ok.GetPairFormat(s.AssetType, true)
 	if err != nil {
@@ -1784,7 +1784,7 @@ func (ok *Okx) ChangePositionMargin(ctx context.Context, req *margin.PositionCha
 	if req.MarginSide == "" {
 		req.MarginSide = "net"
 	}
-	r := IncreaseDecreaseMarginInput{
+	r := &IncreaseDecreaseMarginInput{
 		InstrumentID: fPair.String(),
 		PositionSide: req.MarginSide,
 		Type:         marginType,

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -1513,7 +1513,7 @@ func TestMatchFilter(t *testing.T) {
 	for num, tt := range tests {
 		num := num
 		tt := tt
-		t.Run(fmt.Sprintf("%v", num), func(t *testing.T) {
+		t.Run(strconv.Itoa(num), func(t *testing.T) {
 			t.Parallel()
 			if tt.o.MatchFilter(tt.f) != tt.expectedResult {
 				t.Errorf("tests[%v] failed", num)
@@ -2056,7 +2056,7 @@ func TestAdjustQuoteAmount(t *testing.T) {
 func TestSideUnmarshal(t *testing.T) {
 	t.Parallel()
 	var s Side
-	assert.Nil(t, s.UnmarshalJSON([]byte(`"SELL"`)), "Quoted valid side okay")
+	assert.NoError(t, s.UnmarshalJSON([]byte(`"SELL"`)), "Quoted valid side okay")
 	assert.Equal(t, Sell, s, "Correctly set order Side")
 	assert.ErrorIs(t, s.UnmarshalJSON([]byte(`"STEAL"`)), ErrSideIsInvalid, "Quoted invalid side errors")
 	var jErr *json.UnmarshalTypeError

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -96,7 +96,7 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 	if currencyPair != "" {
 		vals.Set("currencyPair", currencyPair)
 		resp := OrderbookResponse{}
-		path := fmt.Sprintf("/public?command=returnOrderBook&%s", vals.Encode())
+		path := "/public?command=returnOrderBook&" + vals.Encode()
 		err := p.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 		if err != nil {
 			return oba, err
@@ -141,7 +141,7 @@ func (p *Poloniex) GetOrderbook(ctx context.Context, currencyPair string, depth 
 	} else {
 		vals.Set("currencyPair", "all")
 		resp := OrderbookResponseAll{}
-		path := fmt.Sprintf("/public?command=returnOrderBook&%s", vals.Encode())
+		path := "/public?command=returnOrderBook&" + vals.Encode()
 		err := p.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp.Data)
 		if err != nil {
 			return oba, err
@@ -199,8 +199,7 @@ func (p *Poloniex) GetTradeHistory(ctx context.Context, currencyPair string, sta
 	}
 
 	var resp []TradeHistory
-	path := fmt.Sprintf("/public?command=returnTradeHistory&%s", vals.Encode())
-
+	path := "/public?command=returnTradeHistory&" + vals.Encode()
 	return resp, p.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -277,8 +276,7 @@ func (p *Poloniex) GetTimestamp(ctx context.Context) (time.Time, error) {
 // currency, specified by the "currency" GET parameter.
 func (p *Poloniex) GetLoanOrders(ctx context.Context, currency string) (LoanOrders, error) {
 	resp := LoanOrders{}
-	path := fmt.Sprintf("/public?command=returnLoanOrders&currency=%s", currency)
-
+	path := "/public?command=returnLoanOrders&currency=" + currency
 	return resp, p.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -463,7 +461,7 @@ func (p *Poloniex) GetAuthenticatedOrderStatus(ctx context.Context, orderID stri
 	values := url.Values{}
 
 	if orderID == "" {
-		return o, fmt.Errorf("no orderID passed")
+		return o, errors.New("no orderID passed")
 	}
 
 	values.Set("orderNumber", orderID)
@@ -501,7 +499,7 @@ func (p *Poloniex) GetAuthenticatedOrderTrades(ctx context.Context, orderID stri
 	values := url.Values{}
 
 	if orderID == "" {
-		return nil, fmt.Errorf("no orderId passed")
+		return nil, errors.New("no orderID passed")
 	}
 
 	values.Set("orderNumber", orderID)
@@ -512,7 +510,7 @@ func (p *Poloniex) GetAuthenticatedOrderTrades(ctx context.Context, orderID stri
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("received unexpected response")
+		return nil, errors.New("received unexpected response")
 	}
 
 	switch result[0] {
@@ -528,7 +526,7 @@ func (p *Poloniex) GetAuthenticatedOrderTrades(ctx context.Context, orderID stri
 	case '[': // data received
 		err = json.Unmarshal(result, &o)
 	default:
-		return nil, fmt.Errorf("received unexpected response")
+		return nil, errors.New("received unexpected response")
 	}
 
 	return o, err

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -893,8 +893,8 @@ func (w *Websocket) GetChannelDifference(genSubs []subscription.Subscription) (s
 		}
 	}
 
-	for _, c := range unsubMap {
-		unsub = append(unsub, c)
+	for x := range unsubMap {
+		unsub = append(unsub, unsubMap[x])
 	}
 
 	return
@@ -988,7 +988,7 @@ func (w *Websocket) AddSuccessfulSubscriptions(channels ...subscription.Subscrip
 	if w.subscriptions == nil {
 		w.subscriptions = subscriptionMap{}
 	}
-	for _, cN := range channels {
+	for _, cN := range channels { //nolint:gocritic // See below comment
 		c := cN // cN is an iteration var; Not safe to make a pointer to
 		key := c.EnsureKeyed()
 		c.State = subscription.SubscribedState

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -593,11 +593,11 @@ func TestSubscriptionState(t *testing.T) {
 	ws.AddSuccessfulSubscriptions(*c)
 	found = ws.GetSubscription(42)
 	assert.NotNil(t, found, "Should find the subscription")
-	assert.Equal(t, found.State, subscription.SubscribedState, "Subscription should be subscribed state")
+	assert.Equal(t, subscription.SubscribedState, found.State, "Subscription should be subscribed state")
 
 	assert.NoError(t, ws.SetSubscriptionState(c, subscription.UnsubscribingState), "Setting Unsub state should not error")
 	found = ws.GetSubscription(42)
-	assert.Equal(t, found.State, subscription.UnsubscribingState, "Subscription should be unsubscribing state")
+	assert.Equal(t, subscription.UnsubscribingState, found.State, "Subscription should be unsubscribing state")
 }
 
 // TestRemoveSubscriptions tests removing a subscription
@@ -1060,7 +1060,7 @@ func TestGetChannelDifference(t *testing.T) {
 	}
 	subs, unsubs := web.GetChannelDifference(newChans)
 	assert.Len(t, subs, 3, "Should get the correct number of subs")
-	assert.Len(t, unsubs, 0, "Should get the correct number of unsubs")
+	assert.Empty(t, unsubs, "Should get the correct number of unsubs")
 
 	web.AddSuccessfulSubscriptions(subs...)
 
@@ -1071,7 +1071,7 @@ func TestGetChannelDifference(t *testing.T) {
 	}
 
 	subs, unsubs = web.GetChannelDifference(flushedSubs)
-	assert.Len(t, subs, 0, "Should get the correct number of subs")
+	assert.Empty(t, subs, "Should get the correct number of subs")
 	assert.Len(t, unsubs, 2, "Should get the correct number of unsubs")
 
 	flushedSubs = []subscription.Subscription{
@@ -1085,12 +1085,12 @@ func TestGetChannelDifference(t *testing.T) {
 
 	subs, unsubs = web.GetChannelDifference(flushedSubs)
 	if assert.Len(t, subs, 1, "Should get the correct number of subs") {
-		assert.Equal(t, subs[0].Channel, "Test4", "Should subscribe to the right channel")
+		assert.Equal(t, "Test4", subs[0].Channel, "Should subscribe to the right channel")
 	}
 	if assert.Len(t, unsubs, 2, "Should get the correct number of unsubs") {
 		sort.Slice(unsubs, func(i, j int) bool { return unsubs[i].Channel <= unsubs[j].Channel })
-		assert.Equal(t, unsubs[0].Channel, "Test1", "Should unsubscribe from the right channels")
-		assert.Equal(t, unsubs[1].Channel, "Test3", "Should unsubscribe from the right channels")
+		assert.Equal(t, "Test1", unsubs[0].Channel, "Should unsubscribe from the right channels")
+		assert.Equal(t, "Test3", unsubs[1].Channel, "Should unsubscribe from the right channels")
 	}
 }
 

--- a/exchanges/ticker/ticker.go
+++ b/exchanges/ticker/ticker.go
@@ -18,12 +18,13 @@ var (
 	ErrNoTickerFound = errors.New("no ticker found")
 	// ErrBidEqualsAsk error for locked markets
 	ErrBidEqualsAsk = errors.New("bid equals ask this is a crossed or locked market")
+	// ErrExchangeNameIsEmpty is an error for when an exchange name is empty
+	ErrExchangeNameIsEmpty = errors.New("exchange name is empty")
 
-	errInvalidTicker       = errors.New("invalid ticker")
-	errTickerNotFound      = errors.New("ticker not found")
-	errExchangeNameIsEmpty = errors.New("exchange name is empty")
-	errBidGreaterThanAsk   = errors.New("bid greater than ask this is a crossed or locked market")
-	errExchangeNotFound    = errors.New("exchange not found")
+	errInvalidTicker     = errors.New("invalid ticker")
+	errTickerNotFound    = errors.New("ticker not found")
+	errBidGreaterThanAsk = errors.New("bid greater than ask this is a crossed or locked market")
+	errExchangeNotFound  = errors.New("exchange not found")
 )
 
 func init() {
@@ -71,7 +72,7 @@ func SubscribeToExchangeTickers(exchange string) (dispatch.Pipe, error) {
 // GetTicker checks and returns a requested ticker if it exists
 func GetTicker(exchange string, p currency.Pair, a asset.Item) (*Price, error) {
 	if exchange == "" {
-		return nil, errExchangeNameIsEmpty
+		return nil, ErrExchangeNameIsEmpty
 	}
 	if p.IsEmpty() {
 		return nil, currency.ErrCurrencyPairEmpty
@@ -104,7 +105,7 @@ func GetExchangeTickers(exchange string) ([]*Price, error) {
 
 func (s *Service) getExchangeTickers(exchange string) ([]*Price, error) {
 	if exchange == "" {
-		return nil, errExchangeNameIsEmpty
+		return nil, ErrExchangeNameIsEmpty
 	}
 	exchange = strings.ToLower(exchange)
 	s.mu.Lock()
@@ -148,7 +149,7 @@ func ProcessTicker(p *Price) error {
 	}
 
 	if p.ExchangeName == "" {
-		return fmt.Errorf(ErrExchangeNameUnset)
+		return ErrExchangeNameIsEmpty
 	}
 
 	if p.Pair.IsEmpty() {
@@ -240,7 +241,7 @@ func (s *Service) setItemID(t *Ticker, p *Price, exch string) error {
 // getAssociations links a singular book with its dispatch associations
 func (s *Service) getAssociations(exch string) ([]uuid.UUID, error) {
 	if exch == "" {
-		return nil, errExchangeNameIsEmpty
+		return nil, ErrExchangeNameIsEmpty
 	}
 	var ids []uuid.UUID
 	exchangeID, ok := s.Exchange[exch]

--- a/exchanges/ticker/ticker_test.go
+++ b/exchanges/ticker/ticker_test.go
@@ -437,9 +437,7 @@ func TestProcessTicker(t *testing.T) { // non-appending function to tickers
 
 func TestGetAssociation(t *testing.T) {
 	_, err := service.getAssociations("")
-	if !errors.Is(err, errExchangeNameIsEmpty) {
-		t.Errorf("received: %v but expected: %v", err, errExchangeNameIsEmpty)
-	}
+	assert.ErrorIs(t, err, ErrExchangeNameIsEmpty)
 
 	service.mux = nil
 
@@ -453,7 +451,7 @@ func TestGetAssociation(t *testing.T) {
 
 func TestGetExchangeTickersPublic(t *testing.T) {
 	_, err := GetExchangeTickers("")
-	assert.ErrorIs(t, err, errExchangeNameIsEmpty)
+	assert.ErrorIs(t, err, ErrExchangeNameIsEmpty)
 }
 
 func TestGetExchangeTickers(t *testing.T) {
@@ -464,7 +462,7 @@ func TestGetExchangeTickers(t *testing.T) {
 	}
 
 	_, err := s.getExchangeTickers("")
-	assert.ErrorIs(t, err, errExchangeNameIsEmpty)
+	assert.ErrorIs(t, err, ErrExchangeNameIsEmpty)
 
 	_, err = s.getExchangeTickers("test")
 	assert.ErrorIs(t, err, errExchangeNotFound)
@@ -489,5 +487,5 @@ func TestGetExchangeTickers(t *testing.T) {
 	if len(resp) != 1 {
 		t.Fatal("unexpected length")
 	}
-	assert.Equal(t, resp[0].OpenInterest, 1337.0)
+	assert.Equal(t, 1337.0, resp[0].OpenInterest)
 }

--- a/exchanges/ticker/ticker_types.go
+++ b/exchanges/ticker/ticker_types.go
@@ -13,10 +13,9 @@ import (
 
 // const values for the ticker package
 const (
-	ErrExchangeNameUnset = "ticker exchange name not set"
-	errPairNotSet        = "ticker currency pair not set"
-	errAssetTypeNotSet   = "ticker asset type not set"
-	errTickerPriceIsNil  = "ticker price is nil"
+	errPairNotSet       = "ticker currency pair not set"
+	errAssetTypeNotSet  = "ticker asset type not set"
+	errTickerPriceIsNil = "ticker price is nil"
 )
 
 // Vars for the ticker package

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -555,7 +555,7 @@ func (y *Yobit) WithdrawCryptocurrencyFunds(ctx context.Context, withdrawRequest
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.Error) > 0 {
+	if resp.Error != "" {
 		return nil, errors.New(resp.Error)
 	}
 	return &withdraw.ExchangeResponse{}, nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thrasher-corp/gocryptotrader
 
-go 1.21
+go 1.22
 
 require (
 	github.com/buger/jsonparser v1.1.1


### PR DESCRIPTION
# PR Description

Bumps Go to version 1.22
Bumps golangci-lint to v1.56.0
Linter changes:
- Prefer errors.New when no formatting is needed over fmt.Errorf
- Prefer string comparison checks over len, there's no compiler performance difference now but makes code more clear. Refer to Russ Cox's explanation who's the co-creator of Go:
 ```The one that makes the code clear.
If I'm about to look at element x I typically write
len(s) > x, even for x == 0, but if I care about
"is it this specific string" I tend to write s == "".

It's reasonable to assume that a mature compiler will compile
len(s) == 0 and s == "" into the same, efficient code.
Right now 6g etc do compile s == "" into a function call
while len(s) == 0 is not, but that's been on my to-do list to fix.

Make the code clear.
```
- Uses strconv and string addition for performance where possible
- Fixes testify expected vs actual issuess across the codebase impacting quite a few tests
- Better usage of testify test funcs 
- Some hugeParam and rangeVal fixes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
