### PR TITLE
CI/build: Update Go version, linters and fix minor issues

### DIFF
--- a/.github/workflows/arm64.Dockerfile
+++ b/.github/workflows/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.22
+FROM arm64v8/golang:1.23
 
 WORKDIR /app
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,8 +8,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.1
+          version: v1.60.1

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: Setup build depends
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 env:
-  GO_VERSION: 1.22.x
+  GO_VERSION: 1.23.x
 jobs:
   backend-psql:
     name: GoCryptoTrader back-end

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,6 @@ run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  skip-dirs:
-    - vendor
-    - web/
-    - testdata
-    - database/models/
 
 linters:
   disable-all: true
@@ -24,24 +19,25 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+#   - canonicalheader
     - containedctx
 #   - contextcheck
+    - copyloopvar
 #   - cyclop
-#   - deadcode // abandoned by its owner, replaced by unused
     - decorder
 #   - depguard
     - dogsled
 #   - dupl
     - dupword
     - durationcheck
+#   - err113
     - errchkjson
     - errname
 #   - errorlint
-    - execinquery
 #   - exhaustive
-#   - exhaustivestruct // abandoned by its owner, replaced by exhaustruct
 #   - exhaustruct
     - exportloopref
+    - fatcontext
 #   - forbidigo
     - forcetypeassert
 #   - funlen
@@ -57,32 +53,28 @@ linters:
 #   - gocyclo
 #   - godot
 #   - godox
-#   - goerr113
     - gofmt
 #   - gofumpt
 #   - goheader
     - goimports
-#   - golint // deprecated since 1.41.0, replaced by revive
-#   - gomnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
 #   - gosmopolitan
     - grouper
-#   - ifshort // deprecated by its owner
 #   - importas
 #   - inamedparam
 #   - interfacebloat
-#   - interfacer // deprecated by its owner
+#   - intrange
 #   - ireturn
 #   - lll 
 #   - loggercheck
 #   - maintidx
     - makezero
-#   - maligned // deprecated by its owner, replaced by govet 'fieldalignment'
     - mirror
     - misspell
+#   - mnd
 #   - musttag
 #   - nakedret
 #   - nestif
@@ -92,7 +84,6 @@ linters:
     - noctx
     - nolintlint
 #   - nonamedreturns
-#   - nosnakecase // deprecated by its owner, replaced by revive 'var-naming'
     - nosprintfhostport
 #   - paralleltest
     - perfsprint
@@ -103,9 +94,9 @@ linters:
     - reassign
     - revive
     - rowserrcheck
-#   - scopelint // deprecated since v1.39.0, replaced by exportloopref
+#   - sloglint
+#   - spancheck
     - sqlclosecheck
-#   - structcheck // abandoned by its owner, replaced by unused
     - stylecheck
     - tagalign
 #   - tagliatelle
@@ -118,7 +109,6 @@ linters:
     - unconvert
     - unparam
     - usestdlibvars
-#   - varcheck // abandoned by its owner, replaced by unused
 #   - varnamelen
     - wastedassign
     - whitespace
@@ -128,7 +118,8 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable: 
+      - shadow
   goconst:
     min-occurrences: 6
   gocritic:
@@ -157,6 +148,12 @@ issues:
     - text: "Expect WriteFile permissions to be 0600 or less"
       linters:
         - gosec
+
+  exclude-dirs:
+    - vendor
+    - web/
+    - testdata
+    - database/models/
 
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,7 @@ linters:
 #   - importas
 #   - inamedparam
 #   - interfacebloat
-#   - intrange
+    - intrange
 #   - ireturn
 #   - lll 
 #   - loggercheck
@@ -120,6 +120,8 @@ linters-settings:
   govet:
     enable: 
       - shadow
+      - nilness
+      - unusedwrite
   goconst:
     min-occurrences: 6
   gocritic:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as build
+FROM golang:1.23 as build
 WORKDIR /go/src/github.com/thrasher-corp/gocryptotrader
 COPY . .
 RUN GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-corp/gocryptotrader
-LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
+LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 LINTBIN = $(GOPATH)/bin/golangci-lint
 GCTLISTENPORT=9050
 GCTPROFILERLISTENPORT=8085

--- a/backtester/common/common.go
+++ b/backtester/common/common.go
@@ -65,9 +65,9 @@ func FitStringToLimit(str, spacer string, limit int, upper bool) string {
 		return str[0:limit]
 	}
 	spacerLen := len(spacer)
-	for i := 0; i < limResp; i++ {
+	for i := range limResp {
 		str += spacer
-		for j := 0; j < spacerLen; j++ {
+		for j := range spacerLen {
 			if j > 0 {
 				// prevent clever people from going beyond
 				// the limit by having a spacer longer than 1

--- a/backtester/common/common.go
+++ b/backtester/common/common.go
@@ -206,10 +206,10 @@ func Logo() string {
 	sb := strings.Builder{}
 	sb.WriteString("                                                                                \n")
 	sb.WriteString("                               " + CMDColours.White + "@@@@@@@@@@@@@@@@@                                \n")
-	sb.WriteString("                            " + CMDColours.White + "@@@@@@@@@@@@@@@@@@@@@@@    " + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n") //nolint:goconst // not needed for this glorious logo
+	sb.WriteString("                            " + CMDColours.White + "@@@@@@@@@@@@@@@@@@@@@@@    " + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                           " + CMDColours.White + "@@@@@@@@" + CMDColours.Grey + ",,,,,    " + CMDColours.White + "@@@@@@@@@" + CMDColours.Grey + ",,,,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                         " + CMDColours.White + "@@@@@@@@" + CMDColours.Grey + ",,,,,,,       " + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,,," + CMDColours.White + "                   \n")
-	sb.WriteString("                         " + CMDColours.White + "@@@@@@" + CMDColours.Grey + "(,,,,,,,,      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n") //nolint:goconst // not needed for this glorious logo
+	sb.WriteString("                         " + CMDColours.White + "@@@@@@" + CMDColours.Grey + "(,,,,,,,,      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@@" + CMDColours.Grey + ",,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                      " + CMDColours.Grey + ",," + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,   #,,,,,,,,,,,,,,,,,," + CMDColours.White + "                   \n")
 	sb.WriteString("                   " + CMDColours.Grey + ",,,,*" + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,,,,,,,,,,,,,,,,,," + CMDColours.Green + "%%%%%%%" + CMDColours.White + "                \n")
 	sb.WriteString("                " + CMDColours.Grey + ",,,,,,,*" + CMDColours.White + "@@@@@@" + CMDColours.Grey + ",,,,,,,,,,,,,," + CMDColours.Green + "%%%%%" + CMDColours.Grey + " ,,,,,," + CMDColours.Grey + "%" + CMDColours.Green + "%%%%%%" + CMDColours.White + "                 \n")

--- a/backtester/common/common_test.go
+++ b/backtester/common/common_test.go
@@ -89,7 +89,6 @@ func TestCanTransact(t *testing.T) {
 			expected: false,
 		},
 	} {
-		ti := ti
 		t.Run(ti.side.String(), func(t *testing.T) {
 			t.Parallel()
 			if CanTransact(ti.side) != ti.expected {
@@ -124,7 +123,6 @@ func TestDataTypeConversion(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		ti := ti
 		t.Run(ti.title, func(t *testing.T) {
 			t.Parallel()
 			got, err := DataTypeToInt(ti.dataType)

--- a/backtester/config/strategyconfig.go
+++ b/backtester/config/strategyconfig.go
@@ -257,7 +257,7 @@ func (c *Config) PrintSetting() {
 			c.CurrencySettings[i].Asset,
 			c.CurrencySettings[i].Base,
 			c.CurrencySettings[i].Quote)
-		log.Infof(common.Config, currStr[:61])
+		log.Infoln(common.Config, currStr[:61])
 		log.Infof(common.Config, "Exchange: %v", c.CurrencySettings[i].ExchangeName)
 		switch {
 		case c.DataSettings.LiveData != nil && c.DataSettings.LiveData.RealOrders:

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -1416,21 +1416,10 @@ func TestRunLive(t *testing.T) {
 	bt.LiveDataHandler = dc
 	cp := currency.NewPair(currency.BTC, currency.USD)
 	i := &gctkline.Item{
-		Exchange:       testExchange,
 		Pair:           cp,
 		UnderlyingPair: cp,
 		Asset:          asset.Spot,
 		Interval:       gctkline.FifteenSecond,
-		Candles: []gctkline.Candle{
-			{
-				Time:   time.Now(),
-				Open:   1337,
-				High:   1337,
-				Low:    1337,
-				Close:  1337,
-				Volume: 1337,
-			},
-		},
 	}
 	// 	AppendDataSource(exchange gctexchange.IBotExchange, interval gctkline.Interval, asset asset.Asset, pair, underlyingPair currency.Pair, dataType int64) error
 	setup := &liveDataSourceSetup{

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -162,11 +162,13 @@ func TestExecuteStrategyFromConfig(t *testing.T) {
 		}
 		var fd *btrpc.FuturesDetails
 		if defaultConfig.CurrencySettings[i].FuturesDetails != nil {
-			fd.Leverage = &btrpc.Leverage{
-				CanUseLeverage:                 defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.CanUseLeverage,
-				MaximumOrdersWithLeverageRatio: defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumOrdersWithLeverageRatio.String(),
-				MaximumLeverageRate:            defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumOrderLeverageRate.String(),
-				MaximumCollateralLeverageRate:  defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumCollateralLeverageRate.String(),
+			fd = &btrpc.FuturesDetails{
+				Leverage: &btrpc.Leverage{
+					CanUseLeverage:                 defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.CanUseLeverage,
+					MaximumOrdersWithLeverageRatio: defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumOrdersWithLeverageRatio.String(),
+					MaximumLeverageRate:            defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumOrderLeverageRate.String(),
+					MaximumCollateralLeverageRate:  defaultConfig.CurrencySettings[i].FuturesDetails.Leverage.MaximumCollateralLeverageRate.String(),
+				},
 			}
 		}
 		var makerFee, takerFee string

--- a/backtester/engine/live_types.go
+++ b/backtester/engine/live_types.go
@@ -22,7 +22,6 @@ var (
 	ErrLiveDataTimeout = errors.New("no data processed within timeframe")
 
 	errDataSourceExists             = errors.New("data source already exists")
-	errInvalidCredentials           = errors.New("credentials are invalid, please check your config")
 	errNoCredsNoLive                = errors.New("cannot use real orders without credentials to fulfil those real orders")
 	errNoDataSetForClosingPositions = errors.New("no data was set for closing positions")
 	errNilError                     = errors.New("nil error received when expecting an error")

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -198,7 +198,6 @@ func TestPlaceOrder(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	bot.ExchangeManager = em
 	bot.OrderManager, err = engine.SetupOrderManager(em, &engine.CommunicationManager{}, &bot.ServicesWG, &gctconfig.OrderManager{})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
@@ -256,7 +255,6 @@ func TestExecuteOrder(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	bot.ExchangeManager = em
 	bot.OrderManager, err = engine.SetupOrderManager(em, &engine.CommunicationManager{}, &bot.ServicesWG, &gctconfig.OrderManager{})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
@@ -392,7 +390,6 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	bot.ExchangeManager = em
 	bot.OrderManager, err = engine.SetupOrderManager(em, &engine.CommunicationManager{}, &bot.ServicesWG, &gctconfig.OrderManager{})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)

--- a/backtester/eventhandlers/statistics/printresults.go
+++ b/backtester/eventhandlers/statistics/printresults.go
@@ -220,7 +220,7 @@ func (c *CurrencyPairStatistic) PrintResults(e string, a asset.Item, p currency.
 	last.Holdings.TotalValueLost = last.Holdings.TotalValueLostToSlippage.Add(last.Holdings.TotalValueLostToVolumeSizing)
 	sep := fmt.Sprintf("%v %v %v |\t", fSIL(e, limit12), fSIL(a.String(), limit10), fSIL(p.String(), limit14))
 	currStr := fmt.Sprintf(common.CMDColours.H1+"------------------Stats for %v %v %v------------------------------------------------------"+common.CMDColours.Default, e, a, p)
-	log.Infof(common.CurrencyStatistics, currStr[:70])
+	log.Infoln(common.CurrencyStatistics, currStr[:70])
 	if a.IsFutures() {
 		log.Infof(common.CurrencyStatistics, "%s Long orders: %s", sep, convert.IntToHumanFriendlyString(c.BuyOrders, ","))
 		log.Infof(common.CurrencyStatistics, "%s Short orders: %s", sep, convert.IntToHumanFriendlyString(c.SellOrders, ","))

--- a/backtester/eventhandlers/statistics/statistics_test.go
+++ b/backtester/eventhandlers/statistics/statistics_test.go
@@ -826,7 +826,7 @@ func TestCalculateBiggestEventDrawdown(t *testing.T) {
 	a := asset.Spot
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	var events []data.Event
-	for i := int64(0); i < 100; i++ {
+	for i := range int64(100) {
 		tt1 = tt1.Add(gctkline.OneDay.Duration())
 		even := &event.Base{
 			Exchange:     exch,

--- a/backtester/funding/funding_test.go
+++ b/backtester/funding/funding_test.go
@@ -214,10 +214,6 @@ func TestExists(t *testing.T) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
 
-	_, err = f.getFundingForEAP(exchName, a, pair)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
 	// demonstration that you don't need the original *Items
 	// to check for existence, just matching fields
 	baseCopy := Item{
@@ -234,20 +230,7 @@ func TestExists(t *testing.T) {
 		isCollateral:      baseItem.isCollateral,
 		collateralCandles: baseItem.collateralCandles,
 	}
-	quoteCopy := Item{
-		exchange:          quoteItem.exchange,
-		asset:             quoteItem.asset,
-		currency:          quoteItem.currency,
-		initialFunds:      quoteItem.initialFunds,
-		available:         quoteItem.available,
-		reserved:          quoteItem.reserved,
-		transferFee:       quoteItem.transferFee,
-		pairedWith:        quoteItem.pairedWith,
-		trackingCandles:   quoteItem.trackingCandles,
-		snapshot:          quoteItem.snapshot,
-		isCollateral:      quoteItem.isCollateral,
-		collateralCandles: quoteItem.collateralCandles,
-	}
+	quoteCopy := Item{pairedWith: quoteItem.pairedWith}
 	quoteCopy.pairedWith = &baseCopy
 	if !f.Exists(&baseCopy) {
 		t.Errorf("received '%v' expected '%v'", false, true)

--- a/backtester/funding/funding_test.go
+++ b/backtester/funding/funding_test.go
@@ -230,8 +230,6 @@ func TestExists(t *testing.T) {
 		isCollateral:      baseItem.isCollateral,
 		collateralCandles: baseItem.collateralCandles,
 	}
-	quoteCopy := Item{pairedWith: quoteItem.pairedWith}
-	quoteCopy.pairedWith = &baseCopy
 	if !f.Exists(&baseCopy) {
 		t.Errorf("received '%v' expected '%v'", false, true)
 	}

--- a/backtester/funding/trackingcurrencies/trackingcurrencies.go
+++ b/backtester/funding/trackingcurrencies/trackingcurrencies.go
@@ -69,9 +69,6 @@ func CreateUSDTrackingPairs(tp []TrackingPair, em *engine.ExchangeManager) ([]Tr
 		} else {
 			b := exch.GetBase()
 			a := tp[i].Asset
-			if err != nil {
-				return nil, err
-			}
 			if a.IsFutures() {
 				// futures matches to spot, not like this
 				continue

--- a/backtester/funding/trackingcurrencies/trackingcurrencies_test.go
+++ b/backtester/funding/trackingcurrencies/trackingcurrencies_test.go
@@ -140,8 +140,7 @@ func TestFindMatchingUSDPairs(t *testing.T) {
 			expectedErr:    errCurrencyNotFoundInPairs,
 		},
 	}
-	for i := range tests {
-		tt := tests[i]
+	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			basePair, quotePair, err := findMatchingUSDPairs(tt.initialPair, tt.availablePairs)
@@ -222,8 +221,7 @@ func TestPairContainsUSD(t *testing.T) {
 			currency.NewPair(currency.BTC, currency.PAX),
 		},
 	}
-	for i := range pairs {
-		tt := pairs[i]
+	for _, tt := range pairs {
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			resp := pairContainsUSD(tt.pair)

--- a/cmd/exchange_wrapper_coverage/main.go
+++ b/cmd/exchange_wrapper_coverage/main.go
@@ -98,12 +98,12 @@ func testWrappers(e exchange.IBotExchange) ([]string, error) {
 	contextParam := reflect.TypeOf((*context.Context)(nil)).Elem()
 
 	var funcs []string
-	for x := 0; x < iExchange.NumMethod(); x++ {
+	for x := range iExchange.NumMethod() {
 		name := iExchange.Method(x).Name
 		method := actualExchange.MethodByName(name)
 		inputs := make([]reflect.Value, method.Type().NumIn())
 
-		for y := 0; y < method.Type().NumIn(); y++ {
+		for y := range method.Type().NumIn() {
 			input := method.Type().In(y)
 
 			if input.Implements(contextParam) {

--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -175,7 +175,7 @@ func executeExchangeWrapperTests(ctx context.Context, t *testing.T, exch exchang
 	t.Helper()
 	iExchange := reflect.TypeOf(&exch).Elem()
 	actualExchange := reflect.ValueOf(exch)
-	for x := 0; x < iExchange.NumMethod(); x++ {
+	for x := range iExchange.NumMethod() {
 		methodName := iExchange.Method(x).Name
 		if _, ok := excludedMethodNames[methodName]; ok {
 			continue
@@ -183,7 +183,7 @@ func executeExchangeWrapperTests(ctx context.Context, t *testing.T, exch exchang
 		method := actualExchange.MethodByName(methodName)
 
 		var assetLen int
-		for y := 0; y < method.Type().NumIn(); y++ {
+		for y := range method.Type().NumIn() {
 			input := method.Type().In(y)
 			for _, t := range []reflect.Type{
 				assetParam, orderSubmitParam, orderModifyParam, orderCancelParam, orderCancelsParam, pairKeySliceParam, getOrdersRequestParam, latestRateRequest,
@@ -213,7 +213,7 @@ func executeExchangeWrapperTests(ctx context.Context, t *testing.T, exch exchang
 				Start:       s,
 				End:         e,
 			}
-			for z := 0; z < method.Type().NumIn(); z++ {
+			for z := range method.Type().NumIn() {
 				argGenerator.MethodInputType = method.Type().In(z)
 				generatedArg := generateMethodArg(ctx, t, argGenerator)
 				inputs[z] = *generatedArg

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -638,7 +638,7 @@ func getOrderbookStream(c *cli.Context) error {
 			fmt.Println("\t\tBids\t\t\t\tAsks")
 			fmt.Println()
 
-			for i := int64(0); i < maxLen; i++ {
+			for i := range maxLen {
 				var bidAmount, bidPrice float64
 				if i <= bidLen {
 					bidAmount = resp.Bids[i].Amount

--- a/cmd/gen_otp/otp_gen.go
+++ b/cmd/gen_otp/otp_gen.go
@@ -40,7 +40,7 @@ func main() {
 		for {
 			log.Println("Please enter in your OTP secret:")
 			if _, err = fmt.Scanln(&input); err != nil {
-				log.Printf("Failed to read input. Err: %s", err)
+				log.Printf("Failed to read input. Err: %s\n", err)
 				continue
 			}
 			if input != "" {

--- a/cmd/gen_otp/otp_gen.go
+++ b/cmd/gen_otp/otp_gen.go
@@ -39,7 +39,10 @@ func main() {
 		var input string
 		for {
 			log.Println("Please enter in your OTP secret:")
-			fmt.Scanln(&input)
+			if _, err = fmt.Scanln(&input); err != nil {
+				log.Printf("Failed to read input. Err: %s", err)
+				continue
+			}
 			if input != "" {
 				break
 			}

--- a/common/cache/cache_test.go
+++ b/common/cache/cache_test.go
@@ -46,7 +46,7 @@ func TestContainsOrAdd(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	lruCache := New(5)
-	for x := 0; x < 5; x++ {
+	for x := range 5 {
 		lruCache.Add(x, x)
 	}
 	if lruCache.Len() != 5 {

--- a/common/common.go
+++ b/common/common.go
@@ -139,7 +139,7 @@ func NewHTTPClientWithTimeout(t time.Duration) *http.Client {
 // returns an individual string array
 func StringSliceDifference(slice1, slice2 []string) []string {
 	var diff []string
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		for _, s1 := range slice1 {
 			found := false
 			for _, s2 := range slice2 {
@@ -399,7 +399,7 @@ func AddPaddingOnUpperCase(s string) string {
 	}
 	var result []string
 	left := 0
-	for x := 0; x < len(s); x++ {
+	for x := range s {
 		if x == 0 {
 			continue
 		}
@@ -431,7 +431,7 @@ func InArray(val, array interface{}) (exists bool, index int) {
 	switch reflect.TypeOf(array).Kind() {
 	case reflect.Array, reflect.Slice:
 		s := reflect.ValueOf(array)
-		for i := 0; i < s.Len(); i++ {
+		for i := range s.Len() {
 			if reflect.DeepEqual(val, s.Index(i).Interface()) {
 				index = i
 				exists = true

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -558,13 +558,6 @@ func TestChangePermission(t *testing.T) {
 	}
 }
 
-func initStringSlice(size int) (out []string) {
-	for x := 0; x < size; x++ {
-		out = append(out, "gct-"+strconv.Itoa(x))
-	}
-	return
-}
-
 func TestAddPaddingOnUpperCase(t *testing.T) {
 	t.Parallel()
 

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -228,7 +228,6 @@ func TestWriter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Writer(tt.args.file)
 			if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1613,7 +1613,7 @@ func readEncryptedConfWithKey(reader *bufio.Reader, keyProvider func() ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	for errCounter := 0; errCounter < maxAuthFailures; errCounter++ {
+	for range maxAuthFailures {
 		key, err := keyProvider()
 		if err != nil {
 			log.Errorf(log.ConfigMgr, "PromptForConfigKey err: %s", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2141,7 +2141,6 @@ func TestGetDataPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			t.Helper()
@@ -2239,7 +2238,6 @@ func TestMigrateConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(t)

--- a/currency/forexprovider/currencylayer/currencylayer_test.go
+++ b/currency/forexprovider/currencylayer/currencylayer_test.go
@@ -18,8 +18,6 @@ var (
 	apiKeyLevel = 0
 )
 
-var isSet bool
-
 func TestMain(m *testing.M) {
 	if apiKey == "" {
 		apiKey = os.Getenv("CURRENCYLAYER_APIKEY")

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -686,7 +686,7 @@ func TestRandomPairFromPairs(t *testing.T) {
 	// currency pairs
 	pairs = append(pairs, NewPair(ETH, USD))
 	expectedResults := make(map[string]bool)
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		result, err = pairs.GetRandomPair()
 		if !errors.Is(err, nil) {
 			t.Fatalf("received: '%v' but expected: '%v'", err, nil)

--- a/currency/pair_test.go
+++ b/currency/pair_test.go
@@ -834,7 +834,6 @@ func TestPairFormat_Format(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			f := &PairFormat{
 				Uppercase: tt.fields.Uppercase,
@@ -911,7 +910,6 @@ func TestGetOrderParameters(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			var resp *OrderParameters
@@ -978,7 +976,6 @@ func TestIsAssociated(t *testing.T) {
 	}
 
 	for x := range testCases {
-		x := x
 		t.Run(strconv.Itoa(x), func(t *testing.T) {
 			t.Parallel()
 			if testCases[x].Pair.IsAssociated(testCases[x].associate) != testCases[x].expectedResult {

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -307,13 +307,13 @@ pairs:
 		}
 		base := p[x].Base.Lower().String()
 		baseLength := len(base)
-		for y := 0; y < baseLength; y++ {
+		for y := range baseLength {
 			if base[y] != symbol[y] {
 				continue pairs
 			}
 		}
 		quote := p[x].Quote.Lower().String()
-		for y := 0; y < len(quote); y++ {
+		for y := range quote {
 			if quote[y] != symbol[baseLength+y] {
 				continue pairs
 			}

--- a/database/repository/audit/audit_test.go
+++ b/database/repository/audit/audit_test.go
@@ -102,7 +102,7 @@ func writeAudit(t *testing.T) {
 	t.Helper()
 	var wg sync.WaitGroup
 
-	for x := 0; x < 20; x++ {
+	for x := range 20 {
 		wg.Add(1)
 
 		go func(x int) {

--- a/database/repository/audit/audit_test.go
+++ b/database/repository/audit/audit_test.go
@@ -76,8 +76,7 @@ func TestAudit(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			if !testhelpers.CheckValidConfig(&test.config.ConnectionDetails) {
 				t.Skip("database not configured skipping test")

--- a/database/repository/candle/candle_test.go
+++ b/database/repository/candle/candle_test.go
@@ -293,7 +293,7 @@ func genOHCLVData() (out Item, err error) {
 	out.Asset = "spot"
 
 	start := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-	for x := 0; x < 365; x++ {
+	for x := range 365 {
 		out.Candles = append(out.Candles, Candle{
 			Timestamp:        start.Add(time.Hour * 24 * time.Duration(x)),
 			Open:             1000,

--- a/database/repository/datahistoryjob/datahistoryjob_test.go
+++ b/database/repository/datahistoryjob/datahistoryjob_test.go
@@ -118,7 +118,7 @@ func TestDataHistoryJob(t *testing.T) {
 			}
 
 			var jerberinos, jerberoos []*DataHistoryJob
-			for i := 0; i < 20; i++ {
+			for i := range 20 {
 				uu, _ := uuid.NewV4()
 				jerberinos = append(jerberinos, &DataHistoryJob{
 					ID:           uu.String(),
@@ -138,7 +138,7 @@ func TestDataHistoryJob(t *testing.T) {
 				t.Fatal(err)
 			}
 			// insert the same jerbs to test conflict resolution
-			for i := 0; i < 20; i++ {
+			for i := range 20 {
 				uu, _ := uuid.NewV4()
 				j := &DataHistoryJob{
 					ID:           uu.String(),

--- a/database/repository/datahistoryjobresult/datahistoryjobresult_test.go
+++ b/database/repository/datahistoryjobresult/datahistoryjobresult_test.go
@@ -139,7 +139,7 @@ func TestDataHistoryJob(t *testing.T) {
 			}
 
 			var resulterinos, resultaroos []*DataHistoryJobResult
-			for i := 0; i < 20; i++ {
+			for range 20 {
 				uu, _ := uuid.NewV4()
 				resulterinos = append(resulterinos, &DataHistoryJobResult{
 					ID:                uu.String(),
@@ -156,7 +156,7 @@ func TestDataHistoryJob(t *testing.T) {
 				t.Fatal(err)
 			}
 			// insert the same results to test conflict resolution
-			for i := 0; i < 20; i++ {
+			for i := range 20 {
 				uu, _ := uuid.NewV4()
 				j := &DataHistoryJobResult{
 					ID:                uu.String(),

--- a/database/repository/script/script_test.go
+++ b/database/repository/script/script_test.go
@@ -99,7 +99,7 @@ func TestScript(t *testing.T) {
 
 func writeScript() {
 	var wg sync.WaitGroup
-	for x := 0; x < 20; x++ {
+	for x := range 20 {
 		wg.Add(1)
 
 		go func(x int) {

--- a/database/repository/trade/trade_test.go
+++ b/database/repository/trade/trade_test.go
@@ -107,11 +107,11 @@ func TestTrades(t *testing.T) {
 
 func tradeSQLTester(t *testing.T) {
 	t.Helper()
-	var trades, trades2 []Data
+	trades := make([]Data, 20)
 	firstTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		uu, _ := uuid.NewV4()
-		trades = append(trades, Data{
+		trades[i] = Data{
 			ID:        uu.String(),
 			Timestamp: firstTime.Add(time.Minute * time.Duration(i+1)),
 			Exchange:  testExchanges[0].Name,
@@ -122,16 +122,18 @@ func tradeSQLTester(t *testing.T) {
 			Amount:    float64(i * (i + 2)),
 			Side:      order.Buy.String(),
 			TID:       strconv.Itoa(i),
-		})
+		}
 	}
 	err := Insert(trades...)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// insert the same trades to test conflict resolution
-	for i := 0; i < 20; i++ {
+
+	trades2 := make([]Data, 20)
+	for i := range 20 {
 		uu, _ := uuid.NewV4()
-		trades2 = append(trades2, Data{
+		trades2[i] = Data{
 			ID:        uu.String(),
 			Timestamp: firstTime.Add(time.Minute * time.Duration(i+1)),
 			Exchange:  testExchanges[0].Name,
@@ -142,7 +144,7 @@ func tradeSQLTester(t *testing.T) {
 			Amount:    float64(i * (i + 2)),
 			Side:      order.Buy.String(),
 			TID:       strconv.Itoa(i),
-		})
+		}
 	}
 	err = Insert(trades2...)
 	if err != nil {

--- a/database/repository/withdraw/withdraw_test.go
+++ b/database/repository/withdraw/withdraw_test.go
@@ -80,8 +80,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			if !testhelpers.CheckValidConfig(&test.config.ConnectionDetails) {
 				t.Skip("database not configured skipping test")

--- a/database/repository/withdraw/withdraw_test.go
+++ b/database/repository/withdraw/withdraw_test.go
@@ -111,7 +111,7 @@ func TestWithdraw(t *testing.T) {
 }
 
 func seedWithdrawData() {
-	for x := 0; x < 20; x++ {
+	for x := range 20 {
 		test := fmt.Sprintf("test-%v", x)
 		resp := &withdraw.Response{
 			Exchange: withdraw.ExchangeResponse{

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -100,7 +100,7 @@ func (d *Dispatcher) start(workers, channelCapacity int) error {
 	d.maxWorkers = workers
 	d.shutdown = make(chan struct{})
 
-	for i := 0; i < d.maxWorkers; i++ {
+	for range d.maxWorkers {
 		d.wg.Add(1)
 		go d.relayer()
 	}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -60,7 +60,7 @@ func TestStartStop(t *testing.T) {
 	assert.NoError(t, err, "subscribe should not error")
 
 	// Max out jobs channel
-	for x := 0; x < 99; x++ {
+	for range 99 {
 		err = d.publish(id, "woah-nelly")
 		assert.NoError(t, err, "publish should not error")
 	}
@@ -172,7 +172,7 @@ func TestPublish(t *testing.T) {
 	d.routes[nonEmptyUUID] = []chan interface{}{
 		make(chan interface{}),
 	}
-	for x := 0; x < 200; x++ {
+	for range 200 {
 		if err = d.publish(nonEmptyUUID, "test"); err != nil {
 			break
 		}
@@ -193,7 +193,7 @@ func TestPublishReceive(t *testing.T) {
 	require.NoError(t, err, "subscribe should not error")
 
 	go func(d *Dispatcher, id uuid.UUID) {
-		for x := 0; x < 10; x++ {
+		for range 10 {
 			err := d.publish(id, "WOW")
 			assert.NoError(t, err, "publish should not error")
 		}
@@ -294,11 +294,11 @@ func TestMuxSubscribe(t *testing.T) {
 	itemID, err := mux.GetID()
 	require.NoError(t, err, "GetID should not error")
 
-	var pipes []Pipe
-	for i := 0; i < 1000; i++ {
+	pipes := make([]Pipe, 1000)
+	for x := range 1000 {
 		newPipe, err := mux.Subscribe(itemID)
 		assert.NoError(t, err, "Subscribe should not error")
-		pipes = append(pipes, newPipe)
+		pipes[x] = newPipe
 	}
 
 	for i := range pipes {
@@ -319,7 +319,7 @@ func TestMuxPublish(t *testing.T) {
 
 	overloadCeiling := DefaultMaxWorkers * DefaultJobsLimit * 2
 
-	for i := 0; i < overloadCeiling; i++ {
+	for range overloadCeiling {
 		err = mux.Publish("test", itemID)
 		if !assert.NoError(t, err, "Publish should not error when over limit but no listeners") {
 			break
@@ -341,7 +341,7 @@ func TestMuxPublish(t *testing.T) {
 
 	go func() {
 		<-ready // Ensure listener is ready before starting
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			errMux := mux.Publish(i, itemID)
 			if !assert.NoError(t, errMux, "Publish should not error within limits") {
 				return
@@ -354,7 +354,7 @@ func TestMuxPublish(t *testing.T) {
 	// demonstrate that jobs can be limited when subscribed
 	// Published data gets consumed from .jobs to the worker channels, so we're looking to push more than it's consumed and prevent the select reading them too quickly
 	runtime.LockOSThread()
-	for i := 0; i < overloadCeiling; i++ {
+	for range overloadCeiling {
 		if err = mux.Publish("test", itemID); err != nil {
 			break
 		}
@@ -365,7 +365,7 @@ func TestMuxPublish(t *testing.T) {
 	err = mux.Unsubscribe(itemID, pipe.c)
 	assert.NoError(t, err, "Unsubscribe should not error")
 
-	for i := 0; i < overloadCeiling; i++ {
+	for range overloadCeiling {
 		if err = mux.Publish("test", itemID); err != nil {
 			break
 		}

--- a/engine/apiserver.go
+++ b/engine/apiserver.go
@@ -591,7 +591,7 @@ func (c *websocketClient) write() {
 
 		// Add queued chat messages to the current websocket message
 		n := len(c.Send)
-		for i := 0; i < n; i++ {
+		for range n {
 			_, err = w.Write(<-c.Send)
 			if err != nil {
 				log.Errorln(log.APIServerMgr, err)

--- a/engine/datahistory_manager.go
+++ b/engine/datahistory_manager.go
@@ -958,7 +958,7 @@ func (m *DataHistoryManager) validateCandles(job *DataHistoryJob, exch exchange.
 	}
 	var validationIssues []string
 	multiplier := int64(1)
-	for i := int64(0); i < job.DecimalPlaceComparison; i++ {
+	for range job.DecimalPlaceComparison {
 		multiplier *= 10
 	}
 	for i := range apiCandles.Candles {

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -1410,7 +1410,7 @@ func TestSaveCandlesInBatches(t *testing.T) {
 		t.Errorf("received %v expected %v", err, nil)
 	}
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		candles.Candles = append(candles.Candles, kline.Candle{
 			Volume: float64(i),
 		})
@@ -1524,17 +1524,17 @@ func dataHistoryTraderLoader(exch, a, base, quote string, start, _ time.Time) ([
 func dataHistoryCandleLoader(exch string, cp currency.Pair, a asset.Item, interval kline.Interval, start, end time.Time) (*kline.Item, error) {
 	start = start.Truncate(interval.Duration())
 	end = end.Truncate(interval.Duration())
-	var candles []kline.Candle
 	intervals := end.Sub(start) / interval.Duration()
-	for i := 0; i < int(intervals); i++ {
-		candles = append(candles, kline.Candle{
+	candles := make([]kline.Candle, int(intervals))
+	for x := range int(intervals) {
+		candles[x] = kline.Candle{
 			Time:   start,
 			Open:   1,
 			High:   10,
 			Low:    1,
 			Close:  4,
 			Volume: 8,
-		})
+		}
 		start = start.Add(interval.Duration())
 	}
 	return &kline.Item{

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -272,7 +272,7 @@ func (s *Settings) PrintLoadedSettings() {
 	gctlog.Debugln(gctlog.Global)
 	gctlog.Debugf(gctlog.Global, "ENGINE SETTINGS")
 	settings := reflect.ValueOf(*s)
-	for x := 0; x < settings.NumField(); x++ {
+	for x := range settings.NumField() {
 		field := settings.Field(x)
 		if field.Kind() != reflect.Struct {
 			continue
@@ -280,7 +280,7 @@ func (s *Settings) PrintLoadedSettings() {
 
 		fieldName := field.Type().Name()
 		gctlog.Debugln(gctlog.Global, "- "+common.AddPaddingOnUpperCase(fieldName)+":")
-		for y := 0; y < field.NumField(); y++ {
+		for y := range field.NumField() {
 			indvSetting := field.Field(y)
 			indvName := field.Type().Field(y).Name
 			if indvSetting.Kind() == reflect.String && indvSetting.IsZero() {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -65,7 +65,6 @@ func TestLoadConfigWithSettings(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare the 'flags'
 			flagSet := make(map[string]bool)

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -216,7 +216,6 @@ func TestSetSubsystem(t *testing.T) { //nolint // TO-DO: Fix race t.Parallel() u
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.Subsystem, func(t *testing.T) {
 			t.Parallel()
 			err := tt.Engine.SetSubsystem(tt.Subsystem, true)

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -52,7 +52,7 @@ func (m *ntpManager) Start() error {
 		// Sometimes the NTP client can have transient issues due to UDP, try
 		// the default retry limits before giving up
 	check:
-		for i := 0; i < m.retryLimit; i++ {
+		for i := range m.retryLimit {
 			err := m.processTime()
 			switch err {
 			case nil:

--- a/engine/rpcserver.go
+++ b/engine/rpcserver.go
@@ -1758,7 +1758,7 @@ func (s *RPCServer) WithdrawCryptocurrencyFunds(ctx context.Context, r *gctrpc.W
 
 	if exchCfg.API.Credentials.PIN != "" {
 		pinCode, errPin := strconv.ParseInt(exchCfg.API.Credentials.PIN, 10, 64)
-		if err != nil {
+		if errPin != nil {
 			return nil, errPin
 		}
 		req.PIN = pinCode
@@ -1815,12 +1815,12 @@ func (s *RPCServer) WithdrawFiatFunds(ctx context.Context, r *gctrpc.WithdrawFia
 
 	if exchCfg.API.Credentials.OTPSecret != "" {
 		code, errOTP := totp.GenerateCode(exchCfg.API.Credentials.OTPSecret, time.Now())
-		if err != nil {
+		if errOTP != nil {
 			return nil, errOTP
 		}
 
 		codeNum, errOTP := strconv.ParseInt(code, 10, 64)
-		if err != nil {
+		if errOTP != nil {
 			return nil, errOTP
 		}
 		req.OneTimePassword = codeNum
@@ -1828,7 +1828,7 @@ func (s *RPCServer) WithdrawFiatFunds(ctx context.Context, r *gctrpc.WithdrawFia
 
 	if exchCfg.API.Credentials.PIN != "" {
 		pinCode, errPIN := strconv.ParseInt(exchCfg.API.Credentials.PIN, 10, 64)
-		if err != nil {
+		if errPIN != nil {
 			return nil, errPIN
 		}
 		req.PIN = pinCode
@@ -4938,7 +4938,7 @@ func (s *RPCServer) GetCollateral(ctx context.Context, r *gctrpc.GetCollateralRe
 			}
 			tick, err = exch.FetchTicker(ctx, tickerCurr, asset.Spot)
 			if err != nil {
-				log.Errorf(log.GRPCSys, fmt.Sprintf("GetCollateral offline calculation error via FetchTicker %s %s", exch.GetName(), err))
+				log.Errorf(log.GRPCSys, "GetCollateral offline calculation error via FetchTicker %s %s", exch.GetName(), err)
 				continue
 			}
 			if tick.Last == 0 {

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -241,7 +241,7 @@ func (f fExchange) GetHistoricCandles(_ context.Context, p currency.Pair, a asse
 
 func generateCandles(amount int, timeStart time.Time, interval kline.Interval) []kline.Candle {
 	candy := make([]kline.Candle, amount)
-	for x := 0; x < amount; x++ {
+	for x := range amount {
 		candy[x] = kline.Candle{
 			Time:   timeStart,
 			Open:   1337,
@@ -1630,8 +1630,8 @@ func TestCheckVars(t *testing.T) {
 func TestParseEvents(t *testing.T) {
 	t.Parallel()
 	var exchangeName = "Binance"
-	var testData []*withdraw.Response
-	for x := 0; x < 5; x++ {
+	testData := make([]*withdraw.Response, 5)
+	for x := range 5 {
 		test := fmt.Sprintf("test-%v", x)
 		resp := &withdraw.Response{
 			ID: withdraw.DryRunID,
@@ -1668,13 +1668,13 @@ func TestParseEvents(t *testing.T) {
 			resp.RequestDetails.Crypto.FeeAmount = 0
 			resp.RequestDetails.Crypto.AddressTag = test
 		}
-		testData = append(testData, resp)
+		testData[x] = resp
 	}
 	v := parseMultipleEvents(testData)
 	if reflect.TypeOf(v).String() != "*gctrpc.WithdrawalEventsByExchangeResponse" {
 		t.Fatal("expected type to be *gctrpc.WithdrawalEventsByExchangeResponse")
 	}
-	if testData == nil || len(testData) < 2 {
+	if len(testData) < 2 {
 		t.Fatal("expected at least 2")
 	}
 

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -4214,7 +4214,6 @@ func TestStartRPCRESTProxy(t *testing.T) {
 		{"Invalid username but valid password", "bonk", "Sup3rdup3rS3cr3t"},
 		{"Invalid username and password despite glorious credentials", "bonk", "wif"},
 	} {
-		creds := creds
 		t.Run(creds.testDescription, func(t *testing.T) {
 			t.Parallel()
 
@@ -4259,7 +4258,7 @@ func TestRPCProxyAuthClient(t *testing.T) {
 	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("MEOW"))
-		require.NoError(t, err, "Write should not error")
+		assert.NoError(t, err, "Write should not error")
 	})
 
 	handler := s.authClient(dummyHandler)
@@ -4274,7 +4273,6 @@ func TestRPCProxyAuthClient(t *testing.T) {
 		{"Invalid username but valid password", "bonk", "Sup3rdup3rS3cr3t"},
 		{"Invalid username and password despite glorious credentials", "bonk", "wif"},
 	} {
-		creds := creds
 		t.Run(creds.testDescription, func(t *testing.T) {
 			t.Parallel()
 

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -229,7 +229,7 @@ func (m *SyncManager) Start() error {
 		return nil
 	}
 
-	for i := 0; i < m.config.NumWorkers; i++ {
+	for range m.config.NumWorkers {
 		go m.worker()
 	}
 	m.initSyncWG.Done()

--- a/exchanges/account/account_test.go
+++ b/exchanges/account/account_test.go
@@ -211,7 +211,7 @@ func TestGetHoldings(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func(p dispatch.Pipe, wg *sync.WaitGroup) {
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			c := time.NewTimer(time.Second)
 			select {
 			case <-p.Channel():

--- a/exchanges/alert/alert_test.go
+++ b/exchanges/alert/alert_test.go
@@ -14,7 +14,7 @@ func TestWait(t *testing.T) {
 
 	// standard alert
 	wg.Add(100)
-	for x := 0; x < 100; x++ {
+	for range 100 {
 		go func() {
 			w := wait.Wait(nil)
 			wg.Done()
@@ -35,7 +35,7 @@ func TestWait(t *testing.T) {
 	// use kick
 	ch := make(chan struct{})
 	wg.Add(100)
-	for x := 0; x < 100; x++ {
+	for range 100 {
 		go func() {
 			w := wait.Wait(ch)
 			wg.Done()
@@ -55,7 +55,7 @@ func TestWait(t *testing.T) {
 
 	// late receivers
 	wg.Add(100)
-	for x := 0; x < 100; x++ {
+	for x := range 100 {
 		go func(x int) {
 			bb := wait.Wait(ch)
 			wg.Done()

--- a/exchanges/asset/asset_test.go
+++ b/exchanges/asset/asset_test.go
@@ -100,8 +100,7 @@ func TestNew(t *testing.T) {
 		{Input: "option_combo", Expected: OptionCombo},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			returned, err := New(tt.Input)

--- a/exchanges/asset/asset_test.go
+++ b/exchanges/asset/asset_test.go
@@ -120,7 +120,7 @@ func TestSupported(t *testing.T) {
 	if len(supportedList) != len(s) {
 		t.Fatal("TestSupported mismatched lengths")
 	}
-	for i := 0; i < len(supportedList); i++ {
+	for i := range supportedList {
 		if s[i] != supportedList[i] {
 			t.Fatal("TestSupported returned an unexpected result")
 		}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1970,7 +1970,7 @@ func BenchmarkWsHandleData(bb *testing.B) {
 		}
 	}()
 	bb.ResetTimer()
-	for i := 0; i < bb.N; i++ {
+	for range bb.N {
 		for x := range lines {
 			assert.NoError(bb, b.wsHandleData(lines[x]))
 		}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1546,7 +1546,6 @@ func TestGetAggregatedTradesBatched(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.mock != mockTests {
@@ -1602,7 +1601,6 @@ func TestGetAggregatedTradesErrors(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := b.GetAggregatedTrades(context.Background(), tt.args)
@@ -2730,8 +2728,7 @@ func TestFormatSymbol(t *testing.T) {
 			expectedString: "BTCUSDT_211231",
 		},
 	}
-	for i := range testerinos {
-		tt := testerinos[i]
+	for _, tt := range testerinos {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := b.FormatSymbol(tt.pair, tt.asset)

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -563,7 +563,7 @@ var WithdrawalFees = map[currency.Code]float64{
 	currency.LLT:     67.8,
 	currency.YOYO:    1,
 	currency.TRX:     1,
-	currency.STRAT:   0.1,
+	currency.STRAT:   0.1, //nolint:misspell // Not a misspelling
 	currency.SNGLS:   54,
 	currency.BQX:     3.9,
 	currency.KNC:     3.5,

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -120,7 +120,7 @@ func (b *Binance) setupOrderbookManager() {
 		}
 	}
 
-	for i := 0; i < maxWSOrderbookWorkers; i++ {
+	for range maxWSOrderbookWorkers {
 		// 10 workers for synchronising book
 		b.SynchroniseWebsocketOrderbook()
 	}

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -141,8 +141,7 @@ func (b *Binance) KeepAuthKeyAlive() {
 			err := b.MaintainWsAuthStreamKey(context.TODO())
 			if err != nil {
 				b.Websocket.DataHandler <- err
-				log.Warnf(log.ExchangeSys,
-					b.Name+" - Unable to renew auth websocket token, may experience shutdown")
+				log.Warnf(log.ExchangeSys, "%s - Unable to renew auth websocket token, may experience shutdown", b.Name)
 			}
 		}
 	}

--- a/exchanges/binance/ratelimit_test.go
+++ b/exchanges/binance/ratelimit_test.go
@@ -36,7 +36,6 @@ func TestRateLimit_Limit(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, tt := range testTable {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -72,7 +71,6 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, tt := range testTable {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/exchanges/binanceus/binanceus_websocket.go
+++ b/exchanges/binanceus/binanceus_websocket.go
@@ -117,8 +117,7 @@ func (bi *Binanceus) KeepAuthKeyAlive() {
 			err := bi.MaintainWsAuthStreamKey(context.TODO())
 			if err != nil {
 				bi.Websocket.DataHandler <- err
-				log.Warnf(log.ExchangeSys,
-					bi.Name+" - Unable to renew auth websocket token, may experience shutdown")
+				log.Warnf(log.ExchangeSys, "%s - Unable to renew auth websocket token, may experience shutdown", bi.Name)
 			}
 		}
 	}

--- a/exchanges/binanceus/binanceus_websocket.go
+++ b/exchanges/binanceus/binanceus_websocket.go
@@ -634,7 +634,7 @@ func (bi *Binanceus) setupOrderbookManager() {
 			}
 		}
 	}
-	for i := 0; i < maxWSOrderbookWorkers; i++ {
+	for range maxWSOrderbookWorkers {
 		// 10 workers for synchronising book
 		bi.SynchroniseWebsocketOrderbook()
 	}

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1690,7 +1690,7 @@ func (b *Bitfinex) CancelMultipleOrdersV2(ctx context.Context, orderID, clientOr
 					cancelledOrder.AuxLimitPrice = f
 				}
 			}
-			cancelledOrders[y] = cancelledOrder
+			cancelledOrders = append(cancelledOrders, cancelledOrder)
 		}
 	}
 	return cancelledOrders, nil

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -37,7 +37,6 @@ const (
 )
 
 var b *Bitfinex
-var wsConnected bool
 var btcusdPair = currency.NewPair(currency.BTC, currency.USD)
 
 func TestMain(m *testing.M) {

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -2145,7 +2145,7 @@ func validateCRC32(book *orderbook.Base, token int) error {
 
 	// RO precision calculation is based on order ID's and amount values
 	var bids, asks []orderbook.Tranche
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		if i < len(book.Bids) {
 			bids = append(bids, book.Bids[i])
 		}
@@ -2167,7 +2167,7 @@ func validateCRC32(book *orderbook.Base, token int) error {
 	}
 
 	var check strings.Builder
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		if i < len(bids) {
 			check.WriteString(strconv.FormatInt(bids[i].ID, 10))
 			check.WriteString(":")

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -708,14 +708,8 @@ func (b *Bithumb) FetchExchangeLimits(ctx context.Context) ([]order.MinMaxLevel,
 
 	limits := make([]order.MinMaxLevel, 0, len(ticks))
 	for code, data := range ticks {
-		c := currency.NewCode(code)
-		cp := currency.NewPair(c, currency.KRW)
-		if err != nil {
-			return nil, err
-		}
-
 		limits = append(limits, order.MinMaxLevel{
-			Pair:              cp,
+			Pair:              currency.NewPair(currency.NewCode(code), currency.KRW),
 			Asset:             asset.Spot,
 			MinimumBaseAmount: getAmountMinimum(data.ClosingPrice),
 		})

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -643,8 +643,7 @@ func TestGetAmountMinimum(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tt := &testCases[i]
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			minAmount := getAmountMinimum(tt.unitprice)

--- a/exchanges/bithumb/bithumb_types.go
+++ b/exchanges/bithumb/bithumb_types.go
@@ -262,7 +262,7 @@ var WithdrawalFees = map[currency.Code]float64{
 	currency.LRC:   10,
 	currency.GTO:   15,
 	currency.STEEM: 0.01,
-	currency.STRAT: 0.2,
+	currency.STRAT: 0.2, //nolint:misspell // Not a misspelling
 	currency.PPT:   0.5,
 	currency.CTXC:  4,
 	currency.CMT:   20,

--- a/exchanges/bithumb/bithumb_ws_orderbook.go
+++ b/exchanges/bithumb/bithumb_ws_orderbook.go
@@ -195,7 +195,7 @@ func (b *Bithumb) setupOrderbookManager() {
 		}
 	}
 
-	for i := 0; i < maxWSOrderbookWorkers; i++ {
+	for range maxWSOrderbookWorkers {
 		// 10 workers for synchronising book
 		b.SynchroniseWebsocketOrderbook()
 	}

--- a/exchanges/bitmex/bitmex_parameters.go
+++ b/exchanges/bitmex/bitmex_parameters.go
@@ -29,7 +29,7 @@ func StructValsToURLVals(v interface{}) (url.Values, error) {
 	structVal := reflect.ValueOf(v).Elem()
 	structType := structVal.Type()
 
-	for i := 0; i < structVal.NumField(); i++ {
+	for i := range structVal.NumField() {
 		structField := structVal.Field(i)
 
 		var outgoingTag string

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -160,7 +160,7 @@ func TestGetAccountTradingFees(t *testing.T) {
 
 	fees, err := b.GetAccountTradingFees(context.Background())
 	require.NoError(t, err, "GetAccountTradingFee must not error")
-	if assert.Positive(t, len(fees), "Should get back multiple fees") {
+	if assert.NotEmpty(t, fees, "Should get back multiple fees") {
 		fee := fees[0]
 		assert.NotEmpty(t, fee.Symbol, "Should get back a symbol")
 		if mockTests {

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -878,8 +878,7 @@ func TestTrim(t *testing.T) {
 		{Value: 1.01, Expected: "101"},
 	}
 
-	for x := range testCases {
-		tt := testCases[x]
+	for _, tt := range testCases {
 		t.Run("", func(t *testing.T) {
 			received := trim(tt.Value)
 			if received != tt.Expected {

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -464,7 +464,7 @@ func concat(liquidity orderbook.Tranches) string {
 		length = len(liquidity)
 	}
 	var c string
-	for x := 0; x < length; x++ {
+	for x := range length {
 		c += trim(liquidity[x].Price) + trim(liquidity[x].Amount)
 	}
 	return c

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -3661,15 +3660,15 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 
 	is, err = b.IsPerpetualFutureCurrency(asset.CoinMarginedFutures, inverseTradablePair)
 	assert.NoError(t, err)
-	assert.True(t, is, fmt.Sprintf("%s %s should be a perp", asset.CoinMarginedFutures, inverseTradablePair))
+	assert.Truef(t, is, "%s %s should be a perp", asset.CoinMarginedFutures, inverseTradablePair)
 
 	is, err = b.IsPerpetualFutureCurrency(asset.USDTMarginedFutures, usdtMarginedTradablePair)
 	assert.NoError(t, err)
-	assert.True(t, is, fmt.Sprintf("%s %s should be a perp", asset.USDTMarginedFutures, usdtMarginedTradablePair))
+	assert.Truef(t, is, "%s %s should be a perp", asset.USDTMarginedFutures, usdtMarginedTradablePair)
 
 	is, err = b.IsPerpetualFutureCurrency(asset.USDCMarginedFutures, usdcMarginedTradablePair)
 	assert.NoError(t, err)
-	assert.True(t, is, fmt.Sprintf("%s %s should be a perp", asset.USDCMarginedFutures, usdcMarginedTradablePair))
+	assert.Truef(t, is, "%s %s should be a perp", asset.USDCMarginedFutures, usdcMarginedTradablePair)
 }
 
 func TestGetCurrencyTradeURL(t *testing.T) {

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -638,7 +638,7 @@ func TestCurrencyMapInstrumentIDs(t *testing.T) {
 
 func TestGetNonce(t *testing.T) {
 	result := getNonce()
-	for x := 0; x < 100000; x++ {
+	for range 100000 {
 		if result <= 0 || result > coinutMaxNonce {
 			t.Fatal("invalid nonce value")
 		}

--- a/exchanges/credentials_test.go
+++ b/exchanges/credentials_test.go
@@ -207,7 +207,6 @@ func TestVerifyAPICredentials(t *testing.T) {
 	}
 
 	for x, tc := range testCases {
-		x, tc := x, tc
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			b := setupBase(&tc)
@@ -307,7 +306,6 @@ func TestCheckCredentials(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if err := tc.base.CheckCredentials(&tc.base.API.credentials, false); !errors.Is(err, tc.expectedErr) {

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -1299,7 +1299,7 @@ func (e *Endpoints) SetRunning(key, val string) error {
 			key,
 			val,
 			e.Exchange)
-		return nil //nolint:nilerr // non-fatal error as we won't update the running URL
+		return nil
 	}
 	e.defaults[key] = val
 	return nil

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -917,7 +917,7 @@ func (b *Base) SupportsWithdrawPermissions(permissions uint32) bool {
 // FormatWithdrawPermissions will return each of the exchange's compatible withdrawal methods in readable form
 func (b *Base) FormatWithdrawPermissions() string {
 	var services []string
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		var check uint32 = 1 << uint32(i)
 		if b.GetWithdrawPermissions()&check != 0 {
 			switch check {

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -1970,7 +1970,6 @@ func TestGetGetURLTypeFromString(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.Endpoint, func(t *testing.T) {
 			t.Parallel()
 			u, err := getURLTypeFromString(tt.Endpoint)

--- a/exchanges/futures/futures.go
+++ b/exchanges/futures/futures.go
@@ -781,9 +781,6 @@ func (p *PositionTracker) TrackNewOrder(d *order.Detail, isInitialOrder bool) er
 		// adding a new position to something that is already closed
 		return fmt.Errorf("%w cannot process new order %v", ErrPositionClosed, d.OrderID)
 	}
-	if d == nil {
-		return order.ErrSubmissionIsNil
-	}
 	if !p.contractPair.Equal(d.Pair) {
 		return fmt.Errorf("%w pair '%v' received: '%v'",
 			errOrderNotEqualToTracker, d.Pair, p.contractPair)

--- a/exchanges/futures/futures_test.go
+++ b/exchanges/futures/futures_test.go
@@ -766,7 +766,6 @@ func TestCalculateRealisedPNL(t *testing.T) {
 
 func TestSetupPositionTracker(t *testing.T) {
 	t.Parallel()
-	m := &MultiPositionTracker{}
 	p, err := SetupPositionTracker(nil)
 	if !errors.Is(err, errNilSetup) {
 		t.Errorf("received '%v' expected '%v", err, errNilSetup)
@@ -774,7 +773,6 @@ func TestSetupPositionTracker(t *testing.T) {
 	if p != nil {
 		t.Error("expected nil")
 	}
-	m.exchange = testExchange
 	p, err = SetupPositionTracker(&PositionTrackerSetup{
 		Asset: asset.Spot,
 	})
@@ -832,7 +830,6 @@ func TestSetupPositionTracker(t *testing.T) {
 	if !errors.Is(err, ErrNilPNLCalculator) {
 		t.Errorf("received '%v' expected '%v", err, ErrNilPNLCalculator)
 	}
-	m.exchangePNLCalculation = &PNLCalculator{}
 	p, err = SetupPositionTracker(&PositionTrackerSetup{
 		Exchange:                  testExchange,
 		Asset:                     asset.Futures,

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -712,7 +712,7 @@ func (g *Gateio) CancelBatchOrdersWithIDList(ctx context.Context, args []CancelO
 	} else if len(args) > 20 {
 		return nil, fmt.Errorf("%w maximum order size to cancel is 20", errInvalidOrderSize)
 	}
-	for x := 0; x < len(args); x++ {
+	for x := range args {
 		if args[x].CurrencyPair.IsEmpty() || args[x].ID == "" {
 			return nil, errors.New("currency pair and order ID are required")
 		}

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -3569,7 +3569,6 @@ func TestProcessFuturesOrdersPushData(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			processed, err := g.processFuturesOrdersPushData([]byte(tc.incoming), asset.Futures)

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -1252,7 +1252,7 @@ func (g *Gateio) CancelBatchOrders(ctx context.Context, o []order.Cancel) (*orde
 	switch a {
 	case asset.Spot, asset.Margin, asset.CrossMargin:
 		loop := int(math.Ceil(float64(len(cancelSpotOrdersParam)) / 10))
-		for count := 0; count < loop; count++ {
+		for count := range loop {
 			var input []CancelOrderByIDParam
 			if (count + 1) == loop {
 				input = cancelSpotOrdersParam[count*10:]

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -96,16 +96,16 @@ func TestCreateKline(t *testing.T) {
 	}
 
 	tradeTotal := 24000
-	var trades []order.TradeHistory
+	trades := make([]order.TradeHistory, tradeTotal)
 	execution := time.Now()
-	for i := 0; i < tradeTotal; i++ {
+	for x := range tradeTotal {
 		price, rndTime := 1000+float64(rand.Intn(1000)), rand.Intn(10) //nolint:gosec // no need to import crypo/rand for testing
 		execution = execution.Add(time.Duration(rndTime) * time.Second)
-		trades = append(trades, order.TradeHistory{
+		trades[x] = order.TradeHistory{
 			Timestamp: execution,
 			Amount:    1, // Keep as one for counting
 			Price:     price,
-		})
+		}
 	}
 
 	_, err = CreateKline(trades, 0, pair, asset.Spot, "Binance")
@@ -483,7 +483,7 @@ func TestItem_SortCandlesByTimestamp(t *testing.T) {
 		Interval: OneDay,
 	}
 
-	for x := 0; x < 100; x++ {
+	for x := range 100 {
 		y := rand.Float64() //nolint:gosec // used for generating test data, no need to import crypo/rand
 		tempKline.Candles = append(tempKline.Candles,
 			Candle{
@@ -709,7 +709,7 @@ func genOHCLVData() (out candle.Item, outItem Item, err error) {
 	out.Asset = "spot"
 
 	start := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-	for x := 0; x < 365; x++ {
+	for x := range 365 {
 		out.Candles = append(out.Candles, candle.Candle{
 			Timestamp: start.Add(time.Hour * 24 * time.Duration(x)),
 			Open:      1000,
@@ -725,7 +725,7 @@ func genOHCLVData() (out candle.Item, outItem Item, err error) {
 	outItem.Pair = currency.NewPair(currency.BTC, currency.USDT)
 	outItem.Exchange = testExchanges[0].Name
 
-	for x := 0; x < 365; x++ {
+	for x := range 365 {
 		outItem.Candles = append(outItem.Candles, Candle{
 			Time:   start.Add(time.Hour * 24 * time.Duration(x)),
 			Open:   1000,

--- a/exchanges/kline/request_test.go
+++ b/exchanges/kline/request_test.go
@@ -154,7 +154,7 @@ func getOneMinute() []Candle {
 var oneMinuteCandles = func() []Candle {
 	var candles []Candle
 	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	for x := 0; x < 1442; x++ { // two extra candles.
+	for x := range 1442 { // two extra candles.
 		candles = append(candles, Candle{
 			Time:   start,
 			Volume: 1,
@@ -179,7 +179,7 @@ func getOneHour() []Candle {
 var oneHourCandles = func() []Candle {
 	var candles []Candle
 	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	for x := 0; x < 24; x++ {
+	for x := range 24 {
 		candles = append(candles, Candle{
 			Time:   start,
 			Volume: 1,

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -2293,7 +2293,7 @@ func curryWsMockUpgrader(tb testing.TB, h testexch.WsMockFunc) http.HandlerFunc 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "GetWebSocketsToken") {
 			_, err := w.Write([]byte(`{"result":{"token":"mockAuth"}}`))
-			require.NoError(tb, err, "Write should not error")
+			assert.NoError(tb, err, "Write should not error")
 			return
 		}
 		testexch.WsMockUpgrader(tb, w, r, h)

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -1060,7 +1060,7 @@ func (ku *Kucoin) setupOrderbookManager() {
 		}
 		ku.obm.Mutex.Unlock()
 	}
-	for i := 0; i < maxWSOrderbookWorkers; i++ {
+	for range maxWSOrderbookWorkers {
 		// 10 workers for synchronising book
 		ku.SynchroniseWebsocketOrderbook()
 	}

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -1564,14 +1564,14 @@ func (ku *Kucoin) CalculateAssets(topic string, cp currency.Pair) ([]asset.Item,
 	default:
 		resp := make([]asset.Item, 0, 2)
 		spotEnabled, err := ku.IsPairEnabled(cp, asset.Spot)
-		if err != nil && !errors.Is(currency.ErrCurrencyNotFound, err) {
+		if err != nil && !errors.Is(err, currency.ErrCurrencyNotFound) {
 			return nil, err
 		}
 		if spotEnabled {
 			resp = append(resp, asset.Spot)
 		}
 		marginEnabled, err := ku.IsPairEnabled(cp, asset.Margin)
-		if err != nil && !errors.Is(currency.ErrCurrencyNotFound, err) {
+		if err != nil && !errors.Is(err, currency.ErrCurrencyNotFound) {
 			return nil, err
 		}
 		if marginEnabled {

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -573,7 +573,6 @@ func TestGetStatus(t *testing.T) {
 		{status: 4, resp: order.Cancelling},
 		{status: 5, resp: order.UnknownStatus},
 	} {
-		tt := tt
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			resp := l.GetStatus(tt.status)

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -686,7 +686,7 @@ func (l *Lbank) GetActiveOrders(ctx context.Context, getOrdersRequest *order.Mul
 			if err != nil {
 				resp.Fee = lbankFeeNotFound
 			}
-			for y := 0; y < len(getOrdersRequest.Pairs); y++ {
+			for y := range getOrdersRequest.Pairs {
 				if getOrdersRequest.Pairs[y].String() != key {
 					continue
 				}
@@ -742,7 +742,7 @@ func (l *Lbank) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mul
 			if err != nil {
 				return finalResp, err
 			}
-			for x := 0; x < len(tempResp.Orders); x++ {
+			for x := range tempResp.Orders {
 				resp.Exchange = l.Name
 				resp.Pair, err = currency.NewPairFromString(tempResp.Orders[x].Symbol)
 				if err != nil {
@@ -843,9 +843,8 @@ func (l *Lbank) getAllOpenOrderID(ctx context.Context) (map[string][]string, err
 				return resp, nil
 			}
 
-			for c := 0; c < tempData; c++ {
-				resp[fPair.String()] = append(resp[fPair.String()],
-					tempResp.Orders[c].OrderID)
+			for c := range tempData {
+				resp[fPair.String()] = append(resp[fPair.String()], tempResp.Orders[c].OrderID)
 			}
 			tempData = len(tempResp.Orders)
 			b++

--- a/exchanges/okcoin/okcoin_websocket.go
+++ b/exchanges/okcoin/okcoin_websocket.go
@@ -714,7 +714,7 @@ func (o *Okcoin) AppendWsOrderbookItems(entries [][2]types.Number) ([]orderbook.
 func (o *Okcoin) CalculateChecksum(orderbookData *WebsocketOrderBook) (int32, error) {
 	orderbookData.prepareOrderbook()
 	var checksum strings.Builder
-	for i := 0; i < allowableIterations; i++ {
+	for i := range allowableIterations {
 		if len(orderbookData.Bids)-1 >= i {
 			bidPrice := orderbookData.Bids[i][0]
 			bidAmount := orderbookData.Bids[i][1]
@@ -739,7 +739,7 @@ func (o *Okcoin) CalculateChecksum(orderbookData *WebsocketOrderBook) (int32, er
 // CalculateOrderbookUpdateChecksum calculated the orderbook update checksum using currency pair full snapshot.
 func (o *Okcoin) CalculateOrderbookUpdateChecksum(orderbookData *orderbook.Base) int32 {
 	var checksum strings.Builder
-	for i := 0; i < allowableIterations; i++ {
+	for i := range allowableIterations {
 		if len(orderbookData.Bids)-1 >= i {
 			bidPrice := strconv.FormatFloat(orderbookData.Bids[i].Price, 'f', -1, 64)
 			bidAmount := strconv.FormatFloat(orderbookData.Bids[i].Amount, 'f', -1, 64)

--- a/exchanges/okcoin/okcoin_websocket.go
+++ b/exchanges/okcoin/okcoin_websocket.go
@@ -219,7 +219,7 @@ func (o *Okcoin) WsHandleData(respRaw []byte) error {
 				if resp.Data[x].RescheduleDescription != "" {
 					systemStatus = fmt.Sprintf("%s Rescheduled Description: %s", systemStatus, resp.Data[x].RescheduleDescription)
 				}
-				log.Warnf(log.ExchangeSys, systemStatus)
+				log.Warnln(log.ExchangeSys, systemStatus)
 			}
 			o.Websocket.DataHandler <- resp
 			return nil
@@ -258,8 +258,7 @@ func (o *Okcoin) WsHandleData(respRaw []byte) error {
 			o.Websocket.DataHandler <- eventResponse
 		case "error":
 			if o.Verbose {
-				log.Debugf(log.ExchangeSys,
-					o.Name+" - "+eventResponse.Event+" on channel: "+eventResponse.Channel)
+				log.Debugf(log.ExchangeSys, "%s - %s on channel: %s\n", o.Name, eventResponse.Event, eventResponse.Channel)
 			}
 		}
 	}
@@ -860,8 +859,8 @@ func (o *Okcoin) Unsubscribe(channelsToUnsubscribe subscription.List) error {
 func (o *Okcoin) manageSubscriptions(operation string, subs subscription.List) error {
 	subscriptionRequest := WebsocketEventRequest{Operation: operation, Arguments: []map[string]string{}}
 	authRequest := WebsocketEventRequest{Operation: operation, Arguments: []map[string]string{}}
-	temp := WebsocketEventRequest{Operation: operation, Arguments: []map[string]string{}}
-	authTemp := WebsocketEventRequest{Operation: operation, Arguments: []map[string]string{}}
+	temp := WebsocketEventRequest{Arguments: []map[string]string{}}
+	authTemp := WebsocketEventRequest{Arguments: []map[string]string{}}
 	var err error
 	var channels subscription.List
 	var authChannels subscription.List

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -999,7 +999,7 @@ allTrades:
 		if len(trades) == 0 {
 			break
 		}
-		for i := 0; i < len(trades); i++ {
+		for i := range trades {
 			if start.Equal(trades[i].Timestamp.Time()) ||
 				trades[i].Timestamp.Time().Before(start) ||
 				tradeIDEnd == trades[len(trades)-1].TradeID {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3193,8 +3193,7 @@ func TestGetIntervalEnum(t *testing.T) {
 		{Description: "Unsupported interval with UTC", Expected: "", AppendUTC: true},
 	}
 
-	for x := range tests {
-		tt := tests[x]
+	for _, tt := range tests {
 		t.Run(tt.Description, func(t *testing.T) {
 			t.Parallel()
 

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -957,7 +957,7 @@ func (ok *Okx) AppendWsOrderbookItems(entries [][4]string) ([]orderbook.Tranche,
 // eg Bid:Ask:Bid:Ask:Ask:Ask
 func (ok *Okx) CalculateUpdateOrderbookChecksum(orderbookData *orderbook.Base, checksumVal uint32) error {
 	var checksum strings.Builder
-	for i := 0; i < allowableIterations; i++ {
+	for i := range allowableIterations {
 		if len(orderbookData.Bids)-1 >= i {
 			price := strconv.FormatFloat(orderbookData.Bids[i].Price, 'f', -1, 64)
 			amount := strconv.FormatFloat(orderbookData.Bids[i].Amount, 'f', -1, 64)
@@ -979,7 +979,7 @@ func (ok *Okx) CalculateUpdateOrderbookChecksum(orderbookData *orderbook.Base, c
 // CalculateOrderbookChecksum alternates over the first 25 bid and ask entries from websocket data.
 func (ok *Okx) CalculateOrderbookChecksum(orderbookData WsOrderBookData) (int32, error) {
 	var checksum strings.Builder
-	for i := 0; i < allowableIterations; i++ {
+	for i := range allowableIterations {
 		if len(orderbookData.Bids)-1 >= i {
 			bidPrice := orderbookData.Bids[i][0]
 			bidAmount := orderbookData.Bids[i][1]

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -685,7 +685,7 @@ allTrades:
 		if len(trades) == 0 {
 			break
 		}
-		for i := 0; i < len(trades); i++ {
+		for i := range trades {
 			if timestampStart.Equal(trades[i].Timestamp.Time()) ||
 				trades[i].Timestamp.Time().Before(timestampStart) ||
 				tradeIDEnd == trades[len(trades)-1].TradeID {
@@ -990,7 +990,7 @@ ordersLoop:
 	}
 	remaining := cancelAllOrdersRequestParams
 	loop := int(math.Ceil(float64(len(remaining)) / 20.0))
-	for b := 0; b < loop; b++ {
+	for range loop {
 		var response []OrderData
 		if len(remaining) > 20 {
 			if ok.Websocket.CanUseAuthenticatedWebsocketForWrapper() {

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -1575,8 +1575,6 @@ func TestMatchFilter(t *testing.T) {
 	}
 	// specific tests
 	for num, tt := range tests {
-		num := num
-		tt := tt
 		t.Run(strconv.Itoa(num), func(t *testing.T) {
 			t.Parallel()
 			if tt.o.MatchFilter(tt.f) != tt.expectedResult {
@@ -1750,8 +1748,6 @@ func TestIsOrderPlaced(t *testing.T) {
 	}
 	// specific tests
 	for num, tt := range statusTests {
-		num := num
-		tt := tt
 		t.Run(fmt.Sprintf("TEST CASE: %d", num), func(t *testing.T) {
 			t.Parallel()
 			if tt.o.WasOrderPlaced() != tt.expectedResult {

--- a/exchanges/orderbook/calculator.go
+++ b/exchanges/orderbook/calculator.go
@@ -41,30 +41,30 @@ func (b *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error
 	}
 
 	var status string
-	var percent, min, max, amount float64
+	var percent, minPrice, maxPrice, amount float64
 	if buy {
-		min = action.ReferencePrice
-		max = action.TranchePositionPrice
+		minPrice = action.ReferencePrice
+		maxPrice = action.TranchePositionPrice
 		amount = action.QuoteAmount
 		percent = math.CalculatePercentageGainOrLoss(action.TranchePositionPrice, action.ReferencePrice)
 		status = fmt.Sprintf("Buying using %.2f %s worth of %s will send the price from %v to %v [%.2f%%] and impact %d price tranche(s). %s",
-			amount, b.Pair.Quote, b.Pair.Base, min, max,
+			amount, b.Pair.Quote, b.Pair.Base, minPrice, maxPrice,
 			percent, len(action.Tranches), warning)
 	} else {
-		min = action.TranchePositionPrice
-		max = action.ReferencePrice
+		minPrice = action.TranchePositionPrice
+		maxPrice = action.ReferencePrice
 		amount = action.BaseAmount
 		percent = math.CalculatePercentageGainOrLoss(action.TranchePositionPrice, action.ReferencePrice)
 		status = fmt.Sprintf("Selling using %.2f %s worth of %s will send the price from %v to %v [%.2f%%] and impact %d price tranche(s). %s",
-			amount, b.Pair.Base, b.Pair.Quote, max, min,
+			amount, b.Pair.Base, b.Pair.Quote, maxPrice, minPrice,
 			percent, len(action.Tranches), warning)
 	}
 
 	return &WhaleBombResult{
 		Amount:               amount,
 		Orders:               action.Tranches,
-		MinimumPrice:         min,
-		MaximumPrice:         max,
+		MinimumPrice:         minPrice,
+		MaximumPrice:         maxPrice,
 		Status:               status,
 		PercentageGainOrLoss: percent,
 	}, err

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -718,7 +718,6 @@ func TestMovementMethods(t *testing.T) {
 	}
 
 	for _, tt := range movementTests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -87,7 +87,7 @@ func TestRetrieve(t *testing.T) {
 	// If we add anymore options to the options struct later this will complain
 	// generally want to return a full carbon copy
 	mirrored := reflect.Indirect(reflect.ValueOf(d.options))
-	for n := 0; n < mirrored.NumField(); n++ {
+	for n := range mirrored.NumField() {
 		structVal := mirrored.Field(n)
 		assert.Falsef(t, structVal.IsZero(), "struct field '%s' not tested", mirrored.Type().Field(n).Name)
 	}
@@ -737,7 +737,7 @@ func TestMovementMethods(t *testing.T) {
 				assert.NoErrorf(t, err, "sub test %d should not error", i)
 				meta := reflect.Indirect(reflect.ValueOf(move))
 				metaExpect := reflect.Indirect(reflect.ValueOf(subT.expect))
-				for j := 0; j < metaExpect.NumField(); j++ {
+				for j := range metaExpect.NumField() {
 					field := meta.Field(j)
 					expect := metaExpect.Field(j)
 					if field.CanFloat() && !expect.IsZero() {

--- a/exchanges/orderbook/orderbook_test.go
+++ b/exchanges/orderbook/orderbook_test.go
@@ -508,7 +508,7 @@ func TestProcessOrderbook(t *testing.T) {
 
 	var catastrophicFailure bool
 
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		m.Lock()
 		if catastrophicFailure {
 			m.Unlock()
@@ -580,9 +580,9 @@ func TestProcessOrderbook(t *testing.T) {
 }
 
 func deployUnorderedSlice() Tranches {
-	var ts []Tranche
-	for i := 0; i < 1000; i++ {
-		ts = append(ts, Tranche{Amount: 1, Price: rand.Float64(), ID: rand.Int63()}) //nolint:gosec // Not needed in tests
+	ts := make([]Tranche, 1000)
+	for x := range 1000 {
+		ts[x] = Tranche{Amount: 1, Price: rand.Float64(), ID: rand.Int63()} //nolint:gosec // Not needed in tests
 	}
 	return ts
 }
@@ -617,9 +617,9 @@ func TestSorting(t *testing.T) {
 }
 
 func deploySliceOrdered() Tranches {
-	var ts []Tranche
-	for i := 0; i < 1000; i++ {
-		ts = append(ts, Tranche{Amount: 1, Price: float64(i + 1), ID: rand.Int63()}) //nolint:gosec // Not needed in tests
+	ts := make([]Tranche, 1000)
+	for i := range 1000 {
+		ts[i] = Tranche{Amount: 1, Price: float64(i + 1), ID: rand.Int63()} //nolint:gosec // Not needed in tests
 	}
 	return ts
 }

--- a/exchanges/orderbook/tranches_test.go
+++ b/exchanges/orderbook/tranches_test.go
@@ -1252,8 +1252,7 @@ func TestGetMovementByBaseAmount(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
@@ -1387,8 +1386,7 @@ func TestGetBaseAmountFromNominalSlippage(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
@@ -1495,8 +1493,7 @@ func TestGetBaseAmountFromImpact(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
@@ -1581,8 +1578,7 @@ func TestGetMovementByQuoteAmount(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
@@ -1714,8 +1710,7 @@ func TestGetQuoteAmountFromNominalSlippage(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
@@ -1803,8 +1798,7 @@ func TestGetQuoteAmountFromImpact(t *testing.T) {
 		},
 	}
 
-	for x := range cases {
-		tt := cases[x]
+	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -277,7 +277,6 @@ func TestGetOrderStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.mock != mockTests {
@@ -333,7 +332,6 @@ func TestGetOrderTrades(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.mock != mockTests {

--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -445,7 +445,7 @@ var WithdrawalFees = map[currency.Code]float64{
 	currency.SBD:   0.01,
 	currency.XLM:   0.00001,
 	currency.STORJ: 1,
-	currency.STRAT: 0.01,
+	currency.STRAT: 0.01, //nolint:misspell // Not a misspelling
 	currency.AMP:   5,
 	currency.SYS:   0.01,
 	currency.USDT:  10,

--- a/exchanges/request/backoff.go
+++ b/exchanges/request/backoff.go
@@ -10,11 +10,11 @@ func DefaultBackoff() Backoff {
 }
 
 // LinearBackoff applies a backoff increasing by a base amount with each retry capped at a maximum duration.
-func LinearBackoff(base, max time.Duration) Backoff {
+func LinearBackoff(base, maxDuration time.Duration) Backoff {
 	return func(n int) time.Duration {
 		d := base * time.Duration(n)
-		if d > max {
-			return max
+		if d > maxDuration {
+			return maxDuration
 		}
 
 		return d

--- a/exchanges/request/backoff_test.go
+++ b/exchanges/request/backoff_test.go
@@ -65,7 +65,6 @@ func TestLinearBackoff(t *testing.T) {
 	}
 
 	for name, tt := range testTable {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -345,7 +345,7 @@ func TestDoRequest(t *testing.T) {
 	var failed int32
 	var wg sync.WaitGroup
 	wg.Add(5)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		go func(wg *sync.WaitGroup) {
 			var resp struct {
 				Response bool `json:"response"`
@@ -388,7 +388,7 @@ func TestDoRequest_Retries(t *testing.T) {
 	var failed int32
 	var wg sync.WaitGroup
 	wg.Add(4)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		go func(wg *sync.WaitGroup) {
 			defer wg.Done()
 			var resp struct {

--- a/exchanges/request/retry_test.go
+++ b/exchanges/request/retry_test.go
@@ -46,7 +46,6 @@ func TestDefaultRetryPolicy(t *testing.T) {
 	}
 
 	for name, tt := range testTable {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -112,7 +111,6 @@ func TestRetryAfter(t *testing.T) {
 	}
 
 	for name, tt := range testTable {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/exchanges/stream/buffer/buffer_test.go
+++ b/exchanges/stream/buffer/buffer_test.go
@@ -63,18 +63,17 @@ func createSnapshot() (holder *Orderbook, asks, bids orderbook.Tranches, err err
 }
 
 func bidAskGenerator() []orderbook.Tranche {
-	var response []orderbook.Tranche
-	randIterator := 100
-	for i := 0; i < randIterator; i++ {
+	response := make([]orderbook.Tranche, 100)
+	for i := range 100 {
 		price := float64(rand.Intn(1000)) //nolint:gosec // no need to import crypo/rand for testing
 		if price == 0 {
 			price = 1
 		}
-		response = append(response, orderbook.Tranche{
+		response[i] = orderbook.Tranche{
 			Amount: float64(rand.Intn(10)), //nolint:gosec // no need to import crypo/rand for testing
 			Price:  price,
 			ID:     int64(i),
-		})
+		}
 	}
 	return response
 }
@@ -520,7 +519,6 @@ func TestOrderbookLastUpdateID(t *testing.T) {
 func TestRunUpdateWithoutSnapshot(t *testing.T) {
 	t.Parallel()
 	var holder Orderbook
-	var snapShot1 orderbook.Base
 	asks := []orderbook.Tranche{
 		{Price: 4000, Amount: 1, ID: 8},
 	}
@@ -528,10 +526,6 @@ func TestRunUpdateWithoutSnapshot(t *testing.T) {
 		{Price: 5999, Amount: 1, ID: 8},
 		{Price: 4000, Amount: 1, ID: 9},
 	}
-	snapShot1.Asks = asks
-	snapShot1.Bids = bids
-	snapShot1.Asset = asset.Spot
-	snapShot1.Pair = cp
 	holder.exchangeName = exchangeName
 	err := holder.Update(&orderbook.Update{
 		Bids:       bids,
@@ -549,15 +543,10 @@ func TestRunUpdateWithoutSnapshot(t *testing.T) {
 func TestRunUpdateWithoutAnyUpdates(t *testing.T) {
 	t.Parallel()
 	var obl Orderbook
-	var snapShot1 orderbook.Base
-	snapShot1.Asks = []orderbook.Tranche{}
-	snapShot1.Bids = []orderbook.Tranche{}
-	snapShot1.Asset = asset.Spot
-	snapShot1.Pair = cp
 	obl.exchangeName = exchangeName
 	err := obl.Update(&orderbook.Update{
-		Bids:       snapShot1.Asks,
-		Asks:       snapShot1.Bids,
+		Bids:       []orderbook.Tranche{},
+		Asks:       []orderbook.Tranche{},
 		Pair:       cp,
 		UpdateTime: time.Now(),
 		Asset:      asset.Spot,
@@ -912,9 +901,9 @@ func TestEnsureMultipleUpdatesViaPrice(t *testing.T) {
 }
 
 func deploySliceOrdered(size int) orderbook.Tranches {
-	var items []orderbook.Tranche
-	for i := 0; i < size; i++ {
-		items = append(items, orderbook.Tranche{Amount: 1, Price: rand.Float64() + float64(i), ID: rand.Int63()}) //nolint:gosec // Not needed for tests
+	items := make([]orderbook.Tranche, size)
+	for i := range size {
+		items[i] = orderbook.Tranche{Amount: 1, Price: rand.Float64() + float64(i), ID: rand.Int63()} //nolint:gosec // Not needed for tests
 	}
 	return items
 }

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -265,19 +265,19 @@ func (w *WebsocketConnection) parseBinaryResponse(resp []byte) ([]byte, error) {
 
 // GenerateMessageID Creates a random message ID
 func (w *WebsocketConnection) GenerateMessageID(highPrec bool) int64 {
-	var min int64 = 1e8
-	var max int64 = 2e8
+	var minValue int64 = 1e8
+	var maxValue int64 = 2e8
 	if highPrec {
-		max = 2e12
-		min = 1e12
+		maxValue = 2e12
+		minValue = 1e12
 	}
 	// utilization of hard coded positive numbers and default crypto/rand
 	// io.reader will panic on error instead of returning
-	randomNumber, err := rand.Int(rand.Reader, big.NewInt(max-min+1))
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(maxValue-minValue+1))
 	if err != nil {
 		panic(err)
 	}
-	return randomNumber.Int64() + min
+	return randomNumber.Int64() + minValue
 }
 
 // Shutdown shuts down and closes specific connection

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -201,7 +201,7 @@ func TestTrafficMonitorTrafficAlerts(t *testing.T) {
 	assert.True(t, ws.IsTrafficMonitorRunning(), "traffic monitor should be running")
 	require.Equal(t, connectedState, ws.state.Load(), "websocket must be connected")
 
-	for i := 0; i < 6; i++ { // Timeout will happen at 200ms so we want 6 * 50ms checks to pass
+	for i := range 6 { // Timeout will happen at 200ms so we want 6 * 50ms checks to pass
 		select {
 		case ws.TrafficAlert <- signal:
 			if i == 0 {
@@ -896,7 +896,7 @@ func TestGenerateMessageID(t *testing.T) {
 	wc := WebsocketConnection{}
 	const spins = 1000
 	ids := make([]int64, spins)
-	for i := 0; i < spins; i++ {
+	for i := range spins {
 		id := wc.GenerateMessageID(true)
 		assert.NotContains(t, ids, id, "GenerateMessageID must not generate the same ID twice")
 		ids[i] = id

--- a/exchanges/ticker/ticker_test.go
+++ b/exchanges/ticker/ticker_test.go
@@ -369,7 +369,7 @@ func TestProcessTicker(t *testing.T) { // non-appending function to tickers
 	var sm sync.Mutex
 
 	var catastrophicFailure bool
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		if catastrophicFailure {
 			break
 		}

--- a/gctscript/modules/ta/indicators/indicators_test.go
+++ b/gctscript/modules/ta/indicators/indicators_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	for x := 0; x < 100; x++ {
+	for x := range 100 {
 		v := rand.Float64() //nolint:gosec // no need to import crypo/rand for testing
 		candle := &objects.Array{}
 		candle.Value = append(candle.Value, &objects.Time{Value: time.Now()},

--- a/gctscript/modules/ta/indicators/indicators_test.go
+++ b/gctscript/modules/ta/indicators/indicators_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	objects "github.com/d5/tengo/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gct-ta/indicators"
 	"github.com/thrasher-corp/gocryptotrader/gctscript/wrappers/validator"
 )
@@ -35,7 +37,7 @@ func TestMain(m *testing.M) {
 		ohlcvData.Value = append(ohlcvData.Value, candle)
 	}
 
-	for x := 0; x < 5; x++ {
+	for range 5 {
 		candle := &objects.Array{}
 		candle.Value = append(candle.Value, &objects.String{Value: testString},
 			&objects.String{Value: testString},
@@ -96,47 +98,26 @@ func TestMfi(t *testing.T) {
 
 func TestRsi(t *testing.T) {
 	_, err := rsi()
-	if err != nil {
-		if !errors.Is(err, objects.ErrWrongNumArguments) {
-			t.Error(err)
-		}
-	}
+	assert.ErrorIs(t, err, objects.ErrWrongNumArguments)
 
 	v := &objects.String{Value: testString}
 	_, err = rsi(ohlcvData, v)
-	if err != nil {
-		if err.Error() != errFailedConversion {
-			t.Error(err)
-		}
-	}
+	assert.ErrorContains(t, err, errFailedConversion)
 
 	_, err = rsi(ohlcvData, &objects.Int{Value: 14})
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "rsi should not throw an error on valid input")
 
 	_, err = rsi(v, &objects.Int{Value: 14})
-	if err == nil {
-		if err.Error() != "OHLCV data failed conversion" {
-			t.Error(err)
-		}
-	}
+	assert.ErrorContains(t, err, "failed conversion")
 
 	_, err = rsi(ohlcvDataInvalid, &objects.Int{Value: 14})
-	if err == nil {
-		if err.Error() != "OHLCV data failed conversion" {
-			t.Error(err)
-		}
-	}
+	assert.ErrorContains(t, err, "failed conversion")
 
 	validator.IsTestExecution.Store(true)
 	ret, err := rsi(ohlcvData, &objects.Int{Value: 14})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if (ret == &objects.Array{}) {
-		t.Error("expected empty Array on test execution received data")
-	}
+	require.NoError(t, err, "rsi should not throw an error")
+	assert.NotNil(t, ret)
+
 	validator.IsTestExecution.Store(false)
 }
 
@@ -507,8 +488,7 @@ func TestParseIndicatorSelector(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			v, err := ParseIndicatorSelector(test.name)
 			if err != nil {
@@ -546,8 +526,7 @@ func TestParseMAType(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			v, err := ParseMAType(test.name)
 			if err != nil {

--- a/gctscript/vm/manager_test.go
+++ b/gctscript/vm/manager_test.go
@@ -35,7 +35,6 @@ func TestNewManager(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := NewManager(tt.args.config)
@@ -108,7 +107,6 @@ func TestGctScriptManagerGetMaxVirtualMachines(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := &GctScriptManager{
 				config:             tt.fields.config,

--- a/gctscript/vm/vm_test.go
+++ b/gctscript/vm/vm_test.go
@@ -569,12 +569,12 @@ func TestVMCount(t *testing.T) {
 	}
 }
 
-func configHelper(enabled, imports bool, max uint8) *Config {
+func configHelper(enabled, imports bool, maxVMs uint8) *Config {
 	return &Config{
 		Enabled:            enabled,
 		AllowImports:       imports,
 		ScriptTimeout:      testVirtualMachineTimeout,
-		MaxVirtualMachines: max,
+		MaxVirtualMachines: maxVMs,
 		Verbose:            true,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thrasher-corp/gocryptotrader
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/portfolio/withdraw/validate_test.go
+++ b/portfolio/withdraw/validate_test.go
@@ -226,8 +226,7 @@ func TestValidateFiat(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			if test.requestType < 3 {
 				test.request.Type = test.requestType
@@ -304,8 +303,7 @@ func TestValidateCrypto(t *testing.T) {
 		},
 	}
 
-	for _, tests := range testCases {
-		test := tests
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.request.Validate()
 			if err != nil {


### PR DESCRIPTION
# PR Description

Bumps the CI and toolchain go versions to 1.23, golangci-lint to v1.60.1 and fixes issues along the way. 

Adds the following new linters:

- int range
- copyloopvar
- govet: nilness and unusedwrite to match default gopls behaviour

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
