### PR TITLE
Kraken: Fix TestGetOpenInterest

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -67,6 +67,7 @@ var (
 	ErrCannotCalculateOffline = errors.New("cannot calculate offline, unsupported")
 	ErrNoResponse             = errors.New("no response")
 	ErrTypeAssertFailure      = errors.New("type assert failure")
+	ErrUnknownError           = errors.New("unknown error")
 )
 
 var (

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2016,7 +2016,7 @@ func TestSubscribeBadResp(t *testing.T) {
 	}
 	b := testexch.MockWsInstance[Binance](t, testexch.CurryWsMockUpgrader(t, mock)) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	err := b.Subscribe(channels)
-	assert.ErrorIs(t, err, errUnknownError, "Subscribe should error errUnknownError")
+	assert.ErrorIs(t, err, common.ErrUnknownError, "Subscribe should error correctly")
 	assert.ErrorContains(t, err, "carrots", "Subscribe should error containing the carrots")
 }
 

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -46,7 +46,6 @@ var (
 	// maxWSOrderbookWorkers defines a max amount of workers allowed to execute
 	// jobs from the job channel
 	maxWSOrderbookWorkers = 10
-	errUnknownError       = errors.New("unknown error")
 )
 
 // WsConnect initiates a websocket connection
@@ -584,7 +583,7 @@ func (b *Binance) manageSubs(op string, subs subscription.List) error {
 		if v, d, _, rErr := jsonparser.Get(respRaw, "result"); rErr != nil {
 			err = rErr
 		} else if d != jsonparser.Null { // null is the only expected and acceptable response
-			err = fmt.Errorf("%w: %s", errUnknownError, v)
+			err = fmt.Errorf("%w: %s", common.ErrUnknownError, v)
 		}
 	}
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1979,7 +1979,7 @@ func TestGetErrResp(t *testing.T) {
 		case 3: // event != 'error'
 			assert.NoError(t, testErr, "Message with non-'error' event field should not error")
 		case 4: // event="error"
-			assert.ErrorIs(t, testErr, errUnknownError, "error without a message should throw unknown error")
+			assert.ErrorIs(t, testErr, common.ErrUnknownError, "error without a message should throw unknown error")
 			assert.ErrorContains(t, testErr, "code: 0", "error without a code should throw code 0")
 		case 5: // Fully formatted
 			assert.ErrorContains(t, testErr, "redcoats", "message field should be in the error")

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -13,7 +13,6 @@ import (
 var (
 	errSetCannotBeEmpty        = errors.New("set cannot be empty")
 	errNoSeqNo                 = errors.New("no sequence number")
-	errUnknownError            = errors.New("unknown error")
 	errParamNotAllowed         = errors.New("param not allowed")
 	errParsingWSField          = errors.New("error parsing WS field")
 	errTickerInvalidSymbol     = errors.New("invalid ticker symbol")

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -1866,7 +1866,7 @@ func (b *Bitfinex) unsubscribeFromChan(chans subscription.List) error {
 // getErrResp takes a json response string and looks for an error event type
 // If found it parses the error code and message as a wrapped error and returns it
 // It might log parsing errors about the nature of the error
-// If the error message is not defined it will return a wrapped errUnknownError
+// If the error message is not defined it will return a wrapped common.ErrUnknownError
 func (b *Bitfinex) getErrResp(resp []byte) error {
 	event, err := jsonparser.GetUnsafeString(resp, "event")
 	if err != nil {
@@ -1883,7 +1883,7 @@ func (b *Bitfinex) getErrResp(resp []byte) error {
 	var apiErr error
 	if msg, e2 := jsonparser.GetString(resp, "msg"); e2 != nil {
 		log.Errorf(log.ExchangeSys, "%s %s 'msg': %s from message: %s", b.Name, errParsingWSField, e2, resp)
-		apiErr = errUnknownError
+		apiErr = common.ErrUnknownError
 	} else {
 		apiErr = errors.New(msg)
 	}

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -848,13 +848,8 @@ func (k *Kraken) SendHTTPRequest(ctx context.Context, ep exchange.URL, path stri
 		return genResponse.Error.Errors()
 	}
 
-	var genResp genericFuturesResponse
-	if err := json.Unmarshal(rawMessage, &genResp); err != nil {
+	if err := getFuturesErr(rawMessage); err != nil {
 		return err
-	}
-
-	if genResp.Error != "" && genResp.Result != "success" {
-		return errors.New(genResp.Error)
 	}
 
 	return json.Unmarshal(rawMessage, result)

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -2251,6 +2251,9 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
+	k := new(Kraken) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(k), "Test instance Setup must not error")
+
 	_, err := k.GetOpenInterest(context.Background(), key.PairAsset{
 		Base:  currency.ETH.Item,
 		Quote: currency.USDT.Item,
@@ -2258,8 +2261,8 @@ func TestGetOpenInterest(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 
-	cp1 := currency.NewPair(currency.PF, currency.NewCode("ETHUSD"))
-	cp2 := currency.NewPair(currency.PF, currency.NewCode("XBTUSD"))
+	cp1 := currency.NewPair(currency.PF, currency.NewCode("XBTUSD"))
+	cp2 := currency.NewPair(currency.PF, currency.NewCode("ETHUSD"))
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, k, asset.Futures, cp1, cp2)
 
 	resp, err := k.GetOpenInterest(context.Background(), key.PairAsset{

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -93,6 +93,7 @@ type genericFuturesResponse struct {
 	Result     string    `json:"result"`
 	ServerTime time.Time `json:"serverTime"`
 	Error      string    `json:"error"`
+	Errors     []string  `json:"errors"`
 }
 
 // Asset holds asset information

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -66,7 +66,6 @@ var (
 	m                           sync.Mutex
 	errNoWebsocketOrderbookData = errors.New("no websocket orderbook data")
 	errParsingWSField           = errors.New("error parsing WS field")
-	errUnknownError             = errors.New("unknown error")
 	errCancellingOrder          = errors.New("error cancelling order")
 )
 
@@ -1360,7 +1359,7 @@ func (k *Kraken) wsCancelOrder(orderID string) error {
 		return nil
 	}
 
-	err = errUnknownError
+	err = common.ErrUnknownError
 	if msg, pErr := jsonparser.GetUnsafeString(resp, "errorMessage"); pErr == nil && msg != "" {
 		err = errors.New(msg)
 	}


### PR DESCRIPTION
We see daily failures on OpenInterest for Kraken.
This fix assumes that the issue might be related to volume of ETHUSD open interest, and switches the single pair test to XBTUSD instead

Also isolates the test from others, since we're changing stored pairs and we might be colliding on the global k

If we keep getting the issue after this, then we remove the NotEmpty errors I guess.

## Type of change

- [x] Test fix