### PR TITLE
Tests: Fix fail on vendored modules

### DIFF
--- a/internal/testing/utils/path_test.go
+++ b/internal/testing/utils/path_test.go
@@ -27,6 +27,10 @@ func TestRootPathFromCWD(t *testing.T) {
 		w, _ := filepath.Split(p)
 		w = filepath.Clean(w)
 		if w == r {
+			switch d.Name() {
+			case "vendor", "web":
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if d.Type().IsRegular() && d.Name() == "LICENSE" {


### PR DESCRIPTION
This fixes looking for LICENSE files in the vendor directory

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run