### PR TITLE
types/time: filter string that cannot be a unix timestamp

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -33,14 +33,15 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		if r == '.' {
 			return true
 		}
-		// As a mistake this type can be used instead of time.Time and parse int below will not fail.
+		// types.Time may only parse numbers. The below check ensures an error is thrown. time.Time should be used to
+		// parse RFC3339 strings instead.
 		badSyntax = r < '0' || r > '9'
-		return badSyntax // exit early
+		return badSyntax
 	})
 
 	if target != -1 {
 		if badSyntax {
-			return strconv.ErrSyntax
+			return fmt.Errorf("%w for `%v`", strconv.ErrSyntax, string(data))
 		}
 		s = s[:target] + s[target+1:]
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -28,7 +28,20 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		s = s[1 : len(s)-1]
 	}
 
-	if target := strings.Index(s, "."); target != -1 {
+	badSyntax := false
+	target := strings.IndexFunc(s, func(r rune) bool {
+		if r == '.' {
+			return true
+		}
+		// As a mistake this type can be used instead of time.Time and parse int below will not fail.
+		badSyntax = r < '0' || r > '9'
+		return badSyntax // exit early
+	})
+
+	if target != -1 {
+		if badSyntax {
+			return strconv.ErrSyntax
+		}
 		s = s[:target] + s[target+1:]
 	}
 

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -59,7 +59,8 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	// Captures bad syntax when type should be time.Time (RFC3339)
 	require.ErrorIs(t, json.Unmarshal([]byte(`"2025-03-28T08:00:00Z"`), &testTime), strconv.ErrSyntax)
-	require.Error(t, json.Unmarshal([]byte(`123456`), &testTime))
+	// parse int failure
+	require.ErrorIs(t, json.Unmarshal([]byte(`"1606292218213.45.8"`), &testTime), strconv.ErrSyntax)
 }
 
 // 5030734	       240.1 ns/op	     168 B/op	       2 allocs/op (current)

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -56,17 +56,19 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	require.ErrorIs(t, json.Unmarshal([]byte(`"blurp"`), &testTime), strconv.ErrSyntax)
 	require.Error(t, json.Unmarshal([]byte(`"123456"`), &testTime))
+
+	// Captures bad syntax when type should be time.Time (RFC3339)
+	require.ErrorIs(t, json.Unmarshal([]byte(`"2025-03-28T08:00:00Z"`), &testTime), strconv.ErrSyntax)
+	require.Error(t, json.Unmarshal([]byte(`"123456"`), &testTime))
 }
 
-// 5046307	       216.0 ns/op	     168 B/op	       2 allocs/op (current)
+// 5030734	       240.1 ns/op	     168 B/op	       2 allocs/op (current)
 // 2716176	       441.9 ns/op	     352 B/op	       6 allocs/op (previous)
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	var testTime Time
 	for i := 0; i < b.N; i++ {
 		err := json.Unmarshal([]byte(`"1691122380942.173000"`), &testTime)
-		if err != nil {
-			b.Fatal(err)
-		}
+		require.NoError(b, err)
 	}
 }
 

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -59,7 +59,7 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	// Captures bad syntax when type should be time.Time (RFC3339)
 	require.ErrorIs(t, json.Unmarshal([]byte(`"2025-03-28T08:00:00Z"`), &testTime), strconv.ErrSyntax)
-	require.Error(t, json.Unmarshal([]byte(`"123456"`), &testTime))
+	require.Error(t, json.Unmarshal([]byte(`123456`), &testTime))
 }
 
 // 5030734	       240.1 ns/op	     168 B/op	       2 allocs/op (current)


### PR DESCRIPTION
# PR Description

Did not error when using incorrect type. So force check, more performant using time.Time type for that use case so not going to handle potential edge case.

Cherry-picked from #1670 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
