### PR TITLE
Bitfinex: Fix intermittent TestGenerateSubscriptions and ticker FRRAmountAvailable failures

### DIFF
--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -707,7 +707,7 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 	}, nil
 }
 
-var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FFRAmountAvailable"}
+var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FRRAmountAvailable"}
 
 func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 	if len(respAny) != 16 {
@@ -738,7 +738,7 @@ func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 		Volume:             resp[10],
 		High:               resp[11],
 		Low:                resp[12],
-		FFRAmountAvailable: resp[15],
+		FRRAmountAvailable: resp[15],
 	}, nil
 }
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -284,7 +284,7 @@ func TestTickerFromFundingResp(t *testing.T) {
 	assert.Equal(t, 11.11, tick.Volume, "Tick Volume should be correct")
 	assert.Equal(t, 12.12, tick.High, "Tick High should be correct")
 	assert.Equal(t, 13.13, tick.Low, "Tick Low should be correct")
-	assert.Equal(t, 15.15, tick.FFRAmountAvailable, "Tick FFRAmountAvailable should be correct")
+	assert.Equal(t, 15.15, tick.FRRAmountAvailable, "Tick FRRAmountAvailable should be correct")
 }
 
 func TestGetTickerFunding(t *testing.T) {
@@ -314,7 +314,7 @@ func checkFundingTick(tb testing.TB, tick *Ticker) {
 	assert.Positive(tb, tick.AskPeriod, "Tick AskPeriod should be positive")
 	assert.Positive(tb, tick.AskSize, "Tick AskSize should be positive")
 	assert.Positive(tb, tick.Last, "Tick Last should be positive")
-	assert.Positive(tb, tick.FFRAmountAvailable, "Tick FFRAmountavailable should be positive")
+	// Can't test FRRAmountAvailable as it's occasionally 0
 }
 
 func TestGetTrades(t *testing.T) {
@@ -1134,6 +1134,8 @@ func TestWSAuth(t *testing.T) {
 func TestGenerateSubscriptions(t *testing.T) {
 	t.Parallel()
 
+	b := new(Bitfinex) //nolint:govet // Intentional shadow of b to avoid future copy/paste mistakes
+	require.NoError(t, testexch.Setup(b), "Setup must not error")
 	b.Websocket.SetCanUseAuthenticatedEndpoints(true)
 	require.True(t, b.Websocket.CanUseAuthenticatedEndpoints(), "CanUseAuthenticatedEndpoints must return true")
 	subs, err := b.generateSubscriptions()

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -149,7 +149,7 @@ type Ticker struct {
 	Volume             float64
 	High               float64
 	Low                float64
-	FFRAmountAvailable float64
+	FRRAmountAvailable float64
 }
 
 // DerivativeDataResponse stores data for queried derivative

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -149,7 +149,7 @@ type Ticker struct {
 	Volume             float64
 	High               float64
 	Low                float64
-	FRRAmountAvailable float64
+	FRRAmountAvailable float64 // Flash Return Rate amount available
 }
 
 // DerivativeDataResponse stores data for queried derivative


### PR DESCRIPTION
# PR Description

Fix intermittent TestGenerateSubscriptions and ticker FFRAmountAvailable failures since FRRAmountAvailable is sometimes zero, also fixes the typo of FFR to FRR since FRR means Flash Return Rate.

Fixes https://github.com/thrasher-corp/gocryptotrader/issues/1853

## Type of change

- [x] Test/typo fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
