### PR TITLE
Huobi: Fix sending trades to the websocket DataHandler

### DIFF
--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1396,7 +1396,7 @@ func TestWSHandleAllTradesMsg(t *testing.T) {
 			i := 1 - len(h.Websocket.DataHandler)
 			require.Equalf(t, exp[i], v, "Trade [%d] must be correct", i)
 		case error:
-			t.Error()
+			t.Error(v)
 		default:
 			t.Errorf("Unexpected type in DataHandler: %T(%s)", v, v)
 		}

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1369,8 +1369,8 @@ func TestWsHandleAllTradesMsg(t *testing.T) {
 	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", h.wsHandleData)
 	close(h.Websocket.DataHandler)
 	expJSON := []string{
-		`{"TID":"102523573486","AssetType":"spot","CurrencyPair":"BTC-USDT","Side":"BUY","Price":52648.62,"Amount":0.006754,"Timestamp":"2021-09-07T13:09:23.173+07:00"}`,
-		`{"TID":"102523573487","AssetType":"spot","CurrencyPair":"BTC-USDT","Side":"SELL","Price":52648.73,"Amount":0.006755,"Timestamp":"2021-09-07T13:09:23.184+07:00"}`,
+		`{"TID":"102523573486","AssetType":"spot","CurrencyPair":"BTC-USDT","Side":"BUY","Price":52648.62,"Amount":0.006754,"Timestamp":"2021-09-07T06:09:23.173Z"}`,
+		`{"TID":"102523573487","AssetType":"spot","CurrencyPair":"BTC-USDT","Side":"SELL","Price":52648.73,"Amount":0.006755,"Timestamp":"2021-09-07T06:09:23.184Z"}`,
 	}
 	require.Len(t, h.Websocket.DataHandler, len(expJSON), "Must see correct number of trades")
 	for resp := range h.Websocket.DataHandler {

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1379,7 +1379,7 @@ func TestWsHandleAllTradesMsg(t *testing.T) {
 			i := 1 - len(h.Websocket.DataHandler)
 			exp := trade.Data{Exchange: h.Name, CurrencyPair: btcusdtPair}
 			require.NoError(t, json.Unmarshal([]byte(expJSON[i]), &exp), "Must not error unmarshalling json %d:%s", i, expJSON[i])
-			require.Equalf(t, exp, v, "Trade [%d] should be correct", i)
+			require.Equalf(t, exp, v, "Trade [%d] must be correct", i)
 		case error:
 			t.Error()
 		default:

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1357,8 +1357,8 @@ func TestWSOrderbook(t *testing.T) {
 	assert.Equal(t, 0.56281, liq, "Bid Liquidity should be correct")
 }
 
-// TestWsHandleAllTradesMsg checks we can send a trade detail through
-func TestWsHandleAllTradesMsg(t *testing.T) {
+// TestWSHandleAllTradesMsg ensures wsHandleAllTrades sends trade.Data to the ws.DataHandler
+func TestWSHandleAllTradesMsg(t *testing.T) {
 	t.Parallel()
 	h := new(HUOBI) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(h), "Setup Instance must not error")

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -251,7 +251,7 @@ func (h *HUOBI) wsHandleAllTradesMsg(s *subscription.Subscription, respRaw []byt
 			Exchange:     h.Name,
 			AssetType:    s.Asset,
 			CurrencyPair: s.Pairs[0],
-			Timestamp:    t.Tick.Data[i].Timestamp.Time(),
+			Timestamp:    t.Tick.Data[i].Timestamp.Time().UTC(),
 			Amount:       t.Tick.Data[i].Amount,
 			Price:        t.Tick.Data[i].Price,
 			Side:         side,

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -259,7 +259,9 @@ func (h *HUOBI) wsHandleAllTradesMsg(s *subscription.Subscription, respRaw []byt
 		})
 	}
 	if tradeFeed {
-		h.Websocket.DataHandler <- trades
+		for i := range trades {
+			h.Websocket.DataHandler <- trades[i]
+		}
 	}
 	if saveTradeData {
 		return trade.AddTradesToBuffer(trades...)

--- a/exchanges/huobi/testdata/wsAllTrades.json
+++ b/exchanges/huobi/testdata/wsAllTrades.json
@@ -1,1 +1,2 @@
 {"ch":"market.btcusdt.trade.detail","ts":1630994963175,"tick":{"id":137005445109,"ts":1630994963173,"data":[{"id":137005445109359290000000000,"ts":1630994963173,"tradeId":102523573486,"amount":0.006754,"price":52648.62,"direction":"buy"}]}}
+{"ch":"market.btcusdt.trade.detail","ts":1630994963174,"tick":{"id":137005445110,"ts":1630994963184,"data":[{"id":137005445109359300000000000,"ts":1630994963184,"tradeId":102523573487,"amount":0.006755,"price":52648.73,"direction":"sell"}]}}

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -1872,7 +1872,9 @@
     },
     "enabled": {
      "autoPairUpdates": true,
-     "websocketAPI": true
+     "websocketAPI": true,
+     "saveTradeData": false,
+     "tradeFeed": true
     }
    },
    "bankAccounts": [


### PR DESCRIPTION
# PR Description

Like Kraken, the trades are not being sent down to the websocket DataHandler because the IsTradeFeedEnabled is not set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] TestWSTradeDetail

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
