### PR TITLE
linter: Enable gofumpt and run against codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
 #   - godot
 #   - godox
     - gofmt
-#   - gofumpt
+    - gofumpt
 #   - goheader
     - goimports
     - gomoddirectives
@@ -153,6 +153,8 @@ linters-settings:
       - float-compare
       # We deliberately use Equal over Len to avoid spamming the contents of large Slices
       - len
+  gofumpt:
+    extra-rules: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/backtester/btcli/commands.go
+++ b/backtester/btcli/commands.go
@@ -144,7 +144,6 @@ func executeStrategyFromFile(c *cli.Context) error {
 			IntervalOverride:    durationpb.New(intervalOverride),
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -171,7 +170,6 @@ func listAllTasks(c *cli.Context) error {
 		c.Context,
 		&btrpc.ListAllTasksRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -217,7 +215,6 @@ func startTask(c *cli.Context) error {
 			Id: id,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -244,7 +241,6 @@ func startAllTasks(c *cli.Context) error {
 		c.Context,
 		&btrpc.StartAllTasksRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -291,7 +287,6 @@ func stopTask(c *cli.Context) error {
 			Id: id,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -318,7 +313,6 @@ func stopAllTasks(c *cli.Context) error {
 		c.Context,
 		&btrpc.StopAllTasksRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -365,7 +359,6 @@ func clearTask(c *cli.Context) error {
 			Id: id,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -392,7 +385,6 @@ func clearAllTasks(c *cli.Context) error {
 		c.Context,
 		&btrpc.ClearAllTasksRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -623,7 +615,6 @@ func executeStrategyFromConfig(c *cli.Context) error {
 			DoNotStore:          dns,
 		},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/backtester/btcli/main.go
+++ b/backtester/btcli/main.go
@@ -50,7 +50,8 @@ func setupClient(c *cli.Context) (*grpc.ClientConn, context.CancelFunc, error) {
 		return nil, nil, err
 	}
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds),
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
 		grpc.WithPerRPCCredentials(auth.BasicAuth{
 			Username: username,
 			Password: password,

--- a/backtester/data/data_test.go
+++ b/backtester/data/data_test.go
@@ -16,8 +16,10 @@ import (
 	gctkline "github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 )
 
-const exch = "binance"
-const a = asset.Spot
+const (
+	exch = "binance"
+	a    = asset.Spot
+)
 
 var p = currency.NewPair(currency.BTC, currency.USD)
 

--- a/backtester/data/kline/api/api_test.go
+++ b/backtester/data/kline/api/api_test.go
@@ -31,7 +31,8 @@ func TestLoadCandles(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	tt1 := time.Now().Add(-time.Minute).Round(gctkline.OneMin.Duration())
 	tt2 := time.Now().Round(gctkline.OneMin.Duration())
 	interval := gctkline.OneMin
@@ -69,7 +70,8 @@ func TestLoadTrades(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	interval := gctkline.OneMin
 	tt1 := time.Now().Add(-time.Minute * 10).Round(interval.Duration())
 	tt2 := time.Now().Round(interval.Duration())

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -162,7 +162,8 @@ func TestLoadDataAPI(t *testing.T) {
 			APIData: &config.APIData{
 				StartDate: time.Now().Truncate(gctkline.OneMin.Duration()).Add(-time.Minute * 5),
 				EndDate:   time.Now().Truncate(gctkline.OneMin.Duration()),
-			}},
+			},
+		},
 		StrategySettings: config.StrategySettings{
 			Name: dollarcostaverage.Name,
 			CustomSettings: map[string]interface{}{
@@ -183,7 +184,8 @@ func TestLoadDataAPI(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 
 	_, err = bt.loadData(cfg, exch, cp, asset.Spot, false)
 	if err != nil {
@@ -216,7 +218,8 @@ func TestLoadDataCSV(t *testing.T) {
 			Interval: gctkline.OneMin,
 			CSVData: &config.CSVData{
 				FullPath: "test",
-			}},
+			},
+		},
 		StrategySettings: config.StrategySettings{
 			Name: dollarcostaverage.Name,
 			CustomSettings: map[string]interface{}{
@@ -237,7 +240,8 @@ func TestLoadDataCSV(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	_, err = bt.loadData(cfg, exch, cp, asset.Spot, false)
 	if err != nil &&
 		!strings.Contains(err.Error(), "The system cannot find the file specified.") &&
@@ -281,7 +285,8 @@ func TestLoadDataDatabase(t *testing.T) {
 				StartDate:        time.Now().Add(-time.Minute),
 				EndDate:          time.Now(),
 				InclusiveEndDate: true,
-			}},
+			},
+		},
 		StrategySettings: config.StrategySettings{
 			Name: dollarcostaverage.Name,
 			CustomSettings: map[string]interface{}{
@@ -302,7 +307,8 @@ func TestLoadDataDatabase(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	bt.databaseManager, err = engine.SetupDatabaseConnectionManager(&cfg.DataSettings.DatabaseData.Config)
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +363,8 @@ func TestLoadDataLive(t *testing.T) {
 					},
 				},
 				RealOrders: true,
-			}},
+			},
+		},
 		StrategySettings: config.StrategySettings{
 			Name: dollarcostaverage.Name,
 			CustomSettings: map[string]interface{}{
@@ -385,7 +392,8 @@ func TestLoadDataLive(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	_, err = bt.loadData(cfg, exch, cp, asset.Spot, false)
 	if !errors.Is(err, gctkline.ErrCannotConstructInterval) {
 		t.Errorf("received: %v, expected: %v", err, gctkline.ErrCannotConstructInterval)
@@ -717,9 +725,11 @@ func TestTriggerLiquidationsForExchange(t *testing.T) {
 	a := asset.USDTMarginedFutures
 	expectedError = gctcommon.ErrNilPointer
 	ev := &evkline.Kline{
-		Base: &event.Base{Exchange: testExchange,
+		Base: &event.Base{
+			Exchange:     testExchange,
 			AssetType:    a,
-			CurrencyPair: cp},
+			CurrencyPair: cp,
+		},
 	}
 	err = bt.triggerLiquidationsForExchange(ev, nil)
 	if !errors.Is(err, expectedError) {
@@ -885,9 +895,11 @@ func TestProcessSignalEvent(t *testing.T) {
 	cp := currency.NewPair(currency.BTC, currency.USDT)
 	a := asset.USDTMarginedFutures
 	de := &evkline.Kline{
-		Base: &event.Base{Exchange: testExchange,
+		Base: &event.Base{
+			Exchange:     testExchange,
 			AssetType:    a,
-			CurrencyPair: cp},
+			CurrencyPair: cp,
+		},
 	}
 	err := bt.Statistic.SetEventForOffset(de)
 	if !errors.Is(err, expectedError) {
@@ -951,9 +963,11 @@ func TestProcessOrderEvent(t *testing.T) {
 	cp := currency.NewPair(currency.BTC, currency.USDT)
 	a := asset.USDTMarginedFutures
 	de := &evkline.Kline{
-		Base: &event.Base{Exchange: testExchange,
+		Base: &event.Base{
+			Exchange:     testExchange,
 			AssetType:    a,
-			CurrencyPair: cp},
+			CurrencyPair: cp,
+		},
 	}
 	err = bt.Statistic.SetEventForOffset(de)
 	if !errors.Is(err, expectedError) {
@@ -1186,7 +1200,8 @@ func TestProcessFuturesFillEvent(t *testing.T) {
 		Base: &event.Base{
 			Exchange:     testExchange,
 			AssetType:    a,
-			CurrencyPair: cp},
+			CurrencyPair: cp,
+		},
 	}
 	err := bt.Statistic.SetEventForOffset(de)
 	if !errors.Is(err, expectedError) {

--- a/backtester/engine/fakeinterfaces_test.go
+++ b/backtester/engine/fakeinterfaces_test.go
@@ -123,7 +123,6 @@ func (f fakeReport) UseDarkMode(bool) {}
 type fakeStats struct{}
 
 func (f *fakeStats) SetStrategyName(string) {
-
 }
 
 func (f *fakeStats) SetEventForOffset(common.Event) error {
@@ -169,29 +168,30 @@ func (f fakeDataHolder) SetDataForCurrency(string, asset.Item, currency.Pair, da
 
 func (f fakeDataHolder) GetAllData() ([]data.Handler, error) {
 	cp := currency.NewPair(currency.BTC, currency.USD)
-	return []data.Handler{&kline.DataFromKline{
-		Base: &data.Base{},
-		Item: &gctkline.Item{
-			Exchange:       testExchange,
-			Pair:           cp,
-			UnderlyingPair: cp,
-			Asset:          asset.Spot,
-			Interval:       gctkline.OneMin,
-			Candles: []gctkline.Candle{
-				{
-					Time:   time.Now(),
-					Open:   1337,
-					High:   1337,
-					Low:    1337,
-					Close:  1337,
-					Volume: 1337,
+	return []data.Handler{
+		&kline.DataFromKline{
+			Base: &data.Base{},
+			Item: &gctkline.Item{
+				Exchange:       testExchange,
+				Pair:           cp,
+				UnderlyingPair: cp,
+				Asset:          asset.Spot,
+				Interval:       gctkline.OneMin,
+				Candles: []gctkline.Candle{
+					{
+						Time:   time.Now(),
+						Open:   1337,
+						High:   1337,
+						Low:    1337,
+						Close:  1337,
+						Volume: 1337,
+					},
 				},
+				SourceJobID:     uuid.UUID{},
+				ValidationJobID: uuid.UUID{},
 			},
-			SourceJobID:     uuid.UUID{},
-			ValidationJobID: uuid.UUID{},
+			RangeHolder: &gctkline.IntervalRangeHolder{},
 		},
-		RangeHolder: &gctkline.IntervalRangeHolder{},
-	},
 	}, nil
 }
 

--- a/backtester/engine/grpcserver.go
+++ b/backtester/engine/grpcserver.go
@@ -110,7 +110,8 @@ func (s *GRPCServer) StartRPCRESTProxy() error {
 	}
 
 	mux := runtime.NewServeMux()
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds),
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
 		grpc.WithPerRPCCredentials(auth.BasicAuth{
 			Username: s.config.GRPC.Username,
 			Password: s.config.GRPC.Password,

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -21,8 +21,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var dcaConfigPath = filepath.Join("..", "config", "strategyexamples", "dca-api-candles.strat")
-var dbConfigPath = filepath.Join("..", "config", "strategyexamples", "dca-database-candles.strat")
+var (
+	dcaConfigPath = filepath.Join("..", "config", "strategyexamples", "dca-api-candles.strat")
+	dbConfigPath  = filepath.Join("..", "config", "strategyexamples", "dca-database-candles.strat")
+)
 
 func TestExecuteStrategyFromFile(t *testing.T) {
 	t.Parallel()

--- a/backtester/engine/setup.go
+++ b/backtester/engine/setup.go
@@ -663,7 +663,8 @@ func getFees(ctx context.Context, exch gctexchange.IBotExchange, fPair currency.
 		return decimal.Zero, decimal.Zero, currency.ErrCurrencyPairEmpty
 	}
 	fTakerFee, err := exch.GetFeeByType(ctx,
-		&gctexchange.FeeBuilder{FeeType: gctexchange.OfflineTradeFee,
+		&gctexchange.FeeBuilder{
+			FeeType:       gctexchange.OfflineTradeFee,
 			Pair:          fPair,
 			IsMaker:       false,
 			PurchasePrice: 1,

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -83,6 +83,7 @@ func (f *fakeFund) PairReleaser() (funding.IPairReleaser, error) {
 	}
 	return p, nil
 }
+
 func (f *fakeFund) CollateralReleaser() (funding.ICollateralReleaser, error) {
 	i, err := funding.CreateItem(testExchange, asset.Futures, currency.BTC, decimal.Zero, decimal.Zero)
 	if err != nil {

--- a/backtester/eventhandlers/portfolio/compliance/compliance_test.go
+++ b/backtester/eventhandlers/portfolio/compliance/compliance_test.go
@@ -42,7 +42,8 @@ func TestGetSnapshotAtTime(t *testing.T) {
 	t.Parallel()
 	m := Manager{}
 	tt := time.Now()
-	err := m.AddSnapshot(&Snapshot{Offset: 0,
+	err := m.AddSnapshot(&Snapshot{
+		Offset:    0,
 		Timestamp: tt,
 		Orders: []SnapshotOrder{
 			{

--- a/backtester/eventhandlers/portfolio/compliance/compliance_types.go
+++ b/backtester/eventhandlers/portfolio/compliance/compliance_types.go
@@ -8,9 +8,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 )
 
-var (
-	errSnapshotNotFound = errors.New("snapshot not found")
-)
+var errSnapshotNotFound = errors.New("snapshot not found")
 
 // Manager holds a snapshot of all orders at each timeperiod, allowing
 // study of all changes across time

--- a/backtester/eventhandlers/portfolio/holdings/holdings.go
+++ b/backtester/eventhandlers/portfolio/holdings/holdings.go
@@ -117,12 +117,10 @@ func (h *Holding) update(e fill.Event, f funding.IFundReader) error {
 		return nil
 	}
 	switch direction {
-	case order.Buy,
-		order.Bid:
+	case order.Buy, order.Bid:
 		h.BoughtAmount = h.BoughtAmount.Add(amount)
 		h.CommittedFunds = h.BaseSize.Mul(price)
-	case order.Sell,
-		order.Ask:
+	case order.Sell, order.Ask:
 		h.SoldAmount = h.SoldAmount.Add(amount)
 		h.CommittedFunds = h.BaseSize.Mul(price)
 	}

--- a/backtester/eventhandlers/portfolio/portfolio.go
+++ b/backtester/eventhandlers/portfolio/portfolio.go
@@ -83,7 +83,7 @@ func (p *Portfolio) OnSignal(ev signal.Event, exchangeSettings *exchange.Setting
 	o.BuyLimit = ev.GetBuyLimit()
 	o.SellLimit = ev.GetSellLimit()
 	var sizingFunds decimal.Decimal
-	var side = ev.GetDirection()
+	side := ev.GetDirection()
 	if ev.GetAssetType() == asset.Spot {
 		if side == gctorder.ClosePosition {
 			side = gctorder.Sell

--- a/backtester/eventhandlers/portfolio/portfolio_test.go
+++ b/backtester/eventhandlers/portfolio/portfolio_test.go
@@ -134,7 +134,8 @@ func TestSetHoldings(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -143,7 +144,8 @@ func TestSetHoldings(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -161,7 +163,8 @@ func TestGetLatestHoldingsForAllCurrencies(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, errNoPortfolioSettings) {
 		t.Errorf("received: %v, expected: %v", err, errNoPortfolioSettings)
 	}
@@ -181,7 +184,8 @@ func TestGetLatestHoldingsForAllCurrencies(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -194,7 +198,8 @@ func TestGetLatestHoldingsForAllCurrencies(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -238,7 +243,8 @@ func TestViewHoldingAtTimePeriod(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt})
+		Timestamp: tt,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -247,7 +253,8 @@ func TestViewHoldingAtTimePeriod(t *testing.T) {
 		Exchange:  testExchange,
 		Asset:     asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
-		Timestamp: tt.Add(time.Hour)})
+		Timestamp: tt.Add(time.Hour),
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received: %v, expected: %v", err, nil)
 	}
@@ -1068,7 +1075,7 @@ func TestGetHoldingsForTime(t *testing.T) {
 func TestGetPositions(t *testing.T) {
 	t.Parallel()
 	p := &Portfolio{}
-	var expectedError = common.ErrNilEvent
+	expectedError := common.ErrNilEvent
 	_, err := p.GetPositions(nil)
 	if !errors.Is(err, expectedError) {
 		t.Fatalf("received '%v' expected '%v'", err, expectedError)
@@ -1096,7 +1103,7 @@ func TestGetPositions(t *testing.T) {
 func TestGetLatestPNLForEvent(t *testing.T) {
 	t.Parallel()
 	p := &Portfolio{}
-	var expectedError = common.ErrNilEvent
+	expectedError := common.ErrNilEvent
 	_, err := p.GetLatestPNLForEvent(nil)
 	if !errors.Is(err, expectedError) {
 		t.Fatalf("received '%v' expected '%v'", err, expectedError)
@@ -1349,7 +1356,7 @@ func TestGetDirection(t *testing.T) {
 
 func TestCannotPurchase(t *testing.T) {
 	t.Parallel()
-	var expectedError = common.ErrNilEvent
+	expectedError := common.ErrNilEvent
 	_, err := cannotPurchase(nil, nil)
 	if !errors.Is(err, expectedError) {
 		t.Fatalf("received '%v' expected '%v'", err, expectedError)

--- a/backtester/eventhandlers/portfolio/size/size_test.go
+++ b/backtester/eventhandlers/portfolio/size/size_test.go
@@ -104,6 +104,7 @@ func TestMaximumBuySizeEqualZero(t *testing.T) {
 		t.Errorf("expected: %v, received %v, err: %+v", buyLimit, amount, err)
 	}
 }
+
 func TestMaximumSellSizeEqualZero(t *testing.T) {
 	t.Parallel()
 	globalMinMax := exchange.MinMax{

--- a/backtester/eventhandlers/strategies/binancecashandcarry/binancecashandcarry.go
+++ b/backtester/eventhandlers/strategies/binancecashandcarry/binancecashandcarry.go
@@ -227,7 +227,7 @@ func sortSignals(d []data.Handler) ([]cashCarrySignals, error) {
 	if len(d) == 0 {
 		return nil, base.ErrNoDataToProcess
 	}
-	var carryMap = make(map[*currency.Item]map[*currency.Item]cashCarrySignals, len(d))
+	carryMap := make(map[*currency.Item]map[*currency.Item]cashCarrySignals, len(d))
 	for i := range d {
 		l, err := d[i].Latest()
 		if err != nil {

--- a/backtester/eventhandlers/strategies/binancecashandcarry/binancecashandcarry_test.go
+++ b/backtester/eventhandlers/strategies/binancecashandcarry/binancecashandcarry_test.go
@@ -186,7 +186,7 @@ func TestSortSignals(t *testing.T) {
 func TestCreateSignals(t *testing.T) {
 	t.Parallel()
 	s := Strategy{}
-	var expectedError = gctcommon.ErrNilPointer
+	expectedError := gctcommon.ErrNilPointer
 	_, err := s.createSignals(nil, nil, nil, decimal.Zero, false)
 	if !errors.Is(err, expectedError) {
 		t.Errorf("received '%v' expected '%v", err, expectedError)

--- a/backtester/eventhandlers/strategies/strategies_test.go
+++ b/backtester/eventhandlers/strategies/strategies_test.go
@@ -116,21 +116,27 @@ type customStrategy struct {
 func (s *customStrategy) Name() string {
 	return "custom-strategy"
 }
+
 func (s *customStrategy) Description() string {
 	return "this is a demonstration of loading strategies via custom plugins"
 }
+
 func (s *customStrategy) SupportsSimultaneousProcessing() bool {
 	return s.allowSimultaneousProcessing
 }
+
 func (s *customStrategy) OnSignal(d data.Handler, _ funding.IFundingTransferer, _ portfolio.Handler) (signal.Event, error) {
 	return s.createSignal(d)
 }
+
 func (s *customStrategy) OnSimultaneousSignals(_ []data.Handler, _ funding.IFundingTransferer, _ portfolio.Handler) ([]signal.Event, error) {
 	return nil, nil
 }
+
 func (s *customStrategy) createSignal(_ data.Handler) (*signal.Signal, error) {
 	return nil, nil
 }
+
 func (s *customStrategy) SetCustomSettings(map[string]interface{}) error {
 	return nil
 }

--- a/backtester/eventtypes/order/order_test.go
+++ b/backtester/eventtypes/order/order_test.go
@@ -160,6 +160,7 @@ func TestGetFillDependentEvent(t *testing.T) {
 		t.Errorf("received '%v' expected '%v'", k.GetFillDependentEvent(), decimal.NewFromInt(1337))
 	}
 }
+
 func TestIsClosingPosition(t *testing.T) {
 	t.Parallel()
 	k := Order{

--- a/backtester/funding/collateralpair_test.go
+++ b/backtester/funding/collateralpair_test.go
@@ -27,7 +27,8 @@ func TestCollateralTakeProfit(t *testing.T) {
 			asset:        asset.Futures,
 			isCollateral: true,
 		},
-		contract: &Item{asset: asset.Futures,
+		contract: &Item{
+			asset:     asset.Futures,
 			available: decimal.NewFromInt(1),
 		},
 	}
@@ -287,7 +288,8 @@ func TestCollateralLiquidate(t *testing.T) {
 			isCollateral: true,
 			available:    decimal.NewFromInt(1337),
 		},
-		contract: &Item{asset: asset.Futures,
+		contract: &Item{
+			asset:     asset.Futures,
 			available: decimal.NewFromInt(1337),
 		},
 	}

--- a/backtester/funding/funding.go
+++ b/backtester/funding/funding.go
@@ -633,7 +633,7 @@ func (f *FundManager) UpdateAllCollateral(isLive, initialFundsSet bool) error {
 			if usd.IsZero() && exchangeCollateralCalculator.CalculateOffline {
 				continue
 			}
-			var side = gctorder.Buy
+			side := gctorder.Buy
 			if !f.items[y].available.GreaterThan(decimal.Zero) {
 				side = gctorder.Sell
 			}
@@ -718,7 +718,7 @@ func (f *FundManager) UpdateCollateralForEvent(ev common.Event, isLive bool) err
 		if usd.IsZero() {
 			continue
 		}
-		var side = gctorder.Buy
+		side := gctorder.Buy
 		if !f.items[i].available.GreaterThan(decimal.Zero) {
 			side = gctorder.Sell
 		}

--- a/backtester/funding/spotpair.go
+++ b/backtester/funding/spotpair.go
@@ -8,10 +8,8 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 )
 
-var (
-	// ErrNotCollateral is returned when a user requests collateral pair details when it is a funding pair
-	ErrNotCollateral = errors.New("not a collateral pair")
-)
+// ErrNotCollateral is returned when a user requests collateral pair details when it is a funding pair
+var ErrNotCollateral = errors.New("not a collateral pair")
 
 // BaseInitialFunds returns the initial funds
 // from the base in a currency pair

--- a/backtester/main.go
+++ b/backtester/main.go
@@ -20,8 +20,10 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/signaler"
 )
 
-var singleTaskStrategyPath, templatePath, outputPath, btConfigDir, strategyPluginPath, pprofURL string
-var printLogo, generateReport, darkReport, colourOutput, logSubHeader, enablePProf bool
+var (
+	singleTaskStrategyPath, templatePath, outputPath, btConfigDir, strategyPluginPath, pprofURL string
+	printLogo, generateReport, darkReport, colourOutput, logSubHeader, enablePProf              bool
+)
 
 func main() {
 	wd, err := os.Getwd()

--- a/backtester/plugins/strategies/loader_test.go
+++ b/backtester/plugins/strategies/loader_test.go
@@ -50,6 +50,7 @@ func (s *CustomStrategy) SupportsSimultaneousProcessing() bool {
 func (s *CustomStrategy) OnSignal(d data.Handler, _ funding.IFundingTransferer, _ portfolio.Handler) (signal.Event, error) {
 	return s.createSignal(d)
 }
+
 func (s *CustomStrategy) OnSimultaneousSignals(_ []data.Handler, _ funding.IFundingTransferer, _ portfolio.Handler) ([]signal.Event, error) {
 	return nil, nil
 }

--- a/cmd/apichecker/apicheck.go
+++ b/cmd/apichecker/apicheck.go
@@ -595,7 +595,8 @@ func fillData(exchName, checkType string, data interface{}) (ExchangeInfo, error
 					TokenData:     tempData.TokenData,
 					TokenDataEnd:  tempData.TokenDataEnd,
 					Val:           tempData.Val,
-					Path:          tempData.Path},
+					Path:          tempData.Path,
+				},
 			},
 		}, nil
 	default:
@@ -1235,7 +1236,8 @@ func sendGetReq(path string, result interface{}) error {
 		Method:  http.MethodGet,
 		Path:    path,
 		Result:  result,
-		Verbose: verbose}
+		Verbose: verbose,
+	}
 	return requester.SendPayload(context.Background(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, request.UnauthenticatedRequest)
@@ -1253,7 +1255,8 @@ func sendAuthReq(method, path string, result interface{}) error {
 		Method:  method,
 		Path:    path,
 		Result:  result,
-		Verbose: verbose}
+		Verbose: verbose,
+	}
 	return requester.SendPayload(context.Background(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, request.AuthenticatedRequest)

--- a/cmd/apichecker/apicheck_test.go
+++ b/cmd/apichecker/apicheck_test.go
@@ -131,14 +131,16 @@ func TestCheckExistingExchanges(t *testing.T) {
 
 func TestCheckChangeLog(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "revision-history",
 		TokenDataEnd:  "table",
 		TextTokenData: "td",
 		DateFormat:    "2006/01/02",
 		RegExp:        `^20(\d){2}/(\d){2}/(\d){2}$`,
-		Path:          "https://docs.gemini.com/rest-api/#revision-history"}
+		Path:          "https://docs.gemini.com/rest-api/#revision-history",
+	}
 	if _, err := checkChangeLog(&data); err != nil {
 		t.Error(err)
 	}
@@ -162,7 +164,8 @@ func TestAdd(t *testing.T) {
 
 func TestHTMLScrapeGemini(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "revision-history",
 		TokenDataEnd:  "table",
@@ -170,7 +173,8 @@ func TestHTMLScrapeGemini(t *testing.T) {
 		DateFormat:    "2006/01/02",
 		RegExp:        "^20(\\d){2}/(\\d){2}/(\\d){2}$",
 		CheckString:   "2019/11/15",
-		Path:          "https://docs.gemini.com/rest-api/#revision-history"}
+		Path:          "https://docs.gemini.com/rest-api/#revision-history",
+	}
 	_, err := htmlScrapeDefault(&data)
 	if err != nil {
 		t.Error(err)
@@ -179,7 +183,8 @@ func TestHTMLScrapeGemini(t *testing.T) {
 
 func TestHTMLScrapeHuobi(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "change-log",
 		TokenDataEnd:  "h2",
@@ -187,7 +192,8 @@ func TestHTMLScrapeHuobi(t *testing.T) {
 		DateFormat:    "2006.01.02 15:04",
 		RegExp:        "^20(\\d){2}.(\\d){2}.(\\d){2} (\\d){2}:(\\d){2}$",
 		CheckString:   "2019.12.27 19:00",
-		Path:          "https://huobiapi.github.io/docs/spot/v1/en/#change-log"}
+		Path:          "https://huobiapi.github.io/docs/spot/v1/en/#change-log",
+	}
 	_, err := htmlScrapeDefault(&data)
 	if err != nil {
 		t.Error(err)
@@ -196,7 +202,8 @@ func TestHTMLScrapeHuobi(t *testing.T) {
 
 func TestHTMLScrapeCoinbasepro(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "changelog",
 		TokenDataEnd:  "ul",
@@ -204,7 +211,8 @@ func TestHTMLScrapeCoinbasepro(t *testing.T) {
 		DateFormat:    "01/02/06",
 		RegExp:        "^(\\d){1,2}/(\\d){1,2}/(\\d){2}$",
 		CheckString:   "12/16/19",
-		Path:          "https://docs.pro.coinbase.com/#changelog"}
+		Path:          "https://docs.pro.coinbase.com/#changelog",
+	}
 	_, err := htmlScrapeDefault(&data)
 	if err != nil {
 		t.Error(err)
@@ -213,9 +221,11 @@ func TestHTMLScrapeCoinbasepro(t *testing.T) {
 
 func TestHTMLScrapeBitfinex(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{DateFormat: "2006-01-02",
-		RegExp: `section-v-(2\d{3}-\d{1,2}-\d{1,2})`,
-		Path:   "https://docs.bitfinex.com/docs/changelog"}
+	data := HTMLScrapingData{
+		DateFormat: "2006-01-02",
+		RegExp:     `section-v-(2\d{3}-\d{1,2}-\d{1,2})`,
+		Path:       "https://docs.bitfinex.com/docs/changelog",
+	}
 	_, err := htmlScrapeBitfinex(&data)
 	if err != nil {
 		t.Error(err)
@@ -224,14 +234,16 @@ func TestHTMLScrapeBitfinex(t *testing.T) {
 
 func TestHTMLScrapeBitmex(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h4",
+	data := HTMLScrapingData{
+		TokenData:     "h4",
 		Key:           "id",
 		Val:           "",
 		TokenDataEnd:  "",
 		TextTokenData: "",
 		DateFormat:    "Jan-2-2006",
 		RegExp:        `([A-Z]{1}[a-z]{2}-\d{1,2}-2\d{3})`,
-		Path:          "https://www.bitmex.com/static/md/en-US/apiChangelog"}
+		Path:          "https://www.bitmex.com/static/md/en-US/apiChangelog",
+	}
 	if _, err := htmlScrapeBitmex(&data); err != nil {
 		t.Error(err)
 	}
@@ -239,8 +251,10 @@ func TestHTMLScrapeBitmex(t *testing.T) {
 
 func TestHTMLScrapeHitBTC(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `newest version \d{1}.\d{1}`,
-		Path: "https://api.hitbtc.com/"}
+	data := HTMLScrapingData{
+		RegExp: `newest version \d{1}.\d{1}`,
+		Path:   "https://api.hitbtc.com/",
+	}
 	if _, err := htmlScrapeHitBTC(&data); err != nil {
 		t.Error(err)
 	}
@@ -248,8 +262,10 @@ func TestHTMLScrapeHitBTC(t *testing.T) {
 
 func TestHTMLScrapeBTSE(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `^version: \d{1}.\d{1}.\d{1}`,
-		Path: "https://api.btcmarkets.net/openapi/info/index.yaml"}
+	data := HTMLScrapingData{
+		RegExp: `^version: \d{1}.\d{1}.\d{1}`,
+		Path:   "https://api.btcmarkets.net/openapi/info/index.yaml",
+	}
 	if _, err := htmlScrapeBTSE(&data); err != nil {
 		t.Error(err)
 	}
@@ -257,8 +273,10 @@ func TestHTMLScrapeBTSE(t *testing.T) {
 
 func TestHTMLScrapeBTCMarkets(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `^version: \d{1}.\d{1}.\d{1}`,
-		Path: "https://api.btcmarkets.net/openapi/info/index.yaml"}
+	data := HTMLScrapingData{
+		RegExp: `^version: \d{1}.\d{1}.\d{1}`,
+		Path:   "https://api.btcmarkets.net/openapi/info/index.yaml",
+	}
 	if _, err := htmlScrapeBTCMarkets(&data); err != nil {
 		t.Error(err)
 	}
@@ -266,11 +284,13 @@ func TestHTMLScrapeBTCMarkets(t *testing.T) {
 
 func TestHTMLScrapeBitflyer(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "p",
+	data := HTMLScrapingData{
+		TokenData:     "p",
 		TokenDataEnd:  "h3",
 		TextTokenData: "code",
 		RegExp:        `^https://api.bitflyer.com/v\d{1}/$`,
-		Path:          "https://lightning.bitflyer.com/docs?lang=en"}
+		Path:          "https://lightning.bitflyer.com/docs?lang=en",
+	}
 	if _, err := htmlScrapeBitflyer(&data); err != nil {
 		t.Error(err)
 	}
@@ -278,8 +298,10 @@ func TestHTMLScrapeBitflyer(t *testing.T) {
 
 func TestHTMLScrapeANX(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `ANX Exchange API v\d{1}`,
-		Path: "https://anxv3.docs.apiary.io/#reference/quickstart-catalog"}
+	data := HTMLScrapingData{
+		RegExp: `ANX Exchange API v\d{1}`,
+		Path:   "https://anxv3.docs.apiary.io/#reference/quickstart-catalog",
+	}
 	if _, err := htmlScrapeANX(&data); err != nil {
 		t.Error(err)
 	}
@@ -287,14 +309,16 @@ func TestHTMLScrapeANX(t *testing.T) {
 
 func TestHTMLPoloniex(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "changelog",
 		TokenDataEnd:  "div",
 		TextTokenData: "h2",
 		DateFormat:    "2006-01-02",
 		RegExp:        `(2\d{3}-\d{1,2}-\d{1,2})`,
-		Path:          "https://docs.poloniex.com/#changelog"}
+		Path:          "https://docs.poloniex.com/#changelog",
+	}
 	if _, err := htmlScrapePoloniex(&data); err != nil {
 		t.Error(err)
 	}
@@ -302,8 +326,10 @@ func TestHTMLPoloniex(t *testing.T) {
 
 func TestHTMLScrapeExmo(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `Last updated on [\s\S]*, 20\d{2}`,
-		Path: "https://exmo.com/en/api/"}
+	data := HTMLScrapingData{
+		RegExp: `Last updated on [\s\S]*, 20\d{2}`,
+		Path:   "https://exmo.com/en/api/",
+	}
 	if _, err := htmlScrapeExmo(&data); err != nil {
 		t.Error(err)
 	}
@@ -311,8 +337,10 @@ func TestHTMLScrapeExmo(t *testing.T) {
 
 func TestHTMLBitstamp(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{RegExp: `refer to the v\d{1} API for future references.`,
-		Path: "https://www.bitstamp.net/api/"}
+	data := HTMLScrapingData{
+		RegExp: `refer to the v\d{1} API for future references.`,
+		Path:   "https://www.bitstamp.net/api/",
+	}
 	if _, err := htmlScrapeBitstamp(&data); err != nil {
 		t.Error(err)
 	}
@@ -320,11 +348,13 @@ func TestHTMLBitstamp(t *testing.T) {
 
 func TestHTMLKraken(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h3",
+	data := HTMLScrapingData{
+		TokenData:     "h3",
 		TokenDataEnd:  "p",
 		TextTokenData: "p",
 		RegExp:        `URL: https://api.kraken.com/\d{1}/private/Balance`,
-		Path:          "https://www.kraken.com/features/api"}
+		Path:          "https://www.kraken.com/features/api",
+	}
 	if _, err := htmlScrapeKraken(&data); err != nil {
 		t.Error(err)
 	}
@@ -332,13 +362,15 @@ func TestHTMLKraken(t *testing.T) {
 
 func TestHTMLAlphaPoint(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h1",
+	data := HTMLScrapingData{
+		TokenData:     "h1",
 		Key:           "id",
 		Val:           "introduction",
 		TokenDataEnd:  "blockquote",
 		TextTokenData: "h3",
 		RegExp:        `revised-calls-\d{1}-\d{1}-\d{1}-gt-\d{1}-\d{1}-\d{1}`,
-		Path:          "https://alphapoint.github.io/slate/#introduction"}
+		Path:          "https://alphapoint.github.io/slate/#introduction",
+	}
 	if _, err := htmlScrapeAlphaPoint(&data); err != nil {
 		t.Error(err)
 	}
@@ -346,9 +378,11 @@ func TestHTMLAlphaPoint(t *testing.T) {
 
 func TestHTMLYobit(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "h2",
-		Key:  "id",
-		Path: "https://www.yobit.net/en/api/"}
+	data := HTMLScrapingData{
+		TokenData: "h2",
+		Key:       "id",
+		Path:      "https://www.yobit.net/en/api/",
+	}
 	if _, err := htmlScrapeYobit(&data); err != nil {
 		t.Error(err)
 	}
@@ -356,12 +390,14 @@ func TestHTMLYobit(t *testing.T) {
 
 func TestHTMLScrapeOk(t *testing.T) {
 	t.Parallel()
-	data := HTMLScrapingData{TokenData: "a",
+	data := HTMLScrapingData{
+		TokenData:    "a",
 		Key:          "href",
 		Val:          "./#change-change",
 		TokenDataEnd: "./#change-",
 		RegExp:       `./#change-\d{8}`,
-		Path:         "https://www.okx.com/docs/en/"}
+		Path:         "https://www.okx.com/docs/en/",
+	}
 	if _, err := htmlScrapeOk(&data); err != nil {
 		t.Error(err)
 	}
@@ -375,10 +411,14 @@ func TestUpdate(t *testing.T) {
 			exchCheck = *configData.Exchanges[x].Data.HTMLData
 		}
 	}
-	info := ExchangeInfo{Name: "Exmo",
+	info := ExchangeInfo{
+		Name:      "Exmo",
 		CheckType: "HTML String Check",
-		Data: &CheckData{HTMLData: &HTMLScrapingData{RegExp: `Last updated on [\s\S]*, 20\d{2}`,
-			Path: "https://exmo.com/en/api/"},
+		Data: &CheckData{
+			HTMLData: &HTMLScrapingData{
+				RegExp: `Last updated on [\s\S]*, 20\d{2}`,
+				Path:   "https://exmo.com/en/api/",
+			},
 		},
 	}
 	updatedExchs := update("Exmo", configData.Exchanges, info)

--- a/cmd/dbseed/database.go
+++ b/cmd/dbseed/database.go
@@ -13,9 +13,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	dbConn *database.Instance
-)
+var dbConn *database.Instance
 
 func load(c *cli.Context) error {
 	var conf config.Config

--- a/cmd/dbseed/exchange.go
+++ b/cmd/dbseed/exchange.go
@@ -122,7 +122,6 @@ func addSingleExchange(c *cli.Context) error {
 	err = exchangeDB.Insert(exchangeDB.Details{
 		Name: exchangeName,
 	})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -38,7 +38,8 @@ const (
 
 var (
 	// DefaultExcludedDirectories defines the basic directory exclusion list for GCT
-	DefaultExcludedDirectories = []string{".github",
+	DefaultExcludedDirectories = []string{
+		".github",
 		".git",
 		"node_modules",
 		".vscode",
@@ -335,7 +336,8 @@ func main() {
 		dirList,
 		tmpl,
 		contributors,
-		&config})
+		&config,
+	})
 
 	fmt.Println("\nDocumentation Generation Tool - Finished")
 }

--- a/cmd/exchange_template/exchange_template.go
+++ b/cmd/exchange_template/exchange_template.go
@@ -34,9 +34,7 @@ type exchange struct {
 	FIX         bool
 }
 
-var (
-	errInvalidExchangeName = errors.New("invalid exchange name")
-)
+var errInvalidExchangeName = errors.New("invalid exchange name")
 
 func main() {
 	var newExchangeName string
@@ -260,7 +258,7 @@ func runCommand(dir, param string) error {
 func newFile(path string) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		var file, err = os.Create(path)
+		file, err := os.Create(path)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -682,7 +682,7 @@ func getPairFromPairs(t *testing.T, p currency.Pairs) (currency.Pair, error) {
 // isFiat helps determine fiat currency without using currency.storage
 func isFiat(t *testing.T, c string) bool {
 	t.Helper()
-	var fiats = []string{
+	fiats := []string{
 		currency.USD.Item.Lower,
 		currency.AUD.Item.Lower,
 		currency.EUR.Item.Lower,

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -3850,7 +3850,7 @@ var (
 	candleRangeSize, candleGranularity int64
 	getHistoricCandlesCommand          = &cli.Command{
 		Name:      "gethistoriccandles",
-		Usage:     "gets historical candles for the specified granularity up to range size time from now.",
+		Usage:     "gets historical candles for the specified granularity up to range size time from now",
 		ArgsUsage: "<exchange> <pair> <asset> <rangesize> <granularity>",
 		Action:    getHistoricCandles,
 		Flags: []cli.Flag{

--- a/cmd/gctcli/commands.go
+++ b/cmd/gctcli/commands.go
@@ -18,8 +18,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var startTime, endTime, orderingDirection string
-var limit int
+var (
+	startTime, endTime, orderingDirection string
+	limit                                 int
+)
 
 var getInfoCommand = &cli.Command{
 	Name:   "getinfo",
@@ -38,7 +40,6 @@ func getInfo(c *cli.Context) error {
 	result, err := client.GetInfo(c.Context,
 		&gctrpc.GetInfoRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,6 @@ func getSubsystems(c *cli.Context) error {
 	result, err := client.GetSubsystems(c.Context,
 		&gctrpc.GetSubsystemsRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,6 @@ func enableSubsystem(c *cli.Context) error {
 			Subsystem: subsystemName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -164,7 +163,6 @@ func disableSubsystem(c *cli.Context) error {
 			Subsystem: subsystemName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -190,7 +188,6 @@ func getRPCEndpoints(c *cli.Context) error {
 	result, err := client.GetRPCEndpoints(c.Context,
 		&gctrpc.GetRPCEndpointsRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -216,7 +213,6 @@ func getCommunicationRelayers(c *cli.Context) error {
 	result, err := client.GetCommunicationRelayers(c.Context,
 		&gctrpc.GetCommunicationRelayersRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -256,7 +252,6 @@ func getExchanges(c *cli.Context) error {
 			Enabled: enabledOnly,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -302,7 +297,6 @@ func enableExchange(c *cli.Context) error {
 			Exchange: exchangeName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -348,7 +342,6 @@ func disableExchange(c *cli.Context) error {
 			Exchange: exchangeName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -394,7 +387,6 @@ func getExchangeOTPCode(c *cli.Context) error {
 			Exchange: exchangeName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -419,7 +411,6 @@ func getExchangeOTPCodes(c *cli.Context) error {
 	client := gctrpc.NewGoCryptoTraderServiceClient(conn)
 	result, err := client.GetExchangeOTPCodes(c.Context,
 		&gctrpc.GetExchangeOTPsRequest{})
-
 	if err != nil {
 		return err
 	}
@@ -465,7 +456,6 @@ func getExchangeInfo(c *cli.Context) error {
 			Exchange: exchangeName,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -554,7 +544,6 @@ func getTicker(c *cli.Context) error {
 			AssetType: assetType,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -951,7 +940,6 @@ func addPortfolioAddress(c *cli.Context) error {
 			ColdStorage:        coldstorage,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -1022,7 +1010,6 @@ func removePortfolioAddress(c *cli.Context) error {
 			Description: description,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -3240,7 +3227,6 @@ func getTickerStream(c *cli.Context) error {
 			AssetType: assetType,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -3308,7 +3294,6 @@ func getExchangeTickerStream(c *cli.Context) error {
 		&gctrpc.GetExchangeTickerStreamRequest{
 			Exchange: exchangeName,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3430,7 +3415,6 @@ func getAuditEvent(c *cli.Context) error {
 			Limit:     int32(limit), //nolint:gosec // TODO: SQL boiler's QueryMode limit only accepts the int type
 			OrderBy:   orderingDirection,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3439,118 +3423,120 @@ func getAuditEvent(c *cli.Context) error {
 	return nil
 }
 
-var uuid, filename, path string
-var gctScriptCommand = &cli.Command{
-	Name:      "script",
-	Usage:     "execute scripting management command",
-	ArgsUsage: "<command> <args>",
-	Subcommands: []*cli.Command{
-		{
-			Name:      "execute",
-			Usage:     "execute script filename",
-			ArgsUsage: "<filename> <path>",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        "filename",
-					Usage:       "the script filename",
-					Destination: &filename,
+var (
+	uuid, filename, path string
+	gctScriptCommand     = &cli.Command{
+		Name:      "script",
+		Usage:     "execute scripting management command",
+		ArgsUsage: "<command> <args>",
+		Subcommands: []*cli.Command{
+			{
+				Name:      "execute",
+				Usage:     "execute script filename",
+				ArgsUsage: "<filename> <path>",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "filename",
+						Usage:       "the script filename",
+						Destination: &filename,
+					},
+					&cli.StringFlag{
+						Name:        "path",
+						Usage:       "the directory of the script file",
+						Destination: &path,
+					},
 				},
-				&cli.StringFlag{
-					Name:        "path",
-					Usage:       "the directory of the script file",
-					Destination: &path,
-				},
+				Action: gctScriptExecute,
 			},
-			Action: gctScriptExecute,
-		},
-		{
-			Name:  "query",
-			Usage: "query running virtual machine",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        "uuid",
-					Usage:       "the unique id of the script in memory",
-					Destination: &uuid,
+			{
+				Name:  "query",
+				Usage: "query running virtual machine",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "uuid",
+						Usage:       "the unique id of the script in memory",
+						Destination: &uuid,
+					},
 				},
+				Action: gctScriptQuery,
 			},
-			Action: gctScriptQuery,
-		},
-		{
-			Name:  "read",
-			Usage: "read script",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        "name",
-					Usage:       "the script name",
-					Destination: &uuid,
+			{
+				Name:  "read",
+				Usage: "read script",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "name",
+						Usage:       "the script name",
+						Destination: &uuid,
+					},
 				},
+				Action: gctScriptRead,
 			},
-			Action: gctScriptRead,
-		},
-		{
-			Name:   "status",
-			Usage:  "get status of running scripts",
-			Action: gctScriptStatus,
-		},
-		{
-			Name:   "list",
-			Usage:  "lists all scripts in default scriptpath",
-			Action: gctScriptList,
-		},
-		{
-			Name:  "stop",
-			Usage: "terminate running script",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        "uuid",
-					Usage:       "the unique id of the script in memory",
-					Destination: &uuid,
-				},
+			{
+				Name:   "status",
+				Usage:  "get status of running scripts",
+				Action: gctScriptStatus,
 			},
-			Action: gctScriptStop,
-		},
-		{
-			Name:   "stopall",
-			Usage:  "terminate running script",
-			Action: gctScriptStopAll,
-		},
-		{
-			Name:  "upload",
-			Usage: "upload a new script/archive",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        "path",
-					Usage:       "<path> to single script or zip collection",
-					Destination: &filename,
-				},
-				&cli.BoolFlag{
-					Name:  "overwrite",
-					Usage: "<true/false>",
-				},
-				&cli.BoolFlag{
-					Name:  "archived",
-					Usage: "<true/false>",
-				},
+			{
+				Name:   "list",
+				Usage:  "lists all scripts in default scriptpath",
+				Action: gctScriptList,
 			},
-			Action: gctScriptUpload,
-		},
-		{
-			Name:  "autoload",
-			Usage: "add or remove script from autoload list",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  "command",
-					Usage: "<add/remove>",
+			{
+				Name:  "stop",
+				Usage: "terminate running script",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "uuid",
+						Usage:       "the unique id of the script in memory",
+						Destination: &uuid,
+					},
 				},
-				&cli.StringFlag{
-					Name:  "script",
-					Usage: "<script name>",
-				},
+				Action: gctScriptStop,
 			},
-			Action: gctScriptAutoload,
+			{
+				Name:   "stopall",
+				Usage:  "terminate running script",
+				Action: gctScriptStopAll,
+			},
+			{
+				Name:  "upload",
+				Usage: "upload a new script/archive",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "path",
+						Usage:       "<path> to single script or zip collection",
+						Destination: &filename,
+					},
+					&cli.BoolFlag{
+						Name:  "overwrite",
+						Usage: "<true/false>",
+					},
+					&cli.BoolFlag{
+						Name:  "archived",
+						Usage: "<true/false>",
+					},
+				},
+				Action: gctScriptUpload,
+			},
+			{
+				Name:  "autoload",
+				Usage: "add or remove script from autoload list",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "command",
+						Usage: "<add/remove>",
+					},
+					&cli.StringFlag{
+						Name:  "script",
+						Usage: "<script name>",
+					},
+				},
+				Action: gctScriptAutoload,
+			},
 		},
-	},
-}
+	}
+)
 
 func gctScriptAutoload(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {
@@ -3592,7 +3578,6 @@ func gctScriptAutoload(c *cli.Context) error {
 			Script: script,
 			Status: status,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3632,7 +3617,6 @@ func gctScriptExecute(c *cli.Context) error {
 				Path: path,
 			},
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3652,7 +3636,6 @@ func gctScriptStatus(c *cli.Context) error {
 
 	executeCommand, err := client.GCTScriptStatus(c.Context,
 		&gctrpc.GCTScriptStatusRequest{})
-
 	if err != nil {
 		return err
 	}
@@ -3671,7 +3654,6 @@ func gctScriptList(c *cli.Context) error {
 
 	executeCommand, err := client.GCTScriptListAll(c.Context,
 		&gctrpc.GCTScriptListAllRequest{})
-
 	if err != nil {
 		return err
 	}
@@ -3702,7 +3684,6 @@ func gctScriptStop(c *cli.Context) error {
 		&gctrpc.GCTScriptStopRequest{
 			Script: &gctrpc.GCTScript{Uuid: uuid},
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3721,7 +3702,6 @@ func gctScriptStopAll(c *cli.Context) error {
 
 	executeCommand, err := client.GCTScriptStopAll(c.Context,
 		&gctrpc.GCTScriptStopAllRequest{})
-
 	if err != nil {
 		return err
 	}
@@ -3754,7 +3734,6 @@ func gctScriptRead(c *cli.Context) error {
 				Name: uuid,
 			},
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3787,7 +3766,6 @@ func gctScriptQuery(c *cli.Context) error {
 				Uuid: uuid,
 			},
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3856,7 +3834,6 @@ func gctScriptUpload(c *cli.Context) error {
 			Archived:   archived,
 			Overwrite:  overwrite,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -3869,46 +3846,48 @@ const klineMessage = `interval in seconds. supported values are: 15, 60(1min), 1
 		900(15min) 1800(30min), 3600(1h), 7200(2h), 14400(4h), 21600(6h), 28800(8h), 43200(12h),
 		86400(1d), 259200(3d) 604800(1w), 1209600(2w), 1296000(15d), 2592000(1M), 31536000(1Y)`
 
-var candleRangeSize, candleGranularity int64
-var getHistoricCandlesCommand = &cli.Command{
-	Name:      "gethistoriccandles",
-	Usage:     "gets historical candles for the specified granularity up to range size time from now.",
-	ArgsUsage: "<exchange> <pair> <asset> <rangesize> <granularity>",
-	Action:    getHistoricCandles,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "exchange",
-			Aliases: []string{"e"},
-			Usage:   "the exchange to get the candles from",
+var (
+	candleRangeSize, candleGranularity int64
+	getHistoricCandlesCommand          = &cli.Command{
+		Name:      "gethistoriccandles",
+		Usage:     "gets historical candles for the specified granularity up to range size time from now.",
+		ArgsUsage: "<exchange> <pair> <asset> <rangesize> <granularity>",
+		Action:    getHistoricCandles,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "exchange",
+				Aliases: []string{"e"},
+				Usage:   "the exchange to get the candles from",
+			},
+			&cli.StringFlag{
+				Name:  "pair",
+				Usage: "the currency pair to get the candles for",
+			},
+			&cli.StringFlag{
+				Name:  "asset",
+				Usage: "the asset type of the currency pair",
+			},
+			&cli.Int64Flag{
+				Name:        "rangesize",
+				Aliases:     []string{"r"},
+				Usage:       "the amount of time to go back from now to fetch candles in the given granularity",
+				Value:       10,
+				Destination: &candleRangeSize,
+			},
+			&cli.Int64Flag{
+				Name:        "granularity",
+				Aliases:     []string{"g"},
+				Usage:       klineMessage,
+				Value:       86400,
+				Destination: &candleGranularity,
+			},
+			&cli.BoolFlag{
+				Name:  "fillmissingdatawithtrades, fill",
+				Usage: "will create candles for missing intervals using stored trade data <true/false>",
+			},
 		},
-		&cli.StringFlag{
-			Name:  "pair",
-			Usage: "the currency pair to get the candles for",
-		},
-		&cli.StringFlag{
-			Name:  "asset",
-			Usage: "the asset type of the currency pair",
-		},
-		&cli.Int64Flag{
-			Name:        "rangesize",
-			Aliases:     []string{"r"},
-			Usage:       "the amount of time to go back from now to fetch candles in the given granularity",
-			Value:       10,
-			Destination: &candleRangeSize,
-		},
-		&cli.Int64Flag{
-			Name:        "granularity",
-			Aliases:     []string{"g"},
-			Usage:       klineMessage,
-			Value:       86400,
-			Destination: &candleGranularity,
-		},
-		&cli.BoolFlag{
-			Name:  "fillmissingdatawithtrades, fill",
-			Usage: "will create candles for missing intervals using stored trade data <true/false>",
-		},
-	},
-}
+	}
+)
 
 func getHistoricCandles(c *cli.Context) error {
 	if c.NArg() == 0 && c.NumFlags() == 0 {

--- a/cmd/gctcli/currency_state_management.go
+++ b/cmd/gctcli/currency_state_management.go
@@ -148,7 +148,8 @@ func stateGetDeposit(c *cli.Context) error {
 		&gctrpc.CurrencyStateDepositRequest{
 			Exchange: exchange,
 			Code:     code,
-			Asset:    a},
+			Asset:    a,
+		},
 	)
 	if err != nil {
 		return err
@@ -195,7 +196,8 @@ func stateGetWithdrawal(c *cli.Context) error {
 		&gctrpc.CurrencyStateWithdrawRequest{
 			Exchange: exchange,
 			Code:     code,
-			Asset:    a},
+			Asset:    a,
+		},
 	)
 	if err != nil {
 		return err
@@ -242,7 +244,8 @@ func stateGetTrading(c *cli.Context) error {
 		&gctrpc.CurrencyStateTradingRequest{
 			Exchange: exchange,
 			Code:     code,
-			Asset:    a},
+			Asset:    a,
+		},
 	)
 	if err != nil {
 		return err
@@ -289,7 +292,8 @@ func stateGetPairTrading(c *cli.Context) error {
 		&gctrpc.CurrencyStateTradingPairRequest{
 			Exchange: exchange,
 			Pair:     pair,
-			Asset:    a},
+			Asset:    a,
+		},
 	)
 	if err != nil {
 		return err

--- a/cmd/gctcli/main.go
+++ b/cmd/gctcli/main.go
@@ -49,7 +49,8 @@ func setupClient(c *cli.Context) (*grpc.ClientConn, context.CancelFunc, error) {
 		return nil, nil, err
 	}
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds),
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
 		grpc.WithPerRPCCredentials(auth.BasicAuth{
 			Username: username,
 			Password: password,

--- a/cmd/gctcli/orderbook.go
+++ b/cmd/gctcli/orderbook.go
@@ -131,7 +131,6 @@ func getNominal(c *cli.Context) error {
 			Sell:              isSelling,
 			NominalPercentage: percentage,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -217,7 +216,6 @@ func getImpact(c *cli.Context) error {
 			Sell:             isSelling,
 			ImpactPercentage: percentage,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -341,7 +339,6 @@ func getMovement(c *cli.Context) error {
 		Amount:   amount,
 		Purchase: c.Bool("purchase"),
 	})
-
 	if err != nil {
 		return err
 	}
@@ -447,7 +444,6 @@ func getOrderbook(c *cli.Context) error {
 			AssetType: assetType,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -594,7 +590,6 @@ func getOrderbookStream(c *cli.Context) error {
 			AssetType: assetType,
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -731,7 +726,6 @@ func getExchangeOrderbookStream(c *cli.Context) error {
 		&gctrpc.GetExchangeOrderbookStreamRequest{
 			Exchange: exchangeName,
 		})
-
 	if err != nil {
 		return err
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -41,10 +41,8 @@ const (
 	NumberCharacters = "0123456789"
 )
 
-var (
-	// emailRX represents email address matching pattern
-	emailRX = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-)
+// emailRX represents email address matching pattern
+var emailRX = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
 // Vars for common.go operations
 var (
@@ -136,7 +134,8 @@ func NewHTTPClientWithTimeout(t time.Duration) *http.Client {
 	}
 	h := &http.Client{
 		Transport: tr,
-		Timeout:   t}
+		Timeout:   t,
+	}
 	return h
 }
 

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -71,8 +71,8 @@ func TestGetRandomSalt(t *testing.T) {
 
 func TestGetMD5(t *testing.T) {
 	t.Parallel()
-	var originalString = []byte("I am testing the MD5 function in common!")
-	var expectedOutput = []byte("18fddf4a41ba90a7352765e62e7a8744")
+	originalString := []byte("I am testing the MD5 function in common!")
+	expectedOutput := []byte("18fddf4a41ba90a7352765e62e7a8744")
 	actualOutput, err := GetMD5(originalString)
 	if err != nil {
 		t.Fatal(err)
@@ -86,8 +86,8 @@ func TestGetMD5(t *testing.T) {
 
 func TestGetSHA512(t *testing.T) {
 	t.Parallel()
-	var originalString = []byte("I am testing the GetSHA512 function in common!")
-	var expectedOutput = []byte(
+	originalString := []byte("I am testing the GetSHA512 function in common!")
+	expectedOutput := []byte(
 		`a2273f492ea73fddc4f25c267b34b3b74998bd8a6301149e1e1c835678e3c0b90859fce22e4e7af33bde1711cbb924809aedf5d759d648d61774b7185c5dc02b`,
 	)
 	actualOutput, err := GetSHA512(originalString)
@@ -103,8 +103,8 @@ func TestGetSHA512(t *testing.T) {
 
 func TestGetSHA256(t *testing.T) {
 	t.Parallel()
-	var originalString = []byte("I am testing the GetSHA256 function in common!")
-	var expectedOutput = []byte(
+	originalString := []byte("I am testing the GetSHA256 function in common!")
+	expectedOutput := []byte(
 		"0962813d7a9f739cdcb7f0c0be0c2a13bd630167e6e54468266e4af6b1ad9303",
 	)
 	actualOutput, err := GetSHA256(originalString)

--- a/common/file/archive/zip.go
+++ b/common/file/archive/zip.go
@@ -17,9 +17,7 @@ const (
 	ErrUnableToCloseFile string = "Unable to close file %v %v"
 )
 
-var (
-	addFilesToZip func(z *zip.Writer, src string, isDir bool) error
-)
+var addFilesToZip func(z *zip.Writer, src string, isDir bool) error
 
 func init() {
 	addFilesToZip = addFilesToZipWrapper

--- a/communications/base/base_test.go
+++ b/communications/base/base_test.go
@@ -5,9 +5,7 @@ import (
 	"time"
 )
 
-var (
-	b Base
-)
+var b Base
 
 func TestStart(_ *testing.T) {
 	b = Base{
@@ -100,7 +98,8 @@ func TestSetup(t *testing.T) {
 	for _, config := range testConfigs {
 		config.provider = &CommunicationProvider{
 			isEnabled:   config.isEnabled,
-			isConnected: config.isConnected}
+			isConnected: config.isConnected,
+		}
 		ic = append(ic, config.provider)
 	}
 
@@ -134,7 +133,8 @@ func TestPushEvent(t *testing.T) {
 	for _, config := range testConfigs {
 		config.provider = &CommunicationProvider{
 			isEnabled:   config.Enabled,
-			isConnected: config.Connected}
+			isConnected: config.Connected,
+		}
 		ic = append(ic, config.provider)
 	}
 

--- a/communications/slack/slack.go
+++ b/communications/slack/slack.go
@@ -295,6 +295,7 @@ func (s *Slack) handleMessageResponse(resp []byte, data WebsocketResponse) error
 	}
 	return nil
 }
+
 func (s *Slack) handleErrorResponse(data WebsocketResponse) error {
 	if data.Error.Msg == "Socket URL has expired" {
 		if s.Verbose {

--- a/config/versions/v0.go
+++ b/config/versions/v0.go
@@ -6,8 +6,7 @@ import (
 
 // Version0 is a baseline version with no changes, so we can downgrade back to nothing
 // It does not implement any upgrade interfaces
-type Version0 struct {
-}
+type Version0 struct{}
 
 func init() {
 	Manager.registerVersion(0, &Version0{})

--- a/config/versions/v1.go
+++ b/config/versions/v1.go
@@ -10,8 +10,7 @@ import (
 )
 
 // Version1 is an ExchangeVersion to upgrade currency pair format for exchanges
-type Version1 struct {
-}
+type Version1 struct{}
 
 func init() {
 	Manager.registerVersion(1, &Version1{})

--- a/config/versions/v4.go
+++ b/config/versions/v4.go
@@ -16,8 +16,7 @@ var (
 )
 
 // Version4 is an Exchange upgrade to move currencyPairs.assetTypes to currencyPairs.pairs.*.assetEnabled
-type Version4 struct {
-}
+type Version4 struct{}
 
 func init() {
 	Manager.registerVersion(4, &Version4{})
@@ -40,7 +39,7 @@ func (v *Version4) UpgradeExchange(_ context.Context, e []byte) ([]byte, error) 
 		return e, fmt.Errorf("%w: %w", errUpgradingAssetTypes, err)
 	}
 
-	assetEnabledFn := func(assetBytes []byte, v []byte, _ jsonparser.ValueType, _ int) (err error) {
+	assetEnabledFn := func(assetBytes, v []byte, _ jsonparser.ValueType, _ int) (err error) {
 		asset := string(assetBytes)
 		if toEnable[asset] {
 			e, err = jsonparser.Set(e, []byte(`true`), "currencyPairs", "pairs", asset, "assetEnabled")
@@ -70,7 +69,7 @@ func (v *Version4) UpgradeExchange(_ context.Context, e []byte) ([]byte, error) 
 func (v *Version4) DowngradeExchange(_ context.Context, e []byte) ([]byte, error) {
 	assetTypes := []string{}
 
-	assetEnabledFn := func(asset []byte, v []byte, _ jsonparser.ValueType, _ int) error {
+	assetEnabledFn := func(asset, v []byte, _ jsonparser.ValueType, _ int) error {
 		if b, err := jsonparser.GetBoolean(v, "assetEnabled"); err == nil {
 			if b {
 				assetTypes = append(assetTypes, fmt.Sprintf("%q", asset))

--- a/config/versions/v4_test.go
+++ b/config/versions/v4_test.go
@@ -81,7 +81,7 @@ func TestVersion4Downgrade(t *testing.T) {
 	require.Equal(t, jsonparser.Array, vT, "assetTypes must be an array")
 	require.Equal(t, `["spot","options_combo"]`, string(v), "assetTypes must be correct")
 
-	assetEnabledFn := func(k []byte, v []byte, _ jsonparser.ValueType, _ int) error {
+	assetEnabledFn := func(k, v []byte, _ jsonparser.ValueType, _ int) error {
 		_, err = jsonparser.GetBoolean(v, "assetEnabled")
 		require.ErrorIsf(t, err, jsonparser.KeyPathNotFoundError, "assetEnabled must be removed from %s", k)
 		return nil

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -73,7 +73,7 @@ func TestRoleUnmarshalJSON(t *testing.T) {
 		RoleUnknown Role `json:"RoleUnknown"`
 	}
 
-	var outgoing = AllTheRoles{
+	outgoing := AllTheRoles{
 		RoleOne:   Unset,
 		RoleTwo:   Cryptocurrency,
 		RoleThree: Fiat,

--- a/currency/coinmarketcap/coinmarketcap.go
+++ b/currency/coinmarketcap/coinmarketcap.go
@@ -696,7 +696,8 @@ func (c *Coinmarketcap) SendHTTPRequest(method, endpoint string, v url.Values, r
 		Path:    path,
 		Headers: headers,
 		Result:  result,
-		Verbose: c.Verbose}
+		Verbose: c.Verbose,
+	}
 	return c.Requester.SendPayload(context.TODO(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, request.AuthenticatedRequest)

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -112,7 +112,7 @@ func CopyPairFormat(p Pair, pairs []Pair, exact bool) Pair {
 
 // FormatPairs formats a string array to a list of currency pairs with the supplied currency pair format
 func FormatPairs(pairs []string, delimiter string) (Pairs, error) {
-	var result = make(Pairs, len(pairs))
+	result := make(Pairs, len(pairs))
 	for x := range pairs {
 		if pairs[x] == "" {
 			return nil, fmt.Errorf("%w in slice %v", errEmptyPairString, pairs)

--- a/currency/forexprovider/base/base_interface.go
+++ b/currency/forexprovider/base/base_interface.go
@@ -70,7 +70,7 @@ func (p Provider) CheckCurrencies(currencies []string) []string {
 
 // GetCurrencyData returns currency data from enabled FX providers
 func (f *FXHandler) GetCurrencyData(baseCurrency string, currencies []string) (map[string]float64, error) {
-	var fullRange = currencies
+	fullRange := currencies
 
 	if !common.StringSliceCompareInsensitive(currencies, baseCurrency) {
 		fullRange = append(fullRange, baseCurrency)

--- a/currency/forexprovider/currencyconverterapi/currencyconverterapi.go
+++ b/currency/forexprovider/currencyconverterapi/currencyconverterapi.go
@@ -165,11 +165,11 @@ func (c *CurrencyConverter) SendHTTPRequest(endPoint string, values url.Values, 
 	item := &request.Item{
 		Method:  path,
 		Result:  result,
-		Verbose: c.Verbose}
+		Verbose: c.Verbose,
+	}
 	err := c.Requester.SendPayload(context.TODO(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, auth)
-
 	if err != nil {
 		return fmt.Errorf("currency converter API SendHTTPRequest error %s with path %s",
 			err,

--- a/currency/forexprovider/currencyconverterapi/currencyconverterapi_test.go
+++ b/currency/forexprovider/currencyconverterapi/currencyconverterapi_test.go
@@ -51,6 +51,7 @@ func TestGetRates(t *testing.T) {
 		t.Fatal("Test error. Expected 4 rates")
 	}
 }
+
 func TestConvertMany(t *testing.T) {
 	if !IsAPIKeysSet() {
 		t.Skip("API keys unset, skipping")

--- a/currency/forexprovider/currencylayer/currencylayer.go
+++ b/currency/forexprovider/currencylayer/currencylayer.go
@@ -210,7 +210,8 @@ func (c *CurrencyLayer) SendHTTPRequest(endPoint string, values url.Values, resu
 		Method:  http.MethodGet,
 		Path:    path,
 		Result:  &result,
-		Verbose: c.Verbose}
+		Verbose: c.Verbose,
+	}
 	return c.Requester.SendPayload(context.TODO(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, auth)

--- a/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
+++ b/currency/forexprovider/exchangeratesapi.io/exchangeratesapi.go
@@ -47,7 +47,7 @@ func (e *ExchangeRates) cleanCurrencies(baseCurrency, symbols string) string {
 	}
 
 	symbols = strings.Replace(symbols, "RUR", "RUB", -1)
-	var s = strings.Split(symbols, ",")
+	s := strings.Split(symbols, ",")
 	cleanedCurrencies := make([]string, 0, len(s))
 	for _, x := range s {
 		// first make sure that the baseCurrency is not in the symbols list

--- a/currency/forexprovider/fixer.io/fixer.go
+++ b/currency/forexprovider/fixer.io/fixer.go
@@ -238,7 +238,8 @@ func (f *Fixer) SendOpenHTTPRequest(endpoint string, v url.Values, result interf
 		Method:  http.MethodGet,
 		Path:    path,
 		Result:  &result,
-		Verbose: f.Verbose}
+		Verbose: f.Verbose,
+	}
 	return f.Requester.SendPayload(context.Background(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, auth)

--- a/currency/forexprovider/openexchangerates/openexchangerates.go
+++ b/currency/forexprovider/openexchangerates/openexchangerates.go
@@ -222,7 +222,8 @@ func (o *OXR) SendHTTPRequest(endpoint string, values url.Values, result interfa
 		Method:  http.MethodGet,
 		Path:    path,
 		Result:  result,
-		Verbose: o.Verbose}
+		Verbose: o.Verbose,
+	}
 	return o.Requester.SendPayload(context.TODO(), request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, request.AuthenticatedRequest)

--- a/currency/manager_test.go
+++ b/currency/manager_test.go
@@ -508,7 +508,7 @@ func TestAssetEnabled(t *testing.T) {
 // TestFullStoreUnmarshalMarshal tests json Mashal and Unmarshal
 func TestFullStoreUnmarshalMarshal(t *testing.T) {
 	t.Parallel()
-	var um = make(FullStore)
+	um := make(FullStore)
 	um[asset.Spot] = &PairStore{AssetEnabled: true}
 
 	data, err := json.Marshal(um)

--- a/currency/mock_provider_test.go
+++ b/currency/mock_provider_test.go
@@ -30,6 +30,7 @@ func (m *MockProvider) IsPrimaryProvider() bool   { return true }
 func (m *MockProvider) GetSupportedCurrencies() ([]string, error) {
 	return storage.defaultFiatCurrencies.Strings(), nil
 }
+
 func (m *MockProvider) GetRates(baseCurrency, symbols string) (map[string]float64, error) {
 	c := map[string]float64{}
 	for _, s := range strings.Split(symbols, ",") {

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -386,7 +386,7 @@ func (p Pairs) GetStables() Currencies {
 // currencyConstructor takes in an item map and returns the currencies with
 // the same formatting.
 func currencyConstructor(m map[*Item]bool) Currencies {
-	var cryptos = make([]Code, len(m))
+	cryptos := make([]Code, len(m))
 	var target int
 	for code, upper := range m {
 		cryptos[target].Item = code

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -65,10 +65,12 @@ func TestPairsFromString(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 
-	expected := []string{"ALGO-AUD", "BAT-AUD", "BCH-AUD", "BSV-AUD", "BTC-AUD",
+	expected := []string{
+		"ALGO-AUD", "BAT-AUD", "BCH-AUD", "BSV-AUD", "BTC-AUD",
 		"COMP-AUD", "ENJ-AUD", "ETC-AUD", "ETH-AUD", "ETH-BTC", "GNT-AUD",
 		"LINK-AUD", "LTC-AUD", "LTC-BTC", "MCAU-AUD", "OMG-AUD", "POWR-AUD",
-		"UNI-AUD", "USDT-AUD", "XLM-AUD", "XRP-AUD", "XRP-BTC"}
+		"UNI-AUD", "USDT-AUD", "XLM-AUD", "XRP-AUD", "XRP-BTC",
+	}
 
 	returned := pairs.Strings()
 	for x := range returned {
@@ -168,7 +170,7 @@ func TestPairsMarshalJSON(t *testing.T) {
 
 func TestRemovePairsByFilter(t *testing.T) {
 	t.Parallel()
-	var pairs = Pairs{
+	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(LTC, USDT),
@@ -182,7 +184,7 @@ func TestRemovePairsByFilter(t *testing.T) {
 
 func TestGetPairsByFilter(t *testing.T) {
 	t.Parallel()
-	var pairs = Pairs{
+	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(LTC, USDT),
@@ -197,7 +199,7 @@ func TestGetPairsByFilter(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	t.Parallel()
-	var oldPairs = Pairs{
+	oldPairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(LTC, USDT),
@@ -241,7 +243,7 @@ func TestAdd(t *testing.T) {
 
 func TestContains(t *testing.T) {
 	t.Parallel()
-	var pairs = Pairs{
+	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(USD, ZRX),
@@ -266,7 +268,7 @@ func TestContains(t *testing.T) {
 
 func TestContainsAll(t *testing.T) {
 	t.Parallel()
-	var pairs = Pairs{
+	pairs := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(USD, ZRX),
@@ -307,7 +309,7 @@ func TestContainsAll(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 
-	var duplication = Pairs{
+	duplication := Pairs{
 		NewPair(BTC, USD),
 		NewPair(LTC, USD),
 		NewPair(USD, ZRX),
@@ -326,7 +328,7 @@ func TestDeriveFrom(t *testing.T) {
 	if !errors.Is(err, ErrCurrencyPairsEmpty) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, ErrCurrencyPairsEmpty)
 	}
-	var testCases = Pairs{
+	testCases := Pairs{
 		NewPair(BTC, USDT),
 		NewPair(USDC, USDT),
 		NewPair(USDC, USD),
@@ -700,7 +702,8 @@ func TestValidateAndConform(t *testing.T) {
 
 	formatted, err = formatted.ValidateAndConform(PairFormat{
 		Delimiter: UnderscoreDelimiter,
-		Uppercase: false},
+		Uppercase: false,
+	},
 		true)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected '%v'", err, nil)

--- a/database/repository/audit/audit.go
+++ b/database/repository/audit/audit.go
@@ -29,14 +29,14 @@ func Event(id, msgtype, message string) {
 	}
 
 	if repository.GetSQLDialect() == database.DBSQLite3 {
-		var tempEvent = modelSQLite.AuditEvent{
+		tempEvent := modelSQLite.AuditEvent{
 			Type:       msgtype,
 			Identifier: id,
 			Message:    message,
 		}
 		err = tempEvent.Insert(ctx, tx, boil.Blacklist("created_at"))
 	} else {
-		var tempEvent = modelPSQL.AuditEvent{
+		tempEvent := modelPSQL.AuditEvent{
 			Type:       msgtype,
 			Identifier: id,
 			Message:    message,

--- a/database/repository/candle/candle.go
+++ b/database/repository/candle/candle.go
@@ -219,7 +219,7 @@ func Insert(in *Item) (uint64, error) {
 func insertSQLite(ctx context.Context, tx *sql.Tx, in *Item) (uint64, error) {
 	var totalInserted uint64
 	for x := range in.Candles {
-		var tempCandle = modelSQLite.Candle{
+		tempCandle := modelSQLite.Candle{
 			ExchangeNameID: in.ExchangeID,
 			Base:           strings.ToUpper(in.Base),
 			Quote:          strings.ToUpper(in.Quote),
@@ -254,7 +254,7 @@ func insertSQLite(ctx context.Context, tx *sql.Tx, in *Item) (uint64, error) {
 func insertPostgresSQL(ctx context.Context, tx *sql.Tx, in *Item) (uint64, error) {
 	var totalInserted uint64
 	for x := range in.Candles {
-		var tempCandle = modelPSQL.Candle{
+		tempCandle := modelPSQL.Candle{
 			ExchangeNameID: in.ExchangeID,
 			Base:           strings.ToUpper(in.Base),
 			Quote:          strings.ToUpper(in.Quote),

--- a/database/repository/datahistoryjob/datahistoryjob.go
+++ b/database/repository/datahistoryjob/datahistoryjob.go
@@ -246,7 +246,7 @@ func upsertSqlite(ctx context.Context, tx *sql.Tx, jobs ...*DataHistoryJob) erro
 		if jobs[i].ReplaceOnIssue {
 			replaceOnIssue = 1
 		}
-		var tempEvent = sqlite3.Datahistoryjob{
+		tempEvent := sqlite3.Datahistoryjob{
 			ID:                       jobs[i].ID,
 			ExchangeNameID:           exch.ID,
 			Nickname:                 strings.ToLower(jobs[i].Nickname),
@@ -297,7 +297,7 @@ func upsertPostgres(ctx context.Context, tx *sql.Tx, jobs ...*DataHistoryJob) er
 			}
 		}
 
-		var tempEvent = postgres.Datahistoryjob{
+		tempEvent := postgres.Datahistoryjob{
 			ID:                       jobs[i].ID,
 			Nickname:                 strings.ToLower(jobs[i].Nickname),
 			ExchangeNameID:           exch.ID,
@@ -330,6 +330,7 @@ func upsertPostgres(ctx context.Context, tx *sql.Tx, jobs ...*DataHistoryJob) er
 
 	return nil
 }
+
 func (db *DBService) getByNicknameSQLite(nickname string) (*DataHistoryJob, error) {
 	result, err := sqlite3.Datahistoryjobs(qm.Where("nickname = ?", strings.ToLower(nickname))).One(context.TODO(), db.sql)
 	if err != nil {

--- a/database/repository/datahistoryjobresult/datahistoryjobresult.go
+++ b/database/repository/datahistoryjobresult/datahistoryjobresult.go
@@ -116,7 +116,7 @@ func upsertSqlite(ctx context.Context, tx *sql.Tx, results ...*DataHistoryJobRes
 			results[i].ID = freshUUID.String()
 		}
 
-		var tempEvent = sqlite3.Datahistoryjobresult{
+		tempEvent := sqlite3.Datahistoryjobresult{
 			ID:                results[i].ID,
 			JobID:             results[i].JobID,
 			Result:            null.NewString(results[i].Result, results[i].Result != ""),
@@ -145,7 +145,7 @@ func upsertPostgres(ctx context.Context, tx *sql.Tx, results ...*DataHistoryJobR
 			}
 			results[i].ID = freshUUID.String()
 		}
-		var tempEvent = postgres.Datahistoryjobresult{
+		tempEvent := postgres.Datahistoryjobresult{
 			ID:                results[i].ID,
 			JobID:             results[i].JobID,
 			Result:            null.NewString(results[i].Result, results[i].Result != ""),

--- a/database/repository/exchange/exchange.go
+++ b/database/repository/exchange/exchange.go
@@ -138,7 +138,7 @@ func insertSQLite(ctx context.Context, tx *sql.Tx, in []Details) (err error) {
 		if errUUID != nil {
 			return errUUID
 		}
-		var tempInsert = modelSQLite.Exchange{
+		tempInsert := modelSQLite.Exchange{
 			Name: strings.ToLower(in[x].Name),
 			ID:   tempUUID.String(),
 		}
@@ -158,7 +158,7 @@ func insertSQLite(ctx context.Context, tx *sql.Tx, in []Details) (err error) {
 
 func insertPostgresql(ctx context.Context, tx *sql.Tx, in []Details) (err error) {
 	for x := range in {
-		var tempInsert = modelPSQL.Exchange{
+		tempInsert := modelPSQL.Exchange{
 			Name: strings.ToLower(in[x].Name),
 		}
 

--- a/database/repository/script/script.go
+++ b/database/repository/script/script.go
@@ -39,7 +39,7 @@ func Event(id, name, path string, data null.Bytes, executionType, status string,
 			}
 			return
 		}
-		var tempEvent = modelSQLite.Script{}
+		tempEvent := modelSQLite.Script{}
 		if !f {
 			newUUID, errUUID := uuid.NewV4()
 			if errUUID != nil {
@@ -82,7 +82,7 @@ func Event(id, name, path string, data null.Bytes, executionType, status string,
 			return
 		}
 	} else {
-		var tempEvent = modelPSQL.Script{
+		tempEvent := modelPSQL.Script{
 			ScriptID:   id,
 			ScriptName: name,
 			ScriptPath: path,

--- a/database/repository/script/script_test.go
+++ b/database/repository/script/script_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/volatiletech/null"
 )
 
-var (
-	verbose = false
-)
+var verbose = false
 
 func TestMain(m *testing.M) {
 	var err error

--- a/database/repository/trade/trade.go
+++ b/database/repository/trade/trade.go
@@ -154,7 +154,7 @@ func insertSQLite(ctx context.Context, tx *sql.Tx, trades ...Data) error {
 			}
 			trades[i].ID = freshUUID.String()
 		}
-		var tempEvent = sqlite3.Trade{
+		tempEvent := sqlite3.Trade{
 			ID:             trades[i].ID,
 			ExchangeNameID: trades[i].ExchangeNameID,
 			Base:           strings.ToUpper(trades[i].Base),
@@ -190,7 +190,7 @@ func insertPostgres(ctx context.Context, tx *sql.Tx, trades ...Data) error {
 			}
 			trades[i].ID = freshUUID.String()
 		}
-		var tempEvent = postgres.Trade{
+		tempEvent := postgres.Trade{
 			ExchangeNameID: trades[i].ExchangeNameID,
 			Base:           strings.ToUpper(trades[i].Base),
 			Quote:          strings.ToUpper(trades[i].Quote),

--- a/database/repository/withdraw/withdraw.go
+++ b/database/repository/withdraw/withdraw.go
@@ -63,7 +63,7 @@ func Event(res *withdraw.Response) {
 }
 
 func addPSQLEvent(ctx context.Context, tx *sql.Tx, res *withdraw.Response) (err error) {
-	var tempEvent = modelPSQL.WithdrawalHistory{
+	tempEvent := modelPSQL.WithdrawalHistory{
 		ExchangeNameID: res.Exchange.Name,
 		ExchangeID:     res.Exchange.ID,
 		Status:         res.Exchange.Status,
@@ -143,7 +143,7 @@ func addSQLiteEvent(ctx context.Context, tx *sql.Tx, res *withdraw.Response) (er
 		return
 	}
 
-	var tempEvent = modelSQLite.WithdrawalHistory{
+	tempEvent := modelSQLite.WithdrawalHistory{
 		ID:             newUUID.String(),
 		ExchangeNameID: res.Exchange.Name,
 		ExchangeID:     res.Exchange.ID,
@@ -289,14 +289,14 @@ func getByColumns(q []qm.QueryMod) ([]*withdraw.Response, error) {
 	}
 
 	var resp []*withdraw.Response
-	var ctx = context.Background()
+	ctx := context.Background()
 	if repository.GetSQLDialect() == database.DBSQLite3 {
 		v, err := modelSQLite.WithdrawalHistories(q...).All(ctx, database.DB.SQL)
 		if err != nil {
 			return nil, err
 		}
 		for x := range v {
-			var tempResp = &withdraw.Response{}
+			tempResp := &withdraw.Response{}
 			var newUUID uuid.UUID
 			newUUID, err = uuid.FromString(v[x].ID)
 			if err != nil {
@@ -369,7 +369,7 @@ func getByColumns(q []qm.QueryMod) ([]*withdraw.Response, error) {
 		}
 
 		for x := range v {
-			var tempResp = &withdraw.Response{}
+			tempResp := &withdraw.Response{}
 			newUUID, _ := uuid.FromString(v[x].ID)
 			tempResp.ID = newUUID
 			tempResp.Exchange.ID = v[x].ExchangeID

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -265,7 +265,7 @@ func TestMux(t *testing.T) {
 	pipe, err := mux.Subscribe(id)
 	require.NoError(t, err, "Subscribe should not error")
 
-	var ready = make(chan bool)
+	ready := make(chan bool)
 
 	payload := "string"
 

--- a/engine/currency_state_manager.go
+++ b/engine/currency_state_manager.go
@@ -188,7 +188,7 @@ func (c *CurrencyStateManager) GetAllRPC(exchName string) (*gctrpc.CurrencyState
 		return nil, err
 	}
 
-	var resp = &gctrpc.CurrencyStateResponse{}
+	resp := &gctrpc.CurrencyStateResponse{}
 	for x := range sh {
 		resp.CurrencyStates = append(resp.CurrencyStates, &gctrpc.CurrencyState{
 			Currency:        sh[x].Code.String(),

--- a/engine/currency_state_manager_test.go
+++ b/engine/currency_state_manager_test.go
@@ -158,7 +158,8 @@ func TestCurrencyStateManagerIsRunning(t *testing.T) {
 	man := &CurrencyStateManager{
 		shutdown:         make(chan struct{}),
 		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-		sleep:            time.Minute}
+		sleep:            time.Minute,
+	}
 	err = man.Start()
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -923,7 +923,8 @@ func createDHM(t *testing.T) (*DataHistoryManager, *datahistoryjob.DataHistoryJo
 	b.CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
 		Available:    currency.Pairs{cp, cp2},
 		Enabled:      currency.Pairs{cp, cp2},
-		AssetEnabled: true}
+		AssetEnabled: true,
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)

--- a/engine/datahistory_manager_types.go
+++ b/engine/datahistory_manager_types.go
@@ -16,8 +16,10 @@ import (
 
 const dataHistoryManagerName = "data_history_manager"
 
-type dataHistoryStatus int64
-type dataHistoryDataType int64
+type (
+	dataHistoryStatus   int64
+	dataHistoryDataType int64
+)
 
 // Data type descriptors
 const (

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -211,8 +211,9 @@ func TestUnloadExchange(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	e := &Engine{ExchangeManager: em,
-		Config: &config.Config{Exchanges: []config.Exchange{{Name: testExchange}}},
+	e := &Engine{
+		ExchangeManager: em,
+		Config:          &config.Config{Exchanges: []config.Exchange{{Name: testExchange}}},
 	}
 	err = e.UnloadExchange("asdf")
 	if !errors.Is(err, config.ErrExchangeNotFound) {

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -430,7 +430,7 @@ func IsRelatablePairs(p1, p2 currency.Pair, includeUSDT bool) bool {
 		return true
 	}
 
-	var relatablePairs = GetRelatableCurrencies(p1, true, includeUSDT)
+	relatablePairs := GetRelatableCurrencies(p1, true, includeUSDT)
 	if p1.IsCryptoFiatPair() {
 		for x := range relatablePairs {
 			relatablePairs = append(relatablePairs,

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -89,7 +89,8 @@ func CreateTestBot(tb testing.TB) *Engine {
 					Pairs:           pairs2,
 				},
 			},
-		}}}
+		}},
+	}
 	err := bot.LoadExchange(testExchange)
 	assert.NoError(tb, err, "LoadExchange should not error")
 
@@ -193,12 +194,14 @@ func TestSetSubsystem(t *testing.T) { //nolint // TO-DO: Fix race t.Parallel() u
 			Subsystem:    grpcName,
 			Engine:       &Engine{Config: &config.Config{}},
 			EnableError:  errGRPCManagementFault,
-			DisableError: errGRPCManagementFault},
+			DisableError: errGRPCManagementFault,
+		},
 		{
 			Subsystem:    grpcProxyName,
 			Engine:       &Engine{Config: &config.Config{}},
 			EnableError:  errGRPCManagementFault,
-			DisableError: errGRPCManagementFault},
+			DisableError: errGRPCManagementFault,
+		},
 		{
 			Subsystem:    dataHistoryManagerName,
 			Engine:       &Engine{Config: &config.Config{}},
@@ -677,7 +680,7 @@ func TestMapCurrenciesByExchange(t *testing.T) {
 	t.Parallel()
 	e := CreateTestBot(t)
 
-	var pairs = []currency.Pair{
+	pairs := []currency.Pair{
 		currency.NewPair(currency.BTC, currency.USD),
 		currency.NewPair(currency.BTC, currency.EUR),
 	}

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -1193,7 +1193,8 @@ func TestGetFuturesPositionsForExchange(t *testing.T) {
 		Pair:      cp,
 		Side:      order.Buy,
 		Amount:    1,
-		Price:     1})
+		Price:     1,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -1240,7 +1241,8 @@ func TestClearFuturesPositionsForExchange(t *testing.T) {
 		Pair:      cp,
 		Side:      order.Buy,
 		Amount:    1,
-		Price:     1})
+		Price:     1,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -1291,7 +1293,8 @@ func TestUpdateOpenPositionUnrealisedPNL(t *testing.T) {
 		Pair:      cp,
 		Side:      order.Buy,
 		Amount:    1,
-		Price:     1})
+		Price:     1,
+	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}

--- a/engine/portfolio_manager.go
+++ b/engine/portfolio_manager.go
@@ -18,10 +18,8 @@ import (
 // PortfolioManagerName is an exported subsystem name
 const PortfolioManagerName = "portfolio"
 
-var (
-	// PortfolioSleepDelay defines the default sleep time between portfolio manager runs
-	PortfolioSleepDelay = time.Minute
-)
+// PortfolioSleepDelay defines the default sleep time between portfolio manager runs
+var PortfolioSleepDelay = time.Minute
 
 // portfolioManager routinely retrieves a user's holdings through exchange APIs as well
 // as through addresses provided in the config

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -486,7 +486,8 @@ func RPCTestSetup(t *testing.T) *Engine {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -505,7 +506,8 @@ func RPCTestSetup(t *testing.T) *Engine {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -1343,7 +1345,8 @@ func TestGetOrders(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -1453,7 +1456,8 @@ func TestGetOrder(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -1565,7 +1569,7 @@ func TestCheckVars(t *testing.T) {
 	err = checkParams("Binance", e, asset.Spot, currency.NewPair(currency.BTC, currency.USDT))
 	assert.ErrorIs(t, err, errCurrencyPairInvalid, "checkParams should error correctly")
 
-	var data = []currency.Pair{
+	data := []currency.Pair{
 		{Delimiter: currency.DashDelimiter, Base: currency.BTC, Quote: currency.USDT},
 	}
 
@@ -1584,7 +1588,7 @@ func TestCheckVars(t *testing.T) {
 
 func TestParseEvents(t *testing.T) {
 	t.Parallel()
-	var exchangeName = "Binance"
+	exchangeName := "Binance"
 	testData := make([]*withdraw.Response, 5)
 	for x := range 5 {
 		test := fmt.Sprintf("test-%v", x)
@@ -1659,7 +1663,8 @@ func TestRPCServerUpsertDataHistoryJob(t *testing.T) {
 	b.CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
 		Available:    currency.Pairs{cp},
 		Enabled:      currency.Pairs{cp},
-		AssetEnabled: true}
+		AssetEnabled: true,
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -1931,7 +1936,8 @@ func TestGetManagedOrders(t *testing.T) {
 		Enabled:       currency.Pairs{cp},
 		AssetEnabled:  true,
 		ConfigFormat:  &currency.PairFormat{Uppercase: true},
-		RequestFormat: &currency.PairFormat{Uppercase: true}}
+		RequestFormat: &currency.PairFormat{Uppercase: true},
+	}
 	err = em.Add(exch)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
@@ -2161,7 +2167,8 @@ func TestCurrencyStateWithdraw(t *testing.T) {
 		Engine: &Engine{},
 	}).CurrencyStateWithdraw(context.Background(),
 		&gctrpc.CurrencyStateWithdrawRequest{
-			Exchange: "wow", Asset: "meow"})
+			Exchange: "wow", Asset: "meow",
+		})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: %v, but expected: %v", err, asset.ErrNotSupported)
 	}
@@ -2170,7 +2177,8 @@ func TestCurrencyStateWithdraw(t *testing.T) {
 		Engine: &Engine{},
 	}).CurrencyStateWithdraw(context.Background(),
 		&gctrpc.CurrencyStateWithdrawRequest{
-			Exchange: "wow", Asset: "spot"})
+			Exchange: "wow", Asset: "spot",
+		})
 	if !errors.Is(err, ErrSubSystemNotStarted) {
 		t.Fatalf("received: %v, but expected: %v", err, ErrSubSystemNotStarted)
 	}
@@ -2244,8 +2252,10 @@ func TestCurrencyStateTradingPair(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
-	s := RPCServer{Engine: &Engine{ExchangeManager: em,
-		currencyStateManager: &CurrencyStateManager{started: 1, iExchangeManager: em}}}
+	s := RPCServer{Engine: &Engine{
+		ExchangeManager:      em,
+		currencyStateManager: &CurrencyStateManager{started: 1, iExchangeManager: em},
+	}}
 
 	_, err = s.CurrencyStateTradingPair(context.Background(),
 		&gctrpc.CurrencyStateTradingPairRequest{

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -266,6 +266,7 @@ func newCurrencyPairSyncAgent(k key.ExchangePairAsset) *currencyPairSyncAgent {
 		trackers: make([]*syncBase, SyncItemTrade+1),
 	}
 }
+
 func (m *SyncManager) add(k key.ExchangePairAsset, s syncBase) *currencyPairSyncAgent {
 	m.mux.Lock()
 	defer m.mux.Unlock()

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -122,7 +122,7 @@ func TestWebsocketRoutineManagerStop(t *testing.T) {
 }
 
 func TestWebsocketRoutineManagerHandleData(t *testing.T) {
-	var exchName = "Bitstamp"
+	exchName := "Bitstamp"
 	var wg sync.WaitGroup
 	em := NewExchangeManager()
 	exch, err := em.NewExchangeByName(exchName)
@@ -154,7 +154,7 @@ func TestWebsocketRoutineManagerHandleData(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("error '%v', expected '%v'", err, nil)
 	}
-	var orderID = "1337"
+	orderID := "1337"
 	err = m.websocketDataHandler(exchName, errors.New("error"))
 	if err == nil {
 		t.Error("Error not handled correctly")
@@ -225,7 +225,8 @@ func TestWebsocketRoutineManagerHandleData(t *testing.T) {
 	}
 
 	err = m.websocketDataHandler(exchName, stream.UnhandledMessageWarning{
-		Message: "there's an issue here's a tissue"},
+		Message: "there's an issue here's a tissue",
+	},
 	)
 	if err != nil {
 		t.Error(err)

--- a/engine/withdraw_manager_types.go
+++ b/engine/withdraw_manager_types.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 )
 
-var (
-	// ErrWithdrawRequestNotFound message to display when no record is found
-	ErrWithdrawRequestNotFound = errors.New("request not found")
-)
+// ErrWithdrawRequestNotFound message to display when no record is found
+var ErrWithdrawRequestNotFound = errors.New("request not found")
 
 // WithdrawManager is responsible for performing withdrawal requests and
 // saving them to the database

--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -230,7 +230,7 @@ func (a *Alphapoint) GetUserInfo(ctx context.Context) (UserInfo, error) {
 func (a *Alphapoint) SetUserInfo(ctx context.Context, firstName, lastName, cell2FACountryCode, cell2FAValue string, useAuthy2FA, use2FAForWithdraw bool) (UserInfoSet, error) {
 	response := UserInfoSet{}
 
-	var userInfoKVPs = []UserInfoKVP{
+	userInfoKVPs := []UserInfoKVP{
 		{
 			Key:   "FirstName",
 			Value: firstName,
@@ -562,7 +562,8 @@ func (a *Alphapoint) SendHTTPRequest(_ context.Context, ep exchange.URL, method,
 		Result:        result,
 		Verbose:       a.Verbose,
 		HTTPDebugging: a.HTTPDebugging,
-		HTTPRecording: a.HTTPRecording}
+		HTTPRecording: a.HTTPRecording,
+	}
 
 	return a.SendPayload(context.Background(), request.Unset, func() (*request.Item, error) {
 		item.Body = bytes.NewBuffer(PayloadJSON)
@@ -612,7 +613,8 @@ func (a *Alphapoint) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchan
 		NonceEnabled:  true,
 		Verbose:       a.Verbose,
 		HTTPDebugging: a.HTTPDebugging,
-		HTTPRecording: a.HTTPRecording}
+		HTTPRecording: a.HTTPRecording,
+	}
 
 	return a.SendPayload(context.Background(), request.Unset, func() (*request.Item, error) {
 		item.Body = bytes.NewBuffer(PayloadJSON)

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -412,7 +412,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -428,7 +428,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -449,7 +449,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, a, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: a.Name,
 		Pair: currency.Pair{
 			Delimiter: "_",
@@ -482,7 +482,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, a, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.BTC, currency.LTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -504,7 +504,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, a, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.BTC, currency.LTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",

--- a/exchanges/alphapoint/alphapoint_websocket.go
+++ b/exchanges/alphapoint/alphapoint_websocket.go
@@ -36,7 +36,6 @@ func (a *Alphapoint) WebsocketClient() {
 		}
 
 		err = a.WebsocketConn.WriteMessage(websocket.TextMessage, []byte(`{"messageType": "logon"}`))
-
 		if err != nil {
 			log.Errorln(log.ExchangeSys, err)
 			return

--- a/exchanges/asset/asset.go
+++ b/exchanges/asset/asset.go
@@ -75,9 +75,7 @@ const (
 	all                    = "all"
 )
 
-var (
-	supportedList = Items{Spot, Margin, CrossMargin, MarginFunding, Index, Binary, PerpetualContract, PerpetualSwap, Futures, DeliveryFutures, UpsideProfitContract, DownsideProfitContract, CoinMarginedFutures, USDTMarginedFutures, USDCMarginedFutures, Options, LinearContract, OptionCombo, FutureCombo, Spread}
-)
+var supportedList = Items{Spot, Margin, CrossMargin, MarginFunding, Index, Binary, PerpetualContract, PerpetualSwap, Futures, DeliveryFutures, UpsideProfitContract, DownsideProfitContract, CoinMarginedFutures, USDTMarginedFutures, USDCMarginedFutures, Options, LinearContract, OptionCombo, FutureCombo, Spread}
 
 // Supported returns a list of supported asset types
 func Supported() Items {

--- a/exchanges/binance/binance_cfutures.go
+++ b/exchanges/binance/binance_cfutures.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 )
@@ -256,7 +257,7 @@ func (b *Binance) GetFuturesKlineData(ctx context.Context, symbol currency.Pair,
 		params.Set("limit", strconv.FormatUint(limit, 10))
 	}
 	if !slices.Contains(validFuturesIntervals, interval) {
-		return nil, errors.New("invalid interval parsed")
+		return nil, kline.ErrInvalidInterval
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
@@ -375,7 +376,7 @@ func (b *Binance) GetContinuousKlineData(ctx context.Context, pair, contractType
 		params.Set("limit", strconv.FormatUint(limit, 10))
 	}
 	if !slices.Contains(validFuturesIntervals, interval) {
-		return nil, errors.New("invalid interval parsed")
+		return nil, kline.ErrInvalidInterval
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
@@ -490,7 +491,7 @@ func (b *Binance) GetIndexPriceKlines(ctx context.Context, pair, interval string
 		params.Set("limit", strconv.FormatUint(limit, 10))
 	}
 	if !slices.Contains(validFuturesIntervals, interval) {
-		return nil, errors.New("invalid interval parsed")
+		return nil, kline.ErrInvalidInterval
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {
@@ -609,7 +610,7 @@ func (b *Binance) GetMarkPriceKline(ctx context.Context, symbol currency.Pair, i
 		params.Set("limit", strconv.FormatUint(limit, 10))
 	}
 	if !slices.Contains(validFuturesIntervals, interval) {
-		return nil, errors.New("invalid interval parsed")
+		return nil, kline.ErrInvalidInterval
 	}
 	params.Set("interval", interval)
 	if !startTime.IsZero() && !endTime.IsZero() {

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 )
 
@@ -227,7 +228,7 @@ func (b *Binance) UKlineData(ctx context.Context, symbol currency.Pair, interval
 	}
 	params.Set("symbol", symbolValue)
 	if !slices.Contains(validFuturesIntervals, interval) {
-		return nil, errors.New("invalid interval")
+		return nil, kline.ErrInvalidInterval
 	}
 	params.Set("interval", interval)
 	if limit > 0 {

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -535,7 +535,8 @@ func (b *Binance) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTyp
 		orderbookNew, err = b.GetOrderBook(ctx,
 			OrderBookDataRequestParams{
 				Symbol: p,
-				Limit:  1000})
+				Limit:  1000,
+			})
 	case asset.USDTMarginedFutures:
 		orderbookNew, err = b.UFuturesOrderbook(ctx, p, 1000)
 	case asset.CoinMarginedFutures:

--- a/exchanges/binanceus/binanceus.go
+++ b/exchanges/binanceus/binanceus.go
@@ -114,9 +114,7 @@ const (
 	recvWindowSize5000 = 5000
 )
 
-var (
-	recvWindowSize5000String = strconv.Itoa(recvWindowSize5000)
-)
+var recvWindowSize5000String = strconv.Itoa(recvWindowSize5000)
 
 // This is a list of error Messages to be returned by binanceus endpoint methods.
 var (
@@ -1487,7 +1485,7 @@ func (bi *Binanceus) WithdrawCrypto(ctx context.Context, arg *withdraw.Request) 
 	}
 	params.Set("amount", strconv.FormatFloat(arg.Amount, 'f', 0, 64))
 	var response WithdrawalResponse
-	var er = bi.SendAuthHTTPRequest(ctx,
+	er := bi.SendAuthHTTPRequest(ctx,
 		exchange.RestSpotSupplementary,
 		http.MethodPost, applyWithdrawal,
 		params, spotDefaultRate, &response)
@@ -1717,7 +1715,8 @@ func (bi *Binanceus) GetSubAccountDepositAddress(ctx context.Context, arg SubAcc
 
 // GetSubAccountDepositHistory retrieves sub-account deposit history.
 func (bi *Binanceus) GetSubAccountDepositHistory(ctx context.Context, email string, coin currency.Code,
-	status int, startTime, endTime time.Time, limit, offset int) ([]SubAccountDepositItem, error) {
+	status int, startTime, endTime time.Time, limit, offset int,
+) ([]SubAccountDepositItem, error) {
 	params := url.Values{}
 	if !common.MatchesEmailPattern(email) {
 		return nil, errMissingSubAccountEmail
@@ -1807,7 +1806,8 @@ func (bi *Binanceus) SendAPIKeyHTTPRequest(ctx context.Context, ePath exchange.U
 		Result:        result,
 		Verbose:       bi.Verbose,
 		HTTPDebugging: bi.HTTPDebugging,
-		HTTPRecording: bi.HTTPRecording}
+		HTTPRecording: bi.HTTPRecording,
+	}
 
 	return bi.SendPayload(ctx, f, func() (*request.Item, error) {
 		return item, nil
@@ -1854,7 +1854,8 @@ func (bi *Binanceus) SendAuthHTTPRequest(ctx context.Context, ePath exchange.URL
 			Result:        &interim,
 			Verbose:       bi.Verbose,
 			HTTPDebugging: bi.HTTPDebugging,
-			HTTPRecording: bi.HTTPRecording}, nil
+			HTTPRecording: bi.HTTPRecording,
+		}, nil
 	}, request.AuthenticatedRequest)
 	if err != nil {
 		return err

--- a/exchanges/binanceus/binanceus.go
+++ b/exchanges/binanceus/binanceus.go
@@ -1714,9 +1714,7 @@ func (bi *Binanceus) GetSubAccountDepositAddress(ctx context.Context, arg SubAcc
 }
 
 // GetSubAccountDepositHistory retrieves sub-account deposit history.
-func (bi *Binanceus) GetSubAccountDepositHistory(ctx context.Context, email string, coin currency.Code,
-	status int, startTime, endTime time.Time, limit, offset int,
-) ([]SubAccountDepositItem, error) {
+func (bi *Binanceus) GetSubAccountDepositHistory(ctx context.Context, email string, coin currency.Code, status int, startTime, endTime time.Time, limit, offset int) ([]SubAccountDepositItem, error) {
 	params := url.Values{}
 	if !common.MatchesEmailPattern(email) {
 		return nil, errMissingSubAccountEmail

--- a/exchanges/binanceus/binanceus_test.go
+++ b/exchanges/binanceus/binanceus_test.go
@@ -182,7 +182,7 @@ func TestGetFeeByType(t *testing.T) {
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, bi, canManipulateRealOrders)
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Pair: currency.Pair{
 			Base:  currency.XRP,
 			Quote: currency.USD,
@@ -226,7 +226,7 @@ func TestCancelOrder(t *testing.T) {
 	if err != nil && !(errors.Is(err, errEitherOrderIDOrClientOrderIDIsRequired) || strings.Contains(err.Error(), "ID not set")) {
 		t.Errorf("Binanceus CancelOrder() expecting %v, but found %v", errEitherOrderIDOrClientOrderIDIsRequired, err)
 	}
-	var cancellationOrder = &order.Cancel{
+	cancellationOrder := &order.Cancel{
 		OrderID:   "1",
 		Pair:      pair,
 		AssetType: asset.Spot,
@@ -240,7 +240,7 @@ func TestCancelOrder(t *testing.T) {
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		Pair:      currency.NewPair(currency.LTC, currency.BTC),
 		AssetType: asset.Spot,
 	}
@@ -309,7 +309,7 @@ func TestWithdrawFiat(t *testing.T) {
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -349,7 +349,7 @@ func TestWithdraw(t *testing.T) {
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	var feeBuilder = &exchange.FeeBuilder{
+	feeBuilder := &exchange.FeeBuilder{
 		Amount:        1,
 		FeeType:       exchange.CryptocurrencyTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
@@ -359,7 +359,7 @@ func TestGetFee(t *testing.T) {
 	if er != nil {
 		t.Fatal("Binanceus GetFeeByType() error", er)
 	}
-	var withdrawalFeeBuilder = &exchange.FeeBuilder{
+	withdrawalFeeBuilder := &exchange.FeeBuilder{
 		Amount:        1,
 		FeeType:       exchange.CryptocurrencyWithdrawalFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
@@ -369,7 +369,7 @@ func TestGetFee(t *testing.T) {
 	if er != nil {
 		t.Fatal("Binanceus GetFeeByType() error", er)
 	}
-	var offlineFeeTradeBuilder = &exchange.FeeBuilder{
+	offlineFeeTradeBuilder := &exchange.FeeBuilder{
 		Amount:        1,
 		FeeType:       exchange.OfflineTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
@@ -559,6 +559,7 @@ func TestGetUserAPITradingStatus(t *testing.T) {
 		t.Error("Binanceus GetUserAPITradingStatus() error", er)
 	}
 }
+
 func TestGetTradeFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
@@ -1222,6 +1223,7 @@ func TestDepositHistory(t *testing.T) {
 		t.Error("Binanceus DepositHistory() error", er)
 	}
 }
+
 func TestFiatDepositHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
@@ -1540,7 +1542,7 @@ func TestWebsocketPartialOrderBookDepthStream(t *testing.T) {
 
 func TestWebsocketBookTicker(t *testing.T) {
 	t.Parallel()
-	var bookTickerJSON = []byte(
+	bookTickerJSON := []byte(
 		`{
 		"stream": "btcusdt@bookTicker",
 		"data": {
@@ -1555,7 +1557,7 @@ func TestWebsocketBookTicker(t *testing.T) {
 	if err := bi.wsHandleData(bookTickerJSON); err != nil {
 		t.Error("Binanceus Book Ticker error", err)
 	}
-	var bookTickerForAllSymbols = []byte(`
+	bookTickerForAllSymbols := []byte(`
 	{
 		"stream" : "!bookTicker",
 		"data":{
@@ -1574,7 +1576,7 @@ func TestWebsocketBookTicker(t *testing.T) {
 
 func TestWebsocketAggTrade(t *testing.T) {
 	t.Parallel()
-	var aggTradejson = []byte(
+	aggTradejson := []byte(
 		`{  
 			"stream":"btcusdt@aggTrade", 
 			"data": {
@@ -1785,6 +1787,7 @@ func TestQuickEnableCryptoWithdrawal(t *testing.T) {
 		t.Errorf("Binanceus QuickEnableCryptoWithdrawal() expecting %s, but found %v", "unexpected end of JSON input", er)
 	}
 }
+
 func TestQuickDisableCryptoWithdrawal(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)

--- a/exchanges/binanceus/binanceus_websocket.go
+++ b/exchanges/binanceus/binanceus_websocket.go
@@ -541,7 +541,7 @@ func (bi *Binanceus) UpdateLocalBuffer(wsdp *WebsocketDepthStream) (bool, error)
 
 // GenerateSubscriptions generates the default subscription set
 func (bi *Binanceus) GenerateSubscriptions() (subscription.List, error) {
-	var channels = []string{"@ticker", "@trade", "@kline_1m", "@depth@100ms"}
+	channels := []string{"@ticker", "@trade", "@kline_1m", "@depth@100ms"}
 	var subscriptions subscription.List
 
 	pairs, err := bi.GetEnabledPairs(asset.Spot)

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -638,7 +638,7 @@ func (b *Bitfinex) GetTickerBatch(ctx context.Context) (map[string]*Ticker, erro
 	}
 
 	var tickErrs error
-	var tickers = make(map[string]*Ticker)
+	tickers := make(map[string]*Ticker)
 	for _, tickResp := range response {
 		symbol, ok := tickResp[0].(string)
 		if !ok {
@@ -841,7 +841,7 @@ func (b *Bitfinex) GetTrades(ctx context.Context, currencyPair string, limit, ti
 // Values can contain limit amounts for both the asks and bids - Example
 // "len" = 100
 func (b *Bitfinex) GetOrderbook(ctx context.Context, symbol, precision string, limit int64) (Orderbook, error) {
-	var u = url.Values{}
+	u := url.Values{}
 	if limit > 0 {
 		u.Set("len", strconv.FormatInt(limit, 10))
 	}
@@ -1000,7 +1000,7 @@ func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, sta
 		fundingPeriod = ":p30"
 	}
 
-	var path = bitfinexAPIVersion2 +
+	path := bitfinexAPIVersion2 +
 		bitfinexCandles +
 		":" +
 		timeFrame +
@@ -2071,7 +2071,8 @@ func (b *Bitfinex) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 		Result:        result,
 		Verbose:       b.Verbose,
 		HTTPDebugging: b.HTTPDebugging,
-		HTTPRecording: b.HTTPRecording}
+		HTTPRecording: b.HTTPRecording,
+	}
 
 	return b.SendPayload(ctx, e, func() (*request.Item, error) {
 		return item, nil
@@ -2126,7 +2127,8 @@ func (b *Bitfinex) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange
 			NonceEnabled:  true,
 			Verbose:       b.Verbose,
 			HTTPDebugging: b.HTTPDebugging,
-			HTTPRecording: b.HTTPRecording}, nil
+			HTTPRecording: b.HTTPRecording,
+		}, nil
 	}, request.AuthenticatedRequest)
 }
 
@@ -2203,7 +2205,7 @@ func (b *Bitfinex) GetFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) 
 			return 0, err
 		}
 	case exchange.CryptocurrencyDepositFee:
-		//TODO: fee is charged when < $1000USD is transferred, need to infer value in some way
+		// TODO: fee is charged when < $1000USD is transferred, need to infer value in some way
 		fee = 0
 	case exchange.CryptocurrencyWithdrawalFee:
 		acc, err := b.GetWithdrawalFees(ctx)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -39,8 +39,10 @@ const (
 	canManipulateRealOrders = false
 )
 
-var b *Bitfinex
-var btcusdPair = currency.NewPair(currency.BTC, currency.USD)
+var (
+	b          *Bitfinex
+	btcusdPair = currency.NewPair(currency.BTC, currency.USD)
+)
 
 func TestMain(m *testing.M) {
 	b = new(Bitfinex)
@@ -791,7 +793,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := b.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -808,7 +810,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 }
 
 func TestGetFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	t.Parallel()
 
 	if sharedtestvalues.AreAPICredentialsSet(b) {
@@ -883,7 +885,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -900,7 +902,7 @@ func TestGetActiveOrders(t *testing.T) {
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -916,7 +918,7 @@ func TestGetOrderHistory(t *testing.T) {
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Delimiter: "_",
@@ -948,7 +950,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -970,7 +972,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -1036,7 +1038,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:      -1,
 		Currency:    currency.USD,
 		Description: "WITHDRAW IT ALL",
@@ -1058,7 +1060,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:      -1,
 		Currency:    currency.BTC,
 		Description: "WITHDRAW IT ALL",

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -54,13 +54,17 @@ type WalletDataV2 struct {
 }
 
 // AcceptedOrderType defines the accepted market types, exchange strings denote non-contract order types.
-var AcceptedOrderType = []string{"market", "limit", "stop", "trailing-stop",
+var AcceptedOrderType = []string{
+	"market", "limit", "stop", "trailing-stop",
 	"fill-or-kill", "exchange market", "exchange limit", "exchange stop",
-	"exchange trailing-stop", "exchange fill-or-kill"}
+	"exchange trailing-stop", "exchange fill-or-kill",
+}
 
 // AcceptedWalletNames defines different wallets supported by the exchange
-var AcceptedWalletNames = []string{"trading", "exchange", "deposit", "margin",
-	"funding"}
+var AcceptedWalletNames = []string{
+	"trading", "exchange", "deposit", "margin",
+	"funding",
+}
 
 type acceptableMethodStore struct {
 	a map[string][]string

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -314,7 +314,8 @@ func (b *Bitfinex) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Volume:       val.Volume,
 			Pair:         pair,
 			AssetType:    a,
-			ExchangeName: b.Name})
+			ExchangeName: b.Name,
+		})
 		if err != nil {
 			errs = common.AppendError(errs, err)
 		}
@@ -354,7 +355,7 @@ func (b *Bitfinex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 		return o, fmt.Errorf("%w %v", asset.ErrNotSupported, assetType)
 	}
 	b.appendOptionalDelimiter(&fPair)
-	var prefix = "t"
+	prefix := "t"
 	if assetType == asset.MarginFunding {
 		prefix = "f"
 	}
@@ -419,7 +420,7 @@ func (b *Bitfinex) UpdateAccountInfo(ctx context.Context, assetType asset.Item) 
 		return response, err
 	}
 
-	var Accounts = []account.SubAccount{
+	Accounts := []account.SubAccount{
 		{ID: "deposit", AssetType: assetType},
 		{ID: "exchange", AssetType: assetType},
 		{ID: "trading", AssetType: assetType},

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -169,7 +169,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := b.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		// CryptocurrencyTradeFee Basic
@@ -260,7 +260,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -276,7 +276,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -295,7 +295,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -319,7 +319,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -339,7 +339,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -389,7 +389,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 
 	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrNotYetImplemented {
@@ -401,7 +401,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 
 	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -174,7 +174,8 @@ func (b *Bitflyer) UpdateTicker(ctx context.Context, p currency.Pair, a asset.It
 		Last:         tickerNew.Last,
 		Volume:       tickerNew.Volume,
 		ExchangeName: b.Name,
-		AssetType:    a})
+		AssetType:    a,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -207,7 +207,7 @@ func (b *Bithumb) GetAccountInformation(ctx context.Context, orderCurrency, paym
 // GetAccountBalance returns customer wallet information
 func (b *Bithumb) GetAccountBalance(ctx context.Context, c string) (FullBalance, error) {
 	var response Balance
-	var fullBalance = FullBalance{
+	fullBalance := FullBalance{
 		make(map[string]float64),
 		make(map[string]float64),
 		make(map[string]float64),
@@ -596,7 +596,8 @@ func (b *Bithumb) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange.
 			NonceEnabled:  true,
 			Verbose:       b.Verbose,
 			HTTPDebugging: b.HTTPDebugging,
-			HTTPRecording: b.HTTPRecording}, nil
+			HTTPRecording: b.HTTPRecording,
+		}, nil
 	}, request.AuthenticatedRequest)
 	if err != nil {
 		return err

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -55,7 +55,8 @@ var errSymbolIsEmpty = errors.New("symbol cannot be empty")
 // Bithumb is the overarching type across the Bithumb package
 type Bithumb struct {
 	exchange.Base
-	obm orderbookManager
+	location *time.Location
+	obm      orderbookManager
 }
 
 // GetTradablePairs returns a list of tradable currencies

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -286,7 +286,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := b.GetFeeByType(context.Background(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 
@@ -299,7 +299,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	// CryptocurrencyTradeFee Basic
 	_, err := b.GetFee(feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
@@ -361,7 +361,7 @@ func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Side:      order.Sell,
 		AssetType: asset.Spot,
@@ -375,7 +375,7 @@ func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -393,7 +393,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -415,7 +415,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -432,7 +432,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -483,7 +483,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Type:     withdraw.Fiat,
 		Exchange: b.Name,
 		Fiat: withdraw.FiatRequest{
@@ -518,7 +518,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)

--- a/exchanges/bithumb/bithumb_websocket.go
+++ b/exchanges/bithumb/bithumb_websocket.go
@@ -28,8 +28,6 @@ const (
 	tradeTimeLayout  = time.DateTime + ".000000"
 )
 
-var location *time.Location
-
 var defaultSubscriptions = subscription.List{
 	{Enabled: true, Asset: asset.Spot, Channel: subscription.TickerChannel, Interval: kline.ThirtyMin}, // alternatives "1H", "12H", "24H"
 	{Enabled: true, Asset: asset.Spot, Channel: subscription.OrderbookChannel},
@@ -105,9 +103,7 @@ func (b *Bithumb) wsHandleData(respRaw []byte) error {
 			return err
 		}
 		var lu time.Time
-		lu, err = time.ParseInLocation(tickerTimeLayout,
-			tick.Date+tick.Time,
-			location)
+		lu, err = time.ParseInLocation(tickerTimeLayout, tick.Date+tick.Time, b.location)
 		if err != nil {
 			return err
 		}
@@ -138,9 +134,7 @@ func (b *Bithumb) wsHandleData(respRaw []byte) error {
 		toBuffer := make([]trade.Data, len(trades.List))
 		var lu time.Time
 		for x := range trades.List {
-			lu, err = time.ParseInLocation(tradeTimeLayout,
-				trades.List[x].ContractTime,
-				location)
+			lu, err = time.ParseInLocation(tradeTimeLayout, trades.List[x].ContractTime, b.location)
 			if err != nil {
 				return err
 			}

--- a/exchanges/bithumb/bithumb_websocket.go
+++ b/exchanges/bithumb/bithumb_websocket.go
@@ -28,9 +28,7 @@ const (
 	tradeTimeLayout  = time.DateTime + ".000000"
 )
 
-var (
-	location *time.Location
-)
+var location *time.Location
 
 var defaultSubscriptions = subscription.List{
 	{Enabled: true, Asset: asset.Spot, Channel: subscription.TickerChannel, Interval: kline.ThirtyMin}, // alternatives "1H", "12H", "24H"

--- a/exchanges/bithumb/bithumb_websocket_test.go
+++ b/exchanges/bithumb/bithumb_websocket_test.go
@@ -3,6 +3,7 @@ package bithumb
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,7 @@ var (
 
 func TestWsHandleData(t *testing.T) {
 	t.Parallel()
+
 	pairs := currency.Pairs{
 		currency.Pair{
 			Base:  currency.BTC,
@@ -33,6 +35,7 @@ func TestWsHandleData(t *testing.T) {
 	}
 
 	dummy := Bithumb{
+		location: time.Local,
 		Base: exchange.Base{
 			Name: "dummy",
 			Features: exchange.Features{

--- a/exchanges/bithumb/bithumb_websocket_test.go
+++ b/exchanges/bithumb/bithumb_websocket_test.go
@@ -125,8 +125,10 @@ func TestGenerateSubscriptions(t *testing.T) {
 	exp := subscription.List{
 		{Asset: asset.Spot, Channel: subscription.AllTradesChannel, Pairs: p, QualifiedChannel: `{"type":"transaction","symbols":["BTC_KRW","ETH_KRW"]}`},
 		{Asset: asset.Spot, Channel: subscription.OrderbookChannel, Pairs: p, QualifiedChannel: `{"type":"orderbookdepth","symbols":["BTC_KRW","ETH_KRW"]}`},
-		{Asset: asset.Spot, Channel: subscription.TickerChannel, Pairs: p, Interval: kline.ThirtyMin,
-			QualifiedChannel: `{"type":"ticker","symbols":["BTC_KRW","ETH_KRW"],"tickTypes":["30M"]}`},
+		{
+			Asset: asset.Spot, Channel: subscription.TickerChannel, Pairs: p, Interval: kline.ThirtyMin,
+			QualifiedChannel: `{"type":"ticker","symbols":["BTC_KRW","ETH_KRW"],"tickTypes":["30M"]}`,
+		},
 	}
 	testsubs.EqualLists(t, exp, subs)
 }

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -49,6 +49,11 @@ func (b *Bithumb) SetDefaults() {
 		log.Errorln(log.ExchangeSys, err)
 	}
 
+	b.location, err = time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		log.Errorf(log.ExchangeSys, "Bithumb unable to load time location: %s", err)
+	}
+
 	b.Features = exchange.Features{
 		Supports: exchange.FeaturesSupported{
 			REST: true,
@@ -142,11 +147,6 @@ func (b *Bithumb) Setup(exch *config.Exchange) error {
 		return nil
 	}
 	err = b.SetupDefaults(exch)
-	if err != nil {
-		return err
-	}
-
-	location, err = time.LoadLocation("Asia/Seoul")
 	if err != nil {
 		return err
 	}

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -978,7 +978,7 @@ func getOfflineTradeFee(price, amount float64) float64 {
 
 // calculateTradingFee returns the fee for trading any currency on Bitmex
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {
-	var fee = 0.000750
+	fee := 0.000750
 	if isMaker {
 		fee -= 0.000250
 	}

--- a/exchanges/bitmex/bitmex_parameters.go
+++ b/exchanges/bitmex/bitmex_parameters.go
@@ -597,7 +597,6 @@ func (p OrderBookGetL2Params) IsNil() bool {
 
 // PositionGetParams contains all the parameters to send to the API endpoint
 type PositionGetParams struct {
-
 	// Columns - Which columns to fetch. For example, send ["columnName"].
 	Columns string `json:"columns,omitempty"`
 

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -617,7 +617,7 @@ func TestWithdraw(t *testing.T) {
 		Amount:          -1,
 		Currency:        currency.BTC,
 		Description:     "WITHDRAW IT ALL",
-		OneTimePassword: 0o00000, //nolint // gocritic false positive
+		OneTimePassword: 696969,
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -121,7 +121,8 @@ func TestSendTrollboxMessage(t *testing.T) {
 	_, err := b.SendTrollboxMessage(context.Background(),
 		ChatSendParams{
 			ChannelID: 1337,
-			Message:   "Hello,World!"})
+			Message:   "Hello,World!",
+		})
 	require.Error(t, err)
 }
 
@@ -244,10 +245,12 @@ func TestCreateOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 	_, err := b.CreateOrder(context.Background(),
-		&OrderNewParams{Symbol: "XBTM15",
+		&OrderNewParams{
+			Symbol:        "XBTM15",
 			Price:         219.0,
 			ClientOrderID: "mm_bitmex_1a/oemUeQ4CAJZgP3fjHsA",
-			OrderQuantity: 98})
+			OrderQuantity: 98,
+		})
 	require.Error(t, err)
 }
 
@@ -401,7 +404,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := b.GetFeeByType(context.Background(), feeBuilder)
 	require.NoError(t, err)
 	if !sharedtestvalues.AreAPICredentialsSet(b) {
@@ -413,7 +416,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	// CryptocurrencyTradeFee Basic
 	_, err := b.GetFee(feeBuilder)
 	require.NoError(t, err)
@@ -474,7 +477,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -490,7 +493,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Pairs:     []currency.Pair{currency.NewPair(currency.LTC, currency.BTC)},
 		AssetType: asset.Spot,
@@ -512,7 +515,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Base:  currency.XBT,
@@ -539,7 +542,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "123456789012345678901234567890123456",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -560,7 +563,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "123456789012345678901234567890123456",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -614,7 +617,7 @@ func TestWithdraw(t *testing.T) {
 		Amount:          -1,
 		Currency:        currency.BTC,
 		Description:     "WITHDRAW IT ALL",
-		OneTimePassword: 000000, //nolint // gocritic false positive
+		OneTimePassword: 0o00000, //nolint // gocritic false positive
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)
@@ -629,7 +632,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
@@ -638,7 +641,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -363,7 +363,8 @@ instruments:
 			LastUpdated:  tick[j].Timestamp,
 			ExchangeName: b.Name,
 			OpenInterest: tick[j].OpenInterest,
-			AssetType:    a})
+			AssetType:    a,
+		})
 		if err != nil {
 			return err
 		}
@@ -412,7 +413,8 @@ func (b *Bitmex) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType
 	orderbookNew, err := b.GetOrderbook(ctx,
 		OrderBookGetL2Params{
 			Symbol: fPair.String(),
-			Depth:  500})
+			Depth:  500,
+		})
 	if err != nil {
 		return book, err
 	}
@@ -639,7 +641,7 @@ func (b *Bitmex) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		return nil, err
 	}
 
-	var orderNewParams = OrderNewParams{
+	orderNewParams := OrderNewParams{
 		OrderType:     s.Type.Title(),
 		Symbol:        fPair.String(),
 		OrderQuantity: s.Amount,
@@ -671,7 +673,8 @@ func (b *Bitmex) ModifyOrder(ctx context.Context, action *order.Modify) (*order.
 	o, err := b.AmendOrder(ctx, &OrderAmendParams{
 		OrderID:  action.OrderID,
 		OrderQty: int32(action.Amount),
-		Price:    action.Price})
+		Price:    action.Price,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -817,7 +820,7 @@ func (b *Bitmex) WithdrawCryptocurrencyFunds(ctx context.Context, withdrawReques
 	if err := withdrawRequest.Validate(); err != nil {
 		return nil, err
 	}
-	var r = UserRequestWithdrawalParams{
+	r := UserRequestWithdrawalParams{
 		Address:  withdrawRequest.Crypto.Address,
 		Amount:   withdrawRequest.Amount,
 		Currency: withdrawRequest.Currency.String(),

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -356,7 +356,7 @@ func (b *Bitstamp) GetOrderStatus(ctx context.Context, orderID int64) (OrderStat
 
 // CancelExistingOrder cancels order by ID
 func (b *Bitstamp) CancelExistingOrder(ctx context.Context, orderID int64) (CancelOrder, error) {
-	var req = url.Values{}
+	req := url.Values{}
 	req.Add("id", strconv.FormatInt(orderID, 10))
 
 	var result CancelOrder
@@ -378,7 +378,7 @@ func (b *Bitstamp) CancelAllExistingOrders(ctx context.Context) (bool, error) {
 
 // PlaceOrder places an order on the exchange.
 func (b *Bitstamp) PlaceOrder(ctx context.Context, currencyPair string, price, amount float64, buy, market bool) (Order, error) {
-	var req = url.Values{}
+	req := url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("price", strconv.FormatFloat(price, 'f', -1, 64))
 	response := Order{}
@@ -425,7 +425,7 @@ func (b *Bitstamp) GetWithdrawalRequests(ctx context.Context, timedelta int64) (
 // symbol - the type of crypto ie "ltc", "btc", "eth"
 // destTag - only for XRP  default to ""
 func (b *Bitstamp) CryptoWithdrawal(ctx context.Context, amount float64, address, symbol, destTag string) (*CryptoWithdrawalResponse, error) {
-	var req = url.Values{}
+	req := url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("address", address)
 
@@ -449,8 +449,9 @@ func (b *Bitstamp) CryptoWithdrawal(ctx context.Context, amount float64, address
 // OpenBankWithdrawal Opens a bank withdrawal request (SEPA or international)
 func (b *Bitstamp) OpenBankWithdrawal(ctx context.Context, amount float64, currency,
 	name, iban, bic, address, postalCode, city, country,
-	comment, withdrawalType string) (FIATWithdrawalResponse, error) {
-	var req = url.Values{}
+	comment, withdrawalType string,
+) (FIATWithdrawalResponse, error) {
+	req := url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("account_currency", currency)
 	req.Add("name", name)
@@ -471,8 +472,9 @@ func (b *Bitstamp) OpenBankWithdrawal(ctx context.Context, amount float64, curre
 func (b *Bitstamp) OpenInternationalBankWithdrawal(ctx context.Context, amount float64, currency,
 	name, iban, bic, address, postalCode, city, country,
 	bankName, bankAddress, bankPostCode, bankCity, bankCountry, internationalCurrency,
-	comment, withdrawalType string) (FIATWithdrawalResponse, error) {
-	var req = url.Values{}
+	comment, withdrawalType string,
+) (FIATWithdrawalResponse, error) {
+	req := url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("account_currency", currency)
 	req.Add("name", name)
@@ -513,7 +515,7 @@ func (b *Bitstamp) GetUnconfirmedBitcoinDeposits(ctx context.Context) ([]Unconfi
 
 // OHLC returns OHLCV data for step (interval)
 func (b *Bitstamp) OHLC(ctx context.Context, currency string, start, end time.Time, step, limit string) (resp OHLCResponse, err error) {
-	var v = url.Values{}
+	v := url.Values{}
 	v.Add("limit", limit)
 	v.Add("step", step)
 
@@ -535,7 +537,7 @@ func (b *Bitstamp) OHLC(ctx context.Context, currency string, start, end time.Ti
 // subaccount - name of account
 // toMain - bool either to or from account
 func (b *Bitstamp) TransferAccountBalance(ctx context.Context, amount float64, currency, subAccount string, toMain bool) error {
-	var req = url.Values{}
+	req := url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("currency", currency)
 

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -31,8 +31,10 @@ const (
 	canManipulateRealOrders = false
 )
 
-var b = &Bitstamp{}
-var btcusdPair = currency.NewPair(currency.BTC, currency.USD)
+var (
+	b          = &Bitstamp{}
+	btcusdPair = currency.NewPair(currency.BTC, currency.USD)
+)
 
 func setFeeBuilder() *exchange.FeeBuilder {
 	return &exchange.FeeBuilder{
@@ -50,7 +52,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := b.GetFeeByType(context.Background(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 	if mockTests {
@@ -63,7 +65,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	// CryptocurrencyTradeFee Basic
 	if !mockTests {
@@ -616,7 +618,7 @@ func TestWithdrawFiat(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Type:     withdraw.Fiat,
 		Exchange: b.Name,
 		Fiat: withdraw.FiatRequest{
@@ -659,7 +661,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Type:     withdraw.Fiat,
 		Exchange: b.Name,
 		Fiat: withdraw.FiatRequest{

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -266,7 +266,8 @@ func (b *Bitstamp) UpdateTicker(ctx context.Context, p currency.Pair, a asset.It
 		Pair:         fPair,
 		LastUpdated:  time.Unix(tick.Timestamp, 0),
 		ExchangeName: b.Name,
-		AssetType:    a})
+		AssetType:    a,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -726,7 +726,8 @@ func (b *BTCMarkets) GetReport(ctx context.Context, reportID string) (ReportData
 
 // RequestWithdraw requests withdrawals
 func (b *BTCMarkets) RequestWithdraw(ctx context.Context, assetName string, amount float64,
-	toAddress, accountName, accountNumber, bsbNumber, bankName string) (TransferData, error) {
+	toAddress, accountName, accountNumber, bsbNumber, bankName string,
+) (TransferData, error) {
 	var resp TransferData
 	req := make(map[string]interface{})
 	req["assetName"] = assetName

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -150,7 +150,7 @@ func (b *BTSE) GetOHLCV(ctx context.Context, symbol string, start, end time.Time
 		urlValues.Add("start", strconv.FormatInt(start.Unix(), 10))
 		urlValues.Add("end", strconv.FormatInt(end.Unix(), 10))
 	}
-	var res = 60
+	res := 60
 	if resolution != 0 {
 		res = resolution
 	}

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -35,9 +35,11 @@ const (
 	canManipulateRealOrders = false
 )
 
-var b = &BTSE{}
-var futuresPair = currency.NewPair(currency.ENJ, currency.PFC)
-var spotPair = currency.NewPairWithDelimiter("BTC", "USD", "-")
+var (
+	b           = &BTSE{}
+	futuresPair = currency.NewPair(currency.ENJ, currency.PFC)
+	spotPair    = currency.NewPairWithDelimiter("BTC", "USD", "-")
+)
 
 func TestMain(m *testing.M) {
 	b.SetDefaults()
@@ -285,7 +287,7 @@ func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Pairs: []currency.Pair{
 			{
 				Delimiter: "-",
@@ -311,7 +313,7 @@ func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -405,7 +407,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -436,7 +438,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	// TODO: Place an order to make sure we can cancel it
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "b334ecef-2b42-4998-b8a4-b6b14f6d2671",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -460,7 +462,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -248,7 +248,8 @@ func (b *BTSE) UpdateTickers(ctx context.Context, a asset.Item) error {
 				High:         tickers[x].High24Hr,
 				OpenInterest: tickers[x].OpenInterest,
 				ExchangeName: b.Name,
-				AssetType:    a})
+				AssetType:    a,
+			})
 		}
 		if err != nil {
 			errs = common.AppendError(errs, err)
@@ -286,7 +287,8 @@ func (b *BTSE) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item) 
 		Volume:       ticks[0].Volume,
 		High:         ticks[0].High24Hr,
 		ExchangeName: b.Name,
-		AssetType:    a})
+		AssetType:    a,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +576,7 @@ func (b *BTSE) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pair
 			continue
 		}
 
-		var side = order.Buy
+		side := order.Buy
 		if strings.EqualFold(o[i].Side, order.Ask.String()) {
 			side = order.Sell
 		}
@@ -732,7 +734,7 @@ func (b *BTSE) GetActiveOrders(ctx context.Context, req *order.MultiOrderRequest
 		}
 
 		for i := range resp {
-			var side = order.Buy
+			side := order.Buy
 			if strings.EqualFold(resp[i].Side, order.Ask.String()) {
 				side = order.Sell
 			}

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -611,9 +611,7 @@ func (by *Bybit) CancelTradeOrder(ctx context.Context, arg *CancelOrderParams) (
 
 // GetOpenOrders retrieves unfilled or partially filled orders in real-time. To query older order records, please use the order history interface.
 // orderFilter: possible values are 'Order', 'StopOrder', 'tpslOrder', and 'OcoOrder'
-func (by *Bybit) GetOpenOrders(ctx context.Context, category, symbol, baseCoin, settleCoin, orderID, orderLinkID, orderFilter, cursor string,
-	openOnly, limit int64,
-) (*TradeOrders, error) {
+func (by *Bybit) GetOpenOrders(ctx context.Context, category, symbol, baseCoin, settleCoin, orderID, orderLinkID, orderFilter, cursor string, openOnly, limit int64) (*TradeOrders, error) {
 	params, err := fillCategoryAndSymbol(category, symbol, true)
 	if err != nil {
 		return nil, err

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -612,7 +612,8 @@ func (by *Bybit) CancelTradeOrder(ctx context.Context, arg *CancelOrderParams) (
 // GetOpenOrders retrieves unfilled or partially filled orders in real-time. To query older order records, please use the order history interface.
 // orderFilter: possible values are 'Order', 'StopOrder', 'tpslOrder', and 'OcoOrder'
 func (by *Bybit) GetOpenOrders(ctx context.Context, category, symbol, baseCoin, settleCoin, orderID, orderLinkID, orderFilter, cursor string,
-	openOnly, limit int64) (*TradeOrders, error) {
+	openOnly, limit int64,
+) (*TradeOrders, error) {
 	params, err := fillCategoryAndSymbol(category, symbol, true)
 	if err != nil {
 		return nil, err
@@ -670,7 +671,8 @@ func (by *Bybit) CancelAllTradeOrders(ctx context.Context, arg *CancelAllOrdersP
 // orderFilter: possible values are 'Order', 'StopOrder', 'tpslOrder', and 'OcoOrder'
 func (by *Bybit) GetTradeOrderHistory(ctx context.Context, category, symbol, orderID, orderLinkID,
 	baseCoin, settleCoin, orderFilter, orderStatus, cursor string,
-	startTime, endTime time.Time, limit int64) (*TradeOrders, error) {
+	startTime, endTime time.Time, limit int64,
+) (*TradeOrders, error) {
 	params, err := fillCategoryAndSymbol(category, symbol, true)
 	if err != nil {
 		return nil, err
@@ -2564,7 +2566,8 @@ func (by *Bybit) SendHTTPRequest(ctx context.Context, ePath exchange.URL, path s
 			Result:        response,
 			Verbose:       by.Verbose,
 			HTTPDebugging: by.HTTPDebugging,
-			HTTPRecording: by.HTTPRecording}, nil
+			HTTPRecording: by.HTTPRecording,
+		}, nil
 	}, request.UnauthenticatedRequest)
 	if err != nil {
 		return err

--- a/exchanges/bybit/bybit_inverse_websocket.go
+++ b/exchanges/bybit/bybit_inverse_websocket.go
@@ -37,7 +37,7 @@ func (by *Bybit) WsInverseConnect() error {
 // GenerateInverseDefaultSubscriptions generates default subscription
 func (by *Bybit) GenerateInverseDefaultSubscriptions() (subscription.List, error) {
 	var subscriptions subscription.List
-	var channels = []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
+	channels := []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
 	pairs, err := by.GetEnabledPairs(asset.CoinMarginedFutures)
 	if err != nil {
 		return nil, err

--- a/exchanges/bybit/bybit_linear_websocket.go
+++ b/exchanges/bybit/bybit_linear_websocket.go
@@ -44,7 +44,7 @@ func (by *Bybit) WsLinearConnect() error {
 // GenerateLinearDefaultSubscriptions generates default subscription
 func (by *Bybit) GenerateLinearDefaultSubscriptions() (subscription.List, error) {
 	var subscriptions subscription.List
-	var channels = []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
+	channels := []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
 	pairs, err := by.GetEnabledPairs(asset.USDTMarginedFutures)
 	if err != nil {
 		return nil, err

--- a/exchanges/bybit/bybit_options_websocket.go
+++ b/exchanges/bybit/bybit_options_websocket.go
@@ -44,7 +44,7 @@ func (by *Bybit) WsOptionsConnect() error {
 // GenerateOptionsDefaultSubscriptions generates default subscription
 func (by *Bybit) GenerateOptionsDefaultSubscriptions() (subscription.List, error) {
 	var subscriptions subscription.List
-	var channels = []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
+	channels := []string{chanOrderbook, chanPublicTrade, chanPublicTicker}
 	pairs, err := by.GetEnabledPairs(asset.Options)
 	if err != nil {
 		return nil, err

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -250,7 +250,7 @@ func TestSubmitOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange:      b.GetName(),
 		Pair:          spotTradablePair,
 		Side:          order.Buy,
@@ -373,7 +373,8 @@ func TestCancelOrder(t *testing.T) {
 		Exchange:  b.Name,
 		AssetType: asset.Spot,
 		Pair:      spotTradablePair,
-		OrderID:   "1234"})
+		OrderID:   "1234",
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -381,7 +382,8 @@ func TestCancelOrder(t *testing.T) {
 		Exchange:  b.Name,
 		AssetType: asset.USDTMarginedFutures,
 		Pair:      usdtMarginedTradablePair,
-		OrderID:   "1234"})
+		OrderID:   "1234",
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -390,7 +392,8 @@ func TestCancelOrder(t *testing.T) {
 		Exchange:  b.Name,
 		AssetType: asset.CoinMarginedFutures,
 		Pair:      inverseTradablePair,
-		OrderID:   "1234"})
+		OrderID:   "1234",
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -398,7 +401,8 @@ func TestCancelOrder(t *testing.T) {
 		Exchange:  b.Name,
 		AssetType: asset.Options,
 		Pair:      optionsTradablePair,
-		OrderID:   "1234"})
+		OrderID:   "1234",
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -466,7 +470,7 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	var getOrdersRequestSpot = order.MultiOrderRequest{
+	getOrdersRequestSpot := order.MultiOrderRequest{
 		Pairs:     currency.Pairs{spotTradablePair},
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -476,17 +480,17 @@ func TestGetActiveOrders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestLinear = order.MultiOrderRequest{Pairs: currency.Pairs{usdtMarginedTradablePair}, AssetType: asset.USDTMarginedFutures, Side: order.AnySide, Type: order.AnyType}
+	getOrdersRequestLinear := order.MultiOrderRequest{Pairs: currency.Pairs{usdtMarginedTradablePair}, AssetType: asset.USDTMarginedFutures, Side: order.AnySide, Type: order.AnyType}
 	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestLinear)
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestInverse = order.MultiOrderRequest{Pairs: currency.Pairs{inverseTradablePair}, AssetType: asset.CoinMarginedFutures, Side: order.AnySide, Type: order.AnyType}
+	getOrdersRequestInverse := order.MultiOrderRequest{Pairs: currency.Pairs{inverseTradablePair}, AssetType: asset.CoinMarginedFutures, Side: order.AnySide, Type: order.AnyType}
 	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestInverse)
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestFutures = order.MultiOrderRequest{Pairs: currency.Pairs{optionsTradablePair}, AssetType: asset.Options, Side: order.AnySide, Type: order.AnyType}
+	getOrdersRequestFutures := order.MultiOrderRequest{Pairs: currency.Pairs{optionsTradablePair}, AssetType: asset.Options, Side: order.AnySide, Type: order.AnyType}
 	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestFutures)
 	if err != nil {
 		t.Error(err)
@@ -508,7 +512,7 @@ func TestGetOrderHistory(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	var getOrdersRequestSpot = order.MultiOrderRequest{
+	getOrdersRequestSpot := order.MultiOrderRequest{
 		Pairs:     currency.Pairs{spotTradablePair},
 		AssetType: asset.Spot,
 		Type:      order.AnyType,
@@ -518,7 +522,7 @@ func TestGetOrderHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestUMF = order.MultiOrderRequest{
+	getOrdersRequestUMF := order.MultiOrderRequest{
 		Pairs:     currency.Pairs{usdtMarginedTradablePair},
 		AssetType: asset.USDTMarginedFutures,
 		Type:      order.AnyType,
@@ -534,7 +538,7 @@ func TestGetOrderHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestCMF = order.MultiOrderRequest{
+	getOrdersRequestCMF := order.MultiOrderRequest{
 		Pairs:     currency.Pairs{inverseTradablePair},
 		AssetType: asset.CoinMarginedFutures,
 		Type:      order.AnyType,
@@ -544,7 +548,7 @@ func TestGetOrderHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var getOrdersRequestFutures = order.MultiOrderRequest{
+	getOrdersRequestFutures := order.MultiOrderRequest{
 		Pairs:     currency.Pairs{optionsTradablePair},
 		AssetType: asset.Options,
 		Type:      order.AnyType,
@@ -594,7 +598,8 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 			Chain:      currency.LTC.String(),
 			Address:    "3CDJNfdWX8m2NwuGUV3nhXHXEeLygMXoAj",
 			AddressTag: "",
-		}})
+		},
+	})
 	if err != nil && err.Error() != "Withdraw address chain or destination tag are not equal" {
 		t.Fatal(err)
 	}
@@ -867,41 +872,51 @@ func TestPlaceOrder(t *testing.T) {
 		t.Error(err)
 	}
 	// Spot TP/SL order
-	arg = &PlaceOrderParams{Category: "spot",
-		Symbol: spotTradablePair,
-		Side:   "Buy", OrderType: "Limit",
+	arg = &PlaceOrderParams{
+		Category: "spot",
+		Symbol:   spotTradablePair,
+		Side:     "Buy", OrderType: "Limit",
 		OrderQuantity: 0.1, Price: 15600, TriggerPrice: 15000,
-		TimeInForce: "GTC", OrderLinkID: "spot-test-02", IsLeverage: 0, OrderFilter: "tpslOrder"}
+		TimeInForce: "GTC", OrderLinkID: "spot-test-02", IsLeverage: 0, OrderFilter: "tpslOrder",
+	}
 	_, err = b.PlaceOrder(context.Background(), arg)
 	if err != nil {
 		t.Error(err)
 	}
 	// Spot margin normal order (UTA)
-	arg = &PlaceOrderParams{Category: "spot", Symbol: spotTradablePair, Side: "Buy", OrderType: "Limit",
-		OrderQuantity: 0.1, Price: 15600, TimeInForce: "IOC", OrderLinkID: "spot-test-limit", IsLeverage: 1, OrderFilter: "Order"}
+	arg = &PlaceOrderParams{
+		Category: "spot", Symbol: spotTradablePair, Side: "Buy", OrderType: "Limit",
+		OrderQuantity: 0.1, Price: 15600, TimeInForce: "IOC", OrderLinkID: "spot-test-limit", IsLeverage: 1, OrderFilter: "Order",
+	}
 	_, err = b.PlaceOrder(context.Background(), arg)
 	if err != nil {
 		t.Error(err)
 	}
-	arg = &PlaceOrderParams{Category: "spot",
-		Symbol: spotTradablePair,
-		Side:   "Buy", OrderType: "Market", OrderQuantity: 200,
+	arg = &PlaceOrderParams{
+		Category: "spot",
+		Symbol:   spotTradablePair,
+		Side:     "Buy", OrderType: "Market", OrderQuantity: 200,
 		TimeInForce: "IOC", OrderLinkID: "spot-test-04",
-		IsLeverage: 0, OrderFilter: "Order"}
+		IsLeverage: 0, OrderFilter: "Order",
+	}
 	_, err = b.PlaceOrder(context.Background(), arg)
 	if err != nil {
 		t.Error(err)
 	}
 	// USDT Perp open long position (one-way mode)
-	arg = &PlaceOrderParams{Category: "linear",
-		Symbol: usdcMarginedTradablePair, Side: "Buy", OrderType: "Limit", OrderQuantity: 1, Price: 25000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-01", ReduceOnly: false, TakeProfitPrice: 28000, StopLossPrice: 20000, TpslMode: "Partial", TpOrderType: "Limit", SlOrderType: "Limit", TpLimitPrice: 27500, SlLimitPrice: 20500}
+	arg = &PlaceOrderParams{
+		Category: "linear",
+		Symbol:   usdcMarginedTradablePair, Side: "Buy", OrderType: "Limit", OrderQuantity: 1, Price: 25000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-01", ReduceOnly: false, TakeProfitPrice: 28000, StopLossPrice: 20000, TpslMode: "Partial", TpOrderType: "Limit", SlOrderType: "Limit", TpLimitPrice: 27500, SlLimitPrice: 20500,
+	}
 	_, err = b.PlaceOrder(context.Background(), arg)
 	if err != nil {
 		t.Error(err)
 	}
 	// USDT Perp close long position (one-way mode)
-	arg = &PlaceOrderParams{Category: "linear", Symbol: usdtMarginedTradablePair, Side: "Sell",
-		OrderType: "Limit", OrderQuantity: 1, Price: 3000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-02", ReduceOnly: true}
+	arg = &PlaceOrderParams{
+		Category: "linear", Symbol: usdtMarginedTradablePair, Side: "Sell",
+		OrderType: "Limit", OrderQuantity: 1, Price: 3000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-02", ReduceOnly: true,
+	}
 	_, err = b.PlaceOrder(context.Background(), arg)
 	if err != nil {
 		t.Error(err)
@@ -930,13 +945,15 @@ func TestAmendOrder(t *testing.T) {
 	}
 	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
-		Category: "mycat"})
+		Category: "mycat",
+	})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
 	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
-		Category: "option"})
+		Category: "option",
+	})
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyPairEmpty, err)
 	}
@@ -948,7 +965,8 @@ func TestAmendOrder(t *testing.T) {
 		OrderQuantity:   0.15,
 		Price:           1050,
 		TakeProfitPrice: 0,
-		StopLossPrice:   0})
+		StopLossPrice:   0,
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -976,13 +994,15 @@ func TestCancelTradeOrder(t *testing.T) {
 	}
 	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
-		Category: "mycat"})
+		Category: "mycat",
+	})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
 	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
-		Category: "option"})
+		Category: "option",
+	})
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyPairEmpty, err)
 	}
@@ -1148,7 +1168,8 @@ func TestBatchAmendOrder(t *testing.T) {
 			Symbol:                 optionsTradablePair,
 			OrderImpliedVolatility: "6.8",
 			OrderID:                "b551f227-7059-4fb5-a6a6-699c04dbd2f2",
-		}})
+		},
+	})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
@@ -1266,6 +1287,7 @@ func TestGetPositionInfo(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestSetLeverageLevel(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -1499,6 +1521,7 @@ func TestSetAutoAddMargin(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestAddOrReduceMargin(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -1959,6 +1982,7 @@ func TestGetDeliveryRecord(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestGetUSDCSessionSettlement(t *testing.T) {
 	t.Parallel()
 	if !mockTests {
@@ -2067,20 +2091,26 @@ func TestCreateInternalTransfer(t *testing.T) {
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456})
+	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456,
+	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED"})
+	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED",
+	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456,
+	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456,
 		ToAccountType:   "CONTRACT",
-		FromAccountType: "UNIFIED"})
+		FromAccountType: "UNIFIED",
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2172,20 +2202,26 @@ func TestCreateUniversalTransfer(t *testing.T) {
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456})
+	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456,
+	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED"})
+	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED",
+	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{TransferID: transferID,
-		Coin: currency.BTC, Amount: 123.456,
+	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+		TransferID: transferID,
+		Coin:       currency.BTC, Amount: 123.456,
 		ToAccountType:   "CONTRACT",
-		FromAccountType: "UNIFIED"})
+		FromAccountType: "UNIFIED",
+	})
 	if !errors.Is(err, errMemberIDRequired) {
 		t.Fatalf("expected %v, got %v", errMemberIDRequired, err)
 	}
@@ -2753,6 +2789,7 @@ func TestBorrow(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestRepay(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -3094,13 +3131,15 @@ func TestCancelBatchOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	var orderCancellationParams = []order.Cancel{{
+	orderCancellationParams := []order.Cancel{{
 		OrderID:   "1",
 		Pair:      spotTradablePair,
-		AssetType: asset.Spot}, {
+		AssetType: asset.Spot,
+	}, {
 		OrderID:   "1",
 		Pair:      usdtMarginedTradablePair,
-		AssetType: asset.USDTMarginedFutures}}
+		AssetType: asset.USDTMarginedFutures,
+	}}
 	_, err := b.CancelBatchOrders(context.Background(), orderCancellationParams)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
@@ -3109,10 +3148,12 @@ func TestCancelBatchOrders(t *testing.T) {
 		OrderID:   "1",
 		AccountID: "1",
 		Pair:      optionsTradablePair,
-		AssetType: asset.Options}, {
+		AssetType: asset.Options,
+	}, {
 		OrderID:   "2",
 		Pair:      optionsTradablePair,
-		AssetType: asset.Options}}
+		AssetType: asset.Options,
+	}}
 	_, err = b.CancelBatchOrders(context.Background(), orderCancellationParams)
 	if err != nil {
 		t.Error(err)
@@ -3129,6 +3170,7 @@ func TestWsConnect(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestWsLinearConnect(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -3139,6 +3181,7 @@ func TestWsLinearConnect(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestWsInverseConnect(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -3149,6 +3192,7 @@ func TestWsInverseConnect(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestWsOptionsConnect(t *testing.T) {
 	t.Parallel()
 	if mockTests {
@@ -3341,7 +3385,7 @@ func TestWsTicker(t *testing.T) {
 
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = &exchange.FeeBuilder{
+	feeBuilder := &exchange.FeeBuilder{
 		Amount:              1,
 		FeeType:             exchange.CryptocurrencyTradeFee,
 		Pair:                spotTradablePair,

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -229,7 +229,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := c.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -246,7 +246,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 }
 
 func TestGetFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	if sharedtestvalues.AreAPICredentialsSet(c) {
 		// CryptocurrencyTradeFee Basic
@@ -311,7 +311,7 @@ func TestGetFee(t *testing.T) {
 func TestCalculateTradingFee(t *testing.T) {
 	t.Parallel()
 	// uppercase
-	var volume = []Volume{
+	volume := []Volume{
 		{
 			ProductID: "BTC_USD",
 			Volume:    100,
@@ -404,7 +404,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 }
 
 func TestGetActiveOrders(t *testing.T) {
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     []currency.Pair{testPair},
@@ -420,7 +420,7 @@ func TestGetActiveOrders(t *testing.T) {
 }
 
 func TestGetOrderHistory(t *testing.T) {
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     []currency.Pair{testPair},
@@ -459,7 +459,7 @@ func TestSubmitOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
 	// limit order
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: c.Name,
 		Pair: currency.Pair{
 			Delimiter: "-",
@@ -527,7 +527,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -548,7 +548,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -609,7 +609,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:   100,
 		Currency: currency.USD,
 		Fiat: withdraw.FiatRequest{
@@ -632,7 +632,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:   100,
 		Currency: currency.USD,
 		Fiat: withdraw.FiatRequest{

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -288,7 +288,8 @@ func (c *CoinbasePro) UpdateTicker(ctx context.Context, p currency.Pair, a asset
 		Pair:         p,
 		LastUpdated:  tick.Time,
 		ExchangeName: c.Name,
-		AssetType:    a}
+		AssetType:    a,
+	}
 
 	err = ticker.ProcessTicker(tickerPrice)
 	if err != nil {

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -153,7 +153,7 @@ func (c *COINUT) CancelExistingOrder(ctx context.Context, instrumentID, orderID 
 		OrderID      int64 `json:"order_id"`
 	}
 
-	var entry = Request{
+	entry := Request{
 		InstrumentID: instrumentID,
 		OrderID:      orderID,
 	}

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
 )
 
-var c = &COINUT{}
-var wsSetupRan bool
+var (
+	c          = &COINUT{}
+	wsSetupRan bool
+)
 
 // Please supply your own keys here to do better tests
 const (
@@ -122,7 +124,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := c.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +142,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	// CryptocurrencyTradeFee Basic
 	if _, err := c.GetFee(feeBuilder); err != nil {
 		t.Error(err)
@@ -250,7 +252,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -264,7 +266,7 @@ func TestGetActiveOrders(t *testing.T) {
 func TestGetOrderHistoryWrapper(t *testing.T) {
 	t.Parallel()
 	setupWSTestAuth(t)
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     []currency.Pair{currency.NewPair(currency.BTC, currency.USD)},
@@ -284,7 +286,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: c.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -310,7 +312,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.BTC, currency.USD)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -332,7 +334,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -405,7 +407,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := c.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -416,7 +418,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := c.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -218,7 +218,7 @@ func (c *COINUT) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (a
 		}
 	}
 
-	var balances = []account.Balance{
+	balances := []account.Balance{
 		{
 			Currency: currency.BCH,
 			Total:    bal.BCH,
@@ -337,7 +337,8 @@ func (c *COINUT) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item
 		Pair:         p,
 		LastUpdated:  time.Unix(0, tick.Timestamp),
 		ExchangeName: c.Name,
-		AssetType:    a})
+		AssetType:    a,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/currencystate/currency_state_test.go
+++ b/exchanges/currencystate/currency_state_test.go
@@ -218,7 +218,8 @@ func TestStatesUpdateAll(t *testing.T) {
 		currency.BTC: {
 			Withdraw: convert.BoolPtr(true),
 			Trade:    convert.BoolPtr(true),
-			Deposit:  convert.BoolPtr(true)},
+			Deposit:  convert.BoolPtr(true),
+		},
 	})
 
 	if !errors.Is(err, nil) {
@@ -313,7 +314,8 @@ func TestAlerting(_ *testing.T) {
 	c.update(Options{
 		Trade:    convert.BoolPtr(true),
 		Withdraw: convert.BoolPtr(true),
-		Deposit:  convert.BoolPtr(true)})
+		Deposit:  convert.BoolPtr(true),
+	})
 	finish.Wait()
 }
 

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -405,6 +405,7 @@ func TestGetFundingChartData(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestWSRetrieveFundingChartData(t *testing.T) {
 	t.Parallel()
 	_, err := d.WSRetrieveFundingChartData("", "8h")
@@ -465,6 +466,7 @@ func TestGetHistoricalVolatility(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestWSRetrieveHistoricalVolatility(t *testing.T) {
 	t.Parallel()
 	_, err := d.WSRetrieveHistoricalVolatility(currency.EMPTYCODE)
@@ -565,6 +567,7 @@ func TestGetInstrumentsData(t *testing.T) {
 		require.Falsef(t, result[a].IsActive, "expected expired instrument, but got active instrument %s", result[a].InstrumentName)
 	}
 }
+
 func TestWSRetrieveInstrumentsData(t *testing.T) {
 	t.Parallel()
 	_, err := d.WSRetrieveInstrumentsData(currency.EMPTYCODE, "", false)
@@ -584,6 +587,7 @@ func TestGetLastSettlementsByCurrency(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestWSRetrieveLastSettlementsByCurrency(t *testing.T) {
 	t.Parallel()
 	_, err := d.WSRetrieveLastSettlementsByCurrency(currency.EMPTYCODE, "delivery", "5", 0, time.Now().Add(-time.Hour))
@@ -1897,7 +1901,8 @@ func TestSubmitBuy(t *testing.T) {
 		Label: "testOrder", TimeInForce: "",
 		Trigger: "", Advanced: "",
 		Amount: 30, Price: 500000,
-		MaxShow: 0, TriggerPrice: 0})
+		MaxShow: 0, TriggerPrice: 0,
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
@@ -1908,7 +1913,8 @@ func TestSubmitBuy(t *testing.T) {
 		Amount: 30, Price: 500000,
 		MaxShow: 0, TriggerPrice: 0,
 		PostOnly: false, RejectPostOnly: false,
-		ReduceOnly: false, MMP: false})
+		ReduceOnly: false, MMP: false,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1922,7 +1928,8 @@ func TestWSSubmitBuy(t *testing.T) {
 		Label: "testOrder", TimeInForce: "",
 		Trigger: "", Advanced: "",
 		Amount: 30, Price: 500000,
-		MaxShow: 0, TriggerPrice: 0})
+		MaxShow: 0, TriggerPrice: 0,
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
@@ -1933,7 +1940,8 @@ func TestWSSubmitBuy(t *testing.T) {
 		Amount: 30, Price: 500000,
 		MaxShow: 0, TriggerPrice: 0,
 		PostOnly: false, RejectPostOnly: false,
-		ReduceOnly: false, MMP: false})
+		ReduceOnly: false, MMP: false,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1952,6 +1960,7 @@ func TestSubmitSell(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestWSSubmitSell(t *testing.T) {
 	t.Parallel()
 	info, err := d.GetInstrument(context.Background(), btcPerpInstrument)
@@ -1963,7 +1972,8 @@ func TestWSSubmitSell(t *testing.T) {
 		Label: "testOrder", TimeInForce: "",
 		Trigger: "", Advanced: "", Amount: info.ContractSize * 3,
 		Price: 500000, MaxShow: 0, TriggerPrice: 0, PostOnly: false,
-		RejectPostOnly: false, ReduceOnly: false, MMP: false})
+		RejectPostOnly: false, ReduceOnly: false, MMP: false,
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
@@ -1972,7 +1982,8 @@ func TestWSSubmitSell(t *testing.T) {
 		Label: "testOrder", TimeInForce: "",
 		Trigger: "", Advanced: "", Amount: info.ContractSize * 3,
 		Price: 500000, MaxShow: 0, TriggerPrice: 0, PostOnly: false,
-		RejectPostOnly: false, ReduceOnly: false, MMP: false})
+		RejectPostOnly: false, ReduceOnly: false, MMP: false,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1981,16 +1992,22 @@ func TestEditOrderByLabel(t *testing.T) {
 	t.Parallel()
 	_, err := d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: "",
-		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	_, err = d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: "",
+		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
-	_, err = d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
-		Advanced: "", Amount: 0, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	_, err = d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
+		Advanced: "", Amount: 0, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.ErrorIs(t, err, errInvalidAmount)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
-	result, err := d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
-		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	result, err := d.EditOrderByLabel(context.Background(), &OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
+		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1999,16 +2016,22 @@ func TestWSEditOrderByLabel(t *testing.T) {
 	t.Parallel()
 	_, err := d.WSEditOrderByLabel(&OrderBuyAndSellParams{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = d.WSEditOrderByLabel(&OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: "",
-		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	_, err = d.WSEditOrderByLabel(&OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: "",
+		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
-	_, err = d.WSEditOrderByLabel(&OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
-		Advanced: "", Amount: 0, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	_, err = d.WSEditOrderByLabel(&OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
+		Advanced: "", Amount: 0, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.ErrorIs(t, err, errInvalidAmount)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
-	result, err := d.WSEditOrderByLabel(&OrderBuyAndSellParams{Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
-		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false})
+	result, err := d.WSEditOrderByLabel(&OrderBuyAndSellParams{
+		Label: "incorrectUserLabel", Instrument: btcPerpInstrument,
+		Advanced: "", Amount: 1, Price: 30000, TriggerPrice: 0, PostOnly: false, ReduceOnly: false, RejectPostOnly: false, MMP: false,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2256,6 +2279,7 @@ func TestWSRetrieveOpenOrdersByCurrency(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOpenOrdersByLabel(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetOpenOrdersByLabel(context.Background(), currency.EMPTYCODE, "the-label")
@@ -2277,6 +2301,7 @@ func TestWSRetrieveOpenOrdersByLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOpenOrdersByInstrument(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetOpenOrdersByInstrument(context.Background(), "", "all")
@@ -2298,6 +2323,7 @@ func TestWSRetrieveOpenOrdersByInstrument(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOrderHistoryByCurrency(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetOrderHistoryByCurrency(context.Background(), currency.EMPTYCODE, "future", 0, 0, false, false)
@@ -2363,6 +2389,7 @@ func TestWSRetrieveOrderMarginsByID(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOrderState(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetOrderState(context.Background(), "")
@@ -2384,6 +2411,7 @@ func TestWSRetrievesOrderState(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOrderStateByLabel(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetOrderStateByLabel(context.Background(), currency.EMPTYCODE, "the-label")
@@ -2405,6 +2433,7 @@ func TestWsRetrieveOrderStateByLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetTriggerOrderHistory(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetTriggerOrderHistory(context.Background(), currency.EMPTYCODE, "", "", 0)
@@ -2453,6 +2482,7 @@ func TestWSRetrieveUserTradesByCurrency(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetUserTradesByCurrencyAndTime(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetUserTradesByCurrencyAndTime(context.Background(), currency.EMPTYCODE, "future", "default", 5, time.Now().Add(-time.Hour*10), time.Now().Add(-time.Hour*1))
@@ -2474,6 +2504,7 @@ func TestWSRetrieveUserTradesByCurrencyAndTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetUserTradesByInstrument(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetUserTradesByInstrument(context.Background(), "", "asc", 5, 10, 4, true)
@@ -2495,6 +2526,7 @@ func TestWsRetrieveUserTradesByInstrument(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetUserTradesByInstrumentAndTime(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetUserTradesByInstrumentAndTime(context.Background(), "", "asc", 10, time.Now().Add(-time.Hour), time.Now())
@@ -2516,6 +2548,7 @@ func TestWSRetrieveUserTradesByInstrumentAndTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetUserTradesByOrder(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetUserTradesByOrder(context.Background(), "", "default")
@@ -2537,6 +2570,7 @@ func TestWSRetrieveUserTradesByOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestResetMMP(t *testing.T) {
 	t.Parallel()
 	err := d.ResetMMP(context.Background(), currency.EMPTYCODE)
@@ -2556,6 +2590,7 @@ func TestWSResetMMP(t *testing.T) {
 	err = d.WSResetMMP(currency.BTC)
 	assert.NoError(t, err)
 }
+
 func TestSendRequestForQuote(t *testing.T) {
 	t.Parallel()
 	err := d.SendRequestForQuote(context.Background(), "", 1000, order.Buy)
@@ -2575,6 +2610,7 @@ func TestWSSendRequestForQuote(t *testing.T) {
 	err = d.WSSendRequestForQuote(d.formatFuturesTradablePair(futuresTradablePair), 1000, order.Buy)
 	assert.NoError(t, err)
 }
+
 func TestSetMMPConfig(t *testing.T) {
 	t.Parallel()
 	err := d.SetMMPConfig(context.Background(), currency.EMPTYCODE, kline.FiveMin, 5, 0, 0)
@@ -2641,6 +2677,7 @@ func TestWSRetrieveSettlementHistoryByInstrument(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestSubmitEdit(t *testing.T) {
 	t.Parallel()
 	_, err := d.SubmitEdit(context.Background(), &OrderBuyAndSellParams{})
@@ -2692,6 +2729,7 @@ func TestWSRetrieveComboIDS(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, combos)
 }
+
 func TestGetComboDetails(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetComboDetails(context.Background(), "")
@@ -2711,6 +2749,7 @@ func TestWSRetrieveComboDetails(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetCombos(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetCombos(context.Background(), currency.EMPTYCODE)
@@ -2837,6 +2876,7 @@ func TestWSCreateCombo(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestVerifyBlockTrade(t *testing.T) {
 	t.Parallel()
 	_, err := d.VerifyBlockTrade(context.Background(), time.Now(), "", "maker", currency.EMPTYCODE, []BlockTradeParam{})
@@ -2922,6 +2962,7 @@ func TestWsInvalidateBlockTradeSignature(t *testing.T) {
 	err = d.WsInvalidateBlockTradeSignature("verified_signature_string")
 	assert.NoError(t, err)
 }
+
 func TestExecuteBlockTrade(t *testing.T) {
 	t.Parallel()
 	_, err := d.ExecuteBlockTrade(context.Background(), time.Now(), "", "maker", currency.EMPTYCODE, []BlockTradeParam{})
@@ -3014,6 +3055,7 @@ func TestWSRetrieveUserBlockTrade(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetLastBlockTradesbyCurrency(t *testing.T) {
 	t.Parallel()
 	_, err := d.GetLastBlockTradesByCurrency(context.Background(), currency.EMPTYCODE, "", "", 5)
@@ -3035,6 +3077,7 @@ func TestWSRetrieveLastBlockTradesByCurrency(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestMovePositions(t *testing.T) {
 	t.Parallel()
 	_, err := d.MovePositions(context.Background(), currency.EMPTYCODE, 123, 345, []BlockTradeParam{})
@@ -3101,7 +3144,8 @@ func TestWSMovePositions(t *testing.T) {
 			InstrumentName: "",
 			Direction:      "buy",
 			Amount:         100,
-		}})
+		},
+	})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
 	_, err = d.WSMovePositions(currency.BTC, 123, 345, []BlockTradeParam{
 		{
@@ -3137,6 +3181,7 @@ func TestWSMovePositions(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestSimulateBlockTrade(t *testing.T) {
 	t.Parallel()
 	_, err := d.SimulateBlockTrade(context.Background(), "", []BlockTradeParam{})
@@ -3253,6 +3298,7 @@ func TestWsSimulateBlockTrade(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func setupWs() {
 	if !d.Websocket.IsEnabled() {
 		return
@@ -3392,7 +3438,7 @@ func TestWSRetrievePublicPortfolioMargins(t *testing.T) {
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -3448,7 +3494,7 @@ func TestWithdraw(t *testing.T) {
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type: order.AnyType, AssetType: asset.Futures,
 		Side: order.AnySide, Pairs: currency.Pairs{futuresTradablePair},
 	}
@@ -3528,7 +3574,7 @@ func TestGetAssetPairByInstrument(t *testing.T) {
 }
 
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = &exchange.FeeBuilder{
+	feeBuilder := &exchange.FeeBuilder{
 		Amount:              1,
 		FeeType:             exchange.CryptocurrencyTradeFee,
 		Pair:                futuresTradablePair,
@@ -3645,7 +3691,7 @@ func TestModifyOrder(t *testing.T) {
 func TestCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -3807,6 +3853,7 @@ func TestWsDisableCancelOnDisconnect(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestEnableCancelOnDisconnect(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
@@ -3822,12 +3869,14 @@ func TestWsEnableCancelOnDisconnect(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestLogout(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d, canManipulateRealOrders)
 	err := d.WsLogout(true)
 	assert.NoError(t, err)
 }
+
 func TestExchangeToken(t *testing.T) {
 	t.Parallel()
 	_, err := d.ExchangeToken(context.Background(), "", 1234)
@@ -3848,6 +3897,7 @@ func TestWsExchangeToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestForkToken(t *testing.T) {
 	t.Parallel()
 	_, err := d.ForkToken(context.Background(), "", "Sami")

--- a/exchanges/deribit/deribit_wrapper.go
+++ b/exchanges/deribit/deribit_wrapper.go
@@ -537,7 +537,7 @@ func (d *Deribit) GetHistoricTrades(ctx context.Context, p currency.Pair, assetT
 	}
 	var resp []trade.Data
 	var tradesData *PublicTradesData
-	var hasMore = true
+	hasMore := true
 	for hasMore {
 		if d.Websocket.IsConnected() {
 			tradesData, err = d.WSRetrieveLastTradesByInstrumentAndTime(instrumentID, "asc", 100, true, timestampStart, timestampEnd)
@@ -860,7 +860,7 @@ func (d *Deribit) GetActiveOrders(ctx context.Context, getOrdersRequest *order.M
 	if len(getOrdersRequest.Pairs) == 0 {
 		return nil, currency.ErrCurrencyPairsEmpty
 	}
-	var resp = []order.Detail{}
+	resp := []order.Detail{}
 	for x := range getOrdersRequest.Pairs {
 		fmtPair, err := d.FormatExchangeCurrency(getOrdersRequest.Pairs[x], getOrdersRequest.AssetType)
 		if err != nil {

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -37,9 +37,7 @@ const (
 	defaultTestExchange = "Bitfinex"
 )
 
-var (
-	btcusdPair = currency.NewPairWithDelimiter("BTC", "USD", "-")
-)
+var btcusdPair = currency.NewPairWithDelimiter("BTC", "USD", "-")
 
 func TestSupportsRESTTickerBatchUpdates(t *testing.T) {
 	t.Parallel()
@@ -205,7 +203,8 @@ func TestSetClientProxyAddress(t *testing.T) {
 
 	newBase := Base{
 		Name:      "rawr",
-		Requester: requester}
+		Requester: requester,
+	}
 
 	newBase.Websocket = stream.NewWebsocket()
 	err = newBase.SetClientProxyAddress("")
@@ -404,7 +403,7 @@ func TestGetExchangeBankAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var b = Base{Name: "Bitfinex"}
+	b := Base{Name: "Bitfinex"}
 	r, err := b.GetExchangeBankAccounts("", "USD")
 	if err != nil {
 		t.Error(err)
@@ -760,7 +759,7 @@ func TestFormatExchangeCurrencies(t *testing.T) {
 		},
 	}
 
-	var pairs = []currency.Pair{
+	pairs := []currency.Pair{
 		currency.NewPairWithDelimiter("BTC", "USD", "_"),
 		currency.NewPairWithDelimiter("LTC", "BTC", "_"),
 	}
@@ -824,7 +823,7 @@ func TestSetupDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var b = Base{
+	b := Base{
 		Name:      "awesomeTest",
 		Requester: newRequester,
 	}
@@ -980,10 +979,12 @@ func TestUpdatePairs(t *testing.T) {
 		},
 	}
 	UAC.Config = exchCfg
-	exchangeProducts, err := currency.NewPairsFromStrings([]string{"ltcusd",
+	exchangeProducts, err := currency.NewPairsFromStrings([]string{
+		"ltcusd",
 		"btcusd",
 		"usdbtc",
-		"audusd"})
+		"audusd",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,10 +1016,12 @@ func TestUpdatePairs(t *testing.T) {
 	}
 
 	// Test updating exchange products
-	exchangeProducts, err = currency.NewPairsFromStrings([]string{"ltcusd",
+	exchangeProducts, err = currency.NewPairsFromStrings([]string{
+		"ltcusd",
 		"btcusd",
 		"usdbtc",
-		"audbtc"})
+		"audbtc",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1311,6 +1314,7 @@ func TestPrintEnabledPairs(t *testing.T) {
 
 	b.PrintEnabledPairs()
 }
+
 func TestGetBase(t *testing.T) {
 	t.Parallel()
 
@@ -1412,19 +1416,22 @@ func TestSetAssetPairStore(t *testing.T) {
 
 	err = b.SetAssetPairStore(asset.Spot, currency.PairStore{
 		RequestFormat: &currency.PairFormat{Uppercase: true},
-		ConfigFormat:  &currency.PairFormat{Uppercase: true}})
+		ConfigFormat:  &currency.PairFormat{Uppercase: true},
+	})
 	assert.ErrorIs(t, err, errConfigPairFormatRequiresDelimiter)
 
 	err = b.SetAssetPairStore(asset.Futures, currency.PairStore{
 		RequestFormat: &currency.PairFormat{Uppercase: true},
-		ConfigFormat:  &currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter}})
+		ConfigFormat:  &currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter},
+	})
 	assert.NoError(t, err)
 	assert.False(t, b.CurrencyPairs.Pairs[asset.Futures].AssetEnabled, "SetAssetPairStore should not magically enable AssetTypes")
 
 	err = b.SetAssetPairStore(asset.Futures, currency.PairStore{
 		AssetEnabled:  true,
 		RequestFormat: &currency.PairFormat{Uppercase: true},
-		ConfigFormat:  &currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter}})
+		ConfigFormat:  &currency.PairFormat{Uppercase: true, Delimiter: currency.DashDelimiter},
+	})
 	assert.NoError(t, err)
 	assert.True(t, b.CurrencyPairs.Pairs[asset.Futures].AssetEnabled, "AssetEnabled should be respected")
 }
@@ -2636,7 +2643,8 @@ func TestMatchSymbolWithAvailablePairs(t *testing.T) {
 	whatIWant := currency.NewPair(currency.BTC, currency.USDT)
 	err := b.CurrencyPairs.Store(asset.Spot, &currency.PairStore{
 		AssetEnabled: true,
-		Available:    []currency.Pair{whatIWant}})
+		Available:    []currency.Pair{whatIWant},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/exchange_types.go
+++ b/exchanges/exchange_types.go
@@ -311,7 +311,8 @@ var keyURLs = []URL{
 	ChainAnalysis,
 	EdgeCase1,
 	EdgeCase2,
-	EdgeCase3}
+	EdgeCase3,
+}
 
 // URL stores uint conversions
 type URL uint16

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -125,7 +125,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := e.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	// CryptocurrencyTradeFee Basic
 	if _, err := e.GetFee(feeBuilder); err != nil {
@@ -254,7 +254,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -270,7 +270,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -294,7 +294,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: e.Name,
 		Pair: currency.Pair{
 			Delimiter: "_",
@@ -321,7 +321,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -343,7 +343,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -403,7 +403,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := e.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -414,7 +414,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := e.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -184,7 +184,8 @@ func (e *EXMO) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Volume:       tick.Volume,
 			LastUpdated:  time.Unix(tick.Updated, 0),
 			ExchangeName: e.Name,
-			AssetType:    a})
+			AssetType:    a,
+		})
 		if err != nil {
 			return err
 		}

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -3674,6 +3674,7 @@ func (g *Gateio) GetUnderlyingFromCurrencyPair(p currency.Pair) (currency.Pair, 
 	}
 	return currency.Pair{Base: currency.NewCode(ccies[0]), Delimiter: currency.UnderscoreDelimiter, Quote: currency.NewCode(ccies[1])}, nil
 }
+
 func getSettlementFromCurrency(currencyPair currency.Pair) (settlement currency.Code, err error) {
 	quote := currencyPair.Quote.Upper().String()
 

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -71,7 +71,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !errors.Is(err, order.ErrCancelOrderIsNil) {
 		t.Error(err)
 	}
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -133,6 +133,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
@@ -290,6 +291,7 @@ func TestGetCandlesticks(t *testing.T) {
 		t.Errorf("%s GetCandlesticks() error %v", g.Name, err)
 	}
 }
+
 func TestGetTradingFeeRatio(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
@@ -405,10 +407,12 @@ func TestGetSpotOrder(t *testing.T) {
 	if _, err := g.GetSpotOrder(context.Background(), "1234", currency.Pair{
 		Base:      currency.BTC,
 		Delimiter: currency.UnderscoreDelimiter,
-		Quote:     currency.USDT}, asset.Spot); err != nil {
+		Quote:     currency.USDT,
+	}, asset.Spot); err != nil {
 		t.Errorf("%s GetSpotOrder() error %v", g.Name, err)
 	}
 }
+
 func TestAmendSpotOrder(t *testing.T) {
 	t.Parallel()
 	_, err := g.AmendSpotOrder(context.Background(), "", getPair(t, asset.Spot), false, &PriceAndAmount{
@@ -431,6 +435,7 @@ func TestAmendSpotOrder(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestCancelSingleSpotOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
@@ -533,7 +538,8 @@ func TestListMarginAccountBalanceChangeHistory(t *testing.T) {
 	if _, err := g.ListMarginAccountBalanceChangeHistory(context.Background(), currency.BTC, currency.Pair{
 		Base:      currency.BTC,
 		Delimiter: currency.UnderscoreDelimiter,
-		Quote:     currency.USDT}, time.Time{}, time.Time{}, 0, 0); err != nil {
+		Quote:     currency.USDT,
+	}, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Errorf("%s ListMarginAccountBalanceChangeHistory() error %v", g.Name, err)
 	}
 }
@@ -983,6 +989,7 @@ func TestGetFuturesOrderbook(t *testing.T) {
 	_, err = g.GetFuturesOrderbook(context.Background(), settle, getPair(t, asset.Futures).String(), "", 0, false)
 	assert.NoError(t, err, "GetFuturesOrderbook should not error")
 }
+
 func TestGetFuturesTradingHistory(t *testing.T) {
 	t.Parallel()
 	settle, err := getSettlementFromCurrency(getPair(t, asset.Futures))
@@ -1050,6 +1057,7 @@ func TestGetLiquidationHistory(t *testing.T) {
 	_, err = g.GetLiquidationHistory(context.Background(), settle, getPair(t, asset.Futures), time.Time{}, time.Time{}, 0)
 	assert.NoError(t, err, "GetLiquidationHistory should not error")
 }
+
 func TestQueryFuturesAccount(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
@@ -1256,6 +1264,7 @@ func TestUpdatePositionMarginInDualMode(t *testing.T) {
 	_, err = g.UpdatePositionMarginInDualMode(context.Background(), settle, getPair(t, asset.Futures), 0.001, "dual_long")
 	assert.NoError(t, err, "UpdatePositionMarginInDualMode should not error")
 }
+
 func TestUpdatePositionLeverageInDualMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
@@ -1353,12 +1362,14 @@ func TestGetSingleFuturesOrder(t *testing.T) {
 	_, err := g.GetSingleFuturesOrder(context.Background(), currency.BTC, "12345")
 	assert.NoError(t, err, "GetSingleFuturesOrder should not error")
 }
+
 func TestCancelSingleFuturesOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
 	_, err := g.CancelSingleFuturesOrder(context.Background(), currency.BTC, "12345")
 	assert.NoError(t, err, "CancelSingleFuturesOrder should not error")
 }
+
 func TestAmendFuturesOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
@@ -1507,6 +1518,7 @@ func TestQueryDeliveryFuturesAccounts(t *testing.T) {
 	_, err := g.GetDeliveryFuturesAccounts(context.Background(), currency.USDT)
 	assert.NoError(t, err, "GetDeliveryFuturesAccounts should not error")
 }
+
 func TestGetDeliveryAccountBooks(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
@@ -1748,6 +1760,7 @@ func TestCancelOptionOpenOrders(t *testing.T) {
 		t.Errorf("%s CancelOptionOpenOrders() error %v", g.Name, err)
 	}
 }
+
 func TestGetSingleOptionOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
@@ -1954,6 +1967,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 		t.Errorf("%s GetWithdrawalsHistory() error %v", g.Name, err)
 	}
 }
+
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
 	_, err := g.GetRecentTrades(context.Background(), getPair(t, asset.Spot), asset.Spot)
@@ -2060,7 +2074,7 @@ func TestSubmitOrder(t *testing.T) {
 
 func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -2113,7 +2127,8 @@ func TestCancelBatchOrders(t *testing.T) {
 			AccountID:     "1",
 			Pair:          getPair(t, asset.Spot),
 			AssetType:     asset.Spot,
-		}})
+		},
+	})
 	if err != nil {
 		t.Errorf("%s CancelOrder error: %v", g.Name, err)
 	}
@@ -2130,7 +2145,8 @@ func TestCancelBatchOrders(t *testing.T) {
 			AccountID:     "1",
 			Pair:          getPair(t, asset.Futures),
 			AssetType:     asset.Futures,
-		}})
+		},
+	})
 	if err != nil {
 		t.Errorf("%s CancelOrder error: %v", g.Name, err)
 	}
@@ -2147,7 +2163,8 @@ func TestCancelBatchOrders(t *testing.T) {
 			AccountID:     "1",
 			Pair:          getPair(t, asset.DeliveryFutures),
 			AssetType:     asset.DeliveryFutures,
-		}})
+		},
+	})
 	if err != nil {
 		t.Errorf("%s CancelOrder error: %v", g.Name, err)
 	}
@@ -2164,7 +2181,8 @@ func TestCancelBatchOrders(t *testing.T) {
 			AccountID:     "1",
 			Pair:          getPair(t, asset.Options),
 			AssetType:     asset.Options,
-		}})
+		},
+	})
 	if err != nil {
 		t.Errorf("%s CancelOrder error: %v", g.Name, err)
 	}
@@ -2181,7 +2199,8 @@ func TestCancelBatchOrders(t *testing.T) {
 			AccountID:     "1",
 			Pair:          getPair(t, asset.Margin),
 			AssetType:     asset.Margin,
-		}})
+		},
+	})
 	if err != nil {
 		t.Errorf("%s CancelOrder error: %v", g.Name, err)
 	}
@@ -2286,7 +2305,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
-	var multiOrderRequest = order.MultiOrderRequest{
+	multiOrderRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.Buy,
@@ -2387,6 +2406,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 		t.Errorf("%s GetHistoricCandlesExtended() expecting: %v, but found %v", g.Name, asset.ErrNotSupported, err)
 	}
 }
+
 func TestGetAvailableTransferTrains(t *testing.T) {
 	t.Parallel()
 	_, err := g.GetAvailableTransferChains(context.Background(), currency.USDT)
@@ -2880,6 +2900,7 @@ func TestGenerateDeliveryFuturesDefaultSubscriptions(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestGenerateFuturesDefaultSubscriptions(t *testing.T) {
 	t.Parallel()
 	subs, err := g.GenerateFuturesDefaultSubscriptions(currency.USDT)
@@ -2891,6 +2912,7 @@ func TestGenerateFuturesDefaultSubscriptions(t *testing.T) {
 	_, err = g.GenerateFuturesDefaultSubscriptions(currency.TABOO)
 	require.Error(t, err)
 }
+
 func TestGenerateOptionsDefaultSubscriptions(t *testing.T) {
 	t.Parallel()
 	if _, err := g.GenerateOptionsDefaultSubscriptions(); err != nil {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -1101,7 +1101,8 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 			Settle:      settle,
 			ReduceOnly:  s.ReduceOnly,
 			TimeInForce: timeInForce,
-			Text:        s.ClientOrderID})
+			Text:        s.ClientOrderID,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -1109,7 +1110,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		if err != nil {
 			return nil, err
 		}
-		var status = order.Open
+		status := order.Open
 		if fOrder.Status != "open" {
 			status, err = order.StringToOrderStatus(fOrder.FinishAs)
 			if err != nil {
@@ -1156,7 +1157,7 @@ func (g *Gateio) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submi
 		if err != nil {
 			return nil, err
 		}
-		var status = order.Open
+		status := order.Open
 		if newOrder.Status != "open" {
 			status, err = order.StringToOrderStatus(newOrder.FinishAs)
 			if err != nil {

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -243,7 +243,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := g.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -265,7 +265,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	if sharedtestvalues.AreAPICredentialsSet(g) || mockTests {
 		// CryptocurrencyTradeFee Basic
 		if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
@@ -349,7 +349,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type: order.AnyType,
 		Pairs: []currency.Pair{
 			currency.NewPair(currency.LTC, currency.BTC),
@@ -371,7 +371,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Pairs:     []currency.Pair{currency.NewPair(currency.LTC, currency.BTC)},
 		AssetType: asset.Spot,
@@ -397,7 +397,7 @@ func TestSubmitOrder(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 	}
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: g.Name,
 		Pair: currency.Pair{
 			Delimiter: "_",
@@ -428,7 +428,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 	}
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:   "266029865",
 		AssetType: asset.Spot,
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
@@ -452,7 +452,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	}
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -519,7 +519,7 @@ func TestWithdrawFiat(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 	}
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := g.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
@@ -534,7 +534,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 	}
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := g.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -277,7 +277,8 @@ func (g *Gemini) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item
 		Close:        tick.Close,
 		Pair:         fPair,
 		ExchangeName: g.Name,
-		AssetType:    a})
+		AssetType:    a,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -359,7 +359,6 @@ func (h *HitBTC) CancelExistingOrder(ctx context.Context, orderID int64) (bool, 
 		values,
 		tradingRequests,
 		&result)
-
 	if err != nil {
 		return false, err
 	}
@@ -396,7 +395,6 @@ func (h *HitBTC) Withdraw(ctx context.Context, currency, address string, amount 
 		values,
 		otherRequests,
 		&result)
-
 	if err != nil {
 		return false, err
 	}
@@ -481,7 +479,6 @@ func (h *HitBTC) GetFee(ctx context.Context, feeBuilder *exchange.FeeBuilder) (f
 			feeBuilder.Pair.Base.String()+
 				feeBuilder.Pair.Delimiter+
 				feeBuilder.Pair.Quote.String())
-
 		if err != nil {
 			return 0, err
 		}

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -139,7 +139,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := h.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +198,7 @@ func TestGetSingularTicker(t *testing.T) {
 }
 
 func TestGetFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		// CryptocurrencyTradeFee Basic
 		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
@@ -274,7 +274,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Pairs:     []currency.Pair{currency.NewPair(currency.ETH, currency.BTC)},
 		AssetType: asset.Spot,
@@ -291,7 +291,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     []currency.Pair{currency.NewPair(currency.ETH, currency.BTC)},
@@ -312,7 +312,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: h.Name,
 		Pair: currency.Pair{
 			Base:  currency.DGD,
@@ -338,7 +338,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -360,7 +360,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -421,7 +421,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := h.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -432,7 +432,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := h.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {

--- a/exchanges/hitbtc/hitbtc_types.go
+++ b/exchanges/hitbtc/hitbtc_types.go
@@ -98,7 +98,6 @@ type Balance struct {
 	Currency  string  `json:"currency"`
 	Available float64 `json:"available,string"` // Amount available for trading or transfer to main account
 	Reserved  float64 `json:"reserved,string"`  // Amount reserved for active orders or incomplete transfers to main account
-
 }
 
 // DepositCryptoAddresses contains address information

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -243,7 +243,8 @@ func (h *HitBTC) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Pair:         pair,
 			LastUpdated:  tick[x].Timestamp,
 			ExchangeName: h.Name,
-			AssetType:    a})
+			AssetType:    a,
+		})
 		if err != nil {
 			return err
 		}
@@ -520,10 +521,9 @@ func (h *HitBTC) CancelAllOrders(ctx context.Context, _ *order.Cancel) (order.Ca
 
 	for i := range resp {
 		if resp[i].Status != "canceled" {
-			cancelAllOrdersResponse.Status[strconv.FormatInt(resp[i].ID, 10)] =
-				fmt.Sprintf("Could not cancel order %v. Status: %v",
-					resp[i].ID,
-					resp[i].Status)
+			cancelAllOrdersResponse.Status[strconv.FormatInt(resp[i].ID, 10)] = fmt.Sprintf("Could not cancel order %v. Status: %v",
+				resp[i].ID,
+				resp[i].Status)
 		}
 	}
 

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -251,7 +251,6 @@ func (h *HUOBI) GetTrades(ctx context.Context, symbol currency.Pair) ([]Trade, e
 // symbol: string of currency pair
 func (h *HUOBI) GetLatestSpotPrice(ctx context.Context, symbol currency.Pair) (float64, error) {
 	list, err := h.GetTradeHistory(ctx, symbol, 1)
-
 	if err != nil {
 		return 0, err
 	}

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1077,7 +1077,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := h.GetFeeByType(context.Background(), feeBuilder)
 	require.NoError(t, err)
 	if !sharedtestvalues.AreAPICredentialsSet(h) {
@@ -1089,7 +1089,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	// CryptocurrencyTradeFee Basic
 	_, err := h.GetFee(feeBuilder)
 	require.NoError(t, err)
@@ -1155,7 +1155,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		AssetType: asset.Spot,
 		Type:      order.AnyType,
 		Pairs:     []currency.Pair{currency.NewPair(currency.BTC, currency.USDT)},
@@ -1178,7 +1178,7 @@ func TestSubmitOrder(t *testing.T) {
 	accounts, err := h.GetAccounts(context.Background())
 	require.NoError(t, err, "GetAccounts must not error")
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: h.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -1199,7 +1199,7 @@ func TestSubmitOrder(t *testing.T) {
 func TestCancelExchangeOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -1215,7 +1215,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = order.Cancel{
+	orderCancellation := order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -2072,8 +2072,10 @@ func TestBootstrap(t *testing.T) {
 	require.NotNil(t, h.futureContractCodes)
 }
 
-var updatePairsMutex sync.Mutex
-var futureContractCodesCache map[string]currency.Code
+var (
+	updatePairsMutex         sync.Mutex
+	futureContractCodesCache map[string]currency.Code
+)
 
 // updatePairsOnce updates the pairs once, and ensures a future dated contract is enabled
 func updatePairsOnce(tb testing.TB, h *HUOBI) {

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -962,7 +962,7 @@ func (h *HUOBI) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Submit
 			return nil, err
 		}
 		var formattedType SpotNewOrderRequestParamsType
-		var params = SpotNewOrderRequestParams{
+		params := SpotNewOrderRequestParams{
 			Amount:    s.Amount,
 			Source:    "api",
 			Symbol:    s.Pair,
@@ -1261,7 +1261,7 @@ func (h *HUOBI) GetOrderInfo(ctx context.Context, orderID string, pair currency.
 		if respData.ID == 0 {
 			return nil, fmt.Errorf("%s - order not found for orderid %s", h.Name, orderID)
 		}
-		var responseID = strconv.FormatInt(respData.ID, 10)
+		responseID := strconv.FormatInt(respData.ID, 10)
 		if responseID != orderID {
 			return nil, errors.New(h.Name + " - GetOrderInfo orderID mismatch. Expected: " +
 				orderID + " Received: " + responseID)

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -457,7 +457,7 @@ func TestCalculateCandleDateRanges(t *testing.T) {
 
 func TestItem_SortCandlesByTimestamp(t *testing.T) {
 	t.Parallel()
-	var tempKline = Item{
+	tempKline := Item{
 		Exchange: "testExchange",
 		Pair:     currency.NewPair(currency.BTC, currency.USDT),
 		Asset:    asset.Spot,
@@ -1143,7 +1143,8 @@ func TestAddPadding(t *testing.T) {
 			Low:    1337,
 			Close:  6969,
 			Volume: 2520,
-		}}
+		},
+	}
 
 	err = k.addPadding(tn, tn.AddDate(0, 0, 3), false)
 	if !errors.Is(err, errCandleOpenTimeIsNotUTCAligned) {
@@ -1174,7 +1175,8 @@ func TestAddPadding(t *testing.T) {
 			Low:    1337,
 			Close:  6969,
 			Volume: 2520,
-		}}
+		},
+	}
 
 	err = k.addPadding(tn, tn.AddDate(0, 0, 3), false)
 	if !errors.Is(err, nil) {

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -158,7 +158,8 @@ func (k *Kraken) FuturesEditOrder(ctx context.Context, orderID, clientOrderID st
 // FuturesSendOrder sends a futures order
 func (k *Kraken) FuturesSendOrder(ctx context.Context, orderType order.Type, symbol currency.Pair, side, triggerSignal, clientOrderID, reduceOnly string,
 	ioc bool,
-	size, limitPrice, stopPrice float64) (FuturesSendOrderData, error) {
+	size, limitPrice, stopPrice float64,
+) (FuturesSendOrderData, error) {
 	var resp FuturesSendOrderData
 
 	if ioc && orderType != order.Market {

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -549,7 +549,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	f, err := k.GetFeeByType(context.Background(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 	assert.Positive(t, f, "GetFeeByType should return a positive value")
@@ -563,7 +563,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 // TestGetFee exercises GetFee
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	if sharedtestvalues.AreAPICredentialsSet(k) {
 		_, err := k.GetFee(context.Background(), feeBuilder)
@@ -628,7 +628,7 @@ func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     currency.Pairs{spotTestPair},
@@ -644,7 +644,7 @@ func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -670,7 +670,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange:  k.Name,
 		Pair:      spotTestPair,
 		Side:      order.Buy,
@@ -701,7 +701,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:   "OGEX6P-B5Q74-IGZ72R",
 		AssetType: asset.Spot,
 	}
@@ -804,7 +804,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:        -1,
 		Currency:      currency.EUR,
 		Description:   "WITHDRAW IT ALL",
@@ -825,7 +825,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{
+	withdrawFiatRequest := withdraw.Request{
 		Amount:        -1,
 		Currency:      currency.EUR,
 		Description:   "WITHDRAW IT ALL",

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -513,7 +513,6 @@ type WebsocketSubscriptionData struct {
 	Interval int    `json:"interval,omitempty"` // Optional - Timeframe for candles subscription in minutes; default 1. Valid: 1|5|15|30|60|240|1440|10080|21600
 	Depth    int    `json:"depth,omitempty"`    // Optional - Depth associated with orderbook; default 10. Valid: 10|25|100|500|1000
 	Token    string `json:"token,omitempty"`    // Optional - Token for authenticated channels
-
 }
 
 // WebsocketEventResponse holds all data response types

--- a/exchanges/kucoin/kucoin.go
+++ b/exchanges/kucoin/kucoin.go
@@ -109,13 +109,11 @@ func processOB(ob [][2]types.Number) []orderbook.Tranche {
 
 // constructOrderbook parse checks and constructs an *Orderbook instance from *orderbookResponse.
 func constructOrderbook(o *orderbookResponse) (*Orderbook, error) {
-	var (
-		s = Orderbook{
-			Bids: processOB(o.Bids),
-			Asks: processOB(o.Asks),
-			Time: o.Time.Time(),
-		}
-	)
+	s := Orderbook{
+		Bids: processOB(o.Bids),
+		Asks: processOB(o.Asks),
+		Time: o.Time.Time(),
+	}
 	if o.Sequence != "" {
 		var err error
 		s.Sequence, err = strconv.ParseInt(o.Sequence, 10, 64)
@@ -338,7 +336,8 @@ func (ku *Kucoin) PostMarginBorrowOrder(ctx context.Context, arg *MarginBorrowPa
 func (ku *Kucoin) GetMarginBorrowingHistory(ctx context.Context, ccy currency.Code, isIsolated bool,
 	symbol, orderNo string,
 	startTime, endTime time.Time,
-	currentPage, pageSize int64) (*BorrowRepayDetailResponse, error) {
+	currentPage, pageSize int64,
+) (*BorrowRepayDetailResponse, error) {
 	if ccy.IsEmpty() {
 		return nil, currency.ErrCurrencyCodeEmpty
 	}
@@ -417,7 +416,8 @@ func (ku *Kucoin) GetCrossIsolatedMarginInterestRecords(ctx context.Context, isI
 func (ku *Kucoin) GetRepaymentHistory(ctx context.Context, ccy currency.Code, isIsolated bool,
 	symbol, orderNo string,
 	startTime, endTime time.Time,
-	currentPage, pageSize int64) (*BorrowRepayDetailResponse, error) {
+	currentPage, pageSize int64,
+) (*BorrowRepayDetailResponse, error) {
 	if ccy.IsEmpty() {
 		return nil, currency.ErrCurrencyCodeEmpty
 	}
@@ -1081,7 +1081,8 @@ func (ku *Kucoin) GetRecentFills(ctx context.Context) ([]Fill, error) {
 // PostStopOrder used to place two types of stop orders: limit and market
 func (ku *Kucoin) PostStopOrder(ctx context.Context, clientOID, side, symbol, orderType, remark, stop, stp,
 	tradeType, timeInForce string, size, price, stopPrice, cancelAfter, visibleSize,
-	funds float64, postOnly, hidden, iceberg bool) (string, error) {
+	funds float64, postOnly, hidden, iceberg bool,
+) (string, error) {
 	if clientOID == "" {
 		return "", order.ErrClientOrderIDMustBeSet
 	}
@@ -2455,7 +2456,8 @@ func (ku *Kucoin) SendHTTPRequest(ctx context.Context, ePath exchange.URL, epl r
 			Result:        resp,
 			Verbose:       ku.Verbose,
 			HTTPDebugging: ku.HTTPDebugging,
-			HTTPRecording: ku.HTTPRecording}, nil
+			HTTPRecording: ku.HTTPRecording,
+		}, nil
 	}, request.UnauthenticatedRequest)
 	if err != nil {
 		return err
@@ -2526,7 +2528,8 @@ func (ku *Kucoin) SendAuthHTTPRequest(ctx context.Context, ePath exchange.URL, e
 			Result:        &resp,
 			Verbose:       ku.Verbose,
 			HTTPDebugging: ku.HTTPDebugging,
-			HTTPRecording: ku.HTTPRecording}, nil
+			HTTPRecording: ku.HTTPRecording,
+		}, nil
 	}, request.AuthenticatedRequest)
 	if err != nil {
 		return err

--- a/exchanges/kucoin/kucoin_futures_types.go
+++ b/exchanges/kucoin/kucoin_futures_types.go
@@ -7,11 +7,9 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
-var (
-	validGranularity = []string{
-		"1", "5", "15", "30", "60", "120", "240", "480", "720", "1440", "10080",
-	}
-)
+var validGranularity = []string{
+	"1", "5", "15", "30", "60", "120", "240", "480", "720", "1440", "10080",
+}
 
 // Contract store contract details
 type Contract struct {

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -328,7 +328,8 @@ func TestPostRepayment(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	result, err := ku.PostRepayment(context.Background(), &RepayParam{
 		Currency: currency.USDT,
-		Size:     0.05})
+		Size:     0.05,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -401,7 +402,8 @@ func TestPostOrder(t *testing.T) {
 
 	// default order type is limit
 	_, err := ku.PostOrder(context.Background(), &SpotOrderParam{
-		ClientOrderID: ""})
+		ClientOrderID: "",
+	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	customID, err := uuid.NewV4()
@@ -409,21 +411,25 @@ func TestPostOrder(t *testing.T) {
 
 	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
-		OrderType: ""})
+		OrderType: "",
+	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
-		Size: 0.1, Side: "buy", Price: 234565})
+		Size: 0.1, Side: "buy", Price: 234565,
+	})
 
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "limit", Size: 0.1})
+		OrderType: "limit", Size: 0.1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
-		OrderType: "limit", Price: 234565})
+		OrderType: "limit", Price: 234565,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
@@ -433,7 +439,8 @@ func TestPostOrder(t *testing.T) {
 		Symbol:        spotTradablePair,
 		OrderType:     "limit",
 		Size:          0.005,
-		Price:         1000})
+		Price:         1000,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -443,7 +450,8 @@ func TestPostOrderTest(t *testing.T) {
 
 	// default order type is limit
 	_, err := ku.PostOrderTest(context.Background(), &SpotOrderParam{
-		ClientOrderID: ""})
+		ClientOrderID: "",
+	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	customID, err := uuid.NewV4()
@@ -451,21 +459,25 @@ func TestPostOrderTest(t *testing.T) {
 
 	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
-		OrderType: ""})
+		OrderType: "",
+	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
-		Size: 0.1, Side: "buy", Price: 234565})
+		Size: 0.1, Side: "buy", Price: 234565,
+	})
 
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "limit", Size: 0.1})
+		OrderType: "limit", Size: 0.1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
-		OrderType: "limit", Price: 234565})
+		OrderType: "limit", Price: 234565,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
@@ -475,7 +487,8 @@ func TestPostOrderTest(t *testing.T) {
 		Symbol:        spotTradablePair,
 		OrderType:     "limit",
 		Size:          0.005,
-		Price:         1000})
+		Price:         1000,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -484,7 +497,8 @@ func TestHandlePostOrder(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
 	_, err := ku.HandlePostOrder(context.Background(), &SpotOrderParam{
-		ClientOrderID: ""}, "")
+		ClientOrderID: "",
+	}, "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	customID, err := uuid.NewV4()
@@ -492,40 +506,47 @@ func TestHandlePostOrder(t *testing.T) {
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
-		OrderType: ""}, "")
+		OrderType: "",
+	}, "")
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
-		Size: 0.1, Side: "buy", Price: 234565}, "")
+		Size: 0.1, Side: "buy", Price: 234565,
+	}, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "OCO", Size: 0.1}, "")
+		OrderType: "OCO", Size: 0.1,
+	}, "")
 	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "limit", Size: 0.1}, "")
+		OrderType: "limit", Size: 0.1,
+	}, "")
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "limit", Size: 0, Price: 1000}, "")
+		OrderType: "limit", Size: 0, Price: 1000,
+	}, "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
-		OrderType: "limit", Size: .1, Price: 1000, VisibleSize: -1}, "")
+		OrderType: "limit", Size: .1, Price: 1000, VisibleSize: -1,
+	}, "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
-		OrderType: "market", Price: 234565}, "")
+		OrderType: "market", Price: 234565,
+	}, "")
 	require.ErrorIs(t, err, errSizeOrFundIsRequired)
 }
 
@@ -533,24 +554,29 @@ func TestPostMarginOrder(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
 	_, err := ku.PostMarginOrder(context.Background(), &MarginOrderParam{
-		ClientOrderID: ""})
+		ClientOrderID: "",
+	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
-		OrderType: ""})
+		OrderType: "",
+	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: currency.EMPTYPAIR,
-		Size: 0.1, Side: "buy", Price: 234565})
+		Size: 0.1, Side: "buy", Price: 234565,
+	})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
 		Symbol:    marginTradablePair,
-		OrderType: "limit", Size: 0.1})
+		OrderType: "limit", Size: 0.1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
-		OrderType: "limit", Price: 234565})
+		OrderType: "limit", Price: 234565,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
@@ -559,7 +585,8 @@ func TestPostMarginOrder(t *testing.T) {
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
-			Price: 1000, Size: 0.1, PostOnly: true})
+			Price: 1000, Size: 0.1, PostOnly: true,
+		})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
@@ -569,7 +596,8 @@ func TestPostMarginOrder(t *testing.T) {
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
 			OrderType: "market", Funds: 1234,
-			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true})
+			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true,
+		})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -578,24 +606,29 @@ func TestPostMarginOrderTest(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
 	_, err := ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
-		ClientOrderID: ""})
+		ClientOrderID: "",
+	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
-		OrderType: ""})
+		OrderType: "",
+	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: currency.EMPTYPAIR,
-		Size: 0.1, Side: "buy", Price: 234565})
+		Size: 0.1, Side: "buy", Price: 234565,
+	})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
 		Symbol:    marginTradablePair,
-		OrderType: "limit", Size: 0.1})
+		OrderType: "limit", Size: 0.1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
-		OrderType: "limit", Price: 234565})
+		OrderType: "limit", Price: 234565,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
@@ -604,7 +637,8 @@ func TestPostMarginOrderTest(t *testing.T) {
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
-			Price: 1000, Size: 0.1, PostOnly: true})
+			Price: 1000, Size: 0.1, PostOnly: true,
+		})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
@@ -614,7 +648,8 @@ func TestPostMarginOrderTest(t *testing.T) {
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
 			OrderType: "market", Funds: 1234,
-			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true})
+			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true,
+		})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1170,7 +1205,8 @@ func TestCreateDepositAddress(t *testing.T) {
 	result, err = ku.CreateDepositAddress(context.Background(),
 		&DepositAddressParams{
 			Currency: currency.USDT,
-			Chain:    "TRC20"})
+			Chain:    "TRC20",
+		})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1498,37 +1534,51 @@ func TestPostFuturesOrder(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	// With Stop order configuration
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0})
+	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, errInvalidStopPriceType)
 
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0})
+	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0})
+	result, err := ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	// Limit Orders
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
-		OrderType: "limit", Remark: "10", Leverage: 1})
+	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		OrderType: "limit", Remark: "10", Leverage: 1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	result, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0})
+	result, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	// Market Orders
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
-		OrderType: "market", Remark: "10", Leverage: 1})
+	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		OrderType: "market", Remark: "10", Leverage: 1,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
-		Size: 1, Leverage: 1, VisibleSize: 0})
+	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
+		Size: 1, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	result, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
@@ -1544,10 +1594,12 @@ func TestPostFuturesOrder(t *testing.T) {
 		Price:         1000,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0})
+		VisibleSize:   0,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 	t.Parallel()
 	err := ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy"})
@@ -1560,34 +1612,48 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	// With Stop order configuration
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, errInvalidStopPriceType)
 
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+	})
 	assert.NoError(t, err)
 
 	// Limit Orders
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
-		OrderType: "limit", Remark: "10", Leverage: 1})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		OrderType: "limit", Remark: "10", Leverage: 1,
+	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+	})
 	assert.NoError(t, err)
 
 	// Market Orders
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
-		OrderType: "market", Remark: "10", Leverage: 1})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		OrderType: "market", Remark: "10", Leverage: 1,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
-		Size: 0, Leverage: 1, VisibleSize: 0})
+	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
+		Size: 0, Leverage: 1, VisibleSize: 0,
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	err = ku.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
@@ -1603,7 +1669,8 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 		Price:         1000,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0})
+		VisibleSize:   0,
+	})
 	assert.NoError(t, err)
 }
 
@@ -1622,7 +1689,8 @@ func TestPostFuturesOrderTest(t *testing.T) {
 		Size:          1,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0})
+		VisibleSize:   0,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 }
@@ -1968,6 +2036,7 @@ func TestUpdateOrderbook(t *testing.T) {
 		assert.NotNil(t, result)
 	}
 }
+
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 	for _, a := range ku.GetAssetTypes(true) {
@@ -1990,6 +2059,7 @@ func TestUpdateTickers(t *testing.T) {
 		}
 	}
 }
+
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	var result *ticker.Price
@@ -2261,10 +2331,14 @@ func TestGenerateSubscriptions(t *testing.T) {
 	exp := subscription.List{
 		{Channel: subscription.TickerChannel, Asset: asset.Spot, Pairs: pairs["both"], QualifiedChannel: "/market/ticker:" + pairs["both"].Join()},
 		{Channel: subscription.TickerChannel, Asset: asset.Futures, Pairs: pairs["futures"], QualifiedChannel: "/contractMarket/tickerV2:" + pairs["futures"].Join()},
-		{Channel: subscription.OrderbookChannel, Asset: asset.Spot, Pairs: pairs["both"], QualifiedChannel: "/spotMarket/level2Depth5:" + pairs["both"].Join(),
-			Interval: kline.HundredMilliseconds},
-		{Channel: subscription.OrderbookChannel, Asset: asset.Futures, Pairs: pairs["futures"], QualifiedChannel: "/contractMarket/level2Depth5:" + pairs["futures"].Join(),
-			Interval: kline.HundredMilliseconds},
+		{
+			Channel: subscription.OrderbookChannel, Asset: asset.Spot, Pairs: pairs["both"], QualifiedChannel: "/spotMarket/level2Depth5:" + pairs["both"].Join(),
+			Interval: kline.HundredMilliseconds,
+		},
+		{
+			Channel: subscription.OrderbookChannel, Asset: asset.Futures, Pairs: pairs["futures"], QualifiedChannel: "/contractMarket/level2Depth5:" + pairs["futures"].Join(),
+			Interval: kline.HundredMilliseconds,
+		},
 		{Channel: subscription.AllTradesChannel, Asset: asset.Spot, Pairs: pairs["both"], QualifiedChannel: "/market/match:" + pairs["both"].Join()},
 	}
 
@@ -2583,7 +2657,7 @@ func TestSubmitOrder(t *testing.T) {
 func TestCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -2758,13 +2832,16 @@ func TestModifySubAccountSpotAPIs(t *testing.T) {
 	err := json.Unmarshal([]byte(modifySubAccountSpotAPIs), &resp)
 	assert.NoError(t, err)
 	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
-		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "", Passphrase: "mysecretPassphrase123"})
+		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "", Passphrase: "mysecretPassphrase123",
+	})
 	require.ErrorIs(t, err, errInvalidSubAccountName)
 	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
-		SubAccountName: "gocryptoTrader1", Passphrase: "mysecretPassphrase123"})
+		SubAccountName: "gocryptoTrader1", Passphrase: "mysecretPassphrase123",
+	})
 	require.ErrorIs(t, err, errAPIKeyRequired)
 	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
-		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "gocryptoTrader1", Passphrase: ""})
+		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "gocryptoTrader1", Passphrase: "",
+	})
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
@@ -3316,7 +3393,8 @@ func TestPlaceMultipleOrders(t *testing.T) {
 			OrderType:   "limit",
 			Side:        order.Sell.String(),
 			Price:       1234,
-			Size:        1},
+			Size:        1,
+		},
 		{
 			ClientOrderID: "3d07008668054da6b3cb12e432c2b13a",
 			Side:          "buy",
@@ -3342,12 +3420,14 @@ func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	result, err := ku.SyncPlaceMultipleHFOrders(context.Background(), []PlaceHFParam{
-		{TimeInForce: "GTT",
-			Symbol:    spotTradablePair,
-			OrderType: "limit",
-			Side:      order.Sell.String(),
-			Price:     1234,
-			Size:      1},
+		{
+			TimeInForce: "GTT",
+			Symbol:      spotTradablePair,
+			OrderType:   "limit",
+			Side:        order.Sell.String(),
+			Price:       1234,
+			Size:        1,
+		},
 		{
 			ClientOrderID: "3d07008668054da6b3cb12e432c2b13a",
 			Side:          "buy",
@@ -4143,6 +4223,7 @@ func TestGetMarginPairsConfigurations(t *testing.T) {
 	_, err = ku.GetMarginPairsConfigurations(context.Background(), marginTradablePair.String())
 	assert.NoError(t, err)
 }
+
 func TestModifyLeverageMultiplier(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	err := ku.ModifyLeverageMultiplier(context.Background(), spotTradablePair.String(), 1, true)
@@ -4156,6 +4237,7 @@ func TestGetActiveHFOrderSymbols(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestOrderSideString(t *testing.T) {
 	t.Parallel()
 	sideErrInput := []struct {
@@ -4309,7 +4391,7 @@ func TestProcessFuturesKline(t *testing.T) {
 
 func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := ku.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)

--- a/exchanges/kucoin/kucoin_types.go
+++ b/exchanges/kucoin/kucoin_types.go
@@ -1819,7 +1819,7 @@ type SubAccountResponse struct {
 type SubAccount struct {
 	UserID    string     `json:"userId"`
 	SubName   string     `json:"subName"`
-	Type      int64      `json:"type"` // type:1-rebot  or type:0-nomal
+	Type      int64      `json:"type"` // type:1-robot  or type:0-nomal
 	Remarks   string     `json:"remarks"`
 	UID       int64      `json:"uid"`
 	Status    int64      `json:"status"`

--- a/exchanges/kucoin/kucoin_types.go
+++ b/exchanges/kucoin/kucoin_types.go
@@ -1819,7 +1819,7 @@ type SubAccountResponse struct {
 type SubAccount struct {
 	UserID    string     `json:"userId"`
 	SubName   string     `json:"subName"`
-	Type      int64      `json:"type"` //type:1-rebot  or type:0-nomal
+	Type      int64      `json:"type"` // type:1-rebot  or type:0-nomal
 	Remarks   string     `json:"remarks"`
 	UID       int64      `json:"uid"`
 	Status    int64      `json:"status"`

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -31,8 +31,10 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
-var fetchedFuturesOrderbookMutex sync.Mutex
-var fetchedFuturesOrderbook map[string]bool
+var (
+	fetchedFuturesOrderbookMutex sync.Mutex
+	fetchedFuturesOrderbook      map[string]bool
+)
 
 const (
 	publicBullets  = "/v1/bullet-public"
@@ -180,7 +182,8 @@ func (ku *Kucoin) GetInstanceServers(ctx context.Context) (*WSInstanceServers, e
 			Result:        &response,
 			Verbose:       ku.Verbose,
 			HTTPDebugging: ku.HTTPDebugging,
-			HTTPRecording: ku.HTTPRecording}, nil
+			HTTPRecording: ku.HTTPRecording,
+		}, nil
 	}, request.UnauthenticatedRequest)
 }
 
@@ -949,7 +952,7 @@ func (ku *Kucoin) processOrderbook(respData []byte, symbol, topic string) error 
 		return err
 	}
 
-	var lastUpdatedTime = response.Timestamp.Time()
+	lastUpdatedTime := response.Timestamp.Time()
 	if response.Timestamp.Time().IsZero() {
 		lastUpdatedTime = time.Now()
 	}

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -130,7 +130,8 @@ func TestUpdateOrderbook(t *testing.T) {
 	p := currency.Pair{
 		Delimiter: "_",
 		Base:      currency.ETH,
-		Quote:     currency.BTC}
+		Quote:     currency.BTC,
+	}
 
 	_, err := l.UpdateOrderbook(context.Background(), p.Lower(), asset.Spot)
 	if err != nil {
@@ -319,7 +320,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, l, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: l.Name,
 		Pair: currency.Pair{
 			Base:      currency.BTC,

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -178,7 +178,8 @@ func (l *Lbank) UpdateTickers(ctx context.Context, a asset.Item) error {
 				Pair:         tickerInfo[j].Symbol,
 				LastUpdated:  time.Unix(0, tickerInfo[j].Timestamp),
 				ExchangeName: l.Name,
-				AssetType:    a})
+				AssetType:    a,
+			})
 			if err != nil {
 				return err
 			}
@@ -476,7 +477,7 @@ func (l *Lbank) CancelAllOrders(ctx context.Context, o *order.Cancel) (order.Can
 		if key != o.Pair.String() {
 			continue
 		}
-		var x, y = 0, 0
+		x, y := 0, 0
 		var input string
 		var tempSlice []string
 		for x <= len(orderIDs[key]) {
@@ -558,7 +559,8 @@ func (l *Lbank) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pai
 			resp.Fee, err = l.GetFeeByType(ctx, &exchange.FeeBuilder{
 				FeeType:       exchange.CryptocurrencyTradeFee,
 				Amount:        tempResp.Orders[0].Amount,
-				PurchasePrice: tempResp.Orders[0].Price})
+				PurchasePrice: tempResp.Orders[0].Price,
+			})
 			if err != nil {
 				resp.Fee = lbankFeeNotFound
 			}
@@ -646,7 +648,8 @@ func (l *Lbank) GetActiveOrders(ctx context.Context, getOrdersRequest *order.Mul
 				&exchange.FeeBuilder{
 					FeeType:       exchange.CryptocurrencyTradeFee,
 					Amount:        tempResp.Orders[0].Amount,
-					PurchasePrice: tempResp.Orders[0].Price})
+					PurchasePrice: tempResp.Orders[0].Price,
+				})
 			if err != nil {
 				resp.Fee = lbankFeeNotFound
 			}
@@ -729,7 +732,8 @@ func (l *Lbank) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mul
 					&exchange.FeeBuilder{
 						FeeType:       exchange.CryptocurrencyTradeFee,
 						Amount:        tempResp.Orders[x].Amount,
-						PurchasePrice: tempResp.Orders[x].Price})
+						PurchasePrice: tempResp.Orders[x].Price,
+					})
 				if err != nil {
 					resp.Fee = lbankFeeNotFound
 				}

--- a/exchanges/mock/common.go
+++ b/exchanges/mock/common.go
@@ -42,7 +42,7 @@ func MatchURLVals(v1, v2 url.Values) bool {
 
 // DeriveURLValsFromJSONMap gets url vals from a map[string]string encoded JSON body
 func DeriveURLValsFromJSONMap(payload []byte) (url.Values, error) {
-	var vals = url.Values{}
+	vals := url.Values{}
 	if len(payload) == 0 {
 		return vals, nil
 	}

--- a/exchanges/mock/common_test.go
+++ b/exchanges/mock/common_test.go
@@ -17,7 +17,7 @@ func TestMatchURLVals(t *testing.T) {
 	nonceVal1.Add("nonce", "012349723587")
 	nonceVal2.Add("nonce", "9327373874")
 
-	var expected = false
+	expected := false
 	received := MatchURLVals(testVal, emptyVal)
 	if received != expected {
 		t.Errorf("MatchURLVals error expected %v received %v",

--- a/exchanges/mock/recording.go
+++ b/exchanges/mock/recording.go
@@ -409,10 +409,12 @@ func IsExcluded(key string, excludedVars []string) bool {
 	return false
 }
 
-var excludedList Exclusion
-var m sync.Mutex
-var set bool
-var exclusionFile = DefaultDirectory + "exclusion.json"
+var (
+	excludedList  Exclusion
+	m             sync.Mutex
+	set           bool
+	exclusionFile = DefaultDirectory + "exclusion.json"
+)
 
 var defaultExcludedHeaders = []string{
 	"Key",
@@ -421,6 +423,7 @@ var defaultExcludedHeaders = []string{
 	"Apiauth-Key",
 	"X-Bapi-Api-Key",
 }
+
 var defaultExcludedVariables = []string{
 	"bsb",
 	"user",

--- a/exchanges/mock/server.go
+++ b/exchanges/mock/server.go
@@ -249,7 +249,7 @@ func MatchAndGetResponse(mockData []HTTPResponse, requestVals url.Values, isQuer
 			data = mockData[i].BodyParams
 		}
 
-		var mockVals = url.Values{}
+		mockVals := url.Values{}
 		var err error
 		if json.Valid([]byte(data)) {
 			something := make(map[string]interface{})

--- a/exchanges/mock/server_test.go
+++ b/exchanges/mock/server_test.go
@@ -18,8 +18,10 @@ type responsePayload struct {
 	Currency string  `json:"currency"`
 }
 
-const queryString = "currency=btc&command=getprice"
-const testFile = "test.json"
+const (
+	queryString = "currency=btc&command=getprice"
+	testFile    = "test.json"
+)
 
 func TestNewVCRServer(t *testing.T) {
 	_, _, err := NewVCRServer("")
@@ -32,9 +34,11 @@ func TestNewVCRServer(t *testing.T) {
 	test1.Routes = make(map[string]map[string][]HTTPResponse)
 	test1.Routes["/test"] = make(map[string][]HTTPResponse)
 
-	rp, err := json.Marshal(responsePayload{Price: 8000.0,
+	rp, err := json.Marshal(responsePayload{
+		Price:    8000.0,
 		Amount:   1,
-		Currency: "bitcoin"})
+		Currency: "bitcoin",
+	})
 	if err != nil {
 		t.Fatal("marshal error", err)
 	}

--- a/exchanges/okx/okx.go
+++ b/exchanges/okx/okx.go
@@ -1573,8 +1573,7 @@ func (ok *Okx) ConvertTrade(ctx context.Context, arg *ConvertTradeInput) (*Conve
 	}
 	arg.Side = strings.ToLower(arg.Side)
 	switch arg.Side {
-	case order.Buy.Lower(),
-		order.Sell.Lower():
+	case order.Buy.Lower(), order.Sell.Lower():
 	default:
 		return nil, order.ErrSideIsInvalid
 	}
@@ -3101,7 +3100,8 @@ func (ok *Okx) InstantTriggerGridAlgoOrder(ctx context.Context, algoID string) (
 // GetGridAlgoOrdersList retrieves list of pending grid algo orders with the complete data
 func (ok *Okx) GetGridAlgoOrdersList(ctx context.Context, algoOrderType, algoID,
 	instrumentID, instrumentType,
-	after, before string, limit int64) ([]GridAlgoOrderResponse, error) {
+	after, before string, limit int64,
+) ([]GridAlgoOrderResponse, error) {
 	return ok.getGridAlgoOrders(ctx, algoOrderType, algoID,
 		instrumentID, instrumentType,
 		after, before, "tradingBot/grid/orders-algo-pending", limit)
@@ -3110,7 +3110,8 @@ func (ok *Okx) GetGridAlgoOrdersList(ctx context.Context, algoOrderType, algoID,
 // GetGridAlgoOrderHistory retrieves list of grid algo orders with the complete data including the stopped orders
 func (ok *Okx) GetGridAlgoOrderHistory(ctx context.Context, algoOrderType, algoID,
 	instrumentID, instrumentType,
-	after, before string, limit int64) ([]GridAlgoOrderResponse, error) {
+	after, before string, limit int64,
+) ([]GridAlgoOrderResponse, error) {
 	return ok.getGridAlgoOrders(ctx, algoOrderType, algoID,
 		instrumentID, instrumentType,
 		after, before, "tradingBot/grid/orders-algo-history", limit)
@@ -3119,7 +3120,8 @@ func (ok *Okx) GetGridAlgoOrderHistory(ctx context.Context, algoOrderType, algoI
 // getGridAlgoOrderList retrieves list of grid algo orders with the complete data
 func (ok *Okx) getGridAlgoOrders(ctx context.Context, algoOrderType, algoID,
 	instrumentID, instrumentType,
-	after, before, route string, limit int64) ([]GridAlgoOrderResponse, error) {
+	after, before, route string, limit int64,
+) ([]GridAlgoOrderResponse, error) {
 	algoOrderType = strings.ToLower(algoOrderType)
 	if algoOrderType != AlgoOrdTypeGrid && algoOrderType != AlgoOrdTypeContractGrid {
 		return nil, errMissingAlgoOrderType
@@ -3868,7 +3870,8 @@ func (ok *Okx) GetHistoryLeadTraders(ctx context.Context, instrumentType, after,
 // Minimum lead days '1': 7 days '2': 30 days '3': 90 days '4': 180 days
 func (ok *Okx) GetLeadTradersRanks(ctx context.Context, instrumentType, sortType, state,
 	minLeadDays, minAssets, maxAssets, minAssetUnderManagement, maxAssetUnderManagement,
-	dataVersion, page string, limit int64) ([]LeadTradersRank, error) {
+	dataVersion, page string, limit int64,
+) ([]LeadTradersRank, error) {
 	params := url.Values{}
 	if instrumentType != "" {
 		params.Set("instType", instrumentType)
@@ -3979,7 +3982,8 @@ func (ok *Okx) GetLeadTraderCurrencyPreferences(ctx context.Context, instrumentT
 // GetLeadTraderCurrentLeadPositions get current leading positions of lead trader
 // Instrument type "SPOT" "SWAP"
 func (ok *Okx) GetLeadTraderCurrentLeadPositions(ctx context.Context, instrumentType, uniqueCode, afterSubPositionID,
-	beforeSubPositionID string, limit int64) ([]LeadTraderCurrentLeadPosition, error) {
+	beforeSubPositionID string, limit int64,
+) ([]LeadTraderCurrentLeadPosition, error) {
 	if uniqueCode == "" {
 		return nil, errUniqueCodeRequired
 	}
@@ -5412,7 +5416,8 @@ func (ok *Okx) GetOpenInterestAndVolumeExpiry(ctx context.Context, ccy currency.
 
 // GetOpenInterestAndVolumeStrike retrieves the taker volume for both buyers and sellers of calls and puts
 func (ok *Okx) GetOpenInterestAndVolumeStrike(ctx context.Context, ccy currency.Code,
-	expTime time.Time, period kline.Interval) ([]StrikeOpenInterestAndVolume, error) {
+	expTime time.Time, period kline.Interval,
+) ([]StrikeOpenInterestAndVolume, error) {
 	if expTime.IsZero() {
 		return nil, errMissingExpiryTimeParameter
 	}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -4083,7 +4083,8 @@ func TestWSProcessTrades(t *testing.T) {
 			Asset:   a,
 			Pairs:   currency.Pairs{p},
 			Channel: subscription.AllTradesChannel,
-			Key:     fmt.Sprintf("%s-%s", p, a)})
+			Key:     fmt.Sprintf("%s-%s", p, a),
+		})
 		require.NoError(t, err, "AddSubscriptions must not error")
 	}
 	testexch.FixtureToDataHandler(t, "testdata/wsAllTrades.json", ok.WsHandleData)

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -402,7 +402,8 @@ func TestGetInstrument(t *testing.T) {
 	assert.ErrorIs(t, err, errInvalidInstrumentType)
 
 	_, err = ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
-		InstrumentType: instTypeOption, Underlying: ""})
+		InstrumentType: instTypeOption, Underlying: "",
+	})
 	assert.ErrorIs(t, err, errInstrumentFamilyOrUnderlyingRequired)
 
 	result, err := ok.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
@@ -662,6 +663,7 @@ func TestGetTakerVolume(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetMarginLendingRatio(t *testing.T) {
 	t.Parallel()
 	result, err := ok.GetMarginLendingRatio(contextGenerate(), currency.BTC, time.Time{}, time.Time{}, kline.FiveMin)
@@ -914,6 +916,7 @@ func TestAmendOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestAmendMultipleOrders(t *testing.T) {
 	t.Parallel()
 	_, err := ok.AmendMultipleOrders(contextGenerate(), []AmendOrderRequestParams{})
@@ -1184,7 +1187,8 @@ func TestPlaceTakeProfitStopLossOrder(t *testing.T) {
 	_, err = ok.PlaceTakeProfitStopLossOrder(contextGenerate(), &AlgoOrderParams{
 		OrderType:                "conditional",
 		StopLossTriggerPrice:     1234,
-		StopLossTriggerPriceType: "abcd"})
+		StopLossTriggerPriceType: "abcd",
+	})
 	require.ErrorIs(t, err, order.ErrUnknownPriceType)
 
 	// Offline error handling unit tests for the base function PlaceAlgoOrder are already covered within unit test TestPlaceAlgoOrder.
@@ -1301,7 +1305,8 @@ func TestPlaceTrailingStopOrder(t *testing.T) {
 		AlgoClientOrderID: "681096944655273984", CallbackRatio: 0.01,
 		InstrumentID: "BTC-USDT", OrderType: "move_order_stop",
 		Side: order.Buy.Lower(), TradeMode: "isolated",
-		Size: 2, ActivePrice: 1234})
+		Size: 2, ActivePrice: 1234,
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1558,7 +1563,8 @@ func TestSetQuoteProducts(t *testing.T) {
 					Underlying: "ETH-USDT",
 				},
 			},
-		}})
+		},
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1750,19 +1756,23 @@ func TestFundingTransfer(t *testing.T) {
 	_, err := ok.FundingTransfer(contextGenerate(), &FundingTransferRequestInput{})
 	assert.ErrorIs(t, err, common.ErrEmptyParams)
 	_, err = ok.FundingTransfer(contextGenerate(), &FundingTransferRequestInput{
-		BeneficiaryAccountType: "6", RemittingAccountType: "18", Currency: currency.BTC})
+		BeneficiaryAccountType: "6", RemittingAccountType: "18", Currency: currency.BTC,
+	})
 	assert.ErrorIs(t, err, order.ErrAmountBelowMin)
 	_, err = ok.FundingTransfer(contextGenerate(), &FundingTransferRequestInput{
 		Amount: 12.000, BeneficiaryAccountType: "6",
-		RemittingAccountType: "18", Currency: currency.EMPTYCODE})
+		RemittingAccountType: "18", Currency: currency.EMPTYCODE,
+	})
 	assert.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 	_, err = ok.FundingTransfer(contextGenerate(), &FundingTransferRequestInput{
 		Amount: 12.000, BeneficiaryAccountType: "2",
-		RemittingAccountType: "3", Currency: currency.BTC})
+		RemittingAccountType: "3", Currency: currency.BTC,
+	})
 	assert.ErrorIs(t, err, errAddressRequired)
 	_, err = ok.FundingTransfer(contextGenerate(), &FundingTransferRequestInput{
 		Amount: 12.000, BeneficiaryAccountType: "2",
-		RemittingAccountType: "18", Currency: currency.BTC})
+		RemittingAccountType: "18", Currency: currency.BTC,
+	})
 	assert.ErrorIs(t, err, errAddressRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
@@ -1869,7 +1879,8 @@ func TestLightningWithdrawal(t *testing.T) {
 	require.ErrorIs(t, err, common.ErrEmptyParams)
 
 	_, err = ok.LightningWithdrawal(contextGenerate(), &LightningWithdrawalRequestInput{
-		Invoice: "lnbc100u1psnnvhtpp5yq2x3q5hhrzsuxpwx7ptphwzc4k4wk0j3stp0099968m44cyjg9sdqqcqzpgxqzjcsp5hz", Currency: currency.EMPTYCODE})
+		Invoice: "lnbc100u1psnnvhtpp5yq2x3q5hhrzsuxpwx7ptphwzc4k4wk0j3stp0099968m44cyjg9sdqqcqzpgxqzjcsp5hz", Currency: currency.EMPTYCODE,
+	})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	_, err = ok.LightningWithdrawal(contextGenerate(), &LightningWithdrawalRequestInput{Invoice: "", Currency: currency.BTC})
@@ -2170,7 +2181,8 @@ func TestGetBillsDetail(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok)
 	result, err := ok.GetBillsDetailLast7Days(contextGenerate(), &BillsDetailQueryParameter{
-		Limit: 3})
+		Limit: 3,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2672,7 +2684,8 @@ func TestResetSubAccountAPIKey(t *testing.T) {
 	require.ErrorIs(t, err, errInvalidAPIKeyPermission)
 	_, err = ok.ResetSubAccountAPIKey(contextGenerate(), &SubAccountAPIKeyParam{
 		Permissions: []string{"abc"}, SubAccountName: "sam",
-		APIKey: "sample-api-key"})
+		APIKey: "sample-api-key",
+	})
 	require.ErrorIs(t, err, errInvalidAPIKeyPermission)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
@@ -2713,6 +2726,7 @@ func TestGetSubaccountFundingBalance(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetSubAccountMaximumWithdrawal(t *testing.T) {
 	t.Parallel()
 	_, err := ok.GetSubAccountMaximumWithdrawal(contextGenerate(), "", currency.BTC)
@@ -3162,6 +3176,7 @@ func TestGetGridAIParameter(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetOffers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok)
@@ -3538,7 +3553,7 @@ func TestSubmitOrder(t *testing.T) {
 
 func TestCancelOrder(t *testing.T) {
 	t.Parallel()
-	var arg = &order.Cancel{
+	arg := &order.Cancel{
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
 		AssetType:     asset.Binary,
@@ -3557,18 +3572,22 @@ func TestCancelOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
 	err = ok.CancelOrder(contextGenerate(), &order.Cancel{
 		OrderID: "1", WalletAddress: core.BitcoinDonationAddress,
-		AccountID: "1", Pair: spotTP, AssetType: asset.Spot})
+		AccountID: "1", Pair: spotTP, AssetType: asset.Spot,
+	})
 	assert.NoError(t, err)
 
 	err = ok.CancelOrder(contextGenerate(), &order.Cancel{
 		Type:    order.OCO,
 		OrderID: "1", WalletAddress: core.BitcoinDonationAddress,
-		AccountID: "1", Pair: spotTP, AssetType: asset.Spot})
+		AccountID: "1", Pair: spotTP, AssetType: asset.Spot,
+	})
 	assert.NoError(t, err)
 
-	err = ok.CancelOrder(contextGenerate(), &order.Cancel{OrderID: "1",
+	err = ok.CancelOrder(contextGenerate(), &order.Cancel{
+		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress, AccountID: "1",
-		Pair: spreadTP, AssetType: asset.Spread})
+		Pair: spreadTP, AssetType: asset.Spread,
+	})
 	assert.NoError(t, err)
 }
 
@@ -3605,7 +3624,7 @@ func TestCancelBatchOrders(t *testing.T) {
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
-	var orderCancellationParams = []order.Cancel{
+	orderCancellationParams := []order.Cancel{
 		{
 			OrderID:       "1",
 			WalletAddress: core.BitcoinDonationAddress,
@@ -3827,7 +3846,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.Buy,
@@ -3847,6 +3866,7 @@ func TestGetOrderHistory(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetFeeByType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok)
@@ -4132,11 +4152,13 @@ func TestTickersSubscription(t *testing.T) {
 	err = ok.TickersSubscription(contextGenerate(), "unsubscribe", asset.Spot, currency.NewPair(currency.BTC, currency.USDT))
 	assert.NoError(t, err)
 }
+
 func TestOpenInterestSubscription(t *testing.T) {
 	t.Parallel()
 	err := ok.OpenInterestSubscription(contextGenerate(), "subscribe", asset.PerpetualSwap, currency.NewPair(currency.BTC, currency.NewCode("USD-SWAP")))
 	assert.NoError(t, err)
 }
+
 func TestCandlesticksSubscription(t *testing.T) {
 	t.Parallel()
 	enabled, err := ok.GetEnabledPairs(asset.PerpetualSwap)
@@ -4229,6 +4251,7 @@ func TestIndexCandlesticksSubscription(t *testing.T) {
 	err = ok.IndexCandlesticksSubscription(contextGenerate(), "unsubscribe", channelIndexCandle6M, asset.Spot, currency.NewPair(currency.SOL, currency.USD))
 	assert.NoError(t, err)
 }
+
 func TestIndexTickerChannelIndexTickerChannel(t *testing.T) {
 	t.Parallel()
 	err := ok.IndexTickerChannel(contextGenerate(), "subscribe", asset.Spot, currency.NewPair(currency.SOL, currency.USD))
@@ -4252,6 +4275,7 @@ func TestPublicStructureBlockTradesSubscription(t *testing.T) {
 	err = ok.PublicStructureBlockTradesSubscription(contextGenerate(), "unsubscribe", asset.Spot, currency.NewPair(currency.SOL, currency.USD))
 	assert.NoError(t, err)
 }
+
 func TestBlockTickerSubscription(t *testing.T) {
 	t.Parallel()
 	err := ok.BlockTickerSubscription(contextGenerate(), "subscribe", asset.Options, currency.NewPair(currency.BTC, currency.USDT))
@@ -4970,7 +4994,7 @@ func TestGetFuturesContractDetails(t *testing.T) {
 
 func TestWsProcessOrderbook5(t *testing.T) {
 	t.Parallel()
-	var ob5payload = []byte(`{"arg":{"channel":"books5","instId":"OKB-USDT"},"data":[{"asks":[["0.0000007465","2290075956","0","4"],["0.0000007466","1747284705","0","4"],["0.0000007467","1338861655","0","3"],["0.0000007468","1661668387","0","6"],["0.0000007469","2715477116","0","5"]],"bids":[["0.0000007464","15693119","0","1"],["0.0000007463","2330835024","0","4"],["0.0000007462","1182926517","0","2"],["0.0000007461","3818684357","0","4"],["0.000000746","6021641435","0","7"]],"instId":"OKB-USDT","ts":"1695864901807","seqId":4826378794}]}`)
+	ob5payload := []byte(`{"arg":{"channel":"books5","instId":"OKB-USDT"},"data":[{"asks":[["0.0000007465","2290075956","0","4"],["0.0000007466","1747284705","0","4"],["0.0000007467","1338861655","0","3"],["0.0000007468","1661668387","0","6"],["0.0000007469","2715477116","0","5"]],"bids":[["0.0000007464","15693119","0","1"],["0.0000007463","2330835024","0","4"],["0.0000007462","1182926517","0","2"],["0.0000007461","3818684357","0","4"],["0.000000746","6021641435","0","7"]],"instId":"OKB-USDT","ts":"1695864901807","seqId":4826378794}]}`)
 	err := ok.wsProcessOrderbook5(ob5payload)
 	require.NoError(t, err)
 
@@ -5011,7 +5035,8 @@ func TestManualBorrowAndRepayInQuickMarginMode(t *testing.T) {
 	_, err = ok.ManualBorrowAndRepayInQuickMarginMode(contextGenerate(), &BorrowAndRepay{
 		InstrumentID: "BTC-USDT",
 		LoanCcy:      currency.USDT,
-		Side:         "borrow"})
+		Side:         "borrow",
+	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 	_, err = ok.ManualBorrowAndRepayInQuickMarginMode(contextGenerate(), &BorrowAndRepay{
 		Amount:       1,
@@ -5058,6 +5083,7 @@ func TestGetVIPInterestAccruedData(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestGetVIPInterestDeductedData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok)
@@ -5081,6 +5107,7 @@ func TestGetVIPLoanOrderDetail(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
 func TestSetRiskOffsetType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
@@ -5726,8 +5753,10 @@ func TestStopCopying(t *testing.T) {
 		SubPositionCloseType: "manual_close",
 	})
 	require.ErrorIs(t, err, errUniqueCodeRequired)
-	_, err = ok.StopCopying(contextGenerate(), &StopCopyingParameter{InstrumentType: "SWAP",
-		UniqueCode: "25CD5A80241D6FE6"})
+	_, err = ok.StopCopying(contextGenerate(), &StopCopyingParameter{
+		InstrumentType: "SWAP",
+		UniqueCode:     "25CD5A80241D6FE6",
+	})
 	require.ErrorIs(t, err, errSubPositionCloseTypeRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ok, canManipulateRealOrders)
@@ -6357,7 +6386,7 @@ func TestGetAccountInstruments(t *testing.T) {
 
 func TestOrderTypeString(t *testing.T) {
 	t.Parallel()
-	var orderTypesToStringMap = map[order.Type]struct {
+	orderTypesToStringMap := map[order.Type]struct {
 		Expected string
 		Error    error
 	}{

--- a/exchanges/order/order_test.go
+++ b/exchanges/order/order_test.go
@@ -47,7 +47,6 @@ func TestSubmitValidate(t *testing.T) {
 			Submit:      &Submit{Exchange: "test"},
 		}, // empty pair
 		{
-
 			ExpectedErr: ErrAssetNotSet,
 			Submit:      &Submit{Exchange: "test", Pair: testPair},
 		}, // valid pair but invalid asset
@@ -316,7 +315,7 @@ func TestSubmitResponse_DeriveDetail(t *testing.T) {
 func TestOrderSides(t *testing.T) {
 	t.Parallel()
 
-	var os = Buy
+	os := Buy
 	if os.String() != "BUY" {
 		t.Errorf("unexpected string %s", os.String())
 	}
@@ -442,7 +441,7 @@ func TestInferCostsAndTimes(t *testing.T) {
 func TestFilterOrdersByType(t *testing.T) {
 	t.Parallel()
 
-	var orders = []Detail{
+	orders := []Detail{
 		{
 			Type: ImmediateOrCancel,
 		},
@@ -494,7 +493,7 @@ func BenchmarkFilterOrdersByType(b *testing.B) {
 func TestFilterOrdersBySide(t *testing.T) {
 	t.Parallel()
 
-	var orders = []Detail{
+	orders := []Detail{
 		{
 			Side: Buy,
 		},
@@ -546,7 +545,7 @@ func BenchmarkFilterOrdersBySide(b *testing.B) {
 func TestFilterOrdersByTimeRange(t *testing.T) {
 	t.Parallel()
 
-	var orders = []Detail{
+	orders := []Detail{
 		{
 			Date: time.Unix(100, 0),
 		},
@@ -634,7 +633,7 @@ func BenchmarkFilterOrdersByTimeRange(b *testing.B) {
 func TestFilterOrdersByPairs(t *testing.T) {
 	t.Parallel()
 
-	var orders = []Detail{
+	orders := []Detail{
 		{
 			Pair: currency.NewPair(currency.BTC, currency.USD),
 		},
@@ -647,16 +646,20 @@ func TestFilterOrdersByPairs(t *testing.T) {
 		{}, // Unpopulated fields are preserved for API differences
 	}
 
-	currencies := []currency.Pair{currency.NewPair(currency.BTC, currency.USD),
+	currencies := []currency.Pair{
+		currency.NewPair(currency.BTC, currency.USD),
 		currency.NewPair(currency.LTC, currency.EUR),
-		currency.NewPair(currency.DOGE, currency.RUB)}
+		currency.NewPair(currency.DOGE, currency.RUB),
+	}
 	FilterOrdersByPairs(&orders, currencies)
 	if len(orders) != 4 {
 		t.Errorf("Orders failed to be filtered. Expected %v, received %v", 3, len(orders))
 	}
 
-	currencies = []currency.Pair{currency.NewPair(currency.BTC, currency.USD),
-		currency.NewPair(currency.LTC, currency.EUR)}
+	currencies = []currency.Pair{
+		currency.NewPair(currency.BTC, currency.USD),
+		currency.NewPair(currency.LTC, currency.EUR),
+	}
 	FilterOrdersByPairs(&orders, currencies)
 	if len(orders) != 3 {
 		t.Errorf("Orders failed to be filtered. Expected %v, received %v", 2, len(orders))
@@ -1143,7 +1146,7 @@ func TestUpdateOrderFromModifyResponse(t *testing.T) {
 }
 
 func TestUpdateOrderFromDetail(t *testing.T) {
-	var leet = "1337"
+	leet := "1337"
 
 	updated := time.Now()
 
@@ -1432,7 +1435,7 @@ func TestValidationOnOrderTypes(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errUnrecognisedOrderType)
 	}
 
-	var errTestError = errors.New("test error")
+	errTestError := errors.New("test error")
 	getOrders.Type = AnyType
 	err = getOrders.Validate(validate.Check(func() error {
 		return errTestError
@@ -1985,7 +1988,7 @@ func TestGetOrdersRequest_Filter(t *testing.T) {
 	request.Type = AnyType
 	request.Side = AnySide
 
-	var orders = []Detail{
+	orders := []Detail{
 		{OrderID: "0", Pair: btcusd, AssetType: asset.Spot, Type: Limit, Side: Buy},
 		{OrderID: "1", Pair: btcusd, AssetType: asset.Spot, Type: Limit, Side: Sell},
 		{OrderID: "2", Pair: btcusd, AssetType: asset.Spot, Type: Market, Side: Buy},

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -760,154 +760,202 @@ var movementTests = []struct {
 	name  string
 	tests []movementTest
 }{
-	{"HitTheBidsByImpactSlippage",
+	{
+		"HitTheBidsByImpactSlippage",
 		[]movementTest{
 			{[]any{0.7485029940119761, 1336.0}, Movement{Sold: 10}}, // First and second price from best bid - price level target 1326 (which should be kept)
 			{[]any{1.4221556886227544, 1336.0}, Movement{Sold: 19}}, // All the way up to the last price from best bid price
-		}},
-	{"HitTheBidsByImpactSlippageFromMid",
+		},
+	},
+	{
+		"HitTheBidsByImpactSlippageFromMid",
 		[]movementTest{
 			{[]any{0.7485029940119761}, Movement{Sold: 10.0}}, // First and second price from mid - price level target 1326 (which should be kept)
 			{[]any{1.4221556886227544}, Movement{Sold: 19.0}}, // All the way up to the last price from best bid price
-		}},
-	{"HitTheBidsByNominalSlippageFromMid",
+		},
+	},
+	{
+		"HitTheBidsByNominalSlippageFromMid",
 		[]movementTest{
 			{[]any{0.03741114852226}, Movement{Sold: 1.0}},  // First price from mid point
 			{[]any{0.74822297044519}, Movement{Sold: 20.0}}, // All the way up to the last price from mid price
-		}},
-	{"HitTheBidsByNominalSlippageFromBest",
+		},
+	},
+	{
+		"HitTheBidsByNominalSlippageFromBest",
 		[]movementTest{
 			{[]any{0.037425149700599}, Movement{Sold: 2.0}},                             // First and second price from best bid
 			{[]any{0.71107784431138}, Movement{Sold: 20.0, FullBookSideConsumed: true}}, // All the way up to the last price from best bid price
-		}},
-	{"LiftTheAsksByNominalSlippage",
+		},
+	},
+	{
+		"LiftTheAsksByNominalSlippage",
 		[]movementTest{
 			{[]any{0.037397157816006, 1337.0}, Movement{Sold: 2675.0}}, // First and second price
 			{[]any{0.71054599850411, 1337.0}, Movement{Sold: 26930.0}}, // All the way up to the last price
-		}},
-	{"LiftTheAsksByNominalSlippageFromMid",
+		},
+	},
+	{
+		"LiftTheAsksByNominalSlippageFromMid",
 		[]movementTest{
 			{[]any{0.074822297044519}, Movement{Sold: 2675.0}}, // First price from mid point
 			{[]any{0.74822297044519}, Movement{Sold: 26930.0}}, // All the way up to the last price from mid price
-		}},
-	{"LiftTheAsksByNominalSlippageFromBest",
+		},
+	},
+	{
+		"LiftTheAsksByNominalSlippageFromBest",
 		[]movementTest{
 			{[]any{0.037397157816006}, Movement{Sold: 2675.0}}, // First and second price from best bid
 			{[]any{0.71054599850411}, Movement{Sold: 26930.0}}, // All the way up to the last price from best bid price
-		}},
-	{"HitTheBidsByImpactSlippageFromBest",
+		},
+	},
+	{
+		"HitTheBidsByImpactSlippageFromBest",
 		[]movementTest{
 			{[]any{0.7485029940119761}, Movement{Sold: 10.0}}, // First and second price from mid - price level target 1326 (which should be kept)
 			{[]any{1.4221556886227544}, Movement{Sold: 19.0}}, // All the way up to the last price from best bid price
-		}},
-	{"LiftTheAsksByImpactSlippage",
+		},
+	},
+	{
+		"LiftTheAsksByImpactSlippage",
 		[]movementTest{
 			{[]any{0.7479431563201197, 1337.0}, Movement{Sold: 13415.0}}, // First and second price from best bid - price level target 1326 (which should be kept)
 			{[]any{1.4210919970082274, 1337.0}, Movement{Sold: 25574.0}}, // All the way up to the last price from best bid price
-		}},
-	{"LiftTheAsksByImpactSlippageFromMid",
+		},
+	},
+	{
+		"LiftTheAsksByImpactSlippageFromMid",
 		[]movementTest{
 			{[]any{0.7485029940119761}, Movement{Sold: 13415.0}}, // First and second price from mid - price level target 1326 (which should be kept)
 			{[]any{1.4221556886227544}, Movement{Sold: 25574.0}}, // All the way up to the last price from best bid price
-		}},
-	{"LiftTheAsksByImpactSlippageFromBest",
+		},
+	},
+	{
+		"LiftTheAsksByImpactSlippageFromBest",
 		[]movementTest{
 			{[]any{0.7479431563201197}, Movement{Sold: 13415.0}}, // First and second price from mid - price level target 1326 (which should be kept)
 			// All the way up to the last price from best bid price
 			// This goes to price 1356, it will not count that tranches' volume as it is needed to sustain the slippage.
 			{[]any{1.4210919970082274}, Movement{Sold: 25574.0}},
-		}},
-	{"HitTheBidsByNominalSlippage",
+		},
+	},
+	{
+		"HitTheBidsByNominalSlippage",
 		[]movementTest{
 			{[]any{0.0, 1336.0}, Movement{Sold: 1.0, NominalPercentage: 0.0, StartPrice: 1336.0, EndPrice: 1336.0}},                                                          // 1st
 			{[]any{0.037425149700598806, 1336.0}, Movement{Sold: 2.0, NominalPercentage: 0.037425149700598806, StartPrice: 1336.0, EndPrice: 1335.0}},                        // 2nd
 			{[]any{0.02495009980039353, 1336.0}, Movement{Sold: 1.5, NominalPercentage: 0.02495009980039353, StartPrice: 1336.0, EndPrice: 1335.0}},                          // 1.5ish
 			{[]any{0.7110778443113772, 1336.0}, Movement{Sold: 20, NominalPercentage: 0.7110778443113772, StartPrice: 1336.0, EndPrice: 1317.0, FullBookSideConsumed: true}}, // All
-		}},
-	{"HitTheBids",
+		},
+	},
+	{
+		"HitTheBids",
 		[]movementTest{
 			{[]any{20.1, 1336.0, false}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1.0, 1336.0, false}, Movement{ImpactPercentage: 0.07485029940119761, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{19.5, 1336.0, false}, Movement{NominalPercentage: 0.692845079072617, ImpactPercentage: 1.4221556886227544, SlippageCost: 180.5}},
 			{[]any{20.0, 1336.0, false}, Movement{NominalPercentage: 0.7110778443113772, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"HitTheBids_QuotationRequired",
+		},
+	},
+	{
+		"HitTheBids_QuotationRequired",
 		[]movementTest{
 			{[]any{26531.0, 1336.0, true}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1336.0, 1336.0, true}, Movement{ImpactPercentage: 0.07485029940119761, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{25871.5, 1336.0, true}, Movement{NominalPercentage: 0.692845079072617, ImpactPercentage: 1.4221556886227544, SlippageCost: 180.5}},
 			{[]any{26530.0, 1336.0, true}, Movement{NominalPercentage: 0.7110778443113772, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"HitTheBidsFromMid",
+		},
+	},
+	{
+		"HitTheBidsFromMid",
 		[]movementTest{
 			{[]any{20.1, false}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1.0, false}, Movement{ImpactPercentage: 0.11223344556677892, NominalPercentage: 0.03741114852225963, SlippageCost: zero}}, // mid price 1336.5 -> 1335
 			{[]any{19.5, false}, Movement{NominalPercentage: 0.7299970262933156, ImpactPercentage: 1.4590347923681257, SlippageCost: 180.5}},
 			{[]any{20.0, false}, Movement{NominalPercentage: 0.7482229704451926, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"HitTheBidsFromMid_QuotationRequired",
+		},
+	},
+	{
+		"HitTheBidsFromMid_QuotationRequired",
 		[]movementTest{
 			{[]any{26531.0, true}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1336.0, true}, Movement{ImpactPercentage: 0.11223344556677892, NominalPercentage: 0.03741114852225963, SlippageCost: zero}}, // mid price 1336.5 -> 1335
 			{[]any{25871.5, true}, Movement{NominalPercentage: 0.7299970262933156, ImpactPercentage: 1.4590347923681257, SlippageCost: 180.5}},
 			{[]any{26530.0, true}, Movement{NominalPercentage: 0.7482229704451926, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"HitTheBidsFromBest",
+		},
+	},
+	{
+		"HitTheBidsFromBest",
 		[]movementTest{
 			{[]any{20.1, false}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1.0, false}, Movement{ImpactPercentage: 0.07485029940119761, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{19.5, false}, Movement{NominalPercentage: 0.692845079072617, ImpactPercentage: 1.4221556886227544, SlippageCost: 180.5}},
 			{[]any{20.0, false}, Movement{NominalPercentage: 0.7110778443113772, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"HitTheBidsFromBest_QuotationRequired",
+		},
+	},
+	{
+		"HitTheBidsFromBest_QuotationRequired",
 		[]movementTest{
 			{[]any{26531.0, true}, Movement{Sold: 20.0, FullBookSideConsumed: true}},
 			{[]any{1336.0, true}, Movement{ImpactPercentage: 0.07485029940119761, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{25871.5, true}, Movement{NominalPercentage: 0.692845079072617, ImpactPercentage: 1.4221556886227544, SlippageCost: 180.5}},
 			{[]any{26530.0, true}, Movement{NominalPercentage: 0.7110778443113772, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsks",
+		},
+	},
+	{
+		"LiftTheAsks",
 		[]movementTest{
 			{[]any{26931.0, 1337.0, false}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1337.0, 1337.0, false}, Movement{ImpactPercentage: 0.07479431563201197, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{26900.0, 1337.0, false}, Movement{NominalPercentage: 0.7097591258590459, ImpactPercentage: 1.4210919970082274, SlippageCost: 189.57964601770072}},
 			{[]any{26930.0, 1336.0, false}, Movement{NominalPercentage: 0.7859281437125748, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsks_BaseRequired",
+		},
+	},
+	{
+		"LiftTheAsks_BaseRequired",
 		[]movementTest{
 			{[]any{21.0, 1337.0, true}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1.0, 1337.0, true}, Movement{ImpactPercentage: 0.07479431563201197, NominalPercentage: zero, SlippageCost: zero}},
 			{[]any{19.97787610619469, 1337.0, true}, Movement{NominalPercentage: 0.7097591258590459, ImpactPercentage: 1.4210919970082274, SlippageCost: 189.57964601770072}},
 			{[]any{20.0, 1336.0, true}, Movement{NominalPercentage: 0.7859281437125748, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsksFromMid",
+		},
+	},
+	{
+		"LiftTheAsksFromMid",
 		[]movementTest{
 			{[]any{26931.0, false}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1337.0, false}, Movement{NominalPercentage: 0.03741114852225963, ImpactPercentage: 0.11223344556677892, SlippageCost: zero}},
 			{[]any{26900.0, false}, Movement{NominalPercentage: 0.747435803422031, ImpactPercentage: 1.4590347923681257, SlippageCost: 189.57964601770072}},
 			{[]any{26930.0, false}, Movement{NominalPercentage: 0.7482229704451926, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsksFromMid_BaseRequired",
+		},
+	},
+	{
+		"LiftTheAsksFromMid_BaseRequired",
 		[]movementTest{
 			{[]any{21.0, true}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1.0, true}, Movement{NominalPercentage: 0.03741114852225963, ImpactPercentage: 0.11223344556677892, SlippageCost: zero}},
 			{[]any{19.97787610619469, true}, Movement{NominalPercentage: 0.7474358034220139, ImpactPercentage: 1.4590347923681257, SlippageCost: 189.5796460176971}},
 			{[]any{20.0, true}, Movement{NominalPercentage: 0.7482229704451926, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsksFromBest",
+		},
+	},
+	{
+		"LiftTheAsksFromBest",
 		[]movementTest{
 			{[]any{26931.0, false}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1337.0, false}, Movement{NominalPercentage: zero, ImpactPercentage: 0.07479431563201197, SlippageCost: zero}},
 			{[]any{26900.0, false}, Movement{NominalPercentage: 0.7097591258590459, ImpactPercentage: 1.4210919970082274, SlippageCost: 189.579646017701}},
 			{[]any{26930.0, false}, Movement{NominalPercentage: 0.7105459985041137, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
-	{"LiftTheAsksFromBest_BaseRequired",
+		},
+	},
+	{
+		"LiftTheAsksFromBest_BaseRequired",
 		[]movementTest{
 			{[]any{21.0, true}, Movement{Sold: 26930.0, FullBookSideConsumed: true}},
 			{[]any{1.0, true}, Movement{NominalPercentage: zero, ImpactPercentage: 0.07479431563201197, SlippageCost: zero}},
 			{[]any{19.97787610619469, true}, Movement{NominalPercentage: 0.7097591258590459, ImpactPercentage: 1.4210919970082274, SlippageCost: 189.579646017701}},
 			{[]any{20.0, true}, Movement{NominalPercentage: 0.7105459985041137, ImpactPercentage: FullLiquidityExhaustedPercentage, SlippageCost: 190.0, FullBookSideConsumed: true}},
-		}},
+		},
+	},
 }
 
 func TestPair(t *testing.T) {

--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -230,10 +230,10 @@ func (b *Base) Verify() error {
 
 // checker defines specific functionality to determine ascending/descending
 // validation
-type checker func(current Tranche, previous Tranche) error
+type checker func(current, previous Tranche) error
 
 // asc specifically defines ascending price check
-var asc = func(current Tranche, previous Tranche) error {
+var asc = func(current, previous Tranche) error {
 	if current.Price < previous.Price {
 		return errPriceOutOfOrder
 	}
@@ -241,7 +241,7 @@ var asc = func(current Tranche, previous Tranche) error {
 }
 
 // dsc specifically defines descending price check
-var dsc = func(current Tranche, previous Tranche) error {
+var dsc = func(current, previous Tranche) error {
 	if current.Price > previous.Price {
 		return errPriceOutOfOrder
 	}

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -116,7 +116,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := p.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +138,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	t.Parallel()
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	if sharedtestvalues.AreAPICredentialsSet(p) || mockTests {
 		// CryptocurrencyTradeFee Basic
@@ -214,7 +214,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -233,7 +233,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -362,7 +362,7 @@ func TestSubmitOrder(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, p, canManipulateRealOrders)
 	}
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: p.Name,
 		Pair: currency.Pair{
 			Delimiter: currency.UnderscoreDelimiter,
@@ -393,7 +393,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, p, canManipulateRealOrders)
 	}
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -419,7 +419,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	}
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -257,7 +257,8 @@ func (p *Poloniex) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Volume:       tick[curr].BaseVolume,
 			QuoteVolume:  tick[curr].QuoteVolume,
 			ExchangeName: p.Name,
-			AssetType:    a})
+			AssetType:    a,
+		})
 		if err != nil {
 			return err
 		}

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -143,7 +143,7 @@ func RateLimit(ctx context.Context, rateLimiter *RateLimiterWithWeight) error {
 	}
 
 	var finalDelay time.Duration
-	var reservations = make(Reservations, rateLimiter.Weight)
+	reservations := make(Reservations, rateLimiter.Weight)
 	for i := Weight(0); i < rateLimiter.Weight; i++ {
 		// Consume 1 weight at a time as this avoids needing burst capacity in the limiter,
 		// which would otherwise allow the rate limit to be exceeded over short periods

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -26,8 +26,10 @@ import (
 
 const unexpected = "unexpected values"
 
-var testURL string
-var serverLimit *RateLimiterWithWeight
+var (
+	testURL     string
+	serverLimit *RateLimiterWithWeight
+)
 
 func TestMain(m *testing.M) {
 	serverLimitInterval := time.Millisecond * 500
@@ -202,7 +204,8 @@ func TestCheckRequest(t *testing.T) {
 
 var globalshell = RateLimitDefinitions{
 	Auth:   NewWeightedRateLimitByDuration(time.Millisecond * 600),
-	UnAuth: NewRateLimitWithWeight(time.Second*1, 100, 1)}
+	UnAuth: NewRateLimitWithWeight(time.Second*1, 100, 1),
+}
 
 func TestDoRequest(t *testing.T) {
 	t.Parallel()
@@ -301,7 +304,7 @@ func TestDoRequest(t *testing.T) {
 	}
 
 	// Check header contents
-	var passback = http.Header{}
+	passback := http.Header{}
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) {
 		return &Item{
 			Method:         http.MethodGet,

--- a/exchanges/sharedtestvalues/sharedtestvalues.go
+++ b/exchanges/sharedtestvalues/sharedtestvalues.go
@@ -138,7 +138,6 @@ func ForceFileStandard(t *testing.T, pattern string) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to walk directory: %w", err)
 	}

--- a/exchanges/stream/stream_types.go
+++ b/exchanges/stream/stream_types.go
@@ -24,11 +24,11 @@ type Connection interface {
 	// defined in websocket_connection.go.
 	GenerateMessageID(highPrecision bool) int64
 	// SendMessageReturnResponse will send a WS message to the connection and wait for response
-	SendMessageReturnResponse(ctx context.Context, epl request.EndpointLimit, signature any, request any) ([]byte, error)
+	SendMessageReturnResponse(ctx context.Context, epl request.EndpointLimit, signature, request any) ([]byte, error)
 	// SendMessageReturnResponses will send a WS message to the connection and wait for N responses
-	SendMessageReturnResponses(ctx context.Context, epl request.EndpointLimit, signature any, request any, expected int) ([][]byte, error)
+	SendMessageReturnResponses(ctx context.Context, epl request.EndpointLimit, signature, request any, expected int) ([][]byte, error)
 	// SendMessageReturnResponsesWithInspector will send a WS message to the connection and wait for N responses with message inspection
-	SendMessageReturnResponsesWithInspector(ctx context.Context, epl request.EndpointLimit, signature any, request any, expected int, messageInspector Inspector) ([][]byte, error)
+	SendMessageReturnResponsesWithInspector(ctx context.Context, epl request.EndpointLimit, signature, request any, expected int, messageInspector Inspector) ([][]byte, error)
 	// SendRawMessage sends a message over the connection without JSON encoding it
 	SendRawMessage(ctx context.Context, epl request.EndpointLimit, messageType int, message []byte) error
 	// SendJSONMessage sends a JSON encoded message over the connection

--- a/exchanges/stream/websocket_test.go
+++ b/exchanges/stream/websocket_test.go
@@ -32,9 +32,7 @@ const (
 	proxyURL      = "http://212.186.171.4:80" // Replace with a usable proxy server
 )
 
-var (
-	errDastardlyReason = errors.New("some dastardly reason")
-)
+var errDastardlyReason = errors.New("some dastardly reason")
 
 type testStruct struct {
 	Error error
@@ -166,7 +164,7 @@ func TestSetup(t *testing.T) {
 
 func TestConnectionMessageErrors(t *testing.T) {
 	t.Parallel()
-	var wsWrong = &Websocket{}
+	wsWrong := &Websocket{}
 	wsWrong.connector = func() error { return nil }
 	err := wsWrong.Connect()
 	assert.ErrorIs(t, err, ErrWebsocketNotEnabled, "Connect should error correctly")
@@ -657,7 +655,7 @@ func TestDial(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler) }))
 	defer mock.Close()
 
-	var testCases = []testStruct{
+	testCases := []testStruct{
 		{
 			WC: WebsocketConnection{
 				ExchangeName:     "test1",
@@ -709,7 +707,7 @@ func TestSendMessage(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler) }))
 	defer mock.Close()
 
-	var testCases = []testStruct{
+	testCases := []testStruct{
 		{
 			WC: WebsocketConnection{
 				ExchangeName:     "test1",

--- a/exchanges/ticker/ticker_test.go
+++ b/exchanges/ticker/ticker_test.go
@@ -45,7 +45,8 @@ func TestSubscribeTicker(t *testing.T) {
 	err = ProcessTicker(&Price{
 		Pair:         p,
 		ExchangeName: "subscribetest",
-		AssetType:    asset.Spot})
+		AssetType:    asset.Spot,
+	})
 	if err == nil {
 		t.Error("error cannot be nil")
 	}
@@ -55,7 +56,8 @@ func TestSubscribeTicker(t *testing.T) {
 	err = ProcessTicker(&Price{
 		Pair:         sillyP,
 		ExchangeName: "subscribetest",
-		AssetType:    asset.Spot})
+		AssetType:    asset.Spot,
+	})
 	if err == nil {
 		t.Error("error cannot be nil")
 	}
@@ -64,7 +66,8 @@ func TestSubscribeTicker(t *testing.T) {
 	err = ProcessTicker(&Price{
 		Pair:         sillyP,
 		ExchangeName: "subscribetest",
-		AssetType:    asset.Spot})
+		AssetType:    asset.Spot,
+	})
 	if err == nil {
 		t.Error("error cannot be nil")
 	}
@@ -83,7 +86,8 @@ func TestSubscribeTicker(t *testing.T) {
 	err = ProcessTicker(&Price{
 		Pair:         p,
 		ExchangeName: "subscribetest",
-		AssetType:    asset.Spot})
+		AssetType:    asset.Spot,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +109,8 @@ func TestSubscribeToExchangeTickers(t *testing.T) {
 	err = ProcessTicker(&Price{
 		Pair:         p,
 		ExchangeName: "subscribeExchangeTest",
-		AssetType:    asset.Spot})
+		AssetType:    asset.Spot,
+	})
 	if err != nil {
 		t.Error(err)
 	}

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -185,7 +185,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 	_, err := y.GetFeeByType(context.Background(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 }
 
 func TestGetFee(t *testing.T) {
-	var feeBuilder = setFeeBuilder()
+	feeBuilder := setFeeBuilder()
 
 	// CryptocurrencyTradeFee Basic
 	if _, err := y.GetFee(feeBuilder); err != nil {
@@ -323,7 +323,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Pairs:     []currency.Pair{currency.NewPair(currency.LTC, currency.BTC)},
 		AssetType: asset.Spot,
@@ -340,7 +340,7 @@ func TestGetActiveOrders(t *testing.T) {
 
 func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
-	var getOrdersRequest = order.MultiOrderRequest{
+	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Pairs:     []currency.Pair{currency.NewPair(currency.LTC, currency.BTC)},
@@ -363,7 +363,7 @@ func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
-	var orderSubmission = &order.Submit{
+	orderSubmission := &order.Submit{
 		Exchange: y.Name,
 		Pair: currency.Pair{
 			Delimiter: "_",
@@ -390,7 +390,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -412,7 +412,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
 	currencyPair := currency.NewPair(currency.LTC, currency.BTC)
-	var orderCancellation = &order.Cancel{
+	orderCancellation := &order.Cancel{
 		OrderID:       "1",
 		WalletAddress: core.BitcoinDonationAddress,
 		AccountID:     "1",
@@ -473,7 +473,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := y.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
@@ -486,7 +486,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
-	var withdrawFiatRequest = withdraw.Request{}
+	withdrawFiatRequest := withdraw.Request{}
 	_, err := y.WithdrawFiatFundsToInternationalBank(context.Background(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {

--- a/gctscript/modules/gct/common.go
+++ b/gctscript/modules/gct/common.go
@@ -143,7 +143,7 @@ func convertATR(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.AverageTrueRange,
 		},
@@ -178,7 +178,7 @@ func convertBollingerBands(a objects.Object) ([][]string, error) {
 		MAType = "MA_TYPE:EMA"
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.BollingerBands, "", MAType,
 		},
@@ -220,7 +220,7 @@ func convertEMA(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.ExponentialMovingAverage,
 		},
@@ -246,7 +246,7 @@ func convertMACD(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.MovingAverageConvergenceDivergence,
 			fmt.Sprintf("Period:%d Fast:%d Slow:%d",
@@ -293,7 +293,7 @@ func convertMFI(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.MoneyFlowIndex,
 		},
@@ -314,7 +314,7 @@ func convertMFI(a objects.Object) ([][]string, error) {
 }
 
 func convertOBV(a objects.Object) ([][]string, error) {
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.OnBalanceVolume,
 		},
@@ -345,7 +345,7 @@ func convertRSI(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.RelativeStrengthIndex,
 		},
@@ -371,7 +371,7 @@ func convertSMA(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.SimpleMovingAverage,
 		},
@@ -397,7 +397,7 @@ func convertCorrelationCoefficient(a objects.Object) ([][]string, error) {
 		return nil, errors.New("casting failure")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.CorrelationCoefficient,
 		},
@@ -443,7 +443,7 @@ func convertOHLCV(a objects.Object) ([][]string, error) {
 		return nil, errors.New("cannot convert object to string")
 	}
 
-	var bucket = [][]string{
+	bucket := [][]string{
 		{
 			indicators.OHLCV, "Exchange:" + exchange, pair, asset, interval, "",
 		},

--- a/gctscript/modules/gct/exchange.go
+++ b/gctscript/modules/gct/exchange.go
@@ -773,7 +773,7 @@ func exchangeOHLCV(args ...objects.Object) (objects.Object, error) {
 // parseInterval will parse the interval param of indictors that have them and convert to time.Duration
 func parseInterval(in string) (time.Duration, error) {
 	if !common.StringSliceContainsInsensitive(supportedDurations, in) {
-		return time.Nanosecond, errInvalidInterval
+		return time.Nanosecond, kline.ErrInvalidInterval
 	}
 	switch in {
 	case "1d":

--- a/gctscript/modules/gct/gct_test.go
+++ b/gctscript/modules/gct/gct_test.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	objects "github.com/d5/tengo/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/gctscript/modules"
 	"github.com/thrasher-corp/gocryptotrader/gctscript/wrappers/validator"
 )
@@ -330,11 +332,7 @@ func TestParseInterval(t *testing.T) {
 	}
 
 	_, err = parseInterval("6m")
-	if err != nil {
-		if !errors.Is(err, errInvalidInterval) {
-			t.Error(err)
-		}
-	}
+	assert.ErrorIs(t, err, kline.ErrInvalidInterval, "parseInterval should return invalid interval for 6m")
 }
 
 func TestSetVerbose(t *testing.T) {

--- a/gctscript/modules/gct/gct_types.go
+++ b/gctscript/modules/gct/gct_types.go
@@ -1,8 +1,6 @@
 package gct
 
 import (
-	"errors"
-
 	objects "github.com/d5/tengo/v2"
 )
 
@@ -13,10 +11,7 @@ const (
 	ErrEmptyParameter = "received empty parameter for %v"
 )
 
-var (
-	errInvalidInterval = errors.New("invalid interval")
-	supportedDurations = []string{"1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "24h", "1d", "3d", "1w"}
-)
+var supportedDurations = []string{"1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "24h", "1d", "3d", "1w", "1M"}
 
 // Modules map of all loadable modules
 var Modules = map[string]map[string]objects.Object{

--- a/gctscript/modules/gct/gct_types.go
+++ b/gctscript/modules/gct/gct_types.go
@@ -13,8 +13,10 @@ const (
 	ErrEmptyParameter = "received empty parameter for %v"
 )
 
-var errInvalidInterval = errors.New("invalid interval")
-var supportedDurations = []string{"1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "24h", "1d", "3d", "1w"}
+var (
+	errInvalidInterval = errors.New("invalid interval")
+	supportedDurations = []string{"1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "24h", "1d", "3d", "1w"}
+)
 
 // Modules map of all loadable modules
 var Modules = map[string]map[string]objects.Object{

--- a/gctscript/vm/autoload.go
+++ b/gctscript/vm/autoload.go
@@ -51,7 +51,7 @@ func (g *GctScriptManager) autoLoad() {
 				g.config.AutoLoad[x])
 			continue
 		}
-		var name = g.config.AutoLoad[x]
+		name := g.config.AutoLoad[x]
 		if filepath.Ext(name) != common.GctExt {
 			name += common.GctExt
 		}

--- a/gctscript/vm/gctscript_types.go
+++ b/gctscript/vm/gctscript_types.go
@@ -28,10 +28,8 @@ type Error struct {
 	Cause  error
 }
 
-var (
-	// ScriptPath path to load/save scripts
-	ScriptPath string
-)
+// ScriptPath path to load/save scripts
+var ScriptPath string
 
 var (
 	// ErrScriptingDisabled error message displayed when gctscript is disabled

--- a/gctscript/vm/vm_test.go
+++ b/gctscript/vm/vm_test.go
@@ -398,7 +398,6 @@ func TestRemoveVM(t *testing.T) {
 	}
 	id, _ := uuid.FromString("6f20c907-64a0-48f2-848a-7837dee61672")
 	err := manager.RemoveVM(id)
-
 	if err != nil {
 		if err.Error() != "VM 6f20c907-64a0-48f2-848a-7837dee61672 not found" {
 			t.Fatal(err)

--- a/gctscript/wrappers/validator/validator.go
+++ b/gctscript/wrappers/validator/validator.go
@@ -99,9 +99,11 @@ func (w Wrapper) Pairs(exch string, _ bool, _ asset.Item) (*currency.Pairs, erro
 		return nil, errTestFailed
 	}
 
-	pairs, err := currency.NewPairsFromStrings([]string{"btc_usd",
+	pairs, err := currency.NewPairsFromStrings([]string{
+		"btc_usd",
 		"btc_aud",
-		"btc_ltc"})
+		"btc_ltc",
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/exchange/exchange.go
+++ b/internal/testing/exchange/exchange.go
@@ -159,8 +159,10 @@ func FixtureToDataHandlerWithErrors(tb testing.TB, fixturePath string, reader fu
 	return errs
 }
 
-var setupWsMutex sync.Mutex
-var setupWsOnce = make(map[exchange.IBotExchange]bool)
+var (
+	setupWsMutex sync.Mutex
+	setupWsOnce  = make(map[exchange.IBotExchange]bool)
+)
 
 // SetupWs is a helper function to connect both auth and normal websockets
 // It will skip the test if websockets are not enabled
@@ -195,8 +197,10 @@ func SetupWs(tb testing.TB, e exchange.IBotExchange) {
 	setupWsOnce[e] = true
 }
 
-var updatePairsMutex sync.Mutex
-var updatePairsOnce = make(map[string]*currency.PairsManager)
+var (
+	updatePairsMutex sync.Mutex
+	updatePairsOnce  = make(map[string]*currency.PairsManager)
+)
 
 // UpdatePairsOnce ensures pairs are only updated once in parallel tests
 // A clone of the cache of the updated pairs is used to populate duplicate requests

--- a/log/custom_log_hooks_test.go
+++ b/log/custom_log_hooks_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestSetCustomLoghook(t *testing.T) {
 	t.Parallel()
-	logHook := func(_ string, _ string, _ ...interface{}) (bypassLibraryLogSystem bool) {
+	logHook := func(_, _ string, _ ...interface{}) (bypassLibraryLogSystem bool) {
 		return false
 	}
 	SetCustomLogHook(logHook)

--- a/log/logger_setup.go
+++ b/log/logger_setup.go
@@ -210,7 +210,8 @@ func registerNewSubLogger(subLogger string) *SubLogger {
 	tempHolder, err := getWriters(&SubLoggerConfig{
 		Name:   strings.ToUpper(subLogger),
 		Level:  "INFO|WARN|DEBUG|ERROR",
-		Output: "stdout"})
+		Output: "stdout",
+	})
 	if err != nil {
 		return nil
 	}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -37,7 +37,8 @@ var (
 				Name:   "lOg",
 				Level:  "INFO|DEBUG|WARN|ERROR",
 				Output: "stdout",
-			}},
+			},
+		},
 	}
 	testConfigDisabled = &Config{
 		Enabled:         convert.BoolPtr(false),

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -157,14 +157,15 @@ func (b *Base) ExchangeAddressExists(exchangeName string, coinType currency.Code
 func (b *Base) AddExchangeAddress(exchangeName string, coinType currency.Code, balance float64) {
 	if b.ExchangeAddressExists(exchangeName, coinType) {
 		b.UpdateExchangeAddressBalance(exchangeName, coinType, balance)
-	} else {
-		b.Addresses = append(
-			b.Addresses, Address{
-				Address: exchangeName, CoinType: coinType,
-				Balance: balance, Description: ExchangeAddress,
-			},
-		)
+		return
 	}
+
+	b.Addresses = append(b.Addresses, Address{
+		Address:     exchangeName,
+		CoinType:    coinType,
+		Balance:     balance,
+		Description: ExchangeAddress,
+	})
 }
 
 // UpdateAddressBalance updates the portfolio base balance
@@ -208,24 +209,25 @@ func (b *Base) AddAddress(address, description string, coinType currency.Code, b
 
 	if description == ExchangeAddress {
 		b.AddExchangeAddress(address, coinType, balance)
+		return nil
 	}
+
 	if !b.AddressExists(address) {
-		b.Addresses = append(
-			b.Addresses, Address{
-				Address: address, CoinType: coinType,
-				Balance: balance, Description: description,
-			},
-		)
-	} else {
-		if balance <= 0 {
-			err := b.RemoveAddress(address, description, coinType)
-			if err != nil {
-				return err
-			}
-		} else {
-			b.UpdateAddressBalance(address, balance)
+		b.Addresses = append(b.Addresses, Address{
+			Address:     address,
+			CoinType:    coinType,
+			Balance:     balance,
+			Description: description,
+		})
+		return nil
+	}
+
+	if balance <= 0 {
+		if err := b.RemoveAddress(address, description, coinType); err != nil {
+			return err
 		}
 	}
+	b.UpdateAddressBalance(address, balance)
 	return nil
 }
 

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -159,8 +159,10 @@ func (b *Base) AddExchangeAddress(exchangeName string, coinType currency.Code, b
 		b.UpdateExchangeAddressBalance(exchangeName, coinType, balance)
 	} else {
 		b.Addresses = append(
-			b.Addresses, Address{Address: exchangeName, CoinType: coinType,
-				Balance: balance, Description: ExchangeAddress},
+			b.Addresses, Address{
+				Address: exchangeName, CoinType: coinType,
+				Balance: balance, Description: ExchangeAddress,
+			},
 		)
 	}
 }
@@ -209,8 +211,10 @@ func (b *Base) AddAddress(address, description string, coinType currency.Code, b
 	}
 	if !b.AddressExists(address) {
 		b.Addresses = append(
-			b.Addresses, Address{Address: address, CoinType: coinType,
-				Balance: balance, Description: description},
+			b.Addresses, Address{
+				Address: address, CoinType: coinType,
+				Balance: balance, Description: description,
+			},
 		)
 	} else {
 		if balance <= 0 {

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -318,7 +318,8 @@ func TestUpdatePortfolio(t *testing.T) {
 	}
 	err = newBase.UpdatePortfolio([]string{
 		"LdP8Qox1VAhCzLJNqrr74YovaWYyNBUWvL",
-		"LVa8wZ983PvWtdwXZ8viK6SocMENLCXkEy"},
+		"LVa8wZ983PvWtdwXZ8viK6SocMENLCXkEy",
+	},
 		currency.LTC,
 	)
 	if err != nil {
@@ -332,34 +333,40 @@ func TestUpdatePortfolio(t *testing.T) {
 	}
 
 	err = newBase.UpdatePortfolio([]string{
-		"0xb794f5ea0ba39494ce839613fffba74279579268"},
+		"0xb794f5ea0ba39494ce839613fffba74279579268",
+	},
 		currency.ETH)
 	if err != nil {
 		t.Error(err)
 	}
 	err = newBase.UpdatePortfolio([]string{
-		"TESTY"},
+		"TESTY",
+	},
 		currency.ETH)
 	if err == nil {
 		t.Error("UpdatePortfolio error cannot be nil")
 	}
 
-	err = newBase.UpdatePortfolio([]string{ExchangeAddress,
-		PersonalAddress},
+	err = newBase.UpdatePortfolio([]string{
+		ExchangeAddress,
+		PersonalAddress,
+	},
 		currency.LTC)
 	if err != nil {
 		t.Error(err)
 	}
 
 	err = newBase.UpdatePortfolio([]string{
-		"r962iS5subzbVeXZN8MTzyEuuaQKo5qksh"},
+		"r962iS5subzbVeXZN8MTzyEuuaQKo5qksh",
+	},
 		currency.XRP)
 	if err != nil {
 		t.Error(err)
 	}
 
 	err = newBase.UpdatePortfolio([]string{
-		"TESTY"},
+		"TESTY",
+	},
 		currency.XRP)
 	if err == nil {
 		t.Error("error cannot be nil")

--- a/signaler/signaler.go
+++ b/signaler/signaler.go
@@ -6,9 +6,7 @@ import (
 	"syscall"
 )
 
-var (
-	s = make(chan os.Signal, 1)
-)
+var s = make(chan os.Signal, 1)
 
 func init() {
 	sigs := []os.Signal{


### PR DESCRIPTION
# PR Description

Thanks to @junnplus for highlighting this: https://github.com/mvdan/gofumpt ! I think we're all a fan of this style and it's also an easy plugin to enable for gopls. This PR enables gofumpt via golangci-lint and applies fixes to the codebase.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
