### PR TITLE
credentials: Refactor GetCredentials and CheckCredentials

### DIFF
--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -297,13 +297,18 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			}
 		}
 
+		clientID := ""
+		if creds != nil {
+			clientID = creds.ClientID
+		}
+
 		b.Websocket.DataHandler <- &order.Detail{
 			Price:           price,
 			Amount:          originalAmount,
 			RemainingAmount: orderData.OpenVolume,
 			Exchange:        b.Name,
 			OrderID:         orderID,
-			ClientID:        creds.ClientID,
+			ClientID:        clientID,
 			Type:            oType,
 			Side:            oSide,
 			Status:          oStatus,


### PR DESCRIPTION
This pull request introduces several important changes to the `exchanges/credentials.go` file, focusing on improving error handling and credential management. The most significant changes include modifying the `CheckCredentials` function to handle different authentication support scenarios, enhancing error messages in `GetCredentials`, and adding a fallback mechanism for default credentials.

### Error Handling Improvements:
* `func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)`: Enhanced the error message for context credentials store type assertion failures to provide more detailed information.

### Credential Management Enhancements:
* `func (b *Base) CheckCredentials(creds *account.Credentials, isContext bool) error`: Reorganized the logic


* `func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)`: small readability change 


^^^ I mean, if copilot says so 
Test do pass

also 
```
if SubAccountOverride, ok := ctx.Value(account.ContextSubAccountFlag).(string); ok {
		b.API.credMu.RLock()
		creds.SubAccount = SubAccountOverride
		b.API.credMu.RUnlock()
	}

```

Is that lock required? 


EDIT: I was experimenting around to understand the code base. 

Will have to edit the commit, it wasn't supposed to return nil. Not sure, maybe IDE did it automatically since I did saw the comment 

My main question was also about the lock being required. (Don't think it will lead to a noticeable performance gain when removed but can) 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Unnecessary improvement attempt 
## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
