### PR TITLE
Okx: Fix sending trades to the websocket DataHandler

### DIFF
--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -4104,12 +4105,7 @@ func TestWSProcessTrades(t *testing.T) {
 	for _, assetType := range assets {
 		require.Len(t, trades[assetType], len(exp), "Should have received %d trades for asset %v", len(exp), assetType)
 		slices.SortFunc(trades[assetType], func(a, b trade.Data) int {
-			if a.TID < b.TID {
-				return -1
-			} else if a.TID > b.TID {
-				return 1
-			}
-			return 0
+			return strings.Compare(a.TID, b.TID)
 		})
 		for i, tradeData := range trades[assetType] {
 			expected := exp[i]

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -4103,7 +4103,7 @@ func TestWSProcessTrades(t *testing.T) {
 	}
 
 	for _, assetType := range assets {
-		require.Len(t, trades[assetType], len(exp), "Should have received %d trades for asset %v", len(exp), assetType)
+		require.Len(t, trades[assetType], len(exp), "Must have received %d trades for asset %v", len(exp), assetType)
 		slices.SortFunc(trades[assetType], func(a, b trade.Data) int {
 			return strings.Compare(a.TID, b.TID)
 		})
@@ -4112,7 +4112,7 @@ func TestWSProcessTrades(t *testing.T) {
 			expected.AssetType = assetType
 			expected.Exchange = ok.Name
 			expected.CurrencyPair = p
-			require.Equal(t, expected, tradeData, "Trade %d (TID: %s) for asset %v should match expected data", i, tradeData.TID, assetType)
+			require.Equal(t, expected, tradeData, "Trade %d (TID: %s) for asset %v must match expected data", i, tradeData.TID, assetType)
 		}
 	}
 }

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -4110,10 +4110,10 @@ func TestWSProcessTrades(t *testing.T) {
 		sort.Slice(trades[assetType], func(i, j int) bool {
 			return trades[assetType][i].TID < trades[assetType][j].TID
 		})
-		for i, trade := range trades[assetType] {
+		for i, tradeData := range trades[assetType] {
 			expected := exp[i]
 			expected.AssetType = assetType
-			require.Equal(t, expected, trade, "Trade %d (TID: %s) for asset %v should match expected data", i, trade.TID, assetType)
+			require.Equal(t, expected, tradeData, "Trade %d (TID: %s) for asset %v should match expected data", i, tradeData.TID, assetType)
 		}
 	}
 }

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1219,6 +1219,13 @@ func (ok *Okx) wsProcessTrades(data []byte) error {
 	if err != nil {
 		return err
 	}
+
+	saveTradeData := ok.IsSaveTradeDataEnabled()
+	tradeFeed := ok.IsTradeFeedEnabled()
+	if !saveTradeData && !tradeFeed {
+		return nil
+	}
+
 	var assets []asset.Item
 	if response.Argument.InstrumentType != "" {
 		assetType, err := assetTypeFromInstrumentType(response.Argument.InstrumentType)
@@ -1251,7 +1258,13 @@ func (ok *Okx) wsProcessTrades(data []byte) error {
 			})
 		}
 	}
-	return trade.AddTradesToBuffer(trades...)
+	if tradeFeed {
+		ok.Websocket.DataHandler <- trades
+	}
+	if saveTradeData {
+		return trade.AddTradesToBuffer(trades...)
+	}
+	return nil
 }
 
 // wsProcessOrders handles websocket order push data responses.

--- a/exchanges/okx/okx_websocket.go
+++ b/exchanges/okx/okx_websocket.go
@@ -1252,14 +1252,16 @@ func (ok *Okx) wsProcessTrades(data []byte) error {
 				CurrencyPair: pair,
 				Exchange:     ok.Name,
 				Side:         response.Data[i].Side,
-				Timestamp:    response.Data[i].Timestamp.Time(),
+				Timestamp:    response.Data[i].Timestamp.Time().UTC(),
 				TID:          response.Data[i].TradeID,
 				Price:        response.Data[i].Price.Float64(),
 			})
 		}
 	}
 	if tradeFeed {
-		ok.Websocket.DataHandler <- trades
+		for i := range trades {
+			ok.Websocket.DataHandler <- trades[i]
+		}
 	}
 	if saveTradeData {
 		return trade.AddTradesToBuffer(trades...)

--- a/exchanges/okx/testdata/wsAllTrades.json
+++ b/exchanges/okx/testdata/wsAllTrades.json
@@ -1,1 +1,2 @@
 {"arg":{"channel":"trades","instId":"BTC-USDT"},"data":[{"instId":"BTC-USDT","tradeId":"674510826","px":"95634.9","sz":"0.00011186","side":"buy","ts":"1740394561685","count":"1"}]}
+{"arg":{"channel":"trades","instId":"BTC-USDT"},"data":[{"instId":"BTC-USDT","tradeId":"674510827","px":"95635.3","sz":"0.00011194","side":"sell","ts":"1740394561686","count":"1"}]}

--- a/exchanges/okx/testdata/wsAllTrades.json
+++ b/exchanges/okx/testdata/wsAllTrades.json
@@ -1,0 +1,1 @@
+{"arg":{"channel":"trades","instId":"BTC-USDT"},"data":[{"instId":"BTC-USDT","tradeId":"674510826","px":"95634.9","sz":"0.00011186","side":"buy","ts":"1740394561685","count":"1"}]}

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -2271,7 +2271,7 @@
      "autoPairUpdates": true,
      "websocketAPI": true,
      "saveTradeData": false,
-     "tradeFeed": false,
+     "tradeFeed": true,
      "fillsFeed": false
     }
    },


### PR DESCRIPTION
# PR Description

Trades are not being sent down to the websocket DataHandler because the IsTradeFeedEnabled is not set.
Additional changes:

- Send the trades down the DataHandler individually
- Change the timestamp to .UTC()

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] TestWSProcessTrades

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
