### PR TITLE
currency: Make pairs.Add variadic

### DIFF
--- a/backtester/funding/trackingcurrencies/trackingcurrencies_test.go
+++ b/backtester/funding/trackingcurrencies/trackingcurrencies_test.go
@@ -53,12 +53,8 @@ func TestCreateUSDTrackingPairs(t *testing.T) {
 	cp3 := currency.NewPair(currency.LTC, currency.BTC)
 	exchB := exch.GetBase()
 	eba := exchB.CurrencyPairs.Pairs[a]
-	eba.Available = eba.Available.Add(cp)
-	eba.Enabled = eba.Enabled.Add(cp)
-	eba.Available = eba.Available.Add(cp2)
-	eba.Enabled = eba.Enabled.Add(cp2)
-	eba.Available = eba.Available.Add(cp3)
-	eba.Enabled = eba.Enabled.Add(cp3)
+	eba.Available = eba.Available.Add(cp, cp2, cp3)
+	eba.Enabled = eba.Enabled.Add(cp, cp2, cp3)
 	eba.AssetEnabled = convert.BoolPtr(true)
 
 	err = em.Add(exch)

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -212,16 +212,15 @@ func (p Pairs) Remove(pair Pair) (Pairs, error) {
 
 // Add adds a specified pair to the list of pairs if it doesn't exist
 func (p Pairs) Add(pairs ...Pair) Pairs {
-	p2 := make(Pairs, len(pairs))
-	copy(p2, pairs)
+	merge := append(slices.Clone(p), pairs...)
 	var filterInt int
-	for x := range p2 {
-		if !p.Contains(p2[x], true) && !p2[:x].Contains(p2[x], true) {
-			p2[filterInt] = p2[x]
+	for x := len(p); x < len(merge); x++ {
+		if !merge[:len(p)+filterInt].Contains(merge[x], true) {
+			merge[len(p)+filterInt] = merge[x]
 			filterInt++
 		}
 	}
-	return append(slices.Clone(p), p2[:filterInt]...)
+	return merge[:len(p)+filterInt]
 }
 
 // GetMatch returns either the pair that is equal including the reciprocal for

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -212,12 +212,16 @@ func (p Pairs) Remove(pair Pair) (Pairs, error) {
 
 // Add adds a specified pair to the list of pairs if it doesn't exist
 func (p Pairs) Add(pairs ...Pair) Pairs {
-	for x := range pairs {
-		if !p.Contains(pairs[x], true) {
-			p = append(p, pairs[x])
+	p2 := make(Pairs, len(pairs))
+	copy(p2, pairs)
+	var filterInt int
+	for x := range p2 {
+		if !p.Contains(p2[x], true) && !p2[:x].Contains(p2[x], true) {
+			p2[filterInt] = p2[x]
+			filterInt++
 		}
 	}
-	return p
+	return append(slices.Clone(p), p2[:filterInt]...)
 }
 
 // GetMatch returns either the pair that is equal including the reciprocal for

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -213,10 +213,9 @@ func (p Pairs) Remove(pair Pair) (Pairs, error) {
 // Add adds a specified pair to the list of pairs if it doesn't exist
 func (p Pairs) Add(pairs ...Pair) Pairs {
 	for x := range pairs {
-		if p.Contains(pairs[x], true) {
-			continue
+		if !p.Contains(pairs[x], true) {
+			p = append(p, pairs[x])
 		}
-		p = append(p, pairs[x])
 	}
 	return p
 }

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -211,11 +211,13 @@ func (p Pairs) Remove(pair Pair) (Pairs, error) {
 }
 
 // Add adds a specified pair to the list of pairs if it doesn't exist
-func (p Pairs) Add(pair Pair) Pairs {
-	if p.Contains(pair, true) {
-		return p
+func (p Pairs) Add(pairs ...Pair) Pairs {
+	for x := range pairs {
+		if p.Contains(pairs[x], true) {
+			continue
+		}
+		p = append(p, pairs[x])
 	}
-	p = append(p, pair)
 	return p
 }
 

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -278,10 +278,32 @@ func TestAdd(t *testing.T) {
 	if len(pairs) != 4 {
 		t.Error("TestAdd unexpected result")
 	}
+	// Test adding multiple pairs
 	pairs = pairs.Add(NewPair(BTC, LTC), NewPair(ETH, USD))
 	if len(pairs) != 6 {
 		t.Error("TestAdd unexpected result")
 	}
+	// Test adding multiple duplicate pairs
+	pairs = pairs.Add(NewPair(ETH, USDT), NewPair(ETH, USDT))
+	if len(pairs) != 7 {
+		t.Error("TestAdd unexpected result")
+	}
+	// Test whether the original pairs have been modified
+	pairsWithExtraBaggage := make(Pairs, 0, len(pairs)+3)
+	pairsWithExtraBaggage = append(pairsWithExtraBaggage, pairs...)
+	brain := NewPair(BRAIN, USD)
+	withBrain := pairsWithExtraBaggage.Add(NewPair(BTC, LTC), brain)
+	if len(pairs) != 7 {
+		t.Error("TestAdd unexpected result")
+	}
+	assert.Equal(t, brain, withBrain[len(withBrain)-1])
+	badger := NewPair(BADGER, USD)
+	withBadger := pairsWithExtraBaggage.Add(NewPair(BTC, LTC), badger)
+	if len(pairs) != 7 {
+		t.Error("TestAdd unexpected result")
+	}
+	assert.Equal(t, badger, withBadger[len(withBadger)-1])
+	assert.Equal(t, brain, withBrain[len(withBrain)-1])
 }
 
 func TestContains(t *testing.T) {

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -267,17 +267,19 @@ func TestAdd(t *testing.T) {
 		NewPair(LTC, USD),
 		NewPair(LTC, USDT),
 	}
-
 	// Test adding a new pair to the list of pairs
 	p := NewPair(BTC, USDT)
 	pairs = pairs.Add(p)
 	if !pairs.Contains(p, true) || len(pairs) != 4 {
 		t.Error("TestAdd unexpected result")
 	}
-
 	// Now test adding a pair which already exists
 	pairs = pairs.Add(p)
 	if len(pairs) != 4 {
+		t.Error("TestAdd unexpected result")
+	}
+	pairs = pairs.Add(NewPair(BTC, LTC), NewPair(ETH, USD))
+	if len(pairs) != 6 {
 		t.Error("TestAdd unexpected result")
 	}
 }

--- a/exchanges/sharedtestvalues/sharedtestvalues.go
+++ b/exchanges/sharedtestvalues/sharedtestvalues.go
@@ -168,8 +168,8 @@ func SetupCurrencyPairsForExchangeAsset(t *testing.T, exch exchange.IBotExchange
 		t.Fatal(err)
 	}
 	epLen := len(enabledPairs)
-	availPairs.Add(cp...)
-	enabledPairs.Add(cp...)
+	availPairs = availPairs.Add(cp...)
+	enabledPairs = enabledPairs.Add(cp...)
 	if len(availPairs) != apLen {
 		err = b.CurrencyPairs.StorePairs(a, availPairs, false)
 		if err != nil {

--- a/exchanges/sharedtestvalues/sharedtestvalues.go
+++ b/exchanges/sharedtestvalues/sharedtestvalues.go
@@ -168,10 +168,8 @@ func SetupCurrencyPairsForExchangeAsset(t *testing.T, exch exchange.IBotExchange
 		t.Fatal(err)
 	}
 	epLen := len(enabledPairs)
-	for i := range cp {
-		availPairs = availPairs.Add(cp[i])
-		enabledPairs = enabledPairs.Add(cp[i])
-	}
+	availPairs.Add(cp...)
+	enabledPairs.Add(cp...)
 	if len(availPairs) != apLen {
 		err = b.CurrencyPairs.StorePairs(a, availPairs, false)
 		if err != nil {

--- a/exchanges/subscription/subscription.go
+++ b/exchanges/subscription/subscription.go
@@ -156,6 +156,6 @@ func (s *Subscription) AddPairs(pairs ...currency.Pair) {
 		return
 	}
 	s.m.Lock()
-	s.Pairs.Add(pairs...)
+	s.Pairs = s.Pairs.Add(pairs...)
 	s.m.Unlock()
 }

--- a/exchanges/subscription/subscription.go
+++ b/exchanges/subscription/subscription.go
@@ -156,8 +156,6 @@ func (s *Subscription) AddPairs(pairs ...currency.Pair) {
 		return
 	}
 	s.m.Lock()
-	for _, p := range pairs {
-		s.Pairs = s.Pairs.Add(p)
-	}
+	s.Pairs.Add(pairs...)
 	s.m.Unlock()
 }


### PR DESCRIPTION
# PR Description

Alters the Add method on currency.Pairs to accept an arbitrary amount of Pair objects as input, to enable mass-scale safe adding of pairs, in a way that hopefully doesn't break code that currently uses this function.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules