### PR TITLE
engine: Add overridable exchanges command line flag

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -897,12 +897,36 @@ func (bot *Engine) SetupExchanges() error {
 		bot.dryRunParamInteraction("exchangehttpdebugging")
 	}
 
+	var exchangesOverride []string
+	if bot.Settings.Exchanges != "" {
+		bot.dryRunParamInteraction("exchanges")
+		exchangesOverride = strings.Split(bot.Settings.Exchanges, ",")
+		for x := range exchangesOverride {
+			if !common.StringDataCompareInsensitive(exchange.Exchanges, exchangesOverride[x]) {
+				return fmt.Errorf("exchange %s not found", exchangesOverride[x])
+			}
+		}
+	}
+
 	var wg sync.WaitGroup
 	for x := range configs {
-		if !configs[x].Enabled && !bot.Settings.EnableAllExchanges {
+		shouldLoad := false
+		if len(exchangesOverride) > 0 {
+			for y := range exchangesOverride {
+				if strings.EqualFold(configs[x].Name, exchangesOverride[y]) {
+					shouldLoad = true
+					break
+				}
+			}
+		} else {
+			shouldLoad = configs[x].Enabled || bot.Settings.EnableAllExchanges
+		}
+
+		if !shouldLoad {
 			gctlog.Debugf(gctlog.ExchangeSys, "%s: Exchange support: Disabled\n", configs[x].Name)
 			continue
 		}
+
 		wg.Add(1)
 		go func(c config.Exchange) {
 			defer wg.Done()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -854,11 +854,12 @@ func (bot *Engine) dryRunParamInteraction(param string) {
 		return
 	}
 
+	gctlog.Warnf(gctlog.Global,
+		"Command line argument '-%s' induces dry run mode."+
+			" Set -dryrun=false if you wish to override this.",
+		param)
+
 	if !bot.Settings.EnableDryRun {
-		gctlog.Warnf(gctlog.Global,
-			"Command line argument '-%s' induces dry run mode."+
-				" Set -dryrun=false if you wish to override this.",
-			param)
 		bot.Settings.EnableDryRun = true
 	}
 }
@@ -906,6 +907,10 @@ func (bot *Engine) SetupExchanges() error {
 				return fmt.Errorf("exchange %s not found", exchangesOverride[x])
 			}
 		}
+	}
+
+	if bot.Settings.EnableAllExchanges && len(exchangesOverride) > 0 {
+		return errors.New("cannot enable all exchanges and specific exchanges concurrently")
 	}
 
 	var wg sync.WaitGroup

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -430,7 +430,20 @@ func TestSetupExchanges(t *testing.T) {
 		assert.ErrorIs(t, e.SetupExchanges(), ErrNoExchangesLoaded)
 	})
 
-	// Test that adjusting settings induces dry run mode correctly
+	t.Run("EnableAllExchanges with specific exchanges set", func(t *testing.T) {
+		t.Parallel()
+		e := &Engine{
+			Config: &config.Config{},
+			Settings: Settings{
+				CoreSettings: CoreSettings{
+					EnableAllExchanges: true,
+					Exchanges:          "Bitstamp,Bitfinex",
+				},
+			},
+		}
+		assert.EqualError(t, e.SetupExchanges(), "cannot enable all exchanges and specific exchanges concurrently")
+	})
+
 	t.Run("Settings dry run toggling", func(t *testing.T) {
 		t.Parallel()
 		e := &Engine{

--- a/engine/engine_types.go
+++ b/engine/engine_types.go
@@ -60,6 +60,7 @@ type CoreSettings struct {
 	EnableDispatcher            bool
 	DispatchMaxWorkerAmount     int
 	DispatchJobsLimit           int
+	Exchanges                   string
 }
 
 // ExchangeSyncerSettings defines settings for the exchange pair synchronisation

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 	flag.DurationVar(&settings.TradeBufferProcessingInterval, "tradeprocessinginterval", trade.DefaultProcessorIntervalTime, "sets the interval to save trade buffer data to the database")
 	flag.IntVar(&settings.AlertSystemPreAllocationCommsBuffer, "alertbuffer", alert.PreAllocCommsDefaultBuffer, "sets the size of the pre-allocation communications buffer")
 	flag.DurationVar(&settings.ExchangeShutdownTimeout, "exchangeshutdowntimeout", time.Second*10, "sets the maximum amount of time the program will wait for an exchange to shut down gracefully")
+	flag.StringVar(&settings.Exchanges, "exchanges", "", "sets a comma-separated list of exchanges to load. If left empty, all enabled exchanges will be loaded from the config file")
 
 	// Common tuning settings
 	flag.DurationVar(&settings.GlobalHTTPTimeout, "globalhttptimeout", 0, "sets common HTTP timeout value for HTTP requests")


### PR DESCRIPTION
# PR Description

Adds an overridable, dry run protected by default `-exchanges` command line flag to engine which is useful for troubleshooting or in cases where you're only interested in enabling a specific set of exchanges, without requiring you to edit your config file.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] ./gocryptotrader --exchanges=bitstamp

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
