### PR TITLE
BTC Markets: Fix sending trades to the websocket DataHandler

### DIFF
--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -549,9 +549,11 @@ func TestWSTrade(t *testing.T) {
 	b := new(BTCMarkets) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
 	fErrs := testexch.FixtureToDataHandlerWithErrors(t, "testdata/wsAllTrades.json", b.wsHandleData)
-	for _, fErr := range fErrs {
-		require.ErrorIs(t, fErr.Err, order.ErrSideIsInvalid)
-	}
+	require.Equal(t, 2, len(fErrs), "Must get correct number of errors from wsHandleData")
+	assert.ErrorIs(t, fErrs[0].Err, order.ErrSideIsInvalid, "Side.UnmarshalJSON errors should propagate correctly")
+	assert.ErrorContains(t, fErrs[0].Err, "WRONG", "Side.UnmarshalJSON errors should propagate correctly")
+	assert.ErrorIs(t, fErrs[1].Err, order.ErrSideIsInvalid, "wsHandleData errors should propagate correctly")
+	assert.ErrorContains(t, fErrs[1].Err, "ANY", "wsHandleData errors should propagate correctly")
 	close(b.Websocket.DataHandler)
 
 	exp := []trade.Data{

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -546,8 +546,7 @@ func TestWsTicker(t *testing.T) {
 func TestWSTrade(t *testing.T) {
 	t.Parallel()
 
-	b := new(BTCMarkets) //nolint:govet
-	// Intentional shadow to avoid future copy/paste mistakes
+	b := new(BTCMarkets) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
 	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", b.wsHandleData)
 	close(b.Websocket.DataHandler)
@@ -566,7 +565,7 @@ func TestWSTrade(t *testing.T) {
 		{
 			Exchange:     b.Name,
 			CurrencyPair: currency.NewPairWithDelimiter("BTC", "AUD", currency.DashDelimiter),
-			Timestamp:    time.Date(2025, 3, 13, 8, 28, 02, 273000000, time.UTC),
+			Timestamp:    time.Date(2025, 3, 13, 8, 28, 2, 273000000, time.UTC),
 			Price:        131065.01,
 			Amount:       0.05,
 			Side:         order.Sell,

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 	testsubs "github.com/thrasher-corp/gocryptotrader/internal/testing/subscriptions"
 )
@@ -542,18 +543,49 @@ func TestWsTicker(t *testing.T) {
 	}
 }
 
-func TestWsTrade(t *testing.T) {
-	pressXToJSON := []byte(` { "marketId": "BTC-AUD",
-    "timestamp": "2019-04-08T20:54:27.632Z",
-    "tradeId": 3153171493,
-    "price": "7370.11",
-    "volume": "0.10901605",
-    "side": "Ask",
-    "messageType": "trade"
-  }`)
-	err := b.wsHandleData(pressXToJSON)
-	if err != nil {
-		t.Error(err)
+func TestWSTrade(t *testing.T) {
+	t.Parallel()
+
+	b := new(BTCMarkets) //nolint:govet
+	// Intentional shadow to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
+	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", b.wsHandleData)
+	close(b.Websocket.DataHandler)
+
+	exp := []trade.Data{
+		{
+			Exchange:     b.Name,
+			CurrencyPair: currency.NewPairWithDelimiter("BTC", "AUD", currency.DashDelimiter),
+			Timestamp:    time.Date(2025, 3, 13, 8, 27, 55, 691000000, time.UTC),
+			Price:        131200.34,
+			Amount:       0.00151228,
+			Side:         order.Buy,
+			TID:          "7006384466",
+			AssetType:    asset.Spot,
+		},
+		{
+			Exchange:     b.Name,
+			CurrencyPair: currency.NewPairWithDelimiter("BTC", "AUD", currency.DashDelimiter),
+			Timestamp:    time.Date(2025, 3, 13, 8, 28, 02, 273000000, time.UTC),
+			Price:        131065.01,
+			Amount:       0.05,
+			Side:         order.Sell,
+			TID:          "7006384467",
+			AssetType:    asset.Spot,
+		},
+	}
+	require.Len(t, b.Websocket.DataHandler, 2, "Must see correct number of trades")
+
+	for resp := range b.Websocket.DataHandler {
+		switch v := resp.(type) {
+		case trade.Data:
+			i := 1 - len(b.Websocket.DataHandler)
+			require.Equalf(t, exp[i], v, "Trade[%d] must be correct", i)
+		case error:
+			t.Error(v)
+		default:
+			t.Errorf("Unexpected type in DataHandler: %T(%s)", v, v)
+		}
 	}
 }
 

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -548,7 +548,10 @@ func TestWSTrade(t *testing.T) {
 
 	b := new(BTCMarkets) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(b), "Test instance Setup must not error")
-	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", b.wsHandleData)
+	fErrs := testexch.FixtureToDataHandlerWithErrors(t, "testdata/wsAllTrades.json", b.wsHandleData)
+	for _, fErr := range fErrs {
+		require.ErrorIs(t, fErr.Err, order.ErrSideIsInvalid)
+	}
 	close(b.Websocket.DataHandler)
 
 	exp := []trade.Data{

--- a/exchanges/btcmarkets/btcmarkets_types.go
+++ b/exchanges/btcmarkets/btcmarkets_types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
@@ -373,13 +374,13 @@ type WsTick struct {
 
 // WsTrade message received for trade data
 type WsTrade struct {
-	Currency    string    `json:"marketId"`
-	Timestamp   time.Time `json:"timestamp"`
-	TradeID     int64     `json:"tradeId"`
-	Price       float64   `json:"price,string"`
-	Volume      float64   `json:"volume,string"`
-	Side        string    `json:"side"`
-	MessageType string    `json:"messageType"`
+	Currency    string     `json:"marketId"`
+	Timestamp   time.Time  `json:"timestamp"`
+	TradeID     int64      `json:"tradeId"`
+	Price       float64    `json:"price,string"`
+	Volume      float64    `json:"volume,string"`
+	Side        order.Side `json:"side"`
+	MessageType string     `json:"messageType"`
 }
 
 // WsOrderbook message received for orderbook data

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -207,7 +207,7 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			side = order.Sell
 		}
 
-		tr := trade.Data{
+		td := trade.Data{
 			Timestamp:    t.Timestamp,
 			CurrencyPair: p,
 			AssetType:    asset.Spot,
@@ -219,10 +219,10 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 		}
 
 		if tradeFeed {
-			b.Websocket.DataHandler <- tr
+			b.Websocket.DataHandler <- td
 		}
 		if saveTradeData {
-			return trade.AddTradesToBuffer(tr)
+			return trade.AddTradesToBuffer(td)
 		}
 	case tick:
 		var tick WsTick

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -203,8 +203,13 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 		}
 
 		side := order.Buy
-		if t.Side == "Ask" {
+		switch {
+		case t.Side.IsLong():
+			// Nothing to do
+		case t.Side.IsShort():
 			side = order.Sell
+		default:
+			return fmt.Errorf("%w: `%s`", order.ErrSideIsInvalid, t.Side)
 		}
 
 		td := trade.Data{

--- a/exchanges/btcmarkets/testdata/wsAllTrades.json
+++ b/exchanges/btcmarkets/testdata/wsAllTrades.json
@@ -1,3 +1,4 @@
 {"marketId":"BTC-AUD","timestamp":"2025-03-13T08:27:55.691Z","tradeId":7006384466,"price":"131200.34","volume":"0.00151228","messageType":"trade","side":"Bid"}
 {"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.273Z","tradeId":7006384467,"price":"131065.01","volume":"0.05","messageType":"trade","side":"Ask"}
-{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.274Z","tradeId":7006384468,"price":"131065.02","volume":"0.06","messageType":"trade","side":"Invalid"}
+{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.274Z","tradeId":7006384468,"price":"131065.02","volume":"0.06","messageType":"trade","side":"Wrong"}
+{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.274Z","tradeId":7006384469,"price":"131065.02","volume":"0.06","messageType":"trade","side":"Any"}

--- a/exchanges/btcmarkets/testdata/wsAllTrades.json
+++ b/exchanges/btcmarkets/testdata/wsAllTrades.json
@@ -1,0 +1,2 @@
+{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:27:55.691Z","tradeId":7006384466,"price":"131200.34","volume":"0.00151228","messageType":"trade","side":"Bid"}
+{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.273Z","tradeId":7006384467,"price":"131065.01","volume":"0.05","messageType":"trade","side":"Ask"}

--- a/exchanges/btcmarkets/testdata/wsAllTrades.json
+++ b/exchanges/btcmarkets/testdata/wsAllTrades.json
@@ -1,2 +1,3 @@
 {"marketId":"BTC-AUD","timestamp":"2025-03-13T08:27:55.691Z","tradeId":7006384466,"price":"131200.34","volume":"0.00151228","messageType":"trade","side":"Bid"}
 {"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.273Z","tradeId":7006384467,"price":"131065.01","volume":"0.05","messageType":"trade","side":"Ask"}
+{"marketId":"BTC-AUD","timestamp":"2025-03-13T08:28:02.274Z","tradeId":7006384468,"price":"131065.02","volume":"0.06","messageType":"trade","side":"Invalid"}

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -297,7 +297,9 @@
     },
     "enabled": {
      "autoPairUpdates": true,
-     "websocketAPI": false
+     "websocketAPI": false,
+     "saveTradeData": false,
+     "tradeFeed": true
     }
    },
    "bankAccounts": [


### PR DESCRIPTION
# PR Description

Like with other exchanges, websocket trades are not sent down to the DataHandler.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [x] TestWSTrade

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
