### PR TITLE
log: allow external definition of log handling 

### DIFF
--- a/log/custom_log_hooks.go
+++ b/log/custom_log_hooks.go
@@ -1,0 +1,17 @@
+package log
+
+// CustomLogHook is a function type for external log handling. It should return
+// true if the library's internal logging system should be bypassed, or false
+// if the library's internal logging system should be used.
+type CustomLogHook func(header, subLoggerName string, a ...any) (bypassLibraryLogSystem bool)
+
+var customLogHook CustomLogHook
+
+// SetCustomLogHook sets a custom log hook function that allows the complete
+// bypass of the library's internal logging system. This is useful for
+// implementing custom log handling.
+func SetCustomLogHook(h CustomLogHook) {
+	mu.Lock()
+	customLogHook = h
+	mu.Unlock()
+}

--- a/log/custom_log_hooks_test.go
+++ b/log/custom_log_hooks_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestSetCustomLoghook(t *testing.T) {
 	t.Parallel()
-	logHook := func(header, subLoggerName string, a ...interface{}) (bypassLibraryLogSystem bool) {
+	logHook := func(_ string, _ string, _ ...interface{}) (bypassLibraryLogSystem bool) {
 		return false
 	}
 	SetCustomLogHook(logHook)

--- a/log/custom_log_hooks_test.go
+++ b/log/custom_log_hooks_test.go
@@ -1,0 +1,11 @@
+package log
+
+import "testing"
+
+func TestSetCustomLoghook(t *testing.T) {
+	t.Parallel()
+	logHook := func(header, subLoggerName string, a ...interface{}) (bypassLibraryLogSystem bool) {
+		return false
+	}
+	SetCustomLogHook(logHook)
+}

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -264,12 +264,22 @@ func (l *fields) stage(header string, deferFunc deferral) {
 	logFieldsPool.Put(l)
 }
 
-// stageln stages a log event
-func (l *fields) stageln(header string, a ...interface{}) {
+// stageln logs a message with the given header and arguments. It uses the
+// custom log hook if set, otherwise falls back to the library's internal log
+// system.
+func (l *fields) stageln(header string, a ...any) {
+	if customLogHook != nil && customLogHook(header, l.name, a...) {
+		return
+	}
 	l.stage(header, func() string { return fmt.Sprint(a...) })
 }
 
-// stagef stages a log event
-func (l *fields) stagef(header, format string, a ...interface{}) {
+// stagef logs a formatted message with the given header and arguments. It uses
+// the custom log hook if set, otherwise falls back to the library's internal
+// log system.
+func (l *fields) stagef(header, format string, a ...any) {
+	if customLogHook != nil && customLogHook(header, l.name, fmt.Sprintf(format, a...)) {
+		return
+	}
 	l.stage(header, func() string { return fmt.Sprintf(format, a...) })
 }


### PR DESCRIPTION
# PR Description

Allows the logger system to be completely bypassed by a hook while maintaining existing features. This allows clients to define their own independent logger implementations for their specific purpose and/or infrastructure. 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
