### PR TITLE
orders/gateio: Add `GetTradeAmount` method to order.Submit type

### DIFF
--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -1013,19 +1013,14 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 			return nil, err
 		}
 
-		// When doing spot market orders when purchasing base currency, the
-		// quote currency amount is used. When selling the base currency the
-		// base currency amount is used.
-		tradingAmount := s.Amount
-		if tradingAmount == 0 && s.Type == order.Market {
-			tradingAmount = s.QuoteAmount
-		}
-
 		sOrder, err := g.PlaceSpotOrder(ctx, &CreateOrderRequestData{
-			Side:         s.Side.Lower(),
-			Type:         s.Type.Lower(),
-			Account:      g.assetTypeToString(s.AssetType),
-			Amount:       types.Number(tradingAmount),
+			Side:    s.Side.Lower(),
+			Type:    s.Type.Lower(),
+			Account: g.assetTypeToString(s.AssetType),
+			// When doing spot market orders when purchasing base currency, the
+			// quote currency amount is used. When selling the base currency the
+			// base currency amount is used.
+			Amount:       types.Number(s.GetTradeAmount(g.GetTradingRequirements())),
 			Price:        types.Number(s.Price),
 			CurrencyPair: s.Pair,
 			Text:         s.ClientOrderID,

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -2124,4 +2125,23 @@ func TestSideUnmarshal(t *testing.T) {
 	assert.ErrorIs(t, s.UnmarshalJSON([]byte(`"STEAL"`)), ErrSideIsInvalid, "Quoted invalid side errors")
 	var jErr *json.UnmarshalTypeError
 	assert.ErrorAs(t, s.UnmarshalJSON([]byte(`14`)), &jErr, "non-string valid json is rejected")
+}
+
+func TestGetTradeAmount(t *testing.T) {
+	t.Parallel()
+	var s *Submit
+	require.Zero(t, s.GetTradeAmount(protocol.TradingRequirements{}))
+	baseAmount := 420.0
+	quoteAmount := 69.0
+	s = &Submit{Amount: baseAmount, QuoteAmount: quoteAmount}
+	// below will default to base amount with nothing set
+	require.Equal(t, baseAmount, s.GetTradeAmount(protocol.TradingRequirements{}))
+	require.Equal(t, baseAmount, s.GetTradeAmount(protocol.TradingRequirements{SpotMarketOrderAmountPurchaseQuotationOnly: true}))
+	s.AssetType = asset.Spot
+	s.Type = Market
+	s.Side = Buy
+	require.Equal(t, quoteAmount, s.GetTradeAmount(protocol.TradingRequirements{SpotMarketOrderAmountPurchaseQuotationOnly: true}))
+	require.Equal(t, baseAmount, s.GetTradeAmount(protocol.TradingRequirements{SpotMarketOrderAmountSellBaseOnly: true}))
+	s.Side = Sell
+	require.Equal(t, baseAmount, s.GetTradeAmount(protocol.TradingRequirements{SpotMarketOrderAmountSellBaseOnly: true}))
 }

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -129,6 +129,23 @@ func (s *Submit) Validate(requirements protocol.TradingRequirements, opt ...vali
 	return nil
 }
 
+// GetTradeAmount returns the trade amount based on the exchange's trading
+// requirements. Some exchanges depending on direction and order type use
+// quotation (funds in balance) or base amounts. If the exchange does not have
+// any specific requirements it will return the base amount.
+func (s *Submit) GetTradeAmount(tr protocol.TradingRequirements) float64 {
+	if s == nil {
+		return 0
+	}
+	switch {
+	case tr.SpotMarketOrderAmountPurchaseQuotationOnly && s.AssetType == asset.Spot && s.Type == Market && s.Side.IsLong():
+		return s.QuoteAmount
+	case tr.SpotMarketOrderAmountSellBaseOnly && s.AssetType == asset.Spot && s.Type == Market && s.Side.IsShort():
+		return s.Amount
+	}
+	return s.Amount
+}
+
 // UpdateOrderFromDetail Will update an order detail (used in order management)
 // by comparing passed in and existing values
 func (d *Detail) UpdateOrderFromDetail(m *Detail) error {


### PR DESCRIPTION
# PR Description

I had both values populated for Amount and QuoteAmount and when it detected base amount it kept base amount. So this reduces a fat finger chance.  😆 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
