### PR TITLE
CoinbasePro: Skip specific tests due to API deprecation

### DIFF
--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -606,9 +606,10 @@ var unsupportedAssets = []asset.Item{
 var unsupportedExchangeNames = []string{
 	"testexch",
 	"alphapoint",
-	"bitflyer", // Bitflyer has many "ErrNotYetImplemented, which is true, but not what we care to test for here
-	"btse",     // 	TODO rm once timeout issues resolved
-	"poloniex", // 	outdated API // TODO rm once updated
+	"bitflyer",    // Bitflyer has many "ErrNotYetImplemented, which is true, but not what we care to test for here
+	"btse",        // 	TODO rm once timeout issues resolved
+	"poloniex",    // 	outdated API // TODO rm once updated
+	"coinbasepro", // 	outdated API // TODO rm once updated
 }
 
 // cryptoChainPerExchange holds the deposit address chain per exchange

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -357,7 +357,8 @@ func TestSettingsPrint(t *testing.T) {
 }
 
 var unsupportedDefaultConfigExchanges = []string{
-	"poloniex", // poloniex has dropped support for the API GCT has implemented //TODO: drop this when supported
+	"poloniex",    // poloniex has dropped support for the API GCT has implemented //TODO: drop this when supported
+	"coinbasepro", // deprecated API. TODO: Remove this when the Coinbase update is merged
 }
 
 func TestGetDefaultConfigurations(t *testing.T) {

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -67,6 +67,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetProducts(t *testing.T) {
+	t.Skip("API is deprecated")
+
 	_, err := c.GetProducts(context.Background())
 	if err != nil {
 		t.Errorf("Coinbase, GetProducts() Error: %s", err)

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -74,6 +74,8 @@ func TestGetProducts(t *testing.T) {
 }
 
 func TestGetOrderbook(t *testing.T) {
+	t.Skip("API is deprecated")
+
 	_, err := c.GetOrderbook(context.Background(), testPair.String(), 2)
 	if err != nil {
 		t.Error(err)
@@ -85,6 +87,8 @@ func TestGetOrderbook(t *testing.T) {
 }
 
 func TestGetTicker(t *testing.T) {
+	t.Skip("API is deprecated")
+
 	_, err := c.GetTicker(context.Background(), testPair.String())
 	if err != nil {
 		t.Error("GetTicker() error", err)
@@ -99,6 +103,8 @@ func TestGetTrades(t *testing.T) {
 }
 
 func TestGetHistoricRatesGranularityCheck(t *testing.T) {
+	t.Skip("API is deprecated")
+
 	end := time.Now()
 	start := end.Add(-time.Hour * 2)
 	_, err := c.GetHistoricCandles(context.Background(),
@@ -109,6 +115,8 @@ func TestGetHistoricRatesGranularityCheck(t *testing.T) {
 }
 
 func TestCoinbasePro_GetHistoricCandlesExtended(t *testing.T) {
+	t.Skip("API is deprecated")
+
 	start := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
 


### PR DESCRIPTION
# PR Description

Disables deprecated API tests until #1480 is merged

## Type of change

- [x] Test fix

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
