### PR TITLE
Okx: Various fixes including sonic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ env:
   GO_VERSION: 1.24.x
 jobs:
   backend:
-    name: GoCryptoTrader backend (${{ matrix.os }}, ${{ matrix.goarch }}, psql=${{ matrix.psql }}, skip_wrapper_tests=${{ matrix.skip_wrapper_tests}}, sonic=${{ matrix.sonic && matrix.goarch != '386' }})
+    name: GoCryptoTrader backend (${{ matrix.os }}, ${{ matrix.goarch }}, psql=${{ matrix.psql }}, skip_wrapper_tests=${{ matrix.skip_wrapper_tests}}, sonic=${{ matrix.sonic }})
     strategy:
       fail-fast: false
       matrix:
@@ -13,32 +13,32 @@ jobs:
             goarch: amd64
             psql: true
             skip_wrapper_tests: false
-            sonic: true
+            sonic: false
           - os: ubuntu-latest
             goarch: 386
             psql: true
             skip_wrapper_tests: true
-            sonic: true # Sonic is not supported on 386 systems, this ensures our build tag condition defaults to and tests the standard encoding/json implementation
+            sonic: false
           - os: ubuntu-24.04-arm
             goarch: arm64
             psql: false # Not supported
             skip_wrapper_tests: true
-            sonic: false # Disabled temporarily until OKX's unmarshalling is changed for sonic arm64 compatibility
+            sonic: false
           - os: macos-latest
             goarch: arm64
             psql: true
             skip_wrapper_tests: true
-            sonic: false # Same reason as the arm64 ubuntu-latest runner
+            sonic: false
           - os: windows-latest
             goarch: amd64
             psql: true
             skip_wrapper_tests: true
-            sonic: true
+            sonic: false
           - os: ubuntu-latest
             goarch: amd64
             psql: true
             skip_wrapper_tests: false
-            sonic: false # Disabled intentionally to test GCT's standard encoding/json implementation
+            sonic: true # Only test sonic on linux/amd64 since too many races and fatals across other archs and OS
 
     runs-on: ${{ matrix.os }}
 
@@ -96,8 +96,8 @@ jobs:
 
     - name: Set GOFLAGS
       run: |
-        if [ "${{ matrix.sonic }}" = "false" ]; then
-          echo "GOFLAGS=${GOFLAGS} -tags=sonic_off" >> $GITHUB_ENV
+        if [ "${{ matrix.sonic }}" = "true" ]; then
+          echo "GOFLAGS=${GOFLAGS} -tags=sonic_on" >> $GITHUB_ENV
         fi
       shell: bash
 
@@ -119,7 +119,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   
   backend-docker:
-    name: GoCryptoTrader backend docker (ubuntu-latest, amd64, psql=false, skip_wrapper_tests=true, sonic=true)
+    name: GoCryptoTrader backend docker (ubuntu-latest, amd64, psql=false, skip_wrapper_tests=true, sonic=false)
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ geseq | https://github.com/geseq
 TaltaM | https://github.com/TaltaM
 cranktakular | https://github.com/cranktakular
 dackroyd | https://github.com/dackroyd
+junnplus | https://github.com/junnplus
 khcchiu | https://github.com/khcchiu
 yangrq1018 | https://github.com/yangrq1018
 woshidama323 | https://github.com/woshidama323
@@ -29,7 +30,6 @@ crackcomm | https://github.com/crackcomm
 mshogin | https://github.com/mshogin
 herenow | https://github.com/herenow
 tk42 | https://github.com/tk42
-soxipy | https://github.com/soxipy
 andreygrehov | https://github.com/andreygrehov
 azhang | https://github.com/azhang
 bretep | https://github.com/bretep
@@ -54,5 +54,6 @@ m1kola | https://github.com/m1kola
 mattkanwisher | https://github.com/mattkanwisher
 merkeld | https://github.com/merkeld
 mKurrels | https://github.com/mKurrels
+soxipy | https://github.com/soxipy
 starit | https://github.com/starit
 zeldrinn | https://github.com/zeldrinn

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,6 @@ check-jq:
 	@printf "Checking if jq is installed... "
 	@command -v jq >/dev/null 2>&1 && { printf "OK\n"; } || { printf "FAILED. Please install jq to proceed.\n"; exit 1; }
 
-.PHONY: no_sonic
-no_sonic:
-	go build $(LDFLAGS) -tags "sonic_off" 
+.PHONY: sonic
+sonic:
+	go build $(LDFLAGS) -tags "sonic_on" 

--- a/README.md
+++ b/README.md
@@ -124,14 +124,19 @@ mkdir %AppData%\GoCryptoTrader
 copy config_example.json %APPDATA%\GoCryptoTrader\config.json
 ```
 
-By default, GoCryptoTrader uses the [Sonic JSON](https://github.com/bytedance/sonic) library for improved performance unless compiling for 32-bit or arm64 architectures. To disable Sonic and revert to Go's encoding/json, build with the sonic_off tag:
-
-```bash
-go build -tags=sonic_off
-```
-
 + Make any necessary changes to the `config.json` file.
 + Run the `gocryptotrader` binary file.
+
+### Sonic JSON handling
+
+GoCryptoTrader can optionally use the [Sonic](https://github.com/bytedance/sonic) JSON library for improved performance, as a drop in replacement for golang.org/encoding/json.
+Please see sonic [Requirements](https://github.com/bytedance/sonic/#requirement) for supported platforms.
+
+To enable sonic, build with the sonic_on tag:
+
+```bash
+go build -tags=sonic_on
+```
 
 ## Donations
 
@@ -151,15 +156,15 @@ Binaries will be published once the codebase reaches a stable condition.
 
 |User|Contribution Amount|
 |--|--|
-| [thrasher-](https://github.com/thrasher-) | 704 |
-| [shazbert](https://github.com/shazbert) | 361 |
-| [dependabot[bot]](https://github.com/apps/dependabot) | 351 |
-| [gloriousCode](https://github.com/gloriousCode) | 236 |
-| [gbjk](https://github.com/gbjk) | 115 |
+| [thrasher-](https://github.com/thrasher-) | 708 |
+| [shazbert](https://github.com/shazbert) | 362 |
+| [dependabot[bot]](https://github.com/apps/dependabot) | 361 |
+| [gloriousCode](https://github.com/gloriousCode) | 237 |
+| [gbjk](https://github.com/gbjk) | 119 |
 | [dependabot-preview[bot]](https://github.com/apps/dependabot-preview) | 88 |
 | [xtda](https://github.com/xtda) | 47 |
 | [lrascao](https://github.com/lrascao) | 27 |
-| [Beadko](https://github.com/Beadko) | 18 |
+| [Beadko](https://github.com/Beadko) | 21 |
 | [Rots](https://github.com/Rots) | 15 |
 | [vazha](https://github.com/vazha) | 15 |
 | [ydm](https://github.com/ydm) | 15 |
@@ -173,6 +178,7 @@ Binaries will be published once the codebase reaches a stable condition.
 | [TaltaM](https://github.com/TaltaM) | 6 |
 | [cranktakular](https://github.com/cranktakular) | 6 |
 | [dackroyd](https://github.com/dackroyd) | 5 |
+| [junnplus](https://github.com/junnplus) | 5 |
 | [khcchiu](https://github.com/khcchiu) | 5 |
 | [yangrq1018](https://github.com/yangrq1018) | 4 |
 | [woshidama323](https://github.com/woshidama323) | 3 |
@@ -180,7 +186,6 @@ Binaries will be published once the codebase reaches a stable condition.
 | [mshogin](https://github.com/mshogin) | 2 |
 | [herenow](https://github.com/herenow) | 2 |
 | [tk42](https://github.com/tk42) | 2 |
-| [soxipy](https://github.com/soxipy) | 2 |
 | [andreygrehov](https://github.com/andreygrehov) | 2 |
 | [azhang](https://github.com/azhang) | 2 |
 | [bretep](https://github.com/bretep) | 2 |
@@ -205,5 +210,6 @@ Binaries will be published once the codebase reaches a stable condition.
 | [mattkanwisher](https://github.com/mattkanwisher) | 1 |
 | [merkeld](https://github.com/merkeld) | 1 |
 | [mKurrels](https://github.com/mKurrels) | 1 |
+| [soxipy](https://github.com/soxipy) | 2 |
 | [starit](https://github.com/starit) | 1 |
 | [zeldrinn](https://github.com/zeldrinn) | 1 |

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -297,6 +297,11 @@ func main() {
 				Contributions: 1,
 			},
 			{
+				Login:         "soxipy",
+				URL:           "https://github.com/soxipy",
+				Contributions: 2,
+			},
+			{
 				Login:         "starit",
 				URL:           "https://github.com/starit",
 				Contributions: 1,

--- a/cmd/documentation/root_templates/root_readme.tmpl
+++ b/cmd/documentation/root_templates/root_readme.tmpl
@@ -125,14 +125,19 @@ mkdir %AppData%\GoCryptoTrader
 copy config_example.json %APPDATA%\GoCryptoTrader\config.json
 ```
 
-By default, GoCryptoTrader uses the [Sonic JSON](https://github.com/bytedance/sonic) library for improved performance unless compiling for 32-bit or arm64 architectures. To disable Sonic and revert to Go's encoding/json, build with the sonic_off tag:
-
-```bash
-go build -tags=sonic_off
-```
-
 + Make any necessary changes to the `config.json` file.
 + Run the `gocryptotrader` binary file.
+
+### Sonic JSON handling
+
+GoCryptoTrader can optionally use the [Sonic](https://github.com/bytedance/sonic) JSON library for improved performance, as a drop in replacement for golang.org/encoding/json.
+Please see sonic [Requirements](https://github.com/bytedance/sonic/#requirement) for supported platforms.
+
+To enable sonic, build with the sonic_on tag:
+
+```bash
+go build -tags=sonic_on
+```
 
 {{template "donations" .}}
 

--- a/encoding/json/common.go
+++ b/encoding/json/common.go
@@ -1,6 +1,6 @@
 // json is an abstraction middleware package to allow switching between json encoder/decoder implementations
-// The default implementation is sonic.
-// Build with `sonic_off`, '386' or 'arm64' tags to switch to golang.org/encoding/json.
+// The default implementation is golang.org/encoding/json.
+// Build with `sonic_on` tag to switch to using github.com/bytedance/sonic
 package json
 
 import "encoding/json" //nolint:depguard // Acceptable use in gct json wrapper

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -1,4 +1,4 @@
-//go:build !sonic_on && (sonic_off || 386 || arm64)
+//go:build !sonic_on
 
 package json
 

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -1,4 +1,4 @@
-//go:build sonic_off || 386 || arm64
+//go:build !sonic_on && (sonic_off || 386 || arm64)
 
 package json
 

--- a/encoding/json/sonic.go
+++ b/encoding/json/sonic.go
@@ -1,4 +1,4 @@
-//go:build sonic_on || (!sonic_off && !386 && !arm64)
+//go:build sonic_on
 
 package json
 

--- a/encoding/json/sonic.go
+++ b/encoding/json/sonic.go
@@ -1,4 +1,4 @@
-//go:build !sonic_off && !386 && !arm64
+//go:build sonic_on || (!sonic_off && !386 && !arm64)
 
 package json
 

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -5837,9 +5837,20 @@ func (ok *Okx) GetFiatDepositPaymentMethods(ctx context.Context, ccy currency.Co
 		common.EncodeURLValues("fiat/deposit-payment-methods", params), nil, &resp, request.AuthenticatedRequest)
 }
 
-// SendHTTPRequest sends an authenticated http request to a desired
-// path with a JSON payload (of present)
-// URL arguments must be in the request path and not as url.URL values
+/*
+SendHTTPRequest sends an http request, optionally with a JSON payload
+URL arguments must be encoded in the request path
+result must be a pointer
+If useAsItIs is true resp.Data is unmarshaled directly into result,
+When false resp.Data is unmarshaled into a slice; []any{result}
+useAsItIs default value when omitted is:
+
+  - true when result is a pointer to a slice
+
+  - false true for all other types
+
+    There are only a few rare API exceptions where useAsIs default value is correct: resp.Data is an object or resp.Data is a slice containing a slice
+*/
 func (ok *Okx) SendHTTPRequest(ctx context.Context, ep exchange.URL, f request.EndpointLimit, httpMethod, requestPath string, data, result any, authenticated request.AuthType, useAsItIs ...bool) (err error) {
 	rv := reflect.ValueOf(result)
 	if rv.Kind() != reflect.Pointer {

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -1793,8 +1793,8 @@ func (ok *Okx) GetBillsDetail(ctx context.Context, arg *BillsDetailQueryParamete
 }
 
 // GetAccountConfiguration retrieves current account configuration
-func (ok *Okx) GetAccountConfiguration(ctx context.Context) ([]AccountConfigurationResponse, error) {
-	var resp []AccountConfigurationResponse
+func (ok *Okx) GetAccountConfiguration(ctx context.Context) (*AccountConfigurationResponse, error) {
+	var resp *AccountConfigurationResponse
 	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getAccountConfigurationEPL, http.MethodGet, "account/config", nil, &resp, request.AuthenticatedRequest)
 }
 

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -1306,14 +1306,11 @@ func (ok *Okx) CancelWithdrawal(ctx context.Context, withdrawalID string) (strin
 	if withdrawalID == "" {
 		return "", errMissingValidWithdrawalID
 	}
-	type withdrawData struct {
-		WithdrawalID string `json:"wdId"`
-	}
 	arg := &withdrawData{
 		WithdrawalID: withdrawalID,
 	}
-	var response withdrawData
-	return response.WithdrawalID, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelWithdrawalEPL, http.MethodPost, "asset/cancel-withdrawal", arg, &response, request.AuthenticatedRequest)
+	var resp withdrawData
+	return resp.WithdrawalID, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelWithdrawalEPL, http.MethodPost, "asset/cancel-withdrawal", arg, &resp, request.AuthenticatedRequest)
 }
 
 // GetWithdrawalHistory retrieves the withdrawal records according to the currency, withdrawal status, and time range in reverse chronological order.

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -5934,12 +5934,6 @@ func (ok *Okx) SendHTTPRequest(ctx context.Context, ep exchange.URL, f request.E
 		}
 		return err
 	}
-	if rv.Kind() == reflect.Slice {
-		value, okay := result.([]interface{})
-		if !okay || result == nil || len(value) == 0 {
-			return fmt.Errorf("%w, received invalid response", common.ErrNoResponse)
-		}
-	}
 	if err == nil && resp.Code.Int64() != 0 {
 		if resp.Msg != "" {
 			return fmt.Errorf("%w error code: %d message: %s", request.ErrAuthRequestFailed, resp.Code.Int64(), resp.Msg)

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -5860,16 +5860,18 @@ func (ok *Okx) SendHTTPRequest(ctx context.Context, ep exchange.URL, f request.E
 	if err != nil {
 		return err
 	}
-	var respResult interface{}
+	var respResult any
 	switch {
-	case rv.Elem().Kind() == reflect.Slice && len(useAsItIs) > 0 && !useAsItIs[0]:
-		respResult = &[]interface{}{&result}
-	case rv.Elem().Kind() == reflect.Slice ||
-		// When needed to use the result as it is.
-		len(useAsItIs) > 0 && useAsItIs[0]:
+	case len(useAsItIs) > 0:
+		if useAsItIs[0] {
+			respResult = result
+		} else {
+			respResult = &[]any{result}
+		}
+	case rv.Elem().Kind() == reflect.Slice:
 		respResult = result
 	default:
-		respResult = &[]interface{}{result}
+		respResult = &[]any{result}
 	}
 	resp := struct {
 		Code types.Number `json:"code"`

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -1740,7 +1740,7 @@ func (ok *Okx) ApplyBillDetails(ctx context.Context, year, quarter string) ([]Bi
 		return nil, errQuarterValueRequired
 	}
 	var resp []BillsDetailResp
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, billHistoryArchiveEPL, http.MethodPost, "account/bills-history-archive", map[string]string{"year": year, "quarter": quarter}, &resp, request.AuthenticatedRequest, true)
+	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, billHistoryArchiveEPL, http.MethodPost, "account/bills-history-archive", map[string]string{"year": year, "quarter": quarter}, &resp, request.AuthenticatedRequest)
 }
 
 // GetBillsHistoryArchive retrieves bill data archive
@@ -1755,7 +1755,7 @@ func (ok *Okx) GetBillsHistoryArchive(ctx context.Context, year, quarter string)
 	params.Set("year", year)
 	params.Set("quarter", quarter)
 	var resp []BillsArchiveInfo
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getBillHistoryArchiveEPL, http.MethodGet, common.EncodeURLValues("account/bills-history-archive", params), nil, &resp, request.AuthenticatedRequest, true)
+	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getBillHistoryArchiveEPL, http.MethodGet, common.EncodeURLValues("account/bills-history-archive", params), nil, &resp, request.AuthenticatedRequest)
 }
 
 // GetBillsDetail retrieves the bills of the account
@@ -1807,7 +1807,7 @@ func (ok *Okx) GetBillsDetail(ctx context.Context, arg *BillsDetailQueryParamete
 // GetAccountConfiguration retrieves current account configuration
 func (ok *Okx) GetAccountConfiguration(ctx context.Context) ([]AccountConfigurationResponse, error) {
 	var resp []AccountConfigurationResponse
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getAccountConfigurationEPL, http.MethodGet, "account/config", nil, &resp, request.AuthenticatedRequest, true)
+	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getAccountConfigurationEPL, http.MethodGet, "account/config", nil, &resp, request.AuthenticatedRequest)
 }
 
 // SetPositionMode FUTURES and SWAP support both long/short mode and net mode. In net mode, users can only have positions in one direction; In long/short mode, users can hold positions in long and short directions.
@@ -5281,8 +5281,8 @@ func (ok *Okx) GetOptionsTickBands(ctx context.Context, instrumentType, instrume
 
 // GetSupportCoins retrieves the currencies supported by the trading data endpoints
 func (ok *Okx) GetSupportCoins(ctx context.Context) (*SupportedCoinsData, error) {
-	var response *SupportedCoinsData
-	return response, ok.SendHTTPRequest(ctx, exchange.RestSpot, getSupportCoinEPL, http.MethodGet, "rubik/stat/trading-data/support-coin", nil, &response, request.UnauthenticatedRequest, true)
+	var resp *SupportedCoinsData
+	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getSupportCoinEPL, http.MethodGet, "rubik/stat/trading-data/support-coin", nil, &resp, request.UnauthenticatedRequest, true)
 }
 
 // GetTakerVolume retrieves the taker volume for both buyers and sellers
@@ -5507,7 +5507,7 @@ func (ok *Okx) PlaceLendingOrder(ctx context.Context, arg *LendingOrderParam) (*
 		return nil, errLendingTermIsRequired
 	}
 	var resp *LendingOrderResponse
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, placeLendingOrderEPL, http.MethodPost, "finance/fixed-loan/lending-order", arg, &resp, request.AuthenticatedRequest, false)
+	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, placeLendingOrderEPL, http.MethodPost, "finance/fixed-loan/lending-order", arg, &resp, request.AuthenticatedRequest)
 }
 
 // AmendLendingOrder amends a lending order

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -912,11 +912,10 @@ func (ok *Okx) SetQuoteProducts(ctx context.Context, args []SetQuoteProductParam
 	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, setQuoteProductsEPL, http.MethodPost, "rfq/maker-instrument-settings", &args, &resp, request.AuthenticatedRequest)
 }
 
-func (ok *Okx) ResetRFQMMPStatus(ctx context.Context) (time.Time, error) {
-	resp := &struct {
-		Timestamp types.Time `json:"ts"`
-	}{}
-	return resp.Timestamp.Time(), ok.SendHTTPRequest(ctx, exchange.RestSpot, resetRFQMMPEPL, http.MethodPost, "rfq/mmp-reset", nil, resp, request.AuthenticatedRequest)
+// ResetRFQMMPStatus reset the MMP status to be inactive
+func (ok *Okx) ResetRFQMMPStatus(ctx context.Context) (types.Time, error) {
+	resp := &tsResp{}
+	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, resetRFQMMPEPL, http.MethodPost, "rfq/mmp-reset", nil, resp, request.AuthenticatedRequest)
 }
 
 // CreateQuote allows the user to Quote an RFQ that they are a counterparty to. The user MUST quote

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -5843,10 +5842,6 @@ result must be a pointer
 The response will be unmarshalled first into []any{result}, which matches most APIs, and fallback to directly into result
 */
 func (ok *Okx) SendHTTPRequest(ctx context.Context, ep exchange.URL, f request.EndpointLimit, httpMethod, requestPath string, data, result any, authenticated request.AuthType) (err error) {
-	rv := reflect.ValueOf(result)
-	if rv.Kind() != reflect.Pointer {
-		return errInvalidResponseParam
-	}
 	endpoint, err := ok.API.Endpoints.GetURL(ep)
 	if err != nil {
 		return err
@@ -5922,10 +5917,6 @@ func (ok *Okx) SendHTTPRequest(ctx context.Context, ep exchange.URL, f request.E
 		if directErr := json.Unmarshal(resp.Data, result); directErr != nil {
 			return fmt.Errorf("cannot unmarshal as a slice of result (error: %w) or as a reference to result (error: %w)", sliceErr, directErr)
 		}
-	}
-
-	if ptrTo := rv.Elem(); ptrTo.Kind() == reflect.Slice && ptrTo.Len() == 0 {
-		return common.ErrNoResponse
 	}
 
 	return nil

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -864,10 +864,8 @@ func (ok *Okx) CancelMultipleRFQs(ctx context.Context, arg *CancelRFQRequestsPar
 
 // CancelAllRFQs cancels all active RFQs
 func (ok *Okx) CancelAllRFQs(ctx context.Context) (types.Time, error) {
-	var resp types.Time
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelAllRFQsEPL, http.MethodPost, "rfq/cancel-all-rfqs", nil, &struct {
-		Timestamp *types.Time `json:"ts"`
-	}{Timestamp: &resp}, request.AuthenticatedRequest)
+	resp := &tsResp{}
+	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelAllRFQsEPL, http.MethodPost, "rfq/cancel-all-rfqs", nil, resp, request.AuthenticatedRequest)
 }
 
 // ExecuteQuote executes a Quote. It is only used by the creator of the RFQ
@@ -914,7 +912,6 @@ func (ok *Okx) SetQuoteProducts(ctx context.Context, args []SetQuoteProductParam
 	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, setQuoteProductsEPL, http.MethodPost, "rfq/maker-instrument-settings", &args, &resp, request.AuthenticatedRequest)
 }
 
-// ResetRFQMMPStatus reset the MMP status to be inactive
 func (ok *Okx) ResetRFQMMPStatus(ctx context.Context) (time.Time, error) {
 	resp := &struct {
 		Timestamp types.Time `json:"ts"`
@@ -976,11 +973,8 @@ func (ok *Okx) CancelMultipleQuote(ctx context.Context, arg CancelQuotesRequestP
 
 // CancelAllRFQQuotes cancels all active quote orders
 func (ok *Okx) CancelAllRFQQuotes(ctx context.Context) (types.Time, error) {
-	var resp types.Time
-	return resp, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelAllQuotesEPL, http.MethodPost, "rfq/cancel-all-quotes", nil,
-		&struct {
-			Timestamp *types.Time `json:"ts"`
-		}{Timestamp: &resp}, request.AuthenticatedRequest)
+	resp := &tsResp{}
+	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, cancelAllQuotesEPL, http.MethodPost, "rfq/cancel-all-quotes", nil, resp, request.AuthenticatedRequest)
 }
 
 // GetRFQs retrieves details of RFQs where the user is a counterparty, either as the creator or the recipient
@@ -1492,11 +1486,9 @@ func (ok *Okx) ApplyForMonthlyStatement(ctx context.Context, month string) (type
 	if month == "" {
 		return types.Time{}, errMonthNameRequired
 	}
-	resp := &struct {
-		Timestamp types.Time `json:"ts"`
-	}{}
+	resp := &tsResp{}
 	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, applyForMonthlyStatementEPL,
-		http.MethodPost, "asset/monthly-statement", &map[string]string{"month": month}, &resp, request.AuthenticatedRequest)
+		http.MethodPost, "asset/monthly-statement", &map[string]string{"month": month}, resp, request.AuthenticatedRequest)
 }
 
 // GetMonthlyStatement retrieves monthly statements for the past year.
@@ -2652,10 +2644,8 @@ func (ok *Okx) SetRiskOffsetType(ctx context.Context, riskOffsetType string) (*R
 
 // ActivateOption activates option
 func (ok *Okx) ActivateOption(ctx context.Context) (types.Time, error) {
-	resp := &struct {
-		Timestamp types.Time `json:"ts"`
-	}{}
-	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, activateOptionEPL, http.MethodPost, "account/activate-option", nil, &resp, request.AuthenticatedRequest)
+	resp := &tsResp{}
+	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, activateOptionEPL, http.MethodPost, "account/activate-option", nil, resp, request.AuthenticatedRequest)
 }
 
 // SetAutoLoan only applicable to Multi-currency margin and Portfolio margin
@@ -5051,8 +5041,8 @@ func (ok *Okx) GetDiscountRateAndInterestFreeQuota(ctx context.Context, ccy curr
 
 // GetSystemTime retrieve API server time
 func (ok *Okx) GetSystemTime(ctx context.Context) (types.Time, error) {
-	resp := &ServerTime{}
-	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getSystemTimeEPL, http.MethodGet, "public/time", nil, &resp, request.UnauthenticatedRequest)
+	resp := &tsResp{}
+	return resp.Timestamp, ok.SendHTTPRequest(ctx, exchange.RestSpot, getSystemTimeEPL, http.MethodGet, "public/time", nil, resp, request.UnauthenticatedRequest)
 }
 
 // GetLiquidationOrders retrieves information on liquidation orders in the last day

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -6464,9 +6464,9 @@ func TestGetAnnouncements(t *testing.T) {
 
 func TestGetAnnouncementTypes(t *testing.T) {
 	t.Parallel()
-	results, err := ok.GetAnnouncementTypes(contextGenerate())
+	_, err := ok.GetAnnouncementTypes(contextGenerate())
 	require.NoError(t, err)
-	assert.NotEmpty(t, results)
+	// No tests of contents of resp because currently in US based github actions announcement-types returns empty
 }
 
 func TestGetDepositOrderDetail(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -524,6 +524,7 @@ func TestGetSystemTime(t *testing.T) {
 	result, err := ok.GetSystemTime(contextGenerate())
 	require.NoError(t, err)
 	assert.NotNil(t, result)
+	assert.False(t, result.Time().IsZero(), "GetSystemTime should not return a zero time")
 }
 
 func TestGetLiquidationOrders(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -317,7 +317,9 @@ func TestGetIndexComponents(t *testing.T) {
 
 	result, err := ok.GetIndexComponents(contextGenerate(), "ETH-USDT")
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Index, "Index should not be empty")
+	assert.NotEmpty(t, result.Components, "Components should not be empty")
 }
 
 func TestGetBlockTickers(t *testing.T) {
@@ -592,7 +594,8 @@ func TestGetPublicUnderlyings(t *testing.T) {
 
 	result, err := ok.GetPublicUnderlyings(contextGenerate(), instTypeFutures)
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result)
 }
 
 func TestGetInsuranceFundInformation(t *testing.T) {
@@ -652,7 +655,8 @@ func TestGetSupportCoins(t *testing.T) {
 	t.Parallel()
 	result, err := ok.GetSupportCoins(contextGenerate())
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Spot, "SupportedCoins Spot should not be empty")
 }
 
 func TestGetTakerVolume(t *testing.T) {
@@ -721,7 +725,8 @@ func TestGetTakerFlow(t *testing.T) {
 	t.Parallel()
 	result, err := ok.GetTakerFlow(contextGenerate(), currency.BTC, kline.OneDay)
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
+	assert.False(t, result.Timestamp.Time().IsZero(), "Timestamp should not be zero")
 }
 
 func TestPlaceOrder(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -408,11 +408,12 @@ func TestGetInstrument(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, errInstrumentFamilyOrUnderlyingRequired)
 
-	_, err = ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
+	resp, err := ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
 		InstrumentType: instTypeFutures,
 		Underlying:     "SOL-USD",
 	})
-	require.ErrorIs(t, err, common.ErrNoResponse)
+	require.NoError(t, err)
+	assert.Empty(t, resp, "Should get back no instruments for SOL-USD futures")
 
 	result, err := ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
 		InstrumentType: instTypeSpot,

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -227,7 +227,7 @@ func TestGetCandlesticks(t *testing.T) {
 	_, err := ok.GetCandlesticks(contextGenerate(), "", kline.OneHour, time.Now().Add(-time.Minute*2), time.Now(), 2)
 	require.ErrorIs(t, err, errMissingInstrumentID)
 
-	result, err := ok.GetCandlesticks(contextGenerate(), spotTP.String(), kline.OneHour, time.Now().Add(-time.Minute*2), time.Now(), 2)
+	result, err := ok.GetCandlesticks(contextGenerate(), spotTP.String(), kline.OneHour, time.Now().Add(-time.Hour), time.Now(), 2)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -408,14 +408,13 @@ func TestGetInstrument(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, errInstrumentFamilyOrUnderlyingRequired)
 
-	result, err := ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
+	_, err = ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
 		InstrumentType: instTypeFutures,
 		Underlying:     "SOL-USD",
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
+	require.ErrorIs(t, err, common.ErrNoResponse)
 
-	result, err = ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
+	result, err := ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
 		InstrumentType: instTypeSpot,
 	})
 	require.NoError(t, err)

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -5294,3 +5294,7 @@ type MonthlyStatement struct {
 type tsResp struct {
 	Timestamp types.Time `json:"ts"`
 }
+
+type withdrawData struct {
+	WithdrawalID string `json:"wdId"`
+}

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -496,11 +496,6 @@ type DiscountRateInfoItem struct {
 	DiscountCurrencyEquity types.Number `json:"disCcyEq"`
 }
 
-// ServerTime returning  the server time instance
-type ServerTime struct {
-	Timestamp types.Time `json:"ts"`
-}
-
 // LiquidationOrderRequestParams holds information to request liquidation orders
 type LiquidationOrderRequestParams struct {
 	InstrumentType string
@@ -5293,5 +5288,9 @@ type FiatDepositPaymentMethods struct {
 type MonthlyStatement struct {
 	FileHref  string     `json:"fileHref"`
 	State     string     `json:"state"`
+	Timestamp types.Time `json:"ts"`
+}
+
+type tsResp struct {
 	Timestamp types.Time `json:"ts"`
 }

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -2346,7 +2346,7 @@ func (ok *Okx) GetCollateralMode(ctx context.Context, item asset.Item) (collater
 	if err != nil {
 		return 0, err
 	}
-	switch cfg[0].AccountLevel {
+	switch cfg.AccountLevel {
 	case "1":
 		if item != asset.Spot {
 			return 0, fmt.Errorf("%w %v", asset.ErrNotSupported, item)
@@ -2359,7 +2359,7 @@ func (ok *Okx) GetCollateralMode(ctx context.Context, item asset.Item) (collater
 	case "4":
 		return collateral.PortfolioMode, nil
 	default:
-		return collateral.UnknownMode, fmt.Errorf("%w %v", order.ErrCollateralInvalid, cfg[0].AccountLevel)
+		return collateral.UnknownMode, fmt.Errorf("%w %v", order.ErrCollateralInvalid, cfg.AccountLevel)
 	}
 }
 


### PR DESCRIPTION
# PR Description

* Fix GetPublicUnderlying with sonic 1.12.9 on arm64
* Extend tests for UseAsIs non-defaults
* Improve SendHTTPRequest documentation
* Fix AccountConfiguration slice return
* Move withdrawData type to types
* Unify timestamp response types
* Remove redundant useAsIs on slices
* Change ResetRFQMMPStatus to return a types.Time
* Sonic: Add sonic_on build tag

## Notes

Caveat: Right now to test this I'm doing:
```
GOFLAGS="-tags=sonic_on" go test -count=1 ./exchanges/okx/...
```
Without that, we're not going to see the sonic fix actually fixing arm64, but we do see that it still works.

### Fix GetPublicUnderlying with sonic 1.12.9 on arm64

Using `**result` for slices with useAsItIs causes sonic to fail on arm64.
This might be addressed upstream, but it's also not clear what the unmarshal behaviour for an untyped reference to a typed reference should be in the RFC, so we could get a golang.org/encoding/json regression on this too.

There's no harm in fixing this, for consistency, to match our handling for non-slice `[]any` wrapping to just use the pointer as is.

Note: As of today this requires sonic:main for this to work, because of the other bug (bytedance/sonic#751):
```
go get github.com/bytedance/sonic@main
```

### Sonic: Add sonic_on build tag

Thought about other ways to do this, but they amount to the same thing. It's messy, but I don't have another idea.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)