### PR TITLE
common: Replace StringDataCompare with slices.Contains and cleanup string funcs

### DIFF
--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -307,7 +307,7 @@ func checkMissingExchanges() []string {
 	}
 	supportedExchs := exchange.Exchanges
 	for z := 0; z < len(supportedExchs); {
-		if common.StringDataContainsInsensitive(tempArray, supportedExchs[z]) {
+		if common.StringSliceContainsInsensitive(tempArray, supportedExchs[z]) {
 			supportedExchs = append(supportedExchs[:z], supportedExchs[z+1:]...)
 			continue
 		}

--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -51,14 +52,14 @@ func TestAllExchangeWrappers(t *testing.T) {
 		name := strings.ToLower(cfg.Exchanges[i].Name)
 		t.Run(name+" wrapper tests", func(t *testing.T) {
 			t.Parallel()
-			if common.StringDataContains(unsupportedExchangeNames, name) {
+			if slices.Contains(unsupportedExchangeNames, name) {
 				t.Skipf("skipping unsupported exchange %v", name)
 			}
 			if singleExchangeOverride != "" && name != singleExchangeOverride {
 				t.Skip("skipping ", name, " due to override")
 			}
 			ctx := context.Background()
-			if isCITest() && common.StringDataContains(blockedCIExchanges, name) {
+			if isCITest() && slices.Contains(blockedCIExchanges, name) {
 				// rather than skipping tests where execution is blocked, provide an expired
 				// context, so no executions can take place
 				var cancelFn context.CancelFunc

--- a/common/common.go
+++ b/common/common.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -136,66 +135,42 @@ func NewHTTPClientWithTimeout(t time.Duration) *http.Client {
 	return h
 }
 
-// StringSliceDifference concatenates slices together based on its index and
-// returns an individual string array
-func StringSliceDifference(slice1, slice2 []string) []string {
-	var diff []string
-	for i := range 2 {
-		for _, s1 := range slice1 {
-			found := false
-			for _, s2 := range slice2 {
-				if s1 == s2 {
-					found = true
-					break
-				}
-			}
-			if !found {
-				diff = append(diff, s1)
-			}
+// SliceDifference returns the elements that are in slice1 or slice2 but not in both
+func SliceDifference[T comparable](slice1, slice2 []T) []T {
+	var diff []T
+	for x := range slice1 {
+		if !slices.Contains(slice2, slice1[x]) {
+			diff = append(diff, slice1[x])
 		}
-		if i == 0 {
-			slice1, slice2 = slice2, slice1
+	}
+	for x := range slice2 {
+		if !slices.Contains(slice1, slice2[x]) {
+			diff = append(diff, slice2[x])
 		}
 	}
 	return diff
 }
 
-// StringDataContains checks the substring array with an input and returns a bool
-func StringDataContains(haystack []string, needle string) bool {
-	data := strings.Join(haystack, ",")
-	return strings.Contains(data, needle)
+// StringSliceContains returns whether case sensitive needle is contained within haystack
+func StringSliceContains(haystack []string, needle string) bool {
+	return slices.ContainsFunc(haystack, func(s string) bool {
+		return strings.Contains(s, needle)
+	})
 }
 
-// StringDataCompare data checks the substring array with an input and returns a bool
-func StringDataCompare(haystack []string, needle string) bool {
-	for x := range haystack {
-		if haystack[x] == needle {
-			return true
-		}
-	}
-	return false
+// StringSliceCompareInsensitive returns whether case insensitive needle exists within haystack
+func StringSliceCompareInsensitive(haystack []string, needle string) bool {
+	return slices.ContainsFunc(haystack, func(s string) bool {
+		return strings.EqualFold(s, needle)
+	})
 }
 
-// StringDataCompareInsensitive data checks the substring array with an input and returns
-// a bool irrespective of lower or upper case strings
-func StringDataCompareInsensitive(haystack []string, needle string) bool {
-	for x := range haystack {
-		if strings.EqualFold(haystack[x], needle) {
-			return true
-		}
-	}
-	return false
-}
-
-// StringDataContainsInsensitive checks the substring array with an input and returns
-// a bool irrespective of lower or upper case strings
-func StringDataContainsInsensitive(haystack []string, needle string) bool {
-	for _, data := range haystack {
-		if strings.Contains(strings.ToUpper(data), strings.ToUpper(needle)) {
-			return true
-		}
-	}
-	return false
+// StringSliceContainsInsensitive returns whether case insensitive needle is contained within haystack
+func StringSliceContainsInsensitive(haystack []string, needle string) bool {
+	needleUpper := strings.ToUpper(needle)
+	return slices.ContainsFunc(haystack, func(s string) bool {
+		return strings.Contains(strings.ToUpper(s), needleUpper)
+	})
 }
 
 // IsEnabled takes in a boolean param  and returns a string if it is enabled
@@ -420,27 +395,6 @@ func AddPaddingOnUpperCase(s string) string {
 	}
 	result = append(result, s[left:])
 	return strings.Join(result, " ")
-}
-
-// InArray checks if _val_ belongs to _array_
-func InArray(val, array interface{}) (exists bool, index int) {
-	exists = false
-	index = -1
-	if array == nil {
-		return
-	}
-	switch reflect.TypeOf(array).Kind() {
-	case reflect.Array, reflect.Slice:
-		s := reflect.ValueOf(array)
-		for i := range s.Len() {
-			if reflect.DeepEqual(val, s.Index(i).Interface()) {
-				index = i
-				exists = true
-				return
-			}
-		}
-	}
-	return
 }
 
 // fmtError holds a formatted msg and the errors which formatted it

--- a/common/common.go
+++ b/common/common.go
@@ -138,16 +138,12 @@ func NewHTTPClientWithTimeout(t time.Duration) *http.Client {
 // SliceDifference returns the elements that are in slice1 or slice2 but not in both
 func SliceDifference[T comparable](slice1, slice2 []T) []T {
 	diff := make([]T, 0, len(slice1)+len(slice2))
-	target := 0
 	for x := range slice1 {
 		if !slices.Contains(slice2, slice1[x]) {
 			diff = append(diff, slice1[x])
 			continue
 		}
-		slice1[target] = slice1[x]
-		target++
 	}
-	slice1 = slice1[:target]
 	for x := range slice2 {
 		if !slices.Contains(slice1, slice2[x]) {
 			diff = append(diff, slice2[x])

--- a/common/common.go
+++ b/common/common.go
@@ -137,18 +137,23 @@ func NewHTTPClientWithTimeout(t time.Duration) *http.Client {
 
 // SliceDifference returns the elements that are in slice1 or slice2 but not in both
 func SliceDifference[T comparable](slice1, slice2 []T) []T {
-	var diff []T
+	diff := make([]T, 0, len(slice1)+len(slice2))
+	target := 0
 	for x := range slice1 {
 		if !slices.Contains(slice2, slice1[x]) {
 			diff = append(diff, slice1[x])
+			continue
 		}
+		slice1[target] = slice1[x]
+		target++
 	}
+	slice1 = slice1[:target]
 	for x := range slice2 {
 		if !slices.Contains(slice1, slice2[x]) {
 			diff = append(diff, slice2[x])
 		}
 	}
-	return diff
+	return slices.Clip(diff)
 }
 
 // StringSliceContains returns whether case sensitive needle is contained within haystack

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -236,85 +235,41 @@ func TestIsValidCryptoAddress(t *testing.T) {
 	}
 }
 
-func TestStringSliceDifference(t *testing.T) {
+func TestSliceDifference(t *testing.T) {
 	t.Parallel()
-	originalInputOne := []string{"hello"}
-	originalInputTwo := []string{"hello", "moto"}
-	expectedOutput := []string{"hello moto"}
-	actualResult := StringSliceDifference(originalInputOne, originalInputTwo)
-	if reflect.DeepEqual(expectedOutput, actualResult) {
-		t.Errorf("Expected '%s'. Actual '%s'",
-			expectedOutput, actualResult)
+
+	assert.ElementsMatch(t, []string{"world", "go"}, SliceDifference([]string{"hello", "world"}, []string{"hello", "go"}))
+	assert.ElementsMatch(t, []int64{1, 2, 5, 6}, SliceDifference([]int64{1, 2, 3, 4}, []int64{3, 4, 5, 6}))
+	assert.ElementsMatch(t, []float64{1.1, 4.4}, SliceDifference([]float64{1.1, 2.2, 3.3}, []float64{2.2, 3.3, 4.4}))
+	type mixedType struct {
+		A string
+		B int
 	}
+	assert.ElementsMatch(t, []mixedType{{"A", 1}, {"D", 4}}, SliceDifference([]mixedType{{"A", 1}, {"B", 2}, {"C", 3}}, []mixedType{{"B", 2}, {"C", 3}, {"D", 4}}))
+	assert.ElementsMatch(t, []int{1, 2, 3}, SliceDifference([]int{}, []int{1, 2, 3}))
+	assert.ElementsMatch(t, []int{1, 2, 3}, SliceDifference([]int{1, 2, 3}, []int{}))
+	assert.Empty(t, SliceDifference([]int{}, []int{}))
 }
 
-func TestStringDataContains(t *testing.T) {
+func TestStringSliceContains(t *testing.T) {
 	t.Parallel()
 	originalHaystack := []string{"hello", "world", "USDT", "Contains", "string"}
-	originalNeedle := "USD"
-	anotherNeedle := "thing"
-	actualResult := StringDataContains(originalHaystack, originalNeedle)
-	if expectedOutput := true; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
-	actualResult = StringDataContains(originalHaystack, anotherNeedle)
-	if expectedOutput := false; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
+	assert.True(t, StringSliceContains(originalHaystack, "USD"), "Should contain 'USD'")
+	assert.False(t, StringSliceContains(originalHaystack, "thing"), "Should not contain 'thing'")
 }
 
-func TestStringDataCompare(t *testing.T) {
+func TestStringSliceCompareInsensitive(t *testing.T) {
 	t.Parallel()
 	originalHaystack := []string{"hello", "WoRld", "USDT", "Contains", "string"}
-	originalNeedle := "WoRld"
-	anotherNeedle := "USD"
-	actualResult := StringDataCompare(originalHaystack, originalNeedle)
-	if expectedOutput := true; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
-	actualResult = StringDataCompare(originalHaystack, anotherNeedle)
-	if expectedOutput := false; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
+	assert.False(t, StringSliceCompareInsensitive(originalHaystack, "USD"), "Should not contain 'USD'")
+	assert.True(t, StringSliceCompareInsensitive(originalHaystack, "WORLD"), "Should find 'WoRld'")
 }
 
-func TestStringDataCompareUpper(t *testing.T) {
-	t.Parallel()
-	originalHaystack := []string{"hello", "WoRld", "USDT", "Contains", "string"}
-	originalNeedle := "WoRld"
-	anotherNeedle := "WoRldD"
-	actualResult := StringDataCompareInsensitive(originalHaystack, originalNeedle)
-	if expectedOutput := true; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
-
-	actualResult = StringDataCompareInsensitive(originalHaystack, anotherNeedle)
-	if expectedOutput := false; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
-}
-
-func TestStringDataContainsUpper(t *testing.T) {
+func TestStringSliceContainsInsensitive(t *testing.T) {
 	t.Parallel()
 	originalHaystack := []string{"bLa", "BrO", "sUp"}
-	originalNeedle := "Bla"
-	anotherNeedle := "ning"
-	actualResult := StringDataContainsInsensitive(originalHaystack, originalNeedle)
-	if expectedOutput := true; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
-	actualResult = StringDataContainsInsensitive(originalHaystack, anotherNeedle)
-	if expectedOutput := false; actualResult != expectedOutput {
-		t.Errorf("Expected '%v'. Actual '%v'",
-			expectedOutput, actualResult)
-	}
+	assert.True(t, StringSliceContainsInsensitive(originalHaystack, "Bla"), "Should contain 'Bla'")
+	assert.False(t, StringSliceContainsInsensitive(originalHaystack, "ning"), "Should not contain 'ning'")
 }
 
 func TestYesOrNo(t *testing.T) {
@@ -586,45 +541,6 @@ func TestAddPaddingOnUpperCase(t *testing.T) {
 		if received := AddPaddingOnUpperCase(testCases[x].Supplied); received != testCases[x].Expected {
 			t.Fatalf("received '%v' but expected '%v'", received, testCases[x].Expected)
 		}
-	}
-}
-
-func TestInArray(t *testing.T) {
-	t.Parallel()
-	InArray(nil, nil)
-
-	array := [6]int{2, 3, 5, 7, 11, 13}
-	isIn, pos := InArray(5, array)
-	if !isIn {
-		t.Errorf("failed to find the value within the array")
-	}
-	if pos != 2 {
-		t.Errorf("failed return the correct position of the value in the array")
-	}
-	isIn, _ = InArray(1, array)
-	if isIn {
-		t.Errorf("found a non existent value in the array")
-	}
-
-	slice := make([]int, 0)
-	slice = append(append(slice, 5), 3)
-	isIn, pos = InArray(5, slice)
-	if !isIn {
-		t.Errorf("failed to find the value within the slice")
-	}
-	if pos != 0 {
-		t.Errorf("failed return the correct position of the value in the slice")
-	}
-	isIn, pos = InArray(3, slice)
-	if !isIn {
-		t.Errorf("failed to find the value within the slice")
-	}
-	if pos != 1 {
-		t.Errorf("failed return the correct position of the value in the slice")
-	}
-	isIn, _ = InArray(1, slice)
-	if isIn {
-		t.Errorf("found a non existent value in the slice")
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -49,7 +50,7 @@ func (c *Config) GetExchangeBankAccounts(exchangeName, id, depositingCurrency st
 		if strings.EqualFold(c.Exchanges[x].Name, exchangeName) {
 			for y := range c.Exchanges[x].BankAccounts {
 				if strings.EqualFold(c.Exchanges[x].BankAccounts[y].ID, id) {
-					if common.StringDataCompareInsensitive(
+					if common.StringSliceCompareInsensitive(
 						strings.Split(c.Exchanges[x].BankAccounts[y].SupportedCurrencies, ","),
 						depositingCurrency) {
 						return &c.Exchanges[x].BankAccounts[y], nil
@@ -1160,7 +1161,7 @@ func (c *Config) CheckCurrencyConfigValues() error {
 	}
 
 	for i := range c.Currency.ForexProviders {
-		if !common.StringDataContainsInsensitive(supported, c.Currency.ForexProviders[i].Name) {
+		if !common.StringSliceContainsInsensitive(supported, c.Currency.ForexProviders[i].Name) {
 			log.Warnf(log.ConfigMgr,
 				"%s forex provider not supported, please remove from config.\n",
 				c.Currency.ForexProviders[i].Name)
@@ -1305,7 +1306,7 @@ func (c *Config) checkDatabaseConfig() error {
 		return nil
 	}
 
-	if !common.StringDataCompare(database.SupportedDrivers, c.Database.Driver) {
+	if !slices.Contains(database.SupportedDrivers, c.Database.Driver) {
 		c.Database.Enabled = false
 		return fmt.Errorf("unsupported database driver %v, database disabled", c.Database.Driver)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1111,7 +1112,7 @@ func TestGetEnabledExchanges(t *testing.T) {
 	}}
 
 	exchanges := cfg.GetEnabledExchanges()
-	if !common.StringDataCompare(exchanges, bfx) {
+	if !slices.Contains(exchanges, bfx) {
 		t.Error(
 			"TestGetEnabledExchanges. Expected exchange Bitfinex not found",
 		)
@@ -1722,18 +1723,11 @@ func TestCheckConnectionMonitorConfig(t *testing.T) {
 	t.Parallel()
 
 	var c Config
-	c.ConnectionMonitor.CheckInterval = 0
-	c.ConnectionMonitor.DNSList = nil
-	c.ConnectionMonitor.PublicDomainList = nil
 	c.CheckConnectionMonitorConfig()
 
-	if c.ConnectionMonitor.CheckInterval != connchecker.DefaultCheckInterval ||
-		len(common.StringSliceDifference(
-			c.ConnectionMonitor.DNSList, connchecker.DefaultDNSList)) != 0 ||
-		len(common.StringSliceDifference(
-			c.ConnectionMonitor.PublicDomainList, connchecker.DefaultDomainList)) != 0 {
-		t.Error("unexpected values")
-	}
+	assert.Equal(t, connchecker.DefaultCheckInterval, c.ConnectionMonitor.CheckInterval)
+	assert.Equal(t, connchecker.DefaultDNSList, c.ConnectionMonitor.DNSList)
+	assert.Equal(t, connchecker.DefaultDomainList, c.ConnectionMonitor.PublicDomainList)
 }
 
 func TestDefaultFilePath(t *testing.T) {

--- a/currency/forexprovider/base/base_interface.go
+++ b/currency/forexprovider/base/base_interface.go
@@ -61,7 +61,7 @@ func (p *Provider) GetNewRate(base string, currencies []string) (map[string]floa
 func (p Provider) CheckCurrencies(currencies []string) []string {
 	var spillOver []string
 	for _, c := range currencies {
-		if !common.StringDataCompareInsensitive(p.SupportedCurrencies, c) {
+		if !common.StringSliceCompareInsensitive(p.SupportedCurrencies, c) {
 			spillOver = append(spillOver, c)
 		}
 	}
@@ -72,7 +72,7 @@ func (p Provider) CheckCurrencies(currencies []string) []string {
 func (f *FXHandler) GetCurrencyData(baseCurrency string, currencies []string) (map[string]float64, error) {
 	var fullRange = currencies
 
-	if !common.StringDataCompareInsensitive(currencies, baseCurrency) {
+	if !common.StringSliceCompareInsensitive(currencies, baseCurrency) {
 		fullRange = append(fullRange, baseCurrency)
 	}
 

--- a/docs/ADD_NEW_EXCHANGE.md
+++ b/docs/ADD_NEW_EXCHANGE.md
@@ -267,9 +267,9 @@ func TestGetEnabledExchanges(t *testing.T) {
 		t.Errorf("received: '%v' but expected '%v'", len(exchanges), defaultEnabledExchanges)
 	}
 
-	if !common.StringDataCompare(exchanges, "Bitfinex") {
+	if !slices.Contains(exchanges, "Bitfinex") {
 		t.Errorf("received: '%v' but expected '%v'", 
-			common.StringDataCompare(exchanges, "Bitfinex"), 
+			slices.Contains(exchanges, "Bitfinex"), 
 			true)
 	}
 }

--- a/docs/ADD_NEW_EXCHANGE.md
+++ b/docs/ADD_NEW_EXCHANGE.md
@@ -251,43 +251,6 @@ var Exchanges = []string{
 	"yobit",
 ```
 
-#### Increment the default number of supported exchanges in [config/config_test.go](../config/config_test.go):
-```go
-func TestGetEnabledExchanges(t *testing.T) {
-	cfg := GetConfig()
-	err := cfg.LoadConfig(TestFile, true)
-	if !errors.Is(err, errConfigDefineErrorExample) {
-		t.Errorf("received: '%v' but expected '%v'", err, errConfigDefineErrorExample)
-	}
-
-	exchanges := cfg.GetEnabledExchanges()
-	// modify the value of defaultEnabledExchanges at the top of the 
-	// config_test.go file to match the total count of exchanges
-	if len(exchanges) != defaultEnabledExchanges { 
-		t.Errorf("received: '%v' but expected '%v'", len(exchanges), defaultEnabledExchanges)
-	}
-
-	if !slices.Contains(exchanges, "Bitfinex") {
-		t.Errorf("received: '%v' but expected '%v'", 
-			slices.Contains(exchanges, "Bitfinex"), 
-			true)
-	}
-}
-```
-
-#### Increment the number of supported exchanges in [the gctscript exchange wrapper test file](../gctscript/wrappers/gct/exchange/exchange_test.go):
-```go
-func TestExchange_Exchanges(t *testing.T) {
-	t.Parallel()
-	x := exchangeTest.Exchanges(false)
-	y := len(x)
-	expected := 28 // modify this value to match the total count of exchanges
-	if y != expected {
-    	t.Fatalf("expected %v received %v", expected , y)
-	}
-}
-```
-
 #### Setup and run the [documentation tool](../cmd/documentation):
 
 - Create a new file named *exchangename*.tmpl

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -903,7 +903,7 @@ func (bot *Engine) SetupExchanges() error {
 		bot.dryRunParamInteraction("exchanges")
 		exchangesOverride = strings.Split(bot.Settings.Exchanges, ",")
 		for x := range exchangesOverride {
-			if !common.StringDataCompareInsensitive(exchange.Exchanges, exchangesOverride[x]) {
+			if !common.StringSliceCompareInsensitive(exchange.Exchanges, exchangesOverride[x]) {
 				return fmt.Errorf("exchange %s not found", exchangesOverride[x])
 			}
 		}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitfinex"
@@ -372,11 +372,11 @@ func TestGetDefaultConfigurations(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if isCITest() && common.StringDataContains(blockedCIExchanges, name) {
+			if isCITest() && slices.Contains(blockedCIExchanges, name) {
 				t.Skipf("skipping %s due to CI test restrictions", name)
 			}
 
-			if common.StringDataContains(unsupportedDefaultConfigExchanges, name) {
+			if slices.Contains(unsupportedDefaultConfigExchanges, name) {
 				t.Skipf("skipping %s unsupported", name)
 			}
 

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -753,7 +753,7 @@ func (bot *Engine) GetAllExchangeCryptocurrencyDepositAddresses() map[string]map
 					}
 					if len(availChains) > 0 {
 						// store the default non-chain specified address for a specified crypto
-						chainContainsItself := common.StringDataCompareInsensitive(availChains, cryptocurrency)
+						chainContainsItself := common.StringSliceCompareInsensitive(availChains, cryptocurrency)
 						if !chainContainsItself && !requiresChainSet {
 							depositAddr, err := exch.GetDepositAddress(context.TODO(), currency.NewCode(cryptocurrency), "", "")
 							if err != nil {

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -13,12 +13,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/communications"
@@ -733,14 +733,14 @@ func TestGetExchangeNamesByCurrency(t *testing.T) {
 	result := e.GetExchangeNamesByCurrency(btsusd,
 		true,
 		assetType)
-	if !common.StringDataCompare(result, testExchange) {
+	if !slices.Contains(result, testExchange) {
 		t.Fatal("Unexpected result")
 	}
 
 	result = e.GetExchangeNamesByCurrency(btcjpy,
 		true,
 		assetType)
-	if !common.StringDataCompare(result, bf) {
+	if !slices.Contains(result, bf) {
 		t.Fatal("Unexpected result")
 	}
 
@@ -1176,7 +1176,7 @@ func TestGetExchangeNames(t *testing.T) {
 	if err := bot.UnloadExchange(testExchange); err != nil {
 		t.Fatal(err)
 	}
-	if e := bot.GetExchangeNames(true); common.StringDataCompare(e, testExchange) {
+	if e := bot.GetExchangeNames(true); slices.Contains(e, testExchange) {
 		t.Error("Bitstamp should be missing")
 	}
 	if e := bot.GetExchangeNames(false); len(e) != 0 {
@@ -1378,10 +1378,10 @@ func TestNewExchangeByNameWithDefaults(t *testing.T) {
 		name := exchange.Exchanges[x]
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if isCITest() && common.StringDataContains(blockedCIExchanges, name) {
+			if isCITest() && slices.Contains(blockedCIExchanges, name) {
 				t.Skipf("skipping %s due to CI test restrictions", name)
 			}
-			if common.StringDataContains(unsupportedDefaultConfigExchanges, name) {
+			if slices.Contains(unsupportedDefaultConfigExchanges, name) {
 				t.Skipf("skipping %s unsupported", name)
 			}
 			exch, err := NewExchangeByNameWithDefaults(context.Background(), name)

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -375,7 +375,7 @@ func (m *OrderManager) validate(exch exchange.IBotExchange, newOrder *order.Subm
 		}
 
 		if len(m.cfg.AllowedExchanges) > 0 &&
-			!common.StringDataCompareInsensitive(m.cfg.AllowedExchanges, newOrder.Exchange) {
+			!common.StringSliceCompareInsensitive(m.cfg.AllowedExchanges, newOrder.Exchange) {
 			return errors.New("order exchange not found in allowed list")
 		}
 

--- a/exchanges/asset/asset_test.go
+++ b/exchanges/asset/asset_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestString(t *testing.T) {
@@ -21,15 +21,9 @@ func TestString(t *testing.T) {
 	}
 }
 
-func TestToStringArray(t *testing.T) {
+func TestStrings(t *testing.T) {
 	t.Parallel()
-	a := Items{Spot, Futures}
-	result := a.Strings()
-	for x := range a {
-		if !common.StringDataCompare(result, a[x].String()) {
-			t.Fatal("TestToStringArray returned an unexpected result")
-		}
-	}
+	assert.ElementsMatch(t, Items{Spot, Futures}.Strings(), []string{"spot", "futures"})
 }
 
 func TestContains(t *testing.T) {

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -257,7 +257,7 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, interval) {
+	if !slices.Contains(validFuturesIntervals, interval) {
 		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
@@ -369,14 +369,14 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 func (b *Binance) GetContinuousKlineData(ctx context.Context, pair, contractType, interval string, limit int64, startTime, endTime time.Time) ([]FuturesCandleStick, error) {
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validContractType, contractType) {
+	if !slices.Contains(validContractType, contractType) {
 		return nil, errors.New("invalid contractType")
 	}
 	params.Set("contractType", contractType)
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, interval) {
+	if !slices.Contains(validFuturesIntervals, interval) {
 		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
@@ -491,7 +491,7 @@ func (b *Binance) GetIndexPriceKlines(ctx context.Context, pair, interval string
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, interval) {
+	if !slices.Contains(validFuturesIntervals, interval) {
 		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
@@ -610,7 +610,7 @@ func (b *Binance) GetMarkPriceKline(ctx context.Context, symbol currency.Pair, i
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, interval) {
+	if !slices.Contains(validFuturesIntervals, interval) {
 		return nil, errors.New("invalid interval parsed")
 	}
 	params.Set("interval", interval)
@@ -833,11 +833,11 @@ func (b *Binance) GetOpenInterestStats(ctx context.Context, pair, contractType, 
 	if pair != "" {
 		params.Set("pair", pair)
 	}
-	if !common.StringDataCompare(validContractType, contractType) {
+	if !slices.Contains(validContractType, contractType) {
 		return resp, errors.New("invalid contractType")
 	}
 	params.Set("contractType", contractType)
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -859,7 +859,7 @@ func (b *Binance) GetTraderFuturesAccountRatio(ctx context.Context, pair, period
 	var resp []TopTraderAccountRatio
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -881,7 +881,7 @@ func (b *Binance) GetTraderFuturesPositionsRatio(ctx context.Context, pair, peri
 	var resp []TopTraderPositionRatio
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -903,7 +903,7 @@ func (b *Binance) GetMarketRatio(ctx context.Context, pair, period string, limit
 	var resp []TopTraderPositionRatio
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -925,14 +925,14 @@ func (b *Binance) GetFuturesTakerVolume(ctx context.Context, pair, contractType,
 	var resp []TakerBuySellVolume
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validContractType, contractType) {
+	if !slices.Contains(validContractType, contractType) {
 		return resp, errors.New("invalid contractType")
 	}
 	params.Set("contractType", contractType)
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period parsed")
 	}
 	params.Set("period", period)
@@ -951,14 +951,14 @@ func (b *Binance) GetFuturesBasisData(ctx context.Context, pair, contractType, p
 	var resp []FuturesBasisData
 	params := url.Values{}
 	params.Set("pair", pair)
-	if !common.StringDataCompare(validContractType, contractType) {
+	if !slices.Contains(validContractType, contractType) {
 		return resp, errors.New("invalid contractType")
 	}
 	params.Set("contractType", contractType)
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	if !common.StringDataCompare(validFuturesIntervals, period) {
+	if !slices.Contains(validFuturesIntervals, period) {
 		return resp, errors.New("invalid period parsed")
 	}
 	params.Set("period", period)
@@ -986,7 +986,7 @@ func (b *Binance) FuturesNewOrder(ctx context.Context, x *FuturesNewOrderRequest
 	params.Set("symbol", symbolValue)
 	params.Set("side", x.Side)
 	if x.PositionSide != "" {
-		if !common.StringDataCompare(validPositionSide, x.PositionSide) {
+		if !slices.Contains(validPositionSide, x.PositionSide) {
 			return resp, errors.New("invalid positionSide")
 		}
 		params.Set("positionSide", x.PositionSide)
@@ -1005,13 +1005,13 @@ func (b *Binance) FuturesNewOrder(ctx context.Context, x *FuturesNewOrderRequest
 		params.Set("closePosition", x.ClosePosition)
 	}
 	if x.WorkingType != "" {
-		if !common.StringDataCompare(validWorkingType, x.WorkingType) {
+		if !slices.Contains(validWorkingType, x.WorkingType) {
 			return resp, errors.New("invalid workingType")
 		}
 		params.Set("workingType", x.WorkingType)
 	}
 	if x.NewOrderRespType != "" {
-		if !common.StringDataCompare(validNewOrderRespType, x.NewOrderRespType) {
+		if !slices.Contains(validNewOrderRespType, x.NewOrderRespType) {
 			return resp, errors.New("invalid newOrderRespType")
 		}
 		params.Set("newOrderRespType", x.NewOrderRespType)
@@ -1052,17 +1052,17 @@ func (b *Binance) FuturesBatchOrder(ctx context.Context, data []PlaceBatchOrderD
 		}
 		data[x].Symbol = formattedPair.String()
 		if data[x].PositionSide != "" {
-			if !common.StringDataCompare(validPositionSide, data[x].PositionSide) {
+			if !slices.Contains(validPositionSide, data[x].PositionSide) {
 				return resp, errors.New("invalid positionSide")
 			}
 		}
 		if data[x].WorkingType != "" {
-			if !common.StringDataCompare(validWorkingType, data[x].WorkingType) {
+			if !slices.Contains(validWorkingType, data[x].WorkingType) {
 				return resp, errors.New("invalid workingType")
 			}
 		}
 		if data[x].NewOrderRespType != "" {
-			if !common.StringDataCompare(validNewOrderRespType, data[x].NewOrderRespType) {
+			if !slices.Contains(validNewOrderRespType, data[x].NewOrderRespType) {
 				return resp, errors.New("invalid newOrderRespType")
 			}
 		}
@@ -1274,7 +1274,7 @@ func (b *Binance) FuturesChangeMarginType(ctx context.Context, symbol currency.P
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(validMarginType, marginType) {
+	if !slices.Contains(validMarginType, marginType) {
 		return resp, errors.New("invalid marginType")
 	}
 	params.Set("marginType", marginType)
@@ -1291,7 +1291,7 @@ func (b *Binance) ModifyIsolatedPositionMargin(ctx context.Context, symbol curre
 	}
 	params.Set("symbol", symbolValue)
 	if positionSide != "" {
-		if !common.StringDataCompare(validPositionSide, positionSide) {
+		if !slices.Contains(validPositionSide, positionSide) {
 			return resp, errors.New("invalid positionSide")
 		}
 		params.Set("positionSide", positionSide)
@@ -1393,7 +1393,7 @@ func (b *Binance) FuturesIncomeHistory(ctx context.Context, symbol currency.Pair
 		params.Set("symbol", symbolValue)
 	}
 	if incomeType != "" {
-		if !common.StringDataCompare(validIncomeType, incomeType) {
+		if !slices.Contains(validIncomeType, incomeType) {
 			return resp, fmt.Errorf("invalid incomeType: %v", incomeType)
 		}
 		params.Set("incomeType", incomeType)
@@ -1433,7 +1433,7 @@ func (b *Binance) FuturesForceOrders(ctx context.Context, symbol currency.Pair, 
 		params.Set("symbol", symbolValue)
 	}
 	if autoCloseType != "" {
-		if !common.StringDataCompare(validAutoCloseTypes, autoCloseType) {
+		if !slices.Contains(validAutoCloseTypes, autoCloseType) {
 			return resp, errors.New("invalid autoCloseType")
 		}
 		params.Set("autoCloseType", autoCloseType)

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
@@ -96,7 +96,7 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 	params.Set("symbol", symbolValue)
 	strLimit := strconv.FormatInt(limit, 10)
 	if strLimit != "" {
-		if !common.StringDataCompare(uValidOBLimits, strLimit) {
+		if !slices.Contains(uValidOBLimits, strLimit) {
 			return nil, fmt.Errorf("invalid limit: %v", limit)
 		}
 		params.Set("limit", strLimit)
@@ -228,7 +228,7 @@ func (b *Binance) UKlineData(ctx context.Context, symbol currency.Pair, interval
 		return nil, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(validFuturesIntervals, interval) {
+	if !slices.Contains(validFuturesIntervals, interval) {
 		return nil, errors.New("invalid interval")
 	}
 	params.Set("interval", interval)
@@ -494,7 +494,7 @@ func (b *Binance) UOpenInterestStats(ctx context.Context, symbol currency.Pair, 
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, period) {
+	if !slices.Contains(uValidPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -520,7 +520,7 @@ func (b *Binance) UTopAcccountsLongShortRatio(ctx context.Context, symbol curren
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, period) {
+	if !slices.Contains(uValidPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -546,7 +546,7 @@ func (b *Binance) UTopPostionsLongShortRatio(ctx context.Context, symbol currenc
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, period) {
+	if !slices.Contains(uValidPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -572,7 +572,7 @@ func (b *Binance) UGlobalLongShortRatio(ctx context.Context, symbol currency.Pai
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, period) {
+	if !slices.Contains(uValidPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -598,7 +598,7 @@ func (b *Binance) UTakerBuySellVol(ctx context.Context, symbol currency.Pair, pe
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(uValidPeriods, period) {
+	if !slices.Contains(uValidPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -646,7 +646,7 @@ func (b *Binance) UFuturesNewOrder(ctx context.Context, data *UFuturesNewOrderRe
 	params.Set("symbol", symbolValue)
 	params.Set("side", data.Side)
 	if data.PositionSide != "" {
-		if !common.StringDataCompare(validPositionSide, data.PositionSide) {
+		if !slices.Contains(validPositionSide, data.PositionSide) {
 			return resp, errors.New("invalid positionSide")
 		}
 		params.Set("positionSide", data.PositionSide)
@@ -663,13 +663,13 @@ func (b *Binance) UFuturesNewOrder(ctx context.Context, data *UFuturesNewOrderRe
 		params.Set("closePosition", data.ClosePosition)
 	}
 	if data.WorkingType != "" {
-		if !common.StringDataCompare(validWorkingType, data.WorkingType) {
+		if !slices.Contains(validWorkingType, data.WorkingType) {
 			return resp, errors.New("invalid workingType")
 		}
 		params.Set("workingType", data.WorkingType)
 	}
 	if data.NewOrderRespType != "" {
-		if !common.StringDataCompare(validNewOrderRespType, data.NewOrderRespType) {
+		if !slices.Contains(validNewOrderRespType, data.NewOrderRespType) {
 			return resp, errors.New("invalid newOrderRespType")
 		}
 		params.Set("newOrderRespType", data.NewOrderRespType)
@@ -707,17 +707,17 @@ func (b *Binance) UPlaceBatchOrders(ctx context.Context, data []PlaceBatchOrderD
 		}
 		data[x].Symbol = formattedPair.String()
 		if data[x].PositionSide != "" {
-			if !common.StringDataCompare(validPositionSide, data[x].PositionSide) {
+			if !slices.Contains(validPositionSide, data[x].PositionSide) {
 				return resp, errors.New("invalid positionSide")
 			}
 		}
 		if data[x].WorkingType != "" {
-			if !common.StringDataCompare(validWorkingType, data[x].WorkingType) {
+			if !slices.Contains(validWorkingType, data[x].WorkingType) {
 				return resp, errors.New("invalid workingType")
 			}
 		}
 		if data[x].NewOrderRespType != "" {
-			if !common.StringDataCompare(validNewOrderRespType, data[x].NewOrderRespType) {
+			if !slices.Contains(validNewOrderRespType, data[x].NewOrderRespType) {
 				return resp, errors.New("invalid newOrderRespType")
 			}
 		}
@@ -916,7 +916,7 @@ func (b *Binance) UChangeInitialMarginType(ctx context.Context, symbol currency.
 		return err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(validMarginType, marginType) {
+	if !slices.Contains(validMarginType, marginType) {
 		return errors.New("invalid marginType")
 	}
 	params.Set("marginType", marginType)
@@ -1034,7 +1034,7 @@ func (b *Binance) UAccountIncomeHistory(ctx context.Context, symbol currency.Pai
 	}
 	params.Set("symbol", symbolValue)
 	if incomeType != "" {
-		if !common.StringDataCompare(validIncomeType, incomeType) {
+		if !slices.Contains(validIncomeType, incomeType) {
 			return resp, errors.New("invalid incomeType")
 		}
 		params.Set("incomeType", incomeType)
@@ -1094,7 +1094,7 @@ func (b *Binance) UAccountForcedOrders(ctx context.Context, symbol currency.Pair
 		params.Set("symbol", symbolValue)
 	}
 	if autoCloseType != "" {
-		if !common.StringDataCompare(validAutoCloseTypes, autoCloseType) {
+		if !slices.Contains(validAutoCloseTypes, autoCloseType) {
 			return resp, errors.New("invalid incomeType")
 		}
 		params.Set("autoCloseType", autoCloseType)

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -436,7 +437,7 @@ func (b *Bitfinex) GetPairs(ctx context.Context, a asset.Item) ([]string, error)
 		}
 		filtered := make([]string, 0, len(list))
 		for x := range list {
-			if common.StringDataCompare(filter, list[x]) {
+			if slices.Contains(filter, list[x]) {
 				continue
 			}
 			filtered = append(filtered, list[x])
@@ -1262,7 +1263,7 @@ func (b *Bitfinex) GetAccountSummary(ctx context.Context) (AccountSummary, error
 func (b *Bitfinex) NewDeposit(ctx context.Context, method, walletName string, renew uint8) (*Deposit, error) {
 	if walletName == "" {
 		walletName = "funding"
-	} else if !common.StringDataCompare(AcceptedWalletNames, walletName) {
+	} else if !slices.Contains(AcceptedWalletNames, walletName) {
 		return nil,
 			fmt.Errorf("walletname: [%s] is not allowed, supported: %s",
 				walletName,
@@ -1463,7 +1464,7 @@ func (b *Bitfinex) WithdrawFIAT(ctx context.Context, withdrawalType, walletType 
 // NewOrder submits a new order and returns a order information
 // Major Upgrade needed on this function to include all query params
 func (b *Bitfinex) NewOrder(ctx context.Context, currencyPair, orderType string, amount, price float64, buy, hidden bool) (Order, error) {
-	if !common.StringDataCompare(AcceptedOrderType, orderType) {
+	if !slices.Contains(AcceptedOrderType, orderType) {
 		return Order{}, fmt.Errorf("order type %s not accepted", orderType)
 	}
 

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -74,7 +74,7 @@ func (a *acceptableMethodStore) lookup(curr currency.Code) []string {
 	defer a.m.RUnlock()
 	var methods []string
 	for k, v := range a.a {
-		if common.StringDataCompareInsensitive(v, curr.Upper().String()) {
+		if common.StringSliceCompareInsensitive(v, curr.Upper().String()) {
 			methods = append(methods, k)
 		}
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -914,7 +914,7 @@ func (b *Bitfinex) WithdrawCryptocurrencyFunds(ctx context.Context, withdrawRequ
 	}
 	method := methods[0]
 	if len(methods) > 1 && withdrawRequest.Crypto.Chain != "" {
-		if !common.StringDataCompareInsensitive(methods, withdrawRequest.Crypto.Chain) {
+		if !common.StringSliceCompareInsensitive(methods, withdrawRequest.Crypto.Chain) {
 			return nil, fmt.Errorf("invalid chain %s supplied, %v available", withdrawRequest.Crypto.Chain, methods)
 		}
 		method = withdrawRequest.Crypto.Chain

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -358,7 +358,7 @@ func (b *BTCMarkets) Subscribe(subs subscription.List) error {
 
 	var errs error
 	for _, s := range subs {
-		if baseReq.Key == "" && common.StringDataContains(authChannels, s.Channel) {
+		if baseReq.Key == "" && common.StringSliceContains(authChannels, s.Channel) {
 			if err := b.authWsSubscibeReq(baseReq); err != nil {
 				return err
 			}

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1343,7 +1344,7 @@ func (by *Bybit) GetCoinGreeks(ctx context.Context, baseCoin string) (*CoinGreek
 // GetFeeRate retrieves the trading fee rate.
 func (by *Bybit) GetFeeRate(ctx context.Context, category, symbol, baseCoin string) (*AccountFee, error) {
 	params := url.Values{}
-	if !common.StringDataContains(validCategory, category) {
+	if !slices.Contains(validCategory, category) {
 		return nil, fmt.Errorf("%w, valid category values are %v", errInvalidCategory, validCategory)
 	}
 	if category != "" {
@@ -1470,7 +1471,7 @@ func (by *Bybit) GetCoinExchangeRecords(ctx context.Context, fromCoin, toCoin, c
 
 // GetDeliveryRecord retrieves delivery records of USDC futures and Options, sorted by deliveryTime in descending order
 func (by *Bybit) GetDeliveryRecord(ctx context.Context, category, symbol, cursor string, expiryDate time.Time, limit int64) (*DeliveryRecord, error) {
-	if !common.StringDataContains([]string{cLinear, cOption}, category) {
+	if !slices.Contains([]string{cLinear, cOption}, category) {
 		return nil, fmt.Errorf("%w, valid category values are %v", errInvalidCategory, []string{cLinear, cOption})
 	}
 	params := url.Values{}
@@ -1493,7 +1494,7 @@ func (by *Bybit) GetDeliveryRecord(ctx context.Context, category, symbol, cursor
 
 // GetUSDCSessionSettlement retrieves session settlement records of USDC perpetual and futures
 func (by *Bybit) GetUSDCSessionSettlement(ctx context.Context, category, symbol, cursor string, limit int64) (*SettlementSession, error) {
-	if !common.StringDataContains([]string{cLinear}, category) {
+	if category != cLinear {
 		return nil, fmt.Errorf("%w, valid category value is %v", errInvalidCategory, cLinear)
 	}
 	params := url.Values{}

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -224,9 +225,8 @@ func (c *CoinbasePro) GetHistoricRates(ctx context.Context, currencyPair, start,
 		values.Set("end", "")
 	}
 
-	allowedGranularities := [6]int64{60, 300, 900, 3600, 21600, 86400}
-	validGran, _ := common.InArray(granularity, allowedGranularities)
-	if !validGran {
+	allowedGranularities := []int64{60, 300, 900, 3600, 21600, 86400}
+	if !slices.Contains(allowedGranularities, granularity) {
 		return nil, errors.New("Invalid granularity value: " + strconv.FormatInt(granularity, 10) + ". Allowed values are {60, 300, 900, 3600, 21600, 86400}")
 	}
 	if granularity > 0 {

--- a/exchanges/huobi/huobi_cfutures.go
+++ b/exchanges/huobi/huobi_cfutures.go
@@ -136,7 +136,7 @@ func (h *HUOBI) GetSwapKlineData(ctx context.Context, code currency.Pair, period
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
@@ -248,7 +248,7 @@ func (h *HUOBI) GetOpenInterestInfo(ctx context.Context, code currency.Pair, per
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
@@ -287,7 +287,7 @@ func (h *HUOBI) GetTraderSentimentIndexAccount(ctx context.Context, code currenc
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
@@ -305,7 +305,7 @@ func (h *HUOBI) GetTraderSentimentIndexPosition(ctx context.Context, code curren
 		return resp, err
 	}
 
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
@@ -372,7 +372,7 @@ func (h *HUOBI) GetPremiumIndexKlineData(ctx context.Context, code currency.Pair
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
@@ -393,7 +393,7 @@ func (h *HUOBI) GetEstimatedFundingRates(ctx context.Context, code currency.Pair
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
@@ -414,13 +414,13 @@ func (h *HUOBI) GetBasisData(ctx context.Context, code currency.Pair, period, ba
 	if err != nil {
 		return resp, err
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	if size <= 0 || size > 1200 {
 		return resp, errors.New("invalid size provided, only values between 1-1200 are supported")
 	}
-	if !common.StringDataCompareInsensitive(validBasisPriceTypes, basisPriceType) {
+	if !common.StringSliceCompareInsensitive(validBasisPriceTypes, basisPriceType) {
 		return resp, errors.New("invalid period value received")
 	}
 	params := url.Values{}
@@ -581,7 +581,7 @@ func (h *HUOBI) GetSwapOrderLimitInfo(ctx context.Context, code currency.Pair, o
 		return resp, err
 	}
 	req["contract_code"] = codeValue
-	if !common.StringDataCompareInsensitive(validOrderTypes, orderType) {
+	if !common.StringSliceCompareInsensitive(validOrderTypes, orderType) {
 		return resp, errors.New("invalid ordertype provided")
 	}
 	req["order_price_type"] = orderType
@@ -635,7 +635,7 @@ func (h *HUOBI) AccountTransferData(ctx context.Context, code currency.Pair, sub
 	req["contract_code"] = codeValue
 	req["subUid"] = subUID
 	req["amount"] = amount
-	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
+	if !common.StringSliceCompareInsensitive(validTransferType, transferType) {
 		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
@@ -651,7 +651,7 @@ func (h *HUOBI) AccountTransferRecords(ctx context.Context, code currency.Pair, 
 		return resp, err
 	}
 	req["contract_code"] = codeValue
-	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
+	if !common.StringSliceCompareInsensitive(validTransferType, transferType) {
 		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
@@ -682,7 +682,7 @@ func (h *HUOBI) PlaceSwapOrders(ctx context.Context, code currency.Pair, clientO
 	}
 	req["direction"] = direction
 	req["offset"] = offset
-	if !common.StringDataCompareInsensitive(validOrderTypes, orderPriceType) {
+	if !common.StringSliceCompareInsensitive(validOrderTypes, orderPriceType) {
 		return resp, errors.New("invalid ordertype provided")
 	}
 	req["order_price_type"] = orderPriceType
@@ -750,7 +750,7 @@ func (h *HUOBI) PlaceLightningCloseOrder(ctx context.Context, contractCode curre
 		req["client_order_id"] = clientOrderID
 	}
 	if orderPriceType != "" {
-		if !common.StringDataCompareInsensitive(validLightningOrderPriceType, orderPriceType) {
+		if !common.StringSliceCompareInsensitive(validLightningOrderPriceType, orderPriceType) {
 			return resp, errors.New("invalid orderPriceType")
 		}
 		req["order_price_type"] = orderPriceType
@@ -913,7 +913,7 @@ func (h *HUOBI) PlaceSwapTriggerOrder(ctx context.Context, contractCode currency
 	req["volume"] = volume
 	req["lever_rate"] = leverageRate
 	req["order_price"] = orderPrice
-	if !common.StringDataCompareInsensitive(validOrderPriceType, orderPriceType) {
+	if !common.StringSliceCompareInsensitive(validOrderPriceType, orderPriceType) {
 		return resp, errors.New("invalid order price type")
 	}
 	req["order_price_type"] = orderPriceType

--- a/exchanges/huobi/huobi_futures.go
+++ b/exchanges/huobi/huobi_futures.go
@@ -91,7 +91,7 @@ func (h *HUOBI) FGetContractInfo(ctx context.Context, symbol, contractType strin
 		params.Set("symbol", symbol)
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
@@ -130,7 +130,7 @@ func (h *HUOBI) FContractPriceLimitations(ctx context.Context, symbol, contractT
 		params.Set("symbol", symbol)
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, fmt.Errorf("invalid contractType: %s", contractType)
 		}
 		params.Set("contract_type", contractType)
@@ -164,7 +164,7 @@ func (h *HUOBI) ContractOpenInterestUSDT(ctx context.Context, contractCode, pair
 		params.Set("pair", p)
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return nil, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
@@ -187,7 +187,7 @@ func (h *HUOBI) FContractOpenInterest(ctx context.Context, symbol, contractType 
 		params.Set("symbol", symbol)
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, errors.New("invalid contractType")
 		}
 		params.Set("contract_type", contractType)
@@ -263,7 +263,7 @@ func (h *HUOBI) FGetKlineData(ctx context.Context, symbol currency.Pair, period 
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validFuturesPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
@@ -375,11 +375,11 @@ func (h *HUOBI) FQueryHisOpenInterest(ctx context.Context, symbol, contractType,
 	if symbol != "" {
 		params.Set("symbol", symbol)
 	}
-	if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+	if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 		return resp, fmt.Errorf("%w %v", errInvalidContractType, contractType)
 	}
 	params.Set("contract_type", contractType)
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -417,7 +417,7 @@ func (h *HUOBI) FQueryTopAccountsRatio(ctx context.Context, symbol, period strin
 	if symbol != "" {
 		params.Set("symbol", symbol)
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -432,7 +432,7 @@ func (h *HUOBI) FQueryTopPositionsRatio(ctx context.Context, symbol, period stri
 	if symbol != "" {
 		params.Set("symbol", symbol)
 	}
-	if !common.StringDataCompareInsensitive(validPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validPeriods, period) {
 		return resp, errors.New("invalid period")
 	}
 	params.Set("period", period)
@@ -476,7 +476,7 @@ func (h *HUOBI) FIndexKline(ctx context.Context, symbol currency.Pair, period st
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validFuturesPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
@@ -497,12 +497,12 @@ func (h *HUOBI) FGetBasisData(ctx context.Context, symbol currency.Pair, period,
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompareInsensitive(validFuturesPeriods, period) {
+	if !common.StringSliceCompareInsensitive(validFuturesPeriods, period) {
 		return resp, errors.New("invalid period value received")
 	}
 	params.Set("period", period)
 	if basisPriceType != "" {
-		if common.StringDataCompareInsensitive(validBasisPriceTypes, basisPriceType) {
+		if common.StringSliceCompareInsensitive(validBasisPriceTypes, basisPriceType) {
 			params.Set("basis_price_type", basisPriceType)
 		}
 	}
@@ -632,7 +632,7 @@ func (h *HUOBI) FGetOrderLimits(ctx context.Context, symbol, orderPriceType stri
 		req["symbol"] = symbol
 	}
 	if orderPriceType != "" {
-		if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
+		if !common.StringSliceCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
 			return resp, errors.New("invalid orderPriceType")
 		}
 		req["order_price_type"] = orderPriceType
@@ -697,7 +697,7 @@ func (h *HUOBI) FTransfer(ctx context.Context, subUID, symbol, transferType stri
 	req["symbol"] = symbol
 	req["subUid"] = subUID
 	req["amount"] = amount
-	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
+	if !common.StringSliceCompareInsensitive(validTransferType, transferType) {
 		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
@@ -711,7 +711,7 @@ func (h *HUOBI) FGetTransferRecords(ctx context.Context, symbol, transferType st
 	if symbol != "" {
 		req["symbol"] = symbol
 	}
-	if !common.StringDataCompareInsensitive(validTransferType, transferType) {
+	if !common.StringSliceCompareInsensitive(validTransferType, transferType) {
 		return resp, errors.New("invalid transferType received")
 	}
 	req["type"] = transferType
@@ -750,7 +750,7 @@ func (h *HUOBI) FOrder(ctx context.Context, contractCode currency.Pair, symbol, 
 		req["symbol"] = symbol
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
@@ -773,10 +773,10 @@ func (h *HUOBI) FOrder(ctx context.Context, contractCode currency.Pair, symbol, 
 		req["client_order_id"] = id
 	}
 	req["direction"] = direction
-	if !common.StringDataCompareInsensitive(validOffsetTypes, offset) {
+	if !common.StringSliceCompareInsensitive(validOffsetTypes, offset) {
 		return resp, errors.New("invalid offset amounts")
 	}
-	if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
+	if !common.StringSliceCompareInsensitive(validFuturesOrderPriceTypes, orderPriceType) {
 		return resp, errors.New("invalid orderPriceType")
 	}
 	req["order_price_type"] = orderPriceType
@@ -807,14 +807,14 @@ func (h *HUOBI) FPlaceBatchOrder(ctx context.Context, data []fBatchOrderData) (F
 			data[x].ContractCode = formattedPair.String()
 		}
 		if data[x].ContractType != "" {
-			if !common.StringDataCompareInsensitive(validContractTypes, data[x].ContractType) {
+			if !common.StringSliceCompareInsensitive(validContractTypes, data[x].ContractType) {
 				return resp, errors.New("invalid contractType")
 			}
 		}
-		if !common.StringDataCompareInsensitive(validOffsetTypes, data[x].Offset) {
+		if !common.StringSliceCompareInsensitive(validOffsetTypes, data[x].Offset) {
 			return resp, errors.New("invalid offset amounts")
 		}
-		if !common.StringDataCompareInsensitive(validFuturesOrderPriceTypes, data[x].OrderPriceType) {
+		if !common.StringSliceCompareInsensitive(validFuturesOrderPriceTypes, data[x].OrderPriceType) {
 			return resp, errors.New("invalid orderPriceType")
 		}
 	}
@@ -847,7 +847,7 @@ func (h *HUOBI) FCancelAllOrders(ctx context.Context, contractCode currency.Pair
 		req["symbol"] = symbol
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
@@ -868,7 +868,7 @@ func (h *HUOBI) FFlashCloseOrder(ctx context.Context, contractCode currency.Pair
 	req := make(map[string]interface{})
 	req["symbol"] = symbol
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, errors.New("invalid contractType")
 		}
 		req["contract_type"] = contractType
@@ -886,7 +886,7 @@ func (h *HUOBI) FFlashCloseOrder(ctx context.Context, contractCode currency.Pair
 		req["client_order_id"] = clientOrderID
 	}
 	if orderPriceType != "" {
-		if !common.StringDataCompareInsensitive(validOPTypes, orderPriceType) {
+		if !common.StringSliceCompareInsensitive(validOPTypes, orderPriceType) {
 			return resp, errors.New("invalid orderPriceType")
 		}
 		req["orderPriceType"] = orderPriceType
@@ -1040,7 +1040,7 @@ func (h *HUOBI) FPlaceTriggerOrder(ctx context.Context, contractCode currency.Pa
 		req["symbol"] = symbol
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, fmt.Errorf("invalid contractType: %s", contractType)
 		}
 		req["contract_type"] = contractType
@@ -1058,7 +1058,7 @@ func (h *HUOBI) FPlaceTriggerOrder(ctx context.Context, contractCode currency.Pa
 	}
 	req["trigger_type"] = tType
 	req["direction"] = direction
-	if !common.StringDataCompareInsensitive(validOffsetTypes, offset) {
+	if !common.StringSliceCompareInsensitive(validOffsetTypes, offset) {
 		return resp, errors.New("invalid offset")
 	}
 	req["offset"] = offset
@@ -1066,7 +1066,7 @@ func (h *HUOBI) FPlaceTriggerOrder(ctx context.Context, contractCode currency.Pa
 	req["volume"] = volume
 	req["lever_rate"] = leverageRate
 	req["order_price"] = orderPrice
-	if !common.StringDataCompareInsensitive(validOrderPriceType, orderPriceType) {
+	if !common.StringSliceCompareInsensitive(validOrderPriceType, orderPriceType) {
 		return resp, errors.New("invalid order price type")
 	}
 	req["order_price_type"] = orderPriceType
@@ -1095,7 +1095,7 @@ func (h *HUOBI) FCancelAllTriggerOrders(ctx context.Context, contractCode curren
 		req["contract_code"] = codeValue
 	}
 	if contractType != "" {
-		if !common.StringDataCompareInsensitive(validContractTypes, contractType) {
+		if !common.StringSliceCompareInsensitive(validContractTypes, contractType) {
 			return resp, nil
 		}
 		req["contract_type"] = contractType
@@ -1256,7 +1256,7 @@ func (h *HUOBI) formatFuturesCode(p currency.Code) (string, error) {
 
 // formatFuturesPair handles pairs in the format as "BTC-NW" and "BTC210827"
 func (h *HUOBI) formatFuturesPair(p currency.Pair, convertQuoteToExpiry bool) (string, error) {
-	if common.StringDataCompareInsensitive(validContractShortTypes, p.Quote.String()) {
+	if common.StringSliceCompareInsensitive(validContractShortTypes, p.Quote.String()) {
 		if convertQuoteToExpiry {
 			cp, err := h.convertContractShortHandToExpiry(p, time.Now())
 			if err != nil {

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 
@@ -117,7 +118,7 @@ func (k *Kraken) FuturesBatchOrder(ctx context.Context, data []PlaceBatchOrderDa
 		if err != nil {
 			return resp, err
 		}
-		if !common.StringDataCompare(validBatchOrderType, data[x].PlaceOrderType) {
+		if !slices.Contains(validBatchOrderType, data[x].PlaceOrderType) {
 			return resp, fmt.Errorf("%s %w",
 				data[x].PlaceOrderType,
 				errInvalidBatchOrderType)
@@ -175,12 +176,12 @@ func (k *Kraken) FuturesSendOrder(ctx context.Context, orderType order.Type, sym
 		return resp, err
 	}
 	params.Set("symbol", symbolValue)
-	if !common.StringDataCompare(validSide, side) {
+	if !slices.Contains(validSide, side) {
 		return resp, errors.New("invalid side")
 	}
 	params.Set("side", side)
 	if triggerSignal != "" {
-		if !common.StringDataCompare(validTriggerSignal, triggerSignal) {
+		if !slices.Contains(validTriggerSignal, triggerSignal) {
 			return resp, errors.New("invalid triggerSignal")
 		}
 		params.Set("triggerSignal", triggerSignal)
@@ -189,7 +190,7 @@ func (k *Kraken) FuturesSendOrder(ctx context.Context, orderType order.Type, sym
 		params.Set("cliOrdId", clientOrderID)
 	}
 	if reduceOnly != "" {
-		if !common.StringDataCompare(validReduceOnly, reduceOnly) {
+		if !slices.Contains(validReduceOnly, reduceOnly) {
 			return resp, errors.New("invalid reduceOnly")
 		}
 		params.Set("reduceOnly", reduceOnly)

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -1216,7 +1216,7 @@ channels:
 		for _, p := range channelsToSubscribe[i].Pairs {
 			outbound.Pairs = append(outbound.Pairs, p.String())
 		}
-		if common.StringDataContains(authenticatedChannels, channelsToSubscribe[i].Channel) {
+		if common.StringSliceContains(authenticatedChannels, channelsToSubscribe[i].Channel) {
 			outbound.Subscription.Token = authToken
 		}
 
@@ -1228,7 +1228,7 @@ channels:
 	for _, subs := range subscriptions {
 		for i := range *subs {
 			var err error
-			if common.StringDataContains(authenticatedChannels, (*subs)[i].Subscription.Name) {
+			if common.StringSliceContains(authenticatedChannels, (*subs)[i].Subscription.Name) {
 				_, err = k.Websocket.AuthConn.SendMessageReturnResponse(context.TODO(), (*subs)[i].RequestID, (*subs)[i])
 			} else {
 				_, err = k.Websocket.Conn.SendMessageReturnResponse(context.TODO(), (*subs)[i].RequestID, (*subs)[i])
@@ -1262,7 +1262,7 @@ channels:
 		}
 
 		var id int64
-		if common.StringDataContains(authenticatedChannels, channelsToUnsubscribe[x].Channel) {
+		if common.StringSliceContains(authenticatedChannels, channelsToUnsubscribe[x].Channel) {
 			id = k.Websocket.AuthConn.GenerateMessageID(false)
 		} else {
 			id = k.Websocket.Conn.GenerateMessageID(false)
@@ -1277,7 +1277,7 @@ channels:
 			},
 			RequestID: id,
 		}
-		if common.StringDataContains(authenticatedChannels, channelsToUnsubscribe[x].Channel) {
+		if common.StringSliceContains(authenticatedChannels, channelsToUnsubscribe[x].Channel) {
 			unsub.Subscription.Token = authToken
 		}
 		unsub.Channels = append(unsub.Channels, channelsToUnsubscribe[x])
@@ -1287,7 +1287,7 @@ channels:
 	var errs error
 	for i := range unsubs {
 		var err error
-		if common.StringDataContains(authenticatedChannels, unsubs[i].Subscription.Name) {
+		if common.StringSliceContains(authenticatedChannels, unsubs[i].Subscription.Name) {
 			_, err = k.Websocket.AuthConn.SendMessageReturnResponse(context.TODO(), unsubs[i].RequestID, unsubs[i])
 		} else {
 			_, err = k.Websocket.Conn.SendMessageReturnResponse(context.TODO(), unsubs[i].RequestID, unsubs[i])

--- a/exchanges/kucoin/kucoin.go
+++ b/exchanges/kucoin/kucoin.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -301,7 +302,7 @@ func (ku *Kucoin) GetKlines(ctx context.Context, pair, period string, start, end
 	if period == "" {
 		return nil, errors.New("period can not be empty")
 	}
-	if !common.StringDataContains(validPeriods, period) {
+	if !slices.Contains(validPeriods, period) {
 		return nil, errors.New("invalid period")
 	}
 	params.Set("type", period)

--- a/exchanges/kucoin/kucoin_futures.go
+++ b/exchanges/kucoin/kucoin_futures.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -332,7 +333,7 @@ func (ku *Kucoin) GetFuturesKline(ctx context.Context, granularity int64, symbol
 	if granularity == 0 {
 		return nil, errors.New("granularity can not be empty")
 	}
-	if !common.StringDataContains(validGranularity, strconv.FormatInt(granularity, 10)) {
+	if !slices.Contains(validGranularity, strconv.FormatInt(granularity, 10)) {
 		return nil, errors.New("invalid granularity")
 	}
 	params := url.Values{}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -776,7 +777,7 @@ func (p *Poloniex) GetDepositAddress(ctx context.Context, cryptocurrency currenc
 
 	address, ok = depositAddrs.Addresses[strings.ToUpper(targetCurrency)]
 	if !ok {
-		if len(coinParams.ChildChains) > 1 && chain != "" && !common.StringDataCompare(coinParams.ChildChains, targetCurrency) {
+		if len(coinParams.ChildChains) > 1 && chain != "" && !slices.Contains(coinParams.ChildChains, targetCurrency) {
 			// rather than assume, return an error
 			return nil, fmt.Errorf("currency %s has %v chains available, one of these must be specified",
 				cryptocurrency,

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -772,7 +772,7 @@ func exchangeOHLCV(args ...objects.Object) (objects.Object, error) {
 
 // parseInterval will parse the interval param of indictors that have them and convert to time.Duration
 func parseInterval(in string) (time.Duration, error) {
-	if !common.StringDataContainsInsensitive(supportedDurations, in) {
+	if !common.StringSliceContainsInsensitive(supportedDurations, in) {
 		return time.Nanosecond, errInvalidInterval
 	}
 	switch in {

--- a/portfolio/banking/banking.go
+++ b/portfolio/banking/banking.go
@@ -45,7 +45,7 @@ func GetBankAccountByID(id string) (*Account, error) {
 // ExchangeSupported Checks if exchange is supported by bank account
 func (b *Account) ExchangeSupported(exchange string) bool {
 	exchList := strings.Split(b.SupportedExchanges, ",")
-	return common.StringDataCompareInsensitive(exchList, exchange)
+	return common.StringSliceCompareInsensitive(exchList, exchange)
 }
 
 // Validate validates bank account settings
@@ -98,7 +98,7 @@ func (b *Account) ValidateForWithdrawal(exchange string, cur currency.Code) (err
 		err = append(err, ErrAccountCannotBeEmpty)
 	}
 
-	if !common.StringDataCompareInsensitive(strings.Split(b.SupportedCurrencies, ","), cur.String()) {
+	if !common.StringSliceCompareInsensitive(strings.Split(b.SupportedCurrencies, ","), cur.String()) {
 		err = append(err, ErrCurrencyNotSupportedByAccount)
 	}
 

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -415,7 +416,7 @@ func (b *Base) GetPortfolioSummary() Summary {
 	var portfolioExchanges []string
 	for i := range b.Addresses {
 		if strings.EqualFold(b.Addresses[i].Description, ExchangeAddress) {
-			if !common.StringDataCompare(portfolioExchanges, b.Addresses[i].Address) {
+			if !slices.Contains(portfolioExchanges, b.Addresses[i].Address) {
 				portfolioExchanges = append(portfolioExchanges, b.Addresses[i].Address)
 			}
 		}
@@ -514,7 +515,7 @@ func (b *Base) IsExchangeSupported(exchange, address string) (ret bool) {
 			continue
 		}
 		exchangeList := strings.Split(b.Addresses[x].SupportedExchanges, ",")
-		return common.StringDataContainsInsensitive(exchangeList, exchange)
+		return common.StringSliceContainsInsensitive(exchangeList, exchange)
 	}
 	return
 }


### PR DESCRIPTION
# PR Description

Replace StringDataCompare with slices.Contains + a bit of a cleanup.  I've made StringSliceDifference generic since I thought it might be useful moving forward, though since we don't currently use it anywhere now I'd be happy to rm -rf it 😈 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
