### PR TITLE
Websocket: Simplify the connectionMonitor

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -526,7 +526,7 @@ func (w *Websocket) trafficMonitor() {
 			t.Stop()
 			w.Wg.Done()
 			return
-		// this case ensures the timer is reset as close to when the traffic is received
+		// This case ensures the timer is reset as close to when the traffic is received as possible
 		case <-time.After(trafficCheckInterval):
 			select {
 			case <-w.TrafficAlert:

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -291,7 +291,8 @@ func (w *Websocket) Connect() error {
 		return fmt.Errorf("%v Error connecting %w", w.exchangeName, err)
 	}
 	w.setState(connected)
-	if !w.connectionMonitorRunning.CompareAndSwap(false, true) {
+
+	if w.connectionMonitorRunning.CompareAndSwap(false, true) {
 		go w.connectionMonitor()
 	}
 

--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -280,8 +280,8 @@ func (w *Websocket) Connect() error {
 	w.subscriptions = subscriptionMap{}
 	w.subscriptionMutex.Unlock()
 
-	w.dataMonitor()
-	w.trafficMonitor()
+	go w.dataMonitor()
+	go w.trafficMonitor()
 	w.setState(connecting)
 
 	err := w.connector()

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -570,16 +570,12 @@ func TestConnectionMonitor(t *testing.T) {
 	ws.ShutdownC = make(chan struct{}, 1)
 	ws.exchangeName = "hello"
 	ws.Wg = &sync.WaitGroup{}
-	ws.setEnabled(true)
 	ws.connectionMonitorRunning.Store(true)
 	go ws.connectionMonitor()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, ws.connectionMonitorRunning.Load(), "IsConnectionMonitorRunning should return true")
-	}, 5*time.Second, 10*time.Millisecond, "ConnectionMonitor must be running")
 	ws.setEnabled(false)
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.False(c, ws.connectionMonitorRunning.Load(), "IsConnectionMonitorRunning should return false")
-	}, 5*time.Second, 10*time.Millisecond, "ConnectionMonitor must not be running")
+	require.Eventually(t, func() bool {
+		return !ws.connectionMonitorRunning.Load()
+	}, 5*time.Second, 10*time.Millisecond, "ConnectionMonitor must be set to not running")
 }
 
 // TestGetSubscription logic test

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -198,8 +198,6 @@ func TestTrafficMonitorTrafficAlerts(t *testing.T) {
 
 	thenish := time.Now()
 	ws.trafficMonitor()
-
-	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
 	require.Equal(t, connected, ws.state.Load(), "websocket must be connected")
 
 	for i := 0; i < 6; i++ { // Timeout will happen at 200ms so we want 6 * 50ms checks to pass
@@ -225,10 +223,9 @@ func TestTrafficMonitorTrafficAlerts(t *testing.T) {
 		assert.Truef(t, ws.IsConnected(), "state should still be connected; Check #%d", i)
 	}
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, disconnected, ws.state.Load(), "websocket must be disconnected")
-		assert.False(c, ws.IsTrafficMonitorRunning(), "trafficMonitor should be shut down")
-	}, 2*ws.trafficTimeout, patience, "trafficTimeout should trigger a shutdown once we stop feeding trafficAlerts")
+	require.Eventually(t, func() bool {
+		return ws.state.Load() == disconnected
+	}, 4*ws.trafficTimeout, 10*time.Millisecond, "websocket must be disconnected")
 }
 
 // TestTrafficMonitorConnecting ensures connecting status doesn't trigger shutdown
@@ -242,15 +239,13 @@ func TestTrafficMonitorConnecting(t *testing.T) {
 	ws.state.Store(connecting)
 	ws.trafficTimeout = 50 * time.Millisecond
 	ws.trafficMonitor()
-	require.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
 	require.Equal(t, connecting, ws.state.Load(), "websocket must be connecting")
 	<-time.After(4 * ws.trafficTimeout)
 	require.Equal(t, connecting, ws.state.Load(), "websocket must still be connecting after several checks")
 	ws.state.Store(connected)
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, disconnected, ws.state.Load(), "websocket must be disconnected")
-		assert.False(c, ws.IsTrafficMonitorRunning(), "trafficMonitor should be shut down")
-	}, 4*ws.trafficTimeout, 10*time.Millisecond, "trafficTimeout should trigger a shutdown after connecting status changes")
+	require.Eventually(t, func() bool {
+		return ws.state.Load() == disconnected
+	}, 4*ws.trafficTimeout, 10*time.Millisecond, "websocket must be disconnected")
 }
 
 // TestTrafficMonitorShutdown ensures shutdown is processed and waitgroup is cleared
@@ -264,7 +259,6 @@ func TestTrafficMonitorShutdown(t *testing.T) {
 	ws.state.Store(connected)
 	ws.trafficTimeout = time.Minute
 	ws.trafficMonitor()
-	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
 
 	wgReady := make(chan bool)
 	go func() {
@@ -280,7 +274,6 @@ func TestTrafficMonitorShutdown(t *testing.T) {
 	close(ws.ShutdownC)
 
 	<-time.After(2 * trafficCheckInterval)
-	assert.False(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be shutdown")
 	select {
 	case <-wgReady:
 	default:

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -197,7 +197,8 @@ func TestTrafficMonitorTrafficAlerts(t *testing.T) {
 	ws.state.Store(connected)
 
 	thenish := time.Now()
-	ws.trafficMonitor()
+	ws.Wg.Add(1)
+	go ws.trafficMonitor()
 	require.Equal(t, connected, ws.state.Load(), "websocket must be connected")
 
 	for i := 0; i < 6; i++ { // Timeout will happen at 200ms so we want 6 * 50ms checks to pass
@@ -238,7 +239,8 @@ func TestTrafficMonitorConnecting(t *testing.T) {
 	ws.ShutdownC = make(chan struct{})
 	ws.state.Store(connecting)
 	ws.trafficTimeout = 50 * time.Millisecond
-	ws.trafficMonitor()
+	ws.Wg.Add(1)
+	go ws.trafficMonitor()
 	require.Equal(t, connecting, ws.state.Load(), "websocket must be connecting")
 	<-time.After(4 * ws.trafficTimeout)
 	require.Equal(t, connecting, ws.state.Load(), "websocket must still be connecting after several checks")
@@ -258,7 +260,8 @@ func TestTrafficMonitorShutdown(t *testing.T) {
 	ws.ShutdownC = make(chan struct{})
 	ws.state.Store(connected)
 	ws.trafficTimeout = time.Minute
-	ws.trafficMonitor()
+	ws.Wg.Add(1)
+	go ws.trafficMonitor()
 
 	wgReady := make(chan bool)
 	go func() {

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -571,13 +571,14 @@ func TestConnectionMonitor(t *testing.T) {
 	ws.exchangeName = "hello"
 	ws.Wg = &sync.WaitGroup{}
 	ws.setEnabled(true)
+	ws.connectionMonitorRunning.Store(true)
 	go ws.connectionMonitor()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.True(c, ws.IsConnectionMonitorRunning(), "IsConnectionMonitorRunning should return true")
+		assert.True(c, ws.connectionMonitorRunning.Load(), "IsConnectionMonitorRunning should return true")
 	}, 5*time.Second, 10*time.Millisecond, "ConnectionMonitor must be running")
 	ws.setEnabled(false)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.False(c, ws.IsConnectionMonitorRunning(), "IsConnectionMonitorRunning should return false")
+		assert.False(c, ws.connectionMonitorRunning.Load(), "IsConnectionMonitorRunning should return false")
 	}, 5*time.Second, 10*time.Millisecond, "ConnectionMonitor must not be running")
 }
 

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -39,7 +39,6 @@ type Websocket struct {
 	state                        atomic.Uint32
 	verbose                      bool
 	connectionMonitorRunning     atomic.Bool
-	trafficMonitorRunning        atomic.Bool
 	trafficTimeout               time.Duration
 	connectionMonitorDelay       time.Duration
 	proxyAddr                    string

--- a/exchanges/stream/websocket_types.go
+++ b/exchanges/stream/websocket_types.go
@@ -40,7 +40,6 @@ type Websocket struct {
 	verbose                      bool
 	connectionMonitorRunning     atomic.Bool
 	trafficMonitorRunning        atomic.Bool
-	dataMonitorRunning           atomic.Bool
 	trafficTimeout               time.Duration
 	connectionMonitorDelay       time.Duration
 	proxyAddr                    string


### PR DESCRIPTION
# PR Description

Currently, the WebSocket connectionMonitor is adding concurrency within the function. According to [google styleguide](https://google.github.io/styleguide/go/decisions#synchronous-functions), the caller should add the concurrency to the function.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestConnectionMonitor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
