### PR TITLE
Subscriptions: Fix subscription.Clone Params and Pairs

### DIFF
--- a/exchanges/subscription/subscription.go
+++ b/exchanges/subscription/subscription.go
@@ -132,16 +132,14 @@ func (s *Subscription) Clone() *Subscription {
 		Enabled:          s.Enabled,
 		Channel:          s.Channel,
 		Asset:            s.Asset,
-		Params:           s.Params,
+		Params:           maps.Clone(s.Params),
 		Interval:         s.Interval,
 		Levels:           s.Levels,
 		Authenticated:    s.Authenticated,
 		state:            s.state,
-		Pairs:            s.Pairs,
+		Pairs:            slices.Clone(s.Pairs),
 		QualifiedChannel: s.QualifiedChannel,
 	}
-	c.Pairs = slices.Clone(s.Pairs)
-	c.Params = maps.Clone(s.Params)
 	s.m.RUnlock()
 	return c
 }

--- a/exchanges/subscription/subscription.go
+++ b/exchanges/subscription/subscription.go
@@ -140,8 +140,8 @@ func (s *Subscription) Clone() *Subscription {
 		Pairs:            s.Pairs,
 		QualifiedChannel: s.QualifiedChannel,
 	}
-	s.Pairs = slices.Clone(s.Pairs)
-	s.Params = maps.Clone(s.Params)
+	c.Pairs = slices.Clone(s.Pairs)
+	c.Params = maps.Clone(s.Params)
 	s.m.RUnlock()
 	return c
 }

--- a/exchanges/subscription/subscription_test.go
+++ b/exchanges/subscription/subscription_test.go
@@ -93,21 +93,24 @@ func TestSubscriptionMarshaling(t *testing.T) {
 // TestClone exercises Clone
 func TestClone(t *testing.T) {
 	t.Parallel()
+	params := map[string]any{"a": 42}
 	a := &Subscription{
 		Channel:  TickerChannel,
 		Interval: kline.OneHour,
 		Pairs:    currency.Pairs{btcusdtPair},
-		Params:   map[string]any{"a": 42},
+		Params:   params,
 	}
 	a.EnsureKeyed()
 	b := a.Clone()
 	assert.IsType(t, new(Subscription), b, "Clone must return a Subscription pointer")
 	assert.NotSame(t, a, b, "Clone should return a new Subscription")
 	assert.Nil(t, b.Key, "Clone should have a nil key")
-	b.Pairs[0] = ethusdcPair
-	assert.Equal(t, btcusdtPair, a.Pairs[0], "Pairs should be (relatively) deep copied")
+	b.Pairs[0].Delimiter = "🐳"
+	assert.Empty(t, a.Pairs[0].Delimiter, "Pairs should be (relatively) deep copied")
 	b.Params["a"] = 12
 	assert.Equal(t, 42, a.Params["a"], "Params should be (relatively) deep copied")
+	assert.NotEqual(t, params, b.Params, "Params should be cloned")
+	assert.Equal(t, params, a.Params, "Original Params should be left alone")
 	a.m.Lock()
 	assert.True(t, b.m.TryLock(), "Clone must use a different Mutex")
 }


### PR DESCRIPTION
Fixes Clone() affecting the original and not the clone for Pairs and Params.
That actually meant it would pass tests, and kinda work, but not in the way expected, and definitely not thread safe on the original parent

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)