### PR TITLE
Subscriptions: Relax subscription validation for non-existent pairs

### DIFF
--- a/exchanges/subscription/template.go
+++ b/exchanges/subscription/template.go
@@ -104,6 +104,13 @@ func expandTemplate(e iExchange, s *Subscription, ap assetPairs, assets asset.It
 
 	subs := List{}
 
+	if len(s.Pairs) != 0 {
+		// We deliberately do not check Availability of sub Pairs because users have edge cases to subscribe to non-existent pairs
+		for a := range ap {
+			ap[a] = s.Pairs
+		}
+	}
+
 	switch s.Asset {
 	case asset.All:
 		subCtx.AssetPairs = ap
@@ -115,15 +122,6 @@ func expandTemplate(e iExchange, s *Subscription, ap assetPairs, assets asset.It
 		assets = asset.Items{s.Asset}
 		if s.Asset != asset.Empty && len(ap[s.Asset]) == 0 {
 			return List{}, nil // Nothing is enabled for this sub asset
-		}
-	}
-
-	if len(s.Pairs) != 0 {
-		for a, pairs := range subCtx.AssetPairs {
-			if err := pairs.ContainsAll(s.Pairs, true); err != nil { //nolint:govet // Shadow, or gocritic will complain sloppyReassign
-				return nil, err
-			}
-			subCtx.AssetPairs[a] = s.Pairs
 		}
 	}
 

--- a/exchanges/subscription/template_test.go
+++ b/exchanges/subscription/template_test.go
@@ -84,12 +84,17 @@ func TestExpandTemplates(t *testing.T) {
 	}
 	equalLists(t, exp, got)
 
+	// Users can specify pairs which aren't available, even across diverse assets
+	// Use-case: Coinbasepro user sub for futures BTC-USD would return all BTC pairs and all USD pairs, even though BTC-USD might not be enabled or available
+	p := currency.Pairs{currency.NewPairWithDelimiter("BEAR", "PEAR", "🐻")}
+	got, err = List{{Channel: "expand-pairs", Asset: asset.All, Pairs: p}}.ExpandTemplates(e)
+	require.NoError(t, err, "Must not error with fictional pairs")
+	exp = List{{Channel: "expand-pairs", QualifiedChannel: "spot-PEARBEAR-expand-pairs@0", Asset: asset.Spot, Pairs: p}}
+	equalLists(t, exp, got)
+
 	// Error cases
 	_, err = List{{Channel: "nil"}}.ExpandTemplates(e)
 	assert.ErrorIs(t, err, errInvalidTemplate, "Should get correct error on nil template")
-
-	_, err = List{{Channel: "single-channel", Asset: asset.Spot, Pairs: currency.Pairs{currency.NewPairWithDelimiter("NOPE", "POPE", "🐰")}}}.ExpandTemplates(e)
-	assert.ErrorIs(t, err, currency.ErrPairNotContainedInAvailablePairs, "Should error correctly when pair not available")
 
 	e.tpl = "errors.tmpl"
 


### PR DESCRIPTION
The subscription pairs do not need to be validated as enabled or available. The check was just belt-and-braces and didn't have a specific use-case in mind.

Coinbase has a use-case for wanting to subscribe to BTC-USD when it's not enabled.

Moreover, it shouldn't be our job to check this. You want a sub expanded with these pairs? Fine. Done. If it doesn't work, you can work out why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)