### PR TITLE
Huobi: Fix intermittent UpdateTickers failure on expiry

### DIFF
--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -71,14 +72,16 @@ const (
 	huobiCurrenciesReference          = "/v2/reference/currencies"
 	huobiWithdrawHistory              = "/query/deposit-withdraw"
 	huobiBatchCoinMarginSwapContracts = "/v2/swap-ex/market/detail/batch_merged"
-	huobiBatchLinearSwapContracts     = "/linear-swap-ex/market/detail/batch_merged"
+	huobiBatchLinearSwapContracts     = "/v2/linear-swap-ex/market/detail/batch_merged"
 	huobiBatchContracts               = "/v2/market/detail/batch_merged"
 )
 
 // HUOBI is the overarching type across this package
 type HUOBI struct {
 	exchange.Base
-	AccountID string
+	AccountID                string
+	futureContractCodesMutex sync.RWMutex
+	futureContractCodes      map[string]currency.Code
 }
 
 // GetMarginRates gets margin rates

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -633,9 +632,7 @@ func TestFQueryTriggerOrderHistory(t *testing.T) {
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
 	_, err := h.FetchTradablePairs(context.Background(), asset.Futures)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestUpdateTickerSpot(t *testing.T) {
@@ -2674,49 +2671,33 @@ func TestGetAvailableTransferChains(t *testing.T) {
 		t.Error("expected more than one result")
 	}
 }
+
 func TestFormatFuturesPair(t *testing.T) {
 	r, err := h.formatFuturesPair(futuresTestPair, false)
-	if err != nil {
-		t.Error(err)
-	}
-	if r != "BTC_CW" {
-		t.Errorf("expected BTC_CW, got %s", r)
-	}
-	availInstruments, err := h.FetchTradablePairs(context.Background(), asset.Futures)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(availInstruments) == 0 {
-		t.Error("expected instruments, got 0")
-	}
-	// test getting a tradable pair in the format of BTC210827 but make it lower
-	// case to test correct formatting
-	r, err = h.formatFuturesPair(availInstruments[0], false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "BTC_CW", r)
+
+	p, err := h.FetchTradablePairs(context.Background(), asset.Futures)
+	require.NoError(t, err, "FetchTradablePairs must not error")
+	require.NotEmpty(t, p, "FetchTradablePairs must return pairs")
+
+	// test getting a tradable pair in the format of BTC210827 but make it lower case to test correct formatting
+	r, err = h.formatFuturesPair(p[0].Lower(), false)
+	require.NoError(t, err)
+	assert.Len(t, r, 9, "Should be an 9 character string")
 
 	// Test for upper case 'BTC' not lower case 'btc', disregarded numerals
 	// as they not deterministic from this endpoint.
-	if !strings.Contains(r, "BTC") {
-		t.Errorf("expected %s, got %s", "BTC220708", r)
-	}
+	assert.Equal(t, "BTC", r[0:3])
 
 	r, err = h.formatFuturesPair(futuresTestPair, true)
-	if err != nil {
-		t.Error(err)
-	}
-	if r == "BTC_CW" {
-		t.Errorf("expected BTC{{date}}, got %s", r)
-	}
+	require.NoError(t, err)
+	assert.Len(t, r, 9, "Should be an 9 character string")
+	assert.Equal(t, "BTC", r[0:3])
 
 	r, err = h.formatFuturesPair(currency.NewPair(currency.BTC, currency.USDT), false)
-	if err != nil {
-		t.Error(err)
-	}
-	if r != "BTC-USDT" {
-		t.Errorf("expected BTC-USDT, got %s", r)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "BTC-USDT", r)
 }
 
 func TestSearchForExistedWithdrawsAndDeposits(t *testing.T) {
@@ -2870,74 +2851,52 @@ func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 	for _, a := range h.GetAssetTypes(false) {
 		err := h.UpdateTickers(context.Background(), a)
-		assert.NoErrorf(t, err, "asset %s", a)
-
+		require.NoErrorf(t, err, "asset %s", a)
 		avail, err := h.GetAvailablePairs(a)
 		require.NoError(t, err)
-		for x := range avail {
-			_, err = ticker.GetTicker(h.Name, avail[x], a)
-			assert.NoError(t, err)
+		for _, p := range avail {
+			_, err = ticker.GetTicker(h.Name, p, a)
+			assert.NoErrorf(t, err, "Could not get ticker for %s %s", a, p)
 		}
 	}
 }
 
-func TestConvertContractShortHandToExpiry(t *testing.T) {
+func TestPairFromContractExpiryCode(t *testing.T) {
 	t.Parallel()
-	tt := time.Now()
-	cp := currency.NewPair(currency.BTC, currency.NewCode("CW"))
-	cp, err := h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.NotEqual(t, "CW", cp.Quote.String())
-	tick, err := h.FetchTicker(context.Background(), cp, asset.Futures)
-	if assert.NoError(t, err) {
-		assert.NotZero(t, tick.Close)
+
+	h := new(HUOBI) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(h), "Test Instance Setup must not fail")
+
+	_, err := h.FetchTradablePairs(context.Background(), asset.Futures)
+	require.NoError(t, err)
+
+	n := time.Now().Truncate(24 * time.Hour)
+	for _, cType := range contractExpiryNames {
+		p, err := h.pairFromContractExpiryCode(currency.Pair{
+			Base:  currency.BTC,
+			Quote: currency.NewCode(cType),
+		})
+		if cType == "NQ" && err != nil {
+			continue // Next Quarter is intermittently present
+		}
+		require.NoErrorf(t, err, "pairFromContractExpiryCode must not error for %s code", cType)
+		assert.Equal(t, currency.BTC, p.Base, "pair Base should be the same")
+		h.futureContractCodesMutex.RLock()
+		exp, ok := h.futureContractCodes[cType]
+		h.futureContractCodesMutex.RUnlock()
+		require.True(t, ok, "%s type must be in contractExpiryNames", cType)
+		assert.Equal(t, currency.BTC, p.Base, "pair Base should be the same")
+		assert.Equal(t, exp, p.Quote, "pair Quote should be the same")
+		d, err := time.Parse("060102", p.Quote.String())
+		require.NoError(t, err, "currency code must be a parsable date")
+		require.Falsef(t, d.Before(n), "%s expiry must be today or after", cType)
+		switch cType {
+		case "CW", "NW":
+			require.True(t, d.Before(n.Add(24*time.Hour*14)), "%s expiry must be within 2 weeks", cType)
+		case "CQ", "NQ":
+			require.True(t, d.Before(n.Add(24*time.Hour*90*2)), "%s expiry must be within 2 quarters", cType)
+		}
 	}
-
-	cp = currency.NewPair(currency.BTC, currency.NewCode("NW"))
-	cp, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.NotEqual(t, "NW", cp.Quote.String())
-	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
-	if assert.NoError(t, err) {
-		assert.NotZero(t, tick.Close)
-	}
-
-	cp = currency.NewPair(currency.BTC, currency.NewCode("CQ"))
-	cp, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.NotEqual(t, "CQ", cp.Quote.String())
-	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
-	if assert.NoError(t, err) {
-		assert.NotZero(t, tick.Close)
-	}
-
-	// calculate a specific date
-	cp = currency.NewPair(currency.BTC, currency.NewCode("CQ"))
-	tt = time.Date(2021, 6, 3, 0, 0, 0, 0, time.UTC)
-	cp, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.Equal(t, "210625", cp.Quote.String())
-
-	cp = currency.NewPair(currency.BTC, currency.NewCode("CW"))
-	cp, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.Equal(t, "210604", cp.Quote.String())
-
-	cp = currency.NewPair(currency.BTC, currency.NewCode("CWif hat"))
-	_, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.ErrorIs(t, err, errInvalidContractType)
-
-	tt = time.Now()
-	cp = currency.NewPair(currency.BTC, currency.NewCode("NQ"))
-	cp, err = h.convertContractShortHandToExpiry(cp, tt)
-	assert.NoError(t, err)
-	assert.NotEqual(t, "NQ", cp.Quote.String())
-	tick, err = h.FetchTicker(context.Background(), cp, asset.Futures)
-	if err != nil {
-		// Huobi doesn't always have a next-quarter contract, return if no data found
-		return
-	}
-	assert.NotZero(t, tick.Close)
 }
 
 func TestGetOpenInterest(t *testing.T) {
@@ -2948,7 +2907,6 @@ func TestGetOpenInterest(t *testing.T) {
 		Asset: asset.USDTMarginedFutures,
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
-
 	resp, err := h.GetOpenInterest(context.Background(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USD.Item,
@@ -2964,7 +2922,6 @@ func TestGetOpenInterest(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
-
 	resp, err = h.GetOpenInterest(context.Background())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -1166,13 +1166,14 @@ var (
 		"reduceShort":    12,
 	}
 
-	validContractTypes = []string{
-		"this_week", "next_week", "quarter", "next_quarter",
+	contractExpiryNames = map[string]string{
+		"this_week":    "CW",
+		"next_week":    "NW",
+		"quarter":      "CQ",
+		"next_quarter": "NQ",
 	}
 
-	validContractShortTypes = []string{
-		"cw", "nw", "cq", "nq",
-	}
+	validContractExpiryCodes = []string{"CW", "NW", "CQ", "NQ"}
 
 	validFuturesPeriods = []string{
 		"1min", "5min", "15min", "30min", "60min", "1hour", "4hour", "1day",


### PR DESCRIPTION
## Huobi

* Collect and Return all errors from UpdateTickers
* Fix [intermittent failure of TestUpdateTickers](https://github.com/thrasher-corp/gocryptotrader/actions/runs/10917737674/job/30301656625?pr=1652) and implicitly a failure of tickers in runtime too
```
--- FAIL: TestUpdateTickers (2.29s)
    huobi_test.go:2879: 
        	Error Trace:	/home/runner/work/gocryptotrader/gocryptotrader/exchanges/huobi/huobi_test.go:2879
        	Error:      	Received unexpected error:
        	            	no ticker found huobi ETH-241227 futures
        	Test:       	TestUpdateTickers
FAIL
```
* Make contract type errors consistent
* Convert and Send lowercase contract type regardless of user input ( Option to reject uppercase. I'm in favour of that, personally )


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run