### PR TITLE
Kucoin: Abstract a subscriptionNames for assets solution

### DIFF
--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -4335,3 +4335,23 @@ func TestCancelBatchOrders(t *testing.T) {
 	_, err := ku.CancelBatchOrders(context.Background(), nil)
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
+
+func TestChannelName(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		a   asset.Item
+		ch  string
+		exp string
+	}{
+		{asset.Futures, futuresOrderbookDepth50Channel, futuresOrderbookDepth50Channel},
+		{asset.Futures, subscription.OrderbookChannel, futuresOrderbookDepth5Channel},
+		{asset.Futures, subscription.CandlesChannel, marketCandlesChannel},
+		{asset.Futures, subscription.TickerChannel, futuresTickerChannel},
+		{asset.Spot, subscription.OrderbookChannel, marketOrderbookDepth5Channel},
+		{asset.Spot, subscription.AllTradesChannel, marketMatchChannel},
+		{asset.Spot, subscription.CandlesChannel, marketCandlesChannel},
+		{asset.Spot, subscription.TickerChannel, marketTickerChannel},
+	} {
+		assert.Equal(t, tt.exp, channelName(&subscription.Subscription{Channel: tt.ch}, tt.a))
+	}
+}

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -88,6 +88,19 @@ var (
 	maxWSOrderbookWorkers = 10
 )
 
+var subscriptionNames = map[asset.Item]map[string]string{
+	asset.Futures: {
+		subscription.TickerChannel:    futuresTickerChannel,
+		subscription.OrderbookChannel: futuresOrderbookDepth5Channel, // This does not require a REST request to get the orderbook.
+	},
+	asset.All: {
+		subscription.TickerChannel:    marketTickerChannel,
+		subscription.OrderbookChannel: marketOrderbookDepth5Channel, // This does not require a REST request to get the orderbook.
+		subscription.CandlesChannel:   marketCandlesChannel,
+		subscription.AllTradesChannel: marketMatchChannel,
+	},
+}
+
 var defaultSubscriptions = subscription.List{
 	{Enabled: true, Asset: asset.All, Channel: subscription.TickerChannel},
 	{Enabled: true, Asset: asset.All, Channel: subscription.OrderbookChannel, Interval: kline.HundredMilliseconds},
@@ -1669,21 +1682,15 @@ func (ku *Kucoin) checkSubscriptions() {
 
 // channelName returns the correct channel name for the asset
 func channelName(s *subscription.Subscription, a asset.Item) string {
-	switch s.Channel {
-	case subscription.TickerChannel:
-		if a == asset.Futures {
-			return futuresTickerChannel
+	if byAsset, hasAsset := subscriptionNames[a]; hasAsset {
+		if name, ok := byAsset[s.Channel]; ok {
+			return name
 		}
-		return marketTickerChannel
-	case subscription.OrderbookChannel:
-		if a == asset.Futures {
-			return futuresOrderbookDepth5Channel
+	}
+	if allAssets, hasAll := subscriptionNames[asset.All]; hasAll {
+		if name, ok := allAssets[s.Channel]; ok {
+			return name
 		}
-		return marketOrderbookDepth5Channel // This does not require a REST request to get the orderbook.
-	case subscription.CandlesChannel:
-		return marketCandlesChannel // No support in GCT yet for Futures candles
-	case subscription.AllTradesChannel:
-		return marketMatchChannel // No support in GCT yet for Futures all trades
 	}
 	return s.Channel
 }


### PR DESCRIPTION
This PR standardises a way for exchanges to implement subscriptionNames and a channelName function.

It's the most likely standardised way forwards for channelName func.

Providing it immediately so that @cranktakular can make use of it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestChannelName