### PR TITLE
orderbook: depth add new methods and drop error return on GetPair()

### DIFF
--- a/exchanges/orderbook/depth.go
+++ b/exchanges/orderbook/depth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/dispatch"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/alert"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
@@ -778,11 +779,21 @@ func (d *Depth) GetTranches(count int) (ask, bid []Tranche, err error) {
 }
 
 // GetPair returns the pair associated with the depth
-func (d *Depth) GetPair() (currency.Pair, error) {
+func (d *Depth) GetPair() currency.Pair {
+	if d == nil {
+		return currency.EMPTYPAIR
+	}
 	d.m.Lock()
 	defer d.m.Unlock()
-	if d.pair.IsEmpty() {
-		return currency.Pair{}, currency.ErrCurrencyPairEmpty
+	return d.pair
+}
+
+// GetAsset returns the asset associated with the depth
+func (d *Depth) GetAsset() asset.Item {
+	if d == nil {
+		return asset.Empty
 	}
-	return d.pair, nil
+	d.m.Lock()
+	defer d.m.Unlock()
+	return d.asset
 }

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
@@ -679,18 +680,18 @@ func TestGetTranches(t *testing.T) {
 
 func TestGetPair(t *testing.T) {
 	t.Parallel()
+	require.Equal(t, currency.EMPTYPAIR, (*Depth)(nil).GetPair())
 	depth := NewDepth(id)
+	depth.pair = currency.NewPair(currency.BTC, currency.WABI)
+	require.Equal(t, depth.pair, depth.GetPair())
+}
 
-	_, err := depth.GetPair()
-	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "GetPair should error correctly")
-
-	expected := currency.NewPair(currency.BTC, currency.WABI)
-	depth.pair = expected
-
-	pair, err := depth.GetPair()
-	assert.NoError(t, err, "GetPair should not error")
-
-	assert.Equal(t, expected, pair, "GetPair should return correct pair")
+func TestGetAsset(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, asset.Empty, (*Depth)(nil).GetAsset())
+	depth := NewDepth(id)
+	depth.asset = asset.Spot
+	require.Equal(t, depth.asset, depth.GetAsset())
 }
 
 func getInvalidDepth() *Depth {

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -129,6 +129,30 @@ type Base struct {
 	ChecksumStringRequired bool
 }
 
+// State defines critical state values for deployment.
+type State struct {
+	// LastUpdated is the time when a change occurred on the exchange books.
+	// Note: This does not necessarily indicate the change is out of sync with
+	// the exchange. It represents the last known update time from the exchange,
+	// which could be stale if there have been no recent changes.
+	LastUpdated time.Time
+
+	// UpdatePushedAt is the time the exchange pushed this update. This helps
+	// determine factors like distance from exchange (latency) and routing
+	// time, which can affect the time it takes for an update to reach the user
+	// from the exchange.
+	UpdatePushedAt time.Time
+
+	// InsertedAt is the time the update was inserted into the orderbook
+	// management system. This field is used to calculate round-trip times and
+	// processing delays, e.g., InsertedAt.Sub(UpdatePushedAt) represents the
+	// total processing time including network latency.
+	InsertedAt time.Time
+
+	// RestSnapshot defines if the depth state was applied via the REST protocol
+	RestSnapshot bool
+}
+
 type options struct {
 	exchange               string
 	pair                   currency.Pair


### PR DESCRIPTION
# PR Description

* drops error return on method for ease of use.
* Adds GetAsset to obtain asset 
* Adds GetState method to check timings and how the orderbook was updated
* Adds GetKey method to return an immutable key for lookup if needed
* Adds GetBids and GetAsks to individually return a side for inspection, it's a little faster and more pertinent if you are only only inspecting and deploying to one side. 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
