### PR TITLE
exchanges/btse: Handle TRUMPSOL in MarketPair.Pair and add test coverage

### DIFF
--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -765,18 +765,14 @@ func TestMarketPair(t *testing.T) {
 	}{
 		{symbol: "RUNEPFC", base: currency.RUNE.String(), quote: currency.USD.String(), futures: true, expectedSymbol: "RUNEPFC"},
 		{symbol: "TRUMPPFC", base: "TRUMPSOL", quote: currency.USD.String(), futures: true, expectedSymbol: "TRUMPPFC"},
-		{symbol: "BTCUSD", base: "NAUGHTYBASE", quote: currency.USD.String(), futures: true, expectedSymbol: "BTCUSD", expectedErr: errInvalidPairSymbol},
+		{symbol: "BTCUSD", base: "NAUGHTYBASE", quote: currency.USD.String(), futures: true, expectedErr: errInvalidPairSymbol},
 		{symbol: "NAUGHTYSYMBOL", base: currency.BTC.String(), quote: currency.USD.String(), expectedErr: errInvalidPairSymbol},
 		{symbol: "BTC-USD", base: currency.BTC.String(), quote: currency.USD.String(), expectedSymbol: currency.NewPair(currency.BTC, currency.USD).String()},
 	} {
 		mp := MarketPair{Symbol: test.symbol, Base: test.base, Quote: test.quote, Futures: test.futures}
 		p, err := mp.Pair()
-		if test.expectedErr != nil {
-			assert.ErrorIs(t, err, test.expectedErr, "Pair should not error")
-		} else {
-			assert.NoError(t, err, "Pair should not error")
-			assert.Equal(t, test.expectedSymbol, p.String(), "Pair should return expected symbol")
-		}
+		assert.ErrorIs(t, err, test.expectedErr, "Pair should not error")
+		assert.Equal(t, test.expectedSymbol, p.String(), "Pair should return the expected symbol")
 	}
 }
 

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -752,6 +752,34 @@ func TestStripExponent(t *testing.T) {
 	assert.ErrorIs(t, err, errInvalidPairSymbol, "Should error on a symbol with too many underscores")
 }
 
+func TestMarketPair(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		symbol         string
+		base           string
+		quote          string
+		futures        bool
+		expectedErr    error
+		expectedSymbol string
+	}{
+		{symbol: "RUNEPFC", base: currency.RUNE.String(), quote: currency.USD.String(), futures: true, expectedSymbol: "RUNEPFC"},
+		{symbol: "TRUMPPFC", base: "TRUMPSOL", quote: currency.USD.String(), futures: true, expectedSymbol: "TRUMPPFC"},
+		{symbol: "BTCUSD", base: "NAUGHTYBASE", quote: currency.USD.String(), futures: true, expectedSymbol: "BTCUSD", expectedErr: errInvalidPairSymbol},
+		{symbol: "NAUGHTYSYMBOL", base: currency.BTC.String(), quote: currency.USD.String(), expectedErr: errInvalidPairSymbol},
+		{symbol: "BTC-USD", base: currency.BTC.String(), quote: currency.USD.String(), expectedSymbol: currency.NewPair(currency.BTC, currency.USD).String()},
+	} {
+		mp := MarketPair{Symbol: test.symbol, Base: test.base, Quote: test.quote, Futures: test.futures}
+		p, err := mp.Pair()
+		if test.expectedErr != nil {
+			assert.ErrorIs(t, err, test.expectedErr, "Pair should not error")
+		} else {
+			assert.NoError(t, err, "Pair should not error")
+			assert.Equal(t, test.expectedSymbol, p.String(), "Pair should return expected symbol")
+		}
+	}
+}
+
 func TestGenerateSubscriptions(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -755,24 +755,23 @@ func TestStripExponent(t *testing.T) {
 func TestMarketPair(t *testing.T) {
 	t.Parallel()
 
-	for _, test := range []struct {
+	for _, tt := range []struct {
 		symbol         string
 		base           string
-		quote          string
 		futures        bool
 		expectedErr    error
 		expectedSymbol string
 	}{
-		{symbol: "RUNEPFC", base: currency.RUNE.String(), quote: currency.USD.String(), futures: true, expectedSymbol: "RUNEPFC"},
-		{symbol: "TRUMPPFC", base: "TRUMPSOL", quote: currency.USD.String(), futures: true, expectedSymbol: "TRUMPPFC"},
-		{symbol: "BTCUSD", base: "NAUGHTYBASE", quote: currency.USD.String(), futures: true, expectedErr: errInvalidPairSymbol},
-		{symbol: "NAUGHTYSYMBOL", base: currency.BTC.String(), quote: currency.USD.String(), expectedErr: errInvalidPairSymbol},
-		{symbol: "BTC-USD", base: currency.BTC.String(), quote: currency.USD.String(), expectedSymbol: currency.NewPair(currency.BTC, currency.USD).String()},
+		{symbol: "RUNEPFC", base: currency.RUNE.String(), futures: true, expectedSymbol: "RUNEPFC"},
+		{symbol: "TRUMPPFC", base: "TRUMPSOL", futures: true, expectedSymbol: "TRUMPPFC"},
+		{symbol: "BTCUSD", base: "NAUGHTYBASE", futures: true, expectedErr: errInvalidPairSymbol},
+		{symbol: "NAUGHTYSYMBOL", base: currency.BTC.String(), expectedErr: errInvalidPairSymbol},
+		{symbol: "BTC-USD", base: currency.BTC.String(), expectedSymbol: "BTCUSD"},
 	} {
-		mp := MarketPair{Symbol: test.symbol, Base: test.base, Quote: test.quote, Futures: test.futures}
+		mp := MarketPair{Symbol: tt.symbol, Base: tt.base, Quote: "USD", Futures: tt.futures}
 		p, err := mp.Pair()
-		assert.ErrorIs(t, err, test.expectedErr, "Pair should not error")
-		assert.Equal(t, test.expectedSymbol, p.String(), "Pair should return the expected symbol")
+		assert.ErrorIs(t, err, tt.expectedErr, "Pair should not error")
+		assert.Equal(t, tt.expectedSymbol, p.String(), "Pair should return the expected symbol")
 	}
 }
 

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -1051,11 +1051,16 @@ func (m *MarketPair) Pair() (currency.Pair, error) {
 	baseCurr := m.Base
 	var quoteCurr string
 	if m.Futures {
-		s := strings.Split(m.Symbol, m.Base) // e.g. RUNEPFC for RUNE-USD futures pair
-		if len(s) <= 1 {
-			return currency.EMPTYPAIR, errInvalidPairSymbol
+		if baseCurr == "TRUMPSOL" { // Only base currency which is different to the rest
+			baseCurr = "TRUMP"
+			quoteCurr = strings.TrimPrefix(m.Symbol, baseCurr)
+		} else {
+			s := strings.Split(m.Symbol, m.Base) // e.g. RUNEPFC for RUNE-USD futures pair
+			if len(s) <= 1 {
+				return currency.EMPTYPAIR, errInvalidPairSymbol
+			}
+			quoteCurr = s[1]
 		}
-		quoteCurr = s[1]
 	} else {
 		s := strings.Split(m.Symbol, currency.DashDelimiter)
 		if len(s) != 2 {


### PR DESCRIPTION
# PR Description

TRUMP strikes again with a special edge case for BTSE's MarketPair Pair method handling as no other symbols experience this issue. 
Fixes #1802 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
