### PR TITLE
Huobi: Fix GetAvailableTransferChains returning unavailable chains

### DIFF
--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -2623,13 +2623,9 @@ func TestGetHistoricTrades(t *testing.T) {
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	r, err := h.GetAvailableTransferChains(context.Background(), currency.USDT)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(r) < 2 {
-		t.Error("expected more than one result")
-	}
+	c, err := h.GetAvailableTransferChains(context.Background(), currency.USDT)
+	require.NoError(t, err)
+	require.Greater(t, len(c), 2, "Must get more than 2 chains")
 }
 
 func TestFormatFuturesPair(t *testing.T) {

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -35,7 +35,7 @@ type CurrenciesChainData struct {
 	Currency   string `json:"currency"`
 	AssetType  uint8  `json:"assetType"`
 	InstStatus string `json:"instStatus"`
-	ChainData  []struct {
+	ChainData  []*struct {
 		Chain                     string  `json:"chain"`
 		DisplayName               string  `json:"displayName"`
 		BaseChain                 string  `json:"baseChain"`

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -2104,21 +2104,24 @@ func compatibleVars(side, orderPriceType string, status int64) (OrderVars, error
 	return resp, nil
 }
 
-// GetAvailableTransferChains returns the available transfer blockchains for the specific
-// cryptocurrency
+// GetAvailableTransferChains returns the available transfer blockchains for the specific cryptocurrency
 func (h *HUOBI) GetAvailableTransferChains(ctx context.Context, cryptocurrency currency.Code) ([]string, error) {
-	chains, err := h.GetCurrenciesIncludingChains(ctx, cryptocurrency)
+	resp, err := h.GetCurrenciesIncludingChains(ctx, cryptocurrency)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(chains) == 0 {
-		return nil, errors.New("chain data isn't populated")
+	if len(resp) == 0 {
+		return nil, errors.New("no chains returned from currencies API")
 	}
 
-	availableChains := make([]string, len(chains[0].ChainData))
-	for x := range chains[0].ChainData {
-		availableChains[x] = chains[0].ChainData[x].Chain
+	chains := resp[0].ChainData
+
+	availableChains := make([]string, 0, len(chains))
+	for _, c := range chains {
+		if c.DepositStatus == "allowed" || c.WithdrawStatus == "allowed" {
+			availableChains = append(availableChains, c.Chain)
+		}
 	}
 	return availableChains, nil
 }


### PR DESCRIPTION
Fixes:
`[ERROR] | LOG | 08/11/2024 19:39:52 | Huobi failed to get cryptocurrency deposit address for BTC [chain hrc20btc]. Err: unable to match deposit address currency or chain`

This seems sufficient, though I'm unhappy with the way that `GetAvailableTransferChains` might return a withdraw only chain.
Reality right now is that Huobi has no "deposit not allowed" chains which are also "withdraw allowed", so this isn't currently an issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run