### PR TITLE
Subscriptions: Add List.Clone

### DIFF
--- a/exchanges/subscription/list.go
+++ b/exchanges/subscription/list.go
@@ -46,6 +46,15 @@ func (l List) GroupPairs() (n List) {
 	return s.List()
 }
 
+// Clone returns a deep clone of the List
+func (l List) Clone() List {
+	n := make(List, len(l))
+	for i, s := range l {
+		n[i] = s.Clone()
+	}
+	return n
+}
+
 // QualifiedChannels returns a sorted list of all the qualified Channels in the list
 func (l List) QualifiedChannels() []string {
 	c := make([]string, len(l))

--- a/exchanges/subscription/list_test.go
+++ b/exchanges/subscription/list_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 )
 
 // TestListStrings exercises List.Strings()
@@ -90,4 +91,16 @@ func TestAssetPairs(t *testing.T) {
 		_, err = l.assetPairs(&mockEx{errFormat: expErr})
 		assert.ErrorIs(t, err, expErr, "Should error correctly on GetPairFormat")
 	}
+}
+
+func TestListClone(t *testing.T) {
+	t.Parallel()
+	l := List{{Channel: TickerChannel}, {Channel: OrderbookChannel}}
+	n := l.Clone()
+	assert.NotSame(t, n, l, "Slices must not be the same")
+	require.NotEmpty(t, n, "List must not be empty")
+	assert.NotSame(t, n[0], l[0], "Subscriptions must be cloned")
+	assert.Equal(t, n[0], l[0], "Subscriptions should be equal")
+	l[0].Interval = kline.OneHour
+	assert.NotEqual(t, n[0], l[0], "Subscriptions should be cloned")
 }

--- a/exchanges/subscription/subscription_test.go
+++ b/exchanges/subscription/subscription_test.go
@@ -90,8 +90,7 @@ func TestSubscriptionMarshaling(t *testing.T) {
 	assert.Equal(t, `{"enabled":true,"channel":"myTrades","authenticated":true}`, string(j), "Marshalling should be clean and concise")
 }
 
-// TestClone exercises Clone
-func TestClone(t *testing.T) {
+func TestSubscriptionClone(t *testing.T) {
 	t.Parallel()
 	params := map[string]any{"a": 42}
 	a := &Subscription{


### PR DESCRIPTION
This PR just adds Subscription List cloning.

It's broken out from #1579 so that other PRs can move along without such a big dependency chain.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run