### PR TITLE
exchanges/margin: Fix marshalling issue

### DIFF
--- a/exchanges/margin/margin.go
+++ b/exchanges/margin/margin.go
@@ -23,7 +23,7 @@ func (t *Type) UnmarshalJSON(d []byte) error {
 	return err
 }
 
-// MarshalJSON conforms type to the Marshaler interface
+// MarshalJSON conforms type to the json.Marshaler interface
 func (t Type) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }

--- a/exchanges/margin/margin.go
+++ b/exchanges/margin/margin.go
@@ -23,6 +23,11 @@ func (t *Type) UnmarshalJSON(d []byte) error {
 	return err
 }
 
+// MarshalJSON conforms type to the Marshaler interface
+func (t Type) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
 // String returns the string representation of the margin type in lowercase
 // the absence of a lower func should hopefully highlight that String is lower
 func (t Type) String() string {
@@ -37,10 +42,9 @@ func (t Type) String() string {
 		return spotIsolatedStr
 	case NoMargin:
 		return cashStr
-	case Unknown:
+	default:
 		return unknownStr
 	}
-	return ""
 }
 
 // Upper returns the upper case string representation of the margin type

--- a/exchanges/margin/margin_test.go
+++ b/exchanges/margin/margin_test.go
@@ -1,6 +1,7 @@
 package margin
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -33,6 +34,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		"spotIsolated": {`{"margin":"spot_isolated"}`, SpotIsolated, nil},
 		"invalid":      {`{"margin":"hello moto"}`, Unknown, ErrInvalidMarginType},
 		"unset":        {`{"margin":""}`, Unset, nil},
+		"":             {`{"margin":""}`, Unset, nil},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -46,6 +48,28 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestMarshalJSON(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		in   Type
+		want string
+	}{
+		{Isolated, fmt.Sprintf(`%q`, isolatedStr)},
+		{Multi, fmt.Sprintf(`%q`, multiStr)},
+		{NoMargin, fmt.Sprintf(`%q`, cashStr)},
+		{SpotIsolated, fmt.Sprintf(`%q`, spotIsolatedStr)},
+		{Type(uint8(123)), fmt.Sprintf(`%q`, unknownStr)},
+		{Unset, fmt.Sprintf(`%q`, unsetStr)},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			resp, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(resp))
+		})
+	}
+}
+
 func TestString(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, unknownStr, Unknown.String())
@@ -54,7 +78,8 @@ func TestString(t *testing.T) {
 	assert.Equal(t, unsetStr, Unset.String())
 	assert.Equal(t, spotIsolatedStr, SpotIsolated.String())
 	assert.Equal(t, cashStr, NoMargin.String())
-	assert.Equal(t, "", Type(30).String())
+	assert.Equal(t, unknownStr, Type(30).String())
+	assert.Equal(t, "", Unset.String())
 }
 
 func TestUpper(t *testing.T) {

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -2208,7 +2208,7 @@ func TestUnmarshalOrder(t *testing.T) {
 		Price:     1000,
 	}
 	jOrderSubmit, err := json.Marshal(orderSubmit)
-	require.NoError(t, err)
+	require.NoError(t, err, "json.Marshal must not error")
 	var os2 Submit
 	err = json.Unmarshal(jOrderSubmit, &os2)
 	require.NoError(t, err)

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -2202,22 +2202,14 @@ func TestUnmarshalOrder(t *testing.T) {
 		Exchange:  "test",
 		Pair:      btx,
 		AssetType: asset.Spot,
-		Side:      Buy,
-		Type:      Market,
-		Amount:    1,
-		Price:     1000,
+		MarginType: margin.Multi,
+		Side:       Buy,
+		Type:       Market,
+		Amount:     1,
+		Price:      1000,
 	}
-	jOrderSubmit, err := json.Marshal(orderSubmit)
+	j, err := json.Marshal(orderSubmit)
 	require.NoError(t, err, "json.Marshal must not error")
-	var os2 Submit
-	err = json.Unmarshal(jOrderSubmit, &os2)
-	require.NoError(t, err)
-	require.Equal(t, orderSubmit, os2)
-	// Margin-type regression test
-	orderSubmit.MarginType = margin.Multi
-	jOrderSubmit, err = json.Marshal(orderSubmit)
-	require.NoError(t, err)
-	err = json.Unmarshal(jOrderSubmit, &os2)
-	require.NoError(t, err)
-	require.Equal(t, orderSubmit, os2)
+	exp := []byte(`{"Exchange":"test","Type":4,"Side":"BUY","Pair":"BTC-USDT","AssetType":"spot","ImmediateOrCancel":false,"FillOrKill":false,"PostOnly":false,"ReduceOnly":false,"Leverage":0,"Price":1000,"Amount":1,"QuoteAmount":0,"TriggerPrice":0,"TriggerPriceType":0,"ClientID":"","ClientOrderID":"","AutoBorrow":false,"MarginType":"multi","RetrieveFees":false,"RetrieveFeeDelay":0,"RiskManagementModes":{"Mode":"","TakeProfit":{"Enabled":false,"TriggerPriceType":0,"Price":0,"LimitPrice":0,"OrderType":0},"StopLoss":{"Enabled":false,"TriggerPriceType":0,"Price":0,"LimitPrice":0,"OrderType":0},"StopEntry":{"Enabled":false,"TriggerPriceType":0,"Price":0,"LimitPrice":0,"OrderType":0}},"Hidden":false,"Iceberg":false,"TrackingMode":0,"TrackingValue":0}`)
+	assert.Equal(t, exp, j)
 }

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/margin"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/validate"
 )
@@ -2191,4 +2192,32 @@ func TestTrackingModeString(t *testing.T) {
 	for k, v := range inputs {
 		require.Equal(t, v, k.String())
 	}
+}
+
+func TestUnmarshalOrder(t *testing.T) {
+	t.Parallel()
+	btx := currency.NewBTCUSDT()
+	btx.Delimiter = "-"
+	orderSubmit := Submit{
+		Exchange:  "test",
+		Pair:      btx,
+		AssetType: asset.Spot,
+		Side:      Buy,
+		Type:      Market,
+		Amount:    1,
+		Price:     1000,
+	}
+	jOrderSubmit, err := json.Marshal(orderSubmit)
+	require.NoError(t, err)
+	var os2 Submit
+	err = json.Unmarshal(jOrderSubmit, &os2)
+	require.NoError(t, err)
+	require.Equal(t, orderSubmit, os2)
+	// Margin-type regression test
+	orderSubmit.MarginType = margin.Multi
+	jOrderSubmit, err = json.Marshal(orderSubmit)
+	require.NoError(t, err)
+	err = json.Unmarshal(jOrderSubmit, &os2)
+	require.NoError(t, err)
+	require.Equal(t, orderSubmit, os2)
 }

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -2194,14 +2194,14 @@ func TestTrackingModeString(t *testing.T) {
 	}
 }
 
-func TestUnmarshalOrder(t *testing.T) {
+func TestMarshalOrder(t *testing.T) {
 	t.Parallel()
 	btx := currency.NewBTCUSDT()
 	btx.Delimiter = "-"
 	orderSubmit := Submit{
-		Exchange:  "test",
-		Pair:      btx,
-		AssetType: asset.Spot,
+		Exchange:   "test",
+		Pair:       btx,
+		AssetType:  asset.Spot,
 		MarginType: margin.Multi,
 		Side:       Buy,
 		Type:       Market,


### PR DESCRIPTION
# PR Description

## Addresses issue #1810 
There is a bug from a lack of `MarshalJSON` implementation. When unmarshalling and marshalling an order.Submit for example, it will fail from being unable to parse a string into a `margin.Type`


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] TestUnmarshalOrder
- [x] TestMarshalJSON

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
