### PR TITLE
go: Fix darwin/arm64: toolchain not available version directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thrasher-corp/gocryptotrader
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/buger/jsonparser v1.1.1


### PR DESCRIPTION
# PR Description

go build will give following error.

```
go: download go1.22 for darwin/arm64: toolchain not available
```


## Type of change
Refer to this solution
https://github.com/golang/go/issues/65568#issuecomment-1954876836


