### PR TITLE
exchanges/credentials: Improve handling and error reporting

### DIFF
--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -328,6 +328,10 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 				Err:      err,
 			}
 		}
+		clientID := ""
+		if creds != nil {
+			clientID = creds.ClientID
+		}
 
 		b.Websocket.DataHandler <- &order.Detail{
 			Price:           price,
@@ -335,7 +339,7 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			RemainingAmount: orderData.OpenVolume,
 			Exchange:        b.Name,
 			OrderID:         orderID,
-			ClientID:        creds.ClientID,
+			ClientID:        clientID,
 			Type:            oType,
 			Side:            oSide,
 			Status:          oStatus,

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -320,16 +320,14 @@ func (b *BTCMarkets) wsHandleData(respRaw []byte) error {
 			}
 		}
 
-		creds, err := b.GetCredentials(context.TODO())
-		if err != nil {
+		clientID := ""
+		if creds, err := b.GetCredentials(context.TODO()); err != nil {
 			b.Websocket.DataHandler <- order.ClassificationError{
 				Exchange: b.Name,
 				OrderID:  orderID,
 				Err:      err,
 			}
-		}
-		clientID := ""
-		if creds != nil {
+		} else if creds != nil {
 			clientID = creds.ClientID
 		}
 

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -173,6 +173,11 @@ func (c *CoinbasePro) wsHandleData(respRaw []byte) error {
 			}
 		}
 
+		clientID := ""
+		if creds != nil {
+			clientID = creds.ClientID
+		}
+
 		if wsOrder.UserID != "" {
 			var p currency.Pair
 			var a asset.Item
@@ -191,7 +196,7 @@ func (c *CoinbasePro) wsHandleData(respRaw []byte) error {
 				Exchange:        c.Name,
 				OrderID:         wsOrder.OrderID,
 				AccountID:       wsOrder.ProfileID,
-				ClientID:        creds.ClientID,
+				ClientID:        clientID,
 				Type:            oType,
 				Side:            oSide,
 				Status:          oStatus,

--- a/exchanges/credentials.go
+++ b/exchanges/credentials.go
@@ -23,12 +23,11 @@ var (
 	// undertake an authenticated HTTP request.
 	ErrCredentialsAreEmpty = errors.New("credentials are empty")
 	// Errors related to API requirements and failures
-	errRequiresAPIKey            = errors.New("requires API key but default/empty one set")
-	errRequiresAPISecret         = errors.New("requires API secret but default/empty one set")
-	errRequiresAPIPEMKey         = errors.New("requires API PEM key but default/empty one set")
-	errRequiresAPIClientID       = errors.New("requires API Client ID but default/empty one set")
-	errBase64DecodeFailure       = errors.New("base64 decode has failed")
-	errContextCredentialsFailure = errors.New("context credentials type assertion failure")
+	errRequiresAPIKey      = errors.New("requires API key but default/empty one set")
+	errRequiresAPISecret   = errors.New("requires API secret but default/empty one set")
+	errRequiresAPIPEMKey   = errors.New("requires API PEM key but default/empty one set")
+	errRequiresAPIClientID = errors.New("requires API Client ID but default/empty one set")
+	errBase64DecodeFailure = errors.New("base64 decode has failed")
 )
 
 // SetKey sets new key for the default credentials

--- a/exchanges/credentials.go
+++ b/exchanges/credentials.go
@@ -133,7 +133,6 @@ func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)
 		return nil, fmt.Errorf("error checking credentials: %w", err)
 	}
 
-	// Sub account override if set
 	if subAccountOverride, ok := ctx.Value(account.ContextSubAccountFlag).(string); ok {
 		creds.SubAccount = subAccountOverride
 	}

--- a/exchanges/credentials.go
+++ b/exchanges/credentials.go
@@ -120,7 +120,7 @@ func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)
 
 		creds := ctxCredStore.Get()
 		if err := b.CheckCredentials(creds, true); err != nil {
-			return nil, fmt.Errorf("context credentials issue: %w", err)
+			return nil, fmt.Errorf("error checking credentials from context: %w", err)
 		}
 		return creds, nil
 	}

--- a/exchanges/credentials.go
+++ b/exchanges/credentials.go
@@ -136,8 +136,6 @@ func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)
 
 	// Sub account override if set
 	if subAccountOverride, ok := ctx.Value(account.ContextSubAccountFlag).(string); ok {
-		b.API.credMu.RLock()
-		defer b.API.credMu.RUnlock()
 		creds.SubAccount = subAccountOverride
 	}
 

--- a/exchanges/credentials.go
+++ b/exchanges/credentials.go
@@ -130,7 +130,7 @@ func (b *Base) GetCredentials(ctx context.Context) (*account.Credentials, error)
 	creds := b.API.credentials
 	b.API.credMu.RUnlock()
 	if err := b.CheckCredentials(&creds, false); err != nil {
-		return nil, fmt.Errorf("invalid default credentials: %w", err)
+		return nil, fmt.Errorf("error checking credentials: %w", err)
 	}
 
 	// Sub account override if set

--- a/exchanges/credentials_test.go
+++ b/exchanges/credentials_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
 )
@@ -55,8 +56,8 @@ func TestGetCredentials(t *testing.T) {
 
 	ctx = context.WithValue(context.Background(), account.ContextCredentialsFlag, "pewpew")
 	_, err = b.GetCredentials(ctx)
-	if !errors.Is(err, errContextCredentialsFailure) {
-		t.Fatalf("received: %v but expected: %v", err, errContextCredentialsFailure)
+	if !errors.Is(err, common.ErrTypeAssertFailure) {
+		t.Fatalf("received: %v but expected error to wrap: %v", err, common.ErrTypeAssertFailure)
 	}
 
 	b.API.CredentialsValidator.RequiresBase64DecodeSecret = false

--- a/exchanges/credentials_test.go
+++ b/exchanges/credentials_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
@@ -56,9 +57,7 @@ func TestGetCredentials(t *testing.T) {
 
 	ctx = context.WithValue(context.Background(), account.ContextCredentialsFlag, "pewpew")
 	_, err = b.GetCredentials(ctx)
-	if !errors.Is(err, common.ErrTypeAssertFailure) {
-		t.Fatalf("received: %v but expected error to wrap: %v", err, common.ErrTypeAssertFailure)
-	}
+	require.ErrorIs(t, err, common.ErrTypeAssertFailure)
 
 	b.API.CredentialsValidator.RequiresBase64DecodeSecret = false
 	fullCred := &account.Credentials{

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	objects "github.com/d5/tengo/v2"
@@ -194,9 +195,10 @@ func TestAccountInfo(t *testing.T) {
 		t.Fatalf("received: %v but expected: %v", err, nil)
 	}
 	rString, _ := objects.ToString(obj)
-	if rString != `error: "Bitstamp REST or Websocket authentication support is not enabled"` {
-		t.Errorf("received: %v but expected: %v",
-			rString, `error: "Bitstamp REST or Websocket authentication support is not enabled"`)
+	if !strings.Contains(rString, "Bitstamp REST or Websocket authentication support is not enabled") {
+		t.Errorf("received: %v but expected to contain: %v",
+			rString,
+			"Bitstamp REST or Websocket authentication support is not enabled")
 	}
 }
 
@@ -254,10 +256,10 @@ func TestExchangeOrderSubmit(t *testing.T) {
 	}
 
 	rString, _ := objects.ToString(obj)
-	if rString != `error: "Bitstamp REST or Websocket authentication support is not enabled"` {
-		t.Errorf("received: [%v] but expected: %v",
+	if !strings.Contains(rString, "Bitstamp REST or Websocket authentication support is not enabled") {
+		t.Errorf("received: %v but expected to contain: %v",
 			rString,
-			`error: "Bitstamp REST or Websocket authentication support is not enabled"`)
+			"Bitstamp REST or Websocket authentication support is not enabled")
 	}
 }
 

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -245,7 +245,7 @@ func TestExchangeOrderSubmit(t *testing.T) {
 	require.NoError(t, err)
 
 	rString, ok := objects.ToString(obj)
-	require.True(t, ok, "OrderSubmit return value must return correctly from objects.ToString")
+	require.True(t, ok, "ExchangeOrderSubmit return value must return correctly from objects.ToString")
 	require.Contains(t, rString, "Bitstamp REST or Websocket authentication support is not enabled")
 }
 

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	objects "github.com/d5/tengo/v2"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/engine"
@@ -187,19 +187,12 @@ func TestExchangePairs(t *testing.T) {
 func TestAccountInfo(t *testing.T) {
 	t.Parallel()
 	_, err := gct.ExchangeAccountInfo()
-	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
-	}
+	require.ErrorIs(t, err, objects.ErrWrongNumArguments)
 	obj, err := gct.ExchangeAccountInfo(ctx, exch, assetType)
-	if err != nil {
-		t.Fatalf("received: %v but expected: %v", err, nil)
-	}
-	rString, _ := objects.ToString(obj)
-	if !strings.Contains(rString, "Bitstamp REST or Websocket authentication support is not enabled") {
-		t.Errorf("received: %v but expected to contain: %v",
-			rString,
-			"Bitstamp REST or Websocket authentication support is not enabled")
-	}
+	require.NoError(t, err)
+	rString, ok := objects.ToString(obj)
+	require.True(t, ok)
+	require.Contains(t, rString, "Bitstamp REST or Websocket authentication support is not enabled")
 }
 
 func TestExchangeOrderQuery(t *testing.T) {
@@ -231,9 +224,7 @@ func TestExchangeOrderCancel(t *testing.T) {
 func TestExchangeOrderSubmit(t *testing.T) {
 	t.Parallel()
 	_, err := gct.ExchangeOrderSubmit()
-	if !errors.Is(err, objects.ErrWrongNumArguments) {
-		t.Fatal(err)
-	}
+	require.ErrorIs(t, err, objects.ErrWrongNumArguments)
 
 	orderSide := &objects.String{Value: "ASK"}
 	orderType := &objects.String{Value: "LIMIT"}
@@ -251,16 +242,11 @@ func TestExchangeOrderSubmit(t *testing.T) {
 		orderAmount,
 		orderID,
 		orderAsset)
-	if err != nil {
-		t.Fatalf("received: %v but expected: %v", err, nil)
-	}
+	require.NoError(t, err)
 
-	rString, _ := objects.ToString(obj)
-	if !strings.Contains(rString, "Bitstamp REST or Websocket authentication support is not enabled") {
-		t.Errorf("received: %v but expected to contain: %v",
-			rString,
-			"Bitstamp REST or Websocket authentication support is not enabled")
-	}
+	rString, ok := objects.ToString(obj)
+	require.True(t, ok)
+	require.Contains(t, rString, "Bitstamp REST or Websocket authentication support is not enabled")
 }
 
 func TestAllModuleNames(t *testing.T) {

--- a/gctscript/wrappers/gct/gctwrapper_test.go
+++ b/gctscript/wrappers/gct/gctwrapper_test.go
@@ -184,14 +184,14 @@ func TestExchangePairs(t *testing.T) {
 	}
 }
 
-func TestAccountInfo(t *testing.T) {
+func TestExchangeAccountInfo(t *testing.T) {
 	t.Parallel()
 	_, err := gct.ExchangeAccountInfo()
 	require.ErrorIs(t, err, objects.ErrWrongNumArguments)
 	obj, err := gct.ExchangeAccountInfo(ctx, exch, assetType)
 	require.NoError(t, err)
 	rString, ok := objects.ToString(obj)
-	require.True(t, ok)
+	require.True(t, ok, "ExchangeAccountInfo return value must return correctly from objects.ToString")
 	require.Contains(t, rString, "Bitstamp REST or Websocket authentication support is not enabled")
 }
 
@@ -245,7 +245,7 @@ func TestExchangeOrderSubmit(t *testing.T) {
 	require.NoError(t, err)
 
 	rString, ok := objects.ToString(obj)
-	require.True(t, ok)
+	require.True(t, ok, "OrderSubmit return value must return correctly from objects.ToString")
 	require.Contains(t, rString, "Bitstamp REST or Websocket authentication support is not enabled")
 }
 


### PR DESCRIPTION
Swapped out empty credential returns with more specific errors to make things clearer and avoid weird behavior. Added safeguards to handle nil credentials in WebSocket data processing. This gives us better error handling and more reliable fallback options when managing credentials.

# PR Description: Revenge arc commit 

Old PR: https://github.com/thrasher-corp/gocryptotrader/pull/1683
It was unclear what my goal was and what I was trying to do. Also, I synced upstream and made a new branch to start with a clean slate. I didn't want to fight with git at 5:30 in the morning with git force push and mess up (sorry) 


### Context Credentials Error Handling Change

```diff
                creds := ctxCredStore.Get()
                if err := b.CheckCredentials(creds, true); err != nil {
-                       return creds, fmt.Errorf("context credentials issue: %w", err)
+                       return nil, fmt.Errorf("context credentials issue: %w", err)
                }
                return creds, nil
        }
```

**Before**: When context credentials failed validation, the function returned the invalid credentials and an error.

**After**: When context credentials fail validation, the function now returns `nil` instead of the invalid credentials.

This change helps create a more reliable error-handling pattern.

Before, the function might have returned invalid credentials along with an error, which could lead to some unexpected issues if the calling code didn't check the error carefully. Now, it reliably returns `nil` for credentials whenever there's an error, which makes the API safer UwU

## Default Credentials Error Handling Improvement

```diff
+       // Fallback to default credentials
        creds := b.API.credentials
-       err := b.CheckCredentials(&creds, false)
-       if err != nil {
-               // NOTE: Return empty credentials on error to limit panic on websocket
-               // handling.
-               return &account.Credentials{}, err
+       if err := b.CheckCredentials(&creds, false); err != nil {
+               // Instead of returning empty credentials, return a specific error
+               return nil, fmt.Errorf("invalid default credentials: %w", err)
        }
```

**Before**: 
- Used a separate variable for the error
- Returned empty credentials (`&account.Credentials{}`) on error
- Had a comment about limiting panic in websocket handling

**After**:
- Uses inline error assignment & returns `nil` with a more specific error message
- Added comment for fallback to default credentials
- Removes the workaround comment about websocket panic

This change makes the error handling more consistent with the context credentials case and improves code clarity.

Instead of returning empty credentials, which could be misinterpreted as valid (I am sure I've seen it), it returns `nil` with a clear error message.

##  Sub-Account Override Handling Improvement

```diff
-       subAccountOverride, ok := ctx.Value(account.ContextSubAccountFlag).(string)
-       b.API.credMu.RLock()
-       defer b.API.credMu.RUnlock()
-       if ok {
+
+       // Sub account override if set
+       if subAccountOverride, ok := ctx.Value(account.ContextSubAccountFlag).(string); ok {
+               b.API.credMu.RLock()
+               defer b.API.credMu.RUnlock()
                creds.SubAccount = subAccountOverride
        }
+
```

**Before**:
- Declared variables outside the if statement
- Always acquired the read lock, even when no subaccount override was present (from what it seemed like)

**After**:
- Moves the variable declaration into the if statement scope
- Only acquires the lock when a subaccount override is 'actually' present
- No lock overhead for the common case (no subaccount override)
- Writers aren't unnecessarily blocked by readers who don't need the lock
(Don't think this was ever a real bottleneck and this theoretical gain is negligible)


## Error Handling Consistency

The patch sets a standard for error handling: return `nil` for invalid credentials instead of empty ones. This consistency enhances API predictability and usability.

Before this patch, there were two different behaviors:
1. For context credentials: Return invalid credentials with an error
2. For default credentials: Return empty credentials with an error

After the patch, both cases return `nil` with an appropriate error message, creating a unified approach.

### Performance Considerations

The change to the subaccount override handling improves performance by only acquiring the read lock when necessary. This could reduce lock contention and improve overall system performance in high-throughput scenarios with many concurrent API requests.


## Potential Impact on Other Parts of the Codebase

### Websocket Implementation

The websocket code in `exchanges/btcmarkets/btcmarkets_websocket.go` calls `GetCredentials` in two places:

1. In the `signWsReq` method:
```go
func (b *BTCMarkets) signWsReq(r *WsSubscribe) error {
    creds, err := b.GetCredentials(context.TODO())
    if err != nil {
        return err
    }
    // ... use credentials for signing ...
}
```

2. In the `wsHandleData` method when handling order changes:
```go
creds, err := b.GetCredentials(context.TODO())
if err != nil {
    b.Websocket.DataHandler <- order.ClassificationError{
        Exchange: b.Name,
        OrderID:  orderID,
        Err:      err,
    }
}
clientID := ""
if creds != nil {
    clientID = creds.ClientID
}
```

The websocket code already checks whether the returned credentials are `nil` before using them, so it should correctly handle the new behavior. The patch should align with how the websocket code expects credentials to be managed.

I did notice a comment in the original code about "limiting panic on websocket handling" so I guess that was a workaround for some issue.

### Other Exchange Implementations

Other exchange implementations that call `GetCredentials` will need to handle the possibility of receiving `nil` credentials. Most implementations likely already check for errors, but they should also ensure they handle `nil` credentials appropriately.


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ x ] go test ./... -race
- [ ] golangci-lint run  (SICK never heard of it. Might check later, it's 5:30am here)
- [ ] Test X  --> Wait never heard about this either 

## Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code  → I asked Claude if I am insane and he said no
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool (wait which tool)
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x  ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


