### PR TITLE
btcmarkets: remove trailing slash on markets/ticker strings and update endpoint pathways

### DIFF
--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -32,7 +32,7 @@ const (
 
 	// UnAuthenticated EPs
 	btcMarketsAllMarkets         = "/markets"
-	btcMarketsGetTicker          = "/ticker/"
+	btcMarketsGetTicker          = "/ticker"
 	btcMarketsGetTrades          = "/trades?"
 	btcMarketOrderBook           = "/orderbook?"
 	btcMarketsCandles            = "/candles?"

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -31,7 +31,7 @@ const (
 	btcMarketsAPIVersion = "/v3"
 
 	// UnAuthenticated EPs
-	btcMarketsAllMarkets         = "/markets/"
+	btcMarketsAllMarkets         = "/markets"
 	btcMarketsGetTicker          = "/ticker/"
 	btcMarketsGetTrades          = "/trades?"
 	btcMarketOrderBook           = "/orderbook?"
@@ -110,7 +110,7 @@ func (b *BTCMarkets) GetMarkets(ctx context.Context) ([]Market, error) {
 // symbol - example "btc" or "ltc"
 func (b *BTCMarkets) GetTicker(ctx context.Context, marketID string) (Ticker, error) {
 	var tick Ticker
-	return tick, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+marketID+btcMarketsGetTicker, &tick)
+	return tick, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+marketID+btcMarketsGetTicker, &tick)
 }
 
 // GetTrades returns executed trades on the exchange
@@ -129,7 +129,7 @@ func (b *BTCMarkets) GetTrades(ctx context.Context, marketID string, before, aft
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	return trades, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+marketID+btcMarketsGetTrades+params.Encode(),
+	return trades, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+marketID+btcMarketsGetTrades+params.Encode(),
 		&trades)
 }
 
@@ -144,7 +144,7 @@ func (b *BTCMarkets) GetOrderbook(ctx context.Context, marketID string, level in
 		params.Set("level", strconv.FormatInt(level, 10))
 	}
 	var temp tempOrderbook
-	err := b.SendHTTPRequest(ctx, btcMarketsUnauthPath+marketID+btcMarketOrderBook+params.Encode(),
+	err := b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+marketID+btcMarketOrderBook+params.Encode(),
 		&temp)
 	if err != nil {
 		return nil, err
@@ -214,7 +214,7 @@ func (b *BTCMarkets) GetMarketCandles(ctx context.Context, marketID, timeWindow 
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	return out, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+marketID+btcMarketsCandles+params.Encode(), &out)
+	return out, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+marketID+btcMarketsCandles+params.Encode(), &out)
 }
 
 // GetTickers gets multiple tickers
@@ -224,7 +224,7 @@ func (b *BTCMarkets) GetTickers(ctx context.Context, marketIDs currency.Pairs) (
 	for x := range marketIDs {
 		params.Add("marketId", marketIDs[x].String())
 	}
-	return tickers, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+btcMarketsTickers+params.Encode(),
+	return tickers, b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+btcMarketsTickers+params.Encode(),
 		&tickers)
 }
 
@@ -235,7 +235,7 @@ func (b *BTCMarkets) GetMultipleOrderbooks(ctx context.Context, marketIDs []stri
 	for x := range marketIDs {
 		params.Add("marketId", marketIDs[x])
 	}
-	err := b.SendHTTPRequest(ctx, btcMarketsUnauthPath+btcMarketsMultipleOrderbooks+params.Encode(),
+	err := b.SendHTTPRequest(ctx, btcMarketsUnauthPath+"/"+btcMarketsMultipleOrderbooks+params.Encode(),
 		&temp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# PR Description

BTC markets woke up one day and banned the trailing slash. This hopefully appeases the BTCM gods. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
