### PR TITLE
Tests: Various race fixes and move TestFixtureToDataHandler

### DIFF
--- a/backtester/eventhandlers/exchange/slippage/slippage_test.go
+++ b/backtester/eventhandlers/exchange/slippage/slippage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -15,30 +16,23 @@ import (
 func TestRandomSlippage(t *testing.T) {
 	t.Parallel()
 	resp := EstimateSlippagePercentage(decimal.NewFromInt(80), decimal.NewFromInt(100))
-	if resp.LessThan(decimal.NewFromFloat(0.8)) || resp.GreaterThan(decimal.NewFromInt(1)) {
-		t.Error("expected result > 0.8 and < 100")
-	}
+	assert.True(t, resp.GreaterThan(decimal.NewFromFloat(0.8)), "result should be more than 0.8")
+	assert.True(t, resp.LessThan(decimal.NewFromInt(1)), "result should be less than 1")
 }
 
 func TestCalculateSlippageByOrderbook(t *testing.T) {
 	t.Parallel()
 	b := bitstamp.Bitstamp{}
 	b.SetDefaults()
-	err := b.CurrencyPairs.SetAssetEnabled(asset.Spot, true)
-	require.NoError(t, err, "SetAssetEnabled must not error")
 
 	cp := currency.NewPair(currency.BTC, currency.USD)
 	ob, err := b.FetchOrderbook(context.Background(), cp, asset.Spot)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err, "FetchOrderbook must not error")
+
 	amountOfFunds := decimal.NewFromInt(1000)
 	feeRate := decimal.NewFromFloat(0.03)
 	price, amount, err := CalculateSlippageByOrderbook(ob, gctorder.Buy, amountOfFunds, feeRate)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if price.Mul(amount).Add(price.Mul(amount).Mul(feeRate)).GreaterThan(amountOfFunds) {
-		t.Error("order size must be less than funds")
-	}
+	require.NoError(t, err, "CalculateSlippageByOrderbook must not error")
+	orderSize := price.Mul(amount).Add(price.Mul(amount).Mul(feeRate))
+	assert.True(t, orderSize.LessThan(amountOfFunds), "order size must be less than funds")
 }

--- a/backtester/eventhandlers/exchange/slippage/slippage_test.go
+++ b/backtester/eventhandlers/exchange/slippage/slippage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitstamp"
@@ -24,9 +25,8 @@ func TestCalculateSlippageByOrderbook(t *testing.T) {
 	b := bitstamp.Bitstamp{}
 	b.SetDefaults()
 	err := b.CurrencyPairs.SetAssetEnabled(asset.Spot, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "SetAssetEnabled must not error")
+
 	cp := currency.NewPair(currency.BTC, currency.USD)
 	ob, err := b.FetchOrderbook(context.Background(), cp, asset.Spot)
 	if err != nil {

--- a/currency/manager.go
+++ b/currency/manager.go
@@ -398,6 +398,15 @@ func (p *PairsManager) IsAssetEnabled(a asset.Item) error {
 	return nil
 }
 
+// IsAssetSupported returns if the asset is supported by an exchange
+// Does not imply that the Asset is enabled
+func (p *PairsManager) IsAssetSupported(a asset.Item) bool {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	_, ok := p.Pairs[a]
+	return ok
+}
+
 // SetAssetEnabled sets if an asset is enabled or disabled for first run
 func (p *PairsManager) SetAssetEnabled(a asset.Item, enabled bool) error {
 	if !a.IsValid() {

--- a/currency/manager_test.go
+++ b/currency/manager_test.go
@@ -914,3 +914,17 @@ func TestGetFormat(t *testing.T) {
 	_, err = m.GetFormat(asset.Spot, false)
 	assert.ErrorIs(t, err, ErrPairFormatIsNil, "Per Asset GetFormat Should error correctly on nil config format")
 }
+
+// TestIsAssetSupported exercises IsAssetSupported
+func TestIsAssetSupported(t *testing.T) {
+	t.Parallel()
+	p := PairsManager{
+		Pairs: FullStore{
+			asset.Spot: {
+				AssetEnabled: convert.BoolPtr(false),
+			},
+		},
+	}
+	assert.True(t, p.IsAssetSupported(asset.Spot), "Spot should be supported")
+	assert.False(t, p.IsAssetSupported(asset.Index), "Index should not be supported")
+}

--- a/currency/manager_test.go
+++ b/currency/manager_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
@@ -799,15 +798,16 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	assert.ErrorIs(t, base.Load(nil), common.ErrNilPointer, "Load nil should error")
-	if assert.NoError(t, base.Load(&seed), "Loading from seed should not error") {
-		assert.True(t, *base.Pairs[asset.Futures].AssetEnabled, "Futures AssetEnabled should be true")
-		assert.True(t, base.Pairs[asset.Futures].Available.Contains(p, true), "Futures Available Pairs should contain BTCUSDT")
-		assert.False(t, *base.Pairs[asset.Options].AssetEnabled, "Options AssetEnabled should be false")
-		assert.Equal(t, tt, base.LastUpdated, "Last Updated should be correct")
-		assert.Equal(t, fmt1.Uppercase, base.ConfigFormat.Uppercase, "ConfigFormat Uppercase should be correct")
-		assert.Equal(t, fmt2.Delimiter, base.RequestFormat.Delimiter, "RequestFormat Delimiter should be correct")
-	}
+	base.Load(&seed)
+	assert.True(t, *base.Pairs[asset.Futures].AssetEnabled, "Futures AssetEnabled should be true")
+	assert.True(t, base.Pairs[asset.Futures].Available.Contains(p, true), "Futures Available Pairs should contain BTCUSDT")
+	assert.False(t, *base.Pairs[asset.Options].AssetEnabled, "Options AssetEnabled should be false")
+	assert.Equal(t, tt, base.LastUpdated, "Last Updated should be correct")
+	assert.Equal(t, fmt1.Uppercase, base.ConfigFormat.Uppercase, "ConfigFormat Uppercase should be correct")
+	assert.Equal(t, fmt2.Delimiter, base.RequestFormat.Delimiter, "RequestFormat Delimiter should be correct")
+	found, err := base.Match("BTCUSDT", asset.Futures)
+	require.NoError(t, err, "Match must not error")
+	assert.Equal(t, p, found, "Should find the right pair")
 }
 
 func checkPairDelimiter(tb testing.TB, p *PairsManager, err error, d, msg string) {

--- a/currency/pair.go
+++ b/currency/pair.go
@@ -118,6 +118,15 @@ func (f PairFormat) Format(pair Pair) string {
 	return pair.Format(f).String()
 }
 
+// clone returns a clone of the PairFormat
+func (f *PairFormat) clone() *PairFormat {
+	if f == nil {
+		return nil
+	}
+	c := *f
+	return &c
+}
+
 // MatchPairsWithNoDelimiter will move along a predictable index on the provided currencyPair
 // it will then split on that index and verify whether that currencypair exists in the
 // supplied pairs

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -547,6 +547,8 @@ func TestUpdateTicker(t *testing.T) {
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 
+	b := new(Bitfinex) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
 	testexch.UpdatePairsOnce(t, b)
 
 	assets := b.GetAssetTypes(false)

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -455,14 +455,14 @@ func TestUpdateTradablePairs(t *testing.T) {
 func TestGetCurrencyTradeURL(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, b)
-	err := b.CurrencyPairs.SetAssetEnabled(asset.Futures, true)
-	require.NoError(t, err)
+	err := b.CurrencyPairs.SetAssetEnabled(asset.Futures, false)
+	require.NoError(t, err, "SetAssetEnabled must not error")
 	for _, a := range b.GetAssetTypes(false) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
 		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
-		require.NoError(t, err)
-		assert.NotEmpty(t, resp)
+		require.NoError(t, err, "GetCurrencyTradeURL must not error")
+		assert.NotEmpty(t, resp, "GetCurrencyTradeURL should return an url")
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -776,14 +776,15 @@ func TestWsOrderbook2(t *testing.T) {
 func TestWsOrderUpdate(t *testing.T) {
 	t.Parallel()
 
-	n := new(Bitstamp)
-	sharedtestvalues.TestFixtureToDataHandler(t, b, n, "testdata/wsMyOrders.json", n.wsHandleData)
+	b := new(Bitstamp) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
+	testexch.FixtureToDataHandler(t, "testdata/wsMyOrders.json", b.wsHandleData)
 	seen := 0
 	for reading := true; reading; {
 		select {
 		default:
 			reading = false
-		case resp := <-n.GetBase().Websocket.DataHandler:
+		case resp := <-b.Websocket.DataHandler:
 			seen++
 			switch v := resp.(type) {
 			case *order.Detail:

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -779,82 +779,76 @@ func TestWsOrderUpdate(t *testing.T) {
 	b := new(Bitstamp) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
 	testexch.FixtureToDataHandler(t, "testdata/wsMyOrders.json", b.wsHandleData)
-	seen := 0
-	for reading := true; reading; {
-		select {
-		default:
-			reading = false
-		case resp := <-b.Websocket.DataHandler:
-			seen++
-			switch v := resp.(type) {
-			case *order.Detail:
-				switch seen {
-				case 1:
-					assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
-					assert.Equal(t, time.UnixMicro(1693831262313000), v.Date, "Date")
-					assert.Equal(t, "test_market_buy", v.ClientOrderID, "ClientOrderID")
-					assert.Equal(t, order.New, v.Status, "Status")
-					assert.Equal(t, order.Buy, v.Side, "Side")
-					assert.Equal(t, asset.Spot, v.AssetType, "AssetType")
-					assert.Equal(t, currency.NewPairWithDelimiter("BTC", "USD", "/"), v.Pair, "Pair")
-					assert.Equal(t, 0.0, v.ExecutedAmount, "ExecutedAmount")
-					assert.Equal(t, 999999999.0, v.Price, "Price") // Market Buy Price
-					// Note: Amount is 0 for market order create messages, oddly
-				case 2:
-					assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
-					assert.Equal(t, order.PartiallyFilled, v.Status, "Status")
-					assert.Equal(t, 0.00038667, v.Amount, "Amount")
-					assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount") // During live tests we consistently got back this Sat remaining
-					assert.Equal(t, 0.00038666, v.ExecutedAmount, "ExecutedAmount")
-					assert.Equal(t, 25862.0, v.Price, "Price")
-				case 3:
-					assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
-					assert.Equal(t, order.Cancelled, v.Status, "Status") // Even though they probably consider it filled, Deleted + PartialFill = Cancelled
-					assert.Equal(t, 0.00038667, v.Amount, "Amount")
-					assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
-					assert.Equal(t, 0.00038666, v.ExecutedAmount, "ExecutedAmount")
-					assert.Equal(t, 25862.0, v.Price, "Price")
-				case 4:
-					assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
-					assert.Equal(t, order.New, v.Status, "Status")
-					assert.Equal(t, order.Sell, v.Side, "Side")
-					assert.Equal(t, 0.0, v.Price, "Price") // Market Sell Price
-				case 5:
-					assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
-					assert.Equal(t, order.PartiallyFilled, v.Status, "Status")
-					assert.Equal(t, 0.00038679, v.Amount, "Amount")
-					assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
-					assert.Equal(t, 0.00038678, v.ExecutedAmount, "ExecutedAmount")
-					assert.Equal(t, 25854.0, v.Price, "Price")
-				case 6:
-					assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
-					assert.Equal(t, order.Cancelled, v.Status, "Status")
-					assert.Equal(t, 0.00038679, v.Amount, "Amount")
-					assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
-					assert.Equal(t, 0.00038678, v.ExecutedAmount, "ExecutedAmount")
-					assert.Equal(t, 25854.0, v.Price, "Price")
-				case 7:
-					assert.Equal(t, "1658869033291777", v.OrderID, "OrderID")
-					assert.Equal(t, order.New, v.Status, "Status")
-					assert.Equal(t, order.Sell, v.Side, "Side")
-					assert.Equal(t, 25845.0, v.Price, "Price")
-					assert.Equal(t, 0.00038692, v.Amount, "Amount")
-				case 8:
-					assert.Equal(t, "1658869033291777", v.OrderID, "OrderID")
-					assert.Equal(t, order.Filled, v.Status, "Status")
-					assert.Equal(t, 25845.0, v.Price, "Price")
-					assert.Equal(t, 0.00038692, v.Amount, "Amount")
-					assert.Equal(t, 0.0, v.RemainingAmount, "RemainingAmount")
-					assert.Equal(t, 0.00038692, v.ExecutedAmount, "ExecutedAmount")
-				}
-			case error:
-				t.Error(v)
-			default:
-				t.Errorf("Got unexpected data: %T %v", v, v)
+	close(b.Websocket.DataHandler)
+	assert.Len(t, b.Websocket.DataHandler, 8, "Should see 8 orders")
+	for resp := range b.Websocket.DataHandler {
+		switch v := resp.(type) {
+		case *order.Detail:
+			switch len(b.Websocket.DataHandler) {
+			case 7:
+				assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
+				assert.Equal(t, time.UnixMicro(1693831262313000), v.Date, "Date")
+				assert.Equal(t, "test_market_buy", v.ClientOrderID, "ClientOrderID")
+				assert.Equal(t, order.New, v.Status, "Status")
+				assert.Equal(t, order.Buy, v.Side, "Side")
+				assert.Equal(t, asset.Spot, v.AssetType, "AssetType")
+				assert.Equal(t, currency.NewPairWithDelimiter("BTC", "USD", "/"), v.Pair, "Pair")
+				assert.Equal(t, 0.0, v.ExecutedAmount, "ExecutedAmount")
+				assert.Equal(t, 999999999.0, v.Price, "Price") // Market Buy Price
+				// Note: Amount is 0 for market order create messages, oddly
+			case 6:
+				assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
+				assert.Equal(t, order.PartiallyFilled, v.Status, "Status")
+				assert.Equal(t, 0.00038667, v.Amount, "Amount")
+				assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount") // During live tests we consistently got back this Sat remaining
+				assert.Equal(t, 0.00038666, v.ExecutedAmount, "ExecutedAmount")
+				assert.Equal(t, 25862.0, v.Price, "Price")
+			case 5:
+				assert.Equal(t, "1658864794234880", v.OrderID, "OrderID")
+				assert.Equal(t, order.Cancelled, v.Status, "Status") // Even though they probably consider it filled, Deleted + PartialFill = Cancelled
+				assert.Equal(t, 0.00038667, v.Amount, "Amount")
+				assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
+				assert.Equal(t, 0.00038666, v.ExecutedAmount, "ExecutedAmount")
+				assert.Equal(t, 25862.0, v.Price, "Price")
+			case 4:
+				assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
+				assert.Equal(t, order.New, v.Status, "Status")
+				assert.Equal(t, order.Sell, v.Side, "Side")
+				assert.Equal(t, 0.0, v.Price, "Price") // Market Sell Price
+			case 3:
+				assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
+				assert.Equal(t, order.PartiallyFilled, v.Status, "Status")
+				assert.Equal(t, 0.00038679, v.Amount, "Amount")
+				assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
+				assert.Equal(t, 0.00038678, v.ExecutedAmount, "ExecutedAmount")
+				assert.Equal(t, 25854.0, v.Price, "Price")
+			case 2:
+				assert.Equal(t, "1658870500933632", v.OrderID, "OrderID")
+				assert.Equal(t, order.Cancelled, v.Status, "Status")
+				assert.Equal(t, 0.00038679, v.Amount, "Amount")
+				assert.Equal(t, 0.00000001, v.RemainingAmount, "RemainingAmount")
+				assert.Equal(t, 0.00038678, v.ExecutedAmount, "ExecutedAmount")
+				assert.Equal(t, 25854.0, v.Price, "Price")
+			case 1:
+				assert.Equal(t, "1658869033291777", v.OrderID, "OrderID")
+				assert.Equal(t, order.New, v.Status, "Status")
+				assert.Equal(t, order.Sell, v.Side, "Side")
+				assert.Equal(t, 25845.0, v.Price, "Price")
+				assert.Equal(t, 0.00038692, v.Amount, "Amount")
+			case 0:
+				assert.Equal(t, "1658869033291777", v.OrderID, "OrderID")
+				assert.Equal(t, order.Filled, v.Status, "Status")
+				assert.Equal(t, 25845.0, v.Price, "Price")
+				assert.Equal(t, 0.00038692, v.Amount, "Amount")
+				assert.Equal(t, 0.0, v.RemainingAmount, "RemainingAmount")
+				assert.Equal(t, 0.00038692, v.ExecutedAmount, "ExecutedAmount")
 			}
+		case error:
+			t.Error(v)
+		default:
+			t.Errorf("Got unexpected data: %T %v", v, v)
 		}
 	}
-	assert.Equal(t, 8, seen, "Number of messages")
 }
 
 func TestWsRequestReconnect(t *testing.T) {

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -55,10 +55,6 @@ var (
 	errEndpointStringNotFound            = errors.New("endpoint string not found")
 	errConfigPairFormatRequiresDelimiter = errors.New("config pair format requires delimiter")
 	errSymbolCannotBeMatched             = errors.New("symbol cannot be matched")
-	errGlobalRequestFormatIsNil          = errors.New("global request format is nil")
-	errGlobalConfigFormatIsNil           = errors.New("global config format is nil")
-	errAssetRequestFormatIsNil           = errors.New("asset type request format is nil")
-	errAssetConfigFormatIsNil            = errors.New("asset type config format is nil")
 	errSetDefaultsNotCalled              = errors.New("set defaults not called")
 	errExchangeIsNil                     = errors.New("exchange is nil")
 	errBatchSizeZero                     = errors.New("batch size cannot be 0")
@@ -397,39 +393,9 @@ func (b *Base) GetSupportedFeatures() FeaturesSupported {
 	return b.Features.Supports
 }
 
-// GetPairFormat returns the pair format based on the exchange and
-// asset type
-func (b *Base) GetPairFormat(assetType asset.Item, requestFormat bool) (currency.PairFormat, error) {
-	if b.CurrencyPairs.UseGlobalFormat {
-		if requestFormat {
-			if b.CurrencyPairs.RequestFormat == nil {
-				return currency.EMPTYFORMAT, errGlobalRequestFormatIsNil
-			}
-			return *b.CurrencyPairs.RequestFormat, nil
-		}
-
-		if b.CurrencyPairs.ConfigFormat == nil {
-			return currency.EMPTYFORMAT, errGlobalConfigFormatIsNil
-		}
-		return *b.CurrencyPairs.ConfigFormat, nil
-	}
-
-	ps, err := b.CurrencyPairs.Get(assetType)
-	if err != nil {
-		return currency.EMPTYFORMAT, err
-	}
-
-	if requestFormat {
-		if ps.RequestFormat == nil {
-			return currency.EMPTYFORMAT, errAssetRequestFormatIsNil
-		}
-		return *ps.RequestFormat, nil
-	}
-
-	if ps.ConfigFormat == nil {
-		return currency.EMPTYFORMAT, errAssetConfigFormatIsNil
-	}
-	return *ps.ConfigFormat, nil
+// GetPairFormat returns the pair format based on the exchange and asset type
+func (b *Base) GetPairFormat(a asset.Item, r bool) (currency.PairFormat, error) {
+	return b.CurrencyPairs.GetFormat(a, r)
 }
 
 // GetEnabledPairs is a method that returns the enabled currency pairs of

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -1046,12 +1046,10 @@ func (b *Base) StoreAssetPairFormat(a asset.Item, f currency.PairStore) error {
 	return nil
 }
 
-// SetGlobalPairsManager sets defined asset and pairs management system with
-// global formatting
+// SetGlobalPairsManager sets defined asset and pairs management system with global formatting
 func (b *Base) SetGlobalPairsManager(request, config *currency.PairFormat, assets ...asset.Item) error {
 	if request == nil {
-		return fmt.Errorf("%s cannot set pairs manager, request pair format not provided",
-			b.Name)
+		return fmt.Errorf("%s cannot set pairs manager, request pair format not provided", b.Name)
 	}
 
 	if config == nil {
@@ -1083,10 +1081,10 @@ func (b *Base) SetGlobalPairsManager(request, config *currency.PairFormat, asset
 	for i := range assets {
 		if assets[i].String() == "" {
 			b.CurrencyPairs.Pairs = nil
-			return fmt.Errorf("%s cannot set pairs manager, asset is empty string",
-				b.Name)
+			return fmt.Errorf("%s cannot set pairs manager, asset is empty string", b.Name)
 		}
 		b.CurrencyPairs.Pairs[assets[i]] = new(currency.PairStore)
+		b.CurrencyPairs.Pairs[assets[i]].AssetEnabled = convert.BoolPtr(true)
 		b.CurrencyPairs.Pairs[assets[i]].ConfigFormat = config
 		b.CurrencyPairs.Pairs[assets[i]].RequestFormat = request
 	}

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -973,11 +973,9 @@ func (b *Base) FormatWithdrawPermissions() string {
 	return NoAPIWithdrawalMethodsText
 }
 
-// SupportsAsset whether or not the supplied asset is supported
-// by the exchange
+// SupportsAsset whether or not the supplied asset is supported by the exchange
 func (b *Base) SupportsAsset(a asset.Item) bool {
-	_, ok := b.CurrencyPairs.Pairs[a]
-	return ok
+	return b.CurrencyPairs.IsAssetSupported(a)
 }
 
 // PrintEnabledPairs prints the exchanges enabled asset pairs

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -1435,58 +1435,36 @@ func TestStoreAssetPairFormat(t *testing.T) {
 }
 
 func TestSetGlobalPairsManager(t *testing.T) {
-	b := Base{
-		Config: &config.Exchange{Name: "kitties"},
-	}
+	b := Base{Config: &config.Exchange{Name: "kitties"}}
 
 	err := b.SetGlobalPairsManager(nil, nil, asset.Empty)
-	if err == nil {
-		t.Error("error cannot be nil")
-	}
+	assert.ErrorContains(t, err, "cannot set pairs manager, request pair format not provided")
 
 	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true}, nil, asset.Empty)
-	if err == nil {
-		t.Error("error cannot be nil")
-	}
+	assert.ErrorContains(t, err, "cannot set pairs manager, config pair format not provided")
 
-	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true},
-		&currency.PairFormat{Uppercase: true})
-	if err == nil {
-		t.Error("error cannot be nil")
-	}
+	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true}, &currency.PairFormat{Uppercase: true})
+	assert.ErrorContains(t, err, " cannot set pairs manager, no assets provided")
 
-	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true},
-		&currency.PairFormat{Uppercase: true}, asset.Empty)
-	if err == nil {
-		t.Error("error cannot be nil")
-	}
+	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true}, &currency.PairFormat{Uppercase: true}, asset.Empty)
+	assert.ErrorContains(t, err, " cannot set global pairs manager config pair format requires delimiter for assets")
 
 	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true},
 		&currency.PairFormat{Uppercase: true},
 		asset.Spot,
 		asset.Binary)
-	if !errors.Is(err, errConfigPairFormatRequiresDelimiter) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, errConfigPairFormatRequiresDelimiter)
-	}
+	assert.ErrorIs(t, err, errConfigPairFormatRequiresDelimiter)
 
-	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true},
-		&currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter},
-		asset.Spot,
-		asset.Binary)
-	if err != nil {
-		t.Error(err)
-	}
+	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true}, &currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter}, asset.Spot, asset.Binary)
+	require.NoError(t, err, "SetGlobalPairsManager must not error")
 
-	if !b.SupportsAsset(asset.Binary) || !b.SupportsAsset(asset.Spot) {
-		t.Fatal("global pairs manager not set correctly")
-	}
+	assert.True(t, b.SupportsAsset(asset.Binary), "Pairs Manager must support Binary")
+	assert.True(t, b.SupportsAsset(asset.Spot), "Pairs Manager must support Spot")
 
-	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true},
-		&currency.PairFormat{Uppercase: true}, asset.Spot, asset.Binary)
-	if err == nil {
-		t.Error("error cannot be nil")
-	}
+	err = b.SetGlobalPairsManager(&currency.PairFormat{Uppercase: true}, &currency.PairFormat{Uppercase: true}, asset.Spot, asset.Binary)
+	assert.ErrorIs(t, err, errConfigPairFormatRequiresDelimiter, "SetGlobalPairsManager should error correctly")
 }
+
 func Test_FormatExchangeKlineInterval(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -1285,14 +1285,12 @@ func TestSupportsAsset(t *testing.T) {
 	t.Parallel()
 	var b Base
 	b.CurrencyPairs.Pairs = map[asset.Item]*currency.PairStore{
-		asset.Spot: {},
+		asset.Spot: {
+			AssetEnabled: convert.BoolPtr(true),
+		},
 	}
-	if !b.SupportsAsset(asset.Spot) {
-		t.Error("spot should be supported")
-	}
-	if b.SupportsAsset(asset.Index) {
-		t.Error("index shouldn't be supported")
-	}
+	assert.True(t, b.SupportsAsset(asset.Spot), "Spot should be supported")
+	assert.False(t, b.SupportsAsset(asset.Index), "Index should not be supported")
 }
 
 func TestPrintEnabledPairs(t *testing.T) {

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -3753,8 +3753,12 @@ func (g *Gateio) IsValidPairString(currencyPair string) bool {
 	if len(currencyPair) < 3 {
 		return false
 	}
-	if strings.Contains(currencyPair, g.CurrencyPairs.RequestFormat.Delimiter) {
-		result := strings.Split(currencyPair, g.CurrencyPairs.RequestFormat.Delimiter)
+	pf, err := g.CurrencyPairs.GetFormat(asset.Spot, true)
+	if err != nil {
+		return false
+	}
+	if strings.Contains(currencyPair, pf.Delimiter) {
+		result := strings.Split(currencyPair, pf.Delimiter)
 		return len(result) >= 2
 	}
 	return false

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1827,15 +1827,16 @@ func TestWsOwnTrades(t *testing.T) {
 
 func TestWsOpenOrders(t *testing.T) {
 	t.Parallel()
-	n := new(Kraken)
+	k := new(Kraken) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(k), "Test instance Setup must not error")
 	testexch.UpdatePairsOnce(t, k)
-	sharedtestvalues.TestFixtureToDataHandler(t, k, n, "testdata/wsOpenTrades.json", n.wsHandleData)
+	testexch.FixtureToDataHandler(t, "testdata/wsOpenTrades.json", k.wsHandleData)
 	seen := 0
 	for reading := true; reading; {
 		select {
 		default:
 			reading = false
-		case resp := <-n.Websocket.DataHandler:
+		case resp := <-k.Websocket.DataHandler:
 			seen++
 			switch v := resp.(type) {
 			case *order.Detail:

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -130,31 +130,28 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
+	k := new(Kraken) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(k), "Test instance Setup must not error")
 	testexch.UpdatePairsOnce(t, k)
+	err := k.UpdateTickers(context.Background(), asset.Spot)
+	require.NoError(t, err, "UpdateTickers must not error")
 	ap, err := k.GetAvailablePairs(asset.Spot)
-	require.NoError(t, err)
-	err = k.CurrencyPairs.StorePairs(asset.Spot, ap, true)
-	require.NoError(t, err)
-	err = k.UpdateTickers(context.Background(), asset.Spot)
-	assert.NoError(t, err)
+	require.NoError(t, err, "GetAvailablePairs must not error")
 	for i := range ap {
 		_, err = ticker.GetTicker(k.Name, ap[i], asset.Spot)
-		assert.NoError(t, err)
+		require.NoError(t, err, "GetTicker must not error")
 	}
-
 	ap, err = k.GetAvailablePairs(asset.Futures)
-	require.NoError(t, err)
-	err = k.CurrencyPairs.StorePairs(asset.Futures, ap, true)
-	require.NoError(t, err)
+	require.NoError(t, err, "GetAvailablePairs must not error")
 	err = k.UpdateTickers(context.Background(), asset.Futures)
-	assert.NoError(t, err)
+	require.NoError(t, err, "UpdateTickers must not error")
 	for i := range ap {
 		_, err = ticker.GetTicker(k.Name, ap[i], asset.Futures)
-		assert.NoError(t, err)
+		require.NoError(t, err, "GetTicker must not error")
 	}
 
 	err = k.UpdateTickers(context.Background(), asset.Index)
-	assert.ErrorIs(t, err, asset.ErrNotSupported)
+	assert.ErrorIs(t, err, asset.ErrNotSupported, "UpdateTickers should error correctly on Index asset")
 }
 
 func TestUpdateOrderbook(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -2534,14 +2534,15 @@ func TestBalanceAndPosition(t *testing.T) {
 
 func TestOrderPushData(t *testing.T) {
 	t.Parallel()
-	n := new(Okx)
-	sharedtestvalues.TestFixtureToDataHandler(t, ok, n, "testdata/wsOrders.json", n.WsHandleData)
+	ok := new(Okx) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(ok), "Test instance Setup must not error")
+	testexch.FixtureToDataHandler(t, "testdata/wsOrders.json", ok.WsHandleData)
 	seen := 0
 	for reading := true; reading; {
 		select {
 		default:
 			reading = false
-		case resp := <-n.GetBase().Websocket.DataHandler:
+		case resp := <-ok.Websocket.DataHandler:
 			seen++
 			switch v := resp.(type) {
 			case *order.Detail:

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -2206,24 +2206,6 @@ func TestWithdraw(t *testing.T) {
 	}
 }
 
-func TestGetPairFromInstrumentID(t *testing.T) {
-	t.Parallel()
-	instruments := []string{
-		"BTC-USDT",
-		"BTC-USDT-SWAP",
-		"BTC-USDT-ER33234",
-	}
-	if _, err := ok.GetPairFromInstrumentID(instruments[0]); err != nil {
-		t.Error("Okx GetPairFromInstrumentID() error", err)
-	}
-	if _, ere := ok.GetPairFromInstrumentID(instruments[1]); ere != nil {
-		t.Error("Okx GetPairFromInstrumentID() error", ere)
-	}
-	if _, erf := ok.GetPairFromInstrumentID(instruments[2]); erf != nil {
-		t.Error("Okx GetPairFromInstrumentID() error", erf)
-	}
-}
-
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok)

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -688,7 +688,8 @@ func (ok *Okx) wsProcessIndexCandles(respRaw []byte) error {
 	if len(response.Data) == 0 {
 		return errNoCandlestickDataFound
 	}
-	pair, err := ok.GetPairFromInstrumentID(response.Argument.InstrumentID)
+
+	pair, err := currency.NewPairFromString(response.Argument.InstrumentID)
 	if err != nil {
 		return err
 	}
@@ -750,7 +751,7 @@ func (ok *Okx) wsProcessOrderbook5(data []byte) error {
 		return err
 	}
 
-	pair, err := ok.GetPairFromInstrumentID(resp.Argument.InstrumentID)
+	pair, err := currency.NewPairFromString(resp.Argument.InstrumentID)
 	if err != nil {
 		return err
 	}
@@ -809,13 +810,11 @@ func (ok *Okx) wsProcessOrderBooks(data []byte) error {
 		response.Action != wsOrderbookSnapshot {
 		return errors.New("invalid order book action")
 	}
-	var pair currency.Pair
-	var assets []asset.Item
-	assets, err = ok.GetAssetsFromInstrumentTypeOrID(response.Argument.InstrumentType, response.Argument.InstrumentID)
+	assets, err := ok.GetAssetsFromInstrumentTypeOrID(response.Argument.InstrumentType, response.Argument.InstrumentID)
 	if err != nil {
 		return err
 	}
-	pair, err = ok.GetPairFromInstrumentID(response.Argument.InstrumentID)
+	pair, err := currency.NewPairFromString(response.Argument.InstrumentID)
 	if err != nil {
 		return err
 	}
@@ -1062,8 +1061,7 @@ func (ok *Okx) wsProcessTrades(data []byte) error {
 	}
 	trades := make([]trade.Data, 0, len(response.Data)*len(assets))
 	for i := range response.Data {
-		var pair currency.Pair
-		pair, err = ok.GetPairFromInstrumentID(response.Data[i].InstrumentID)
+		pair, err := currency.NewPairFromString(response.Data[i].InstrumentID)
 		if err != nil {
 			return err
 		}
@@ -1086,7 +1084,6 @@ func (ok *Okx) wsProcessTrades(data []byte) error {
 // wsProcessOrders handles websocket order push data responses.
 func (ok *Okx) wsProcessOrders(respRaw []byte) error {
 	var response WsOrderResponse
-	var pair currency.Pair
 	err := json.Unmarshal(respRaw, &response)
 	if err != nil {
 		return err
@@ -1109,7 +1106,7 @@ func (ok *Okx) wsProcessOrders(respRaw []byte) error {
 				Err:      err,
 			}
 		}
-		pair, err = ok.GetPairFromInstrumentID(response.Data[x].InstrumentID)
+		pair, err := currency.NewPairFromString(response.Data[x].InstrumentID)
 		if err != nil {
 			return err
 		}
@@ -1189,7 +1186,7 @@ func (ok *Okx) wsProcessCandles(respRaw []byte) error {
 	if len(response.Data) == 0 {
 		return errNoCandlestickDataFound
 	}
-	pair, err := ok.GetPairFromInstrumentID(response.Argument.InstrumentID)
+	pair, err := currency.NewPairFromString(response.Argument.InstrumentID)
 	if err != nil {
 		return err
 	}
@@ -1260,8 +1257,7 @@ func (ok *Okx) wsProcessTickers(data []byte) error {
 		if err != nil {
 			return err
 		}
-		var c currency.Pair
-		c, err = ok.GetPairFromInstrumentID(response.Data[i].InstrumentID)
+		c, err := currency.NewPairFromString(response.Data[i].InstrumentID)
 		if err != nil {
 			return err
 		}

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -259,9 +259,13 @@ func (ok *Okx) FetchTradablePairs(ctx context.Context, a asset.Item) (currency.P
 	if err != nil {
 		return nil, err
 	}
+	pf, err := ok.CurrencyPairs.GetFormat(a, false)
+	if err != nil {
+		return nil, err
+	}
 	pairs := make([]currency.Pair, len(insts))
 	for x := range insts {
-		pairs[x], err = currency.NewPairDelimiter(insts[x].InstrumentID, ok.CurrencyPairs.ConfigFormat.Delimiter)
+		pairs[x], err = currency.NewPairDelimiter(insts[x].InstrumentID, pf.Delimiter)
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +382,7 @@ func (ok *Okx) UpdateTickers(ctx context.Context, assetType asset.Item) error {
 	}
 
 	for y := range ticks {
-		pair, err := ok.GetPairFromInstrumentID(ticks[y].InstrumentID)
+		pair, err := currency.NewPairFromString(ticks[y].InstrumentID)
 		if err != nil {
 			return err
 		}
@@ -1192,8 +1196,7 @@ allOrders:
 				break allOrders
 			}
 			orderSide := orderList[i].Side
-			var pair currency.Pair
-			pair, err = ok.GetPairFromInstrumentID(orderList[i].InstrumentID)
+			pair, err := currency.NewPairFromString(orderList[i].InstrumentID)
 			if err != nil {
 				return nil, err
 			}
@@ -1286,8 +1289,7 @@ allOrders:
 				// reached end of orders to crawl
 				break allOrders
 			}
-			var pair currency.Pair
-			pair, err = ok.GetPairFromInstrumentID(orderList[i].InstrumentID)
+			pair, err := currency.NewPairFromString(orderList[i].InstrumentID)
 			if err != nil {
 				return nil, err
 			}

--- a/exchanges/sharedtestvalues/sharedtestvalues.go
+++ b/exchanges/sharedtestvalues/sharedtestvalues.go
@@ -1,7 +1,6 @@
 package sharedtestvalues
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -9,15 +8,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/stream/buffer"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 )
 
@@ -64,6 +62,7 @@ func NewTestWebsocket() *stream.Websocket {
 		Subscribe:         make(chan []subscription.Subscription, 10),
 		Unsubscribe:       make(chan []subscription.Subscription, 10),
 		Match:             stream.NewMatch(),
+		Orderbook:         buffer.Orderbook{},
 	}
 }
 
@@ -152,38 +151,6 @@ func ForceFileStandard(t *testing.T, pattern string) error {
 		return fmt.Errorf("failed to walk directory: %w", err)
 	}
 	return nil
-}
-
-// TestFixtureToDataHandler takes a new empty exchange and configures a new websocket handler for it, and squirts the json path contents to it
-// It accepts a reader function, which is probably e.wsHandleData but could be anything
-func TestFixtureToDataHandler(t *testing.T, seed, e exchange.IBotExchange, fixturePath string, reader func([]byte) error) {
-	t.Helper()
-	b := e.GetBase()
-	seedBase := seed.GetBase()
-
-	err := b.CurrencyPairs.Load(&seedBase.CurrencyPairs)
-	assert.NoError(t, err, "Loading currency pairs should not error")
-
-	b.Name = "fixture"
-	b.Websocket = &stream.Websocket{
-		Wg:          new(sync.WaitGroup),
-		DataHandler: make(chan interface{}, 128),
-	}
-	b.API.Endpoints = b.NewEndpoints()
-
-	fixture, err := os.Open(fixturePath)
-	assert.NoError(t, err, "Opening fixture '%s' should not error", fixturePath)
-	defer func() {
-		assert.NoError(t, fixture.Close(), "Closing the fixture file should not error")
-	}()
-
-	s := bufio.NewScanner(fixture)
-	for s.Scan() {
-		msg := s.Bytes()
-		err := reader(msg)
-		assert.NoErrorf(t, err, "Fixture message should not error:\n%s", msg)
-	}
-	assert.NoError(t, s.Err(), "Fixture Scanner should not error")
 }
 
 // SetupCurrencyPairsForExchangeAsset enables an asset for an exchange

--- a/internal/testing/exchange/exchange.go
+++ b/internal/testing/exchange/exchange.go
@@ -214,7 +214,8 @@ func UpdatePairsOnce(tb testing.TB, e exchange.IBotExchange) {
 	updatePairsMutex.Lock()
 	defer updatePairsMutex.Unlock()
 
-	if updatePairsOnce[e] {
+	b := e.GetBase()
+	if c, ok := updatePairsOnce[e.GetName()]; ok {
 		b.CurrencyPairs.Load(c)
 		return
 	}

--- a/internal/testing/exchange/exchange.go
+++ b/internal/testing/exchange/exchange.go
@@ -213,6 +213,7 @@ func UpdatePairsOnce(tb testing.TB, e exchange.IBotExchange) {
 	defer updatePairsMutex.Unlock()
 
 	if updatePairsOnce[e] {
+		b.CurrencyPairs.Load(c)
 		return
 	}
 

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -667,12 +667,14 @@
     },
     "useGlobalFormat": true,
     "lastUpdated": 1566798411,
-    "assetTypes": [
-     "spot",
-     "futures"
-    ],
     "pairs": {
+     "futures": {
+      "assetEnabled": true,
+      "enabled": "",
+      "available": ""
+     },
      "spot": {
+      "assetEnabled": true,
       "enabled": "BTC_JPY,ETH_BTC,BCH_BTC",
       "available": "BTC_JPY,FXBTC_JPY,ETH_BTC,BCH_BTC"
      }


### PR DESCRIPTION
* Fix a instance pair manager race intermittently causing Bitfinex and Kraken to fail
* Fix PairsManager.Load breaking matcher
* Fix UpdatePairsOnce not working across instances
* Move and Simplify FixtureToDataHandler
* Rename PairStore.copy to PairStore.clone and replace various builtin `copy` with slices.Clone
* Add Fullstore.clone and PairFormat.clone

## Type of change

- [x] Test fixes and improvements

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
