### PR TITLE
Binance: Add order side

### DIFF
--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -198,7 +198,7 @@ type TradeStream struct {
 	BuyerOrderID   int64        `json:"b"`
 	SellerOrderID  int64        `json:"a"`
 	TimeStamp      time.Time    `json:"T"`
-	Maker          bool         `json:"m"`
+	IsBuyerMaker   bool         `json:"m"`
 	BestMatchPrice bool         `json:"M"`
 }
 

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -288,7 +288,7 @@ type AggregatedTrade struct {
 	FirstTradeID   int64     `json:"f"`
 	LastTradeID    int64     `json:"l"`
 	TimeStamp      time.Time `json:"T"`
-	Maker          bool      `json:"m"`
+	IsBuyerMaker   bool      `json:"m"`
 	BestMatchPrice bool      `json:"M"`
 }
 

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -344,7 +344,6 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 			Amount:       t.Quantity.Float64(),
 			Exchange:     b.Name,
 			AssetType:    asset.Spot,
-			Side:         order.Sell,
 			TID:          strconv.FormatInt(t.TradeID, 10)}
 
 		if t.IsBuyerMaker { // Seller is Taker

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -337,6 +337,11 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 				b.Name,
 				err)
 		}
+		// maker placed buy order, so taker market sell
+		side := order.Buy
+		if t.Maker {
+			side = order.Sell
+		}
 		return b.Websocket.Trade.Update(saveTradeData,
 			trade.Data{
 				CurrencyPair: pair,
@@ -345,6 +350,7 @@ func (b *Binance) wsHandleData(respRaw []byte) error {
 				Amount:       t.Quantity.Float64(),
 				Exchange:     b.Name,
 				AssetType:    asset.Spot,
+				Side:         side,
 				TID:          strconv.FormatInt(t.TradeID, 10),
 			})
 	case "ticker":

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -783,21 +783,21 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
-			// maker placed buy order, so taker market sell
-			side := order.Buy
-			if tradeData[i].IsBuyerMaker {
-				side = order.Sell
-			}
-			resp = append(resp, trade.Data{
+			td := trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
 				CurrencyPair: p,
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Quantity,
-				Side:         side,
 				Timestamp:    tradeData[i].Time,
-			})
+			}
+			if tradeData[i].IsBuyerMaker { // Seller is Taker
+				td.Side = order.Sell
+			} else { // Buyer is Taker
+				td.Side = order.Buy
+			}
+			resp = append(resp, td)
 		}
 	case asset.USDTMarginedFutures:
 		tradeData, err := b.URecentTrades(ctx, pFmt, "", limit)
@@ -806,21 +806,21 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
-			// maker placed buy order, so taker market sell
-			side := order.Buy
-			if tradeData[i].IsBuyerMaker {
-				side = order.Sell
-			}
-			resp = append(resp, trade.Data{
+			td := trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
 				CurrencyPair: p,
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Qty,
-				Side:         side,
 				Timestamp:    tradeData[i].Time.Time(),
-			})
+			}
+			if tradeData[i].IsBuyerMaker { // Seller is Taker
+				td.Side = order.Sell
+			} else { // Buyer is Taker
+				td.Side = order.Buy
+			}
+			resp = append(resp, td)
 		}
 	case asset.CoinMarginedFutures:
 		tradeData, err := b.GetFuturesPublicTrades(ctx, pFmt, limit)
@@ -829,21 +829,21 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
-			// maker placed buy order, so taker market sell
-			side := order.Buy
-			if tradeData[i].IsBuyerMaker {
-				side = order.Sell
-			}
-			resp = append(resp, trade.Data{
+			td := trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
 				CurrencyPair: p,
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Qty,
-				Side:         side,
 				Timestamp:    tradeData[i].Time.Time(),
-			})
+			}
+			if tradeData[i].IsBuyerMaker { // Seller is Taker
+				td.Side = order.Sell
+			} else { // Buyer is Taker
+				td.Side = order.Buy
+			}
+			resp = append(resp, td)
 		}
 	}
 
@@ -882,12 +882,7 @@ func (b *Binance) GetHistoricTrades(ctx context.Context, p currency.Pair, a asse
 	}
 	result := make([]trade.Data, len(trades))
 	for i := range trades {
-		// maker placed buy order, so taker market sell
-		side := order.Buy
-		if trades[i].Maker {
-			side = order.Sell
-		}
-		result[i] = trade.Data{
+		td := trade.Data{
 			CurrencyPair: p,
 			TID:          strconv.FormatInt(trades[i].ATradeID, 10),
 			Amount:       trades[i].Quantity,
@@ -895,8 +890,13 @@ func (b *Binance) GetHistoricTrades(ctx context.Context, p currency.Pair, a asse
 			Price:        trades[i].Price,
 			Timestamp:    trades[i].TimeStamp,
 			AssetType:    a,
-			Side:         side,
 		}
+		if trades[i].IsBuyerMaker { // Seller is Taker
+			td.Side = order.Sell
+		} else { // Buyer is Taker
+			td.Side = order.Buy
+		}
+		result[i] = td
 	}
 	return result, nil
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -783,6 +783,11 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
+			// maker placed buy order, so taker market sell
+			side := order.Buy
+			if tradeData[i].IsBuyerMaker {
+				side = order.Sell
+			}
 			resp = append(resp, trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
@@ -790,6 +795,7 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Quantity,
+				Side:         side,
 				Timestamp:    tradeData[i].Time,
 			})
 		}
@@ -800,6 +806,11 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
+			// maker placed buy order, so taker market sell
+			side := order.Buy
+			if tradeData[i].IsBuyerMaker {
+				side = order.Sell
+			}
 			resp = append(resp, trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
@@ -807,6 +818,7 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Qty,
+				Side:         side,
 				Timestamp:    tradeData[i].Time.Time(),
 			})
 		}
@@ -817,6 +829,11 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 		}
 
 		for i := range tradeData {
+			// maker placed buy order, so taker market sell
+			side := order.Buy
+			if tradeData[i].IsBuyerMaker {
+				side = order.Sell
+			}
 			resp = append(resp, trade.Data{
 				TID:          strconv.FormatInt(tradeData[i].ID, 10),
 				Exchange:     b.Name,
@@ -824,6 +841,7 @@ func (b *Binance) GetRecentTrades(ctx context.Context, p currency.Pair, a asset.
 				AssetType:    a,
 				Price:        tradeData[i].Price,
 				Amount:       tradeData[i].Qty,
+				Side:         side,
 				Timestamp:    tradeData[i].Time.Time(),
 			})
 		}
@@ -864,6 +882,11 @@ func (b *Binance) GetHistoricTrades(ctx context.Context, p currency.Pair, a asse
 	}
 	result := make([]trade.Data, len(trades))
 	for i := range trades {
+		// maker placed buy order, so taker market sell
+		side := order.Buy
+		if trades[i].Maker {
+			side = order.Sell
+		}
 		result[i] = trade.Data{
 			CurrencyPair: p,
 			TID:          strconv.FormatInt(trades[i].ATradeID, 10),
@@ -872,7 +895,7 @@ func (b *Binance) GetHistoricTrades(ctx context.Context, p currency.Pair, a asse
 			Price:        trades[i].Price,
 			Timestamp:    trades[i].TimeStamp,
 			AssetType:    a,
-			Side:         order.AnySide,
+			Side:         side,
 		}
 	}
 	return result, nil


### PR DESCRIPTION
# PR Description

Currently, the Binance side is marked as unknown. The raw data includes the isBuyerMaker: bool flag, which indicates the initiating side. Based on that, add a side.
Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [x] TestGetRecentTrades
- [x] TestGetMostRecentTrades 
- [x] TestWsTradeUpdate 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
