### PR TITLE
Huobi: Remove suspended API endpoints

### DIFF
--- a/exchanges/huobi/huobi_cfutures.go
+++ b/exchanges/huobi/huobi_cfutures.go
@@ -17,58 +17,56 @@ import (
 
 const (
 	// Coin Margined Swap (perpetual futures) endpoints
-	huobiSwapMarkets                     = "/swap-api/v1/swap_contract_info"
-	huobiSwapFunding                     = "/swap-api/v1/swap_funding_rate"
-	huobiSwapBatchFunding                = "/swap-api/v1/swap_batch_funding_rate"
-	huobiSwapIndexPriceInfo              = "/swap-api/v1/swap_index"
-	huobiSwapPriceLimitation             = "/swap-api/v1/swap_price_limit"
-	huobiSwapOpenInterestInfo            = "/swap-api/v1/swap_open_interest"
-	huobiSwapMarketDepth                 = "/swap-ex/market/depth"
-	huobiKLineData                       = "/swap-ex/market/history/kline"
-	huobiMarketDataOverview              = "/swap-ex/market/detail/merged"
-	huobiLastTradeContract               = "/swap-ex/market/trade"
-	huobiRequestBatchOfTradingRecords    = "/swap-ex/market/history/trade"
-	huobiInsuranceBalanceAndClawbackRate = "/swap-api/v1/swap_risk_info"
-	huobiInsuranceBalanceHistory         = "/swap-api/v1/swap_insurance_fund"
-	huobiTieredAdjustmentFactor          = "/swap-api/v1/swap_adjustfactor"
-	huobiOpenInterestInfo                = "/swap-api/v1/swap_his_open_interest"
-	huobiSwapSystemStatus                = "/swap-api/v1/swap_api_state"
-	huobiSwapSentimentAccountData        = "/swap-api/v1/swap_elite_account_ratio"
-	huobiSwapSentimentPosition           = "/swap-api/v1/swap_elite_position_ratio"
-	huobiSwapLiquidationOrders           = "/swap-api/v3/swap_liquidation_orders"
-	huobiSwapHistoricalFundingRate       = "/swap-api/v1/swap_historical_funding_rate"
-	huobiPremiumIndexKlineData           = "/index/market/history/swap_premium_index_kline"
-	huobiPredictedFundingRateData        = "/index/market/history/swap_estimated_rate_kline"
-	huobiBasisData                       = "/index/market/history/swap_basis"
-	huobiSwapAccInfo                     = "/swap-api/v1/swap_account_info"
-	huobiSwapPosInfo                     = "/swap-api/v1/swap_position_info"
-	huobiSwapAssetsAndPos                = "/swap-api/v1/swap_account_position_info" //nolint // false positive gosec
-	huobiSwapSubAccList                  = "/swap-api/v1/swap_sub_account_list"
-	huobiSwapSubAccInfo                  = "/swap-api/v1/swap_sub_account_info"
-	huobiSwapSubAccPosInfo               = "/swap-api/v1/swap_sub_position_info"
-	huobiSwapFinancialRecords            = "/swap-api/v1/swap_financial_record"
-	huobiSwapSettlementRecords           = "/swap-api/v1/swap_user_settlement_records"
-	huobiSwapAvailableLeverage           = "/swap-api/v1/swap_available_level_rate"
-	huobiSwapOrderLimitInfo              = "/swap-api/v1/swap_order_limit"
-	huobiSwapTradingFeeInfo              = "/swap-api/v1/swap_fee"
-	huobiSwapTransferLimitInfo           = "/swap-api/v1/swap_transfer_limit"
-	huobiSwapPositionLimitInfo           = "/swap-api/v1/swap_position_limit"
-	huobiSwapInternalTransferData        = "/swap-api/v1/swap_master_sub_transfer"
-	huobiSwapInternalTransferRecords     = "/swap-api/v1/swap_master_sub_transfer_record"
-	huobiSwapPlaceOrder                  = "/swap-api/v1/swap_order"
-	huobiSwapPlaceBatchOrder             = "/swap-api/v1/swap_batchorder"
-	huobiSwapCancelOrder                 = "/swap-api/v1/swap_cancel"
-	huobiSwapCancelAllOrders             = "/swap-api/v1/swap_cancelall"
-	huobiSwapLightningCloseOrder         = "/swap-api/v1/swap_lightning_close_position"
-	huobiSwapOrderInfo                   = "/swap-api/v1/swap_order_info"
-	huobiSwapOrderDetails                = "/swap-api/v1/swap_order_detail"
-	huobiSwapOpenOrders                  = "/swap-api/v1/swap_openorders"
-	huobiSwapOrderHistory                = "/swap-api/v1/swap_hisorders"
-	huobiSwapTradeHistory                = "/swap-api/v1/swap_matchresults"
-	huobiSwapTriggerOrder                = "/swap-api/v1/swap_trigger_order"
-	huobiSwapCancelTriggerOrder          = "/swap-api/v1/swap_trigger_cancel"
-	huobiSwapCancelAllTriggerOrders      = "/swap-api/v1/swap_trigger_cancelall"
-	huobiSwapTriggerOrderHistory         = "/swap-api/v1/swap_trigger_hisorders"
+	huobiSwapMarkets                  = "/swap-api/v1/swap_contract_info"
+	huobiSwapFunding                  = "/swap-api/v1/swap_funding_rate"
+	huobiSwapBatchFunding             = "/swap-api/v1/swap_batch_funding_rate"
+	huobiSwapIndexPriceInfo           = "/swap-api/v1/swap_index"
+	huobiSwapPriceLimitation          = "/swap-api/v1/swap_price_limit"
+	huobiSwapOpenInterestInfo         = "/swap-api/v1/swap_open_interest"
+	huobiSwapMarketDepth              = "/swap-ex/market/depth"
+	huobiKLineData                    = "/swap-ex/market/history/kline"
+	huobiMarketDataOverview           = "/swap-ex/market/detail/merged"
+	huobiLastTradeContract            = "/swap-ex/market/trade"
+	huobiRequestBatchOfTradingRecords = "/swap-ex/market/history/trade"
+	huobiTieredAdjustmentFactor       = "/swap-api/v1/swap_adjustfactor"
+	huobiOpenInterestInfo             = "/swap-api/v1/swap_his_open_interest"
+	huobiSwapSystemStatus             = "/swap-api/v1/swap_api_state"
+	huobiSwapSentimentAccountData     = "/swap-api/v1/swap_elite_account_ratio"
+	huobiSwapSentimentPosition        = "/swap-api/v1/swap_elite_position_ratio"
+	huobiSwapLiquidationOrders        = "/swap-api/v3/swap_liquidation_orders"
+	huobiSwapHistoricalFundingRate    = "/swap-api/v1/swap_historical_funding_rate"
+	huobiPremiumIndexKlineData        = "/index/market/history/swap_premium_index_kline"
+	huobiPredictedFundingRateData     = "/index/market/history/swap_estimated_rate_kline"
+	huobiBasisData                    = "/index/market/history/swap_basis"
+	huobiSwapAccInfo                  = "/swap-api/v1/swap_account_info"
+	huobiSwapPosInfo                  = "/swap-api/v1/swap_position_info"
+	huobiSwapAssetsAndPos             = "/swap-api/v1/swap_account_position_info" //nolint // false positive gosec
+	huobiSwapSubAccList               = "/swap-api/v1/swap_sub_account_list"
+	huobiSwapSubAccInfo               = "/swap-api/v1/swap_sub_account_info"
+	huobiSwapSubAccPosInfo            = "/swap-api/v1/swap_sub_position_info"
+	huobiSwapFinancialRecords         = "/swap-api/v1/swap_financial_record"
+	huobiSwapSettlementRecords        = "/swap-api/v1/swap_user_settlement_records"
+	huobiSwapAvailableLeverage        = "/swap-api/v1/swap_available_level_rate"
+	huobiSwapOrderLimitInfo           = "/swap-api/v1/swap_order_limit"
+	huobiSwapTradingFeeInfo           = "/swap-api/v1/swap_fee"
+	huobiSwapTransferLimitInfo        = "/swap-api/v1/swap_transfer_limit"
+	huobiSwapPositionLimitInfo        = "/swap-api/v1/swap_position_limit"
+	huobiSwapInternalTransferData     = "/swap-api/v1/swap_master_sub_transfer"
+	huobiSwapInternalTransferRecords  = "/swap-api/v1/swap_master_sub_transfer_record"
+	huobiSwapPlaceOrder               = "/swap-api/v1/swap_order"
+	huobiSwapPlaceBatchOrder          = "/swap-api/v1/swap_batchorder"
+	huobiSwapCancelOrder              = "/swap-api/v1/swap_cancel"
+	huobiSwapCancelAllOrders          = "/swap-api/v1/swap_cancelall"
+	huobiSwapLightningCloseOrder      = "/swap-api/v1/swap_lightning_close_position"
+	huobiSwapOrderInfo                = "/swap-api/v1/swap_order_info"
+	huobiSwapOrderDetails             = "/swap-api/v1/swap_order_detail"
+	huobiSwapOpenOrders               = "/swap-api/v1/swap_openorders"
+	huobiSwapOrderHistory             = "/swap-api/v1/swap_hisorders"
+	huobiSwapTradeHistory             = "/swap-api/v1/swap_matchresults"
+	huobiSwapTriggerOrder             = "/swap-api/v1/swap_trigger_order"
+	huobiSwapCancelTriggerOrder       = "/swap-api/v1/swap_trigger_cancel"
+	huobiSwapCancelAllTriggerOrders   = "/swap-api/v1/swap_trigger_cancelall"
+	huobiSwapTriggerOrderHistory      = "/swap-api/v1/swap_trigger_hisorders"
 )
 
 // QuerySwapIndexPriceInfo gets perpetual swap index's price info
@@ -193,38 +191,6 @@ func (h *HUOBI) GetBatchTrades(ctx context.Context, code currency.Pair, size int
 	params.Set("contract_code", codeValue)
 	params.Set("size", strconv.FormatInt(size, 10))
 	path := common.EncodeURLValues(huobiRequestBatchOfTradingRecords, params)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
-}
-
-// GetInsuranceData gets insurance fund data and clawback rates
-func (h *HUOBI) GetInsuranceData(ctx context.Context, code currency.Pair) (InsuranceAndClawbackData, error) {
-	var resp InsuranceAndClawbackData
-	codeValue, err := h.FormatSymbol(code, asset.CoinMarginedFutures)
-	if err != nil {
-		return resp, err
-	}
-	params := url.Values{}
-	params.Set("contract_code", codeValue)
-	path := common.EncodeURLValues(huobiInsuranceBalanceAndClawbackRate, params)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
-}
-
-// GetHistoricalInsuranceData gets historical insurance fund data and clawback rates
-func (h *HUOBI) GetHistoricalInsuranceData(ctx context.Context, code currency.Pair, pageIndex, pageSize int64) (HistoricalInsuranceFundBalance, error) {
-	var resp HistoricalInsuranceFundBalance
-	codeValue, err := h.FormatSymbol(code, asset.CoinMarginedFutures)
-	if err != nil {
-		return resp, err
-	}
-	params := url.Values{}
-	params.Set("contract_code", codeValue)
-	if pageIndex != 0 {
-		params.Set("page_index", strconv.FormatInt(pageIndex, 10))
-	}
-	if pageSize != 0 {
-		params.Set("page_size", strconv.FormatInt(pageIndex, 10))
-	}
-	path := common.EncodeURLValues(huobiInsuranceBalanceHistory, params)
 	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
 }
 

--- a/exchanges/huobi/huobi_futures.go
+++ b/exchanges/huobi/huobi_futures.go
@@ -35,8 +35,6 @@ const (
 	fMarketOverview            = "/market/detail/merged"
 	fLastTradeContract         = "/market/trade"
 	fContractBatchTradeRecords = "/market/history/trade"
-	fInsuranceAndClawback      = "/api/v1/contract_risk_info"
-	fInsuranceBalanceHistory   = "/api/v1/contract_insurance_fund"
 	fTieredAdjustmentFactor    = "/api/v1/contract_adjustfactor"
 	fHisContractOpenInterest   = "/api/v1/contract_his_open_interest"
 	fSystemStatus              = "/api/v1/contract_api_state"
@@ -323,36 +321,6 @@ func (h *HUOBI) FRequestPublicBatchTrades(ctx context.Context, symbol currency.P
 	}
 	var resp FBatchTradesForContractData
 	path := common.EncodeURLValues(fContractBatchTradeRecords, params)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
-}
-
-// FQueryInsuranceAndClawbackData gets insurance and clawback data for a futures contract
-func (h *HUOBI) FQueryInsuranceAndClawbackData(ctx context.Context, symbol currency.Code) (FClawbackRateAndInsuranceData, error) {
-	var resp FClawbackRateAndInsuranceData
-	params := url.Values{}
-	if !symbol.IsEmpty() {
-		codeValue, err := h.formatFuturesCode(symbol)
-		if err != nil {
-			return resp, err
-		}
-		params.Set("symbol", codeValue)
-	}
-	path := common.EncodeURLValues(fInsuranceAndClawback, params)
-	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
-}
-
-// FQueryHistoricalInsuranceData gets insurance data
-func (h *HUOBI) FQueryHistoricalInsuranceData(ctx context.Context, symbol currency.Code) (FHistoricalInsuranceRecordsData, error) {
-	var resp FHistoricalInsuranceRecordsData
-	params := url.Values{}
-	if !symbol.IsEmpty() {
-		codeValue, err := h.formatFuturesCode(symbol)
-		if err != nil {
-			return resp, err
-		}
-		params.Set("symbol", codeValue)
-	}
-	path := common.EncodeURLValues(fInsuranceBalanceHistory, params)
 	return resp, h.SendHTTPRequest(ctx, exchange.RestFutures, path, &resp)
 }
 

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -195,22 +195,6 @@ func TestFRequestPublicBatchTrades(t *testing.T) {
 	}
 }
 
-func TestFQueryInsuranceAndClawbackData(t *testing.T) {
-	t.Parallel()
-	_, err := h.FQueryInsuranceAndClawbackData(context.Background(), currency.BTC)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestFQueryHistoricalInsuranceData(t *testing.T) {
-	t.Parallel()
-	_, err := h.FQueryHistoricalInsuranceData(context.Background(), currency.BTC)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestFQueryTieredAdjustmentFactor(t *testing.T) {
 	t.Parallel()
 	_, err := h.FQueryTieredAdjustmentFactor(context.Background(), currency.BTC)
@@ -865,30 +849,6 @@ func TestGetBatchTrades(t *testing.T) {
 		t.Error(err)
 	}
 	_, err = h.GetBatchTrades(context.Background(), cp, 5)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestGetInsuranceData(t *testing.T) {
-	t.Parallel()
-	cp, err := currency.NewPairFromString("BTC-USD")
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = h.GetInsuranceData(context.Background(), cp)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestGetHistoricalInsuranceData(t *testing.T) {
-	t.Parallel()
-	cp, err := currency.NewPairFromString("BTC-USD")
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = h.GetHistoricalInsuranceData(context.Background(), cp, 0, 0)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
# PR Description

Removes Huobi suspended endpoints as these have been moved into the "Downline interface" section of the new API docs. Unfortunately their new endpoints are reporting "service errors" which they're working on a fix to implement.

## Type of change

- [x] Test fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
