### PR TITLE
Subscriptions: Fix no enabled pairs for one asset

### DIFF
--- a/exchanges/subscription/list.go
+++ b/exchanges/subscription/list.go
@@ -96,7 +96,7 @@ func (l List) SetStates(state State) error {
 
 func fillAssetPairs(ap assetPairs, a asset.Item, e IExchange) error {
 	p, err := e.GetEnabledPairs(a)
-	if err != nil {
+	if err != nil || len(p) == 0 {
 		return err
 	}
 	f, err := e.GetPairFormat(a, true)

--- a/exchanges/subscription/list_test.go
+++ b/exchanges/subscription/list_test.go
@@ -114,6 +114,17 @@ func TestAssetPairs(t *testing.T) {
 	}
 }
 
+// TestFillAssetPairs exercises AssetPairs handling with no enabled pairs
+// All other code is covered under TestAssetPairs and TestExpandTemplates
+func TestFillAssetPairs(t *testing.T) {
+	e := newMockEx()
+	e.pairs = currency.Pairs{}
+	ap := assetPairs{}
+	err := fillAssetPairs(ap, asset.Spot, e)
+	require.NoError(t, err, "fillAssetPairs must not error with no pairs enabled")
+	assert.Empty(t, ap, "fillAssetPairs should return an empty map with no pairs enabled")
+}
+
 func TestListClone(t *testing.T) {
 	t.Parallel()
 	l := List{{Channel: TickerChannel}, {Channel: OrderbookChannel}}


### PR DESCRIPTION
If one asset is enabled but has no enabled pairs, we should ignore that asset, even for non-pair related subscriptions.
That matches the existing code, but wasn't happening in the context of asset.All subscriptions with just one asset in this state. If a user wanted to have non-pair subscriptions, they should use asset.Empty. Would expect other breakages with no pairs enabled, too.

Note: No enabled pairs for an enabled asset is a transient issue which can occur due to enableOnePair racing against no available pairs. The second run, available pairs would be populated and enableOnePair would work. This situation could persist due to running with --dry or containerised, though.

Fixes:
`
Okx websocket: subscription failure, myOrders all : subscription template did not generate the expected number of pair records for spread: Got 1; Expected 0
`

Relates to #1420

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)