### PR TITLE
CI/GHA: Add stale activity action for issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: stale-checks
+on:
+  schedule:
+    - cron: '0 0 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+    contents: read
+
+env:
+  DAYS_BEFORE_STALE: ${{ vars.DAYS_BEFORE_STALE }}
+  DAYS_BEFORE_CLOSE: ${{ vars.DAYS_BEFORE_CLOSE }}
+  EXEMPT_ISSUE_LABELS: ${{ vars.EXEMPT_ISSUE_LABELS }}
+  EXEMPT_PR_LABELS: ${{ vars.EXEMPT_PR_LABELS }}
+
+jobs:
+  stale:
+    name: Stale issues and PRs check
+    runs-on: ubuntu-latest
+    environment: ci
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # General settings
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+          exempt-issue-labels: ${{ env.EXEMPT_ISSUE_LABELS }}
+          exempt-pr-labels: ${{ env.EXEMPT_PR_LABELS }}
+          enable-statistics: true
+
+          # Issue settings
+          stale-issue-message: 'This issue is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Please provide an update or this issue will be automatically closed in ${{ env.DAYS_BEFORE_CLOSE }} days.'
+          close-issue-message: 'This issue was closed because it has been stalled for ${{ env.DAYS_BEFORE_CLOSE }} days with no activity.'
+          stale-issue-label: 'stale'
+         
+          # PR settings
+          stale-pr-message: 'This PR is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Please provide an update on the progress of this PR.'
+          days-before-pr-close: -1
+          stale-pr-label: 'stale'


### PR DESCRIPTION
# PR Description

Adds a GHA for stale issues/PRs. By default, the following settings have been defined however these are set via GH envs which make it easy to adjust these without having to commit changes. The settings will also be displayed each time the job is run however they're listed below:

Runs every Monday-Friday during AEST/AEDT hours at midnight UTC which is 10AM-11AM AEST/AEDT.
Days before an issue or PR goes stale: 30 days.
Days before an issue is closed after going stale: 7 days.
PRs will never be closed automatically.
Will automatically set the tag of the PRs/issues to `stale`.

**Tag exemptions:**
Issues: in progress,todo
PRs: nomerge requires dependency,blocked

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] Own fork

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
