### PR TITLE
Huobi: Fix invalid contract type error when autoUpdatePairs is false

### DIFF
--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -2991,3 +2991,19 @@ func TestChannelName(t *testing.T) {
 	assert.Panics(t, func() { channelName(&subscription.Subscription{Channel: wsOrderbookChannel}, p) })
 	assert.Panics(t, func() { channelName(&subscription.Subscription{Channel: subscription.MyAccountChannel}, p) }, "Should panic on V2 endpoints until implemented")
 }
+
+func TestBootstrap(t *testing.T) {
+	t.Parallel()
+	h := new(HUOBI)
+	require.NoError(t, testexch.Setup(h), "Test Instance Setup must not fail")
+
+	c, err := h.Bootstrap(context.Background())
+	require.NoError(t, err)
+	assert.True(t, c, "Bootstrap should return true to continue")
+
+	h.futureContractCodes = nil
+	h.Features.Enabled.AutoPairUpdates = false
+	_, err = h.Bootstrap(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, h.futureContractCodes)
+}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -187,6 +187,17 @@ func (h *HUOBI) SetDefaults() {
 	h.WebsocketOrderbookBufferLimit = exchange.DefaultWebsocketOrderbookBufferLimit
 }
 
+// Bootstrap ensures that future contract expiry codes are loaded if AutoPairUpdates is not enabled
+func (h *HUOBI) Bootstrap(_ context.Context) (continueBootstrap bool, err error) {
+	continueBootstrap = true
+
+	if !h.GetEnabledFeatures().AutoPairUpdates && h.SupportsAsset(asset.Futures) {
+		_, err = h.FetchTradablePairs(context.Background(), asset.Futures)
+	}
+
+	return
+}
+
 // Setup sets user configuration
 func (h *HUOBI) Setup(exch *config.Exchange) error {
 	err := exch.Validate()


### PR DESCRIPTION
We were relying on autoUpdatePairs to fetch contract types before we need them. If the user disables it in config, we'll lazily fetch just the relevant Futures.


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run