### PR TITLE
Assets: Fix LinearContracts support

### DIFF
--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -22,37 +22,36 @@ type Items []Item
 
 // Supported Assets
 const (
-	Empty Item = 0
-	Spot  Item = 1 << (iota - 1)
+	Empty Item = iota
+	Spot
 	Margin
 	CrossMargin
 	MarginFunding
 	Index
 	Binary
+	// Futures asset consts must come below this comment for method `IsFutures`
+	Futures
 	PerpetualContract
 	PerpetualSwap
-	Futures
 	DeliveryFutures
 	UpsideProfitContract
 	DownsideProfitContract
 	CoinMarginedFutures
 	USDTMarginedFutures
 	USDCMarginedFutures
+	FutureCombo
+	LinearContract
+	// Options asset consts must come below this comment for method `IsOptions`
 	Options
 	OptionCombo
-	FutureCombo
-	LinearContract // Derivatives with a linear Base (e.g. USDT or USDC)
-	All            // Must come immediately after all valid assets
+	// All asset const must come immediately after all valid assets for method `IsValid`
+	All
 )
 
 const (
-	optionsFlag   = OptionCombo | Options
-	futuresFlag   = PerpetualContract | PerpetualSwap | Futures | DeliveryFutures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | LinearContract | FutureCombo
-	supportedFlag = Spot | Margin | CrossMargin | MarginFunding | Index | Binary | PerpetualContract | PerpetualSwap | Futures | DeliveryFutures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | Options | LinearContract | OptionCombo | FutureCombo
-
 	spot                   = "spot"
 	margin                 = "margin"
-	crossMargin            = "cross_margin" // for Gateio exchange
+	crossMargin            = "cross_margin"
 	marginFunding          = "marginfunding"
 	index                  = "index"
 	binary                 = "binary"
@@ -160,7 +159,17 @@ func (a Items) JoinToString(separator string) string {
 
 // IsValid returns whether or not the supplied asset type is valid or not
 func (a Item) IsValid() bool {
-	return a != Empty && supportedFlag&a == a
+	return a > Empty && a < All
+}
+
+// IsFutures checks if the asset type is a futures contract based asset
+func (a Item) IsFutures() bool {
+	return a >= Futures && a < Options
+}
+
+// IsOptions checks if the asset type is options contract based asset
+func (a Item) IsOptions() bool {
+	return a >= Options && a < All
 }
 
 // UnmarshalJSON conforms type to the umarshaler interface
@@ -241,14 +250,4 @@ func New(input string) (Item, error) {
 // UseDefault returns default asset type
 func UseDefault() Item {
 	return Spot
-}
-
-// IsFutures checks if the asset type is a futures contract based asset
-func (a Item) IsFutures() bool {
-	return a != Empty && futuresFlag&a == a
-}
-
-// IsOptions checks if the asset type is options contract based asset
-func (a Item) IsOptions() bool {
-	return a != Empty && optionsFlag&a == a
 }

--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -20,10 +20,10 @@ type Item uint32
 // Items stores a list of assets types
 type Items []Item
 
-// Const vars for asset package
+// Supported Assets
 const (
 	Empty Item = 0
-	Spot  Item = 1 << iota
+	Spot  Item = 1 << (iota - 1)
 	Margin
 	CrossMargin
 	MarginFunding
@@ -41,9 +41,11 @@ const (
 	Options
 	OptionCombo
 	FutureCombo
-	LinearContract // Added to represent a USDT and USDC based linear derivatives(futures/perpetual) assets in Bybit V5
-	All
+	LinearContract // Derivatives with a linear Base (e.g. USDT or USDC)
+	All            // Must come immediately after all valid assets
+)
 
+const (
 	optionsFlag   = OptionCombo | Options
 	futuresFlag   = PerpetualContract | PerpetualSwap | Futures | DeliveryFutures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | LinearContract | FutureCombo
 	supportedFlag = Spot | Margin | CrossMargin | MarginFunding | Index | Binary | PerpetualContract | PerpetualSwap | Futures | DeliveryFutures | UpsideProfitContract | DownsideProfitContract | CoinMarginedFutures | USDTMarginedFutures | USDCMarginedFutures | Options | LinearContract | OptionCombo | FutureCombo
@@ -67,6 +69,7 @@ const (
 	options                = "options"
 	optionCombo            = "option_combo"
 	futureCombo            = "future_combo"
+	linearContract         = "linearcontract"
 	all                    = "all"
 )
 
@@ -118,6 +121,8 @@ func (a Item) String() string {
 		return optionCombo
 	case FutureCombo:
 		return futureCombo
+	case LinearContract:
+		return linearContract
 	case All:
 		return all
 	default:
@@ -224,6 +229,8 @@ func New(input string) (Item, error) {
 		return OptionCombo, nil
 	case futureCombo:
 		return FutureCombo, nil
+	case linearContract:
+		return LinearContract, nil
 	case all:
 		return All, nil
 	default:

--- a/exchanges/asset/asset_test.go
+++ b/exchanges/asset/asset_test.go
@@ -10,15 +10,10 @@ import (
 
 func TestString(t *testing.T) {
 	t.Parallel()
-	a := Spot
-	if a.String() != "spot" {
-		t.Fatal("TestString returned an unexpected result")
+	for a := Item(1); a <= All; a <<= 1 {
+		assert.NotEmptyf(t, a.String(), "%s.String should return non-empty", a)
 	}
-
-	a = 0
-	if a.String() != "" {
-		t.Fatal("TestString returned an unexpected result")
-	}
+	assert.Empty(t, Empty.String(), "Empty.String should return empty")
 }
 
 func TestStrings(t *testing.T) {
@@ -90,8 +85,9 @@ func TestNew(t *testing.T) {
 		{Input: "Options", Expected: Options},
 		{Input: "Option", Expected: Options},
 		{Input: "Future", Error: ErrNotSupported},
-		{Input: "future_combo", Expected: FutureCombo},
 		{Input: "option_combo", Expected: OptionCombo},
+		{Input: "future_combo", Expected: FutureCombo},
+		{Input: "linearContract", Expected: LinearContract},
 	}
 
 	for _, tt := range cases {
@@ -123,75 +119,11 @@ func TestSupported(t *testing.T) {
 
 func TestIsFutures(t *testing.T) {
 	t.Parallel()
-	type scenario struct {
-		item      Item
-		isFutures bool
+	for _, a := range []Item{Spot, Margin, MarginFunding, Index, Binary} {
+		assert.Falsef(t, a.IsFutures(), "%s should return correctly for IsFutures", a)
 	}
-	scenarios := []scenario{
-		{
-			item:      Spot,
-			isFutures: false,
-		},
-		{
-			item:      Margin,
-			isFutures: false,
-		},
-		{
-			item:      MarginFunding,
-			isFutures: false,
-		},
-		{
-			item:      Index,
-			isFutures: false,
-		},
-		{
-			item:      Binary,
-			isFutures: false,
-		},
-		{
-			item:      PerpetualContract,
-			isFutures: true,
-		},
-		{
-			item:      PerpetualSwap,
-			isFutures: true,
-		},
-		{
-			item:      Futures,
-			isFutures: true,
-		},
-		{
-			item:      UpsideProfitContract,
-			isFutures: true,
-		},
-		{
-			item:      DownsideProfitContract,
-			isFutures: true,
-		},
-		{
-			item:      CoinMarginedFutures,
-			isFutures: true,
-		},
-		{
-			item:      USDTMarginedFutures,
-			isFutures: true,
-		},
-		{
-			item:      USDCMarginedFutures,
-			isFutures: true,
-		}, {
-			item:      FutureCombo,
-			isFutures: true,
-		},
-	}
-	for _, s := range scenarios {
-		testScenario := s
-		t.Run(testScenario.item.String(), func(t *testing.T) {
-			t.Parallel()
-			if testScenario.item.IsFutures() != testScenario.isFutures {
-				t.Errorf("expected %v isFutures to be %v", testScenario.item, testScenario.isFutures)
-			}
-		})
+	for _, a := range []Item{PerpetualContract, PerpetualSwap, Futures, UpsideProfitContract, DownsideProfitContract, CoinMarginedFutures, USDTMarginedFutures, USDCMarginedFutures, FutureCombo} {
+		assert.Truef(t, a.IsFutures(), "%s should return correctly for IsFutures", a)
 	}
 }
 

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -55,7 +55,7 @@ func TestSubmit_Validate(t *testing.T) {
 			Submit: &Submit{
 				Exchange:  "test",
 				Pair:      testPair,
-				AssetType: 255,
+				AssetType: asset.All,
 			},
 		}, // valid pair but invalid asset
 		{


### PR DESCRIPTION
Fixes Linear assets missing from list of strings for asset conversion.
Drive-Bys a couple of other minor fixes from another branch that shouldn't be contentious.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
