### PR TITLE
Subscriptions: Fix IBotExchange not implementing sub.IExchange

### DIFF
--- a/exchanges/interfaces.go
+++ b/exchanges/interfaces.go
@@ -51,6 +51,7 @@ type IBotExchange interface {
 	UpdateTradablePairs(ctx context.Context, forceUpdate bool) error
 	GetEnabledPairs(a asset.Item) (currency.Pairs, error)
 	GetAvailablePairs(a asset.Item) (currency.Pairs, error)
+	GetPairFormat(asset.Item, bool) (currency.PairFormat, error)
 	SetPairs(pairs currency.Pairs, a asset.Item, enabled bool) error
 	GetAssetTypes(enabled bool) asset.Items
 	GetRecentTrades(ctx context.Context, p currency.Pair, a asset.Item) ([]trade.Data, error)

--- a/exchanges/subscription/interface_test.go
+++ b/exchanges/subscription/interface_test.go
@@ -1,0 +1,16 @@
+package subscription_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
+	shared "github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
+)
+
+// TestIExchange ensures that IExchange is a subset of IBotExchange, so when an exchange is passed by interface, it can still use ExpandTemplates
+func TestIExchange(t *testing.T) {
+	assert.Implements(t, (*subscription.IExchange)(nil), exchange.IBotExchange(&shared.CustomEx{}))
+	var _ subscription.IExchange = exchange.IBotExchange(nil)
+}

--- a/exchanges/subscription/list.go
+++ b/exchanges/subscription/list.go
@@ -14,7 +14,8 @@ type List []*Subscription
 
 type assetPairs map[asset.Item]currency.Pairs
 
-type iExchange interface {
+// IExchange provides method requirements for exchanges to use subscription templating
+type IExchange interface {
 	GetAssetTypes(enabled bool) asset.Items
 	GetEnabledPairs(asset.Item) (currency.Pairs, error)
 	GetPairFormat(asset.Item, bool) (currency.PairFormat, error)
@@ -93,7 +94,7 @@ func (l List) SetStates(state State) error {
 	return err
 }
 
-func fillAssetPairs(ap assetPairs, a asset.Item, e iExchange) error {
+func fillAssetPairs(ap assetPairs, a asset.Item, e IExchange) error {
 	p, err := e.GetEnabledPairs(a)
 	if err != nil {
 		return err
@@ -107,7 +108,7 @@ func fillAssetPairs(ap assetPairs, a asset.Item, e iExchange) error {
 }
 
 // assetPairs returns a map of enabled pairs for the subscriptions in the list, formatted for the asset
-func (l List) assetPairs(e iExchange) (assetPairs, error) {
+func (l List) assetPairs(e IExchange) (assetPairs, error) {
 	at := []asset.Item{}
 	for _, a := range e.GetAssetTypes(true) {
 		if e.IsAssetWebsocketSupported(a) {

--- a/exchanges/subscription/template.go
+++ b/exchanges/subscription/template.go
@@ -42,7 +42,7 @@ type tplCtx struct {
 // Calls e.GetSubscriptionTemplate to find a template for each subscription
 // Filters out Authenticated subscriptions if !e.CanUseAuthenticatedEndpoints
 // See README.md for more details
-func (l List) ExpandTemplates(e iExchange) (List, error) {
+func (l List) ExpandTemplates(e IExchange) (List, error) {
 	if !slices.ContainsFunc(l, func(s *Subscription) bool { return s.QualifiedChannel == "" }) {
 		// Empty list, or already processed
 		return slices.Clone(l), nil
@@ -82,7 +82,7 @@ func (l List) ExpandTemplates(e iExchange) (List, error) {
 	return subs, err
 }
 
-func expandTemplate(e iExchange, s *Subscription, ap assetPairs, assets asset.Items) (List, error) {
+func expandTemplate(e IExchange, s *Subscription, ap assetPairs, assets asset.Items) (List, error) {
 	if s.QualifiedChannel != "" {
 		return List{s}, nil
 	}


### PR DESCRIPTION
Adds GetPairFormat to IBotExchange

Thusfar ExpandTemplates had only been called internally. All methods consumers might want to get, in this case GetPairFormat, need to be in the interface we're passing out, otherwise users can't call them (or things that use them, like ExpandTemplates)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)