### PR TITLE
account: fix balance issue returning only one balance

### DIFF
--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -105,7 +105,6 @@ func GetHoldings(exch string, creds *Credentials, assetType asset.Item) (Holding
 	}
 
 	var currencyBalances = make([]Balance, 0, len(subAccountHoldings))
-	accountsHoldings := make([]SubAccount, 1)
 	cpy := *creds
 	for mapKey, assetHoldings := range subAccountHoldings {
 		if mapKey.Asset != assetType {
@@ -133,13 +132,12 @@ func GetHoldings(exch string, creds *Credentials, assetType asset.Item) (Holding
 			assetType,
 			errAssetHoldingsNotFound)
 	}
-	accountsHoldings[0] = SubAccount{
+	return Holdings{Exchange: exch, Accounts: []SubAccount{{
 		Credentials: Protected{creds: cpy},
 		ID:          cpy.SubAccount,
 		AssetType:   assetType,
 		Currencies:  currencyBalances,
-	}
-	return Holdings{Exchange: exch, Accounts: accountsHoldings}, nil
+	}}}, nil
 }
 
 // GetBalance returns the internal balance for that asset item.

--- a/exchanges/account/account.go
+++ b/exchanges/account/account.go
@@ -105,7 +105,7 @@ func GetHoldings(exch string, creds *Credentials, assetType asset.Item) (Holding
 	}
 
 	var currencyBalances = make([]Balance, 0, len(subAccountHoldings))
-	accountsHoldings := make([]SubAccount, 0, len(subAccountHoldings))
+	accountsHoldings := make([]SubAccount, 1)
 	cpy := *creds
 	for mapKey, assetHoldings := range subAccountHoldings {
 		if mapKey.Asset != assetType {
@@ -121,8 +121,7 @@ func GetHoldings(exch string, creds *Credentials, assetType asset.Item) (Holding
 			Borrowed:               assetHoldings.borrowed,
 		})
 		assetHoldings.m.Unlock()
-
-		if cpy.SubAccount == "" {
+		if cpy.SubAccount == "" && mapKey.SubAccount != "" {
 			// TODO: fix this backwards population
 			// the subAccount here may not be associated with the balance across all subAccountHoldings
 			cpy.SubAccount = mapKey.SubAccount
@@ -134,12 +133,12 @@ func GetHoldings(exch string, creds *Credentials, assetType asset.Item) (Holding
 			assetType,
 			errAssetHoldingsNotFound)
 	}
-	accountsHoldings = append(accountsHoldings, SubAccount{
+	accountsHoldings[0] = SubAccount{
 		Credentials: Protected{creds: cpy},
 		ID:          cpy.SubAccount,
 		AssetType:   assetType,
 		Currencies:  currencyBalances,
-	})
+	}
 	return Holdings{Exchange: exch, Accounts: accountsHoldings}, nil
 }
 

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -646,6 +646,14 @@ func (b *Binance) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (
 	info.Exchange = b.Name
 	switch assetType {
 	case asset.Spot:
+		creds, err := b.GetCredentials(ctx)
+		if err != nil {
+			return info, err
+		}
+		if creds.SubAccount != "" {
+			// TODO: implement sub-account endpoints
+			return info, common.ErrNotYetImplemented
+		}
 		raw, err := b.GetAccount(ctx)
 		if err != nil {
 			return info, err


### PR DESCRIPTION
# PR Description

This was brought initially to my attention by vancake on Slack. However, I started getting broken order results when I actually wanted to do something with my account details.

## The issue:
`GetAccountInfo` only collects a single currency before calling `Break` in the underlying `account` package, however `UpdateAccountInfo` initially does not, leading to an inconsistent output when using the `FetchAccountInfo` endpoint for wrappers.

## The fix:
I've slightly changed it so it doesn't call `break`. I would call the section of code quite strange, and I think I could do more refactorings there, but I don't think I should do that yet and just prioritise the bug. I will point to this if a review comment is asking for too much 😄 

## To replicate:
- Run GCT
- Call `FetchAccountInfo`
   - eg via GCTCLI: `go run . getaccountinfo binance spot`
- Call it again
- See that only one randomised currency is returned on `master`, or all currencies for those credentials on this branch 

this branch:
```
go run . getaccountinfo binance spot
{
 "exchange": "binance",
 "accounts": [
  {
   "id": "Key:[lolFake...] SubAccount:[] ClientID:[]",
   "currencies": [
    {
     "currency": "GMX",
     "total_value": 1333333333333337,
     "free": 1333333333333337
    },
    {
     "currency": "WIF",
     "total_value": 1333333333333337,
     "free": 1333333333333337
    },
...
```

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested
- [x] go test ./... -race
- [x] golangci-lint run
- [x] Running tests locally with credentials

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
