### PR TITLE
stream: Add verbosity to outbound requests that also returns responses

### DIFF
--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -167,7 +167,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 			return err
 		}
 
-		verbose := isVerbose(ctx, p.Verbose)
+		verbose := IsVerbose(ctx, p.Verbose)
 
 		if verbose {
 			log.Debugf(log.RequestSys, "%s attempt %d request path: %s", r.name, attempt, p.Path)
@@ -380,9 +380,9 @@ func WithVerbose(ctx context.Context) context.Context {
 	return context.WithValue(ctx, contextVerboseFlag, true)
 }
 
-// isVerbose checks main verbosity first then checks context verbose values
+// IsVerbose checks main verbosity first then checks context verbose values
 // for specific request verbosity.
-func isVerbose(ctx context.Context, verbose bool) bool {
+func IsVerbose(ctx context.Context, verbose bool) bool {
 	if verbose {
 		return true
 	}

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -700,29 +700,10 @@ func TestGetHTTPClientUserAgent(t *testing.T) {
 
 func TestContextVerbosity(t *testing.T) {
 	t.Parallel()
-	if isVerbose(context.Background(), false) {
-		t.Fatal("unexpected value")
-	}
-
-	if !isVerbose(context.Background(), true) {
-		t.Fatal("unexpected value")
-	}
-
-	ctx := context.Background()
-	ctx = WithVerbose(ctx)
-	if !isVerbose(ctx, false) {
-		t.Fatal("unexpected value")
-	}
-
-	ctx = context.Background()
-	ctx = context.WithValue(ctx, contextVerboseFlag, false)
-	if isVerbose(ctx, false) {
-		t.Fatal("unexpected value")
-	}
-
-	ctx = context.Background()
-	ctx = context.WithValue(ctx, contextVerboseFlag, "bruh")
-	if isVerbose(ctx, false) {
-		t.Fatal("unexpected value")
-	}
+	require.False(t, IsVerbose(context.Background(), false))
+	require.True(t, IsVerbose(context.Background(), true))
+	require.True(t, IsVerbose(WithVerbose(context.Background()), false))
+	require.False(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, false), false))
+	require.False(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, "bruh"), false))
+	require.True(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, true), false))
 }

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -321,7 +321,8 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 		w.Reporter.Latency(w.ExchangeName, outbound, time.Since(start))
 	}
 
-if request.IsVerbose(ctx, w.Verbose) && expected > 1 {
+	// Only check context verbosity. If the exchange is verbose, it will log the responses in the ReadMessage() call.
+	if request.IsVerbose(ctx, false) {
 		for i := range resps {
 			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
 		}

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -60,7 +60,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
 			if msg, err := json.Marshal(data); err == nil { // WriteJSON will error for us anyway
-				log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(msg))
+				log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(msg))
 			}
 		}
 		return w.Connection.WriteJSON(data)
@@ -71,7 +71,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 func (w *WebsocketConnection) SendRawMessage(ctx context.Context, messageType int, message []byte) error {
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
-			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(message))
+			log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(message))
 		}
 		return w.Connection.WriteMessage(messageType, message)
 	})
@@ -191,12 +191,12 @@ func (w *WebsocketConnection) ReadMessage() Response {
 	case websocket.BinaryMessage:
 		standardMessage, err = w.parseBinaryResponse(resp)
 		if err != nil {
-			log.Errorf(log.WebsocketMgr, "%v %v websocket connection: Parse binary response error: %v", w.ExchangeName, removeQuery(w.URL), err)
+			log.Errorf(log.WebsocketMgr, "%v %v: Parse binary response error: %v", w.ExchangeName, removeQuery(w.URL), err)
 			return Response{}
 		}
 	}
 	if w.Verbose {
-		log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Message received: %v", w.ExchangeName, removeQuery(w.URL), string(standardMessage))
+		log.Debugf(log.WebsocketMgr, "%v %v: Message received: %v", w.ExchangeName, removeQuery(w.URL), string(standardMessage))
 	}
 	return Response{Raw: standardMessage, Type: mType}
 }
@@ -324,7 +324,7 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 	// Only check context verbosity. If the exchange is verbose, it will log the responses in the ReadMessage() call.
 	if request.IsVerbose(ctx, false) {
 		for i := range resps {
-			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
+			log.Debugf(log.WebsocketMgr, "%v %v: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
 		}
 	}
 

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -59,7 +60,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
 			if msg, err := json.Marshal(data); err == nil { // WriteJSON will error for us anyway
-				log.Debugf(log.WebsocketMgr, "%s websocket connection: sending message: %s\n", w.ExchangeName, msg)
+				log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(msg))
 			}
 		}
 		return w.Connection.WriteJSON(data)
@@ -70,7 +71,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 func (w *WebsocketConnection) SendRawMessage(ctx context.Context, messageType int, message []byte) error {
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
-			log.Debugf(log.WebsocketMgr, "%v websocket connection: sending message [%s]\n", w.ExchangeName, message)
+			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(message))
 		}
 		return w.Connection.WriteMessage(messageType, message)
 	})
@@ -190,18 +191,12 @@ func (w *WebsocketConnection) ReadMessage() Response {
 	case websocket.BinaryMessage:
 		standardMessage, err = w.parseBinaryResponse(resp)
 		if err != nil {
-			log.Errorf(log.WebsocketMgr,
-				"%v websocket connection: parseBinaryResponse error: %v",
-				w.ExchangeName,
-				err)
+			log.Errorf(log.WebsocketMgr, "%v %v websocket connection: Parse binary response error: %v", w.ExchangeName, removeQuery(w.URL), err)
 			return Response{}
 		}
 	}
 	if w.Verbose {
-		log.Debugf(log.WebsocketMgr,
-			"%v websocket connection: message received: %v",
-			w.ExchangeName,
-			string(standardMessage))
+		log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Message received: %v", w.ExchangeName, removeQuery(w.URL), string(standardMessage))
 	}
 	return Response{Raw: standardMessage, Type: mType}
 }
@@ -298,10 +293,6 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 		return nil, err
 	}
 
-	if request.IsVerbose(ctx, w.Verbose) {
-		log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Sending message: %v", w.ExchangeName, w.URL, string(outbound))
-	}
-
 	start := time.Now()
 	err = w.SendRawMessage(ctx, websocket.TextMessage, outbound)
 	if err != nil {
@@ -332,9 +323,16 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 
 	if request.IsVerbose(ctx, w.Verbose) {
 		for i := range resps {
-			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, w.URL, i+1, len(resps), string(resps[i]))
+			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
 		}
 	}
 
 	return resps, err
+}
+
+func removeQuery(url string) string {
+	if index := strings.Index(url, "?"); index != -1 {
+		return url[:index]
+	}
+	return url
 }

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -332,7 +332,7 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 
 	if request.IsVerbose(ctx, w.Verbose) {
 		for i := range resps {
-			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d out of %d]: %v", w.ExchangeName, w.URL, i+1, len(resps), string(resps[i]))
+			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, w.URL, i+1, len(resps), string(resps[i]))
 		}
 	}
 

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -321,7 +321,7 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 		w.Reporter.Latency(w.ExchangeName, outbound, time.Since(start))
 	}
 
-	if request.IsVerbose(ctx, w.Verbose) {
+if request.IsVerbose(ctx, w.Verbose) && expected > 1 {
 		for i := range resps {
 			log.Debugf(log.WebsocketMgr, "%v %v websocket connection: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
 		}

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -60,7 +60,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
 			if msg, err := json.Marshal(data); err == nil { // WriteJSON will error for us anyway
-				log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(msg))
+				log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeURLQueryString(w.URL), string(msg))
 			}
 		}
 		return w.Connection.WriteJSON(data)
@@ -71,7 +71,7 @@ func (w *WebsocketConnection) SendJSONMessage(ctx context.Context, data interfac
 func (w *WebsocketConnection) SendRawMessage(ctx context.Context, messageType int, message []byte) error {
 	return w.writeToConn(ctx, func() error {
 		if request.IsVerbose(ctx, w.Verbose) {
-			log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeQuery(w.URL), string(message))
+			log.Debugf(log.WebsocketMgr, "%v %v: Sending message: %v", w.ExchangeName, removeURLQueryString(w.URL), string(message))
 		}
 		return w.Connection.WriteMessage(messageType, message)
 	})
@@ -191,12 +191,12 @@ func (w *WebsocketConnection) ReadMessage() Response {
 	case websocket.BinaryMessage:
 		standardMessage, err = w.parseBinaryResponse(resp)
 		if err != nil {
-			log.Errorf(log.WebsocketMgr, "%v %v: Parse binary response error: %v", w.ExchangeName, removeQuery(w.URL), err)
+			log.Errorf(log.WebsocketMgr, "%v %v: Parse binary response error: %v", w.ExchangeName, removeURLQueryString(w.URL), err)
 			return Response{}
 		}
 	}
 	if w.Verbose {
-		log.Debugf(log.WebsocketMgr, "%v %v: Message received: %v", w.ExchangeName, removeQuery(w.URL), string(standardMessage))
+		log.Debugf(log.WebsocketMgr, "%v %v: Message received: %v", w.ExchangeName, removeURLQueryString(w.URL), string(standardMessage))
 	}
 	return Response{Raw: standardMessage, Type: mType}
 }
@@ -324,7 +324,7 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 	// Only check context verbosity. If the exchange is verbose, it will log the responses in the ReadMessage() call.
 	if request.IsVerbose(ctx, false) {
 		for i := range resps {
-			log.Debugf(log.WebsocketMgr, "%v %v: Received response [%d/%d]: %v", w.ExchangeName, removeQuery(w.URL), i+1, len(resps), string(resps[i]))
+			log.Debugf(log.WebsocketMgr, "%v %v: Received response [%d/%d]: %v", w.ExchangeName, removeURLQueryString(w.URL), i+1, len(resps), string(resps[i]))
 		}
 	}
 

--- a/exchanges/stream/websocket_connection.go
+++ b/exchanges/stream/websocket_connection.go
@@ -331,7 +331,7 @@ func (w *WebsocketConnection) SendMessageReturnResponses(ctx context.Context, si
 	return resps, err
 }
 
-func removeQuery(url string) string {
+func removeURLQueryString(url string) string {
 	if index := strings.Index(url, "?"); index != -1 {
 		return url[:index]
 	}

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -1246,5 +1246,5 @@ func TestRemoveQuery(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com?test=1"), "removeQuery should remove query string")
 	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com"), "removeQuery should not change URL")
-	assert.Equal(t, "", removeQuery(""), "removeQuery should not error on empty string")
+	assert.Equal(t, "", removeQuery(""), "removeQuery should be equal")
 }

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -1241,3 +1241,10 @@ func TestCheckSubscriptions(t *testing.T) {
 	err = ws.checkSubscriptions(subscription.List{{}})
 	assert.NoError(t, err, "checkSubscriptions should not error")
 }
+
+func TestRemoveQuery(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com?test=1"), "removeQuery should remove query string")
+	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com"), "removeQuery should not change URL")
+	assert.Equal(t, "", removeQuery(""), "removeQuery should not error on empty string")
+}

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -1242,9 +1242,9 @@ func TestCheckSubscriptions(t *testing.T) {
 	assert.NoError(t, err, "checkSubscriptions should not error")
 }
 
-func TestRemoveQuery(t *testing.T) {
+func TestRemoveURLQueryString(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com?test=1"), "removeQuery should remove query string")
-	assert.Equal(t, "https://www.google.com", removeQuery("https://www.google.com"), "removeQuery should not change URL")
-	assert.Equal(t, "", removeQuery(""), "removeQuery should be equal")
+	assert.Equal(t, "https://www.google.com", removeURLQueryString("https://www.google.com?test=1"), "removeURLQueryString should remove query string")
+	assert.Equal(t, "https://www.google.com", removeURLQueryString("https://www.google.com"), "removeURLQueryString should not change URL")
+	assert.Equal(t, "", removeURLQueryString(""), "removeURLQueryString should be equal")
 }


### PR DESCRIPTION
# PR Description

![image](https://github.com/user-attachments/assets/6cc0dfb0-9a3d-42d3-bab7-fb1f191caee3)


* ~~Adds verbosity for debugging for outbound websocket requests and also the responses.~~ Adds verbosity for responses when its context verbose. 
* Exposes IsVerbose func from request package so that verbosity can be set via context and only that specific request gets hit and returns the outbound and inbound info without the need for a global state.
* Adds connection URL for multi connection differentiation.

This was pulled from #1603 as that PR is not a huge priority over this change and the sweeping changes of "multi-connection ws handling"

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
