### PR TITLE
Deribit: bug fixes, test fixes and implement GetCurrencyTradeURL

### DIFF
--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2705,7 +2705,7 @@ func (d *Deribit) getAssetPairByInstrument(instrument string) (currency.Pair, as
 
 	var item asset.Item
 	// Find the first occurrence of the delimiter and split the instrument string accordingly
-	parts := strings.SplitN(instrument, currency.DashDelimiter, -1)
+	parts := strings.Split(instrument, currency.DashDelimiter)
 	switch {
 	case len(parts) == 1:
 		if i := strings.IndexAny(instrument, currency.UnderscoreDelimiter); i == -1 {

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2697,16 +2697,14 @@ func (d *Deribit) getAssetPairByInstrument(instrument string) (currency.Pair, as
 	}
 
 	var item asset.Item
-	delimiter := currency.DashDelimiter
 	// Find the first occurrence of the delimiter and split the instrument string accordingly
-	parts := strings.SplitN(instrument, delimiter, -1)
+	parts := strings.SplitN(instrument, currency.DashDelimiter, -1)
 	switch {
 	case len(parts) == 1:
 		if i := strings.IndexAny(instrument, currency.UnderscoreDelimiter); i == -1 {
 			return currency.EMPTYPAIR, asset.Empty, fmt.Errorf("%w %s", errUnsupportedInstrumentFormat, instrument)
 		}
 		item = asset.Spot
-		delimiter = currency.UnderscoreDelimiter
 	case len(parts) == 2:
 		item = asset.Futures
 	case parts[len(parts)-1] == "C" || parts[len(parts)-1] == "P":
@@ -2724,7 +2722,7 @@ func (d *Deribit) getAssetPairByInstrument(instrument string) (currency.Pair, as
 	default:
 		return currency.EMPTYPAIR, asset.Empty, fmt.Errorf("%w %s", errUnsupportedInstrumentFormat, instrument)
 	}
-	cp, err := currency.NewPairDelimiter(instrument, delimiter)
+	cp, err := currency.NewPairFromString(instrument)
 	if err != nil {
 		return currency.EMPTYPAIR, asset.Empty, err
 	}

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2836,13 +2836,16 @@ func (d *Deribit) formatFuturesTradablePair(pair currency.Pair) string {
 // it has both uppercase or lowercase characters, which we can not achieve with the Upper=true or Upper=false
 func (d *Deribit) optionPairToString(pair currency.Pair) string {
 	subCodes := strings.Split(pair.Quote.String(), currency.DashDelimiter)
-	if len(subCodes) == 3 {
-		if match, err := regexp.MatchString(`^[a-zA-Z0-9_]*$`, subCodes[1]); match && err == nil {
-			subCodes[1] = strings.ToLower(subCodes[1])
+	initialDelimiter := currency.DashDelimiter
+	if subCodes[0] == "USDC" {
+		initialDelimiter = currency.UnderscoreDelimiter
+	}
+	for i := range subCodes {
+		if match, err := regexp.MatchString(`[0-9]{1,}(D)[0-9]{1,}`, subCodes[i]); match && err == nil {
+			subCodes[i] = strings.ToLower(subCodes[i])
+			break
 		}
 	}
-	if subCodes[0] == "USDC" {
-		return pair.Base.String() + currency.UnderscoreDelimiter + strings.Join(subCodes, currency.DashDelimiter)
-	}
-	return pair.Base.String() + currency.DashDelimiter + strings.Join(subCodes, currency.DashDelimiter)
+
+	return pair.Base.String() + initialDelimiter + strings.Join(subCodes, currency.DashDelimiter)
 }

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2840,7 +2840,6 @@ func (d *Deribit) formatFuturesTradablePair(pair currency.Pair) string {
 // optionPairToString to format and return an Options currency pairs with the following format: MATIC_USDC-6APR24-0d98-P
 // it has both uppercase or lowercase characters, which we can not achieve with the Upper=true or Upper=false
 func (d *Deribit) optionPairToString(pair currency.Pair) string {
-	// err excluded as this is valid regex
 	subCodes := strings.Split(pair.Quote.String(), currency.DashDelimiter)
 	initialDelimiter := currency.DashDelimiter
 	if subCodes[0] == "USDC" {

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3484,9 +3484,9 @@ func TestGetAssetPairByInstrument(t *testing.T) {
 		_, _, err := d.getAssetPairByInstrument("")
 		assert.ErrorIs(t, err, errInvalidInstrumentName)
 	})
-	t.Run("this_is_a_fake_currency_pair", func(t *testing.T) {
+	t.Run("thisIsAFakeCurrency", func(t *testing.T) {
 		t.Parallel()
-		_, _, err := d.getAssetPairByInstrument("this_is_a_fake_currency_pair")
+		_, _, err := d.getAssetPairByInstrument("thisIsAFakeCurrency")
 		assert.ErrorIs(t, err, errUnsupportedInstrumentFormat)
 	})
 }

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -129,8 +129,8 @@ func TestUpdateTicker(t *testing.T) {
 
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.UpdateTicker(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -138,7 +138,7 @@ func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.UpdateOrderbook(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "%w for asset type: %v", err, assetType)
+		require.NoErrorf(t, err, "asset type: %v", assetType)
 		require.NotNil(t, result)
 	}
 }
@@ -147,11 +147,12 @@ func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetHistoricTrades(context.Background(), futureComboTradablePair, asset.FutureCombo, time.Now().Add(-time.Minute*10), time.Now())
 	require.ErrorIs(t, err, asset.ErrNotSupported)
+	d.Verbose = true
 	var result []trade.Data
 	for assetType, cp := range map[asset.Item]currency.Pair{asset.Spot: spotTradablePair, asset.Futures: futuresTradablePair} {
-		result, err = d.GetHistoricTrades(context.Background(), cp, assetType, time.Now().Add(-time.Minute*10), time.Now())
-		require.NoErrorf(t, err, "%w asset type: %v", err, assetType)
-		require.NotNilf(t, result, "Expected value not to be nil for asset type: %s", err, assetType.String())
+		result, err = d.GetHistoricTrades(context.Background(), cp, assetType, time.Now().Add(-time.Hour), time.Now())
+		require.NoErrorf(t, err, "asset type: %v", assetType)
+		require.NotNilf(t, result, "%s expected value not to be nil for asset type: %s", err, assetType)
 	}
 }
 
@@ -159,8 +160,8 @@ func TestFetchRecentTrades(t *testing.T) {
 	t.Parallel()
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.GetRecentTrades(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -223,8 +224,8 @@ func TestSubmitOrder(t *testing.T) {
 	var info *InstrumentData
 	for assetType, cp := range assetToPairStringMap {
 		info, err = d.GetInstrument(context.Background(), d.formatPairString(assetType, cp))
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 
 		result, err = d.SubmitOrder(
 			context.Background(),
@@ -238,8 +239,8 @@ func TestSubmitOrder(t *testing.T) {
 				Pair:      cp,
 			},
 		)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -260,7 +261,7 @@ func TestGetMarkPriceHistory(t *testing.T) {
 	} {
 		result, err = d.GetMarkPriceHistory(context.Background(), ps, time.Now().Add(-5*time.Minute), time.Now())
 		require.NoErrorf(t, err, "expected nil, got %v for pair %s", err, ps)
-		require.NotNilf(t, result, "Expected result not to be nil for pair %s", ps)
+		require.NotNilf(t, result, "expected result not to be nil for pair %s", ps)
 	}
 }
 
@@ -278,7 +279,7 @@ func TestWSRetrieveMarkPriceHistory(t *testing.T) {
 	} {
 		result, err = d.WSRetrieveMarkPriceHistory(ps, time.Now().Add(-4*time.Hour), time.Now())
 		require.NoErrorf(t, err, "expected %v, got %v currency pair %v", nil, err, ps)
-		require.NotNilf(t, result, "Expected value not to be nil for pair: %v", ps)
+		require.NotNilf(t, result, "expected value not to be nil for pair: %v", ps)
 	}
 }
 
@@ -322,7 +323,7 @@ func TestGetBookSummaryByInstrument(t *testing.T) {
 	} {
 		result, err = d.GetBookSummaryByInstrument(context.Background(), ps)
 		require.NoErrorf(t, err, "expected nil, got %v for pair %s", err, ps)
-		require.NotNilf(t, result, "Expected result not to be nil for pair %s", ps)
+		require.NotNilf(t, result, "expected result not to be nil for pair %s", ps)
 	}
 }
 
@@ -340,7 +341,7 @@ func TestWSRetrieveBookSummaryByInstrument(t *testing.T) {
 	} {
 		result, err = d.WSRetrieveBookSummaryByInstrument(ps)
 		require.NoErrorf(t, err, "expected nil, got %v for pair %s", err, ps)
-		require.NotNilf(t, result, "Expected result not to be nil for pair %s", ps)
+		require.NotNilf(t, result, "expected result not to be nil for pair %s", ps)
 	}
 }
 
@@ -535,8 +536,8 @@ func TestGetInstrumentData(t *testing.T) {
 	var result *InstrumentData
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.GetInstrument(context.Background(), d.formatPairString(assetType, cp))
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -548,8 +549,8 @@ func TestWSRetrieveInstrumentData(t *testing.T) {
 	var result *InstrumentData
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.WSRetrieveInstrumentData(d.formatPairString(assetType, cp))
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -670,7 +671,7 @@ func TestGetLastTradesByInstrument(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.GetLastTradesByInstrument(context.Background(), d.formatPairString(assetType, cp), "30500", "31500", "desc", 0, true)
 		require.NoErrorf(t, err, "expected %v, got %v currency asset %v pair %v", nil, err, assetType, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for asset %v pair: %v", assetType, cp)
+		require.NotNilf(t, result, "expected value not to be nil for asset %v pair: %v", assetType, cp)
 	}
 }
 
@@ -682,7 +683,7 @@ func TestWSRetrieveLastTradesByInstrument(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.WSRetrieveLastTradesByInstrument(d.formatPairString(assetType, cp), "30500", "31500", "desc", 0, true)
 		require.NoErrorf(t, err, "expected %v, got %v currency asset %v pair %v", nil, err, assetType, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for asset %v pair: %v", assetType, cp)
+		require.NotNilf(t, result, "expected value not to be nil for asset %v pair: %v", assetType, cp)
 	}
 }
 
@@ -694,7 +695,7 @@ func TestGetLastTradesByInstrumentAndTime(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.GetLastTradesByInstrumentAndTime(context.Background(), d.formatPairString(assetType, cp), "", 0, time.Now().Add(-8*time.Hour), time.Now())
 		require.NoErrorf(t, err, "expected %v, got %v currency pair %v", nil, err, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for pair: %v", cp)
+		require.NotNilf(t, result, "expected value not to be nil for pair: %v", cp)
 	}
 }
 
@@ -706,7 +707,7 @@ func TestWSRetrieveLastTradesByInstrumentAndTime(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.WSRetrieveLastTradesByInstrumentAndTime(d.formatPairString(assetType, cp), "", 0, true, time.Now().Add(-8*time.Hour), time.Now())
 		require.NoErrorf(t, err, "expected %v, got %v currency pair %v", nil, err, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for pair: %v", cp)
+		require.NotNilf(t, result, "expected value not to be nil for pair: %v", cp)
 	}
 }
 
@@ -719,7 +720,7 @@ func TestGetOrderbookData(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.GetOrderbook(context.Background(), d.formatPairString(assetType, cp), 0)
 		require.NoErrorf(t, err, "expected %v, got %v currency pair %v", nil, err, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for pair: %v", cp)
+		require.NotNilf(t, result, "expected value not to be nil for pair: %v", cp)
 	}
 }
 
@@ -735,7 +736,7 @@ func TestWSRetrieveOrderbookData(t *testing.T) {
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.WSRetrieveOrderbookData(d.formatPairString(assetType, cp), 0)
 		require.NoErrorf(t, err, "expected %v, got %v currency pair %v", nil, err, cp)
-		require.NotNilf(t, result, "Expected value not to be nil for pair: %v", cp)
+		require.NotNilf(t, result, "expected value not to be nil for pair: %v", cp)
 	}
 }
 
@@ -3281,8 +3282,8 @@ func TestFetchTicker(t *testing.T) {
 	var err error
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.FetchTicker(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3292,8 +3293,8 @@ func TestFetchOrderbook(t *testing.T) {
 	var err error
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.FetchOrderbook(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s", assetType.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s", assetType)
 	}
 }
 
@@ -3311,8 +3312,8 @@ func TestFetchAccountInfo(t *testing.T) {
 	assetTypes := d.GetAssetTypes(true)
 	for _, assetType := range assetTypes {
 		result, err := d.FetchAccountInfo(context.Background(), assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s", assetType.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s", assetType)
 	}
 }
 
@@ -3338,8 +3339,8 @@ func TestGetRecentTrades(t *testing.T) {
 	var err error
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err = d.GetRecentTrades(context.Background(), cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3369,8 +3370,8 @@ func TestCancelAllOrders(t *testing.T) {
 		orderCancellation.AssetType = assetType
 		orderCancellation.Pair = cp
 		result, err = d.CancelAllOrders(context.Background(), orderCancellation)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3379,8 +3380,8 @@ func TestGetOrderInfo(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
 	for assetType, cp := range assetTypeToPairsMap {
 		result, err := d.GetOrderInfo(context.Background(), "1234", cp, assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3421,8 +3422,8 @@ func TestGetActiveOrders(t *testing.T) {
 		getOrdersRequest.Pairs = []currency.Pair{cp}
 		getOrdersRequest.AssetType = assetType
 		result, err := d.GetActiveOrders(context.Background(), &getOrdersRequest)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3434,8 +3435,8 @@ func TestGetOrderHistory(t *testing.T) {
 			Type: order.AnyType, AssetType: assetType,
 			Side: order.AnySide, Pairs: []currency.Pair{cp},
 		})
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType.String(), cp.String())
-		require.NotNilf(t, result, "Expected result not to be nil for asset type %s pair %s", assetType.String(), cp.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
+		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
 }
 
@@ -3443,8 +3444,8 @@ func TestGetAssetFromPair(t *testing.T) {
 	var assetTypeNew asset.Item
 	for _, assetType := range []asset.Item{asset.Spot, asset.Futures, asset.Options, asset.OptionCombo, asset.FutureCombo} {
 		availablePairs, err := d.GetEnabledPairs(assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType.String())
-		require.NotNilf(t, availablePairs, "Expected result not to be nil for asset type %s", assetType.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType)
+		require.NotNilf(t, availablePairs, "expected result not to be nil for asset type %s", assetType)
 
 		format, err := d.GetPairFormat(assetType, true)
 		require.NoError(t, err)
@@ -3467,8 +3468,8 @@ func TestGetAssetPairByInstrument(t *testing.T) {
 	t.Parallel()
 	for _, assetType := range []asset.Item{asset.Spot, asset.Futures, asset.Options, asset.OptionCombo, asset.FutureCombo} {
 		availablePairs, err := d.GetAvailablePairs(assetType)
-		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType.String())
-		require.NotNilf(t, availablePairs, "Expected result not to be nil for asset type %s", assetType.String())
+		require.NoErrorf(t, err, "expected nil, got %v for asset type %s", err, assetType)
+		require.NotNilf(t, availablePairs, "expected result not to be nil for asset type %s", assetType)
 		for _, cp := range availablePairs {
 			t.Run(fmt.Sprintf("%s %s", assetType, cp), func(t *testing.T) {
 				t.Parallel()
@@ -3505,9 +3506,9 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	if !sharedtestvalues.AreAPICredentialsSet(d) {
-		assert.Equalf(t, exchange.OfflineTradeFee, feeBuilder.FeeType, "Expected %f, received %f", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		assert.Equalf(t, exchange.OfflineTradeFee, feeBuilder.FeeType, "expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
 	} else {
-		assert.Equalf(t, exchange.CryptocurrencyTradeFee, feeBuilder.FeeType, "Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		assert.Equalf(t, exchange.CryptocurrencyTradeFee, feeBuilder.FeeType, "expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
 	}
 }
 
@@ -3684,10 +3685,10 @@ func TestFormatFuturesTradablePair(t *testing.T) {
 func TestOptionPairToString(t *testing.T) {
 	t.Parallel()
 	optionsList := map[currency.Pair]string{
-		{Delimiter: currency.DashDelimiter, Base: currency.BTC, Quote: currency.NewCode("30MAY24-61000-C")}:    "BTC-30MAY24-61000-C",
-		{Delimiter: currency.DashDelimiter, Base: currency.ETH, Quote: currency.NewCode("1JUN24-3200-P")}:      "ETH-1JUN24-3200-P",
-		{Delimiter: currency.DashDelimiter, Base: currency.SOL, Quote: currency.NewCode("USDC-31MAY24-162-P")}: "SOL_USDC-31MAY24-162-P",
-		{Delimiter: currency.DashDelimiter, Base: currency.XRP, Quote: currency.NewCode("USDC-28JUN24-0D9-P")}: "XRP_USDC-28JUN24-0D9-P",
+		{Delimiter: currency.DashDelimiter, Base: currency.BTC, Quote: currency.NewCode("30MAY24-61000-C")}:      "BTC-30MAY24-61000-C",
+		{Delimiter: currency.DashDelimiter, Base: currency.ETH, Quote: currency.NewCode("1JUN24-3200-P")}:        "ETH-1JUN24-3200-P",
+		{Delimiter: currency.DashDelimiter, Base: currency.SOL, Quote: currency.NewCode("USDC-31MAY24-162-P")}:   "SOL_USDC-31MAY24-162-P",
+		{Delimiter: currency.DashDelimiter, Base: currency.MATIC, Quote: currency.NewCode("USDC-6APR24-0d98-P")}: "MATIC_USDC-6APR24-0d98-P",
 	}
 	for pair, instrumentID := range optionsList {
 		t.Run(instrumentID, func(t *testing.T) {
@@ -4013,16 +4014,6 @@ func TestGetResolutionFromInterval(t *testing.T) {
 		require.ErrorIs(t, err, intervalStringMap[x].Error)
 		require.Equal(t, intervalStringMap[x].IntervalString, result)
 	}
-}
-
-func getAssetToPairMap(items asset.Item) map[asset.Item]currency.Pair {
-	newMap := make(map[asset.Item]currency.Pair)
-	for a := range assetTypeToPairsMap {
-		if a&items == a {
-			newMap[a] = assetTypeToPairsMap[a]
-		}
-	}
-	return newMap
 }
 
 func TestGetValidatedCurrencyCode(t *testing.T) {

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -147,12 +147,9 @@ func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetHistoricTrades(context.Background(), futureComboTradablePair, asset.FutureCombo, time.Now().Add(-time.Minute*10), time.Now())
 	require.ErrorIs(t, err, asset.ErrNotSupported)
-	d.Verbose = true
-	var result []trade.Data
 	for assetType, cp := range map[asset.Item]currency.Pair{asset.Spot: spotTradablePair, asset.Futures: futuresTradablePair} {
-		result, err = d.GetHistoricTrades(context.Background(), cp, assetType, time.Now().Add(-time.Hour), time.Now())
+		_, err = d.GetHistoricTrades(context.Background(), cp, assetType, time.Now().Add(-time.Minute*10), time.Now())
 		require.NoErrorf(t, err, "asset type: %v", assetType)
-		require.NotNilf(t, result, "%s expected value not to be nil for asset type: %s", err, assetType)
 	}
 }
 
@@ -4033,14 +4030,6 @@ func TestGetValidatedCurrencyCode(t *testing.T) {
 	for x := range pairs {
 		result := getValidatedCurrencyCode(x)
 		require.Equal(t, pairs[x], result, "expected: %s actual  : %s for currency pair: %v", x, result, pairs[x])
-	}
-}
-
-func TestFetchTradablePairs(t *testing.T) {
-	t.Parallel()
-	for _, a := range d.GetAssetTypes(false) {
-		_, err := d.FetchTradablePairs(context.Background(), a)
-		require.NoError(t, err)
 	}
 }
 

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -397,7 +397,7 @@ func (d *Deribit) processUserOrderChanges(respRaw []byte, channels []string) err
 		if err != nil {
 			return err
 		}
-		cp, a, err := d.getAssetPairByInstrument(changeData.Trades[x].InstrumentName)
+		cp, a, err := d.getAssetPairByInstrument(changeData.Orders[x].InstrumentName)
 		if err != nil {
 			return err
 		}

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -255,7 +255,7 @@ func (d *Deribit) wsHandleData(respRaw []byte) error {
 			accessLog := &wsAccessLog{}
 			return d.processData(respRaw, accessLog)
 		case "changes":
-			return d.processChanges(respRaw, channels)
+			return d.processUserOrderChanges(respRaw, channels)
 		case "lock":
 			userLock := &WsUserLock{}
 			return d.processData(respRaw, userLock)
@@ -265,7 +265,7 @@ func (d *Deribit) wsHandleData(respRaw []byte) error {
 			}
 			return d.processData(respRaw, data)
 		case "orders":
-			return d.processOrders(respRaw, channels)
+			return d.processUserOrders(respRaw, channels)
 		case "portfolio":
 			portfolio := &wsUserPortfolio{}
 			return d.processData(respRaw, portfolio)
@@ -294,33 +294,20 @@ func (d *Deribit) wsHandleData(respRaw []byte) error {
 	return nil
 }
 
-func (d *Deribit) processOrders(respRaw []byte, channels []string) error {
-	var currencyPair currency.Pair
-	var err error
-	var a asset.Item
-	switch len(channels) {
-	case 4:
-		currencyPair, err = currency.NewPairFromString(channels[2])
-		if err != nil {
-			return err
-		}
-	case 5:
-		a, err = d.StringToAssetKind(channels[2])
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("%w, expected format 'user.orders.{instrument_name}.raw, user.orders.{instrument_name}.{interval}, user.orders.{kind}.{currency}.raw, or user.orders.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
-	}
+func (d *Deribit) processUserOrders(respRaw []byte, channels []string) error {
 	var response WsResponse
 	orderData := []WsOrder{}
 	response.Params.Data = orderData
-	err = json.Unmarshal(respRaw, &response)
+	err := json.Unmarshal(respRaw, &response)
 	if err != nil {
 		return err
 	}
 	orderDetails := make([]order.Detail, len(orderData))
 	for x := range orderData {
+		cp, a, err := d.getAssetPairByInstrument(orderData[x].InstrumentName)
+		if err != nil {
+			return err
+		}
 		oType, err := order.StringToOrderType(orderData[x].OrderType)
 		if err != nil {
 			return err
@@ -330,16 +317,6 @@ func (d *Deribit) processOrders(respRaw []byte, channels []string) error {
 			return err
 		}
 		status, err := order.StringToOrderStatus(orderData[x].OrderState)
-		if err != nil {
-			return err
-		}
-		if a != asset.Empty {
-			currencyPair, err = currency.NewPairFromString(orderData[x].InstrumentName)
-			if err != nil {
-				return err
-			}
-		}
-		a, err = guessAssetTypeFromInstrument(currencyPair)
 		if err != nil {
 			return err
 		}
@@ -356,14 +333,14 @@ func (d *Deribit) processOrders(respRaw []byte, channels []string) error {
 			AssetType:       a,
 			Date:            orderData[x].CreationTimestamp.Time(),
 			LastUpdated:     orderData[x].LastUpdateTimestamp.Time(),
-			Pair:            currencyPair,
+			Pair:            cp,
 		}
 	}
 	d.Websocket.DataHandler <- orderDetails
 	return nil
 }
 
-func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
+func (d *Deribit) processUserOrderChanges(respRaw []byte, channels []string) error {
 	var response WsResponse
 	changeData := &wsChanges{}
 	response.Params.Data = changeData
@@ -371,43 +348,20 @@ func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
 	if err != nil {
 		return err
 	}
-	var currencyPair currency.Pair
-	var a asset.Item
-	switch len(channels) {
-	case 4:
-		currencyPair, err = currency.NewPairFromString(channels[2])
-		if err != nil {
-			return err
-		}
-	case 5:
-		a, err = d.StringToAssetKind(channels[2])
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("%w, expected format 'trades.{instrument_name}.{interval} or trades.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
-	}
-	tradeDatas := make([]trade.Data, len(changeData.Trades))
+	td := make([]trade.Data, len(changeData.Trades))
 	for x := range changeData.Trades {
 		var side order.Side
 		side, err = order.StringToOrderSide(changeData.Trades[x].Direction)
 		if err != nil {
 			return err
 		}
-		if currencyPair.IsEmpty() {
-			currencyPair, err = currency.NewPairFromString(changeData.Trades[x].InstrumentName)
-			if err != nil {
-				return err
-			}
+		cp, a, err := d.getAssetPairByInstrument(changeData.Trades[x].InstrumentName)
+		if err != nil {
+			return err
 		}
-		if a == asset.Empty {
-			a, err = guessAssetTypeFromInstrument(currencyPair)
-			if err != nil {
-				return err
-			}
-		}
-		tradeDatas[x] = trade.Data{
-			CurrencyPair: currencyPair,
+
+		td[x] = trade.Data{
+			CurrencyPair: cp,
 			Exchange:     d.Name,
 			Timestamp:    changeData.Trades[x].Timestamp.Time(),
 			Price:        changeData.Trades[x].Price,
@@ -417,7 +371,7 @@ func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
 			AssetType:    a,
 		}
 	}
-	err = trade.AddTradesToBuffer(d.Name, tradeDatas...)
+	err = trade.AddTradesToBuffer(d.Name, td...)
 	if err != nil {
 		return err
 	}
@@ -435,16 +389,9 @@ func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
 		if err != nil {
 			return err
 		}
-		if a != asset.Empty {
-			currencyPair, err = currency.NewPairFromString(changeData.Orders[x].InstrumentName)
-			if err != nil {
-				return err
-			}
-		} else {
-			a, err = guessAssetTypeFromInstrument(currencyPair)
-			if err != nil {
-				return err
-			}
+		cp, a, err := d.getAssetPairByInstrument(changeData.Trades[x].InstrumentName)
+		if err != nil {
+			return err
 		}
 		orders[x] = order.Detail{
 			Price:           changeData.Orders[x].Price,
@@ -459,7 +406,7 @@ func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
 			AssetType:       a,
 			Date:            changeData.Orders[x].CreationTimestamp.Time(),
 			LastUpdated:     changeData.Orders[x].LastUpdateTimestamp.Time(),
-			Pair:            currencyPair,
+			Pair:            cp,
 		}
 	}
 	d.Websocket.DataHandler <- orders
@@ -468,7 +415,7 @@ func (d *Deribit) processChanges(respRaw []byte, channels []string) error {
 }
 
 func (d *Deribit) processQuoteTicker(respRaw []byte, channels []string) error {
-	cp, err := currency.NewPairFromString(channels[1])
+	cp, a, err := d.getAssetPairByInstrument(channels[1])
 	if err != nil {
 		return err
 	}
@@ -476,10 +423,6 @@ func (d *Deribit) processQuoteTicker(respRaw []byte, channels []string) error {
 	quoteTicker := &wsQuoteTickerInformation{}
 	response.Params.Data = quoteTicker
 	err = json.Unmarshal(respRaw, &response)
-	if err != nil {
-		return err
-	}
-	a, err := guessAssetTypeFromInstrument(cp)
 	if err != nil {
 		return err
 	}
@@ -497,55 +440,28 @@ func (d *Deribit) processQuoteTicker(respRaw []byte, channels []string) error {
 }
 
 func (d *Deribit) processTrades(respRaw []byte, channels []string) error {
-	var err error
-	var currencyPair currency.Pair
-	var a asset.Item
-	switch {
-	case (len(channels) == 3 && channels[0] == "trades") || (len(channels) == 4 && channels[0] == "user"):
-		currencyPair, err = currency.NewPairFromString(channels[len(channels)-2])
-		if err != nil {
-			return err
-		}
-	case (len(channels) == 4 && channels[0] == "trades") || (len(channels) == 5 && channels[0] == "user"):
-		a, err = d.StringToAssetKind(channels[len(channels)-3])
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("%w, expected format 'trades.{instrument_name}.{interval} or trades.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
-	}
 	var response WsResponse
-	tradeList := []wsTrade{}
+	var tradeList []wsTrade
 	response.Params.Data = &tradeList
-	err = json.Unmarshal(respRaw, &response)
+	err := json.Unmarshal(respRaw, &response)
 	if err != nil {
 		return err
 	}
 	if len(tradeList) == 0 {
 		return fmt.Errorf("%v, empty list of trades found", common.ErrNoResponse)
 	}
-	if a == asset.Empty && currencyPair.IsEmpty() {
-		currencyPair, err = currency.NewPairFromString(tradeList[0].InstrumentName)
-		if err != nil {
-			return err
-		}
-		a, err = guessAssetTypeFromInstrument(currencyPair)
-		if err != nil {
-			return err
-		}
-	}
 	tradeDatas := make([]trade.Data, len(tradeList))
 	for x := range tradeDatas {
+		cp, a, err := d.getAssetPairByInstrument(tradeList[x].InstrumentName)
+		if err != nil {
+			return err
+		}
 		side, err := order.StringToOrderSide(tradeList[x].Direction)
 		if err != nil {
 			return err
 		}
-		currencyPair, err = currency.NewPairFromString(tradeList[x].InstrumentName)
-		if err != nil {
-			return err
-		}
 		tradeDatas[x] = trade.Data{
-			CurrencyPair: currencyPair,
+			CurrencyPair: cp,
 			Exchange:     d.Name,
 			Timestamp:    tradeList[x].Timestamp.Time(),
 			Price:        tradeList[x].Price,
@@ -562,7 +478,7 @@ func (d *Deribit) processIncrementalTicker(respRaw []byte, channels []string) er
 	if len(channels) != 2 {
 		return fmt.Errorf("%w, expected format 'incremental_ticker.{instrument_name}', but found %s", errMalformedData, strings.Join(channels, "."))
 	}
-	cp, err := currency.NewPairFromString(channels[1])
+	cp, a, err := d.getAssetPairByInstrument(channels[1])
 	if err != nil {
 		return err
 	}
@@ -573,14 +489,10 @@ func (d *Deribit) processIncrementalTicker(respRaw []byte, channels []string) er
 	if err != nil {
 		return err
 	}
-	assetType, err := guessAssetTypeFromInstrument(cp)
-	if err != nil {
-		return err
-	}
 	d.Websocket.DataHandler <- &ticker.Price{
 		ExchangeName: d.Name,
 		Pair:         cp,
-		AssetType:    assetType,
+		AssetType:    a,
 		LastUpdated:  incrementalTicker.Timestamp.Time(),
 		BidSize:      incrementalTicker.BestBidAmount,
 		AskSize:      incrementalTicker.BestAskAmount,
@@ -602,19 +514,14 @@ func (d *Deribit) processInstrumentTicker(respRaw []byte, channels []string) err
 }
 
 func (d *Deribit) processTicker(respRaw []byte, channels []string) error {
-	cp, err := currency.NewPairFromString(channels[1])
+	cp, a, err := d.getAssetPairByInstrument(channels[1])
 	if err != nil {
 		return err
 	}
-	var a asset.Item
 	var response WsResponse
 	tickerPriceResponse := &wsTicker{}
 	response.Params.Data = tickerPriceResponse
 	err = json.Unmarshal(respRaw, &response)
-	if err != nil {
-		return err
-	}
-	a, err = guessAssetTypeFromInstrument(cp)
 	if err != nil {
 		return err
 	}
@@ -658,19 +565,14 @@ func (d *Deribit) processCandleChart(respRaw []byte, channels []string) error {
 	if len(channels) != 4 {
 		return fmt.Errorf("%w, expected format 'chart.trades.{instrument_name}.{resolution}', but found %s", errMalformedData, strings.Join(channels, "."))
 	}
-	cp, err := currency.NewPairFromString(channels[2])
+	cp, a, err := d.getAssetPairByInstrument(channels[2])
 	if err != nil {
 		return err
 	}
 	var response WsResponse
-	var a asset.Item
 	candleData := &wsCandlestickData{}
 	response.Params.Data = candleData
 	err = json.Unmarshal(respRaw, &response)
-	if err != nil {
-		return err
-	}
-	a, err = guessAssetTypeFromInstrument(cp)
 	if err != nil {
 		return err
 	}
@@ -696,9 +598,8 @@ func (d *Deribit) processOrderbook(respRaw []byte, channels []string) error {
 	if err != nil {
 		return err
 	}
-	var assetType asset.Item
 	if len(channels) == 3 {
-		cp, err := currency.NewPairFromString(orderbookData.InstrumentName)
+		cp, a, err := d.getAssetPairByInstrument(orderbookData.InstrumentName)
 		if err != nil {
 			return err
 		}
@@ -743,10 +644,6 @@ func (d *Deribit) processOrderbook(respRaw []byte, channels []string) error {
 		if len(asks) == 0 && len(bids) == 0 {
 			return nil
 		}
-		assetType, err = guessAssetTypeFromInstrument(cp)
-		if err != nil {
-			return err
-		}
 		if orderbookData.Type == "snapshot" {
 			return d.Websocket.Orderbook.LoadSnapshot(&orderbook.Base{
 				Exchange:        d.Name,
@@ -755,7 +652,7 @@ func (d *Deribit) processOrderbook(respRaw []byte, channels []string) error {
 				Pair:            cp,
 				Asks:            asks,
 				Bids:            bids,
-				Asset:           assetType,
+				Asset:           a,
 				LastUpdateID:    orderbookData.ChangeID,
 			})
 		} else if orderbookData.Type == "change" {
@@ -763,17 +660,13 @@ func (d *Deribit) processOrderbook(respRaw []byte, channels []string) error {
 				Asks:       asks,
 				Bids:       bids,
 				Pair:       cp,
-				Asset:      assetType,
+				Asset:      a,
 				UpdateID:   orderbookData.ChangeID,
 				UpdateTime: orderbookData.Timestamp.Time(),
 			})
 		}
 	} else if len(channels) == 5 {
-		cp, err := currency.NewPairFromString(orderbookData.InstrumentName)
-		if err != nil {
-			return err
-		}
-		assetType, err = guessAssetTypeFromInstrument(cp)
+		cp, a, err := d.getAssetPairByInstrument(orderbookData.InstrumentName)
 		if err != nil {
 			return err
 		}
@@ -824,7 +717,7 @@ func (d *Deribit) processOrderbook(respRaw []byte, channels []string) error {
 			Asks:         asks,
 			Bids:         bids,
 			Pair:         cp,
-			Asset:        assetType,
+			Asset:        a,
 			Exchange:     d.Name,
 			LastUpdateID: orderbookData.ChangeID,
 			LastUpdated:  orderbookData.Timestamp.Time(),
@@ -864,8 +757,8 @@ func (d *Deribit) GenerateDefaultSubscriptions() ([]subscription.Subscription, e
 		case chartTradesChannel:
 			for _, a := range assets {
 				for z := range assetPairs[a] {
-					if ((assetPairs[a][z].Quote.Upper().String() == "PERPETUAL" ||
-						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), "PERPETUAL")) &&
+					if ((assetPairs[a][z].Quote.Upper().String() == perpString ||
+						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), perpString)) &&
 						a == asset.Futures) || (a != asset.Spot && a != asset.Futures) {
 						continue
 					}
@@ -885,8 +778,8 @@ func (d *Deribit) GenerateDefaultSubscriptions() ([]subscription.Subscription, e
 			rawUserOrdersChannel:
 			for _, a := range assets {
 				for z := range assetPairs[a] {
-					if ((assetPairs[a][z].Quote.Upper().String() == "PERPETUAL" ||
-						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), "PERPETUAL")) &&
+					if ((assetPairs[a][z].Quote.Upper().String() == perpString ||
+						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), perpString)) &&
 						a == asset.Futures) || (a != asset.Spot && a != asset.Futures) {
 						continue
 					}
@@ -900,8 +793,8 @@ func (d *Deribit) GenerateDefaultSubscriptions() ([]subscription.Subscription, e
 		case orderbookChannel:
 			for _, a := range assets {
 				for z := range assetPairs[a] {
-					if ((assetPairs[a][z].Quote.Upper().String() == "PERPETUAL" ||
-						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), "PERPETUAL")) &&
+					if ((assetPairs[a][z].Quote.Upper().String() == perpString ||
+						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), perpString)) &&
 						a == asset.Futures) || (a != asset.Spot && a != asset.Futures) {
 						continue
 					}
@@ -936,8 +829,8 @@ func (d *Deribit) GenerateDefaultSubscriptions() ([]subscription.Subscription, e
 			tradesChannel:
 			for _, a := range assets {
 				for z := range assetPairs[a] {
-					if ((assetPairs[a][z].Quote.Upper().String() != "PERPETUAL" &&
-						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), "PERPETUAL")) &&
+					if ((assetPairs[a][z].Quote.Upper().String() != perpString &&
+						!strings.Contains(assetPairs[a][z].Quote.Upper().String(), perpString)) &&
 						a == asset.Futures) || (a != asset.Spot && a != asset.Futures) {
 						continue
 					}
@@ -955,7 +848,7 @@ func (d *Deribit) GenerateDefaultSubscriptions() ([]subscription.Subscription, e
 			userTradesChannelByInstrument:
 			for _, a := range assets {
 				for z := range assetPairs[a] {
-					if subscriptionChannels[x] == perpetualChannel && !strings.Contains(assetPairs[a][z].Quote.Upper().String(), "PERPETUAL") {
+					if subscriptionChannels[x] == perpetualChannel && !strings.Contains(assetPairs[a][z].Quote.Upper().String(), perpString) {
 						continue
 					}
 					subscriptions = append(subscriptions,

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -344,7 +344,7 @@ func (d *Deribit) processUserOrders(respRaw []byte, channels []string) error {
 }
 
 func (d *Deribit) processUserOrderChanges(respRaw []byte, channels []string) error {
-	if len(channels) != 4 && len(channels) != 5 {
+	if len(channels) < 4 || len(channels) > 5 {
 		return fmt.Errorf("%w, expected format 'trades.{instrument_name}.{interval} or trades.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
 	}
 	var response WsResponse
@@ -448,7 +448,7 @@ func (d *Deribit) processQuoteTicker(respRaw []byte, channels []string) error {
 }
 
 func (d *Deribit) processTrades(respRaw []byte, channels []string) error {
-	if len(channels) != 3 && len(channels) != 4 {
+	if len(channels) < 3 || len(channels) > 5 {
 		return fmt.Errorf("%w, expected format 'trades.{instrument_name}.{interval} or trades.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
 	}
 	var response WsResponse

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -295,11 +295,11 @@ func (d *Deribit) wsHandleData(respRaw []byte) error {
 }
 
 func (d *Deribit) processUserOrders(respRaw []byte, channels []string) error {
-	var response WsResponse
 	if len(channels) != 4 && len(channels) != 5 {
 		return fmt.Errorf("%w, expected format 'user.orders.{instrument_name}.raw, user.orders.{instrument_name}.{interval}, user.orders.{kind}.{currency}.raw, or user.orders.{kind}.{currency}.{interval}', but found %s", errMalformedData, strings.Join(channels, "."))
 	}
-	var orderData []WsOrder
+	var response WsResponse
+	orderData := []WsOrder{}
 	response.Params.Data = orderData
 	err := json.Unmarshal(respRaw, &response)
 	if err != nil {

--- a/exchanges/deribit/deribit_wrapper.go
+++ b/exchanges/deribit/deribit_wrapper.go
@@ -1097,7 +1097,7 @@ func (d *Deribit) GetHistoricCandles(ctx context.Context, pair currency.Pair, a 
 	if err != nil {
 		return nil, err
 	}
-	intervalString, err := d.GetResolutionFromInterval(interval)
+	intervalString, err := d.GetResolutionFromInterval(req.ExchangeInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/deribit/deribit_wrapper.go
+++ b/exchanges/deribit/deribit_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -207,6 +208,10 @@ func (d *Deribit) Setup(exch *config.Exchange) error {
 	if err != nil {
 		return err
 	}
+
+	// setup option decimal regex at startup to make constant checks more efficient
+	optionRegex = regexp.MustCompile(optionDecimalRegex)
+
 	return d.Websocket.SetupNewConnection(stream.ConnectionSetup{
 		URL:                  d.Websocket.GetWebsocketURL(),
 		ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,

--- a/exchanges/deribit/deribit_wrapper.go
+++ b/exchanges/deribit/deribit_wrapper.go
@@ -264,11 +264,7 @@ func (d *Deribit) UpdateTradablePairs(ctx context.Context, forceUpdate bool) err
 				errs.C <- err
 				return
 			}
-			err = d.UpdatePairs(pairs, assets[x], false, forceUpdate)
-			if err != nil {
-				errs.C <- err
-				return
-			}
+			errs.C <- d.UpdatePairs(pairs, assets[x], false, forceUpdate)
 		}(x)
 	}
 	return errs.Collect()

--- a/exchanges/deribit/deribit_wrapper.go
+++ b/exchanges/deribit/deribit_wrapper.go
@@ -1150,7 +1150,7 @@ func (d *Deribit) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 	switch a {
 	case asset.Futures, asset.Spot:
 		for x := range req.RangeHolder.Ranges {
-			intervalString, err := d.GetResolutionFromInterval(interval)
+			intervalString, err := d.GetResolutionFromInterval(req.ExchangeInterval)
 			if err != nil {
 				return nil, err
 			}

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -198,8 +198,9 @@ func (k *Item) addPadding(start, exclusiveEnd time.Time, purgeOnPartial bool) er
 			padded[x].Time = start
 		case !k.Candles[target].Time.Equal(start):
 			if k.Candles[target].Time.Before(start) {
-				return fmt.Errorf("%w when it should be %s truncated at a %s interval",
+				return fmt.Errorf("%w '%s' should be '%s' at '%s' interval",
 					errCandleOpenTimeIsNotUTCAligned,
+					k.Candles[target].Time,
 					start.Add(k.Interval.Duration()),
 					k.Interval)
 			}

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -216,7 +216,7 @@ func (b *Base) Verify() error {
 	// level books. In the event that there is a massive liquidity change where
 	// a book dries up, this will still update so we do not traverse potential
 	// incorrect old data.
-	if len(b.Asks) == 0 || len(b.Bids) == 0 {
+	if (len(b.Asks) == 0 || len(b.Bids) == 0) && !b.Asset.IsOptions() {
 		log.Warnf(log.OrderBook,
 			bookLengthIssue,
 			b.Exchange,


### PR DESCRIPTION
# PR Description
These are the kinds of bugs that can only pop up after proper use, it was still an excellent PR Sam 🕊️ 

This PR does the following:
- Speeds up `UpdateTradablePairs` utilising concurrency since its so slow. Reduces `go test -race -count=0` from `28s` to `20s`
- Implement `GetCurrencyTradeURL`
- Update function `IsPerpetualFuture`
- Update `optionPairToString` and add test coverage
- Simplifies some tests
- Rename `guessAssetTypeFromInstrument` to `getAssetFromPair` as its not guessing
- Adds `getAssetPairByInstrument` to help parse WS pair data after getting some errors
- Handles currency processing via the `any` subscriptions (eg trades) using `getAssetPairByInstrument`
   - This moves the parsing of currency data to inside loops, because `any` can have multiple currencies in the slice/ the currency isn't in the channel name 
- Fix an issue with a lack of candle data due to incorrect kline choice (fixes large output about missing candle data in tests)
- Changed `TestGetHistoricTrades` to not check results, because sometimes there are no trades, but its an expensive test to go back further in time to ensure trades. If there is an issue, deribit will error.
- Stop checking orderbooks bid/ask len for options.


I made sure that `getAssetPairByInstrument` was performant before using it
```go
func BenchmarkGetAssetPairByInstrumentFutures(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		_, _, err := d.getAssetPairByInstrument("DOGE_USDC-PERPETUAL")
		if err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkGetAssetPairByInstrumentOptions(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		_, _, err := d.getAssetPairByInstrument("MATIC_USDC-3JUN24-0D64-P")
		if err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkGetAssetPairByInstrumentSpot(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		_, _, err := d.getAssetPairByInstrument("DOGE_USDC")
		if err != nil {
			b.Fatal(err)
		}
	}
}

```

```
BenchmarkGetAssetPairByInstrumentFutures-10    	11103615	       108.5 ns/op	      36 B/op	       2 allocs/op
BenchmarkGetAssetPairByInstrumentOptions-10    	 7306069	       139.4 ns/op	      68 B/op	       2 allocs/op
BenchmarkGetAssetPairByInstrumentSpot-10       	12750432	        96.06 ns/op	      20 B/op	       2 allocs/op
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] `TestOptionPairToString`
- [x] `GetCurrencyTradeURL`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
