### PR TITLE
Kraken: Fix GetLatestFundingRates requiring pair enabled

### DIFF
--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -185,17 +185,15 @@ func executeExchangeWrapperTests(ctx context.Context, t *testing.T, exch exchang
 		var assetLen int
 		for y := 0; y < method.Type().NumIn(); y++ {
 			input := method.Type().In(y)
-			if input.AssignableTo(assetParam) ||
-				input.AssignableTo(orderSubmitParam) ||
-				input.AssignableTo(orderModifyParam) ||
-				input.AssignableTo(orderCancelParam) ||
-				input.AssignableTo(orderCancelsParam) ||
-				input.AssignableTo(pairKeySliceParam) ||
-				input.AssignableTo(getOrdersRequestParam) ||
-				input.AssignableTo(pairKeySliceParam) {
-				// this allows wrapper functions that support assets types
-				// to be tested with all supported assets
-				assetLen = len(assetParams) - 1
+			for _, t := range []reflect.Type{
+				assetParam, orderSubmitParam, orderModifyParam, orderCancelParam, orderCancelsParam, pairKeySliceParam, getOrdersRequestParam, latestRateRequest,
+			} {
+				if input.AssignableTo(t) {
+					// this allows wrapper functions that support assets types
+					// to be tested with all supported assets
+					assetLen = len(assetParams) - 1
+					break
+				}
 			}
 		}
 		tt := time.Now()

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -1695,12 +1695,10 @@ func (k *Kraken) GetLatestFundingRates(ctx context.Context, r *fundingrate.Lates
 		return nil, fmt.Errorf("%w %v", asset.ErrNotSupported, r.Asset)
 	}
 	if !r.Pair.IsEmpty() {
-		_, isEnabled, err := k.MatchSymbolCheckEnabled(r.Pair.String(), r.Asset, r.Pair.Delimiter != "")
-		if err != nil && !errors.Is(err, currency.ErrPairNotFound) {
+		if ok, err := k.CurrencyPairs.IsPairAvailable(r.Pair, r.Asset); err != nil {
 			return nil, err
-		}
-		if !isEnabled {
-			return nil, fmt.Errorf("%w %v", currency.ErrPairNotEnabled, r.Pair)
+		} else if !ok {
+			return nil, currency.ErrPairNotContainedInAvailablePairs
 		}
 	}
 


### PR DESCRIPTION
APIs like this should not require the pair to be enabled.
Fixes intermittent test failure on cmd/exchange_wrapper_standards:
```
exchange_wrapper_standards_test.go:227: Kraken Func 'GetLatestFundingRates' Error: 'pair not enabled FF-TEST-DELIM-solusd_240628'. Inputs: [context.Background {futures FF-TEST-DELIM-solusd_240628 true}].
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run