### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -28,7 +28,7 @@ func TestWrite(t *testing.T) {
 	}
 
 	var tests []testTable
-	tempDir := filepath.Join(os.TempDir(), "gct-temp")
+	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "gcttest.txt")
 	switch runtime.GOOS {
 	case "windows":
@@ -48,10 +48,6 @@ func TestWrite(t *testing.T) {
 		if err != nil && !tests[x].ErrExpected {
 			t.Errorf("Test %d failed, unexpected err %s\n", x, err)
 		}
-	}
-
-	if err := os.RemoveAll(tempDir); err != nil {
-		t.Errorf("unable to remove temp test dir %s, manual deletion required", tempDir)
 	}
 }
 

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -498,13 +498,9 @@ func setupTest(t *testing.T) {
 		}
 	}
 
-	var err error
 	testhelpers.MigrationDir = filepath.Join("..", "..", "database", "migrations")
 	testhelpers.PostgresTestDatabase = testhelpers.GetConnectionDetails()
-	testhelpers.TempDir, err = os.MkdirTemp("", "gct-temp")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	testhelpers.TempDir = t.TempDir()
 }
 
 func TestStoreInDatabase(t *testing.T) {


### PR DESCRIPTION
# PR Description

 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
