### PR TITLE
Binance: update orderbook, ticker rate limits.

### DIFF
--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -536,7 +536,7 @@ func (b *Binance) GetTickers(ctx context.Context, symbols ...currency.Pair) ([]P
 		}
 		symbolValues[i] = symbolValue
 	}
-	if len(symbolValues) > 0 {
+	if symbolLength > 0 {
 		// this is just easier to format it to  ["x","y"...] than manually
 		symbolsJSON, err := json.Marshal(symbolValues)
 		if err != nil {

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -134,8 +134,12 @@ func (b *Binance) GetOrderBook(ctx context.Context, obd OrderBookDataRequestPara
 		return nil, err
 	}
 	params.Set("symbol", symbol)
-	params.Set("limit", strconv.Itoa(obd.Limit))
-
+	if obd.Limit == 0 {
+		// default to help select rate limits when no limit is provided
+		obd.Limit = 500
+	} else {
+		params.Set("limit", strconv.Itoa(obd.Limit))
+	}
 	var resp OrderBookData
 	if err := b.SendHTTPRequest(ctx,
 		exchange.RestSpotSupplementary,
@@ -494,9 +498,9 @@ func (b *Binance) GetAveragePrice(ctx context.Context, symbol currency.Pair) (Av
 func (b *Binance) GetPriceChangeStats(ctx context.Context, symbol currency.Pair) (PriceChangeStats, error) {
 	resp := PriceChangeStats{}
 	params := url.Values{}
-	rateLimit := spotPriceChangeAllRate
+	rateLimit := spotTickerAllRate
 	if !symbol.IsEmpty() {
-		rateLimit = spotDefaultRate
+		rateLimit = spotTicker1Rate
 		symbolValue, err := b.FormatSymbol(symbol, asset.Spot)
 		if err != nil {
 			return resp, err
@@ -505,15 +509,43 @@ func (b *Binance) GetPriceChangeStats(ctx context.Context, symbol currency.Pair)
 	}
 	path := priceChange + "?" + params.Encode()
 
-	return resp, b.SendHTTPRequest(ctx,
-		exchange.RestSpotSupplementary, path, rateLimit, &resp)
+	return resp, b.SendHTTPRequest(ctx, exchange.RestSpotSupplementary, path, rateLimit, &resp)
 }
 
 // GetTickers returns the ticker data for the last 24 hrs
-func (b *Binance) GetTickers(ctx context.Context) ([]PriceChangeStats, error) {
+func (b *Binance) GetTickers(ctx context.Context, symbols ...currency.Pair) ([]PriceChangeStats, error) {
 	var resp []PriceChangeStats
-	return resp, b.SendHTTPRequest(ctx,
-		exchange.RestSpotSupplementary, priceChange, spotPriceChangeAllRate, &resp)
+	symbolLength := len(symbols)
+	params := url.Values{}
+	var rl request.EndpointLimit
+	switch {
+	case symbolLength == 1:
+		rl = spotTicker1Rate
+	case symbolLength > 1 && symbolLength <= 20:
+		rl = spotTicker20Rate
+	case symbolLength > 20 && symbolLength <= 100:
+		rl = spotTicker100Rate
+	case symbolLength > 100, symbolLength == 0:
+		rl = spotTickerAllRate
+	}
+	symbolValues := make([]string, symbolLength)
+	for i := range symbols {
+		symbolValue, err := b.FormatSymbol(symbols[i], asset.Spot)
+		if err != nil {
+			return resp, err
+		}
+		symbolValues[i] = symbolValue
+	}
+	if len(symbolValues) > 0 {
+		// this is just easier to format it to  ["x","y"...] than manually
+		symbolsJSON, err := json.Marshal(symbolValues)
+		if err != nil {
+			return resp, err
+		}
+		params.Set("symbols", string(symbolsJSON))
+	}
+	path := priceChange + "?" + params.Encode()
+	return resp, b.SendHTTPRequest(ctx, exchange.RestSpotSupplementary, path, rl, &resp)
 }
 
 // GetLatestSpotPrice returns latest spot price of symbol
@@ -522,7 +554,7 @@ func (b *Binance) GetTickers(ctx context.Context) ([]PriceChangeStats, error) {
 func (b *Binance) GetLatestSpotPrice(ctx context.Context, symbol currency.Pair) (SymbolPrice, error) {
 	resp := SymbolPrice{}
 	params := url.Values{}
-	rateLimit := spotSymbolPriceAllRate
+	rateLimit := spotTickerAllRate
 	if !symbol.IsEmpty() {
 		rateLimit = spotDefaultRate
 		symbolValue, err := b.FormatSymbol(symbol, asset.Spot)

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -92,9 +92,12 @@ func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair,
 	params.Set("symbol", symbolValue)
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
+	} else {
+		// default to help select rate limits when no limit is provided
+		limit = 500
 	}
 
-	rateBudget := cFuturesDefaultRate
+	rateBudget := cFuturesOrderbook1000Rate
 	switch {
 	case limit == 5, limit == 10, limit == 20, limit == 50:
 		rateBudget = cFuturesOrderbook50Rate
@@ -102,8 +105,6 @@ func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair,
 		rateBudget = cFuturesOrderbook100Rate
 	case limit >= 500 && limit < 1000:
 		rateBudget = cFuturesOrderbook500Rate
-	case limit == 1000:
-		rateBudget = cFuturesOrderbook1000Rate
 	}
 
 	var data OrderbookData

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -92,9 +92,6 @@ func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair,
 	params.Set("symbol", symbolValue)
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
-	} else {
-		// default to help select rate limits when no limit is provided
-		limit = 500
 	}
 
 	rateBudget := cFuturesOrderbook1000Rate
@@ -103,7 +100,7 @@ func (b *Binance) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair,
 		rateBudget = cFuturesOrderbook50Rate
 	case limit >= 100 && limit < 500:
 		rateBudget = cFuturesOrderbook100Rate
-	case limit >= 500 && limit < 1000:
+	case limit == 0, limit >= 500 && limit < 1000:
 		rateBudget = cFuturesOrderbook500Rate
 	}
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1192,11 +1192,14 @@ func TestGetPriceChangeStats(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-
 	_, err := b.GetTickers(context.Background())
-	if err != nil {
-		t.Error("Binance TestGetTickers error", err)
-	}
+	require.NoError(t, err)
+
+	resp, err := b.GetTickers(context.Background(),
+		currency.NewPair(currency.BTC, currency.USDT),
+		currency.NewPair(currency.ETH, currency.USDT))
+	require.NoError(t, err)
+	require.Len(t, resp, 2)
 }
 
 func TestGetLatestSpotPrice(t *testing.T) {
@@ -2819,7 +2822,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 	}
 }
 
-func TestGetFundingRates(t *testing.T) {
+func TestGetHistoricalFundingRates(t *testing.T) {
 	t.Parallel()
 	s, e := getTime()
 	_, err := b.GetHistoricalFundingRates(context.Background(), &fundingrate.HistoricalRatesRequest{

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -327,25 +327,27 @@ type AveragePrice struct {
 
 // PriceChangeStats contains statistics for the last 24 hours trade
 type PriceChangeStats struct {
-	Symbol             string    `json:"symbol"`
-	PriceChange        float64   `json:"priceChange,string"`
-	PriceChangePercent float64   `json:"priceChangePercent,string"`
-	WeightedAvgPrice   float64   `json:"weightedAvgPrice,string"`
-	PrevClosePrice     float64   `json:"prevClosePrice,string"`
-	LastPrice          float64   `json:"lastPrice,string"`
-	LastQty            float64   `json:"lastQty,string"`
-	BidPrice           float64   `json:"bidPrice,string"`
-	AskPrice           float64   `json:"askPrice,string"`
-	OpenPrice          float64   `json:"openPrice,string"`
-	HighPrice          float64   `json:"highPrice,string"`
-	LowPrice           float64   `json:"lowPrice,string"`
-	Volume             float64   `json:"volume,string"`
-	QuoteVolume        float64   `json:"quoteVolume,string"`
-	OpenTime           time.Time `json:"openTime"`
-	CloseTime          time.Time `json:"closeTime"`
-	FirstID            int64     `json:"firstId"`
-	LastID             int64     `json:"lastId"`
-	Count              int64     `json:"count"`
+	Symbol             string       `json:"symbol"`
+	PriceChange        types.Number `json:"priceChange"`
+	PriceChangePercent types.Number `json:"priceChangePercent"`
+	WeightedAvgPrice   types.Number `json:"weightedAvgPrice"`
+	PrevClosePrice     types.Number `json:"prevClosePrice"`
+	LastPrice          types.Number `json:"lastPrice"`
+	LastQty            types.Number `json:"lastQty"`
+	BidPrice           types.Number `json:"bidPrice"`
+	AskPrice           types.Number `json:"askPrice"`
+	BidQuantity        types.Number `json:"bidQty"`
+	AskQuantity        types.Number `json:"askQty"`
+	OpenPrice          types.Number `json:"openPrice"`
+	HighPrice          types.Number `json:"highPrice"`
+	LowPrice           types.Number `json:"lowPrice"`
+	Volume             types.Number `json:"volume"`
+	QuoteVolume        types.Number `json:"quoteVolume"`
+	OpenTime           time.Time    `json:"openTime"`
+	CloseTime          time.Time    `json:"closeTime"`
+	FirstID            int64        `json:"firstId"`
+	LastID             int64        `json:"lastId"`
+	Count              int64        `json:"count"`
 }
 
 // SymbolPrice holds basic symbol price

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -300,8 +300,8 @@ type IndexMarkPrice struct {
 	IndexPrice           types.Number `json:"indexPrice"`
 	EstimatedSettlePrice types.Number `json:"estimatedSettlePrice"`
 	LastFundingRate      types.Number `json:"lastFundingRate"`
-	NextFundingTime      int64        `json:"nextFundingTime"`
-	Time                 int64        `json:"time"`
+	NextFundingTime      types.Time   `json:"nextFundingTime"`
+	Time                 types.Time   `json:"time"`
 }
 
 // CandleStick holds kline data

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -94,10 +94,6 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 
 	params := url.Values{}
 	params.Set("symbol", symbolValue)
-	if limit == 0 {
-		// default to help select rate limits when no limit is provided
-		limit = 500
-	}
 	strLimit := strconv.FormatInt(limit, 10)
 	if strLimit != "" {
 		if !slices.Contains(uValidOBLimits, strLimit) {
@@ -108,6 +104,8 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 
 	rateBudget := uFuturesOrderbook1000Rate
 	switch {
+	case limit == 0:
+		rateBudget = uFuturesOrderbook500Rate
 	case limit == 5, limit == 10, limit == 20, limit == 50:
 		rateBudget = uFuturesOrderbook50Rate
 	case limit >= 100 && limit < 500:

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -104,13 +104,11 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 
 	rateBudget := uFuturesOrderbook1000Rate
 	switch {
-	case limit == 0:
-		rateBudget = uFuturesOrderbook500Rate
 	case limit == 5, limit == 10, limit == 20, limit == 50:
 		rateBudget = uFuturesOrderbook50Rate
 	case limit >= 100 && limit < 500:
 		rateBudget = uFuturesOrderbook100Rate
-	case limit >= 500 && limit < 1000:
+	case limit == 0, limit >= 500 && limit < 1000:
 		rateBudget = uFuturesOrderbook500Rate
 	}
 

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -94,6 +94,10 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 
 	params := url.Values{}
 	params.Set("symbol", symbolValue)
+	if limit == 0 {
+		// default to help select rate limits when no limit is provided
+		limit = 500
+	}
 	strLimit := strconv.FormatInt(limit, 10)
 	if strLimit != "" {
 		if !slices.Contains(uValidOBLimits, strLimit) {
@@ -102,7 +106,7 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 		params.Set("limit", strLimit)
 	}
 
-	rateBudget := uFuturesDefaultRate
+	rateBudget := uFuturesOrderbook1000Rate
 	switch {
 	case limit == 5, limit == 10, limit == 20, limit == 50:
 		rateBudget = uFuturesOrderbook50Rate
@@ -110,8 +114,6 @@ func (b *Binance) UFuturesOrderbook(ctx context.Context, symbol currency.Pair, l
 		rateBudget = uFuturesOrderbook100Rate
 	case limit >= 500 && limit < 1000:
 		rateBudget = uFuturesOrderbook500Rate
-	case limit == 1000:
-		rateBudget = uFuturesOrderbook1000Rate
 	}
 
 	var data OrderbookData

--- a/exchanges/binance/ratelimit.go
+++ b/exchanges/binance/ratelimit.go
@@ -11,7 +11,7 @@ const (
 	// Global dictates the max rate limit for general request items which is
 	// 1200 requests per minute
 	spotInterval    = time.Minute
-	spotRequestRate = 600
+	spotRequestRate = 6000
 	// Order related limits which are segregated from the global rate limits
 	// 100 requests per 10 seconds and max 100000 requests per day.
 	spotOrderInterval              = 10 * time.Second

--- a/exchanges/binance/ratelimit.go
+++ b/exchanges/binance/ratelimit.go
@@ -14,18 +14,16 @@ const (
 	spotRequestRate = 6000
 	// Order related limits which are segregated from the global rate limits
 	// 100 requests per 10 seconds and max 100000 requests per day.
-	spotOrderInterval              = 10 * time.Second
-	spotOrderRequestRate           = 100
-	cFuturesInterval               = time.Minute
-	cFuturesRequestRate            = 2400
-	cFuturesOrderInterval          = time.Minute
-	cFuturesOrderRequestRate       = 1200
-	uFuturesInterval               = time.Minute
-	uFuturesRequestRate            = 2400
-	uFuturesOrderInterval          = time.Second * 10
-	uFuturesOrderRequestRate       = 300
-	uFuturesFundingRequestRate     = 500
-	uFuturesFundingRequestInterval = time.Minute * 5
+	spotOrderInterval        = 10 * time.Second
+	spotOrderRequestRate     = 100
+	cFuturesInterval         = time.Minute
+	cFuturesRequestRate      = 2400
+	cFuturesOrderInterval    = time.Minute
+	cFuturesOrderRequestRate = 1200
+	uFuturesInterval         = time.Minute
+	uFuturesRequestRate      = 2400
+	uFuturesOrderInterval    = time.Second * 10
+	uFuturesOrderRequestRate = 300
 )
 
 // Binance Spot rate limits

--- a/exchanges/binance/ratelimit_test.go
+++ b/exchanges/binance/ratelimit_test.go
@@ -21,11 +21,11 @@ func TestRateLimit_Limit(t *testing.T) {
 		Deadline time.Time
 	}{
 		"Open Orders":          {Expected: spotOpenOrdersSpecificRate, Limit: openOrdersLimit(symbol)},
-		"Orderbook Depth 5":    {Expected: spotDefaultRate, Limit: orderbookLimit(5)},
-		"Orderbook Depth 10":   {Expected: spotDefaultRate, Limit: orderbookLimit(10)},
-		"Orderbook Depth 20":   {Expected: spotDefaultRate, Limit: orderbookLimit(20)},
-		"Orderbook Depth 50":   {Expected: spotDefaultRate, Limit: orderbookLimit(50)},
-		"Orderbook Depth 100":  {Expected: spotDefaultRate, Limit: orderbookLimit(100)},
+		"Orderbook Depth 5":    {Expected: spotOrderbookDepth100Rate, Limit: orderbookLimit(5)},
+		"Orderbook Depth 10":   {Expected: spotOrderbookDepth100Rate, Limit: orderbookLimit(10)},
+		"Orderbook Depth 20":   {Expected: spotOrderbookDepth100Rate, Limit: orderbookLimit(20)},
+		"Orderbook Depth 50":   {Expected: spotOrderbookDepth100Rate, Limit: orderbookLimit(50)},
+		"Orderbook Depth 100":  {Expected: spotOrderbookDepth100Rate, Limit: orderbookLimit(100)},
 		"Orderbook Depth 500":  {Expected: spotOrderbookDepth500Rate, Limit: orderbookLimit(500)},
 		"Orderbook Depth 1000": {Expected: spotOrderbookDepth1000Rate, Limit: orderbookLimit(1000)},
 		"Orderbook Depth 5000": {Expected: spotOrderbookDepth5000Rate, Limit: orderbookLimit(5000)},
@@ -63,7 +63,7 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 	testTable := map[string]request.EndpointLimit{
 		"Default":           spotDefaultRate,
 		"Historical Trades": spotHistoricalTradesRate,
-		"All Price Changes": spotPriceChangeAllRate,
+		"All Price Changes": spotTickerAllRate,
 		"All Orders":        spotAllOrdersRate,
 	}
 

--- a/exchanges/binance/ufutures_types.go
+++ b/exchanges/binance/ufutures_types.go
@@ -73,13 +73,13 @@ type UCompressedTradeData struct {
 
 // UMarkPrice stores mark price data
 type UMarkPrice struct {
-	Symbol               string  `json:"symbol"`
-	MarkPrice            float64 `json:"markPrice,string"`
-	IndexPrice           float64 `json:"indexPrice,string"`
-	LastFundingRate      float64 `json:"lastFundingRate,string"`
-	EstimatedSettlePrice float64 `json:"estimatedSettlePrice,string"`
-	NextFundingTime      int64   `json:"nextFundingTime"`
-	Time                 int64   `json:"time"`
+	Symbol               string     `json:"symbol"`
+	MarkPrice            float64    `json:"markPrice,string"`
+	IndexPrice           float64    `json:"indexPrice,string"`
+	LastFundingRate      float64    `json:"lastFundingRate,string"`
+	EstimatedSettlePrice float64    `json:"estimatedSettlePrice,string"`
+	NextFundingTime      types.Time `json:"nextFundingTime"`
+	Time                 types.Time `json:"time"`
 }
 
 // FundingRateInfoResponse stores funding rate info


### PR DESCRIPTION
# PR Description
![image](https://github.com/user-attachments/assets/522f7994-21c2-42e3-8cb5-551e334b8e2c)
I've been getting banned a lot from Binance and these rate limits are why. This PR is non-exhaustive and just looks to fix up the areas where I'm being banned. For more updates, please see #1546 

~I also noticed `GetFundingRateInfo` now just returns `[]` so I removed its usage in the wrapper~

### Please enjoy at your leisure

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Updates test `UpdateTickers` since now it can take in multiple pairs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
