### PR TITLE
common/math: Add math.Abs to PercentageDifference calculation

### DIFF
--- a/common/math/math.go
+++ b/common/math/math.go
@@ -27,7 +27,7 @@ var (
 
 	one         = decimal.NewFromInt(1)
 	two         = decimal.NewFromInt(2)
-	oneZeroZero = decimal.NewFromInt(100)
+	oneHundred = decimal.NewFromInt(100)
 )
 
 // CalculateAmountWithFee returns a calculated fee included amount on fee

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -25,8 +25,8 @@ var (
 	errCAGRZeroOpenValue       = errors.New("cannot calculate CAGR with an open value of 0")
 	errInformationBadLength    = errors.New("benchmark rates length does not match returns rates")
 
-	one         = decimal.NewFromInt(1)
-	two         = decimal.NewFromInt(2)
+	one        = decimal.NewFromInt(1)
+	two        = decimal.NewFromInt(2)
 	oneHundred = decimal.NewFromInt(100)
 )
 
@@ -49,6 +49,12 @@ func CalculatePercentageGainOrLoss(priceNow, priceThen float64) float64 {
 // CalculatePercentageDifference returns the percentage difference between two
 // numbers
 func CalculatePercentageDifference(a, b float64) float64 {
+	return (a - b) / ((a + b) / 2) * 100
+}
+
+// CalculateAbsPercentageDifference returns the percentage difference between
+// two numbers.
+func CalculateAbsPercentageDifference(a, b float64) float64 {
 	return math.Abs(a-b) / ((a + b) / 2) * 100
 }
 
@@ -58,7 +64,16 @@ func DecimalPercentageDifference(d1, d2 decimal.Decimal) decimal.Decimal {
 	if d1.IsZero() && d2.IsZero() {
 		return decimal.Zero
 	}
-	return d1.Sub(d2).Abs().Div(d1.Add(d2).Div(two)).Mul(oneZeroZero)
+	return d1.Sub(d2).Div(d1.Add(d2).Div(two)).Mul(oneHundred)
+}
+
+// DecimalAbsPercentageDifference returns the percentage difference between
+// decimal values.
+func DecimalAbsPercentageDifference(d1, d2 decimal.Decimal) decimal.Decimal {
+	if d1.IsZero() && d2.IsZero() {
+		return decimal.Zero
+	}
+	return d1.Sub(d2).Abs().Div(d1.Add(d2).Div(two)).Mul(oneHundred)
 }
 
 // CalculateNetProfit returns net profit
@@ -280,7 +295,7 @@ func DecimalCompoundAnnualGrowthRate(openValue, closeValue, intervalsPerYear, nu
 	if pow.IsZero() {
 		return decimal.Zero, ErrPowerDifferenceTooSmall
 	}
-	k := pow.Sub(one).Mul(oneZeroZero)
+	k := pow.Sub(one).Mul(oneHundred)
 	return k, nil
 }
 

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -40,36 +40,31 @@ func CalculateFee(amount, fee float64) float64 {
 	return amount * (fee / 100)
 }
 
-// CalculatePercentageGainOrLoss returns the percentage rise over a certain
-// period
-func CalculatePercentageGainOrLoss(priceNow, priceThen float64) float64 {
-	return (priceNow - priceThen) / priceThen * 100
+// PercentageChange returns the percentage change between two numbers, v1 is reference value.
+func PercentageChange(v1, v2 float64) float64 {
+	return (v2 - v1) / v1 * 100
 }
 
-// CalculatePercentageDifference returns the percentage difference between two
-// numbers
-func CalculatePercentageDifference(a, b float64) float64 {
-	return (a - b) / ((a + b) / 2) * 100
+// PercentageDifference returns the percentage difference between two numbers
+func PercentageDifference(v1, v2 float64) float64 {
+	return (v1 - v2) / ((v1 + v2) / 2) * 100
 }
 
-// CalculateAbsPercentageDifference returns the percentage difference between
-// two numbers.
-func CalculateAbsPercentageDifference(a, b float64) float64 {
-	return math.Abs(a-b) / ((a + b) / 2) * 100
+// PercentageDifferenceAbs returns the absolute percentage difference between two numbers
+func PercentageDifferenceAbs(v1, v2 float64) float64 {
+	return math.Abs(v1-v2) / ((v1 + v2) / 2) * 100
 }
 
-// DecimalPercentageDifference returns the percentage difference between
-// decimal values.
-func DecimalPercentageDifference(d1, d2 decimal.Decimal) decimal.Decimal {
+// PercentageDifferenceDecimal returns the percentage difference between decimal values
+func PercentageDifferenceDecimal(d1, d2 decimal.Decimal) decimal.Decimal {
 	if d1.IsZero() && d2.IsZero() {
 		return decimal.Zero
 	}
 	return d1.Sub(d2).Div(d1.Add(d2).Div(two)).Mul(oneHundred)
 }
 
-// DecimalAbsPercentageDifference returns the percentage difference between
-// decimal values.
-func DecimalAbsPercentageDifference(d1, d2 decimal.Decimal) decimal.Decimal {
+// PercentageDifferenceDecimalAbs returns the absolute percentage difference between decimal values
+func PercentageDifferenceDecimalAbs(d1, d2 decimal.Decimal) decimal.Decimal {
 	if d1.IsZero() && d2.IsZero() {
 		return decimal.Zero
 	}

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -40,35 +40,22 @@ func CalculateFee(amount, fee float64) float64 {
 	return amount * (fee / 100)
 }
 
-// PercentageChange returns the percentage change between two numbers, v1 is reference value.
-func PercentageChange(v1, v2 float64) float64 {
-	return (v2 - v1) / v1 * 100
+// PercentageChange returns the percentage change between two numbers, x is reference value.
+func PercentageChange(x, y float64) float64 {
+	return (y - x) / x * 100
 }
 
-// PercentageDifference returns the percentage difference between two numbers
-func PercentageDifference(v1, v2 float64) float64 {
-	return (v1 - v2) / ((v1 + v2) / 2) * 100
+// PercentageDifference returns difference between two numbers as a percentage of their average
+func PercentageDifference(x, y float64) float64 {
+	return math.Abs(x-y) / ((x + y) / 2) * 100
 }
 
-// PercentageDifferenceAbs returns the absolute percentage difference between two numbers
-func PercentageDifferenceAbs(v1, v2 float64) float64 {
-	return math.Abs(v1-v2) / ((v1 + v2) / 2) * 100
-}
-
-// PercentageDifferenceDecimal returns the percentage difference between decimal values
-func PercentageDifferenceDecimal(d1, d2 decimal.Decimal) decimal.Decimal {
-	if d1.IsZero() && d2.IsZero() {
+// PercentageDifferenceDecimal returns the difference between two decimal values as a percentage of their average
+func PercentageDifferenceDecimal(x, y decimal.Decimal) decimal.Decimal {
+	if x.IsZero() && y.IsZero() {
 		return decimal.Zero
 	}
-	return d1.Sub(d2).Div(d1.Add(d2).Div(two)).Mul(oneHundred)
-}
-
-// PercentageDifferenceDecimalAbs returns the absolute percentage difference between decimal values
-func PercentageDifferenceDecimalAbs(d1, d2 decimal.Decimal) decimal.Decimal {
-	if d1.IsZero() && d2.IsZero() {
-		return decimal.Zero
-	}
-	return d1.Sub(d2).Abs().Div(d1.Add(d2).Div(two)).Mul(oneHundred)
+	return x.Sub(y).Abs().Div(x.Add(y).Div(two)).Mul(oneHundred)
 }
 
 // CalculateNetProfit returns net profit

--- a/common/math/math.go
+++ b/common/math/math.go
@@ -330,7 +330,7 @@ func DecimalPopulationStandardDeviation(values []decimal.Decimal) (decimal.Decim
 	diffs := make([]decimal.Decimal, len(values))
 	for x := range values {
 		val := values[x].Sub(valAvg)
-		exp := decimal.NewFromInt(2)
+		exp := two
 		pow := DecimalPow(val, exp)
 		diffs[x] = pow
 	}
@@ -362,7 +362,7 @@ func DecimalSampleStandardDeviation(values []decimal.Decimal) (decimal.Decimal, 
 	superMean := make([]decimal.Decimal, len(values))
 	var combined decimal.Decimal
 	for i := range values {
-		pow := values[i].Sub(mean).Pow(decimal.NewFromInt(2))
+		pow := values[i].Sub(mean).Pow(two)
 		superMean[i] = pow
 		combined.Add(pow)
 	}
@@ -459,7 +459,7 @@ func DecimalSortinoRatio(movementPerCandle []decimal.Decimal, riskFreeRatePerInt
 	totalNegativeResultsSquared := decimal.Zero
 	for x := range movementPerCandle {
 		if movementPerCandle[x].Sub(riskFreeRatePerInterval).LessThan(decimal.Zero) {
-			totalNegativeResultsSquared = totalNegativeResultsSquared.Add(movementPerCandle[x].Sub(riskFreeRatePerInterval).Pow(decimal.NewFromInt(2)))
+			totalNegativeResultsSquared = totalNegativeResultsSquared.Add(movementPerCandle[x].Sub(riskFreeRatePerInterval).Pow(two))
 		}
 	}
 	if totalNegativeResultsSquared.IsZero() {

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateFee(t *testing.T) {
@@ -42,13 +43,32 @@ func TestCalculatePercentageGainOrLoss(t *testing.T) {
 
 func TestCalculatePercentageDifference(t *testing.T) {
 	t.Parallel()
-	originalInput := float64(10)
-	secondAmount := float64(5)
-	expectedOutput := 66.66666666666666
-	actualResult := CalculatePercentageDifference(originalInput, secondAmount)
-	if expectedOutput != actualResult {
-		t.Errorf(
-			"Expected '%f'. Actual '%f'.", expectedOutput, actualResult)
+	require.Equal(t, 0.13605442176870758, CalculatePercentageDifference(1.469, 1.471))
+	require.Equal(t, 0.13605442176870758, CalculatePercentageDifference(1.471, 1.469))
+	require.Equal(t, 0.0, CalculatePercentageDifference(1.0, 1.0))
+	require.True(t, math.IsNaN(CalculatePercentageDifference(0.0, 0.0)))
+}
+
+// 1000000000	         0.2215 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkCalculatePercentageDifference(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		CalculatePercentageDifference(1.469, 1.471)
+	}
+}
+
+func TestDecimalPercentageDifference(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "0.13605442176871", DecimalPercentageDifference(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
+	require.Equal(t, "0.13605442176871", DecimalPercentageDifference(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
+	require.Equal(t, "0", DecimalPercentageDifference(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
+	require.Equal(t, "0", DecimalPercentageDifference(decimal.Zero, decimal.Zero).String())
+}
+
+// 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op
+func BenchmarkDecimalPercentageDifference(b *testing.B) {
+	d1, d2 := decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)
+	for i := 0; i < b.N; i++ {
+		DecimalPercentageDifference(d1, d2)
 	}
 }
 

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,62 +30,61 @@ func TestCalculateAmountWithFee(t *testing.T) {
 	}
 }
 
-func TestCalculatePercentageGainOrLoss(t *testing.T) {
+func TestPercentageChange(t *testing.T) {
 	t.Parallel()
-	originalInput := float64(9300)
-	secondInput := float64(9000)
-	expectedOutput := 3.3333333333333335
-	actualResult := CalculatePercentageGainOrLoss(originalInput, secondInput)
-	if expectedOutput != actualResult {
-		t.Errorf(
-			"Expected '%v'. Actual '%v'.", expectedOutput, actualResult)
-	}
+	assert.Equal(t, 3.3333333333333335, PercentageChange(9000, 9300))
+	assert.Equal(t, -3.225806451612903, PercentageChange(9300, 9000))
+	assert.True(t, math.IsNaN(PercentageChange(0, 0)))
+	assert.Equal(t, 0.0, PercentageChange(1, 1))
+	assert.Equal(t, 0.0, PercentageChange(-1, -1))
+	assert.True(t, math.IsInf(PercentageChange(0, 1), 1))
+	assert.Equal(t, -100., PercentageChange(1, 0))
 }
 
-func TestCalculatePercentageDifference(t *testing.T) {
+func TestPercentageDifference(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, -196.03960396039605, CalculatePercentageDifference(1, 100))
-	require.Equal(t, 196.03960396039605, CalculatePercentageDifference(100, 1))
-	require.Equal(t, 0.0, CalculatePercentageDifference(1.0, 1.0))
-	require.True(t, math.IsNaN(CalculatePercentageDifference(0.0, 0.0)))
+	require.Equal(t, -196.03960396039605, PercentageDifference(1, 100))
+	require.Equal(t, 196.03960396039605, PercentageDifference(100, 1))
+	require.Equal(t, 0.0, PercentageDifference(1.0, 1.0))
+	require.True(t, math.IsNaN(PercentageDifference(0.0, 0.0)))
 }
 
-func TestCalculateAbsPercentageDifference(t *testing.T) {
+func TestPercentageDifferenceAbs(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, 0.13605442176870758, CalculateAbsPercentageDifference(1.469, 1.471))
-	require.Equal(t, 0.13605442176870758, CalculateAbsPercentageDifference(1.471, 1.469))
-	require.Equal(t, 0.0, CalculateAbsPercentageDifference(1.0, 1.0))
-	require.True(t, math.IsNaN(CalculateAbsPercentageDifference(0.0, 0.0)))
+	require.Equal(t, 0.13605442176870758, PercentageDifferenceAbs(1.469, 1.471))
+	require.Equal(t, 0.13605442176870758, PercentageDifferenceAbs(1.471, 1.469))
+	require.Equal(t, 0.0, PercentageDifferenceAbs(1.0, 1.0))
+	require.True(t, math.IsNaN(PercentageDifferenceAbs(0.0, 0.0)))
 }
 
 // 1000000000	         0.2215 ns/op	       0 B/op	       0 allocs/op
-func BenchmarkCalculatePercentageDifference(b *testing.B) {
+func BenchmarkPercentageDifference(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		CalculatePercentageDifference(1.469, 1.471)
+		PercentageDifference(1.469, 1.471)
 	}
 }
 
-func TestDecimalPercentageDifference(t *testing.T) {
+func TestPercentageDifferenceDecimal(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "-196.03960396039604", DecimalPercentageDifference(decimal.NewFromFloat(1), decimal.NewFromFloat(100)).String())
-	require.Equal(t, "196.03960396039604", DecimalPercentageDifference(decimal.NewFromFloat(100), decimal.NewFromFloat(1)).String())
-	require.Equal(t, "0", DecimalPercentageDifference(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
-	require.Equal(t, "0", DecimalPercentageDifference(decimal.Zero, decimal.Zero).String())
+	require.Equal(t, "-196.03960396039604", PercentageDifferenceDecimal(decimal.NewFromFloat(1), decimal.NewFromFloat(100)).String())
+	require.Equal(t, "196.03960396039604", PercentageDifferenceDecimal(decimal.NewFromFloat(100), decimal.NewFromFloat(1)).String())
+	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
+	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.Zero, decimal.Zero).String())
 }
 
-func TestDecimalAbsPercentageDifference(t *testing.T) {
+func TestPercentageDifferenceDecimalAbs(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "0.13605442176871", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
-	require.Equal(t, "0.13605442176871", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
-	require.Equal(t, "0", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
-	require.Equal(t, "0", DecimalAbsPercentageDifference(decimal.Zero, decimal.Zero).String())
+	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
+	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
+	require.Equal(t, "0", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
+	require.Equal(t, "0", PercentageDifferenceDecimalAbs(decimal.Zero, decimal.Zero).String())
 }
 
 // 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op
 func BenchmarkDecimalPercentageDifference(b *testing.B) {
 	d1, d2 := decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)
 	for i := 0; i < b.N; i++ {
-		DecimalPercentageDifference(d1, d2)
+		PercentageDifferenceDecimal(d1, d2)
 	}
 }
 

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -43,18 +43,12 @@ func TestPercentageChange(t *testing.T) {
 
 func TestPercentageDifference(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, -196.03960396039605, PercentageDifference(1, 100))
+	require.Equal(t, 196.03960396039605, PercentageDifference(1, 100))
 	require.Equal(t, 196.03960396039605, PercentageDifference(100, 1))
+	require.Equal(t, 0.13605442176870758, PercentageDifference(1.469, 1.471))
+	require.Equal(t, 0.13605442176870758, PercentageDifference(1.471, 1.469))
 	require.Equal(t, 0.0, PercentageDifference(1.0, 1.0))
 	require.True(t, math.IsNaN(PercentageDifference(0.0, 0.0)))
-}
-
-func TestPercentageDifferenceAbs(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, 0.13605442176870758, PercentageDifferenceAbs(1.469, 1.471))
-	require.Equal(t, 0.13605442176870758, PercentageDifferenceAbs(1.471, 1.469))
-	require.Equal(t, 0.0, PercentageDifferenceAbs(1.0, 1.0))
-	require.True(t, math.IsNaN(PercentageDifferenceAbs(0.0, 0.0)))
 }
 
 // 1000000000	         0.2215 ns/op	       0 B/op	       0 allocs/op
@@ -66,18 +60,12 @@ func BenchmarkPercentageDifference(b *testing.B) {
 
 func TestPercentageDifferenceDecimal(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "-196.03960396039604", PercentageDifferenceDecimal(decimal.NewFromFloat(1), decimal.NewFromFloat(100)).String())
+	require.Equal(t, "196.03960396039604", PercentageDifferenceDecimal(decimal.NewFromFloat(1), decimal.NewFromFloat(100)).String())
 	require.Equal(t, "196.03960396039604", PercentageDifferenceDecimal(decimal.NewFromFloat(100), decimal.NewFromFloat(1)).String())
+	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimal(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
+	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimal(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
 	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
 	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.Zero, decimal.Zero).String())
-}
-
-func TestPercentageDifferenceDecimalAbs(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
-	require.Equal(t, "0.13605442176871", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
-	require.Equal(t, "0", PercentageDifferenceDecimalAbs(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
-	require.Equal(t, "0", PercentageDifferenceDecimalAbs(decimal.Zero, decimal.Zero).String())
 }
 
 // 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -43,10 +43,18 @@ func TestCalculatePercentageGainOrLoss(t *testing.T) {
 
 func TestCalculatePercentageDifference(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, 0.13605442176870758, CalculatePercentageDifference(1.469, 1.471))
-	require.Equal(t, 0.13605442176870758, CalculatePercentageDifference(1.471, 1.469))
+	require.Equal(t, -196.03960396039605, CalculatePercentageDifference(1, 100))
+	require.Equal(t, 196.03960396039605, CalculatePercentageDifference(100, 1))
 	require.Equal(t, 0.0, CalculatePercentageDifference(1.0, 1.0))
 	require.True(t, math.IsNaN(CalculatePercentageDifference(0.0, 0.0)))
+}
+
+func TestCalculateAbsPercentageDifference(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 0.13605442176870758, CalculateAbsPercentageDifference(1.469, 1.471))
+	require.Equal(t, 0.13605442176870758, CalculateAbsPercentageDifference(1.471, 1.469))
+	require.Equal(t, 0.0, CalculateAbsPercentageDifference(1.0, 1.0))
+	require.True(t, math.IsNaN(CalculateAbsPercentageDifference(0.0, 0.0)))
 }
 
 // 1000000000	         0.2215 ns/op	       0 B/op	       0 allocs/op
@@ -58,10 +66,18 @@ func BenchmarkCalculatePercentageDifference(b *testing.B) {
 
 func TestDecimalPercentageDifference(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "0.13605442176871", DecimalPercentageDifference(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
-	require.Equal(t, "0.13605442176871", DecimalPercentageDifference(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
+	require.Equal(t, "-196.03960396039604", DecimalPercentageDifference(decimal.NewFromFloat(1), decimal.NewFromFloat(100)).String())
+	require.Equal(t, "196.03960396039604", DecimalPercentageDifference(decimal.NewFromFloat(100), decimal.NewFromFloat(1)).String())
 	require.Equal(t, "0", DecimalPercentageDifference(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
 	require.Equal(t, "0", DecimalPercentageDifference(decimal.Zero, decimal.Zero).String())
+}
+
+func TestDecimalAbsPercentageDifference(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "0.13605442176871", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)).String())
+	require.Equal(t, "0.13605442176871", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.471), decimal.NewFromFloat(1.469)).String())
+	require.Equal(t, "0", DecimalAbsPercentageDifference(decimal.NewFromFloat(1.0), decimal.NewFromFloat(1.0)).String())
+	require.Equal(t, "0", DecimalAbsPercentageDifference(decimal.Zero, decimal.Zero).String())
 }
 
 // 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op

--- a/engine/datahistory_manager.go
+++ b/engine/datahistory_manager.go
@@ -1049,10 +1049,10 @@ func (m *DataHistoryManager) CheckCandleIssue(job *DataHistoryJob, multiplier in
 	}
 	if apiData != dbData {
 		var diff float64
-		if apiData > dbData {
-			diff = gctmath.CalculatePercentageGainOrLoss(apiData, dbData)
+		if apiData < dbData {
+			diff = gctmath.PercentageChange(apiData, dbData)
 		} else {
-			diff = gctmath.CalculatePercentageGainOrLoss(dbData, apiData)
+			diff = gctmath.PercentageChange(dbData, apiData)
 		}
 		if diff > job.IssueTolerancePercentage {
 			issue = fmt.Sprintf("%s api: %v db: %v diff: %v %%", candleField, apiData, dbData, diff)

--- a/exchanges/orderbook/calculator.go
+++ b/exchanges/orderbook/calculator.go
@@ -46,7 +46,7 @@ func (b *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error
 		minPrice = action.ReferencePrice
 		maxPrice = action.TranchePositionPrice
 		amount = action.QuoteAmount
-		percent = math.CalculatePercentageGainOrLoss(action.TranchePositionPrice, action.ReferencePrice)
+		percent = math.PercentageChange(action.ReferencePrice, action.TranchePositionPrice)
 		status = fmt.Sprintf("Buying using %.2f %s worth of %s will send the price from %v to %v [%.2f%%] and impact %d price tranche(s). %s",
 			amount, b.Pair.Quote, b.Pair.Base, minPrice, maxPrice,
 			percent, len(action.Tranches), warning)
@@ -54,7 +54,7 @@ func (b *Base) WhaleBomb(priceTarget float64, buy bool) (*WhaleBombResult, error
 		minPrice = action.TranchePositionPrice
 		maxPrice = action.ReferencePrice
 		amount = action.BaseAmount
-		percent = math.CalculatePercentageGainOrLoss(action.TranchePositionPrice, action.ReferencePrice)
+		percent = math.PercentageChange(action.ReferencePrice, action.TranchePositionPrice)
 		status = fmt.Sprintf("Selling using %.2f %s worth of %s will send the price from %v to %v [%.2f%%] and impact %d price tranche(s). %s",
 			amount, b.Pair.Base, b.Pair.Quote, maxPrice, minPrice,
 			percent, len(action.Tranches), warning)
@@ -108,7 +108,7 @@ func (b *Base) SimulateOrder(amount float64, buy bool) (*WhaleBombResult, error)
 		warning = fullLiquidityUsageWarning
 	}
 
-	pct := math.CalculatePercentageGainOrLoss(action.TranchePositionPrice, action.ReferencePrice)
+	pct := math.PercentageChange(action.ReferencePrice, action.TranchePositionPrice)
 	status := fmt.Sprintf("%s using %f %v worth of %v will send the price from %v to %v [%.2f%%] and impact %v price tranche(s). %s",
 		direction, soldAmount, sold, bought, action.ReferencePrice,
 		action.TranchePositionPrice, pct, len(action.Tranches), warning)

--- a/exchanges/orderbook/tranches.go
+++ b/exchanges/orderbook/tranches.go
@@ -400,7 +400,7 @@ func (bids *bidTranches) hitBidsByNominalSlippage(slippage, refPrice float64) (*
 		currentTotalAmounts := cumulativeAmounts + bids.Tranches[x].Amount
 
 		nominal.AverageOrderCost = currentFullValue / currentTotalAmounts
-		percent := math.CalculatePercentageGainOrLoss(nominal.AverageOrderCost, refPrice)
+		percent := math.PercentageChange(refPrice, nominal.AverageOrderCost)
 		if percent != 0 {
 			percent *= -1
 		}
@@ -461,7 +461,7 @@ func (bids *bidTranches) hitBidsByImpactSlippage(slippage, refPrice float64) (*M
 
 	impact := &Movement{StartPrice: refPrice, EndPrice: refPrice}
 	for x := range bids.Tranches {
-		percent := math.CalculatePercentageGainOrLoss(bids.Tranches[x].Price, refPrice)
+		percent := math.PercentageChange(refPrice, bids.Tranches[x].Price)
 		if percent != 0 {
 			percent *= -1
 		}
@@ -529,7 +529,7 @@ func (ask *askTranches) liftAsksByNominalSlippage(slippage, refPrice float64) (*
 		currentAmounts := cumulativeAmounts + ask.Tranches[x].Amount
 
 		nominal.AverageOrderCost = currentValue / currentAmounts
-		percent := math.CalculatePercentageGainOrLoss(nominal.AverageOrderCost, refPrice)
+		percent := math.PercentageChange(refPrice, nominal.AverageOrderCost)
 
 		if slippage < percent {
 			targetCost := (1 + slippage/100) * refPrice
@@ -582,7 +582,7 @@ func (ask *askTranches) liftAsksByImpactSlippage(slippage, refPrice float64) (*M
 
 	impact := &Movement{StartPrice: refPrice, EndPrice: refPrice}
 	for x := range ask.Tranches {
-		percent := math.CalculatePercentageGainOrLoss(ask.Tranches[x].Price, refPrice)
+		percent := math.PercentageChange(refPrice, ask.Tranches[x].Price)
 		impact.ImpactPercentage = percent
 		impact.EndPrice = ask.Tranches[x].Price
 		if slippage <= percent {
@@ -625,7 +625,7 @@ func (m *Movement) finalizeFields(cost, amount, headPrice, leftover float64, swa
 
 	// Nominal percentage is the difference from the reference price to average
 	// order cost.
-	m.NominalPercentage = math.CalculatePercentageGainOrLoss(m.AverageOrderCost, m.StartPrice)
+	m.NominalPercentage = math.PercentageChange(m.StartPrice, m.AverageOrderCost)
 	if m.NominalPercentage < 0 {
 		m.NominalPercentage *= -1
 	}
@@ -634,7 +634,7 @@ func (m *Movement) finalizeFields(cost, amount, headPrice, leftover float64, swa
 		// Impact percentage is how much the orderbook slips from the reference
 		// price to the remaining tranche price.
 
-		m.ImpactPercentage = math.CalculatePercentageGainOrLoss(m.EndPrice, m.StartPrice)
+		m.ImpactPercentage = math.PercentageChange(m.StartPrice, m.EndPrice)
 		if m.ImpactPercentage < 0 {
 			m.ImpactPercentage *= -1
 		}


### PR DESCRIPTION
# PR Description

* Needed absolute value as it was returning negative values. 
* Adds decimal package calc
* Adds vars so that less decimal structs are allocated
* Rename `CalculatePercentageGainOrLoss` -> `PercentageChange`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
