### PR TITLE
Codespell: Fix failures with 2.4.0

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,3 +2,4 @@
 skip = ./.git,./web,./currency/code_types.go,*.json,*.sum,*.html
 exclude-file = ./contrib/spellcheck/exclude_lines.txt
 ignore-words = ./contrib/spellcheck/ignore_words.txt
+ignore-regex = currency\.\w+

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = ./.git,./web,./currency/code_types.go,*.json,*.sum,*.html
+skip = ./.git,./web,./currency/code_types.go,*.json,*.sum,*.html,./vendor
 exclude-file = ./contrib/spellcheck/exclude_lines.txt
 ignore-words = ./contrib/spellcheck/ignore_words.txt
 ignore-regex = currency\.\w+

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -7,8 +7,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@master
-        with:
-          exclude_file: contrib/spellcheck/exclude_lines.txt
-          skip: ./.git,./web,./currency/code_types.go,*.json,*.sum,*.html
-          ignore_words_file: contrib/spellcheck/ignore_words.txt
-          ignore_regex: currency\.\w+

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -11,3 +11,4 @@ jobs:
           exclude_file: contrib/spellcheck/exclude_lines.txt
           skip: ./.git,./web,./currency/code_types.go,*.json,*.sum,*.html
           ignore_words_file: contrib/spellcheck/ignore_words.txt
+          ignore_regex: currency\.\w+

--- a/backtester/engine/grpcserver.go
+++ b/backtester/engine/grpcserver.go
@@ -211,36 +211,32 @@ func (s *GRPCServer) ExecuteStrategyFromFile(_ context.Context, request *btrpc.E
 		return nil, err
 	}
 
-	io64 := int64(request.IntervalOverride)
-	if io64 > 0 {
+	if io64 := int64(request.IntervalOverride); io64 > 0 {
 		if io64 < gctkline.FifteenSecond.Duration().Nanoseconds() {
 			return nil, fmt.Errorf("%w, interval must be >= 15 seconds, received '%v'", gctkline.ErrInvalidInterval, time.Duration(request.IntervalOverride))
 		}
 		cfg.DataSettings.Interval = gctkline.Interval(request.IntervalOverride)
 	}
-	sto := request.StartTimeOverride.AsTime()
-	if sto.Unix() != 0 && !sto.IsZero() {
+
+	if startTime := request.StartTimeOverride.AsTime(); startTime.Unix() != 0 && !startTime.IsZero() {
 		if cfg.DataSettings.DatabaseData != nil {
-			cfg.DataSettings.DatabaseData.StartDate = request.StartTimeOverride.AsTime()
+			cfg.DataSettings.DatabaseData.StartDate = startTime
 		} else if cfg.DataSettings.APIData != nil {
-			cfg.DataSettings.APIData.StartDate = request.StartTimeOverride.AsTime()
+			cfg.DataSettings.APIData.StartDate = startTime
 		}
 	}
-	eto := request.EndTimeOverride.AsTime()
-	if eto.Unix() != 0 && !eto.IsZero() {
+	if endTime := request.EndTimeOverride.AsTime(); endTime.Unix() != 0 && !endTime.IsZero() {
 		if cfg.DataSettings.DatabaseData != nil {
-			cfg.DataSettings.DatabaseData.EndDate = request.EndTimeOverride.AsTime()
+			cfg.DataSettings.DatabaseData.EndDate = endTime
 		} else if cfg.DataSettings.APIData != nil {
-			cfg.DataSettings.APIData.EndDate = request.EndTimeOverride.AsTime()
+			cfg.DataSettings.APIData.EndDate = endTime
 		}
 	}
-	err = cfg.Validate()
-	if err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	if cfg == nil {
-		err = fmt.Errorf("%w backtester config", gctcommon.ErrNilPointer)
-		return nil, err
+		return nil, fmt.Errorf("%w backtester config", gctcommon.ErrNilPointer)
 	}
 
 	if !s.config.Report.GenerateReport {

--- a/contrib/spellcheck/exclude_lines.txt
+++ b/contrib/spellcheck/exclude_lines.txt
@@ -4,16 +4,6 @@
 	tt, errOt := order.StringToOrderType(genOrderDetail.Type)
 	if errOt != nil {
 		return order.Detail{}, fmt.Errorf("error parsing order type: %s", errOt)
-	currency.CANN:       0.2,
-	currency.DOTA:       0.01,
-	currency.SCRPT:      0.01,
-	currency.NOO:        0.002,
-	currency.BU:       0.1,
-	currency.HAV:      10,
-	currency.GARD:     100,
-	currency.DASHS:      0.01,
-	currency.ALIS:       0.05,
-	currency.MIS:        0.002,
 	const pressXToJSON = `[0,"bu",[4131.85,4131.85]]`
 	wsTradeExecuted                        = "te"
 	wsBalanceUpdate                        = "bu"

--- a/contrib/spellcheck/ignore_words.txt
+++ b/contrib/spellcheck/ignore_words.txt
@@ -2,7 +2,6 @@ strat
 datas
 prevend
 flate
-freez
 zar
 insid
 totalin

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -1301,7 +1301,7 @@ type CrossMarginBalance struct {
 	BorrowedNet         string       `json:"borrowed_net"`
 	TotalNetAssetInUSDT string       `json:"net"`
 	PositionLeverage    string       `json:"leverage"`
-	Risk                string       `json:"risk"` // Risk rate. When it belows 110%, liquidation will be triggered. Calculation formula: total / (borrowed+interest)
+	Risk                string       `json:"risk"` // Risk percentage; Liquidation is triggered when this falls below required margin. Calculation: total / (borrowed+interest)
 }
 
 // WalletSavedAddress represents currency saved address

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -204,7 +204,7 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 			return checkErr
 		} else if retry {
 			if err == nil {
-				// If the body isn't fully read, the connection cannot be re-used
+				// If the body isn't fully read, the connection cannot be reused
 				r.drainBody(resp.Body)
 			}
 


### PR DESCRIPTION
* Moves currency checks to be a regex, avoiding hardcoding the digits in the ignore lines, and having to keep adding them
* DriveBy mini-refactor in grpcserver whilst sidestepping `eto` complaint like Neo in that scene. You know, right.
* Grabs the latest PR suggestion for the fix to gateio's risk type
  * > Fixes the codespell failure about the word belows 
* Removes the github action config
  * Because we have .codespellrc already and consistency is better between dev-env and CI
  * Because the stupid github action enforces it's own opinion of what valid options should be, and doesn't support ignore-regex

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)