### PR TITLE
BTSE: Fix sending trades to the websocket DataHandler

### DIFF
--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -819,7 +819,7 @@ func TestGenerateSubscriptions(t *testing.T) {
 	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
 
 	exp := subscription.List{
-		{Channel: subscription.AllTradesChannel, QualifiedChannel: "tradeHistory:BTC-USD", Asset: asset.Spot, Pairs: currency.Pairs{spotPair}},
+		{Channel: subscription.AllTradesChannel, QualifiedChannel: "tradeHistoryApi:BTC-USD", Asset: asset.Spot, Pairs: currency.Pairs{spotPair}},
 		{Channel: subscription.MyTradesChannel, QualifiedChannel: "notificationApi"},
 	}
 

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -484,7 +484,7 @@ func TestWsOrderbook(t *testing.T) {
 	// TODO: Meaningful test of data parsing
 }
 
-func TestWsTrades(t *testing.T) {
+func TestWSTrades(t *testing.T) {
 	t.Parallel()
 
 	b := new(BTSE) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -492,16 +492,17 @@ func TestWSTrades(t *testing.T) {
 	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", b.wsHandleData)
 	close(b.Websocket.DataHandler)
 
-	exp := []trade.Data{{
-		Exchange:     b.Name,
-		CurrencyPair: spotPair,
-		Timestamp:    time.UnixMilli(1741836562893).UTC(),
-		Price:        83894.01,
-		Amount:       0.00067,
-		Side:         order.Buy,
-		TID:          "74040596",
-		AssetType:    asset.Spot,
-	},
+	exp := []trade.Data{
+		{
+			Exchange:     b.Name,
+			CurrencyPair: spotPair,
+			Timestamp:    time.UnixMilli(1741836562893).UTC(),
+			Price:        83894.01,
+			Amount:       0.00067,
+			Side:         order.Buy,
+			TID:          "74040596",
+			AssetType:    asset.Spot,
+		},
 		{
 			Exchange:     b.Name,
 			CurrencyPair: spotPair,

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stream"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 	testsubs "github.com/thrasher-corp/gocryptotrader/internal/testing/subscriptions"
 )
@@ -485,10 +486,45 @@ func TestWsOrderbook(t *testing.T) {
 
 func TestWsTrades(t *testing.T) {
 	t.Parallel()
-	pressXToJSON := []byte(`{"topic":"tradeHistory:BTC-USD","data":[{"amount":0.09,"gain":1,"newest":0,"price":9273.6,"serialId":0,"transactionUnixtime":1580349090693}]}`)
-	err := b.wsHandleData(pressXToJSON)
-	assert.NoError(t, err, "wsHandleData tradeHistory should not error")
-	// TODO: Meaningful test of data parsing
+
+	b := new(BTSE) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Setup Instance must not error")
+	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", b.wsHandleData)
+	close(b.Websocket.DataHandler)
+
+	exp := []trade.Data{{
+		Exchange:     b.Name,
+		CurrencyPair: spotPair,
+		Timestamp:    time.UnixMilli(1741836562893).UTC(),
+		Price:        83894.01,
+		Amount:       0.00067,
+		Side:         order.Buy,
+		TID:          "74040596",
+		AssetType:    asset.Spot,
+	},
+		{
+			Exchange:     b.Name,
+			CurrencyPair: spotPair,
+			Timestamp:    time.UnixMilli(1741836562687).UTC(),
+			Price:        83894.87,
+			Amount:       0.0035,
+			Side:         order.Sell,
+			TID:          "74040529",
+			AssetType:    asset.Spot,
+		},
+	}
+	require.Len(t, b.Websocket.DataHandler, 2, "Must see the correct number of trades")
+	for resp := range b.Websocket.DataHandler {
+		switch v := resp.(type) {
+		case trade.Data:
+			i := 1 - len(b.Websocket.DataHandler)
+			require.Equalf(t, exp[i], v, "Trade [%d] must be correct", i)
+		case error:
+			t.Error(v)
+		default:
+			t.Errorf("Unexpected type in DataHandler: %T(%s)", v, v)
+		}
+	}
 }
 
 func TestWsOrderNotification(t *testing.T) {

--- a/exchanges/btse/btse_types.go
+++ b/exchanges/btse/btse_types.go
@@ -2,6 +2,8 @@ package btse
 
 import (
 	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -313,12 +315,12 @@ type wsOrderBook struct {
 }
 
 type wsTradeData struct {
-	Amount          float64 `json:"amount"`
-	Gain            int64   `json:"gain"`
-	Newest          int64   `json:"newest"`
-	Price           float64 `json:"price"`
-	ID              int64   `json:"serialId"`
-	TransactionTime int64   `json:"transactionUnixTime"`
+	Symbol    string     `json:"symbol"`
+	Side      string     `json:"side"`
+	Size      float64    `json:"size"`
+	Price     float64    `json:"price"`
+	TID       int64      `json:"tradeID"`
+	Timestamp types.Time `json:"timestamp"`
 }
 
 type wsTradeHistory struct {

--- a/exchanges/btse/btse_types.go
+++ b/exchanges/btse/btse_types.go
@@ -3,6 +3,7 @@ package btse
 import (
 	"time"
 
+	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
@@ -316,7 +317,7 @@ type wsOrderBook struct {
 
 type wsTradeData struct {
 	Symbol    string     `json:"symbol"`
-	Side      string     `json:"side"`
+	Side      order.Side `json:"side"`
 	Size      float64    `json:"size"`
 	Price     float64    `json:"price"`
 	TID       int64      `json:"tradeID"`

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -30,7 +30,7 @@ const (
 
 var subscriptionNames = map[string]string{
 	subscription.MyTradesChannel:  "notificationApi",
-	subscription.AllTradesChannel: "tradeHistory",
+	subscription.AllTradesChannel: "tradeHistoryApi",
 }
 
 var defaultSubscriptions = subscription.List{

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -257,7 +257,7 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 			}
 
 			var p currency.Pair
-			p, err = currency.NewPairFromString(strings.TrimPrefix(tradeHistory.Topic, "tradeHistoryApi:"))
+			p, err = currency.NewPairFromString(tradeHistory.Data[x].Symbol)
 			if err != nil {
 				return err
 			}

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -240,7 +240,7 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 				Pair:         p,
 			}
 		}
-	case strings.Contains(topic, "tradeHistory"):
+	case strings.Contains(topic, "tradeHistoryApi"):
 		saveTradeData := b.IsSaveTradeDataEnabled()
 		tradeFeed := b.IsTradeFeedEnabled()
 		if !saveTradeData && !tradeFeed {
@@ -254,7 +254,6 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 		}
 		var trades []trade.Data
 		for x := range tradeHistory.Data {
-
 			var p currency.Pair
 			p, err = currency.NewPairFromString(tradeHistory.Data[x].Symbol)
 			if err != nil {

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -241,8 +241,11 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 			}
 		}
 	case strings.Contains(topic, "tradeHistory"):
-		saveTradedata := b.IsSaveTradeDataEnabled()
+		saveTradeData := b.IsSaveTradeDataEnabled()
 		tradeFeed := b.IsTradeFeedEnabled()
+		if !saveTradeData && !tradeFeed {
+			return nil
+		}
 
 		var tradeHistory wsTradeHistory
 		err = json.Unmarshal(respRaw, &tradeHistory)
@@ -282,7 +285,7 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 				b.Websocket.DataHandler <- trades[i]
 			}
 		}
-		if saveTradedata {
+		if saveTradeData {
 			return trade.AddTradesToBuffer(trades...)
 		}
 	case strings.Contains(topic, "orderBookL2Api"): // TODO: Fix orderbook updates.

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -254,9 +254,9 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 		}
 		var trades []trade.Data
 		for x := range tradeHistory.Data {
-			side := order.Buy
-			if tradeHistory.Data[x].Side != "BUY" {
-				side = order.Sell
+			side, err := order.StringToOrderSide(tradeHistory.Data[x].Side)
+			if err != nil {
+				return err
 			}
 
 			var p currency.Pair

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -254,10 +254,6 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 		}
 		var trades []trade.Data
 		for x := range tradeHistory.Data {
-			side, err := order.StringToOrderSide(tradeHistory.Data[x].Side)
-			if err != nil {
-				return err
-			}
 
 			var p currency.Pair
 			p, err = currency.NewPairFromString(tradeHistory.Data[x].Symbol)
@@ -276,7 +272,7 @@ func (b *BTSE) wsHandleData(respRaw []byte) error {
 				Exchange:     b.Name,
 				Price:        tradeHistory.Data[x].Price,
 				Amount:       tradeHistory.Data[x].Size,
-				Side:         side,
+				Side:         tradeHistory.Data[x].Side,
 				TID:          strconv.FormatInt(tradeHistory.Data[x].TID, 10),
 			})
 		}

--- a/exchanges/btse/testdata/wsAllTrades.json
+++ b/exchanges/btse/testdata/wsAllTrades.json
@@ -1,0 +1,2 @@
+{"topic":"tradeHistoryApi:BTC-USD","data":[{"symbol":"BTC-USD","side":"BUY","size":0.00067,"price":83894.01,"tradeId":74040596,"timestamp":1741836562893}]}
+{"topic":"tradeHistoryApi:BTC-USD","data":[{"symbol":"BTC-USD","side":"SELL","size":0.0035,"price":83894.87,"tradeId":74040529,"timestamp":1741836562687}]}

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -377,7 +377,9 @@
     },
     "enabled": {
      "autoPairUpdates": true,
-     "websocketAPI": true
+     "websocketAPI": true,
+     "saveTradeData": false,
+     "tradeFeed": true
     }
    },
    "bankAccounts": [


### PR DESCRIPTION
# PR Description
Currently, the BTSE trades are not streaming via the websocket.
The following changes were made:

- Update the raw trade data to match the API docs
- Fix extracting the pair from the topic
- Update the test
- Amend the configtest to enable the trade feed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] TestWsTrades

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
