### PR TITLE
BTSE: Various fixes

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -50,37 +50,28 @@ var (
 	_HTTPClient    *http.Client
 	_HTTPUserAgent string
 	m              sync.RWMutex
-	// ErrNotYetImplemented defines a common error across the code base that
-	// alerts of a function that has not been completed or tied into main code
-	ErrNotYetImplemented = errors.New("not yet implemented")
-	// ErrFunctionNotSupported defines a standardised error for an unsupported
-	// wrapper function by an API
-	ErrFunctionNotSupported  = errors.New("unsupported wrapper function")
-	errInvalidCryptoCurrency = errors.New("invalid crypto currency")
-	// ErrDateUnset is an error for start end check calculations
-	ErrDateUnset = errors.New("date unset")
-	// ErrStartAfterEnd is an error for start end check calculations
-	ErrStartAfterEnd = errors.New("start date after end date")
-	// ErrStartEqualsEnd is an error for start end check calculations
-	ErrStartEqualsEnd = errors.New("start date equals end date")
-	// ErrStartAfterTimeNow is an error for start end check calculations
-	ErrStartAfterTimeNow = errors.New("start date is after current time")
-	// ErrNilPointer defines an error for a nil pointer
-	ErrNilPointer = errors.New("nil pointer")
-	// ErrCannotCalculateOffline is returned when a request wishes to calculate
-	// something offline, but has an online requirement
-	ErrCannotCalculateOffline = errors.New("cannot calculate offline, unsupported")
-	// ErrNoResponse is returned when a response has no entries/is empty
-	// when one is expected
-	ErrNoResponse = errors.New("no response")
+	zeroValueUnix  = time.Unix(0, 0)
+)
 
+// Public common Errors
+var (
+	ErrNotYetImplemented      = errors.New("not yet implemented")
+	ErrFunctionNotSupported   = errors.New("unsupported wrapper function")
+	errInvalidCryptoCurrency  = errors.New("invalid crypto currency")
+	ErrDateUnset              = errors.New("date unset")
+	ErrStartAfterEnd          = errors.New("start date after end date")
+	ErrStartEqualsEnd         = errors.New("start date equals end date")
+	ErrStartAfterTimeNow      = errors.New("start date is after current time")
+	ErrNilPointer             = errors.New("nil pointer")
+	ErrCannotCalculateOffline = errors.New("cannot calculate offline, unsupported")
+	ErrNoResponse             = errors.New("no response")
+	ErrTypeAssertFailure      = errors.New("type assert failure")
+)
+
+var (
 	errCannotSetInvalidTimeout = errors.New("cannot set new HTTP client with timeout that is equal or less than 0")
 	errUserAgentInvalid        = errors.New("cannot set invalid user agent")
 	errHTTPClientInvalid       = errors.New("custom http client cannot be nil")
-
-	zeroValueUnix = time.Unix(0, 0)
-	// ErrTypeAssertFailure defines an error when type assertion fails
-	ErrTypeAssertFailure = errors.New("type assert failure")
 )
 
 // MatchesEmailPattern ensures that the string is an email address by regexp check

--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -7,12 +7,10 @@ import (
 	"strings"
 )
 
+// Public errors related to assets
 var (
-	// ErrNotSupported is an error for an unsupported asset type
 	ErrNotSupported = errors.New("unsupported asset type")
-	// ErrNotEnabled is an error for an asset not enabled
-	ErrNotEnabled = errors.New("asset type not enabled")
-	// ErrInvalidAsset is returned when the assist isn't valid
+	ErrNotEnabled   = errors.New("asset type not enabled")
 	ErrInvalidAsset = errors.New("asset is invalid")
 )
 

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -68,8 +68,9 @@ func (b *BTSE) FetchFundingHistory(ctx context.Context, symbol string) (map[stri
 	return resp, b.SendHTTPRequest(ctx, exchange.RestFutures, http.MethodGet, btseFuturesFunding+params.Encode(), &resp, false, queryFunc)
 }
 
-// GetMarketSummary stores market summary data
-func (b *BTSE) GetMarketSummary(ctx context.Context, symbol string, spot bool) (MarketSummary, error) {
+// GetRawMarketSummary returns an unfiltered list of market pairs
+// Consider using the wrapper function GetMarketSummary instead
+func (b *BTSE) GetRawMarketSummary(ctx context.Context, symbol string, spot bool) (MarketSummary, error) {
 	var m MarketSummary
 	path := btseMarketOverview
 	if symbol != "" {
@@ -619,23 +620,7 @@ func parseOrderTime(timeStr string) (time.Time, error) {
 	return time.Parse(time.DateTime, timeStr)
 }
 
-// MillionPairs returns a map of symbol names which have a IsMillion equivalent
-func (m *MarketSummary) MillionPairs() map[string]bool {
-	pairs := map[string]bool{}
-	for _, s := range *m {
-		if s.Active && s.HasLiquidity() && s.IsMillions() {
-			pairs[strings.TrimPrefix(s.Symbol, "M_")] = true
-		}
-	}
-	return pairs
-}
-
 // HasLiquidity returns if a market pair has a bid or ask != 0
 func (m *MarketPair) HasLiquidity() bool {
 	return m.LowestAsk != 0 || m.HighestBid != 0
-}
-
-// IsMillions returns if a market pair represents a million of Base / Quote
-func (m *MarketPair) IsMillions() bool {
-	return strings.HasPrefix(m.Symbol, "M_")
 }

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -729,3 +729,23 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		assert.NotEmpty(t, resp)
 	}
 }
+
+// TestStripExponent exercises StripExponent
+func TestStripExponent(t *testing.T) {
+	t.Parallel()
+	s, err := (&MarketPair{Symbol: "BTC-ETH"}).StripExponent()
+	assert.NoError(t, err, "Should not error on a symbol without exponent")
+	assert.Empty(t, s, "Should return an empty symbol without exponent")
+
+	for _, p := range []string{"B", "M", "K"} {
+		s, err = (&MarketPair{Symbol: p + "_BTC-ETH"}).StripExponent()
+		assert.NoError(t, err, "Should not error on a symbol with exponent")
+		assert.Equal(t, "BTC-ETH", s, "Should return the symbol without the exponent")
+	}
+
+	_, err = (&MarketPair{Symbol: "Z_BTC-ETH"}).StripExponent()
+	assert.ErrorIs(t, err, errInvalidPairSymbol, "Should error on a symbol with unknown exponent")
+
+	_, err = (&MarketPair{Symbol: "M_BTC_ETH"}).StripExponent()
+	assert.ErrorIs(t, err, errInvalidPairSymbol, "Should error on a symbol with too many underscores")
+}

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -144,6 +144,10 @@ func TestFormatExchangeKlineInterval(t *testing.T) {
 
 func TestGetHistoricCandles(t *testing.T) {
 	t.Parallel()
+	r := b.Requester
+	b := new(BTSE) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test exchange Setup must not error")
+	b.Requester = r
 	start := time.Now().AddDate(0, 0, -3)
 	_, err := b.GetHistoricCandles(context.Background(), spotPair, asset.Spot, kline.OneHour, start, time.Now())
 	assert.NoError(t, err, "GetHistoricCandles should not error")
@@ -154,6 +158,10 @@ func TestGetHistoricCandles(t *testing.T) {
 
 func TestGetHistoricCandlesExtended(t *testing.T) {
 	t.Parallel()
+	r := b.Requester
+	b := new(BTSE) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test exchange Setup must not error")
+	b.Requester = r
 	err := b.CurrencyPairs.StorePairs(asset.Futures, currency.Pairs{futuresPair}, true)
 	assert.NoError(t, err, "StorePairs should not error")
 
@@ -718,7 +726,11 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
+	r := b.Requester
+	b := new(BTSE) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test exchange Setup must not error")
 	testexch.UpdatePairsOnce(t, b)
+	b.Requester = r
 	cp1 := currency.NewPair(currency.BTC, currency.PFC)
 	cp2 := currency.NewPair(currency.ETH, currency.PFC)
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, b, asset.Futures, futuresPair, cp1, cp2)

--- a/exchanges/btse/btse_types.go
+++ b/exchanges/btse/btse_types.go
@@ -1,7 +1,6 @@
 package btse
 
 import (
-	"sync"
 	"time"
 )
 
@@ -353,16 +352,6 @@ type ErrorResponse struct {
 	Message   string `json:"message"`
 	Status    int    `json:"status"`
 }
-
-// OrderSizeLimit holds accepted minimum, maximum, and size increment when submitting new orders
-type OrderSizeLimit struct {
-	MinOrderSize     float64
-	MaxOrderSize     float64
-	MinSizeIncrement float64
-}
-
-// orderSizeLimitMap map of OrderSizeLimit per currency
-var orderSizeLimitMap sync.Map
 
 // WsSubscriptionAcknowledgement contains successful subscription messages
 type WsSubscriptionAcknowledgement struct {

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -279,7 +279,11 @@ func (b *BTSE) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item) 
 	if !b.SupportsAsset(a) {
 		return nil, fmt.Errorf("%w %v", asset.ErrNotSupported, a)
 	}
-	ticks, err := b.GetMarketSummary(ctx, p.String(), a == asset.Spot)
+	symbol, err := b.FormatSymbol(p, a)
+	if err != nil {
+		return nil, err
+	}
+	ticks, err := b.GetMarketSummary(ctx, symbol, a == asset.Spot)
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -1107,6 +1107,11 @@ func (b *BTSE) GetMarketSummary(ctx context.Context, symbol string, spot bool) (
 		if ePairs[l.Symbol] { // Skip pair with an exponent sibling
 			continue
 		}
+		if !spot {
+			// BTSE API for futures does not return futures field at all, and the docs show it coming back as false
+			// Much easier for our data flow if we can trust this field
+			l.Futures = true
+		}
 		filtered = append(filtered, l)
 	}
 	return filtered, nil

--- a/exchanges/order/limits.go
+++ b/exchanges/order/limits.go
@@ -10,45 +10,25 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
+// Public errors for order limits
 var (
-	// ErrExchangeLimitNotLoaded defines if an exchange does not have minmax
-	// values
-	ErrExchangeLimitNotLoaded = errors.New("exchange limits not loaded")
-	// ErrPriceBelowMin is when the price is lower than the minimum price
-	// limit accepted by the exchange
-	ErrPriceBelowMin = errors.New("price below minimum limit")
-	// ErrPriceExceedsMax is when the price is higher than the maximum price
-	// limit accepted by the exchange
-	ErrPriceExceedsMax = errors.New("price exceeds maximum limit")
-	// ErrPriceExceedsStep is when the price is not divisible by its step
-	ErrPriceExceedsStep = errors.New("price exceeds step limit")
-	// ErrAmountBelowMin is when the amount is lower than the minimum amount
-	// limit accepted by the exchange
-	ErrAmountBelowMin = errors.New("amount below minimum limit")
-	// ErrAmountExceedsMax is when the amount is higher than the maximum amount
-	// limit accepted by the exchange
-	ErrAmountExceedsMax = errors.New("amount exceeds maximum limit")
-	// ErrAmountExceedsStep is when the amount is not divisible by its step
-	ErrAmountExceedsStep = errors.New("amount exceeds step limit")
-	// ErrNotionalValue is when the notional value does not exceed currency pair
-	// requirements
-	ErrNotionalValue = errors.New("total notional value is under minimum limit")
-	// ErrMarketAmountBelowMin is when the amount is lower than the minimum
-	// amount limit accepted by the exchange for a market order
-	ErrMarketAmountBelowMin = errors.New("market order amount below minimum limit")
-	// ErrMarketAmountExceedsMax is when the amount is higher than the maximum
-	// amount limit accepted by the exchange for a market order
-	ErrMarketAmountExceedsMax = errors.New("market order amount exceeds maximum limit")
-	// ErrMarketAmountExceedsStep is when the amount is not divisible by its
-	// step for a market order
-	ErrMarketAmountExceedsStep = errors.New("market order amount exceeds step limit")
-	// ErrCannotValidateAsset is thrown when the asset is not loaded
-	ErrCannotValidateAsset = errors.New("cannot check limit, asset not loaded")
-	// ErrCannotValidateBaseCurrency is thrown when the base currency is not loaded
-	ErrCannotValidateBaseCurrency = errors.New("cannot check limit, base currency not loaded")
-	// ErrCannotValidateQuoteCurrency is thrown when the quote currency is not loaded
+	ErrExchangeLimitNotLoaded      = errors.New("exchange limits not loaded")
+	ErrPriceBelowMin               = errors.New("price below minimum limit")
+	ErrPriceExceedsMax             = errors.New("price exceeds maximum limit")
+	ErrPriceExceedsStep            = errors.New("price exceeds step limit") // price is not divisible by its step
+	ErrAmountBelowMin              = errors.New("amount below minimum limit")
+	ErrAmountExceedsMax            = errors.New("amount exceeds maximum limit")
+	ErrAmountExceedsStep           = errors.New("amount exceeds step limit") // amount is not divisible by its step
+	ErrNotionalValue               = errors.New("total notional value is under minimum limit")
+	ErrMarketAmountBelowMin        = errors.New("market order amount below minimum limit")
+	ErrMarketAmountExceedsMax      = errors.New("market order amount exceeds maximum limit")
+	ErrMarketAmountExceedsStep     = errors.New("market order amount exceeds step limit") // amount is not divisible by its step for a market order
+	ErrCannotValidateAsset         = errors.New("cannot check limit, asset not loaded")
+	ErrCannotValidateBaseCurrency  = errors.New("cannot check limit, base currency not loaded")
 	ErrCannotValidateQuoteCurrency = errors.New("cannot check limit, quote currency not loaded")
+)
 
+var (
 	errExchangeLimitBase   = errors.New("exchange limits not found for base currency")
 	errExchangeLimitQuote  = errors.New("exchange limits not found for quote currency")
 	errCannotLoadLimit     = errors.New("cannot load limit, levels not supplied")

--- a/exchanges/order/limits.go
+++ b/exchanges/order/limits.go
@@ -86,9 +86,7 @@ func (e *ExecutionLimits) LoadLimits(levels []MinMaxLevel) error {
 
 	for x := range levels {
 		if !levels[x].Asset.IsValid() {
-			return fmt.Errorf("cannot load levels for '%s': %w",
-				levels[x].Asset,
-				asset.ErrNotSupported)
+			return fmt.Errorf("cannot load levels for '%s': %w", levels[x].Asset, asset.ErrNotSupported)
 		}
 		m1, ok := e.m[levels[x].Asset]
 		if !ok {

--- a/exchanges/order/limits.go
+++ b/exchanges/order/limits.go
@@ -12,6 +12,7 @@ import (
 
 // Public errors for order limits
 var (
+	ErrLoadLimitsFailed            = errors.New("failed to load exchange limits")
 	ErrExchangeLimitNotLoaded      = errors.New("exchange limits not loaded")
 	ErrPriceBelowMin               = errors.New("price below minimum limit")
 	ErrPriceExceedsMax             = errors.New("price exceeds maximum limit")


### PR DESCRIPTION
* Replace `seedOrderSizeLimits` with standard `UpdateOrderExecutionLimits`
* Remove checks for limits from SubmitOrder; No other exchange implements them at the exchange level
* Fix handling of K_ prefix symbols
* Overload `GetRawMarketSummary` with `GetMarketSummary` to filter pairs
* Fix MarketPair.Futures field
* Fixes for tests prone to racing on currency updates

## Type of change

- [x] Bug fix

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestUpdateOrderExecutionLimts
