### PR TITLE
golangci-lint: Enable usetesting and unused linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-#   - unused
+    - unused
 
 # disabled by default linters
 #   - asasalint
@@ -105,7 +105,7 @@ linters:
     - unconvert
     - unparam
     - usestdlibvars
-#   - usetesting # Disabled temporarily due to the number of t.Context changes required
+    - usetesting
 #   - varnamelen
     - wastedassign
     - whitespace

--- a/backtester/data/kline/api/api_test.go
+++ b/backtester/data/kline/api/api_test.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/engine"
@@ -19,9 +19,7 @@ func TestLoadCandles(t *testing.T) {
 	t.Parallel()
 	em := engine.NewExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
 	exch.SetDefaults()
 	cp := currency.NewPair(currency.BTC, currency.USDT)
 	b := exch.GetBase()
@@ -37,30 +35,18 @@ func TestLoadCandles(t *testing.T) {
 	tt2 := time.Now().Round(gctkline.OneMin.Duration())
 	interval := gctkline.OneMin
 	a := asset.Spot
-	var data *gctkline.Item
-	data, err = LoadData(context.Background(),
-		common.DataCandle, tt1, tt2, interval.Duration(), exch, cp, a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data.Candles) == 0 {
-		t.Error("expected candles")
-	}
-
-	_, err = LoadData(context.Background(),
-		-1, tt1, tt2, interval.Duration(), exch, cp, a)
-	if !errors.Is(err, common.ErrInvalidDataType) {
-		t.Errorf("received: %v, expected: %v", err, common.ErrInvalidDataType)
-	}
+	data, err := LoadData(t.Context(), common.DataCandle, tt1, tt2, interval.Duration(), exch, cp, a)
+	require.NoError(t, err, "LoadData must not error")
+	assert.NotEmpty(t, data.Candles, "Candles should not be empty")
+	_, err = LoadData(t.Context(), -1, tt1, tt2, interval.Duration(), exch, cp, a)
+	assert.ErrorIs(t, err, common.ErrInvalidDataType)
 }
 
 func TestLoadTrades(t *testing.T) {
 	t.Parallel()
 	em := engine.NewExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
 	exch.SetDefaults()
 	cp := currency.NewPair(currency.BTC, currency.USDT)
 	b := exch.GetBase()
@@ -76,13 +62,7 @@ func TestLoadTrades(t *testing.T) {
 	tt1 := time.Now().Add(-time.Minute * 10).Round(interval.Duration())
 	tt2 := time.Now().Round(interval.Duration())
 	a := asset.Spot
-	var data *gctkline.Item
-	data, err = LoadData(context.Background(),
-		common.DataTrade, tt1, tt2, interval.Duration(), exch, cp, a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data.Candles) == 0 {
-		t.Error("expected candles")
-	}
+	data, err := LoadData(t.Context(), common.DataTrade, tt1, tt2, interval.Duration(), exch, cp, a)
+	require.NoError(t, err, "LoadData must not error")
+	assert.NotEmpty(t, data.Candles, "Candles should not be empty")
 }

--- a/backtester/data/kline/live/live_test.go
+++ b/backtester/data/kline/live/live_test.go
@@ -1,11 +1,11 @@
 package live
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/engine"
@@ -22,9 +22,7 @@ func TestLoadCandles(t *testing.T) {
 	a := asset.Spot
 	em := engine.NewExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
 	pFormat := &currency.PairFormat{Uppercase: true}
 	b := exch.GetBase()
 	exch.SetDefaults()
@@ -36,18 +34,11 @@ func TestLoadCandles(t *testing.T) {
 		RequestFormat: pFormat,
 		ConfigFormat:  pFormat,
 	}
-	var data *gctkline.Item
-	data, err = LoadData(context.Background(), time.Now().Add(-interval.Duration()*10), exch, common.DataCandle, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data.Candles) == 0 {
-		t.Error("expected candles")
-	}
-	_, err = LoadData(context.Background(), time.Now(), exch, -1, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
-	if !errors.Is(err, common.ErrInvalidDataType) {
-		t.Errorf("received: %v, expected: %v", err, common.ErrInvalidDataType)
-	}
+	data, err := LoadData(t.Context(), time.Now().Add(-interval.Duration()*10), exch, common.DataCandle, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
+	require.NoError(t, err, "LoadData must not error")
+	assert.NotEmpty(t, data.Candles, "Candles should not be empty")
+	_, err = LoadData(t.Context(), time.Now(), exch, -1, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
+	assert.ErrorIs(t, err, common.ErrInvalidDataType)
 }
 
 func TestLoadTrades(t *testing.T) {
@@ -57,9 +48,7 @@ func TestLoadTrades(t *testing.T) {
 	a := asset.Spot
 	em := engine.NewExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
 	pFormat := &currency.PairFormat{Uppercase: true}
 	b := exch.GetBase()
 	exch.SetDefaults()
@@ -71,12 +60,7 @@ func TestLoadTrades(t *testing.T) {
 		RequestFormat: pFormat,
 		ConfigFormat:  pFormat,
 	}
-	var data *gctkline.Item
-	data, err = LoadData(context.Background(), time.Now().Add(-interval.Duration()*60), exch, common.DataTrade, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data.Candles) == 0 {
-		t.Error("expected candles")
-	}
+	data, err := LoadData(t.Context(), time.Now().Add(-interval.Duration()*60), exch, common.DataTrade, interval.Duration(), cp, currency.EMPTYPAIR, a, true)
+	require.NoError(t, err, "LoadData must not error")
+	assert.NotEmpty(t, data.Candles, "Candles should not be empty")
 }

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -1589,25 +1588,18 @@ func TestSetExchangeCredentials(t *testing.T) {
 
 func TestGetFees(t *testing.T) {
 	t.Parallel()
-	_, _, err := getFees(context.Background(), nil, currency.EMPTYPAIR)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expected '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, _, err := getFees(t.Context(), nil, currency.EMPTYPAIR)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	f := &binance.Binance{}
 	f.SetDefaults()
-	_, _, err = getFees(context.Background(), f, currency.EMPTYPAIR)
-	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
-		t.Errorf("received '%v' expected '%v'", err, currency.ErrCurrencyPairEmpty)
-	}
+	_, _, err = getFees(t.Context(), f, currency.EMPTYPAIR)
+	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
-	maker, taker, err := getFees(context.Background(), f, currency.NewPair(currency.BTC, currency.USDT))
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, currency.ErrCurrencyPairEmpty)
-	}
-	if maker.IsZero() || taker.IsZero() {
-		t.Error("expected maker and taker fees")
-	}
+	maker, taker, err := getFees(t.Context(), f, currency.NewPair(currency.BTC, currency.USDT))
+	assert.NoError(t, err, "getFees should not error")
+	assert.False(t, maker.IsZero(), "maker fee should be set")
+	assert.False(t, taker.IsZero(), "taker fee should be set")
 }
 
 func TestGenerateSummary(t *testing.T) {

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -1598,8 +1598,8 @@ func TestGetFees(t *testing.T) {
 
 	maker, taker, err := getFees(t.Context(), f, currency.NewPair(currency.BTC, currency.USDT))
 	assert.NoError(t, err, "getFees should not error")
-	assert.False(t, maker.IsZero(), "maker fee should be set")
-	assert.False(t, taker.IsZero(), "taker fee should be set")
+	assert.False(t, maker.IsZero(), "getFees should return a non-zero maker fee")
+	assert.False(t, taker.IsZero(), "getFees should return a non-zero taker fee")
 }
 
 func TestGenerateSummary(t *testing.T) {

--- a/backtester/engine/backtest_test.go
+++ b/backtester/engine/backtest_test.go
@@ -1598,8 +1598,8 @@ func TestGetFees(t *testing.T) {
 
 	maker, taker, err := getFees(t.Context(), f, currency.NewPair(currency.BTC, currency.USDT))
 	assert.NoError(t, err, "getFees should not error")
-	assert.False(t, maker.IsZero(), "getFees should return a non-zero maker fee")
-	assert.False(t, taker.IsZero(), "getFees should return a non-zero taker fee")
+	assert.NotZero(t, maker, "getFees should return a non-zero maker fee")
+	assert.NotZero(t, taker, "getFees should return a non-zero taker fee")
 }
 
 func TestGenerateSummary(t *testing.T) {

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -84,17 +84,17 @@ func TestExecuteStrategyFromConfig(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
 	_, err := s.ExecuteStrategyFromConfig(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromConfig should error correctly with a nil config")
 
 	s.config, err = config.GenerateDefaultConfig()
 	require.NoError(t, err, "GenerateDefaultConfig must not error")
 	_, err = s.ExecuteStrategyFromConfig(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromConfig should error correctly with a nil task manager")
 
 	s.config.Report.GenerateReport = false
 	s.manager = NewTaskManager()
 	_, err = s.ExecuteStrategyFromConfig(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromConfig should error correctly with a nil request")
 
 	defaultConfig, err := config.ReadStrategyConfigFromFile(dcaConfigPath)
 	require.NoError(t, err, "ReadStrategyConfigFromFile must not error")

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -28,18 +28,18 @@ func TestExecuteStrategyFromFile(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
 	_, err := s.ExecuteStrategyFromFile(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromFile should error correctly with a nil config")
 
 	s.config, err = config.GenerateDefaultConfig()
 	require.NoError(t, err, "GenerateDefaultConfig must not error")
 
 	s.config.Report.GenerateReport = false
 	_, err = s.ExecuteStrategyFromFile(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromFile should error correctly with a nil task manager")
 
 	s.manager = NewTaskManager()
 	_, err = s.ExecuteStrategyFromFile(t.Context(), nil)
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer, "ExecuteStrategyFromFile should error correctly with a nil request")
 
 	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{})
 	assert.ErrorIs(t, err, common.ErrFileNotFound)

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -397,7 +397,7 @@ func TestGRPCStopTask(t *testing.T) {
 		Id: bt.MetaData.ID.String(),
 	})
 	assert.ErrorIs(t, err, errTaskHasNotRan)
-	assert.Len(t, s.manager.tasks, 1, "StopTask should not remove task")
+	require.Len(t, s.manager.tasks, 1, "StopTask must not remove task")
 
 	s.manager.tasks[0].MetaData.DateStarted = time.Now()
 	_, err = s.StopTask(t.Context(), &btrpc.StopTaskRequest{
@@ -429,7 +429,7 @@ func TestGRPCStopAllTasks(t *testing.T) {
 	assert.NoError(t, err, "AddTask should not error")
 	resp, err := s.StopAllTasks(t.Context(), &btrpc.StopAllTasksRequest{})
 	assert.NoError(t, err, "StopAllTasks should not error")
-	assert.Len(t, s.manager.tasks, 1, "StopAllTasks should return 1 task")
+	require.Len(t, s.manager.tasks, 1, "StopAllTasks must return 1 task")
 	assert.Empty(t, resp.TasksStopped, "TasksStopped should be empty")
 
 	s.manager.tasks[0].MetaData.DateStarted = time.Now()
@@ -463,7 +463,7 @@ func TestGRPCStartTask(t *testing.T) {
 		Id: bt.MetaData.ID.String(),
 	})
 	require.NoError(t, err, "StartTask must not error")
-	require.Len(t, s.manager.tasks, 1, "StartTask should return 1 task")
+	require.Len(t, s.manager.tasks, 1, "StartTask must return 1 task")
 	assert.False(t, s.manager.tasks[0].MetaData.DateStarted.IsZero(), "DateStarted should not be zero")
 }
 
@@ -489,7 +489,7 @@ func TestGRPCStartAllTasks(t *testing.T) {
 
 	_, err = s.StartAllTasks(t.Context(), &btrpc.StartAllTasksRequest{})
 	require.NoError(t, err, "StartAllTasks must not error")
-	assert.Len(t, s.manager.tasks, 1, "StartAllTasks should return 1 task")
+	require.Len(t, s.manager.tasks, 1, "StartAllTasks must return 1 task")
 	assert.False(t, s.manager.tasks[0].MetaData.DateStarted.IsZero(), "DateStarted should not be zero")
 }
 

--- a/backtester/engine/grpcserver_test.go
+++ b/backtester/engine/grpcserver_test.go
@@ -1,13 +1,14 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/backtester/btrpc"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/config"
@@ -21,122 +22,82 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var (
-	dcaConfigPath = filepath.Join("..", "config", "strategyexamples", "dca-api-candles.strat")
-	dbConfigPath  = filepath.Join("..", "config", "strategyexamples", "dca-database-candles.strat")
-)
+var dcaConfigPath = filepath.Join("..", "config", "strategyexamples", "dca-api-candles.strat")
 
 func TestExecuteStrategyFromFile(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.ExecuteStrategyFromFile(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.ExecuteStrategyFromFile(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.config, err = config.GenerateDefaultConfig()
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	require.NoError(t, err, "GenerateDefaultConfig must not error")
+
 	s.config.Report.GenerateReport = false
-	_, err = s.ExecuteStrategyFromFile(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.ExecuteStrategyFromFile(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.ExecuteStrategyFromFile(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.ExecuteStrategyFromFile(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{})
-	if !errors.Is(err, common.ErrFileNotFound) {
-		t.Errorf("received '%v' expecting '%v'", err, common.ErrFileNotFound)
-	}
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{})
+	assert.ErrorIs(t, err, common.ErrFileNotFound)
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{
 		StrategyFilePath: dcaConfigPath,
 	})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	assert.NoError(t, err, "ExecuteStrategyFromFile should not error")
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{
 		StrategyFilePath:  dcaConfigPath,
 		StartTimeOverride: timestamppb.New(time.Now()),
 		EndTimeOverride:   timestamppb.New(time.Now().Add(-time.Minute)),
 	})
-	if !errors.Is(err, gctcommon.ErrStartAfterEnd) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrStartAfterEnd)
-	}
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
-		StrategyFilePath:  dbConfigPath,
-		StartTimeOverride: timestamppb.New(time.Now()),
-		EndTimeOverride:   timestamppb.New(time.Now().Add(-time.Minute)),
-	})
-	if !errors.Is(err, gctcommon.ErrStartAfterEnd) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrStartAfterEnd)
-	}
+	assert.ErrorIs(t, err, gctcommon.ErrStartAfterEnd)
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{
 		StrategyFilePath:  dcaConfigPath,
 		StartTimeOverride: timestamppb.New(time.Now().Add(-time.Minute)),
 		EndTimeOverride:   timestamppb.New(time.Now()),
 		IntervalOverride:  durationpb.New(time.Duration(1)),
 	})
-	if !errors.Is(err, gctkline.ErrInvalidInterval) {
-		t.Errorf("received '%v' expecting '%v'", err, gctkline.ErrInvalidInterval)
-	}
+	assert.ErrorIs(t, err, gctkline.ErrInvalidInterval)
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{
 		StrategyFilePath:  dcaConfigPath,
 		StartTimeOverride: timestamppb.New(time.Now().Add(-time.Hour * 6).Truncate(time.Hour)),
 		EndTimeOverride:   timestamppb.New(time.Now().Add(-time.Hour * 2).Truncate(time.Hour)),
 		IntervalOverride:  durationpb.New(time.Hour),
 	})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	assert.NoError(t, err, "ExecuteStrategyFromFile should not error")
 
-	_, err = s.ExecuteStrategyFromFile(context.Background(), &btrpc.ExecuteStrategyFromFileRequest{
+	_, err = s.ExecuteStrategyFromFile(t.Context(), &btrpc.ExecuteStrategyFromFileRequest{
 		StrategyFilePath:    dcaConfigPath,
 		DoNotRunImmediately: true,
 		DoNotStore:          true,
 	})
-	if !errors.Is(err, errCannotHandleRequest) {
-		t.Errorf("received '%v' expecting '%v'", err, errCannotHandleRequest)
-	}
+	assert.ErrorIs(t, err, errCannotHandleRequest)
 }
 
 func TestExecuteStrategyFromConfig(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.ExecuteStrategyFromConfig(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.ExecuteStrategyFromConfig(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.config, err = config.GenerateDefaultConfig()
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	_, err = s.ExecuteStrategyFromConfig(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	require.NoError(t, err, "GenerateDefaultConfig must not error")
+	_, err = s.ExecuteStrategyFromConfig(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.config.Report.GenerateReport = false
 	s.manager = NewTaskManager()
-	_, err = s.ExecuteStrategyFromConfig(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.ExecuteStrategyFromConfig(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	defaultConfig, err := config.ReadStrategyConfigFromFile(dcaConfigPath)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	require.NoError(t, err, "ReadStrategyConfigFromFile must not error")
 	customSettings := make([]*btrpc.CustomSettings, len(defaultConfig.StrategySettings.CustomSettings))
 	x := 0
 	for k, v := range defaultConfig.StrategySettings.CustomSettings {
@@ -318,21 +279,17 @@ func TestExecuteStrategyFromConfig(t *testing.T) {
 		},
 	}
 
-	_, err = s.ExecuteStrategyFromConfig(context.Background(), &btrpc.ExecuteStrategyFromConfigRequest{
+	_, err = s.ExecuteStrategyFromConfig(t.Context(), &btrpc.ExecuteStrategyFromConfigRequest{
 		Config: cfg,
 	})
-	if !errors.Is(err, nil) {
-		t.Fatalf("received '%v' expecting '%v'", err, nil)
-	}
+	require.NoError(t, err, "ExecuteStrategyFromConfig must not error")
 
-	_, err = s.ExecuteStrategyFromConfig(context.Background(), &btrpc.ExecuteStrategyFromConfigRequest{
+	_, err = s.ExecuteStrategyFromConfig(t.Context(), &btrpc.ExecuteStrategyFromConfigRequest{
 		DoNotRunImmediately: true,
 		DoNotStore:          true,
 		Config:              cfg,
 	})
-	if !errors.Is(err, errCannotHandleRequest) {
-		t.Errorf("received '%v' expecting '%v'", err, errCannotHandleRequest)
-	}
+	assert.ErrorIs(t, err, errCannotHandleRequest)
 
 	// coverage test to ensure the rest of the config can successfully be converted
 	// this will not have a successful response
@@ -385,27 +342,22 @@ func TestExecuteStrategyFromConfig(t *testing.T) {
 		cfg.CurrencySettings[i].SpotDetails.InitialQuoteFunds = ""
 		cfg.CurrencySettings[i].SpotDetails.InitialBaseFunds = ""
 	}
-	_, err = s.ExecuteStrategyFromConfig(context.Background(), &btrpc.ExecuteStrategyFromConfigRequest{
+	_, err = s.ExecuteStrategyFromConfig(t.Context(), &btrpc.ExecuteStrategyFromConfigRequest{
 		Config: cfg,
 	})
-	if err == nil {
-		t.Error("expected an error from a bad setup")
-	}
+	assert.True(t, errors.Is(err, gctcommon.ErrStartEqualsEnd) || errors.Is(err, errAmbiguousDataSource),
+		"ExecuteStrategyFromConfig should error")
 }
 
 func TestListAllTasks(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.ListAllTasks(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.ListAllTasks(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.ListAllTasks(context.Background(), nil)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	_, err = s.ListAllTasks(t.Context(), nil)
+	assert.NoError(t, err, "ListAllTasks should not error")
 
 	bt := &BackTest{
 		Strategy:   &binancecashandcarry.Strategy{},
@@ -415,31 +367,21 @@ func TestListAllTasks(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	resp, err := s.ListAllTasks(context.Background(), &btrpc.ListAllTasksRequest{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(resp.Tasks) != 1 {
-		t.Errorf("received '%v' expecting '%v'", len(resp.Tasks), 1)
-	}
+	assert.NoError(t, err, "AddTask should not error")
+	resp, err := s.ListAllTasks(t.Context(), &btrpc.ListAllTasksRequest{})
+	assert.NoError(t, err, "ListAllTasks should not error")
+	assert.Len(t, resp.Tasks, 1, "ListAllTasks should return 1 task")
 }
 
 func TestGRPCStopTask(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.StopTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.StopTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.StopTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.StopTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	bt := &BackTest{
 		Strategy:   &fakeStrat{},
@@ -450,44 +392,30 @@ func TestGRPCStopTask(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	_, err = s.StopTask(context.Background(), &btrpc.StopTaskRequest{
+	assert.NoError(t, err, "AddTask should not error")
+	_, err = s.StopTask(t.Context(), &btrpc.StopTaskRequest{
 		Id: bt.MetaData.ID.String(),
 	})
-	if !errors.Is(err, errTaskHasNotRan) {
-		t.Errorf("received '%v' expecting '%v'", err, errTaskHasNotRan)
-	}
-	if len(s.manager.tasks) != 1 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 1)
-	}
+	assert.ErrorIs(t, err, errTaskHasNotRan)
+	assert.Len(t, s.manager.tasks, 1, "StopTask should not remove task")
 
 	s.manager.tasks[0].MetaData.DateStarted = time.Now()
-	_, err = s.StopTask(context.Background(), &btrpc.StopTaskRequest{
+	_, err = s.StopTask(t.Context(), &btrpc.StopTaskRequest{
 		Id: bt.MetaData.ID.String(),
 	})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if s.manager.tasks[0].MetaData.DateEnded.IsZero() {
-		t.Errorf("received '%v' expecting '%v'", s.manager.tasks[0].MetaData.DateEnded, "a date")
-	}
+	require.NoError(t, err, "StopTask must not error")
+	assert.False(t, s.manager.tasks[0].MetaData.DateEnded.IsZero(), "DateEnded should not be zero")
 }
 
 func TestGRPCStopAllTasks(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.StopAllTasks(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.StopAllTasks(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.StopAllTasks(context.Background(), nil)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	_, err = s.StopAllTasks(t.Context(), nil)
+	assert.NoError(t, err, "StopAllTasks should not error")
 
 	bt := &BackTest{
 		Strategy:   &fakeStrat{},
@@ -498,46 +426,28 @@ func TestGRPCStopAllTasks(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	resp, err := s.StopAllTasks(context.Background(), &btrpc.StopAllTasksRequest{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(s.manager.tasks) != 1 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 1)
-	}
-	if len(resp.TasksStopped) != 0 {
-		t.Errorf("received '%v' expecting '%v'", len(resp.TasksStopped), 0)
-	}
+	assert.NoError(t, err, "AddTask should not error")
+	resp, err := s.StopAllTasks(t.Context(), &btrpc.StopAllTasksRequest{})
+	assert.NoError(t, err, "StopAllTasks should not error")
+	assert.Len(t, s.manager.tasks, 1, "StopAllTasks should return 1 task")
+	assert.Empty(t, resp.TasksStopped, "TasksStopped should be empty")
 
 	s.manager.tasks[0].MetaData.DateStarted = time.Now()
-	resp, err = s.StopAllTasks(context.Background(), &btrpc.StopAllTasksRequest{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if s.manager.tasks[0].MetaData.DateEnded.IsZero() {
-		t.Errorf("received '%v' expecting '%v'", s.manager.tasks[0].MetaData.DateEnded, "a date")
-	}
-	if len(resp.TasksStopped) != 1 {
-		t.Errorf("received '%v' expecting '%v'", len(resp.TasksStopped), 1)
-	}
+	resp, err = s.StopAllTasks(t.Context(), &btrpc.StopAllTasksRequest{})
+	require.NoError(t, err, "StopAllTasks must not error")
+	assert.False(t, s.manager.tasks[0].MetaData.DateEnded.IsZero(), "DateEnded should not be zero")
+	assert.Len(t, resp.TasksStopped, 1, "TasksStopped should be 1 task")
 }
 
 func TestGRPCStartTask(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.StartTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.StartTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.StartTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.StartTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	bt := &BackTest{
 		Strategy:   &fakeStrat{},
@@ -548,36 +458,24 @@ func TestGRPCStartTask(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	_, err = s.StartTask(context.Background(), &btrpc.StartTaskRequest{
+	assert.NoError(t, err, "AddTask should not error")
+	_, err = s.StartTask(t.Context(), &btrpc.StartTaskRequest{
 		Id: bt.MetaData.ID.String(),
 	})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(s.manager.tasks) != 1 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 1)
-	}
-	if s.manager.tasks[0].MetaData.DateStarted.IsZero() {
-		t.Errorf("received '%v' expecting '%v'", s.manager.tasks[0].MetaData.DateStarted, "a date")
-	}
+	require.NoError(t, err, "StartTask must not error")
+	require.Len(t, s.manager.tasks, 1, "StartTask should return 1 task")
+	assert.False(t, s.manager.tasks[0].MetaData.DateStarted.IsZero(), "DateStarted should not be zero")
 }
 
 func TestGRPCStartAllTasks(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.StartAllTasks(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.StartAllTasks(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.StartAllTasks(context.Background(), nil)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	_, err = s.StartAllTasks(t.Context(), nil)
+	assert.NoError(t, err, "StartAllTasks should not error")
 
 	bt := &BackTest{
 		Strategy:   &binancecashandcarry.Strategy{},
@@ -587,34 +485,23 @@ func TestGRPCStartAllTasks(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	_, err = s.StartAllTasks(context.Background(), &btrpc.StartAllTasksRequest{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(s.manager.tasks) != 1 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 1)
-	}
-	if s.manager.tasks[0].MetaData.DateStarted.IsZero() {
-		t.Errorf("received '%v' expecting '%v'", s.manager.tasks[0].MetaData.DateStarted, "a date")
-	}
+	assert.NoError(t, err, "AddTask should not error")
+
+	_, err = s.StartAllTasks(t.Context(), &btrpc.StartAllTasksRequest{})
+	require.NoError(t, err, "StartAllTasks must not error")
+	assert.Len(t, s.manager.tasks, 1, "StartAllTasks should return 1 task")
+	assert.False(t, s.manager.tasks[0].MetaData.DateStarted.IsZero(), "DateStarted should not be zero")
 }
 
 func TestGRPCClearTask(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.ClearTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.ClearTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.ClearTask(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err = s.ClearTask(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	bt := &BackTest{
 		Strategy:   &binancecashandcarry.Strategy{},
@@ -624,33 +511,24 @@ func TestGRPCClearTask(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	_, err = s.ClearTask(context.Background(), &btrpc.ClearTaskRequest{
+	assert.NoError(t, err, "AddTask should not error")
+
+	_, err = s.ClearTask(t.Context(), &btrpc.ClearTaskRequest{
 		Id: bt.MetaData.ID.String(),
 	})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(s.manager.tasks) != 0 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 0)
-	}
+	assert.NoError(t, err, "ClearTask should not error")
+	assert.Empty(t, s.manager.tasks, "tasks should be empty")
 }
 
 func TestGRPCClearAllTasks(t *testing.T) {
 	t.Parallel()
 	s := &GRPCServer{}
-	_, err := s.ClearAllTasks(context.Background(), nil)
-	if !errors.Is(err, gctcommon.ErrNilPointer) {
-		t.Errorf("received '%v' expecting '%v'", err, gctcommon.ErrNilPointer)
-	}
+	_, err := s.ClearAllTasks(t.Context(), nil)
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
 	s.manager = NewTaskManager()
-	_, err = s.ClearAllTasks(context.Background(), nil)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
+	_, err = s.ClearAllTasks(t.Context(), nil)
+	assert.NoError(t, err, "ClearAllTasks should not error")
 
 	bt := &BackTest{
 		Strategy:   &binancecashandcarry.Strategy{},
@@ -660,14 +538,9 @@ func TestGRPCClearAllTasks(t *testing.T) {
 		shutdown:   make(chan struct{}),
 	}
 	err = s.manager.AddTask(bt)
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
-	_, err = s.ClearAllTasks(context.Background(), &btrpc.ClearAllTasksRequest{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expecting '%v'", err, nil)
-	}
-	if len(s.manager.tasks) != 0 {
-		t.Fatalf("received '%v' expecting '%v'", len(s.manager.tasks), 0)
-	}
+	assert.NoError(t, err, "AddTask should not error")
+
+	_, err = s.ClearAllTasks(t.Context(), &btrpc.ClearAllTasksRequest{})
+	assert.NoError(t, err, "ClearAllTasks should not error")
+	assert.Empty(t, s.manager.tasks, "tasks should be empty")
 }

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -449,10 +448,7 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	cs.BuySide.MinimumSize = decimal.NewFromFloat(0.01)
 	e.CurrencySettings = []Settings{cs}
 	_, err = e.ExecuteOrder(o, d, bot.OrderManager, &fakeFund{})
-	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
-		t.Error(err)
-	}
-	assert.NoError(t, err, "limitReducedAmount adjusted to 0.99999999, direction BUY, should fall in  buyside {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
+	assert.NoError(t, err, "ExecuteOrder should not error when limitReducedAmount adjusted to 0.99999999, direction BUY {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
 
 	o = &order.Order{
 		Base:           ev,
@@ -464,10 +460,7 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	cs.SellSide.MinimumSize = decimal.NewFromFloat(0.01)
 	e.CurrencySettings = []Settings{cs}
 	_, err = e.ExecuteOrder(o, d, bot.OrderManager, &fakeFund{})
-	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
-		t.Error(err)
-	}
-	assert.NoError(t, err, "limitReducedAmount adjust to 0.99999999, should fall in sell size {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
+	assert.NoError(t, err, "ExecuteOrder should not error when limitReducedAmount adjusted to 0.99999999, direction SELL {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
 
 	o = &order.Order{
 		Base:           ev,

--- a/backtester/eventhandlers/exchange/exchange_test.go
+++ b/backtester/eventhandlers/exchange/exchange_test.go
@@ -1,13 +1,13 @@
 package exchange
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/backtester/common"
 	"github.com/thrasher-corp/gocryptotrader/backtester/data"
@@ -186,63 +186,47 @@ func TestCalculateExchangeFee(t *testing.T) {
 func TestPlaceOrder(t *testing.T) {
 	t.Parallel()
 	bot := &engine.Engine{}
-	var err error
+
 	em := engine.NewExchangeManager()
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
+
 	exch.SetDefaults()
 	exchB := exch.GetBase()
 	exchB.States = currencystate.NewCurrencyStates()
 	err = em.Add(exch)
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
-	}
+	require.NoError(t, err, "Add exchange must not error")
 	bot.OrderManager, err = engine.SetupOrderManager(em, &engine.CommunicationManager{}, &bot.ServicesWG, &gctconfig.OrderManager{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received '%v' expected '%v'", err, nil)
-	}
+	require.NoError(t, err, "SetupOrderManager must not error")
 	err = bot.OrderManager.Start()
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
+	require.NoError(t, err, "Start must not error")
+
 	e := Exchange{}
-	_, err = e.placeOrder(context.Background(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, nil, nil)
-	if !errors.Is(err, common.ErrNilEvent) {
-		t.Errorf("received: %v, expected: %v", err, common.ErrNilEvent)
-	}
+	_, err = e.placeOrder(t.Context(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, nil, nil)
+	assert.ErrorIs(t, err, common.ErrNilEvent)
 	f := &fill.Fill{
 		Base: &event.Base{},
 	}
-	_, err = e.placeOrder(context.Background(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
-	if !errors.Is(err, engine.ErrExchangeNameIsEmpty) {
-		t.Errorf("received: %v, expected: %v", err, engine.ErrExchangeNameIsEmpty)
-	}
+	_, err = e.placeOrder(t.Context(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
+	assert.ErrorIs(t, err, engine.ErrExchangeNameIsEmpty)
 
 	f.Exchange = testExchange
-	_, err = e.placeOrder(context.Background(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
-	if !errors.Is(err, gctorder.ErrPairIsEmpty) {
-		t.Errorf("received: %v, expected: %v", err, gctorder.ErrPairIsEmpty)
-	}
+	_, err = e.placeOrder(t.Context(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
+	assert.ErrorIs(t, err, gctorder.ErrPairIsEmpty)
+
 	f.CurrencyPair = currency.NewPair(currency.BTC, currency.USDT)
 	f.AssetType = asset.Spot
 	f.Direction = gctorder.Buy
-	_, err = e.placeOrder(context.Background(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
-
-	_, err = e.placeOrder(context.Background(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, true, true, f, bot.OrderManager)
-	if !errors.Is(err, exchange.ErrCredentialsAreEmpty) {
-		t.Errorf("received: %v but expected: %v", err, exchange.ErrCredentialsAreEmpty)
-	}
+	_, err = e.placeOrder(t.Context(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, false, true, f, bot.OrderManager)
+	assert.NoError(t, err, "placeOrder should not error")
+	_, err = e.placeOrder(t.Context(), decimal.NewFromInt(1), decimal.NewFromInt(1), decimal.Zero, true, true, f, bot.OrderManager)
+	assert.ErrorIs(t, err, exchange.ErrCredentialsAreEmpty)
 }
 
 func TestExecuteOrder(t *testing.T) {
 	t.Parallel()
 	bot := &engine.Engine{}
-	var err error
+
 	em := engine.NewExchangeManager()
 	const testExchange = "binanceus"
 	exch, err := em.NewExchangeByName(testExchange)
@@ -260,7 +244,7 @@ func TestExecuteOrder(t *testing.T) {
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	a := asset.Spot
 	require.NoError(t, exchB.CurrencyPairs.SetAssetEnabled(a, true), "SetAssetEnabled must not error")
-	_, err = exch.UpdateOrderbook(context.Background(), p, a)
+	_, err = exch.UpdateOrderbook(t.Context(), p, a)
 	require.NoError(t, err, "UpdateOrderbook must not error")
 	f := &binanceus.Binanceus{}
 	f.Name = testExchange
@@ -356,13 +340,10 @@ func TestExecuteOrder(t *testing.T) {
 func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	t.Parallel()
 	bot := &engine.Engine{}
-	var err error
 	em := engine.NewExchangeManager()
 	const testExchange = "BTC Markets"
 	exch, err := em.NewExchangeByName(testExchange)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewExchangeByName must not error")
 	exch.SetDefaults()
 	exchB := exch.GetBase()
 	exchB.CurrencyPairs = currency.PairsManager{
@@ -379,33 +360,23 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	}
 	exchB.States = currencystate.NewCurrencyStates()
 	err = em.Add(exch)
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
-	}
+	require.NoError(t, err, "Add exchange must not error")
 	bot.OrderManager, err = engine.SetupOrderManager(em, &engine.CommunicationManager{}, &bot.ServicesWG, &gctconfig.OrderManager{})
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
+	require.NoError(t, err, "SetupOrderManager must not error")
 	err = bot.OrderManager.Start()
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
+	require.NoError(t, err, "Start must not error")
+
 	p := currency.NewPair(currency.BTC, currency.AUD)
 	a := asset.Spot
-	_, err = exch.UpdateOrderbook(context.Background(), p, a)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err = exch.UpdateOrderbook(t.Context(), p, a)
+	require.NoError(t, err, "UpdateOrderbook must not error")
 
-	err = exch.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = exch.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
+	require.NoError(t, err, "UpdateOrderExecutionLimits must not error")
 
 	limits, err := exch.GetOrderExecutionLimits(a, p)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "GetOrderExecutionLimits must not error")
+
 	f := &btcmarkets.BTCMarkets{}
 	f.Name = testExchange
 	cs := Settings{
@@ -460,17 +431,14 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 		},
 	}
 	err = d.Load()
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
+	require.NoError(t, err, "Load must not error")
+
 	_, err = d.Next()
-	if !errors.Is(err, nil) {
-		t.Errorf("received: %v, expected: %v", err, nil)
-	}
+	require.NoError(t, err, "Next must not error")
+
 	_, err = e.ExecuteOrder(o, d, bot.OrderManager, &fakeFund{})
-	if !errors.Is(err, errExceededPortfolioLimit) {
-		t.Errorf("received %v expected %v", err, errExceededPortfolioLimit)
-	}
+	assert.ErrorIs(t, err, errExceededPortfolioLimit)
+
 	o = &order.Order{
 		Base:           ev,
 		Direction:      gctorder.Buy,
@@ -484,9 +452,8 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
 		t.Error(err)
 	}
-	if err != nil {
-		t.Error("limitReducedAmount adjusted to 0.99999999, direction BUY, should fall in  buyside {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
-	}
+	assert.NoError(t, err, "limitReducedAmount adjusted to 0.99999999, direction BUY, should fall in  buyside {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
+
 	o = &order.Order{
 		Base:           ev,
 		Direction:      gctorder.Sell,
@@ -500,9 +467,7 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "exceed minimum size") {
 		t.Error(err)
 	}
-	if err != nil {
-		t.Error("limitReducedAmount adjust to 0.99999999, should fall in sell size {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
-	}
+	assert.NoError(t, err, "limitReducedAmount adjust to 0.99999999, should fall in sell size {MinimumSize:0.01 MaximumSize:0 MaximumTotal:0}")
 
 	o = &order.Order{
 		Base:           ev,
@@ -514,9 +479,7 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 	cs.SellSide.MinimumSize = decimal.NewFromInt(1)
 	e.CurrencySettings = []Settings{cs}
 	_, err = e.ExecuteOrder(o, d, bot.OrderManager, &fakeFund{})
-	if !errors.Is(err, errExceededPortfolioLimit) {
-		t.Errorf("received %v expected %v", err, errExceededPortfolioLimit)
-	}
+	assert.ErrorIs(t, err, errExceededPortfolioLimit)
 
 	o = &order.Order{
 		Base:           ev,
@@ -534,9 +497,7 @@ func TestExecuteOrderBuySellSizeLimit(t *testing.T) {
 
 	e.CurrencySettings = []Settings{cs}
 	_, err = e.ExecuteOrder(o, d, bot.OrderManager, &fakeFund{})
-	if !errors.Is(err, exchange.ErrCredentialsAreEmpty) {
-		t.Errorf("received: %v but expected: %v", err, exchange.ErrCredentialsAreEmpty)
-	}
+	assert.ErrorIs(t, err, exchange.ErrCredentialsAreEmpty)
 }
 
 func TestApplySlippageToPrice(t *testing.T) {

--- a/backtester/eventhandlers/exchange/slippage/slippage_test.go
+++ b/backtester/eventhandlers/exchange/slippage/slippage_test.go
@@ -1,7 +1,6 @@
 package slippage
 
 import (
-	"context"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -26,7 +25,7 @@ func TestCalculateSlippageByOrderbook(t *testing.T) {
 	b.SetDefaults()
 
 	cp := currency.NewPair(currency.BTC, currency.USD)
-	ob, err := b.UpdateOrderbook(context.Background(), cp, asset.Spot)
+	ob, err := b.UpdateOrderbook(t.Context(), cp, asset.Spot)
 	require.NoError(t, err, "UpdateOrderbook must not error")
 
 	amountOfFunds := decimal.NewFromInt(1000)

--- a/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
+++ b/cmd/exchange_wrapper_standards/exchange_wrapper_standards_test.go
@@ -62,12 +62,12 @@ func TestAllExchangeWrappers(t *testing.T) {
 			if singleExchangeOverride != "" && name != singleExchangeOverride {
 				t.Skip("skipping ", name, " due to override")
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			if isCITest() && slices.Contains(blockedCIExchanges, name) {
 				// rather than skipping tests where execution is blocked, provide an expired
 				// context, so no executions can take place
 				var cancelFn context.CancelFunc
-				ctx, cancelFn = context.WithTimeout(context.Background(), 0)
+				ctx, cancelFn = context.WithTimeout(ctx, 0)
 				cancelFn()
 			}
 			exch, assetPairs := setupExchange(ctx, t, name, cfg)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,21 +30,21 @@ func TestSendHTTPRequest(t *testing.T) {
 	headers := make(map[string]string)
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-	_, err := SendHTTPRequest(context.Background(),
+	_, err := SendHTTPRequest(t.Context(),
 		methodGarbage, "https://www.google.com", headers,
 		strings.NewReader(""), true,
 	)
 	if err == nil {
 		t.Error("Expected error 'invalid HTTP method specified'")
 	}
-	_, err = SendHTTPRequest(context.Background(),
+	_, err = SendHTTPRequest(t.Context(),
 		methodPost, "https://www.google.com", headers,
 		strings.NewReader(""), true,
 	)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = SendHTTPRequest(context.Background(),
+	_, err = SendHTTPRequest(t.Context(),
 		methodGet, "https://www.google.com", headers,
 		strings.NewReader(""), true,
 	)
@@ -58,21 +57,21 @@ func TestSendHTTPRequest(t *testing.T) {
 		t.Fatalf("received: %v but expected: %v", err, nil)
 	}
 
-	_, err = SendHTTPRequest(context.Background(),
+	_, err = SendHTTPRequest(t.Context(),
 		methodDelete, "https://www.google.com", headers,
 		strings.NewReader(""), true,
 	)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = SendHTTPRequest(context.Background(),
+	_, err = SendHTTPRequest(t.Context(),
 		methodGet, ":missingprotocolscheme", headers,
 		strings.NewReader(""), true,
 	)
 	if err == nil {
 		t.Error("Common HTTPRequest accepted missing protocol")
 	}
-	_, err = SendHTTPRequest(context.Background(),
+	_, err = SendHTTPRequest(t.Context(),
 		methodGet, "test://unsupportedprotocolscheme", headers,
 		strings.NewReader(""), true,
 	)

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -356,11 +356,10 @@ func TestSaveConfigToFileWithErrorInPasswordPrompt(t *testing.T) {
 		EncryptConfig: fileEncryptionEnabled,
 	}
 	testData := []byte("testdata")
-	f, err := os.CreateTemp("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err, "CreateTemp must not error")
 
 	targetFile := f.Name()
-	defer os.Remove(targetFile)
 
 	_, err = io.Copy(f, bytes.NewReader(testData))
 	require.NoError(t, err, "io.Copy must not error")
@@ -378,7 +377,7 @@ func TestSaveConfigToFileWithErrorInPasswordPrompt(t *testing.T) {
 
 func withInteractiveResponse(tb testing.TB, response string, fn func()) {
 	tb.Helper()
-	f, err := os.CreateTemp("", "*.in")
+	f, err := os.CreateTemp(tb.TempDir(), "*.in")
 	require.NoError(tb, err, "CreateTemp must not error")
 	defer f.Close()
 	defer os.Remove(f.Name())

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -380,7 +380,6 @@ func withInteractiveResponse(tb testing.TB, response string, fn func()) {
 	f, err := os.CreateTemp(tb.TempDir(), "*.in")
 	require.NoError(tb, err, "CreateTemp must not error")
 	defer f.Close()
-	defer os.Remove(f.Name())
 	_, err = f.WriteString(response)
 	require.NoError(tb, err, "WriteString must not error")
 	_, err = f.Seek(0, 0)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1506,19 +1506,12 @@ func TestLoadConfig(t *testing.T) {
 func TestSaveConfigToFile(t *testing.T) {
 	cfg := &Config{}
 	err := cfg.LoadConfig(TestFile, true)
-	if err != nil {
-		t.Errorf("TestSaveConfig.LoadConfig: %s", err.Error())
-	}
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Errorf("TestSaveConfig create file: %s", err)
-	}
-	f.Close()
-	defer os.Remove(f.Name())
-	err2 := cfg.SaveConfigToFile(f.Name())
-	if err2 != nil {
-		t.Errorf("TestSaveConfig.SaveConfig, %s", err2.Error())
-	}
+	require.NoError(t, err, "LoadConfig must not error")
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoError(t, err, "CreateTemp must not error")
+	require.NoError(t, f.Close(), "Close must not error")
+	err = cfg.SaveConfigToFile(f.Name())
+	require.NoError(t, err, "SaveConfigToFile must not error")
 }
 
 func TestCheckConnectionMonitorConfig(t *testing.T) {

--- a/config/versions/v0/v0_test.go
+++ b/config/versions/v0/v0_test.go
@@ -1,7 +1,6 @@
 package v0_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +11,7 @@ import (
 func TestUpgradeConfig(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"untouched":true}`)
-	out, err := new(v0.Version).UpgradeConfig(context.Background(), in)
+	out, err := new(v0.Version).UpgradeConfig(t.Context(), in)
 	require.NoError(t, err)
 	assert.Equal(t, in, out)
 }
@@ -20,7 +19,7 @@ func TestUpgradeConfig(t *testing.T) {
 func TestDowngradeConfig(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"untouched":true}`)
-	out, err := new(v0.Version).DowngradeConfig(context.Background(), in)
+	out, err := new(v0.Version).DowngradeConfig(t.Context(), in)
 	require.NoError(t, err)
 	assert.Equal(t, in, out)
 }

--- a/config/versions/v1/v1_test.go
+++ b/config/versions/v1/v1_test.go
@@ -2,7 +2,6 @@ package v1_test
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ func TestUpgradeExchange(t *testing.T) {
 	in := []byte(`{"name":"Wibble","pairsLastUpdated":1566798411,"assetTypes":"spot","configCurrencyPairFormat":{"uppercase":true,"delimiter":"_"},"requestCurrencyPairFormat":{"uppercase":false,"delimiter":"_","separator":"-"},"enabledPairs":"LTC_BTC","availablePairs":"LTC_BTC,ETH_BTC,BTC_USD"}`)
 	exp := []byte(`{"name":"Wibble","currencyPairs":{"bypassConfigFormatUpgrades":false,"requestFormat":{"uppercase":false,"delimiter":"_","separator":"-"},"configFormat":{"uppercase":true,"delimiter":"_"},"useGlobalFormat":true,"lastUpdated":1566798411,"pairs":{"spot":{"enabled":"LTC_BTC","available":"LTC_BTC,ETH_BTC,BTC_USD"}}}}`)
 
-	out, err := v.UpgradeExchange(context.Background(), in)
+	out, err := v.UpgradeExchange(t.Context(), in)
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
 	assert.Equal(t, string(exp), string(out))
@@ -31,7 +30,7 @@ func TestUpgradeExchange(t *testing.T) {
 func TestDowngradeExchange(t *testing.T) {
 	t.Parallel()
 	in := []byte("just leave me alone, mkay?")
-	out, err := new(v1.Version).DowngradeExchange(context.Background(), bytes.Clone(in))
+	out, err := new(v1.Version).DowngradeExchange(t.Context(), bytes.Clone(in))
 	require.NoError(t, err)
 	assert.Equal(t, out, in)
 }

--- a/config/versions/v2/v2_test.go
+++ b/config/versions/v2/v2_test.go
@@ -1,7 +1,6 @@
 package v2_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,7 @@ func TestUpgradeExchange(t *testing.T) {
 		{"Kraken", "Kraken"},
 		{"CoinbasePro", "CoinbasePro"},
 	} {
-		out, err := new(v2.Version).UpgradeExchange(context.Background(), []byte(`{"name":"`+tt[0]+`"}`))
+		out, err := new(v2.Version).UpgradeExchange(t.Context(), []byte(`{"name":"`+tt[0]+`"}`))
 		require.NoError(t, err)
 		require.NotEmpty(t, out)
 		assert.Equalf(t, `{"name":"`+tt[1]+`"}`, string(out), "Test exchange name %s", tt[0])
@@ -30,7 +29,7 @@ func TestDowngradeExchange(t *testing.T) {
 		{"Kraken", "Kraken"},
 		{"CoinbasePro", "GDAX"},
 	} {
-		out, err := new(v2.Version).DowngradeExchange(context.Background(), []byte(`{"name":"`+tt[0]+`"}`))
+		out, err := new(v2.Version).DowngradeExchange(t.Context(), []byte(`{"name":"`+tt[0]+`"}`))
 		require.NoError(t, err)
 		require.NotEmpty(t, out)
 		assert.Equalf(t, `{"name":"`+tt[1]+`"}`, string(out), "Test exchange name %s", tt[0])

--- a/config/versions/v3/v3_test.go
+++ b/config/versions/v3/v3_test.go
@@ -1,7 +1,6 @@
 package v3_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,13 +10,13 @@ import (
 func TestUpgradeExchange(t *testing.T) {
 	t.Parallel()
 
-	got, err := (&v3.Version{}).UpgradeExchange(context.Background(), nil)
+	got, err := (&v3.Version{}).UpgradeExchange(t.Context(), nil)
 	require.NoError(t, err)
 	require.Nil(t, got)
 
 	payload := []byte(`{"orderbook": {"verificationBypass": false,"websocketBufferLimit": 5,"websocketBufferEnabled": false,"publishPeriod": 10000000000}}`)
 	expected := []byte(`{"orderbook": {"verificationBypass": false,"websocketBufferLimit": 5,"websocketBufferEnabled": false}}`)
-	got, err = (&v3.Version{}).UpgradeExchange(context.Background(), payload)
+	got, err = (&v3.Version{}).UpgradeExchange(t.Context(), payload)
 	require.NoError(t, err)
 	require.Equal(t, expected, got)
 }
@@ -25,13 +24,13 @@ func TestUpgradeExchange(t *testing.T) {
 func TestDowngradeExchange(t *testing.T) {
 	t.Parallel()
 
-	got, err := (&v3.Version{}).DowngradeExchange(context.Background(), nil)
+	got, err := (&v3.Version{}).DowngradeExchange(t.Context(), nil)
 	require.NoError(t, err)
 	require.Nil(t, got)
 
 	payload := []byte(`{"orderbook": {"verificationBypass": false,"websocketBufferLimit": 5,"websocketBufferEnabled": false}}`)
 	expected := []byte(`{"orderbook": {"verificationBypass": false,"websocketBufferLimit": 5,"websocketBufferEnabled": false,"publishPeriod":10000000000}}`)
-	got, err = (&v3.Version{}).DowngradeExchange(context.Background(), payload)
+	got, err = (&v3.Version{}).DowngradeExchange(t.Context(), payload)
 	require.NoError(t, err)
 	require.Equal(t, expected, got)
 }

--- a/config/versions/v4/v4_test.go
+++ b/config/versions/v4/v4_test.go
@@ -2,7 +2,6 @@ package v4_test
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/buger/jsonparser"
@@ -19,14 +18,14 @@ func TestExchanges(t *testing.T) {
 func TestUpgradeExchange(t *testing.T) {
 	t.Parallel()
 
-	_, err := new(v4.Version).UpgradeExchange(context.Background(), []byte{})
+	_, err := new(v4.Version).UpgradeExchange(t.Context(), []byte{})
 	require.ErrorContains(t, err, `error upgrading assetTypes`)
 
-	_, err = new(v4.Version).UpgradeExchange(context.Background(), []byte(`{}`))
+	_, err = new(v4.Version).UpgradeExchange(t.Context(), []byte(`{}`))
 	require.ErrorContains(t, err, `error upgrading currencyPairs.pairs`)
 
 	in := []byte(`{"name":"Cracken","currencyPairs":{"assetTypes":["spot"],"pairs":{"spot":{"enabled":"BTC-AUD","available":"BTC-AUD"},"futures":{"assetEnabled":true},"options":{},"margin":{"assetEnabled":null}}}}`)
-	out, err := new(v4.Version).UpgradeExchange(context.Background(), in)
+	out, err := new(v4.Version).UpgradeExchange(t.Context(), in)
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
 
@@ -49,16 +48,16 @@ func TestUpgradeExchange(t *testing.T) {
 	require.NoError(t, err, "Must find assetEnabled for margin")
 	assert.False(t, e, "assetEnabled should be set to false")
 
-	out2, err := new(v4.Version).UpgradeExchange(context.Background(), out)
+	out2, err := new(v4.Version).UpgradeExchange(t.Context(), out)
 	require.NoError(t, err, "Must not error on re-upgrading")
 	assert.Equal(t, out, out2, "Should not affect an already upgraded config")
 
 	in = []byte(`{"name":"Cracken","currencyPairs":{"assetTypes":["spot"],"pairs":{"spot":{"assetEnabled":{}}}}}`)
-	_, err = new(v4.Version).UpgradeExchange(context.Background(), in)
+	_, err = new(v4.Version).UpgradeExchange(t.Context(), in)
 	require.NoError(t, err)
 
 	in = []byte(`{"name":"Cracken","currencyPairs":{"assetTypes":["spot"],"pairs":{"margin":{"assetEnabled":{}}}}}`)
-	_, err = new(v4.Version).UpgradeExchange(context.Background(), in)
+	_, err = new(v4.Version).UpgradeExchange(t.Context(), in)
 	require.ErrorIs(t, err, jsonparser.UnknownValueTypeError)
 	require.ErrorContains(t, err, "`margin`")
 	require.ErrorContains(t, err, "`object`")
@@ -68,7 +67,7 @@ func TestDowngradeExchange(t *testing.T) {
 	t.Parallel()
 
 	in := []byte(`{"name":"Cracken","currencyPairs":{"pairs":{"spot":{"enabled":"BTC-AUD","available":"BTC-AUD","assetEnabled":true},"futures":{"assetEnabled":false},"options":{},"options_combo":{"assetEnabled":true}}}}`)
-	out, err := new(v4.Version).DowngradeExchange(context.Background(), in)
+	out, err := new(v4.Version).DowngradeExchange(t.Context(), in)
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
 

--- a/config/versions/v5/v5_test.go
+++ b/config/versions/v5/v5_test.go
@@ -2,7 +2,6 @@ package v5_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json" //nolint:depguard // Direct use of golang json for Compact func
 	"strings"
 	"testing"
@@ -38,7 +37,7 @@ func TestUpgradeConfig(t *testing.T) {
 	for _, tt := range tests {
 		_ = t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out, err := new(v5.Version).UpgradeConfig(context.Background(), []byte(tt.in))
+			out, err := new(v5.Version).UpgradeConfig(t.Context(), []byte(tt.in))
 			if tt.err != nil {
 				require.ErrorIs(t, err, tt.err)
 				return
@@ -56,11 +55,11 @@ func TestDowngradeConfig(t *testing.T) {
 
 	in := `{"orderManager":{"enabled":false,"verbose":true,"activelyTrackFuturesPositions":false,"futuresTrackingSeekDuration":-47000,"cancelOrdersOnShutdown":true,"respectOrderHistoryLimits":true}}`
 	exp := `{"orderManager":{"enabled":false,"verbose":true,"activelyTrackFuturesPositions":false,"futuresTrackingSeekDuration":-47000,"cancelOrdersOnShutdown":true,"respectOrderHistoryLimits":true}}`
-	out, err := new(v5.Version).DowngradeConfig(context.Background(), []byte(in))
+	out, err := new(v5.Version).DowngradeConfig(t.Context(), []byte(in))
 	require.NoError(t, err)
 	assert.Equal(t, exp, string(out), "DowngradeConfig should just reverse the futuresTrackingSeekDuration")
 
-	out, err = new(v5.Version).DowngradeConfig(context.Background(), []byte(exp))
+	out, err = new(v5.Version).DowngradeConfig(t.Context(), []byte(exp))
 	require.NoError(t, err)
 	assert.Equal(t, exp, string(out), "DowngradeConfig should leave an already negative futuresTrackingSeekDuration alone")
 }

--- a/config/versions/v6/v6_test.go
+++ b/config/versions/v6/v6_test.go
@@ -2,7 +2,6 @@ package v6_test
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/buger/jsonparser"
@@ -18,11 +17,11 @@ func TestUpgradeConfig(t *testing.T) {
 {"portfolioAddresses":{"addresses":[{"Address":"1JCe8z4jJVNXSjohjM4i9Hh813dLCNx2Sy","CoinType":"BTC","Balance":0.00108832,"Description":"","WhiteListed":false,"ColdStorage":false,"SupportedExchanges":""}]}}
 	`)
 
-	r, err := new(v6.Version).UpgradeConfig(context.Background(), in)
+	r, err := new(v6.Version).UpgradeConfig(t.Context(), in)
 	require.NoError(t, err, "UpgradeConfig must not error")
 	require.True(t, bytes.Contains(r, v6.DefaultConfig))
 
-	r2, err := new(v6.Version).UpgradeConfig(context.Background(), r)
+	r2, err := new(v6.Version).UpgradeConfig(t.Context(), r)
 	require.NoError(t, err, "UpgradeConfig must not error")
 	assert.Equal(t, r, r2, "UpgradeConfig should not affect an already upgraded config")
 }
@@ -34,7 +33,7 @@ func TestDowngradeConfig(t *testing.T) {
 {"portfolioAddresses":{"addresses":[{"Address":"1JCe8z4jJVNXSjohjM4i9Hh813dLCNx2Sy","CoinType":"BTC","Balance":0.00108832,"Description":"","WhiteListed":false,"ColdStorage":false,"SupportedExchanges":""}],"providers":[{"name":"Ethplorer","enabled":true},{"name":"XRPScan","enabled":true},{"name":"CryptoID","enabled":false,"apiKey":"Key"}]}}
 `)
 
-	r, err := new(v6.Version).DowngradeConfig(context.Background(), in)
+	r, err := new(v6.Version).DowngradeConfig(t.Context(), in)
 	require.NoError(t, err, "DowngradeConfig must not error")
 	_, _, _, err = jsonparser.Get(r, "portfolioAddresses", "providers") //nolint:dogsled // Return values not needed
 	assert.ErrorIs(t, err, jsonparser.KeyPathNotFoundError, "providers should be removed")

--- a/config/versions/v7/v7_test.go
+++ b/config/versions/v7/v7_test.go
@@ -1,7 +1,6 @@
 package v7_test
 
 import (
-	"context"
 	"encoding/json" //nolint:depguard // Used instead of gct encoding/json so that we can ensure consistent library functionality between versions
 	"testing"
 
@@ -20,22 +19,22 @@ func TestUpgrade(t *testing.T) {
 	t.Parallel()
 
 	in := []byte(`{"name":"GateIO","currencyPairs":{}}`)
-	_, err := new(v7.Version).UpgradeExchange(context.Background(), in)
+	_, err := new(v7.Version).UpgradeExchange(t.Context(), in)
 	require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError)
 
 	in = []byte(`{"name":"GateIO","currencyPairs":{"pairs":14}}`)
-	_, err = new(v7.Version).UpgradeExchange(context.Background(), in)
+	_, err = new(v7.Version).UpgradeExchange(t.Context(), in)
 	require.Error(t, err)
 	var jsonErr *json.UnmarshalTypeError
 	assert.ErrorAs(t, err, &jsonErr, "UpgradeExchange should return a json.UnmarshalTypeError on bad type for pairs")
 
 	in = []byte(`{"name":"GateIO","currencyPairs":{"pairs":{"spot":{"assetEnabled":true,"enabled":"BTC-USDT","available":"BTC-USDT"},"futures":{"assetEnabled":true,"enabled":"BTC_USD,BTC_USDT,ETH_USDT","available":"BTC_USD,BTC_USDT,ETH_USDT,LTC_USDT"}}}}`)
-	out, err := new(v7.Version).UpgradeExchange(context.Background(), in)
+	out, err := new(v7.Version).UpgradeExchange(t.Context(), in)
 	require.NoError(t, err)
 	exp := `{"name":"GateIO","currencyPairs":{"pairs":{"coinmarginedfutures":{"assetEnabled":true,"enabled":"BTC_USD","available":"BTC_USD"},"spot":{"assetEnabled":true,"enabled":"BTC-USDT","available":"BTC-USDT"},"usdtmarginedfutures":{"assetEnabled":true,"enabled":"BTC_USDT,ETH_USDT","available":"BTC_USDT,ETH_USDT,LTC_USDT"}}}}`
 	assert.Equal(t, exp, string(out))
 
-	out, err = new(v7.Version).UpgradeExchange(context.Background(), out)
+	out, err = new(v7.Version).UpgradeExchange(t.Context(), out)
 	require.NoError(t, err)
 	assert.Equal(t, exp, string(out), "UpgradeExchange without futures should not alter the new entries")
 }
@@ -44,17 +43,17 @@ func TestDowngrade(t *testing.T) {
 	t.Parallel()
 
 	in := []byte(`{"name":"GateIO","currencyPairs":{}}`)
-	_, err := new(v7.Version).DowngradeExchange(context.Background(), in)
+	_, err := new(v7.Version).DowngradeExchange(t.Context(), in)
 	require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError)
 
 	in = []byte(`{"name":"GateIO","currencyPairs":{"pairs":14}}`)
-	_, err = new(v7.Version).DowngradeExchange(context.Background(), in)
+	_, err = new(v7.Version).DowngradeExchange(t.Context(), in)
 	require.Error(t, err)
 	var jsonErr *json.UnmarshalTypeError
 	assert.ErrorAs(t, err, &jsonErr)
 
 	in = []byte(`{"name":"GateIO","currencyPairs":{"pairs":{"spot":{"assetEnabled":true,"enabled":"BTC-USDT","available":"BTC-USDT,WIF-USDT"},"coinmarginedfutures":{"assetEnabled":true,"enabled":"BTC_USD","available":"BTC_USD"},"usdtmarginedfutures":{"assetEnabled":true,"enabled":"BTC_USDT,ETH_USDT","available":"BTC_USDT,ETH_USDT,LTC_USDT"}}}}`)
-	out, err := new(v7.Version).DowngradeExchange(context.Background(), in)
+	out, err := new(v7.Version).DowngradeExchange(t.Context(), in)
 	require.NoError(t, err)
 
 	exp := `{"name":"GateIO","currencyPairs":{"pairs":{"futures":{"assetEnabled":true,"enabled":"BTC_USD,BTC_USDT,ETH_USDT","available":"BTC_USD,BTC_USDT,ETH_USDT,LTC_USDT"},"spot":{"assetEnabled":true,"enabled":"BTC-USDT","available":"BTC-USDT,WIF-USDT"}}}}`

--- a/config/versions/versions_test.go
+++ b/config/versions/versions_test.go
@@ -1,7 +1,6 @@
 package versions
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -18,59 +17,59 @@ import (
 func TestDeploy(t *testing.T) {
 	t.Parallel()
 	m := manager{}
-	_, err := m.Deploy(context.Background(), []byte(``), UseLatestVersion)
+	_, err := m.Deploy(t.Context(), []byte(``), UseLatestVersion)
 	assert.ErrorIs(t, err, errNoVersions)
 
 	m.registerVersion(1, &TestVersion1{})
-	_, err = m.Deploy(context.Background(), []byte(``), UseLatestVersion)
+	_, err = m.Deploy(t.Context(), []byte(``), UseLatestVersion)
 	require.ErrorIs(t, err, errVersionIncompatible)
 
 	m = manager{}
 
 	m.registerVersion(0, &v0.Version{})
 	m.registerVersion(1, &v1.Version{})
-	_, err = m.Deploy(context.Background(), []byte(`not an object`), UseLatestVersion)
+	_, err = m.Deploy(t.Context(), []byte(`not an object`), UseLatestVersion)
 	require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError, "Must throw the correct error trying to add version to bad json")
 	require.ErrorIs(t, err, common.ErrSettingField, "Must throw the correct error trying to add version to bad json")
 	require.ErrorContains(t, err, "version", "Must throw the correct error trying to add version to bad json")
 
-	_, err = m.Deploy(context.Background(), []byte(`{"version":"not an int"}`), UseLatestVersion)
+	_, err = m.Deploy(t.Context(), []byte(`{"version":"not an int"}`), UseLatestVersion)
 	require.ErrorIs(t, err, common.ErrGettingField, "Must throw the correct error trying to get version from bad json")
 
-	_, err = m.Deploy(context.Background(), []byte(`{"version":65535}`), UseLatestVersion)
+	_, err = m.Deploy(t.Context(), []byte(`{"version":65535}`), UseLatestVersion)
 	require.ErrorIs(t, err, errConfigVersionMax, "Must throw the correct error when version is too high")
 
-	_, err = m.Deploy(context.Background(), []byte(`{"version":-1}`), UseLatestVersion)
+	_, err = m.Deploy(t.Context(), []byte(`{"version":-1}`), UseLatestVersion)
 	require.ErrorIs(t, err, errConfigVersionNegative, "Must throw the correct error when version is negative")
 
 	in := []byte(`{"version":0,"exchanges":[{"name":"Juan"}]}`)
-	j, err := m.Deploy(context.Background(), in, UseLatestVersion)
+	j, err := m.Deploy(t.Context(), in, UseLatestVersion)
 	require.NoError(t, err)
 	assert.Contains(t, string(j), `"version": 1`)
 
-	j2, err := m.Deploy(context.Background(), j, UseLatestVersion)
+	j2, err := m.Deploy(t.Context(), j, UseLatestVersion)
 	require.NoError(t, err, "Deploy the same version again must not error")
 	require.Equal(t, string(j2), string(j), "Deploy the same version again must not change config")
 
-	_, err = m.Deploy(context.Background(), j, 2)
+	_, err = m.Deploy(t.Context(), j, 2)
 	assert.ErrorIs(t, err, errTargetVersion, "Downgrade to a unregistered version should not be allowed")
 
 	m.versions = append(m.versions, &TestVersion2{ConfigErr: true, ExchErr: false})
-	_, err = m.Deploy(context.Background(), j, UseLatestVersion)
+	_, err = m.Deploy(t.Context(), j, UseLatestVersion)
 	require.ErrorIs(t, err, errUpgrade)
 
 	m.versions[len(m.versions)-1] = &TestVersion2{ConfigErr: false, ExchErr: true}
-	_, err = m.Deploy(context.Background(), in, UseLatestVersion)
+	_, err = m.Deploy(t.Context(), in, UseLatestVersion)
 	require.Implements(t, (*ExchangeVersion)(nil), m.versions[1])
 	require.ErrorIs(t, err, errUpgrade)
 	require.ErrorContains(t, err, "for `Juan`")
 
-	j2, err = m.Deploy(context.Background(), j, 0)
+	j2, err = m.Deploy(t.Context(), j, 0)
 	require.NoError(t, err)
 	assert.Contains(t, string(j2), `"version": 0`, "Explicit downgrade should work correctly")
 
 	m.versions = m.versions[:1]
-	_, err = m.Deploy(context.Background(), j, UseLatestVersion)
+	_, err = m.Deploy(t.Context(), j, UseLatestVersion)
 	assert.ErrorIs(t, err, errConfigVersionUnavail, "Config version ahead of latest version should error")
 }
 
@@ -79,12 +78,12 @@ func TestDeploy(t *testing.T) {
 func TestExchangeDeploy(t *testing.T) {
 	t.Parallel()
 	m := manager{}
-	_, err := m.Deploy(context.Background(), []byte(``), UseLatestVersion)
+	_, err := m.Deploy(t.Context(), []byte(``), UseLatestVersion)
 	assert.ErrorIs(t, err, errNoVersions)
 
 	v := &TestVersion2{}
 	in := []byte(`{"version":0,"exchanges":[{}]}`)
-	_, err = exchangeDeploy(context.Background(), v, ExchangeVersion.UpgradeExchange, in)
+	_, err = exchangeDeploy(t.Context(), v, ExchangeVersion.UpgradeExchange, in)
 	require.ErrorIs(t, err, errModifyingExchange)
 	require.ErrorIs(t, err, common.ErrGettingField)
 	require.ErrorIs(t, err, jsonparser.KeyPathNotFoundError)
@@ -92,7 +91,7 @@ func TestExchangeDeploy(t *testing.T) {
 	require.ErrorContains(t, err, "[0]")
 
 	in = []byte(`{"version":0,"exchanges":[{"name":"Juan"},{"name":"Megashaft"}]}`)
-	_, err = exchangeDeploy(context.Background(), v, ExchangeVersion.UpgradeExchange, in)
+	_, err = exchangeDeploy(t.Context(), v, ExchangeVersion.UpgradeExchange, in)
 	require.NoError(t, err)
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"os"
 	"slices"
@@ -380,7 +379,7 @@ func TestGetDefaultConfigurations(t *testing.T) {
 				t.Skipf("skipping %s unsupported", name)
 			}
 
-			defaultCfg, err := exchange.GetDefaultConfig(context.Background(), exch)
+			defaultCfg, err := exchange.GetDefaultConfig(t.Context(), exch)
 			require.NoError(t, err, "GetDefaultConfig must not error")
 			require.NotNil(t, defaultCfg)
 			assert.NotEmpty(t, defaultCfg.Name, "Name should not be empty")
@@ -480,7 +479,7 @@ func TestSetupExchanges(t *testing.T) {
 		exchLoader := func(exch exchange.IBotExchange) {
 			exch.SetDefaults()
 			exch.GetBase().Features.Supports.RESTCapabilities.AutoPairUpdates = false
-			cfg, err := exchange.GetDefaultConfig(context.Background(), exch)
+			cfg, err := exchange.GetDefaultConfig(t.Context(), exch)
 			require.NoError(t, err)
 			e.Config.Exchanges = append(e.Config.Exchanges, *cfg)
 		}

--- a/engine/event_manager_test.go
+++ b/engine/event_manager_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -277,7 +276,7 @@ func TestCheckEventCondition(t *testing.T) {
 	exch, err := em.NewExchangeByName(testExchange)
 	require.NoError(t, err, "NewExchangeByName must not error")
 
-	conf, err := exchange.GetDefaultConfig(context.Background(), exch)
+	conf, err := exchange.GetDefaultConfig(t.Context(), exch)
 	require.NoError(t, err, "GetDefaultConfig must not error")
 
 	require.NoError(t, exch.Setup(conf), "Setup must not error")
@@ -293,7 +292,7 @@ func TestCheckEventCondition(t *testing.T) {
 	assert.ErrorIs(t, err, ticker.ErrTickerNotFound)
 	m.m.Unlock()
 
-	_, err = exch.UpdateTicker(context.Background(), currency.NewPair(currency.BTC, currency.USD), asset.Spot)
+	_, err = exch.UpdateTicker(t.Context(), currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	require.NoError(t, err, "UpdateTicker must not error")
 
 	m.m.Lock()
@@ -311,7 +310,7 @@ func TestCheckEventCondition(t *testing.T) {
 	assert.ErrorIs(t, err, orderbook.ErrOrderbookNotFound)
 	m.m.Unlock()
 
-	_, err = exch.UpdateOrderbook(context.Background(), currency.NewPair(currency.BTC, currency.USD), asset.Spot)
+	_, err = exch.UpdateOrderbook(t.Context(), currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	require.NoError(t, err, "UpdateOrderbook must not error")
 
 	m.m.Lock()

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/communications"
@@ -1021,27 +1022,20 @@ func TestGetCryptocurrencyDepositAddressesByExchange(t *testing.T) {
 func TestGetExchangeCryptocurrencyDepositAddress(t *testing.T) {
 	t.Parallel()
 	e := createDepositEngine(&fakeDepositExchangeOpts{SupportsAuth: true, SupportsMultiChain: true})
+	_, err := e.GetExchangeCryptocurrencyDepositAddress(t.Context(), "non-existent", "", "", currency.BTC, false)
+	assert.ErrorIs(t, err, ErrExchangeNotFound)
+
 	const exchName = "fake"
-	if _, err := e.GetExchangeCryptocurrencyDepositAddress(context.Background(), "non-existent", "", "", currency.BTC, false); !errors.Is(err, ErrExchangeNotFound) {
-		t.Errorf("received %s, expected: %s", err, ErrExchangeNotFound)
-	}
-	r, err := e.GetExchangeCryptocurrencyDepositAddress(context.Background(), exchName, "", "", currency.BTC, false)
-	if err != nil {
-		t.Error(err)
-	}
-	if r.Address != "fakeaddr" {
-		t.Error("unexpected address")
-	}
+	r, err := e.GetExchangeCryptocurrencyDepositAddress(t.Context(), exchName, "", "", currency.BTC, false)
+	require.NoError(t, err, "GetExchangeCryptocurrencyDepositAddress must not error")
+	assert.Equal(t, "fakeaddr", r.Address, "Address must be equal to fakeaddr")
 	e.DepositAddressManager = SetupDepositAddressManager()
-	if err := e.DepositAddressManager.Sync(e.GetAllExchangeCryptocurrencyDepositAddresses()); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := e.GetExchangeCryptocurrencyDepositAddress(context.Background(), "meow", "", "", currency.BTC, false); !errors.Is(err, ErrExchangeNotFound) {
-		t.Errorf("received %s, expected: %s", err, ErrExchangeNotFound)
-	}
-	if _, err := e.GetExchangeCryptocurrencyDepositAddress(context.Background(), exchName, "", "", currency.BTC, false); err != nil {
-		t.Error(err)
-	}
+	err = e.DepositAddressManager.Sync(e.GetAllExchangeCryptocurrencyDepositAddresses())
+	assert.NoError(t, err, "Sync should not error")
+	_, err = e.GetExchangeCryptocurrencyDepositAddress(t.Context(), "meow", "", "", currency.BTC, false)
+	assert.ErrorIs(t, err, ErrExchangeNotFound)
+	_, err = e.GetExchangeCryptocurrencyDepositAddress(t.Context(), exchName, "", "", currency.BTC, false)
+	assert.NoError(t, err, "GetExchangeCryptocurrencyDepositAddress should not error")
 }
 
 func TestGetAllExchangeCryptocurrencyDepositAddresses(t *testing.T) {
@@ -1281,7 +1275,7 @@ func TestNewSupportedExchangeByName(t *testing.T) {
 func TestNewExchangeByNameWithDefaults(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewExchangeByNameWithDefaults(context.Background(), "moarunlikelymeow")
+	_, err := NewExchangeByNameWithDefaults(t.Context(), "moarunlikelymeow")
 	assert.ErrorIs(t, err, ErrExchangeNotFound, "Invalid exchange name should error")
 	for x := range exchange.Exchanges {
 		name := exchange.Exchanges[x]
@@ -1293,7 +1287,7 @@ func TestNewExchangeByNameWithDefaults(t *testing.T) {
 			if slices.Contains(unsupportedDefaultConfigExchanges, name) {
 				t.Skipf("skipping %s unsupported", name)
 			}
-			exch, err := NewExchangeByNameWithDefaults(context.Background(), name)
+			exch, err := NewExchangeByNameWithDefaults(t.Context(), name)
 			if assert.NoError(t, err, "NewExchangeByNameWithDefaults should not error") {
 				assert.Equal(t, name, strings.ToLower(exch.GetName()), "Should get correct exchange name")
 			}

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -1028,7 +1028,7 @@ func TestGetExchangeCryptocurrencyDepositAddress(t *testing.T) {
 	const exchName = "fake"
 	r, err := e.GetExchangeCryptocurrencyDepositAddress(t.Context(), exchName, "", "", currency.BTC, false)
 	require.NoError(t, err, "GetExchangeCryptocurrencyDepositAddress must not error")
-	assert.Equal(t, "fakeaddr", r.Address, "Address must be equal to fakeaddr")
+	assert.Equal(t, "fakeaddr", r.Address, "Should return the correct r.Address")
 	e.DepositAddressManager = SetupDepositAddressManager()
 	err = e.DepositAddressManager.Sync(e.GetAllExchangeCryptocurrencyDepositAddresses())
 	assert.NoError(t, err, "Sync should not error")

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -561,11 +561,11 @@ func TestGetSavedTrades(t *testing.T) {
 	engerino := RPCTestSetup(t)
 	defer CleanRPCTest(t, engerino)
 	s := RPCServer{Engine: engerino}
-	_, err := s.GetSavedTrades(context.Background(), &gctrpc.GetSavedTradesRequest{})
+	_, err := s.GetSavedTrades(t.Context(), &gctrpc.GetSavedTradesRequest{})
 	if !errors.Is(err, errInvalidArguments) {
 		t.Error(err)
 	}
-	_, err = s.GetSavedTrades(context.Background(), &gctrpc.GetSavedTradesRequest{
+	_, err = s.GetSavedTrades(t.Context(), &gctrpc.GetSavedTradesRequest{
 		Exchange: fakeExchangeName,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -579,7 +579,7 @@ func TestGetSavedTrades(t *testing.T) {
 	if !errors.Is(err, ErrExchangeNotFound) {
 		t.Error(err)
 	}
-	_, err = s.GetSavedTrades(context.Background(), &gctrpc.GetSavedTradesRequest{
+	_, err = s.GetSavedTrades(t.Context(), &gctrpc.GetSavedTradesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -611,7 +611,7 @@ func TestGetSavedTrades(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = s.GetSavedTrades(context.Background(), &gctrpc.GetSavedTradesRequest{
+	_, err = s.GetSavedTrades(t.Context(), &gctrpc.GetSavedTradesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -632,13 +632,13 @@ func TestConvertTradesToCandles(t *testing.T) {
 	defer CleanRPCTest(t, engerino)
 	s := RPCServer{Engine: engerino}
 	// bad param test
-	_, err := s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{})
+	_, err := s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{})
 	if !errors.Is(err, errInvalidArguments) {
 		t.Error(err)
 	}
 
 	// bad exchange test
-	_, err = s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{
+	_, err = s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{
 		Exchange: "faker",
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -655,7 +655,7 @@ func TestConvertTradesToCandles(t *testing.T) {
 	}
 
 	// no trades test
-	_, err = s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{
+	_, err = s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -688,7 +688,7 @@ func TestConvertTradesToCandles(t *testing.T) {
 
 	// get candle from one trade
 	var candles *gctrpc.GetHistoricCandlesResponse
-	candles, err = s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{
+	candles, err = s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -708,7 +708,7 @@ func TestConvertTradesToCandles(t *testing.T) {
 	}
 
 	// save generated candle to database
-	_, err = s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{
+	_, err = s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -726,7 +726,7 @@ func TestConvertTradesToCandles(t *testing.T) {
 	}
 
 	// forcefully remove previous candle and insert a new one
-	_, err = s.ConvertTradesToCandles(context.Background(), &gctrpc.ConvertTradesToCandlesRequest{
+	_, err = s.ConvertTradesToCandles(t.Context(), &gctrpc.ConvertTradesToCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -745,7 +745,7 @@ func TestConvertTradesToCandles(t *testing.T) {
 	}
 
 	// load the saved candle to verify that it was overwritten
-	candles, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	candles, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -775,7 +775,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	defaultStart := time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC)
 	defaultEnd := time.Date(2020, 0, 0, 1, 0, 0, 0, time.UTC)
 	cp := currency.NewPair(currency.BTC, currency.USD)
-	_, err := s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	_, err := s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: "",
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -789,7 +789,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
-	_, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	_, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: "bruh",
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -803,7 +803,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, ErrExchangeNotFound)
 	}
 
-	_, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	_, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange:  testExchange,
 		Start:     defaultStart.Format(common.SimpleTimeFormatWithTimezone),
 		End:       defaultEnd.Format(common.SimpleTimeFormatWithTimezone),
@@ -813,7 +813,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	if !errors.Is(err, errCurrencyPairUnset) {
 		t.Errorf("received '%v', expected '%v'", err, errCurrencyPairUnset)
 	}
-	_, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	_, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Base:  currency.BTC.String(),
@@ -827,7 +827,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	}
 	var results *gctrpc.GetHistoricCandlesResponse
 	// default run
-	results, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	results, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -846,7 +846,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	}
 
 	// sync run
-	results, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	results, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -867,7 +867,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	}
 
 	// db run
-	results, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	results, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -900,7 +900,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		return
 	}
 	// db run including trades
-	results, err = s.GetHistoricCandles(context.Background(), &gctrpc.GetHistoricCandlesRequest{
+	results, err = s.GetHistoricCandles(t.Context(), &gctrpc.GetHistoricCandlesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Base:  cp.Base.String(),
@@ -926,7 +926,7 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 	defer CleanRPCTest(t, engerino)
 	s := RPCServer{Engine: engerino}
 	// bad request checks
-	_, err := s.FindMissingSavedTradeIntervals(context.Background(), &gctrpc.FindMissingTradePeriodsRequest{})
+	_, err := s.FindMissingSavedTradeIntervals(t.Context(), &gctrpc.FindMissingTradePeriodsRequest{})
 	if err == nil {
 		t.Error("expected error")
 		return
@@ -940,7 +940,7 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 	defaultStart := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).UTC()
 	defaultEnd := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC).UTC()
 	var resp *gctrpc.FindMissingIntervalsResponse
-	resp, err = s.FindMissingSavedTradeIntervals(context.Background(), &gctrpc.FindMissingTradePeriodsRequest{
+	resp, err = s.FindMissingSavedTradeIntervals(t.Context(), &gctrpc.FindMissingTradePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -972,7 +972,7 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 		return
 	}
 
-	resp, err = s.FindMissingSavedTradeIntervals(context.Background(), &gctrpc.FindMissingTradePeriodsRequest{
+	resp, err = s.FindMissingSavedTradeIntervals(t.Context(), &gctrpc.FindMissingTradePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -1005,7 +1005,7 @@ func TestFindMissingSavedTradeIntervals(t *testing.T) {
 		return
 	}
 
-	resp, err = s.FindMissingSavedTradeIntervals(context.Background(), &gctrpc.FindMissingTradePeriodsRequest{
+	resp, err = s.FindMissingSavedTradeIntervals(t.Context(), &gctrpc.FindMissingTradePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -1028,7 +1028,7 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 	defer CleanRPCTest(t, engerino)
 	s := RPCServer{Engine: engerino}
 	// bad request checks
-	_, err := s.FindMissingSavedCandleIntervals(context.Background(), &gctrpc.FindMissingCandlePeriodsRequest{})
+	_, err := s.FindMissingSavedCandleIntervals(t.Context(), &gctrpc.FindMissingCandlePeriodsRequest{})
 	if err == nil {
 		t.Error("expected error")
 		return
@@ -1042,7 +1042,7 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 	defaultStart := time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC)
 	defaultEnd := time.Date(2020, 0, 0, 4, 0, 0, 0, time.UTC)
 	var resp *gctrpc.FindMissingIntervalsResponse
-	_, err = s.FindMissingSavedCandleIntervals(context.Background(), &gctrpc.FindMissingCandlePeriodsRequest{
+	_, err = s.FindMissingSavedCandleIntervals(t.Context(), &gctrpc.FindMissingCandlePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -1080,7 +1080,7 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 		return
 	}
 
-	_, err = s.FindMissingSavedCandleIntervals(context.Background(), &gctrpc.FindMissingCandlePeriodsRequest{
+	_, err = s.FindMissingSavedCandleIntervals(t.Context(), &gctrpc.FindMissingCandlePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -1117,7 +1117,7 @@ func TestFindMissingSavedCandleIntervals(t *testing.T) {
 		return
 	}
 
-	resp, err = s.FindMissingSavedCandleIntervals(context.Background(), &gctrpc.FindMissingCandlePeriodsRequest{
+	resp, err = s.FindMissingSavedCandleIntervals(t.Context(), &gctrpc.FindMissingCandlePeriodsRequest{
 		ExchangeName: testExchange,
 		AssetType:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -1153,7 +1153,7 @@ func TestSetExchangeTradeProcessing(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.SetExchangeTradeProcessing(context.Background(), &gctrpc.SetExchangeTradeProcessingRequest{Exchange: testExchange, Status: true})
+	_, err = s.SetExchangeTradeProcessing(t.Context(), &gctrpc.SetExchangeTradeProcessingRequest{Exchange: testExchange, Status: true})
 	if err != nil {
 		t.Error(err)
 		return
@@ -1161,7 +1161,7 @@ func TestSetExchangeTradeProcessing(t *testing.T) {
 	if !b.IsSaveTradeDataEnabled() {
 		t.Error("expected true")
 	}
-	_, err = s.SetExchangeTradeProcessing(context.Background(), &gctrpc.SetExchangeTradeProcessingRequest{Exchange: testExchange, Status: false})
+	_, err = s.SetExchangeTradeProcessing(t.Context(), &gctrpc.SetExchangeTradeProcessingRequest{Exchange: testExchange, Status: false})
 	if err != nil {
 		t.Error(err)
 		return
@@ -1175,11 +1175,11 @@ func TestGetRecentTrades(t *testing.T) {
 	engerino := RPCTestSetup(t)
 	defer CleanRPCTest(t, engerino)
 	s := RPCServer{Engine: engerino}
-	_, err := s.GetRecentTrades(context.Background(), &gctrpc.GetSavedTradesRequest{})
+	_, err := s.GetRecentTrades(t.Context(), &gctrpc.GetSavedTradesRequest{})
 	if !errors.Is(err, errInvalidArguments) {
 		t.Error(err)
 	}
-	_, err = s.GetRecentTrades(context.Background(), &gctrpc.GetSavedTradesRequest{
+	_, err = s.GetRecentTrades(t.Context(), &gctrpc.GetSavedTradesRequest{
 		Exchange: fakeExchangeName,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -1193,7 +1193,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if !errors.Is(err, ErrExchangeNotFound) {
 		t.Error(err)
 	}
-	_, err = s.GetRecentTrades(context.Background(), &gctrpc.GetSavedTradesRequest{
+	_, err = s.GetRecentTrades(t.Context(), &gctrpc.GetSavedTradesRequest{
 		Exchange: testExchange,
 		Pair: &gctrpc.CurrencyPair{
 			Delimiter: currency.DashDelimiter,
@@ -1279,7 +1279,7 @@ func TestGetAccountInfo(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.GetAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Spot.String()})
+	_, err = s.GetAccountInfo(t.Context(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Spot.String()})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -1308,17 +1308,17 @@ func TestUpdateAccountInfo(t *testing.T) {
 	}
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
 
-	_, err = s.GetAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Spot.String()})
+	_, err = s.GetAccountInfo(t.Context(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Spot.String()})
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
 
-	_, err = s.UpdateAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Futures.String()})
+	_, err = s.UpdateAccountInfo(t.Context(), &gctrpc.GetAccountInfoRequest{Exchange: fakeExchangeName, AssetType: asset.Futures.String()})
 	if !errors.Is(err, currency.ErrAssetNotFound) {
 		t.Errorf("received '%v', expected '%v'", err, currency.ErrAssetNotFound)
 	}
 
-	_, err = s.UpdateAccountInfo(context.Background(), &gctrpc.GetAccountInfoRequest{
+	_, err = s.UpdateAccountInfo(t.Context(), &gctrpc.GetAccountInfoRequest{
 		Exchange:  fakeExchangeName,
 		AssetType: asset.Spot.String(),
 	})
@@ -1365,12 +1365,12 @@ func TestGetOrders(t *testing.T) {
 		Quote:     currency.USDT.String(),
 	}
 
-	_, err = s.GetOrders(context.Background(), nil)
+	_, err = s.GetOrders(t.Context(), nil)
 	if !errors.Is(err, errInvalidArguments) {
 		t.Errorf("received '%v', expected '%v'", err, errInvalidArguments)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		AssetType: asset.Spot.String(),
 		Pair:      p,
 	})
@@ -1378,7 +1378,7 @@ func TestGetOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", ErrExchangeNameIsEmpty, err)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  "bruh",
 		AssetType: asset.Spot.String(),
 		Pair:      p,
@@ -1387,7 +1387,7 @@ func TestGetOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", ErrExchangeNotFound, err)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 	})
@@ -1395,7 +1395,7 @@ func TestGetOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, errCurrencyPairUnset)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange: exchName,
 		Pair:     p,
 	})
@@ -1403,7 +1403,7 @@ func TestGetOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 		Pair:      p,
@@ -1414,7 +1414,7 @@ func TestGetOrders(t *testing.T) {
 		t.Errorf("received %v, expected %v", err, common.ErrStartAfterEnd)
 	}
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 		Pair:      p,
@@ -1428,7 +1428,7 @@ func TestGetOrders(t *testing.T) {
 	b.SetCredentials("test", "test", "", "", "", "")
 	b.API.AuthenticatedSupport = true
 
-	_, err = s.GetOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 		Pair:      p,
@@ -1478,12 +1478,12 @@ func TestGetOrder(t *testing.T) {
 		Quote:     "USDT",
 	}
 
-	_, err = s.GetOrder(context.Background(), nil)
+	_, err = s.GetOrder(t.Context(), nil)
 	if !errors.Is(err, errInvalidArguments) {
 		t.Errorf("received '%v', expected '%v'", err, errInvalidArguments)
 	}
 
-	_, err = s.GetOrder(context.Background(), &gctrpc.GetOrderRequest{
+	_, err = s.GetOrder(t.Context(), &gctrpc.GetOrderRequest{
 		Exchange: "test123",
 		OrderId:  "",
 		Pair:     p,
@@ -1493,7 +1493,7 @@ func TestGetOrder(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, ErrExchangeNotFound)
 	}
 
-	_, err = s.GetOrder(context.Background(), &gctrpc.GetOrderRequest{
+	_, err = s.GetOrder(t.Context(), &gctrpc.GetOrderRequest{
 		Exchange: exchName,
 		OrderId:  "",
 		Pair:     nil,
@@ -1503,7 +1503,7 @@ func TestGetOrder(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, errCurrencyPairUnset)
 	}
 
-	_, err = s.GetOrder(context.Background(), &gctrpc.GetOrderRequest{
+	_, err = s.GetOrder(t.Context(), &gctrpc.GetOrderRequest{
 		Exchange: exchName,
 		OrderId:  "",
 		Pair:     p,
@@ -1513,7 +1513,7 @@ func TestGetOrder(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
 
-	_, err = s.GetOrder(context.Background(), &gctrpc.GetOrderRequest{
+	_, err = s.GetOrder(t.Context(), &gctrpc.GetOrderRequest{
 		Exchange: exchName,
 		OrderId:  "",
 		Pair:     p,
@@ -1522,7 +1522,7 @@ func TestGetOrder(t *testing.T) {
 	if !errors.Is(err, ErrOrderIDCannotBeEmpty) {
 		t.Errorf("received '%v', expected '%v'", err, ErrOrderIDCannotBeEmpty)
 	}
-	_, err = s.GetOrder(context.Background(), &gctrpc.GetOrderRequest{
+	_, err = s.GetOrder(t.Context(), &gctrpc.GetOrderRequest{
 		Exchange: exchName,
 		OrderId:  "1234",
 		Pair:     p,
@@ -1670,12 +1670,12 @@ func TestRPCServerUpsertDataHistoryJob(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 	s := RPCServer{Engine: &Engine{dataHistoryManager: m, ExchangeManager: em}}
-	_, err = s.UpsertDataHistoryJob(context.Background(), nil)
+	_, err = s.UpsertDataHistoryJob(t.Context(), nil)
 	if !errors.Is(err, errNilRequestData) {
 		t.Errorf("received %v, expected %v", err, errNilRequestData)
 	}
 
-	_, err = s.UpsertDataHistoryJob(context.Background(), &gctrpc.UpsertDataHistoryJobRequest{})
+	_, err = s.UpsertDataHistoryJob(t.Context(), &gctrpc.UpsertDataHistoryJobRequest{})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received %v, expected %v", err, asset.ErrNotSupported)
 	}
@@ -1698,7 +1698,7 @@ func TestRPCServerUpsertDataHistoryJob(t *testing.T) {
 		BatchSize:        500,
 	}
 
-	_, err = s.UpsertDataHistoryJob(context.Background(), job)
+	_, err = s.UpsertDataHistoryJob(t.Context(), job)
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
@@ -1723,32 +1723,32 @@ func TestGetDataHistoryJobDetails(t *testing.T) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
 
-	_, err = s.GetDataHistoryJobDetails(context.Background(), nil)
+	_, err = s.GetDataHistoryJobDetails(t.Context(), nil)
 	if !errors.Is(err, errNilRequestData) {
 		t.Errorf("received %v, expected %v", err, errNilRequestData)
 	}
 
-	_, err = s.GetDataHistoryJobDetails(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{})
+	_, err = s.GetDataHistoryJobDetails(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{})
 	if !errors.Is(err, errNicknameIDUnset) {
 		t.Errorf("received %v, expected %v", err, errNicknameIDUnset)
 	}
 
-	_, err = s.GetDataHistoryJobDetails(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{Id: "123", Nickname: "123"})
+	_, err = s.GetDataHistoryJobDetails(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{Id: "123", Nickname: "123"})
 	if !errors.Is(err, errOnlyNicknameOrID) {
 		t.Errorf("received %v, expected %v", err, errOnlyNicknameOrID)
 	}
 
-	_, err = s.GetDataHistoryJobDetails(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobDetails"})
+	_, err = s.GetDataHistoryJobDetails(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobDetails"})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
 
-	_, err = s.GetDataHistoryJobDetails(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{Id: dhj.ID.String()})
+	_, err = s.GetDataHistoryJobDetails(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{Id: dhj.ID.String()})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
 
-	resp, err := s.GetDataHistoryJobDetails(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobDetails", FullDetails: true})
+	resp, err := s.GetDataHistoryJobDetails(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobDetails", FullDetails: true})
 	if !errors.Is(err, nil) {
 		t.Fatalf("received %v, expected %v", err, nil)
 	}
@@ -1778,38 +1778,38 @@ func TestSetDataHistoryJobStatus(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Fatalf("received %v, expected %v", err, nil)
 	}
-	_, err = s.SetDataHistoryJobStatus(context.Background(), nil)
+	_, err = s.SetDataHistoryJobStatus(t.Context(), nil)
 	if !errors.Is(err, errNilRequestData) {
 		t.Errorf("received %v, expected %v", err, errNilRequestData)
 	}
 
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{})
 	if !errors.Is(err, errNicknameIDUnset) {
 		t.Errorf("received %v, expected %v", err, errNicknameIDUnset)
 	}
 
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{Id: "123", Nickname: "123"})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{Id: "123", Nickname: "123"})
 	if !errors.Is(err, errOnlyNicknameOrID) {
 		t.Errorf("received %v, expected %v", err, errOnlyNicknameOrID)
 	}
 
 	id := dhj.ID
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{Nickname: "TestDeleteDataHistoryJob", Status: int64(dataHistoryStatusRemoved)})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{Nickname: "TestDeleteDataHistoryJob", Status: int64(dataHistoryStatusRemoved)})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
 	dhj.ID = id
 	j.Status = int64(dataHistoryStatusActive)
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusRemoved)})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusRemoved)})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusActive)})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusActive)})
 	if !errors.Is(err, errBadStatus) {
 		t.Errorf("received %v, expected %v", err, errBadStatus)
 	}
 	j.Status = int64(dataHistoryStatusActive)
-	_, err = s.SetDataHistoryJobStatus(context.Background(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusPaused)})
+	_, err = s.SetDataHistoryJobStatus(t.Context(), &gctrpc.SetDataHistoryJobStatusRequest{Id: id.String(), Status: int64(dataHistoryStatusPaused)})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
@@ -1837,7 +1837,7 @@ func TestGetActiveDataHistoryJobs(t *testing.T) {
 		t.Fatalf("received %v, expected %v", err, nil)
 	}
 
-	r, err := s.GetActiveDataHistoryJobs(context.Background(), nil)
+	r, err := s.GetActiveDataHistoryJobs(t.Context(), nil)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received %v, expected %v", err, nil)
 	}
@@ -1861,12 +1861,12 @@ func TestGetDataHistoryJobsBetween(t *testing.T) {
 		Interval:  kline.OneMin,
 	}
 
-	_, err := s.GetDataHistoryJobsBetween(context.Background(), nil)
+	_, err := s.GetDataHistoryJobsBetween(t.Context(), nil)
 	if !errors.Is(err, errNilRequestData) {
 		t.Fatalf("received %v, expected %v", err, errNilRequestData)
 	}
 
-	_, err = s.GetDataHistoryJobsBetween(context.Background(), &gctrpc.GetDataHistoryJobsBetweenRequest{
+	_, err = s.GetDataHistoryJobsBetween(t.Context(), &gctrpc.GetDataHistoryJobsBetweenRequest{
 		StartDate: time.Now().UTC().Add(time.Minute).Format(common.SimpleTimeFormatWithTimezone),
 		EndDate:   time.Now().UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
@@ -1879,7 +1879,7 @@ func TestGetDataHistoryJobsBetween(t *testing.T) {
 		t.Fatalf("received %v, expected %v", err, nil)
 	}
 
-	r, err := s.GetDataHistoryJobsBetween(context.Background(), &gctrpc.GetDataHistoryJobsBetweenRequest{
+	r, err := s.GetDataHistoryJobsBetween(t.Context(), &gctrpc.GetDataHistoryJobsBetweenRequest{
 		StartDate: time.Now().Add(-time.Minute).UTC().Format(common.SimpleTimeFormatWithTimezone),
 		EndDate:   time.Now().Add(time.Minute).UTC().Format(common.SimpleTimeFormatWithTimezone),
 	})
@@ -1906,13 +1906,13 @@ func TestGetDataHistoryJobSummary(t *testing.T) {
 		Interval:  kline.OneMin,
 	}
 	assert.NoError(t, m.UpsertJob(dhj, false), "UpsertJob should not error")
-	_, err := s.GetDataHistoryJobSummary(context.Background(), nil)
+	_, err := s.GetDataHistoryJobSummary(t.Context(), nil)
 	assert.ErrorIs(t, err, errNilRequestData)
 
-	_, err = s.GetDataHistoryJobSummary(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{})
+	_, err = s.GetDataHistoryJobSummary(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{})
 	assert.ErrorIs(t, err, errNicknameUnset)
 
-	resp, err := s.GetDataHistoryJobSummary(context.Background(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobSummary"})
+	resp, err := s.GetDataHistoryJobSummary(t.Context(), &gctrpc.GetDataHistoryJobDetailsRequest{Nickname: "TestGetDataHistoryJobSummary"})
 	assert.NoError(t, err, "GetDataHistoryJobSummary should not error")
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Nickname)
@@ -1956,12 +1956,12 @@ func TestGetManagedOrders(t *testing.T) {
 		Quote:     currency.USDT.String(),
 	}
 
-	_, err = s.GetManagedOrders(context.Background(), nil)
+	_, err = s.GetManagedOrders(t.Context(), nil)
 	if !errors.Is(err, errInvalidArguments) {
 		t.Errorf("received '%v', expected '%v'", err, errInvalidArguments)
 	}
 
-	_, err = s.GetManagedOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetManagedOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		AssetType: asset.Spot.String(),
 		Pair:      p,
 	})
@@ -1969,7 +1969,7 @@ func TestGetManagedOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", ErrExchangeNameIsEmpty, err)
 	}
 
-	_, err = s.GetManagedOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetManagedOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  "bruh",
 		AssetType: asset.Spot.String(),
 		Pair:      p,
@@ -1978,7 +1978,7 @@ func TestGetManagedOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", ErrExchangeNotFound, err)
 	}
 
-	_, err = s.GetManagedOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetManagedOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: asset.Spot.String(),
 	})
@@ -1986,7 +1986,7 @@ func TestGetManagedOrders(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, errCurrencyPairUnset)
 	}
 
-	_, err = s.GetManagedOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	_, err = s.GetManagedOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange: exchName,
 		Pair:     p,
 	})
@@ -2009,7 +2009,7 @@ func TestGetManagedOrders(t *testing.T) {
 		t.Errorf("Error: %v", err)
 	}
 
-	oo, err := s.GetManagedOrders(context.Background(), &gctrpc.GetOrdersRequest{
+	oo, err := s.GetManagedOrders(t.Context(), &gctrpc.GetOrdersRequest{
 		Exchange:  exchName,
 		AssetType: "spot",
 		Pair:      p,
@@ -2103,7 +2103,7 @@ func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
 
 	// Check if timestamp returned is in seconds if !TimeInNanoSeconds.
 	server.Config.RemoteControl.GRPC.TimeInNanoSeconds = false
-	one, err := server.GetTicker(context.Background(), request)
+	one, err := server.GetTicker(t.Context(), request)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2113,7 +2113,7 @@ func TestRPCServer_GetTicker_LastUpdatedNanos(t *testing.T) {
 
 	// Check if timestamp returned is in nanoseconds if TimeInNanoSeconds.
 	server.Config.RemoteControl.GRPC.TimeInNanoSeconds = true
-	two, err := server.GetTicker(context.Background(), request)
+	two, err := server.GetTicker(t.Context(), request)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2126,24 +2126,24 @@ func TestUpdateDataHistoryJobPrerequisite(t *testing.T) {
 	t.Parallel()
 	m, _ := createDHM(t)
 	s := RPCServer{Engine: &Engine{dataHistoryManager: m}}
-	_, err := s.UpdateDataHistoryJobPrerequisite(context.Background(), nil)
+	_, err := s.UpdateDataHistoryJobPrerequisite(t.Context(), nil)
 	if !errors.Is(err, errNilRequestData) {
 		t.Errorf("received %v, expected %v", err, errNilRequestData)
 	}
 
-	_, err = s.UpdateDataHistoryJobPrerequisite(context.Background(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{})
+	_, err = s.UpdateDataHistoryJobPrerequisite(t.Context(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{})
 	if !errors.Is(err, errNicknameUnset) {
 		t.Errorf("received %v, expected %v", err, errNicknameUnset)
 	}
 
-	_, err = s.UpdateDataHistoryJobPrerequisite(context.Background(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{
+	_, err = s.UpdateDataHistoryJobPrerequisite(t.Context(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{
 		Nickname: "test456",
 	})
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
 
-	_, err = s.UpdateDataHistoryJobPrerequisite(context.Background(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{
+	_, err = s.UpdateDataHistoryJobPrerequisite(t.Context(), &gctrpc.UpdateDataHistoryJobPrerequisiteRequest{
 		Nickname:                "test456",
 		PrerequisiteJobNickname: "test123",
 	})
@@ -2154,7 +2154,7 @@ func TestUpdateDataHistoryJobPrerequisite(t *testing.T) {
 
 func TestCurrencyStateGetAll(t *testing.T) {
 	t.Parallel()
-	_, err := (&RPCServer{Engine: &Engine{}}).CurrencyStateGetAll(context.Background(),
+	_, err := (&RPCServer{Engine: &Engine{}}).CurrencyStateGetAll(t.Context(),
 		&gctrpc.CurrencyStateGetAllRequest{Exchange: fakeExchangeName})
 	if !errors.Is(err, ErrSubSystemNotStarted) {
 		t.Errorf("received %v, expected %v", err, ErrSubSystemNotStarted)
@@ -2165,7 +2165,7 @@ func TestCurrencyStateWithdraw(t *testing.T) {
 	t.Parallel()
 	_, err := (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateWithdraw(context.Background(),
+	}).CurrencyStateWithdraw(t.Context(),
 		&gctrpc.CurrencyStateWithdrawRequest{
 			Exchange: "wow", Asset: "meow",
 		})
@@ -2175,7 +2175,7 @@ func TestCurrencyStateWithdraw(t *testing.T) {
 
 	_, err = (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateWithdraw(context.Background(),
+	}).CurrencyStateWithdraw(t.Context(),
 		&gctrpc.CurrencyStateWithdrawRequest{
 			Exchange: "wow", Asset: "spot",
 		})
@@ -2188,7 +2188,7 @@ func TestCurrencyStateDeposit(t *testing.T) {
 	t.Parallel()
 	_, err := (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateDeposit(context.Background(),
+	}).CurrencyStateDeposit(t.Context(),
 		&gctrpc.CurrencyStateDepositRequest{Exchange: "wow", Asset: "meow"})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: %v, but expected: %v", err, asset.ErrNotSupported)
@@ -2196,7 +2196,7 @@ func TestCurrencyStateDeposit(t *testing.T) {
 
 	_, err = (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateDeposit(context.Background(),
+	}).CurrencyStateDeposit(t.Context(),
 		&gctrpc.CurrencyStateDepositRequest{Exchange: "wow", Asset: "spot"})
 	if !errors.Is(err, ErrSubSystemNotStarted) {
 		t.Fatalf("received: %v, but expected: %v", err, ErrSubSystemNotStarted)
@@ -2207,7 +2207,7 @@ func TestCurrencyStateTrading(t *testing.T) {
 	t.Parallel()
 	_, err := (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateTrading(context.Background(),
+	}).CurrencyStateTrading(t.Context(),
 		&gctrpc.CurrencyStateTradingRequest{Exchange: "wow", Asset: "meow"})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: %v, but expected: %v", err, asset.ErrNotSupported)
@@ -2215,7 +2215,7 @@ func TestCurrencyStateTrading(t *testing.T) {
 
 	_, err = (&RPCServer{
 		Engine: &Engine{},
-	}).CurrencyStateTrading(context.Background(),
+	}).CurrencyStateTrading(t.Context(),
 		&gctrpc.CurrencyStateTradingRequest{Exchange: "wow", Asset: "spot"})
 	if !errors.Is(err, ErrSubSystemNotStarted) {
 		t.Fatalf("received: %v, but expected: %v", err, ErrSubSystemNotStarted)
@@ -2257,7 +2257,7 @@ func TestCurrencyStateTradingPair(t *testing.T) {
 		currencyStateManager: &CurrencyStateManager{started: 1, iExchangeManager: em},
 	}}
 
-	_, err = s.CurrencyStateTradingPair(context.Background(),
+	_, err = s.CurrencyStateTradingPair(t.Context(),
 		&gctrpc.CurrencyStateTradingPairRequest{
 			Exchange: fakeExchangeName,
 			Pair:     "btc-usd",
@@ -2325,7 +2325,7 @@ func TestGetFuturesPositionsOrders(t *testing.T) {
 		},
 	}
 
-	_, err = s.GetFuturesPositionsOrders(context.Background(), &gctrpc.GetFuturesPositionsOrdersRequest{
+	_, err = s.GetFuturesPositionsOrders(t.Context(), &gctrpc.GetFuturesPositionsOrdersRequest{
 		Exchange: fakeExchangeName,
 		Asset:    asset.Futures.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -2338,7 +2338,7 @@ func TestGetFuturesPositionsOrders(t *testing.T) {
 		t.Fatalf("received '%v', expected '%v'", err, nil)
 	}
 
-	_, err = s.GetFuturesPositionsOrders(context.Background(), &gctrpc.GetFuturesPositionsOrdersRequest{
+	_, err = s.GetFuturesPositionsOrders(t.Context(), &gctrpc.GetFuturesPositionsOrdersRequest{
 		Exchange: fakeExchangeName,
 		Asset:    asset.Spot.String(),
 		Pair: &gctrpc.CurrencyPair{
@@ -2398,7 +2398,7 @@ func TestGetCollateral(t *testing.T) {
 		},
 	}
 
-	_, err = s.GetCollateral(context.Background(), &gctrpc.GetCollateralRequest{
+	_, err = s.GetCollateral(t.Context(), &gctrpc.GetCollateralRequest{
 		Exchange: fakeExchangeName,
 		Asset:    asset.Futures.String(),
 	})
@@ -2406,7 +2406,7 @@ func TestGetCollateral(t *testing.T) {
 		t.Fatalf("received '%v', expected '%v'", err, exchange.ErrCredentialsAreEmpty)
 	}
 
-	ctx := account.DeployCredentialsToContext(context.Background(),
+	ctx := account.DeployCredentialsToContext(t.Context(),
 		&account.Credentials{Key: "fakerino", Secret: "supafake"})
 
 	_, err = s.GetCollateral(ctx, &gctrpc.GetCollateralRequest{
@@ -2417,7 +2417,7 @@ func TestGetCollateral(t *testing.T) {
 		t.Fatalf("received '%v', expected '%v'", err, errNoAccountInformation)
 	}
 
-	ctx = account.DeployCredentialsToContext(context.Background(),
+	ctx = account.DeployCredentialsToContext(t.Context(),
 		&account.Credentials{Key: "fakerino", Secret: "supafake", SubAccount: "1337"})
 
 	r, err := s.GetCollateral(ctx, &gctrpc.GetCollateralRequest{
@@ -2458,19 +2458,19 @@ func TestGetCollateral(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	t.Parallel()
 	s := RPCServer{Engine: &Engine{}}
-	_, err := s.Shutdown(context.Background(), &gctrpc.ShutdownRequest{})
+	_, err := s.Shutdown(t.Context(), &gctrpc.ShutdownRequest{})
 	if !errors.Is(err, errShutdownNotAllowed) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errShutdownNotAllowed)
 	}
 
 	s.Engine.Settings.EnableGRPCShutdown = true
-	_, err = s.Shutdown(context.Background(), &gctrpc.ShutdownRequest{})
+	_, err = s.Shutdown(t.Context(), &gctrpc.ShutdownRequest{})
 	if !errors.Is(err, errGRPCShutdownSignalIsNil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errGRPCShutdownSignalIsNil)
 	}
 
 	s.Engine.GRPCShutdownSignal = make(chan struct{}, 1)
-	_, err = s.Shutdown(context.Background(), &gctrpc.ShutdownRequest{})
+	_, err = s.Shutdown(t.Context(), &gctrpc.ShutdownRequest{})
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -2522,19 +2522,19 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		},
 	}
 
-	_, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{})
+	_, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{})
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
-	_, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	_, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange: fakeExchangeName,
 	})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
-	_, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	_, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:  fakeExchangeName,
 		AssetType: "upsideprofitcontract",
 		Pair:      &gctrpc.CurrencyPair{},
@@ -2543,7 +2543,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errExpectedTestError)
 	}
 
-	_, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	_, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:  fakeExchangeName,
 		AssetType: "spot",
 		Pair:      &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2553,7 +2553,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errInvalidStrategy)
 	}
 
-	resp, err := s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err := s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2568,7 +2568,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", resp.Signals["TWAP"].Signals[0], 1337)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2583,7 +2583,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["VWAP"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2599,7 +2599,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["ATR"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:              fakeExchangeName,
 		AssetType:             "spot",
 		Pair:                  &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2625,7 +2625,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["LOWER"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2642,7 +2642,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["COCO"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2658,7 +2658,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["SMA"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2674,7 +2674,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["EMA"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2700,7 +2700,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["HISTOGRAM"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2716,7 +2716,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["MFI"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2732,7 +2732,7 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 		t.Fatalf("received: '%v' but expected: '%v'", len(resp.Signals["OBV"].Signals), 33)
 	}
 
-	resp, err = s.GetTechnicalAnalysis(context.Background(), &gctrpc.GetTechnicalAnalysisRequest{
+	resp, err = s.GetTechnicalAnalysis(t.Context(), &gctrpc.GetTechnicalAnalysisRequest{
 		Exchange:      fakeExchangeName,
 		AssetType:     "spot",
 		Pair:          &gctrpc.CurrencyPair{Base: "btc", Quote: "usd"},
@@ -2787,31 +2787,31 @@ func TestGetMarginRatesHistory(t *testing.T) {
 			},
 		},
 	}
-	_, err = s.GetMarginRatesHistory(context.Background(), nil)
+	_, err = s.GetMarginRatesHistory(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	request := &gctrpc.GetMarginRatesHistoryRequest{}
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Errorf("received '%v' expected '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
 	request.Exchange = fakeExchangeName
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v' expected '%v'", err, asset.ErrNotSupported)
 	}
 
 	request.Asset = asset.Spot.String()
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, currency.ErrCurrencyNotFound) {
 		t.Errorf("received '%v' expected '%v'", err, currency.ErrCurrencyNotFound)
 	}
 
 	request.Currency = "usd"
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
@@ -2821,7 +2821,7 @@ func TestGetMarginRatesHistory(t *testing.T) {
 	request.GetBorrowCosts = true
 	request.GetPredictedRate = true
 	request.IncludeAllRates = true
-	resp, err := s.GetMarginRatesHistory(context.Background(), request)
+	resp, err := s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
@@ -2848,19 +2848,19 @@ func TestGetMarginRatesHistory(t *testing.T) {
 	}
 
 	request.CalculateOffline = true
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, common.ErrCannotCalculateOffline) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrCannotCalculateOffline)
 	}
 
 	request.TakerFeeRate = "-1337"
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, common.ErrCannotCalculateOffline) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrCannotCalculateOffline)
 	}
 
 	request.TakerFeeRate = "1337"
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, common.ErrCannotCalculateOffline) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrCannotCalculateOffline)
 	}
@@ -2871,7 +2871,7 @@ func TestGetMarginRatesHistory(t *testing.T) {
 			HourlyRate: "1337",
 		},
 	}
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
@@ -2884,7 +2884,7 @@ func TestGetMarginRatesHistory(t *testing.T) {
 			BorrowCost:     &gctrpc.BorrowCost{Size: "1337"},
 		},
 	}
-	_, err = s.GetMarginRatesHistory(context.Background(), request)
+	_, err = s.GetMarginRatesHistory(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
@@ -2955,7 +2955,7 @@ func TestGetFundingRates(t *testing.T) {
 		},
 	}
 
-	_, err = s.GetFundingRates(context.Background(), nil)
+	_, err = s.GetFundingRates(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
@@ -2968,18 +2968,18 @@ func TestGetFundingRates(t *testing.T) {
 		IncludePredicted: false,
 		IncludePayments:  false,
 	}
-	_, err = s.GetFundingRates(context.Background(), request)
+	_, err = s.GetFundingRates(t.Context(), request)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Errorf("received: '%v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 	request.Exchange = exch.GetName()
-	_, err = s.GetFundingRates(context.Background(), request)
+	_, err = s.GetFundingRates(t.Context(), request)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	request.Asset = asset.Spot.String()
-	_, err = s.GetFundingRates(context.Background(), request)
+	_, err = s.GetFundingRates(t.Context(), request)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Errorf("received: '%v' but expected: '%v'", err, futures.ErrNotFuturesAsset)
 	}
@@ -2992,7 +2992,7 @@ func TestGetFundingRates(t *testing.T) {
 	}
 	request.IncludePredicted = true
 	request.IncludePayments = true
-	_, err = s.GetFundingRates(context.Background(), request)
+	_, err = s.GetFundingRates(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -3061,7 +3061,7 @@ func TestGetLatestFundingRate(t *testing.T) {
 		},
 	}
 
-	_, err = s.GetLatestFundingRate(context.Background(), nil)
+	_, err = s.GetLatestFundingRate(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received: '%v' but expected: '%v'", err, common.ErrNilPointer)
 	}
@@ -3071,18 +3071,18 @@ func TestGetLatestFundingRate(t *testing.T) {
 		Pair:             nil,
 		IncludePredicted: false,
 	}
-	_, err = s.GetLatestFundingRate(context.Background(), request)
+	_, err = s.GetLatestFundingRate(t.Context(), request)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Errorf("received: '%v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 	request.Exchange = exch.GetName()
-	_, err = s.GetLatestFundingRate(context.Background(), request)
+	_, err = s.GetLatestFundingRate(t.Context(), request)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	request.Asset = asset.Spot.String()
-	_, err = s.GetLatestFundingRate(context.Background(), request)
+	_, err = s.GetLatestFundingRate(t.Context(), request)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Errorf("received: '%v' but expected: '%v'", err, futures.ErrNotFuturesAsset)
 	}
@@ -3094,7 +3094,7 @@ func TestGetLatestFundingRate(t *testing.T) {
 		Quote:     cp.Quote.String(),
 	}
 	request.IncludePredicted = true
-	_, err = s.GetLatestFundingRate(context.Background(), request)
+	_, err = s.GetLatestFundingRate(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -3160,13 +3160,13 @@ func TestGetManagedPosition(t *testing.T) {
 			OrderManager: om,
 		},
 	}
-	_, err = s.GetManagedPosition(context.Background(), nil)
+	_, err = s.GetManagedPosition(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v', expected '%v'", err, common.ErrNilPointer)
 	}
 
 	request := &gctrpc.GetManagedPositionRequest{}
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v', expected '%v'", err, common.ErrNilPointer)
 	}
@@ -3176,19 +3176,19 @@ func TestGetManagedPosition(t *testing.T) {
 		Base:      "BTC",
 		Quote:     "USD",
 	}
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Errorf("received '%v', expected '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
 	request.Exchange = fakeExchangeName
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
 
 	request.Asset = asset.Spot.String()
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Errorf("received '%v', expected '%v'", err, futures.ErrNotFuturesAsset)
 	}
@@ -3200,7 +3200,7 @@ func TestGetManagedPosition(t *testing.T) {
 	}
 	s.OrderManager.started = 1
 	s.OrderManager.activelyTrackFuturesPositions = true
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, futures.ErrPositionNotFound) {
 		t.Errorf("received '%v', expected '%v'", err, futures.ErrPositionNotFound)
 	}
@@ -3236,7 +3236,7 @@ func TestGetManagedPosition(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
-	_, err = s.GetManagedPosition(context.Background(), request)
+	_, err = s.GetManagedPosition(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -3302,7 +3302,7 @@ func TestGetAllManagedPositions(t *testing.T) {
 			OrderManager: om,
 		},
 	}
-	_, err = s.GetAllManagedPositions(context.Background(), nil)
+	_, err = s.GetAllManagedPositions(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v', expected '%v'", err, common.ErrNilPointer)
 	}
@@ -3313,7 +3313,7 @@ func TestGetAllManagedPositions(t *testing.T) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
 	s.OrderManager.started = 1
-	_, err = s.GetAllManagedPositions(context.Background(), request)
+	_, err = s.GetAllManagedPositions(t.Context(), request)
 	if !errors.Is(err, futures.ErrNoPositionsFound) {
 		t.Errorf("received '%v', expected '%v'", err, futures.ErrNoPositionsFound)
 	}
@@ -3347,7 +3347,7 @@ func TestGetAllManagedPositions(t *testing.T) {
 	request.GetFundingPayments = true
 	request.IncludeFullFundingRates = true
 	request.IncludeFullOrderData = true
-	_, err = s.GetAllManagedPositions(context.Background(), request)
+	_, err = s.GetAllManagedPositions(t.Context(), request)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -3390,20 +3390,20 @@ func TestGetOrderbookMovement(t *testing.T) {
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
 
 	req := &gctrpc.GetOrderbookMovementRequest{}
-	_, err = s.GetOrderbookMovement(context.Background(), req)
+	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
 	req.Exchange = "fake"
-	_, err = s.GetOrderbookMovement(context.Background(), req)
+	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	req.Asset = asset.Spot.String()
 	req.Pair = &gctrpc.CurrencyPair{}
-	_, err = s.GetOrderbookMovement(context.Background(), req)
+	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, currency.ErrCurrencyPairEmpty)
 	}
@@ -3412,7 +3412,7 @@ func TestGetOrderbookMovement(t *testing.T) {
 		Base:  currency.BTC.String(),
 		Quote: currency.METAL.String(),
 	}
-	_, err = s.GetOrderbookMovement(context.Background(), req)
+	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if !strings.Contains(err.Error(), "cannot find orderbook") {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, "cannot find orderbook")
 	}
@@ -3439,13 +3439,13 @@ func TestGetOrderbookMovement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = s.GetOrderbookMovement(context.Background(), req)
+	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if err.Error() != "quote amount invalid" {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, "quote amount invalid")
 	}
 
 	req.Amount = 11
-	move, err := s.GetOrderbookMovement(context.Background(), req)
+	move, err := s.GetOrderbookMovement(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3456,7 +3456,7 @@ func TestGetOrderbookMovement(t *testing.T) {
 
 	req.Sell = true
 	req.Amount = 1
-	move, err = s.GetOrderbookMovement(context.Background(), req)
+	move, err = s.GetOrderbookMovement(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3503,20 +3503,20 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
 
 	req := &gctrpc.GetOrderbookAmountByNominalRequest{}
-	_, err = s.GetOrderbookAmountByNominal(context.Background(), req)
+	_, err = s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
 	req.Exchange = "fake"
-	_, err = s.GetOrderbookAmountByNominal(context.Background(), req)
+	_, err = s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	req.Asset = asset.Spot.String()
 	req.Pair = &gctrpc.CurrencyPair{}
-	_, err = s.GetOrderbookAmountByNominal(context.Background(), req)
+	_, err = s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, currency.ErrCurrencyPairEmpty)
 	}
@@ -3525,7 +3525,7 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 		Base:  currency.BTC.String(),
 		Quote: currency.MEME.String(),
 	}
-	_, err = s.GetOrderbookAmountByNominal(context.Background(), req)
+	_, err = s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !strings.Contains(err.Error(), "cannot find orderbook") {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, "cannot find orderbook")
 	}
@@ -3552,7 +3552,7 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nominal, err := s.GetOrderbookAmountByNominal(context.Background(), req)
+	nominal, err := s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3562,7 +3562,7 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 	}
 
 	req.Sell = true
-	nominal, err = s.GetOrderbookAmountByNominal(context.Background(), req)
+	nominal, err = s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3609,20 +3609,20 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
 
 	req := &gctrpc.GetOrderbookAmountByImpactRequest{}
-	_, err = s.GetOrderbookAmountByImpact(context.Background(), req)
+	_, err = s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, ErrExchangeNameIsEmpty)
 	}
 
 	req.Exchange = "fake"
-	_, err = s.GetOrderbookAmountByImpact(context.Background(), req)
+	_, err = s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	req.Asset = asset.Spot.String()
 	req.Pair = &gctrpc.CurrencyPair{}
-	_, err = s.GetOrderbookAmountByImpact(context.Background(), req)
+	_, err = s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, currency.ErrCurrencyPairEmpty)
 	}
@@ -3631,7 +3631,7 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 		Base:  currency.BTC.String(),
 		Quote: currency.MAD.String(),
 	}
-	_, err = s.GetOrderbookAmountByImpact(context.Background(), req)
+	_, err = s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !strings.Contains(err.Error(), "cannot find orderbook") {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, "cannot find orderbook")
 	}
@@ -3659,7 +3659,7 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 	}
 
 	req.ImpactPercentage = 9.090909090909092
-	impact, err := s.GetOrderbookAmountByImpact(context.Background(), req)
+	impact, err := s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3670,7 +3670,7 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 
 	req.Sell = true
 	req.ImpactPercentage = 10
-	impact, err = s.GetOrderbookAmountByImpact(context.Background(), req)
+	impact, err = s.GetOrderbookAmountByImpact(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%+v' but expected: '%v'", err, nil)
 	}
@@ -3715,13 +3715,13 @@ func TestChangePositionMargin(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.ChangePositionMargin(context.Background(), nil)
+	_, err = s.ChangePositionMargin(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.ChangePositionMarginRequest{}
-	_, err = s.ChangePositionMargin(context.Background(), req)
+	_, err = s.ChangePositionMargin(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Errorf("received '%v' expected '%v'", err, currency.ErrCurrencyPairEmpty)
 	}
@@ -3737,7 +3737,7 @@ func TestChangePositionMargin(t *testing.T) {
 	req.OriginalAllocatedMargin = 1337
 	req.NewAllocatedMargin = 1338
 	req.MarginType = "isolated"
-	_, err = s.ChangePositionMargin(context.Background(), req)
+	_, err = s.ChangePositionMargin(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v' expected '%v'", err, nil)
 	}
@@ -3778,13 +3778,13 @@ func TestSetLeverage(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.SetLeverage(context.Background(), nil)
+	_, err = s.SetLeverage(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.SetLeverageRequest{}
-	_, err = s.SetLeverage(context.Background(), req)
+	_, err = s.SetLeverage(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
@@ -3803,19 +3803,19 @@ func TestSetLeverage(t *testing.T) {
 	req.Asset = asset.USDTMarginedFutures.String()
 	req.MarginType = "isolated"
 	req.Leverage = 1337
-	_, err = s.SetLeverage(context.Background(), req)
+	_, err = s.SetLeverage(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
 
 	req.OrderSide = "lol"
-	_, err = s.SetLeverage(context.Background(), req)
+	_, err = s.SetLeverage(t.Context(), req)
 	if !errors.Is(err, order.ErrSideIsInvalid) {
 		t.Error(err)
 	}
 
 	req.OrderSide = order.Long.String()
-	_, err = s.SetLeverage(context.Background(), req)
+	_, err = s.SetLeverage(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3856,13 +3856,13 @@ func TestGetLeverage(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.GetLeverage(context.Background(), nil)
+	_, err = s.GetLeverage(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.GetLeverageRequest{}
-	_, err = s.GetLeverage(context.Background(), req)
+	_, err = s.GetLeverage(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
@@ -3880,7 +3880,7 @@ func TestGetLeverage(t *testing.T) {
 	}
 	req.Asset = asset.USDTMarginedFutures.String()
 	req.MarginType = "isolated"
-	lev, err := s.GetLeverage(context.Background(), req)
+	lev, err := s.GetLeverage(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3889,13 +3889,13 @@ func TestGetLeverage(t *testing.T) {
 	}
 
 	req.OrderSide = "lol"
-	_, err = s.GetLeverage(context.Background(), req)
+	_, err = s.GetLeverage(t.Context(), req)
 	if !errors.Is(err, order.ErrSideIsInvalid) {
 		t.Error(err)
 	}
 
 	req.OrderSide = order.Long.String()
-	_, err = s.GetLeverage(context.Background(), req)
+	_, err = s.GetLeverage(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3936,13 +3936,13 @@ func TestSetMarginType(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.SetMarginType(context.Background(), nil)
+	_, err = s.SetMarginType(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.SetMarginTypeRequest{}
-	_, err = s.SetMarginType(context.Background(), req)
+	_, err = s.SetMarginType(t.Context(), req)
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Error(err)
 	}
@@ -3955,7 +3955,7 @@ func TestSetMarginType(t *testing.T) {
 	}
 	req.Asset = asset.USDTMarginedFutures.String()
 	req.MarginType = "isolated"
-	_, err = s.SetMarginType(context.Background(), req)
+	_, err = s.SetMarginType(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3996,13 +3996,13 @@ func TestSetCollateralMode(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.SetCollateralMode(context.Background(), nil)
+	_, err = s.SetCollateralMode(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.SetCollateralModeRequest{}
-	_, err = s.SetCollateralMode(context.Background(), req)
+	_, err = s.SetCollateralMode(t.Context(), req)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Error(err)
 	}
@@ -4010,7 +4010,7 @@ func TestSetCollateralMode(t *testing.T) {
 	req.Exchange = fakeExchangeName
 	req.Asset = asset.USDTMarginedFutures.String()
 	req.CollateralMode = "single"
-	_, err = s.SetCollateralMode(context.Background(), req)
+	_, err = s.SetCollateralMode(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -4041,20 +4041,20 @@ func TestGetCollateralMode(t *testing.T) {
 	}
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.GetCollateralMode(context.Background(), nil)
+	_, err = s.GetCollateralMode(t.Context(), nil)
 	if !errors.Is(err, common.ErrNilPointer) {
 		t.Errorf("received '%v' expected '%v'", err, common.ErrNilPointer)
 	}
 
 	req := &gctrpc.GetCollateralModeRequest{}
-	_, err = s.GetCollateralMode(context.Background(), req)
+	_, err = s.GetCollateralMode(t.Context(), req)
 	if !errors.Is(err, ErrExchangeNameIsEmpty) {
 		t.Error(err)
 	}
 
 	req.Exchange = fakeExchangeName
 	req.Asset = asset.USDTMarginedFutures.String()
-	_, err = s.GetCollateralMode(context.Background(), req)
+	_, err = s.GetCollateralMode(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -4082,22 +4082,22 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.GetOpenInterest(context.Background(), nil)
+	_, err = s.GetOpenInterest(t.Context(), nil)
 	assert.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &gctrpc.GetOpenInterestRequest{}
-	_, err = s.GetOpenInterest(context.Background(), req)
+	_, err = s.GetOpenInterest(t.Context(), req)
 	assert.ErrorIs(t, err, ErrExchangeNameIsEmpty)
 
 	req.Exchange = fakeExchangeName
-	_, err = s.GetOpenInterest(context.Background(), req)
+	_, err = s.GetOpenInterest(t.Context(), req)
 	assert.NoError(t, err)
 
 	req.Data = append(req.Data, &gctrpc.OpenInterestDataRequest{
 		Asset: asset.USDTMarginedFutures.String(),
 		Pair:  &gctrpc.CurrencyPair{Base: currency.BTC.String(), Quote: currency.USDT.String()},
 	})
-	_, err = s.GetOpenInterest(context.Background(), req)
+	_, err = s.GetOpenInterest(t.Context(), req)
 	assert.NoError(t, err)
 }
 
@@ -4165,7 +4165,7 @@ func TestStartRPCRESTProxy(t *testing.T) {
 		t.Run(creds.testDescription, func(t *testing.T) {
 			t.Parallel()
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost:"+strconv.Itoa(gRPCProxyPort)+"/v1/getinfo", http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://localhost:"+strconv.Itoa(gRPCProxyPort)+"/v1/getinfo", http.NoBody)
 			require.NoError(t, err, "NewRequestWithContext should not error")
 			req.SetBasicAuth(creds.username, creds.password)
 			resp, err := client.Do(req)
@@ -4224,7 +4224,7 @@ func TestRPCProxyAuthClient(t *testing.T) {
 		t.Run(creds.testDescription, func(t *testing.T) {
 			t.Parallel()
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
 			require.NoError(t, err, "NewRequestWithContext should not error")
 			req.SetBasicAuth(creds.username, creds.password)
 			rr := httptest.NewRecorder()
@@ -4268,19 +4268,19 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 	require.NoError(t, err)
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em}}
-	_, err = s.GetCurrencyTradeURL(context.Background(), nil)
+	_, err = s.GetCurrencyTradeURL(t.Context(), nil)
 	assert.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &gctrpc.GetCurrencyTradeURLRequest{}
-	_, err = s.GetCurrencyTradeURL(context.Background(), req)
+	_, err = s.GetCurrencyTradeURL(t.Context(), req)
 	assert.ErrorIs(t, err, ErrExchangeNameIsEmpty)
 
 	req.Exchange = fakeExchangeName
-	_, err = s.GetCurrencyTradeURL(context.Background(), req)
+	_, err = s.GetCurrencyTradeURL(t.Context(), req)
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 
 	req.Asset = "spot"
-	_, err = s.GetCurrencyTradeURL(context.Background(), req)
+	_, err = s.GetCurrencyTradeURL(t.Context(), req)
 	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	req.Pair = &gctrpc.CurrencyPair{
@@ -4288,7 +4288,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		Base:      "btc",
 		Quote:     "usdt",
 	}
-	resp, err := s.GetCurrencyTradeURL(context.Background(), req)
+	resp, err := s.GetCurrencyTradeURL(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp.Url)
 }

--- a/engine/withdraw_manager_test.go
+++ b/engine/withdraw_manager_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -24,7 +23,7 @@ func withdrawManagerTestHelper(t *testing.T) (*ExchangeManager, *portfolioManage
 	t.Helper()
 	em := NewExchangeManager()
 	b := new(okx.Okx)
-	cfg, err := exchange.GetDefaultConfig(context.Background(), b)
+	cfg, err := exchange.GetDefaultConfig(t.Context(), b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +79,7 @@ func TestSubmitWithdrawal(t *testing.T) {
 			Bank: bank,
 		},
 	}
-	_, err = m.SubmitWithdrawal(context.Background(), req)
+	_, err = m.SubmitWithdrawal(t.Context(), req)
 	if !errors.Is(err, common.ErrFunctionNotSupported) {
 		t.Errorf("received %v, expected %v", err, common.ErrFunctionNotSupported)
 	}
@@ -88,7 +87,7 @@ func TestSubmitWithdrawal(t *testing.T) {
 	req.Type = withdraw.Crypto
 	req.Currency = currency.BTC
 	req.Crypto.Address = "1337"
-	_, err = m.SubmitWithdrawal(context.Background(), req)
+	_, err = m.SubmitWithdrawal(t.Context(), req)
 	if !errors.Is(err, withdraw.ErrStrAddressNotWhiteListed) {
 		t.Errorf("received %v, expected %v", err, withdraw.ErrStrAddressNotWhiteListed)
 	}
@@ -106,24 +105,24 @@ func TestSubmitWithdrawal(t *testing.T) {
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}
-	_, err = m.SubmitWithdrawal(context.Background(), req)
+	_, err = m.SubmitWithdrawal(t.Context(), req)
 	if !errors.Is(err, withdraw.ErrStrExchangeNotSupportedByAddress) {
 		t.Errorf("received %v, expected %v", err, withdraw.ErrStrExchangeNotSupportedByAddress)
 	}
 
 	adds[0].SupportedExchanges = withdrawManagerTestExchangeName
-	_, err = m.SubmitWithdrawal(context.Background(), req)
+	_, err = m.SubmitWithdrawal(t.Context(), req)
 	if !errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
 		t.Errorf("received '%v', expected '%v'", err, exchange.ErrAuthenticationSupportNotEnabled)
 	}
 
-	_, err = m.SubmitWithdrawal(context.Background(), nil)
+	_, err = m.SubmitWithdrawal(t.Context(), nil)
 	if !errors.Is(err, withdraw.ErrRequestCannotBeNil) {
 		t.Errorf("received %v, expected %v", err, withdraw.ErrRequestCannotBeNil)
 	}
 
 	m.isDryRun = true
-	_, err = m.SubmitWithdrawal(context.Background(), req)
+	_, err = m.SubmitWithdrawal(t.Context(), req)
 	if !errors.Is(err, nil) {
 		t.Errorf("received %v, expected %v", err, nil)
 	}

--- a/exchanges/account/credentials_test.go
+++ b/exchanges/account/credentials_test.go
@@ -1,7 +1,6 @@
 package account
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -27,30 +26,30 @@ func TestIsEmpty(t *testing.T) {
 
 func TestParseCredentialsMetadata(t *testing.T) {
 	t.Parallel()
-	_, err := ParseCredentialsMetadata(context.Background(), nil)
+	_, err := ParseCredentialsMetadata(t.Context(), nil)
 	if !errors.Is(err, errMetaDataIsNil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errMetaDataIsNil)
 	}
 
-	_, err = ParseCredentialsMetadata(context.Background(), metadata.MD{})
+	_, err = ParseCredentialsMetadata(t.Context(), metadata.MD{})
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
 
-	ctx := metadata.AppendToOutgoingContext(context.Background(),
+	ctx := metadata.AppendToOutgoingContext(t.Context(),
 		string(ContextCredentialsFlag), "wow", string(ContextCredentialsFlag), "wow2")
 	nortyMD, _ := metadata.FromOutgoingContext(ctx)
 
-	_, err = ParseCredentialsMetadata(context.Background(), nortyMD)
+	_, err = ParseCredentialsMetadata(t.Context(), nortyMD)
 	if !errors.Is(err, errInvalidCredentialMetaDataLength) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errInvalidCredentialMetaDataLength)
 	}
 
-	ctx = metadata.AppendToOutgoingContext(context.Background(),
+	ctx = metadata.AppendToOutgoingContext(t.Context(),
 		string(ContextCredentialsFlag), "brokenstring")
 	nortyMD, _ = metadata.FromOutgoingContext(ctx)
 
-	_, err = ParseCredentialsMetadata(context.Background(), nortyMD)
+	_, err = ParseCredentialsMetadata(t.Context(), nortyMD)
 	if !errors.Is(err, errMissingInfo) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errMissingInfo)
 	}
@@ -65,10 +64,10 @@ func TestParseCredentialsMetadata(t *testing.T) {
 	}
 
 	flag, outGoing := beforeCreds.GetMetaData()
-	ctx = metadata.AppendToOutgoingContext(context.Background(), flag, outGoing)
+	ctx = metadata.AppendToOutgoingContext(t.Context(), flag, outGoing)
 	lovelyMD, _ := metadata.FromOutgoingContext(ctx)
 
-	ctx, err = ParseCredentialsMetadata(context.Background(), lovelyMD)
+	ctx, err = ParseCredentialsMetadata(t.Context(), lovelyMD)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -95,10 +94,10 @@ func TestParseCredentialsMetadata(t *testing.T) {
 	}
 
 	flag, outGoing = subaccount.GetMetaData()
-	ctx = metadata.AppendToOutgoingContext(context.Background(), flag, outGoing)
+	ctx = metadata.AppendToOutgoingContext(t.Context(), flag, outGoing)
 	lovelyMD, _ = metadata.FromOutgoingContext(ctx)
 
-	ctx, err = ParseCredentialsMetadata(context.Background(), lovelyMD)
+	ctx, err = ParseCredentialsMetadata(t.Context(), lovelyMD)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -1,7 +1,6 @@
 package alphapoint
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -37,12 +36,12 @@ func TestGetTicker(t *testing.T) {
 	var ticker Ticker
 	var err error
 	if onlineTest {
-		ticker, err = a.GetTicker(context.Background(), "BTCUSD")
+		ticker, err = a.GetTicker(t.Context(), "BTCUSD")
 		if err != nil {
 			t.Fatal("Alphapoint GetTicker init error: ", err)
 		}
 
-		_, err = a.GetTicker(context.Background(), "wigwham")
+		_, err = a.GetTicker(t.Context(), "wigwham")
 		if err == nil {
 			t.Error("Alphapoint GetTicker Expected error")
 		}
@@ -71,12 +70,12 @@ func TestGetTrades(t *testing.T) {
 	var trades Trades
 	var err error
 	if onlineTest {
-		trades, err = a.GetTrades(context.Background(), "BTCUSD", 0, 10)
+		trades, err = a.GetTrades(t.Context(), "BTCUSD", 0, 10)
 		if err != nil {
 			t.Fatalf("Init error: %s", err)
 		}
 
-		_, err = a.GetTrades(context.Background(), "wigwham", 0, 10)
+		_, err = a.GetTrades(t.Context(), "wigwham", 0, 10)
 		if err == nil {
 			t.Fatal("GetTrades Expected error")
 		}
@@ -109,12 +108,12 @@ func TestGetTradesByDate(t *testing.T) {
 	var trades Trades
 	var err error
 	if onlineTest {
-		trades, err = a.GetTradesByDate(context.Background(),
+		trades, err = a.GetTradesByDate(t.Context(),
 			"BTCUSD", 1414799400, 1414800000)
 		if err != nil {
 			t.Errorf("Init error: %s", err)
 		}
-		_, err = a.GetTradesByDate(context.Background(),
+		_, err = a.GetTradesByDate(t.Context(),
 			"wigwham", 1414799400, 1414800000)
 		if err == nil {
 			t.Error("GetTradesByDate Expected error")
@@ -155,12 +154,12 @@ func TestGetOrderbook(t *testing.T) {
 	var orderBook Orderbook
 	var err error
 	if onlineTest {
-		orderBook, err = a.GetOrderbook(context.Background(), "BTCUSD")
+		orderBook, err = a.GetOrderbook(t.Context(), "BTCUSD")
 		if err != nil {
 			t.Errorf("Init error: %s", err)
 		}
 
-		_, err = a.GetOrderbook(context.Background(), "wigwham")
+		_, err = a.GetOrderbook(t.Context(), "wigwham")
 		if err == nil {
 			t.Error("GetOrderbook() Expected error")
 		}
@@ -198,7 +197,7 @@ func TestGetProductPairs(t *testing.T) {
 	var err error
 
 	if onlineTest {
-		products, err = a.GetProductPairs(context.Background())
+		products, err = a.GetProductPairs(t.Context())
 		if err != nil {
 			t.Errorf("Init error: %s", err)
 		}
@@ -236,7 +235,7 @@ func TestGetProducts(t *testing.T) {
 	var err error
 
 	if onlineTest {
-		products, err = a.GetProducts(context.Background())
+		products, err = a.GetProducts(t.Context())
 		if err != nil {
 			t.Errorf("Init error: %s", err)
 		}
@@ -272,17 +271,17 @@ func TestCreateAccount(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	err := a.CreateAccount(context.Background(),
+	err := a.CreateAccount(t.Context(),
 		"test", "account", "something@something.com", "0292383745", "lolcat123")
 	if err != nil {
 		t.Errorf("Init error: %s", err)
 	}
-	err = a.CreateAccount(context.Background(),
+	err = a.CreateAccount(t.Context(),
 		"test", "account", "something@something.com", "0292383745", "bla")
 	if err == nil {
 		t.Errorf("CreateAccount() Expected error")
 	}
-	err = a.CreateAccount(context.Background(), "", "", "", "", "lolcat123")
+	err = a.CreateAccount(t.Context(), "", "", "", "", "lolcat123")
 	if err == nil {
 		t.Errorf("CreateAccount() Expected error")
 	}
@@ -292,7 +291,7 @@ func TestGetUserInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.GetUserInfo(context.Background())
+	_, err := a.GetUserInfo(t.Context())
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -302,7 +301,7 @@ func TestSetUserInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.SetUserInfo(context.Background(),
+	_, err := a.SetUserInfo(t.Context(),
 		"bla", "bla", "1", "meh", true, true)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
@@ -313,7 +312,7 @@ func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := a.UpdateAccountInfo(t.Context(), asset.Spot)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -323,7 +322,7 @@ func TestGetAccountTrades(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.GetAccountTrades(context.Background(), "", 1, 2)
+	_, err := a.GetAccountTrades(t.Context(), "", 1, 2)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -333,7 +332,7 @@ func TestGetDepositAddresses(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.GetDepositAddresses(context.Background())
+	_, err := a.GetDepositAddresses(t.Context())
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -343,7 +342,7 @@ func TestWithdrawCoins(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	err := a.WithdrawCoins(context.Background(), "", "", "", 0.01)
+	err := a.WithdrawCoins(t.Context(), "", "", "", 0.01)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -353,7 +352,7 @@ func TestCreateOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.CreateOrder(context.Background(),
+	_, err := a.CreateOrder(t.Context(),
 		"", "", order.Limit.String(), 0.01, 0)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
@@ -364,7 +363,7 @@ func TestModifyExistingOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.ModifyExistingOrder(context.Background(), "", 1, 1)
+	_, err := a.ModifyExistingOrder(t.Context(), "", 1, 1)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -374,7 +373,7 @@ func TestCancelAllExistingOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	err := a.CancelAllExistingOrders(context.Background(), "")
+	err := a.CancelAllExistingOrders(t.Context(), "")
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -384,7 +383,7 @@ func TestGetOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.GetOrders(context.Background())
+	_, err := a.GetOrders(t.Context())
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -394,7 +393,7 @@ func TestGetOrderFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a)
 
-	_, err := a.GetOrderFee(context.Background(), "", "", 1, 1)
+	_, err := a.GetOrderFee(t.Context(), "", "", 1, 1)
 	if err == nil {
 		t.Error("GetUserInfo() Expected error")
 	}
@@ -417,7 +416,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := a.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := a.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(a) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(a) && err == nil {
@@ -433,7 +432,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := a.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := a.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(a) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(a) && err == nil {
@@ -463,7 +462,7 @@ func TestSubmitOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	response, err := a.SubmitOrder(context.Background(), orderSubmission)
+	response, err := a.SubmitOrder(t.Context(), orderSubmission)
 	if !sharedtestvalues.AreAPICredentialsSet(a) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -488,7 +487,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := a.CancelOrder(context.Background(), orderCancellation)
+	err := a.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(a) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -509,7 +508,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := a.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := a.CancelAllOrders(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(a) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -525,7 +524,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a, canManipulateRealOrders)
-	_, err := a.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := a.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
 	}
@@ -533,7 +532,7 @@ func TestModifyOrder(t *testing.T) {
 
 func TestWithdraw(t *testing.T) {
 	t.Parallel()
-	_, err := a.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := a.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdraw.Request{})
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected 'Not implemented', received %v", err)
@@ -544,7 +543,7 @@ func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a, canManipulateRealOrders)
 
-	_, err := a.WithdrawFiatFunds(context.Background(),
+	_, err := a.WithdrawFiatFunds(t.Context(),
 		&withdraw.Request{})
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrNotYetImplemented, err)
@@ -555,7 +554,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, a, canManipulateRealOrders)
 
-	_, err := a.WithdrawFiatFundsToInternationalBank(context.Background(), &withdraw.Request{})
+	_, err := a.WithdrawFiatFundsToInternationalBank(t.Context(), &withdraw.Request{})
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrNotYetImplemented, err)
 	}
@@ -567,7 +566,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = a.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = a.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil && err != common.ErrNotYetImplemented {
 		t.Error(err)
 	}
@@ -579,7 +578,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = a.GetHistoricTrades(context.Background(),
+	_, err = a.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrNotYetImplemented {
 		t.Error(err)

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -36,8 +36,8 @@ const (
 	ufuturesAPIURL = "https://fapi.binance.com"
 	tradeBaseURL   = "https://www.binance.com/en/"
 
-	testnetSpotURL = "https://testnet.binance.vision/api" //nolint:unused // Can be used for testing
-	testnetFutures = "https://testnet.binancefuture.com"  //nolint:unused // Can be used for testing
+	testnetSpotURL = "https://testnet.binance.vision/api" //nolint:unused // Can be used for testing via setting useTestNet to true
+	testnetFutures = "https://testnet.binancefuture.com"  //nolint:unused // Can be used for testing via setting useTestNet to true
 
 	// Public endpoints
 	exchangeInfo      = "/api/v3/exchangeInfo"

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -36,8 +36,8 @@ const (
 	ufuturesAPIURL = "https://fapi.binance.com"
 	tradeBaseURL   = "https://www.binance.com/en/"
 
-	testnetSpotURL = "https://testnet.binance.vision/api"
-	testnetFutures = "https://testnet.binancefuture.com"
+	testnetSpotURL = "https://testnet.binance.vision/api" //nolint:unused // Can be used for testing
+	testnetFutures = "https://testnet.binancefuture.com"  //nolint:unused // Can be used for testing
 
 	// Public endpoints
 	exchangeInfo      = "/api/v3/exchangeInfo"

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -2,7 +2,6 @@ package binance
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -72,7 +71,7 @@ func getTime() (start, end time.Time) {
 
 func TestUServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.UServerTime(context.Background())
+	_, err := b.UServerTime(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,12 +79,12 @@ func TestUServerTime(t *testing.T) {
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetServerTime(context.Background(), asset.Empty)
+	_, err := b.GetServerTime(t.Context(), asset.Empty)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
-	st, err := b.GetServerTime(context.Background(), asset.Spot)
+	st, err := b.GetServerTime(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -94,7 +93,7 @@ func TestWrapperGetServerTime(t *testing.T) {
 		t.Fatal("expected a time")
 	}
 
-	st, err = b.GetServerTime(context.Background(), asset.USDTMarginedFutures)
+	st, err = b.GetServerTime(t.Context(), asset.USDTMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -103,7 +102,7 @@ func TestWrapperGetServerTime(t *testing.T) {
 		t.Fatal("expected a time")
 	}
 
-	st, err = b.GetServerTime(context.Background(), asset.CoinMarginedFutures)
+	st, err = b.GetServerTime(t.Context(), asset.CoinMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -115,50 +114,50 @@ func TestWrapperGetServerTime(t *testing.T) {
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	r, err := b.UpdateTicker(context.Background(), testPairMapping, asset.Spot)
+	r, err := b.UpdateTicker(t.Context(), testPairMapping, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
 	if r.Pair.Base != currency.DOGE && r.Pair.Quote != currency.USDT {
 		t.Error("invalid pair values")
 	}
-	tradablePairs, err := b.FetchTradablePairs(context.Background(), asset.CoinMarginedFutures)
+	tradablePairs, err := b.FetchTradablePairs(t.Context(), asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 	if len(tradablePairs) == 0 {
 		t.Fatal("no tradable pairs")
 	}
-	_, err = b.UpdateTicker(context.Background(), tradablePairs[0], asset.CoinMarginedFutures)
+	_, err = b.UpdateTicker(t.Context(), tradablePairs[0], asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 
-	usdtMarginedPairs, err := b.FetchTradablePairs(context.Background(), asset.USDTMarginedFutures)
+	usdtMarginedPairs, err := b.FetchTradablePairs(t.Context(), asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 	if len(usdtMarginedPairs) == 0 {
 		t.Errorf("no pairs are enabled")
 	}
-	_, err = b.UpdateTicker(context.Background(), usdtMarginedPairs[0], asset.USDTMarginedFutures)
+	_, err = b.UpdateTicker(t.Context(), usdtMarginedPairs[0], asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestUpdateTickers(t *testing.T) {
-	err := b.UpdateTickers(context.Background(), asset.Spot)
+	err := b.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = b.UpdateTickers(context.Background(), asset.CoinMarginedFutures)
+	err = b.UpdateTickers(t.Context(), asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = b.UpdateTickers(context.Background(), asset.USDTMarginedFutures)
+	err = b.UpdateTickers(t.Context(), asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -170,15 +169,15 @@ func TestUpdateOrderbook(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), cp, asset.Spot)
+	_, err = b.UpdateOrderbook(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), cp, asset.Margin)
+	_, err = b.UpdateOrderbook(t.Context(), cp, asset.Margin)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), cp, asset.USDTMarginedFutures)
+	_, err = b.UpdateOrderbook(t.Context(), cp, asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -186,7 +185,7 @@ func TestUpdateOrderbook(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), cp2, asset.CoinMarginedFutures)
+	_, err = b.UpdateOrderbook(t.Context(), cp2, asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,7 +195,7 @@ func TestUpdateOrderbook(t *testing.T) {
 
 func TestUExchangeInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.UExchangeInfo(context.Background())
+	_, err := b.UExchangeInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -204,7 +203,7 @@ func TestUExchangeInfo(t *testing.T) {
 
 func TestUFuturesOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.UFuturesOrderbook(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 1000)
+	_, err := b.UFuturesOrderbook(t.Context(), currency.NewPair(currency.BTC, currency.USDT), 1000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -212,7 +211,7 @@ func TestUFuturesOrderbook(t *testing.T) {
 
 func TestURecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.URecentTrades(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", 1000)
+	_, err := b.URecentTrades(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", 1000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -220,12 +219,12 @@ func TestURecentTrades(t *testing.T) {
 
 func TestUCompressedTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.UCompressedTrades(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", 5, time.Time{}, time.Time{})
+	_, err := b.UCompressedTrades(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UCompressedTrades(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "", 0, start, end)
+	_, err = b.UCompressedTrades(t.Context(), currency.NewPair(currency.LTC, currency.USDT), "", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -233,12 +232,12 @@ func TestUCompressedTrades(t *testing.T) {
 
 func TestUKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := b.UKlineData(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "1d", 5, time.Time{}, time.Time{})
+	_, err := b.UKlineData(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "1d", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UKlineData(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "5m", 0, start, end)
+	_, err = b.UKlineData(t.Context(), currency.NewPair(currency.LTC, currency.USDT), "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -246,11 +245,11 @@ func TestUKlineData(t *testing.T) {
 
 func TestUGetMarkPrice(t *testing.T) {
 	t.Parallel()
-	_, err := b.UGetMarkPrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UGetMarkPrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UGetMarkPrice(context.Background(), currency.EMPTYPAIR)
+	_, err = b.UGetMarkPrice(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -258,12 +257,12 @@ func TestUGetMarkPrice(t *testing.T) {
 
 func TestUGetFundingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.UGetFundingHistory(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 1, time.Time{}, time.Time{})
+	_, err := b.UGetFundingHistory(t.Context(), currency.NewPair(currency.BTC, currency.USDT), 1, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UGetFundingHistory(context.Background(), currency.NewPair(currency.LTC, currency.USDT), 1, start, end)
+	_, err = b.UGetFundingHistory(t.Context(), currency.NewPair(currency.LTC, currency.USDT), 1, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -271,11 +270,11 @@ func TestUGetFundingHistory(t *testing.T) {
 
 func TestU24HTickerPriceChangeStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.U24HTickerPriceChangeStats(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.U24HTickerPriceChangeStats(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.U24HTickerPriceChangeStats(context.Background(), currency.EMPTYPAIR)
+	_, err = b.U24HTickerPriceChangeStats(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -283,11 +282,11 @@ func TestU24HTickerPriceChangeStats(t *testing.T) {
 
 func TestUSymbolPriceTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.USymbolPriceTicker(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.USymbolPriceTicker(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.USymbolPriceTicker(context.Background(), currency.EMPTYPAIR)
+	_, err = b.USymbolPriceTicker(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -295,11 +294,11 @@ func TestUSymbolPriceTicker(t *testing.T) {
 
 func TestUSymbolOrderbookTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.USymbolOrderbookTicker(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.USymbolOrderbookTicker(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.USymbolOrderbookTicker(context.Background(), currency.EMPTYPAIR)
+	_, err = b.USymbolOrderbookTicker(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -307,7 +306,7 @@ func TestUSymbolOrderbookTicker(t *testing.T) {
 
 func TestUOpenInterest(t *testing.T) {
 	t.Parallel()
-	_, err := b.UOpenInterest(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UOpenInterest(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -315,12 +314,12 @@ func TestUOpenInterest(t *testing.T) {
 
 func TestUOpenInterestStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.UOpenInterestStats(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 1, time.Time{}, time.Time{})
+	_, err := b.UOpenInterestStats(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 1, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UOpenInterestStats(context.Background(), currency.NewPair(currency.LTC, currency.USDT), "1d", 10, start, end)
+	_, err = b.UOpenInterestStats(t.Context(), currency.NewPair(currency.LTC, currency.USDT), "1d", 10, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -328,12 +327,12 @@ func TestUOpenInterestStats(t *testing.T) {
 
 func TestUTopAcccountsLongShortRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.UTopAcccountsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, time.Time{}, time.Time{})
+	_, err := b.UTopAcccountsLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UTopAcccountsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, start, end)
+	_, err = b.UTopAcccountsLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 2, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -341,12 +340,12 @@ func TestUTopAcccountsLongShortRatio(t *testing.T) {
 
 func TestUTopPostionsLongShortRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.UTopPostionsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 3, time.Time{}, time.Time{})
+	_, err := b.UTopPostionsLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 3, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UTopPostionsLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "1d", 0, start, end)
+	_, err = b.UTopPostionsLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "1d", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -354,12 +353,12 @@ func TestUTopPostionsLongShortRatio(t *testing.T) {
 
 func TestUGlobalLongShortRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.UGlobalLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 3, time.Time{}, time.Time{})
+	_, err := b.UGlobalLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 3, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.UGlobalLongShortRatio(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "4h", 0, start, end)
+	_, err = b.UGlobalLongShortRatio(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "4h", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -368,7 +367,7 @@ func TestUGlobalLongShortRatio(t *testing.T) {
 func TestUTakerBuySellVol(t *testing.T) {
 	t.Parallel()
 	start, end := getTime()
-	_, err := b.UTakerBuySellVol(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "5m", 10, start, end)
+	_, err := b.UTakerBuySellVol(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "5m", 10, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -380,11 +379,11 @@ func TestUCompositeIndexInfo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UCompositeIndexInfo(context.Background(), cp)
+	_, err = b.UCompositeIndexInfo(t.Context(), cp)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UCompositeIndexInfo(context.Background(), currency.EMPTYPAIR)
+	_, err = b.UCompositeIndexInfo(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -393,7 +392,7 @@ func TestUCompositeIndexInfo(t *testing.T) {
 func TestUFuturesNewOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UFuturesNewOrder(context.Background(),
+	_, err := b.UFuturesNewOrder(t.Context(),
 		&UFuturesNewOrderRequest{
 			Symbol:      currency.NewPair(currency.BTC, currency.USDT),
 			Side:        "BUY",
@@ -420,7 +419,7 @@ func TestUPlaceBatchOrders(t *testing.T) {
 	tempData.Price = 1
 	tempData.TimeInForce = "GTC"
 	data = append(data, tempData)
-	_, err := b.UPlaceBatchOrders(context.Background(), data)
+	_, err := b.UPlaceBatchOrders(t.Context(), data)
 	if err != nil {
 		t.Error(err)
 	}
@@ -429,7 +428,7 @@ func TestUPlaceBatchOrders(t *testing.T) {
 func TestUGetOrderData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UGetOrderData(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
+	_, err := b.UGetOrderData(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -438,7 +437,7 @@ func TestUGetOrderData(t *testing.T) {
 func TestUCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UCancelOrder(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
+	_, err := b.UCancelOrder(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -447,7 +446,7 @@ func TestUCancelOrder(t *testing.T) {
 func TestUCancelAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UCancelAllOpenOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UCancelAllOpenOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -456,7 +455,7 @@ func TestUCancelAllOpenOrders(t *testing.T) {
 func TestUCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UCancelBatchOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), []string{"123"}, []string{})
+	_, err := b.UCancelBatchOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT), []string{"123"}, []string{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -465,7 +464,7 @@ func TestUCancelBatchOrders(t *testing.T) {
 func TestUAutoCancelAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UAutoCancelAllOpenOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 30)
+	_, err := b.UAutoCancelAllOpenOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT), 30)
 	if err != nil {
 		t.Error(err)
 	}
@@ -474,7 +473,7 @@ func TestUAutoCancelAllOpenOrders(t *testing.T) {
 func TestUFetchOpenOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UFetchOpenOrder(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
+	_, err := b.UFetchOpenOrder(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "123", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +482,7 @@ func TestUFetchOpenOrder(t *testing.T) {
 func TestUAllAccountOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAllAccountOpenOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UAllAccountOpenOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -492,11 +491,11 @@ func TestUAllAccountOpenOrders(t *testing.T) {
 func TestUAllAccountOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAllAccountOrders(context.Background(), currency.EMPTYPAIR, 0, 0, time.Time{}, time.Time{})
+	_, err := b.UAllAccountOrders(t.Context(), currency.EMPTYPAIR, 0, 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UAllAccountOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 0, 5, time.Now().Add(-time.Hour*4), time.Now())
+	_, err = b.UAllAccountOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT), 0, 5, time.Now().Add(-time.Hour*4), time.Now())
 	if err != nil {
 		t.Error(err)
 	}
@@ -505,7 +504,7 @@ func TestUAllAccountOrders(t *testing.T) {
 func TestUAccountBalanceV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAccountBalanceV2(context.Background())
+	_, err := b.UAccountBalanceV2(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -514,7 +513,7 @@ func TestUAccountBalanceV2(t *testing.T) {
 func TestUAccountInformationV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAccountInformationV2(context.Background())
+	_, err := b.UAccountInformationV2(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -523,7 +522,7 @@ func TestUAccountInformationV2(t *testing.T) {
 func TestUChangeInitialLeverageRequest(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UChangeInitialLeverageRequest(context.Background(), currency.NewPair(currency.BTC, currency.USDT), 2)
+	_, err := b.UChangeInitialLeverageRequest(t.Context(), currency.NewPair(currency.BTC, currency.USDT), 2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -532,7 +531,7 @@ func TestUChangeInitialLeverageRequest(t *testing.T) {
 func TestUChangeInitialMarginType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.UChangeInitialMarginType(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "ISOLATED")
+	err := b.UChangeInitialMarginType(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "ISOLATED")
 	if err != nil {
 		t.Error(err)
 	}
@@ -541,7 +540,7 @@ func TestUChangeInitialMarginType(t *testing.T) {
 func TestUModifyIsolatedPositionMarginReq(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UModifyIsolatedPositionMarginReq(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "LONG", "add", 5)
+	_, err := b.UModifyIsolatedPositionMarginReq(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "LONG", "add", 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -550,7 +549,7 @@ func TestUModifyIsolatedPositionMarginReq(t *testing.T) {
 func TestUPositionMarginChangeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UPositionMarginChangeHistory(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "add", 5, time.Time{}, time.Time{})
+	_, err := b.UPositionMarginChangeHistory(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "add", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -559,7 +558,7 @@ func TestUPositionMarginChangeHistory(t *testing.T) {
 func TestUPositionsInfoV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UPositionsInfoV2(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UPositionsInfoV2(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -568,7 +567,7 @@ func TestUPositionsInfoV2(t *testing.T) {
 func TestUAccountTradesHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAccountTradesHistory(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", 5, time.Time{}, time.Time{})
+	_, err := b.UAccountTradesHistory(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -577,7 +576,7 @@ func TestUAccountTradesHistory(t *testing.T) {
 func TestUAccountIncomeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAccountIncomeHistory(context.Background(), currency.EMPTYPAIR, "", 5, time.Now().Add(-time.Hour*48), time.Now())
+	_, err := b.UAccountIncomeHistory(t.Context(), currency.EMPTYPAIR, "", 5, time.Now().Add(-time.Hour*48), time.Now())
 	if err != nil {
 		t.Error(err)
 	}
@@ -586,7 +585,7 @@ func TestUAccountIncomeHistory(t *testing.T) {
 func TestUGetNotionalAndLeverageBrackets(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UGetNotionalAndLeverageBrackets(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UGetNotionalAndLeverageBrackets(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -595,7 +594,7 @@ func TestUGetNotionalAndLeverageBrackets(t *testing.T) {
 func TestUPositionsADLEstimate(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UPositionsADLEstimate(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.UPositionsADLEstimate(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error(err)
 	}
@@ -604,7 +603,7 @@ func TestUPositionsADLEstimate(t *testing.T) {
 func TestUAccountForcedOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.UAccountForcedOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "ADL", 5, time.Time{}, time.Time{})
+	_, err := b.UAccountForcedOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "ADL", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -614,7 +613,7 @@ func TestUAccountForcedOrders(t *testing.T) {
 
 func TestGetFuturesExchangeInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.FuturesExchangeInfo(context.Background())
+	_, err := b.FuturesExchangeInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -622,7 +621,7 @@ func TestGetFuturesExchangeInfo(t *testing.T) {
 
 func TestGetFuturesOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesOrderbook(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 1000)
+	_, err := b.GetFuturesOrderbook(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 1000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -630,7 +629,7 @@ func TestGetFuturesOrderbook(t *testing.T) {
 
 func TestGetFuturesPublicTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesPublicTrades(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5)
+	_, err := b.GetFuturesPublicTrades(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -638,7 +637,7 @@ func TestGetFuturesPublicTrades(t *testing.T) {
 
 func TestGetPastPublicTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPastPublicTrades(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5, 0)
+	_, err := b.GetPastPublicTrades(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -646,7 +645,7 @@ func TestGetPastPublicTrades(t *testing.T) {
 
 func TestGetAggregatedTradesList(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesAggregatedTradesList(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 0, 5, time.Time{}, time.Time{})
+	_, err := b.GetFuturesAggregatedTradesList(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 0, 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -654,7 +653,7 @@ func TestGetAggregatedTradesList(t *testing.T) {
 
 func TestGetPerpsExchangeInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPerpMarkets(context.Background())
+	_, err := b.GetPerpMarkets(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -662,7 +661,7 @@ func TestGetPerpsExchangeInfo(t *testing.T) {
 
 func TestGetIndexAndMarkPrice(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetIndexAndMarkPrice(context.Background(), "", "BTCUSD")
+	_, err := b.GetIndexAndMarkPrice(t.Context(), "", "BTCUSD")
 	if err != nil {
 		t.Error(err)
 	}
@@ -670,13 +669,13 @@ func TestGetIndexAndMarkPrice(t *testing.T) {
 
 func TestGetFuturesKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesKlineData(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "1M", 5, time.Time{}, time.Time{})
+	_, err := b.GetFuturesKlineData(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "1M", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 
 	start, end := getTime()
-	_, err = b.GetFuturesKlineData(context.Background(), currency.NewPairWithDelimiter("LTCUSD", "PERP", "_"), "5m", 5, start, end)
+	_, err = b.GetFuturesKlineData(t.Context(), currency.NewPairWithDelimiter("LTCUSD", "PERP", "_"), "5m", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -684,12 +683,12 @@ func TestGetFuturesKlineData(t *testing.T) {
 
 func TestGetContinuousKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetContinuousKlineData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, time.Time{}, time.Time{})
+	_, err := b.GetContinuousKlineData(t.Context(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetContinuousKlineData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, start, end)
+	_, err = b.GetContinuousKlineData(t.Context(), "BTCUSD", "CURRENT_QUARTER", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -697,12 +696,12 @@ func TestGetContinuousKlineData(t *testing.T) {
 
 func TestGetIndexPriceKlines(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetIndexPriceKlines(context.Background(), "BTCUSD", "1M", 5, time.Time{}, time.Time{})
+	_, err := b.GetIndexPriceKlines(t.Context(), "BTCUSD", "1M", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetIndexPriceKlines(context.Background(), "BTCUSD", "1M", 5, start, end)
+	_, err = b.GetIndexPriceKlines(t.Context(), "BTCUSD", "1M", 5, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -710,15 +709,15 @@ func TestGetIndexPriceKlines(t *testing.T) {
 
 func TestGetFuturesSwapTickerChangeStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesSwapTickerChangeStats(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
+	_, err := b.GetFuturesSwapTickerChangeStats(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesSwapTickerChangeStats(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
+	_, err = b.GetFuturesSwapTickerChangeStats(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesSwapTickerChangeStats(context.Background(), currency.EMPTYPAIR, "")
+	_, err = b.GetFuturesSwapTickerChangeStats(t.Context(), currency.EMPTYPAIR, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -727,12 +726,12 @@ func TestGetFuturesSwapTickerChangeStats(t *testing.T) {
 func TestFuturesGetFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesGetFundingHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5, time.Time{}, time.Time{})
+	_, err := b.FuturesGetFundingHistory(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.FuturesGetFundingHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 50, start, end)
+	_, err = b.FuturesGetFundingHistory(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 50, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -741,11 +740,11 @@ func TestFuturesGetFundingHistory(t *testing.T) {
 func TestGetFuturesHistoricalTrades(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFuturesHistoricalTrades(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", 5)
+	_, err := b.GetFuturesHistoricalTrades(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", 5)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesHistoricalTrades(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", 0)
+	_, err = b.GetFuturesHistoricalTrades(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -753,7 +752,7 @@ func TestGetFuturesHistoricalTrades(t *testing.T) {
 
 func TestGetFuturesSymbolPriceTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesSymbolPriceTicker(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
+	_, err := b.GetFuturesSymbolPriceTicker(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -761,11 +760,11 @@ func TestGetFuturesSymbolPriceTicker(t *testing.T) {
 
 func TestGetFuturesOrderbookTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesOrderbookTicker(context.Background(), currency.EMPTYPAIR, "")
+	_, err := b.GetFuturesOrderbookTicker(t.Context(), currency.EMPTYPAIR, "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesOrderbookTicker(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
+	_, err = b.GetFuturesOrderbookTicker(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -773,7 +772,7 @@ func TestGetFuturesOrderbookTicker(t *testing.T) {
 
 func TestOpenInterest(t *testing.T) {
 	t.Parallel()
-	_, err := b.OpenInterest(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"))
+	_, err := b.OpenInterest(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -781,12 +780,12 @@ func TestOpenInterest(t *testing.T) {
 
 func TestGetOpenInterestStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOpenInterestStats(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetOpenInterestStats(t.Context(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetOpenInterestStats(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
+	_, err = b.GetOpenInterestStats(t.Context(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -794,12 +793,12 @@ func TestGetOpenInterestStats(t *testing.T) {
 
 func TestGetTraderFuturesAccountRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTraderFuturesAccountRatio(context.Background(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetTraderFuturesAccountRatio(t.Context(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetTraderFuturesAccountRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
+	_, err = b.GetTraderFuturesAccountRatio(t.Context(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -807,12 +806,12 @@ func TestGetTraderFuturesAccountRatio(t *testing.T) {
 
 func TestGetTraderFuturesPositionsRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTraderFuturesPositionsRatio(context.Background(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetTraderFuturesPositionsRatio(t.Context(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetTraderFuturesPositionsRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
+	_, err = b.GetTraderFuturesPositionsRatio(t.Context(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -820,12 +819,12 @@ func TestGetTraderFuturesPositionsRatio(t *testing.T) {
 
 func TestGetMarketRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarketRatio(context.Background(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetMarketRatio(t.Context(), "BTCUSD", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetMarketRatio(context.Background(), "BTCUSD", "5m", 0, start, end)
+	_, err = b.GetMarketRatio(t.Context(), "BTCUSD", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -833,12 +832,12 @@ func TestGetMarketRatio(t *testing.T) {
 
 func TestGetFuturesTakerVolume(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesTakerVolume(context.Background(), "BTCUSD", "ALL", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetFuturesTakerVolume(t.Context(), "BTCUSD", "ALL", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetFuturesTakerVolume(context.Background(), "BTCUSD", "ALL", "5m", 0, start, end)
+	_, err = b.GetFuturesTakerVolume(t.Context(), "BTCUSD", "ALL", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -846,12 +845,12 @@ func TestGetFuturesTakerVolume(t *testing.T) {
 
 func TestFuturesBasisData(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesBasisData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Time{}, time.Time{})
+	_, err := b.GetFuturesBasisData(t.Context(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
 	start, end := getTime()
-	_, err = b.GetFuturesBasisData(context.Background(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
+	_, err = b.GetFuturesBasisData(t.Context(), "BTCUSD", "CURRENT_QUARTER", "5m", 0, start, end)
 	if err != nil {
 		t.Error(err)
 	}
@@ -861,7 +860,7 @@ func TestFuturesNewOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	_, err := b.FuturesNewOrder(
-		context.Background(),
+		t.Context(),
 		&FuturesNewOrderRequest{
 			Symbol:      currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"),
 			Side:        "BUY",
@@ -889,7 +888,7 @@ func TestFuturesBatchOrder(t *testing.T) {
 	tempData.TimeInForce = "GTC"
 
 	data = append(data, tempData)
-	_, err := b.FuturesBatchOrder(context.Background(), data)
+	_, err := b.FuturesBatchOrder(t.Context(), data)
 	if err != nil {
 		t.Error(err)
 	}
@@ -898,7 +897,7 @@ func TestFuturesBatchOrder(t *testing.T) {
 func TestFuturesBatchCancelOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.FuturesBatchCancelOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), []string{"123"}, []string{})
+	_, err := b.FuturesBatchCancelOrders(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), []string{"123"}, []string{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -907,7 +906,7 @@ func TestFuturesBatchCancelOrders(t *testing.T) {
 func TestFuturesGetOrderData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesGetOrderData(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "123", "")
+	_, err := b.FuturesGetOrderData(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "123", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -916,7 +915,7 @@ func TestFuturesGetOrderData(t *testing.T) {
 func TestCancelAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.FuturesCancelAllOpenOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"))
+	_, err := b.FuturesCancelAllOpenOrders(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -925,7 +924,7 @@ func TestCancelAllOpenOrders(t *testing.T) {
 func TestAutoCancelAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.AutoCancelAllOpenOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 30000)
+	_, err := b.AutoCancelAllOpenOrders(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 30000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -934,7 +933,7 @@ func TestAutoCancelAllOpenOrders(t *testing.T) {
 func TestFuturesOpenOrderData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesOpenOrderData(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", "")
+	_, err := b.FuturesOpenOrderData(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -943,7 +942,7 @@ func TestFuturesOpenOrderData(t *testing.T) {
 func TestGetFuturesAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFuturesAllOpenOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
+	_, err := b.GetFuturesAllOpenOrders(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -952,7 +951,7 @@ func TestGetFuturesAllOpenOrders(t *testing.T) {
 func TestGetAllFuturesOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAllFuturesOrders(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), currency.EMPTYPAIR, time.Time{}, time.Time{}, 0, 2)
+	_, err := b.GetAllFuturesOrders(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), currency.EMPTYPAIR, time.Time{}, time.Time{}, 0, 2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -961,7 +960,7 @@ func TestGetAllFuturesOrders(t *testing.T) {
 func TestFuturesChangeMarginType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.FuturesChangeMarginType(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "ISOLATED")
+	_, err := b.FuturesChangeMarginType(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "ISOLATED")
 	if err != nil {
 		t.Error(err)
 	}
@@ -970,7 +969,7 @@ func TestFuturesChangeMarginType(t *testing.T) {
 func TestGetFuturesAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFuturesAccountBalance(context.Background())
+	_, err := b.GetFuturesAccountBalance(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -979,7 +978,7 @@ func TestGetFuturesAccountBalance(t *testing.T) {
 func TestGetFuturesAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFuturesAccountInfo(context.Background())
+	_, err := b.GetFuturesAccountInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -988,7 +987,7 @@ func TestGetFuturesAccountInfo(t *testing.T) {
 func TestFuturesChangeInitialLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.FuturesChangeInitialLeverage(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5)
+	_, err := b.FuturesChangeInitialLeverage(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -997,7 +996,7 @@ func TestFuturesChangeInitialLeverage(t *testing.T) {
 func TestModifyIsolatedPositionMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ModifyIsolatedPositionMargin(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "BOTH", "add", 5)
+	_, err := b.ModifyIsolatedPositionMargin(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "BOTH", "add", 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1006,7 +1005,7 @@ func TestModifyIsolatedPositionMargin(t *testing.T) {
 func TestFuturesMarginChangeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesMarginChangeHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "add", time.Time{}, time.Time{}, 10)
+	_, err := b.FuturesMarginChangeHistory(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "add", time.Time{}, time.Time{}, 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1015,7 +1014,7 @@ func TestFuturesMarginChangeHistory(t *testing.T) {
 func TestFuturesPositionsInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesPositionsInfo(context.Background(), "BTCUSD", "")
+	_, err := b.FuturesPositionsInfo(t.Context(), "BTCUSD", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1024,7 +1023,7 @@ func TestFuturesPositionsInfo(t *testing.T) {
 func TestFuturesTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesTradeHistory(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", time.Time{}, time.Time{}, 5, 0)
+	_, err := b.FuturesTradeHistory(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "", time.Time{}, time.Time{}, 5, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1033,7 +1032,7 @@ func TestFuturesTradeHistory(t *testing.T) {
 func TestFuturesIncomeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesIncomeHistory(context.Background(), currency.EMPTYPAIR, "TRANSFER", time.Time{}, time.Time{}, 5)
+	_, err := b.FuturesIncomeHistory(t.Context(), currency.EMPTYPAIR, "TRANSFER", time.Time{}, time.Time{}, 5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1042,7 +1041,7 @@ func TestFuturesIncomeHistory(t *testing.T) {
 func TestFuturesForceOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesForceOrders(context.Background(), currency.EMPTYPAIR, "ADL", time.Time{}, time.Time{})
+	_, err := b.FuturesForceOrders(t.Context(), currency.EMPTYPAIR, "ADL", time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1051,11 +1050,11 @@ func TestFuturesForceOrders(t *testing.T) {
 func TestUGetNotionalLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesNotionalBracket(context.Background(), "BTCUSD")
+	_, err := b.FuturesNotionalBracket(t.Context(), "BTCUSD")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.FuturesNotionalBracket(context.Background(), "")
+	_, err = b.FuturesNotionalBracket(t.Context(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1064,7 +1063,7 @@ func TestUGetNotionalLeverage(t *testing.T) {
 func TestFuturesPositionsADLEstimate(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.FuturesPositionsADLEstimate(context.Background(), currency.EMPTYPAIR)
+	_, err := b.FuturesPositionsADLEstimate(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1072,7 +1071,7 @@ func TestFuturesPositionsADLEstimate(t *testing.T) {
 
 func TestGetMarkPriceKline(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarkPriceKline(context.Background(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "1M", 5, time.Time{}, time.Time{})
+	_, err := b.GetMarkPriceKline(t.Context(), currency.NewPairWithDelimiter("BTCUSD", "PERP", "_"), "1M", 5, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1080,7 +1079,7 @@ func TestGetMarkPriceKline(t *testing.T) {
 
 func TestGetExchangeInfo(t *testing.T) {
 	t.Parallel()
-	info, err := b.GetExchangeInfo(context.Background())
+	info, err := b.GetExchangeInfo(t.Context())
 	require.NoError(t, err, "GetExchangeInfo must not error")
 	if mockTests {
 		exp := time.Date(2024, 5, 10, 6, 8, 1, int(707*time.Millisecond), time.UTC)
@@ -1092,17 +1091,17 @@ func TestGetExchangeInfo(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := b.FetchTradablePairs(context.Background(), asset.Spot)
+	_, err := b.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error("Binance FetchTradablePairs(asset asets.AssetType) error", err)
 	}
 
-	_, err = b.FetchTradablePairs(context.Background(), asset.CoinMarginedFutures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.FetchTradablePairs(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1110,7 +1109,7 @@ func TestFetchTradablePairs(t *testing.T) {
 
 func TestGetOrderBook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderBook(context.Background(),
+	_, err := b.GetOrderBook(t.Context(),
 		OrderBookDataRequestParams{
 			Symbol: currency.NewPair(currency.BTC, currency.USDT),
 			Limit:  1000,
@@ -1122,7 +1121,7 @@ func TestGetOrderBook(t *testing.T) {
 
 func TestGetMostRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMostRecentTrades(context.Background(),
+	_, err := b.GetMostRecentTrades(t.Context(),
 		RecentTradeRequestParams{
 			Symbol: currency.NewPair(currency.BTC, currency.USDT),
 			Limit:  15,
@@ -1134,7 +1133,7 @@ func TestGetMostRecentTrades(t *testing.T) {
 
 func TestGetHistoricalTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetHistoricalTrades(context.Background(), "BTCUSDT", 5, -1)
+	_, err := b.GetHistoricalTrades(t.Context(), "BTCUSDT", 5, -1)
 	if !mockTests && err == nil {
 		t.Errorf("Binance GetHistoricalTrades() error: %v", "expected error")
 	} else if mockTests && err != nil {
@@ -1144,7 +1143,7 @@ func TestGetHistoricalTrades(t *testing.T) {
 
 func TestGetAggregatedTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetAggregatedTrades(context.Background(),
+	_, err := b.GetAggregatedTrades(t.Context(),
 		&AggregatedTradeRequestParams{
 			Symbol: currency.NewPair(currency.BTC, currency.USDT),
 			Limit:  5,
@@ -1157,7 +1156,7 @@ func TestGetAggregatedTrades(t *testing.T) {
 func TestGetSpotKline(t *testing.T) {
 	t.Parallel()
 	start, end := getTime()
-	_, err := b.GetSpotKline(context.Background(),
+	_, err := b.GetSpotKline(t.Context(),
 		&KlinesRequestParams{
 			Symbol:    currency.NewPair(currency.BTC, currency.USDT),
 			Interval:  kline.FiveMin.Short(),
@@ -1173,7 +1172,7 @@ func TestGetSpotKline(t *testing.T) {
 func TestGetAveragePrice(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetAveragePrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.GetAveragePrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetAveragePrice() error", err)
 	}
@@ -1182,7 +1181,7 @@ func TestGetAveragePrice(t *testing.T) {
 func TestGetPriceChangeStats(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetPriceChangeStats(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.GetPriceChangeStats(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetPriceChangeStats() error", err)
 	}
@@ -1190,10 +1189,10 @@ func TestGetPriceChangeStats(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTickers(context.Background())
+	_, err := b.GetTickers(t.Context())
 	require.NoError(t, err)
 
-	resp, err := b.GetTickers(context.Background(),
+	resp, err := b.GetTickers(t.Context(),
 		currency.NewPair(currency.BTC, currency.USDT),
 		currency.NewPair(currency.ETH, currency.USDT))
 	require.NoError(t, err)
@@ -1203,7 +1202,7 @@ func TestGetTickers(t *testing.T) {
 func TestGetLatestSpotPrice(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetLatestSpotPrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.GetLatestSpotPrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetLatestSpotPrice() error", err)
 	}
@@ -1212,7 +1211,7 @@ func TestGetLatestSpotPrice(t *testing.T) {
 func TestGetBestPrice(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetBestPrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.GetBestPrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetBestPrice() error", err)
 	}
@@ -1221,7 +1220,7 @@ func TestGetBestPrice(t *testing.T) {
 func TestQueryOrder(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.QueryOrder(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", 1337)
+	_, err := b.QueryOrder(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", 1337)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("QueryOrder() error", err)
@@ -1235,13 +1234,13 @@ func TestQueryOrder(t *testing.T) {
 func TestOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.OpenOrders(context.Background(), currency.EMPTYPAIR)
+	_, err := b.OpenOrders(t.Context(), currency.EMPTYPAIR)
 	if err != nil {
 		t.Error(err)
 	}
 
 	p := currency.NewPair(currency.BTC, currency.USDT)
-	_, err = b.OpenOrders(context.Background(), p)
+	_, err = b.OpenOrders(t.Context(), p)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1250,7 +1249,7 @@ func TestOpenOrders(t *testing.T) {
 func TestAllOrders(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.AllOrders(context.Background(), currency.NewPair(currency.BTC, currency.USDT), "", "")
+	_, err := b.AllOrders(t.Context(), currency.NewPair(currency.BTC, currency.USDT), "", "")
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("AllOrders() error", err)
@@ -1266,7 +1265,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1288,7 +1287,7 @@ func TestGetFee(t *testing.T) {
 
 	if sharedtestvalues.AreAPICredentialsSet(b) && mockTests {
 		// CryptocurrencyTradeFee Basic
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -1296,21 +1295,21 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
@@ -1318,14 +1317,14 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -1333,7 +1332,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
 	feeBuilder.FiatCurrency = currency.HKD
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -1341,7 +1340,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.HKD
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -1369,7 +1368,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("GetActiveOrders() error", err)
@@ -1389,7 +1388,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if err == nil {
 		t.Error("Expected: 'At least one currency is required to fetch order history'. received nil")
 	}
@@ -1399,7 +1398,7 @@ func TestGetOrderHistory(t *testing.T) {
 			currency.BTC),
 	}
 
-	_, err = b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err = b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("GetOrderHistory() error", err)
@@ -1422,7 +1421,7 @@ func TestNewOrderTest(t *testing.T) {
 		TimeInForce: BinanceRequestParamsTimeGTC,
 	}
 
-	err := b.NewOrderTest(context.Background(), req)
+	err := b.NewOrderTest(t.Context(), req)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("NewOrderTest() error", err)
@@ -1440,7 +1439,7 @@ func TestNewOrderTest(t *testing.T) {
 		QuoteOrderQty: 10,
 	}
 
-	err = b.NewOrderTest(context.Background(), req)
+	err = b.NewOrderTest(t.Context(), req)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("NewOrderTest() error", err)
@@ -1456,7 +1455,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	p := currency.NewPair(currency.BTC, currency.USDT)
 	start := time.Unix(1577977445, 0)  // 2020-01-02 15:04:05
 	end := start.Add(15 * time.Minute) // 2020-01-02 15:19:05
-	result, err := b.GetHistoricTrades(context.Background(), p, asset.Spot, start, end)
+	result, err := b.GetHistoricTrades(t.Context(), p, asset.Spot, start, end)
 	assert.NoError(t, err, "GetHistoricTrades should not error")
 	expected := 2134
 	if mockTests {
@@ -1551,7 +1550,7 @@ func TestGetAggregatedTradesBatched(t *testing.T) {
 			if tt.mock != mockTests {
 				t.Skip("mock mismatch, skipping")
 			}
-			result, err := b.GetAggregatedTrades(context.Background(), tt.args)
+			result, err := b.GetAggregatedTrades(t.Context(), tt.args)
 			if err != nil {
 				t.Error(err)
 			}
@@ -1603,7 +1602,7 @@ func TestGetAggregatedTradesErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := b.GetAggregatedTrades(context.Background(), tt.args)
+			_, err := b.GetAggregatedTrades(t.Context(), tt.args)
 			if err == nil {
 				t.Errorf("Binance.GetAggregatedTrades() error = %v, wantErr true", err)
 				return
@@ -1637,7 +1636,7 @@ func TestSubmitOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	_, err := b.SubmitOrder(context.Background(), orderSubmission)
+	_, err := b.SubmitOrder(t.Context(), orderSubmission)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("SubmitOrder() error", err)
@@ -1661,7 +1660,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("CancelExchangeOrder() error", err)
@@ -1685,7 +1684,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	_, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	_, err := b.CancelAllOrders(t.Context(), orderCancellation)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("CancelAllExchangeOrders() error", err)
@@ -1709,7 +1708,7 @@ func TestGetAccountInfo(t *testing.T) {
 		assetType := items[i]
 		t.Run(fmt.Sprintf("Update info of account [%s]", assetType.String()), func(t *testing.T) {
 			t.Parallel()
-			_, err := b.UpdateAccountInfo(context.Background(), assetType)
+			_, err := b.UpdateAccountInfo(t.Context(), assetType)
 			if err != nil {
 				t.Error(err)
 			}
@@ -1724,7 +1723,7 @@ func TestWrapperGetActiveOrders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
+	_, err = b.GetActiveOrders(t.Context(), &order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 		Pairs:     currency.Pairs{p},
@@ -1738,7 +1737,7 @@ func TestWrapperGetActiveOrders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
+	_, err = b.GetActiveOrders(t.Context(), &order.MultiOrderRequest{
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 		Pairs:     currency.Pairs{p2},
@@ -1756,7 +1755,7 @@ func TestWrapperGetOrderHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrderHistory(context.Background(), &order.MultiOrderRequest{
+	_, err = b.GetOrderHistory(t.Context(), &order.MultiOrderRequest{
 		Type:        order.AnyType,
 		Side:        order.AnySide,
 		FromOrderID: "123",
@@ -1771,7 +1770,7 @@ func TestWrapperGetOrderHistory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrderHistory(context.Background(), &order.MultiOrderRequest{
+	_, err = b.GetOrderHistory(t.Context(), &order.MultiOrderRequest{
 		Type:        order.AnyType,
 		Side:        order.AnySide,
 		FromOrderID: "123",
@@ -1782,7 +1781,7 @@ func TestWrapperGetOrderHistory(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = b.GetOrderHistory(context.Background(), &order.MultiOrderRequest{
+	_, err = b.GetOrderHistory(t.Context(), &order.MultiOrderRequest{
 		AssetType: asset.USDTMarginedFutures,
 	})
 	if err == nil {
@@ -1801,7 +1800,7 @@ func TestCancelOrder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.CancelOrder(context.Background(), &order.Cancel{
+	err = b.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.CoinMarginedFutures,
 		Pair:      fPair,
 		OrderID:   "1234",
@@ -1818,7 +1817,7 @@ func TestCancelOrder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.CancelOrder(context.Background(), &order.Cancel{
+	err = b.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.USDTMarginedFutures,
 		Pair:      fpair2,
 		OrderID:   "1234",
@@ -1831,7 +1830,7 @@ func TestCancelOrder(t *testing.T) {
 func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	tradablePairs, err := b.FetchTradablePairs(context.Background(),
+	tradablePairs, err := b.FetchTradablePairs(t.Context(),
 		asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
@@ -1839,7 +1838,7 @@ func TestGetOrderInfo(t *testing.T) {
 	if len(tradablePairs) == 0 {
 		t.Fatal("no tradable pairs")
 	}
-	_, err = b.GetOrderInfo(context.Background(),
+	_, err = b.GetOrderInfo(t.Context(),
 		"123", tradablePairs[0], asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
@@ -1848,7 +1847,7 @@ func TestGetOrderInfo(t *testing.T) {
 
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
-	_, err := b.ModifyOrder(context.Background(),
+	_, err := b.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() error cannot be nil")
@@ -1860,7 +1859,7 @@ func TestGetAllCoinsInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetAllCoinsInfo(context.Background())
+	_, err := b.GetAllCoinsInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1882,7 +1881,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := b.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := b.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
@@ -1897,7 +1896,7 @@ func TestDepositHistory(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 	}
-	_, err := b.DepositHistory(context.Background(), currency.ETH, "", time.Time{}, time.Time{}, 0, 10000)
+	_, err := b.DepositHistory(t.Context(), currency.ETH, "", time.Time{}, time.Time{}, 0, 10000)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error(err)
@@ -1911,7 +1910,7 @@ func TestWithdrawHistory(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 	}
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.ETH, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.ETH, asset.Spot)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("GetWithdrawalsHistory() error", err)
@@ -1922,7 +1921,7 @@ func TestWithdrawHistory(t *testing.T) {
 
 func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
-	_, err := b.WithdrawFiatFunds(context.Background(),
+	_, err := b.WithdrawFiatFunds(t.Context(),
 		&withdraw.Request{})
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -1931,7 +1930,7 @@ func TestWithdrawFiat(t *testing.T) {
 
 func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
-	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdraw.Request{})
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -1940,7 +1939,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetDepositAddress(context.Background(), currency.USDT, "", currency.BNB.String())
+	_, err := b.GetDepositAddress(t.Context(), currency.USDT, "", currency.BNB.String())
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error("GetDepositAddress() error", err)
@@ -2241,7 +2240,7 @@ func TestWsOCO(t *testing.T) {
 }
 
 func TestGetWsAuthStreamKey(t *testing.T) {
-	key, err := b.GetWsAuthStreamKey(context.Background())
+	key, err := b.GetWsAuthStreamKey(t.Context())
 	switch {
 	case mockTests && err != nil,
 		!mockTests && sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
@@ -2256,7 +2255,7 @@ func TestGetWsAuthStreamKey(t *testing.T) {
 }
 
 func TestMaintainWsAuthStreamKey(t *testing.T) {
-	err := b.MaintainWsAuthStreamKey(context.Background())
+	err := b.MaintainWsAuthStreamKey(t.Context())
 	switch {
 	case mockTests && err != nil,
 		!mockTests && sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
@@ -2303,7 +2302,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		if err != nil && !errors.Is(err, currency.ErrPairAlreadyEnabled) {
 			t.Fatal(err)
 		}
-		_, err = b.GetHistoricCandles(context.Background(), cps[0], bAssets[i], kline.OneDay, startTime, end)
+		_, err = b.GetHistoricCandles(t.Context(), cps[0], bAssets[i], kline.OneDay, startTime, end)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2314,7 +2313,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		t.Fatal(err)
 	}
 	startTime = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, err = b.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.Interval(time.Hour*7), startTime, end)
+	_, err = b.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.Interval(time.Hour*7), startTime, end)
 	if !errors.Is(err, kline.ErrRequestExceedsExchangeLimits) {
 		t.Fatalf("received: '%v', but expected: '%v'", err, kline.ErrRequestExceedsExchangeLimits)
 	}
@@ -2334,7 +2333,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 		if err != nil && !errors.Is(err, currency.ErrPairAlreadyEnabled) {
 			t.Fatal(err)
 		}
-		_, err = b.GetHistoricCandlesExtended(context.Background(), cps[0], bAssets[i], kline.OneDay, startTime, end)
+		_, err = b.GetHistoricCandlesExtended(t.Context(), cps[0], bAssets[i], kline.OneDay, startTime, end)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2385,19 +2384,19 @@ func TestBinance_FormatExchangeKlineInterval(t *testing.T) {
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
 	pair := currency.NewPair(currency.BTC, currency.USDT)
-	_, err := b.GetRecentTrades(context.Background(),
+	_, err := b.GetRecentTrades(t.Context(),
 		pair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetRecentTrades(context.Background(),
+	_, err = b.GetRecentTrades(t.Context(),
 		pair, asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 	pair.Base = currency.NewCode("BTCUSD")
 	pair.Quote = currency.PERP
-	_, err = b.GetRecentTrades(context.Background(),
+	_, err = b.GetRecentTrades(t.Context(),
 		pair, asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
@@ -2406,7 +2405,7 @@ func TestGetRecentTrades(t *testing.T) {
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetAvailableTransferChains(context.Background(), currency.BTC)
+	_, err := b.GetAvailableTransferChains(t.Context(), currency.BTC)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(b) && err != nil:
 		t.Error(err)
@@ -2419,7 +2418,7 @@ func TestGetAvailableTransferChains(t *testing.T) {
 
 func TestSeedLocalCache(t *testing.T) {
 	t.Parallel()
-	err := b.SeedLocalCache(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	err := b.SeedLocalCache(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2505,11 +2504,11 @@ func TestUFuturesHistoricalTrades(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UFuturesHistoricalTrades(context.Background(), cp, "", 5)
+	_, err = b.UFuturesHistoricalTrades(t.Context(), cp, "", 5)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UFuturesHistoricalTrades(context.Background(), cp, "", 0)
+	_, err = b.UFuturesHistoricalTrades(t.Context(), cp, "", 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2517,21 +2516,21 @@ func TestUFuturesHistoricalTrades(t *testing.T) {
 
 func TestSetExchangeOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
+	err := b.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.CoinMarginedFutures)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.USDTMarginedFutures)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.CoinMarginedFutures)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.Binary)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.USDTMarginedFutures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.Binary)
 	if err == nil {
 		t.Fatal("expected unhandled case")
 	}
@@ -2760,15 +2759,15 @@ func TestFormatUSDTMarginedFuturesPair(t *testing.T) {
 
 func TestFetchExchangeLimits(t *testing.T) {
 	t.Parallel()
-	limits, err := b.FetchExchangeLimits(context.Background(), asset.Spot)
+	limits, err := b.FetchExchangeLimits(t.Context(), asset.Spot)
 	assert.NoError(t, err, "FetchExchangeLimits should not error")
 	assert.NotEmpty(t, limits, "Should get some limits back")
 
-	limits, err = b.FetchExchangeLimits(context.Background(), asset.Margin)
+	limits, err = b.FetchExchangeLimits(t.Context(), asset.Margin)
 	assert.NoError(t, err, "FetchExchangeLimits should not error")
 	assert.NotEmpty(t, limits, "Should get some limits back")
 
-	_, err = b.FetchExchangeLimits(context.Background(), asset.Futures)
+	_, err = b.FetchExchangeLimits(t.Context(), asset.Futures)
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "FetchExchangeLimits should error on other asset types")
 }
 
@@ -2780,14 +2779,14 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 		asset.Margin: currency.NewPair(currency.ETH, currency.BTC),
 	}
 	for _, a := range []asset.Item{asset.CoinMarginedFutures, asset.USDTMarginedFutures} {
-		pairs, err := b.FetchTradablePairs(context.Background(), a)
+		pairs, err := b.FetchTradablePairs(t.Context(), a)
 		require.NoErrorf(t, err, "FetchTradablePairs should not error for %s", a)
 		require.NotEmptyf(t, pairs, "Should get some pairs for %s", a)
 		tests[a] = pairs[0]
 	}
 
 	for _, a := range b.GetAssetTypes(false) {
-		err := b.UpdateOrderExecutionLimits(context.Background(), a)
+		err := b.UpdateOrderExecutionLimits(t.Context(), a)
 		require.NoError(t, err, "UpdateOrderExecutionLimits should not error")
 
 		p := tests[a]
@@ -2820,7 +2819,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 func TestGetHistoricalFundingRates(t *testing.T) {
 	t.Parallel()
 	s, e := getTime()
-	_, err := b.GetHistoricalFundingRates(context.Background(), &fundingrate.HistoricalRatesRequest{
+	_, err := b.GetHistoricalFundingRates(t.Context(), &fundingrate.HistoricalRatesRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
 		StartDate:            s,
@@ -2832,7 +2831,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = b.GetHistoricalFundingRates(context.Background(), &fundingrate.HistoricalRatesRequest{
+	_, err = b.GetHistoricalFundingRates(t.Context(), &fundingrate.HistoricalRatesRequest{
 		Asset:           asset.USDTMarginedFutures,
 		Pair:            currency.NewPair(currency.BTC, currency.USDT),
 		StartDate:       s,
@@ -2852,7 +2851,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		r.IncludePayments = true
 	}
-	_, err = b.GetHistoricalFundingRates(context.Background(), r)
+	_, err = b.GetHistoricalFundingRates(t.Context(), r)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2862,7 +2861,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetHistoricalFundingRates(context.Background(), r)
+	_, err = b.GetHistoricalFundingRates(t.Context(), r)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2871,7 +2870,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPair(currency.BTC, currency.USDT)
-	_, err := b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 cp,
 		IncludePredictedRate: true,
@@ -2883,14 +2882,14 @@ func TestGetLatestFundingRates(t *testing.T) {
 	if err != nil && !errors.Is(err, currency.ErrPairAlreadyEnabled) {
 		t.Fatal(err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.USDTMarginedFutures,
 		Pair:  cp,
 	})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.CoinMarginedFutures,
 	})
 	if err != nil {
@@ -2942,7 +2941,7 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 func TestGetUserMarginInterestHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetUserMarginInterestHistory(context.Background(), currency.USDT, currency.NewPair(currency.BTC, currency.USDT), time.Now().Add(-time.Hour*24), time.Now(), 1, 10, false)
+	_, err := b.GetUserMarginInterestHistory(t.Context(), currency.USDT, currency.NewPair(currency.BTC, currency.USDT), time.Now().Add(-time.Hour*24), time.Now(), 1, 10, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2951,17 +2950,17 @@ func TestGetUserMarginInterestHistory(t *testing.T) {
 func TestSetAssetsMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	is, err := b.GetAssetsMode(context.Background())
+	is, err := b.GetAssetsMode(t.Context())
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
 
-	err = b.SetAssetsMode(context.Background(), !is)
+	err = b.SetAssetsMode(t.Context(), !is)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
 
-	err = b.SetAssetsMode(context.Background(), is)
+	err = b.SetAssetsMode(t.Context(), is)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -2970,7 +2969,7 @@ func TestSetAssetsMode(t *testing.T) {
 func TestGetAssetsMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAssetsMode(context.Background())
+	_, err := b.GetAssetsMode(t.Context())
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -2979,15 +2978,15 @@ func TestGetAssetsMode(t *testing.T) {
 func TestGetCollateralMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.GetCollateralMode(context.Background(), asset.Spot)
+	_, err := b.GetCollateralMode(t.Context(), asset.Spot)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
-	_, err = b.GetCollateralMode(context.Background(), asset.CoinMarginedFutures)
+	_, err = b.GetCollateralMode(t.Context(), asset.CoinMarginedFutures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
-	_, err = b.GetCollateralMode(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.GetCollateralMode(t.Context(), asset.USDTMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
@@ -2996,19 +2995,19 @@ func TestGetCollateralMode(t *testing.T) {
 func TestSetCollateralMode(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetCollateralMode(context.Background(), asset.Spot, collateral.SingleMode)
+	err := b.SetCollateralMode(t.Context(), asset.Spot, collateral.SingleMode)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
-	err = b.SetCollateralMode(context.Background(), asset.CoinMarginedFutures, collateral.SingleMode)
+	err = b.SetCollateralMode(t.Context(), asset.CoinMarginedFutures, collateral.SingleMode)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("received '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
-	err = b.SetCollateralMode(context.Background(), asset.USDTMarginedFutures, collateral.MultiMode)
+	err = b.SetCollateralMode(t.Context(), asset.USDTMarginedFutures, collateral.MultiMode)
 	if !errors.Is(err, nil) {
 		t.Errorf("received '%v', expected '%v'", err, nil)
 	}
-	err = b.SetCollateralMode(context.Background(), asset.USDTMarginedFutures, collateral.PortfolioMode)
+	err = b.SetCollateralMode(t.Context(), asset.USDTMarginedFutures, collateral.PortfolioMode)
 	if !errors.Is(err, order.ErrCollateralInvalid) {
 		t.Errorf("received '%v', expected '%v'", err, order.ErrCollateralInvalid)
 	}
@@ -3017,7 +3016,7 @@ func TestSetCollateralMode(t *testing.T) {
 func TestChangePositionMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ChangePositionMargin(context.Background(), &margin.PositionChangeRequest{
+	_, err := b.ChangePositionMargin(t.Context(), &margin.PositionChangeRequest{
 		Pair:                    currency.NewBTCUSDT(),
 		Asset:                   asset.USDTMarginedFutures,
 		MarginType:              margin.Isolated,
@@ -3034,7 +3033,7 @@ func TestGetPositionSummary(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
 	bb := currency.NewBTCUSDT()
-	_, err := b.GetFuturesPositionSummary(context.Background(), &futures.PositionSummaryRequest{
+	_, err := b.GetFuturesPositionSummary(t.Context(), &futures.PositionSummaryRequest{
 		Asset: asset.USDTMarginedFutures,
 		Pair:  bb,
 	})
@@ -3043,7 +3042,7 @@ func TestGetPositionSummary(t *testing.T) {
 	}
 
 	bb.Quote = currency.BUSD
-	_, err = b.GetFuturesPositionSummary(context.Background(), &futures.PositionSummaryRequest{
+	_, err = b.GetFuturesPositionSummary(t.Context(), &futures.PositionSummaryRequest{
 		Asset: asset.USDTMarginedFutures,
 		Pair:  bb,
 	})
@@ -3056,7 +3055,7 @@ func TestGetPositionSummary(t *testing.T) {
 		t.Fatal(err)
 	}
 	bb.Quote = currency.USD
-	_, err = b.GetFuturesPositionSummary(context.Background(), &futures.PositionSummaryRequest{
+	_, err = b.GetFuturesPositionSummary(t.Context(), &futures.PositionSummaryRequest{
 		Asset:          asset.CoinMarginedFutures,
 		Pair:           p,
 		UnderlyingPair: bb,
@@ -3065,7 +3064,7 @@ func TestGetPositionSummary(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = b.GetFuturesPositionSummary(context.Background(), &futures.PositionSummaryRequest{
+	_, err = b.GetFuturesPositionSummary(t.Context(), &futures.PositionSummaryRequest{
 		Asset:          asset.Spot,
 		Pair:           p,
 		UnderlyingPair: bb,
@@ -3078,7 +3077,7 @@ func TestGetPositionSummary(t *testing.T) {
 func TestGetFuturesPositionOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFuturesPositionOrders(context.Background(), &futures.PositionsRequest{
+	_, err := b.GetFuturesPositionOrders(t.Context(), &futures.PositionsRequest{
 		Asset:                     asset.USDTMarginedFutures,
 		Pairs:                     []currency.Pair{currency.NewBTCUSDT()},
 		StartDate:                 time.Now().Add(-time.Hour * 24 * 70),
@@ -3092,7 +3091,7 @@ func TestGetFuturesPositionOrders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetFuturesPositionOrders(context.Background(), &futures.PositionsRequest{
+	_, err = b.GetFuturesPositionOrders(t.Context(), &futures.PositionsRequest{
 		Asset:                     asset.CoinMarginedFutures,
 		Pairs:                     []currency.Pair{p},
 		StartDate:                 time.Now().Add(time.Hour * 24 * -70),
@@ -3107,7 +3106,7 @@ func TestSetMarginType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	err := b.SetMarginType(context.Background(), asset.USDTMarginedFutures, currency.NewPair(currency.BTC, currency.USDT), margin.Isolated)
+	err := b.SetMarginType(t.Context(), asset.USDTMarginedFutures, currency.NewPair(currency.BTC, currency.USDT), margin.Isolated)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3116,12 +3115,12 @@ func TestSetMarginType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = b.SetMarginType(context.Background(), asset.CoinMarginedFutures, p, margin.Isolated)
+	err = b.SetMarginType(t.Context(), asset.CoinMarginedFutures, p, margin.Isolated)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
 
-	err = b.SetMarginType(context.Background(), asset.Spot, currency.NewPair(currency.BTC, currency.USDT), margin.Isolated)
+	err = b.SetMarginType(t.Context(), asset.Spot, currency.NewPair(currency.BTC, currency.USDT), margin.Isolated)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
@@ -3130,7 +3129,7 @@ func TestSetMarginType(t *testing.T) {
 func TestGetLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetLeverage(context.Background(), asset.USDTMarginedFutures, currency.NewBTCUSDT(), 0, order.UnknownSide)
+	_, err := b.GetLeverage(t.Context(), asset.USDTMarginedFutures, currency.NewBTCUSDT(), 0, order.UnknownSide)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3139,11 +3138,11 @@ func TestGetLeverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetLeverage(context.Background(), asset.CoinMarginedFutures, p, 0, order.UnknownSide)
+	_, err = b.GetLeverage(t.Context(), asset.CoinMarginedFutures, p, 0, order.UnknownSide)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetLeverage(context.Background(), asset.Spot, currency.NewBTCUSDT(), 0, order.UnknownSide)
+	_, err = b.GetLeverage(t.Context(), asset.Spot, currency.NewBTCUSDT(), 0, order.UnknownSide)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
@@ -3152,7 +3151,7 @@ func TestGetLeverage(t *testing.T) {
 func TestSetLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetLeverage(context.Background(), asset.USDTMarginedFutures, currency.NewBTCUSDT(), margin.Multi, 5, order.UnknownSide)
+	err := b.SetLeverage(t.Context(), asset.USDTMarginedFutures, currency.NewBTCUSDT(), margin.Multi, 5, order.UnknownSide)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3161,11 +3160,11 @@ func TestSetLeverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = b.SetLeverage(context.Background(), asset.CoinMarginedFutures, p, margin.Multi, 5, order.UnknownSide)
+	err = b.SetLeverage(t.Context(), asset.CoinMarginedFutures, p, margin.Multi, 5, order.UnknownSide)
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.SetLeverage(context.Background(), asset.Spot, p, margin.Multi, 5, order.UnknownSide)
+	err = b.SetLeverage(t.Context(), asset.Spot, p, margin.Multi, 5, order.UnknownSide)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
@@ -3174,28 +3173,28 @@ func TestSetLeverage(t *testing.T) {
 func TestGetCryptoLoansIncomeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanIncomeHistory(context.Background(), currency.USDT, "", time.Time{}, time.Time{}, 100); err != nil {
+	if _, err := b.CryptoLoanIncomeHistory(t.Context(), currency.USDT, "", time.Time{}, time.Time{}, 100); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCryptoLoanBorrow(t *testing.T) {
 	t.Parallel()
-	if _, err := b.CryptoLoanBorrow(context.Background(), currency.EMPTYCODE, 1000, currency.BTC, 1, 7); !errors.Is(err, errLoanCoinMustBeSet) {
+	if _, err := b.CryptoLoanBorrow(t.Context(), currency.EMPTYCODE, 1000, currency.BTC, 1, 7); !errors.Is(err, errLoanCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanCoinMustBeSet)
 	}
-	if _, err := b.CryptoLoanBorrow(context.Background(), currency.USDT, 1000, currency.EMPTYCODE, 1, 7); !errors.Is(err, errCollateralCoinMustBeSet) {
+	if _, err := b.CryptoLoanBorrow(t.Context(), currency.USDT, 1000, currency.EMPTYCODE, 1, 7); !errors.Is(err, errCollateralCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errCollateralCoinMustBeSet)
 	}
-	if _, err := b.CryptoLoanBorrow(context.Background(), currency.USDT, 0, currency.BTC, 1, 0); !errors.Is(err, errLoanTermMustBeSet) {
+	if _, err := b.CryptoLoanBorrow(t.Context(), currency.USDT, 0, currency.BTC, 1, 0); !errors.Is(err, errLoanTermMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanTermMustBeSet)
 	}
-	if _, err := b.CryptoLoanBorrow(context.Background(), currency.USDT, 0, currency.BTC, 0, 7); !errors.Is(err, errEitherLoanOrCollateralAmountsMustBeSet) {
+	if _, err := b.CryptoLoanBorrow(t.Context(), currency.USDT, 0, currency.BTC, 0, 7); !errors.Is(err, errEitherLoanOrCollateralAmountsMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errEitherLoanOrCollateralAmountsMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.CryptoLoanBorrow(context.Background(), currency.USDT, 1000, currency.BTC, 1, 7); err != nil {
+	if _, err := b.CryptoLoanBorrow(t.Context(), currency.USDT, 1000, currency.BTC, 1, 7); err != nil {
 		t.Error(err)
 	}
 }
@@ -3203,7 +3202,7 @@ func TestCryptoLoanBorrow(t *testing.T) {
 func TestCryptoLoanBorrowHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanBorrowHistory(context.Background(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.CryptoLoanBorrowHistory(t.Context(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3211,22 +3210,22 @@ func TestCryptoLoanBorrowHistory(t *testing.T) {
 func TestCryptoLoanOngoingOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanOngoingOrders(context.Background(), 0, currency.USDT, currency.BTC, 0, 0); err != nil {
+	if _, err := b.CryptoLoanOngoingOrders(t.Context(), 0, currency.USDT, currency.BTC, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCryptoLoanRepay(t *testing.T) {
 	t.Parallel()
-	if _, err := b.CryptoLoanRepay(context.Background(), 0, 1000, 1, false); !errors.Is(err, errOrderIDMustBeSet) {
+	if _, err := b.CryptoLoanRepay(t.Context(), 0, 1000, 1, false); !errors.Is(err, errOrderIDMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errOrderIDMustBeSet)
 	}
-	if _, err := b.CryptoLoanRepay(context.Background(), 42069, 0, 1, false); !errors.Is(err, errAmountMustBeSet) {
+	if _, err := b.CryptoLoanRepay(t.Context(), 42069, 0, 1, false); !errors.Is(err, errAmountMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errAmountMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.CryptoLoanRepay(context.Background(), 42069, 1000, 1, false); err != nil {
+	if _, err := b.CryptoLoanRepay(t.Context(), 42069, 1000, 1, false); err != nil {
 		t.Error(err)
 	}
 }
@@ -3234,22 +3233,22 @@ func TestCryptoLoanRepay(t *testing.T) {
 func TestCryptoLoanRepaymentHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanRepaymentHistory(context.Background(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.CryptoLoanRepaymentHistory(t.Context(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCryptoLoanAdjustLTV(t *testing.T) {
 	t.Parallel()
-	if _, err := b.CryptoLoanAdjustLTV(context.Background(), 0, true, 1); !errors.Is(err, errOrderIDMustBeSet) {
+	if _, err := b.CryptoLoanAdjustLTV(t.Context(), 0, true, 1); !errors.Is(err, errOrderIDMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errOrderIDMustBeSet)
 	}
-	if _, err := b.CryptoLoanAdjustLTV(context.Background(), 42069, true, 0); !errors.Is(err, errAmountMustBeSet) {
+	if _, err := b.CryptoLoanAdjustLTV(t.Context(), 42069, true, 0); !errors.Is(err, errAmountMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errAmountMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.CryptoLoanAdjustLTV(context.Background(), 42069, true, 1); err != nil {
+	if _, err := b.CryptoLoanAdjustLTV(t.Context(), 42069, true, 1); err != nil {
 		t.Error(err)
 	}
 }
@@ -3257,7 +3256,7 @@ func TestCryptoLoanAdjustLTV(t *testing.T) {
 func TestCryptoLoanLTVAdjustmentHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanLTVAdjustmentHistory(context.Background(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.CryptoLoanLTVAdjustmentHistory(t.Context(), 0, currency.USDT, currency.BTC, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3265,7 +3264,7 @@ func TestCryptoLoanLTVAdjustmentHistory(t *testing.T) {
 func TestCryptoLoanAssetsData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanAssetsData(context.Background(), currency.EMPTYCODE, 0); err != nil {
+	if _, err := b.CryptoLoanAssetsData(t.Context(), currency.EMPTYCODE, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3273,55 +3272,55 @@ func TestCryptoLoanAssetsData(t *testing.T) {
 func TestCryptoLoanCollateralAssetsData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanCollateralAssetsData(context.Background(), currency.EMPTYCODE, 0); err != nil {
+	if _, err := b.CryptoLoanCollateralAssetsData(t.Context(), currency.EMPTYCODE, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCryptoLoanCheckCollateralRepayRate(t *testing.T) {
 	t.Parallel()
-	if _, err := b.CryptoLoanCheckCollateralRepayRate(context.Background(), currency.EMPTYCODE, currency.BNB, 69); !errors.Is(err, errLoanCoinMustBeSet) {
+	if _, err := b.CryptoLoanCheckCollateralRepayRate(t.Context(), currency.EMPTYCODE, currency.BNB, 69); !errors.Is(err, errLoanCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanCoinMustBeSet)
 	}
-	if _, err := b.CryptoLoanCheckCollateralRepayRate(context.Background(), currency.BUSD, currency.EMPTYCODE, 69); !errors.Is(err, errCollateralCoinMustBeSet) {
+	if _, err := b.CryptoLoanCheckCollateralRepayRate(t.Context(), currency.BUSD, currency.EMPTYCODE, 69); !errors.Is(err, errCollateralCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errCollateralCoinMustBeSet)
 	}
-	if _, err := b.CryptoLoanCheckCollateralRepayRate(context.Background(), currency.BUSD, currency.BNB, 0); !errors.Is(err, errAmountMustBeSet) {
+	if _, err := b.CryptoLoanCheckCollateralRepayRate(t.Context(), currency.BUSD, currency.BNB, 0); !errors.Is(err, errAmountMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errAmountMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.CryptoLoanCheckCollateralRepayRate(context.Background(), currency.BUSD, currency.BNB, 69); err != nil {
+	if _, err := b.CryptoLoanCheckCollateralRepayRate(t.Context(), currency.BUSD, currency.BNB, 69); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCryptoLoanCustomiseMarginCall(t *testing.T) {
 	t.Parallel()
-	if _, err := b.CryptoLoanCustomiseMarginCall(context.Background(), 0, currency.BTC, 0); err == nil {
+	if _, err := b.CryptoLoanCustomiseMarginCall(t.Context(), 0, currency.BTC, 0); err == nil {
 		t.Error("expected an error")
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.CryptoLoanCustomiseMarginCall(context.Background(), 1337, currency.BTC, .70); err != nil {
+	if _, err := b.CryptoLoanCustomiseMarginCall(t.Context(), 1337, currency.BTC, .70); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestFlexibleLoanBorrow(t *testing.T) {
 	t.Parallel()
-	if _, err := b.FlexibleLoanBorrow(context.Background(), currency.EMPTYCODE, currency.USDC, 1, 0); !errors.Is(err, errLoanCoinMustBeSet) {
+	if _, err := b.FlexibleLoanBorrow(t.Context(), currency.EMPTYCODE, currency.USDC, 1, 0); !errors.Is(err, errLoanCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanCoinMustBeSet)
 	}
-	if _, err := b.FlexibleLoanBorrow(context.Background(), currency.ATOM, currency.EMPTYCODE, 1, 0); !errors.Is(err, errCollateralCoinMustBeSet) {
+	if _, err := b.FlexibleLoanBorrow(t.Context(), currency.ATOM, currency.EMPTYCODE, 1, 0); !errors.Is(err, errCollateralCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errCollateralCoinMustBeSet)
 	}
-	if _, err := b.FlexibleLoanBorrow(context.Background(), currency.ATOM, currency.USDC, 0, 0); !errors.Is(err, errEitherLoanOrCollateralAmountsMustBeSet) {
+	if _, err := b.FlexibleLoanBorrow(t.Context(), currency.ATOM, currency.USDC, 0, 0); !errors.Is(err, errEitherLoanOrCollateralAmountsMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errEitherLoanOrCollateralAmountsMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.FlexibleLoanBorrow(context.Background(), currency.ATOM, currency.USDC, 1, 0); err != nil {
+	if _, err := b.FlexibleLoanBorrow(t.Context(), currency.ATOM, currency.USDC, 1, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3329,7 +3328,7 @@ func TestFlexibleLoanBorrow(t *testing.T) {
 func TestFlexibleLoanOngoingOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleLoanOngoingOrders(context.Background(), currency.EMPTYCODE, currency.EMPTYCODE, 0, 0); err != nil {
+	if _, err := b.FlexibleLoanOngoingOrders(t.Context(), currency.EMPTYCODE, currency.EMPTYCODE, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3337,7 +3336,7 @@ func TestFlexibleLoanOngoingOrders(t *testing.T) {
 func TestFlexibleLoanBorrowHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleLoanBorrowHistory(context.Background(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.FlexibleLoanBorrowHistory(t.Context(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3345,18 +3344,18 @@ func TestFlexibleLoanBorrowHistory(t *testing.T) {
 func TestFlexibleLoanRepay(t *testing.T) {
 	t.Parallel()
 
-	if _, err := b.FlexibleLoanRepay(context.Background(), currency.EMPTYCODE, currency.BTC, 1, false, false); !errors.Is(err, errLoanCoinMustBeSet) {
+	if _, err := b.FlexibleLoanRepay(t.Context(), currency.EMPTYCODE, currency.BTC, 1, false, false); !errors.Is(err, errLoanCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanCoinMustBeSet)
 	}
-	if _, err := b.FlexibleLoanRepay(context.Background(), currency.USDT, currency.EMPTYCODE, 1, false, false); !errors.Is(err, errCollateralCoinMustBeSet) {
+	if _, err := b.FlexibleLoanRepay(t.Context(), currency.USDT, currency.EMPTYCODE, 1, false, false); !errors.Is(err, errCollateralCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errCollateralCoinMustBeSet)
 	}
-	if _, err := b.FlexibleLoanRepay(context.Background(), currency.USDT, currency.BTC, 0, false, false); !errors.Is(err, errAmountMustBeSet) {
+	if _, err := b.FlexibleLoanRepay(t.Context(), currency.USDT, currency.BTC, 0, false, false); !errors.Is(err, errAmountMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errAmountMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.FlexibleLoanRepay(context.Background(), currency.ATOM, currency.USDC, 1, false, false); err != nil {
+	if _, err := b.FlexibleLoanRepay(t.Context(), currency.ATOM, currency.USDC, 1, false, false); err != nil {
 		t.Error(err)
 	}
 }
@@ -3364,22 +3363,22 @@ func TestFlexibleLoanRepay(t *testing.T) {
 func TestFlexibleLoanRepayHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleLoanRepayHistory(context.Background(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.FlexibleLoanRepayHistory(t.Context(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestFlexibleLoanAdjustLTV(t *testing.T) {
 	t.Parallel()
-	if _, err := b.FlexibleLoanAdjustLTV(context.Background(), currency.EMPTYCODE, currency.BTC, 1, true); !errors.Is(err, errLoanCoinMustBeSet) {
+	if _, err := b.FlexibleLoanAdjustLTV(t.Context(), currency.EMPTYCODE, currency.BTC, 1, true); !errors.Is(err, errLoanCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errLoanCoinMustBeSet)
 	}
-	if _, err := b.FlexibleLoanAdjustLTV(context.Background(), currency.USDT, currency.EMPTYCODE, 1, true); !errors.Is(err, errCollateralCoinMustBeSet) {
+	if _, err := b.FlexibleLoanAdjustLTV(t.Context(), currency.USDT, currency.EMPTYCODE, 1, true); !errors.Is(err, errCollateralCoinMustBeSet) {
 		t.Errorf("received %v, expected %v", err, errCollateralCoinMustBeSet)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	if _, err := b.FlexibleLoanAdjustLTV(context.Background(), currency.USDT, currency.BTC, 1, true); err != nil {
+	if _, err := b.FlexibleLoanAdjustLTV(t.Context(), currency.USDT, currency.BTC, 1, true); err != nil {
 		t.Error(err)
 	}
 }
@@ -3387,7 +3386,7 @@ func TestFlexibleLoanAdjustLTV(t *testing.T) {
 func TestFlexibleLoanLTVAdjustmentHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleLoanLTVAdjustmentHistory(context.Background(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
+	if _, err := b.FlexibleLoanLTVAdjustmentHistory(t.Context(), currency.EMPTYCODE, currency.EMPTYCODE, time.Time{}, time.Time{}, 0, 0); err != nil {
 		t.Error(err)
 	}
 }
@@ -3395,7 +3394,7 @@ func TestFlexibleLoanLTVAdjustmentHistory(t *testing.T) {
 func TestFlexibleLoanAssetsData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleLoanAssetsData(context.Background(), currency.EMPTYCODE); err != nil {
+	if _, err := b.FlexibleLoanAssetsData(t.Context(), currency.EMPTYCODE); err != nil {
 		t.Error(err)
 	}
 }
@@ -3403,26 +3402,26 @@ func TestFlexibleLoanAssetsData(t *testing.T) {
 func TestFlexibleCollateralAssetsData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	if _, err := b.FlexibleCollateralAssetsData(context.Background(), currency.EMPTYCODE); err != nil {
+	if _, err := b.FlexibleCollateralAssetsData(t.Context(), currency.EMPTYCODE); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := b.GetFuturesContractDetails(t.Context(), asset.Spot)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.Futures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.Futures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.CoinMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.CoinMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3430,19 +3429,19 @@ func TestGetFuturesContractDetails(t *testing.T) {
 
 func TestGetFundingRateInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFundingRateInfo(context.Background())
+	_, err := b.GetFundingRateInfo(t.Context())
 	assert.NoError(t, err)
 }
 
 func TestUGetFundingRateInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.UGetFundingRateInfo(context.Background())
+	_, err := b.UGetFundingRateInfo(t.Context())
 	assert.NoError(t, err)
 }
 
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
-	resp, err := b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.USDTMarginedFutures,
@@ -3450,7 +3449,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.NewCode("BTCUSD").Item,
 		Quote: currency.PERP.Item,
 		Asset: asset.CoinMarginedFutures,
@@ -3458,7 +3457,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	_, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.Spot,
@@ -3473,7 +3472,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/binance/ratelimit_test.go
+++ b/exchanges/binance/ratelimit_test.go
@@ -44,7 +44,7 @@ func TestRateLimit_Limit(t *testing.T) {
 				t.Fatalf("incorrect limit applied.\nexp: %v\ngot: %v", exp, got)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if !tt.Deadline.IsZero() {
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithDeadline(ctx, tt.Deadline)
@@ -74,7 +74,7 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if err := rl.InitiateRateLimit(context.Background(), tt); err != nil {
+			if err := rl.InitiateRateLimit(t.Context(), tt); err != nil {
 				t.Fatalf("error applying rate limit: %v", err)
 			}
 		})

--- a/exchanges/binanceus/binanceus_test.go
+++ b/exchanges/binanceus/binanceus_test.go
@@ -1,7 +1,6 @@
 package binanceus
 
 import (
-	"context"
 	"errors"
 	"log"
 	"os"
@@ -68,7 +67,7 @@ func TestMain(m *testing.M) {
 
 func TestServerTime(t *testing.T) {
 	t.Parallel()
-	if _, er := bi.GetServerTime(context.Background(), asset.Spot); er != nil {
+	if _, er := bi.GetServerTime(t.Context(), asset.Spot); er != nil {
 		t.Error("Binanceus SystemTime() error", er)
 	}
 }
@@ -76,14 +75,14 @@ func TestServerTime(t *testing.T) {
 func TestServerStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetSystemStatus(context.Background()); er != nil {
+	if _, er := bi.GetSystemStatus(t.Context()); er != nil {
 		t.Error("Binanceus GetSystemStatus() error", er)
 	}
 }
 
 func TestGetExchangeInfo(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetExchangeInfo(context.Background())
+	_, err := bi.GetExchangeInfo(t.Context())
 	if err != nil {
 		t.Error("Binanceus GetExchangeInfo() error", err)
 	}
@@ -91,7 +90,7 @@ func TestGetExchangeInfo(t *testing.T) {
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	r, err := bi.UpdateTicker(context.Background(), testPairMapping, asset.Spot)
+	r, err := bi.UpdateTicker(t.Context(), testPairMapping, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +101,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := bi.UpdateTickers(context.Background(), asset.Spot)
+	err := bi.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,7 +109,7 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestUpdateOrderBook(t *testing.T) {
 	t.Parallel()
-	_, er := bi.UpdateOrderbook(context.Background(), testPairMapping, asset.Spot)
+	_, er := bi.UpdateOrderbook(t.Context(), testPairMapping, asset.Spot)
 	if er != nil {
 		t.Error("Binanceus UpdateOrderBook() error", er)
 	}
@@ -119,7 +118,7 @@ func TestUpdateOrderBook(t *testing.T) {
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, err := bi.FetchTradablePairs(context.Background(), asset.Spot)
+	_, err := bi.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error("Binanceus FetchTradablePairs() error", err)
 	}
@@ -127,7 +126,7 @@ func TestFetchTradablePairs(t *testing.T) {
 
 func TestUpdateTradablePairs(t *testing.T) {
 	t.Parallel()
-	err := bi.UpdateTradablePairs(context.Background(), false)
+	err := bi.UpdateTradablePairs(t.Context(), false)
 	if err != nil {
 		t.Error("Binanceus UpdateTradablePairs() error", err)
 	}
@@ -136,7 +135,7 @@ func TestUpdateTradablePairs(t *testing.T) {
 func TestUpdateAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, err := bi.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := bi.UpdateAccountInfo(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error("Binanceus UpdateAccountInfo() error", err)
 	}
@@ -145,7 +144,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
 	pair := currency.Pair{Base: currency.BTC, Quote: currency.USD}
-	_, err := bi.GetRecentTrades(context.Background(), pair, asset.Spot)
+	_, err := bi.GetRecentTrades(t.Context(), pair, asset.Spot)
 	if err != nil {
 		t.Error("Binanceus GetRecentTrades() error", err)
 	}
@@ -154,7 +153,7 @@ func TestGetRecentTrades(t *testing.T) {
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
 	pair := currency.Pair{Base: currency.BTC, Quote: currency.USD}
-	_, err := bi.GetHistoricTrades(context.Background(), pair, asset.Spot, time.Time{}, time.Time{})
+	_, err := bi.GetHistoricTrades(t.Context(), pair, asset.Spot, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error("Binanceus GetHistoricTrades() error", err)
 	}
@@ -163,14 +162,14 @@ func TestGetHistoricTrades(t *testing.T) {
 func TestGetFeeByType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetFeeByType(context.Background(), &exchange.FeeBuilder{
+	if _, er := bi.GetFeeByType(t.Context(), &exchange.FeeBuilder{
 		IsMaker: true,
 		Pair:    currency.NewPair(currency.USD, currency.BTC),
 		FeeType: exchange.CryptocurrencyTradeFee,
 	}); er != nil {
 		t.Error("Binanceus GetFeeByType() error", er)
 	}
-	if _, er := bi.GetFeeByType(context.Background(), &exchange.FeeBuilder{
+	if _, er := bi.GetFeeByType(t.Context(), &exchange.FeeBuilder{
 		IsMaker: true,
 		Pair:    currency.NewPair(currency.USD, currency.BTC),
 		FeeType: exchange.CryptocurrencyWithdrawalFee,
@@ -195,7 +194,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "binanceSamOrder",
 		Exchange:  bi.Name,
 	}
-	response, err := bi.SubmitOrder(context.Background(), orderSubmission)
+	response, err := bi.SubmitOrder(t.Context(), orderSubmission)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(bi) && err != nil && strings.Contains(err.Error(), "{\"code\":-1013,\"msg\":\"Market is closed.\""):
 		t.Skip("Binanceus SubmitOrder() Market is Closed")
@@ -212,18 +211,18 @@ func TestCancelOrder(t *testing.T) {
 	t.Parallel()
 
 	pair := currency.NewPair(currency.BTC, currency.USD)
-	err := bi.CancelOrder(context.Background(), &order.Cancel{
+	err := bi.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.Spot,
 		OrderID:   "1337",
 	})
 	require.ErrorIs(t, err, errMissingCurrencySymbol)
-	err = bi.CancelOrder(context.Background(), &order.Cancel{
+	err = bi.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.Futures,
 		OrderID:   "69",
 		Pair:      pair,
 	})
 	require.ErrorIs(t, err, asset.ErrNotSupported)
-	err = bi.CancelOrder(context.Background(), &order.Cancel{
+	err = bi.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.Spot,
 		OrderID:   "",
 		Pair:      pair,
@@ -236,7 +235,7 @@ func TestCancelOrder(t *testing.T) {
 		Pair:      pair,
 		AssetType: asset.Spot,
 	}
-	err = bi.CancelOrder(context.Background(), cancellationOrder)
+	err = bi.CancelOrder(t.Context(), cancellationOrder)
 	assert.ErrorContains(t, err, "Unknown order sent.")
 }
 
@@ -247,7 +246,7 @@ func TestCancelAllOrders(t *testing.T) {
 		Pair:      currency.NewPair(currency.LTC, currency.BTC),
 		AssetType: asset.Spot,
 	}
-	if _, err := bi.CancelAllOrders(context.Background(), orderCancellation); err != nil {
+	if _, err := bi.CancelAllOrders(t.Context(), orderCancellation); err != nil {
 		t.Error("Binanceus CancelAllOrders() error", err)
 	}
 }
@@ -255,7 +254,7 @@ func TestCancelAllOrders(t *testing.T) {
 func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	tradablePairs, err := bi.FetchTradablePairs(context.Background(),
+	tradablePairs, err := bi.FetchTradablePairs(t.Context(),
 		asset.Spot)
 	if err != nil {
 		t.Error(err)
@@ -263,7 +262,7 @@ func TestGetOrderInfo(t *testing.T) {
 	if len(tradablePairs) == 0 {
 		t.Fatal("Binanceus GetOrderInfo() no tradable pairs")
 	}
-	_, err = bi.GetOrderInfo(context.Background(),
+	_, err = bi.GetOrderInfo(t.Context(),
 		"123",
 		tradablePairs[0],
 		asset.Spot)
@@ -275,11 +274,11 @@ func TestGetOrderInfo(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, err := bi.GetDepositAddress(context.Background(), currency.EMPTYCODE, "", currency.BNB.String())
+	_, err := bi.GetDepositAddress(t.Context(), currency.EMPTYCODE, "", currency.BNB.String())
 	if err != nil && !errors.Is(err, errMissingRequiredArgumentCoin) {
 		t.Errorf("Binanceus GetDepositAddress() expecting %v, but found %v", errMissingRequiredArgumentCoin, err)
 	}
-	if _, err := bi.GetDepositAddress(context.Background(), currency.USDT, "", currency.BNB.String()); err != nil {
+	if _, err := bi.GetDepositAddress(t.Context(), currency.USDT, "", currency.BNB.String()); err != nil {
 		t.Error("Binanceus GetDepositAddress() error", err)
 	}
 }
@@ -287,7 +286,7 @@ func TestGetDepositAddress(t *testing.T) {
 func TestGetWithdrawalHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, bi, canManipulateRealOrders)
-	_, err := bi.GetWithdrawalsHistory(context.Background(), currency.ETH, asset.Spot)
+	_, err := bi.GetWithdrawalsHistory(t.Context(), currency.ETH, asset.Spot)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(bi) && err != nil:
 		t.Error("Binanceus GetWithdrawalsHistory() error", err)
@@ -299,7 +298,7 @@ func TestGetWithdrawalHistory(t *testing.T) {
 func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	if _, er := bi.WithdrawFiat(context.Background(), &WithdrawFiatRequestParams{
+	if _, er := bi.WithdrawFiat(t.Context(), &WithdrawFiatRequestParams{
 		PaymentChannel: "SILVERGATE",
 		PaymentAccount: "myaccount",
 		PaymentMethod:  "SEN",
@@ -317,7 +316,7 @@ func TestGetActiveOrders(t *testing.T) {
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
 	}
-	_, err := bi.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := bi.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if err != nil {
 		t.Error("Binanceus GetActiveOrders() error", err)
 	}
@@ -336,14 +335,14 @@ func TestWithdraw(t *testing.T) {
 			Chain:   "BSC",
 		},
 	}
-	_, err := bi.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)
+	_, err := bi.WithdrawCryptocurrencyFunds(t.Context(), &withdrawCryptoRequest)
 	if err != nil && !strings.EqualFold(errAmountValueMustBeGreaterThan0.Error(), err.Error()) {
 		t.Errorf("Binanceus Withdraw() expecting %v, but found %v", errAmountValueMustBeGreaterThan0, err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(bi) && err == nil {
 		t.Error("Binanceus Withdraw() expecting an error when no keys are set")
 	}
 	withdrawCryptoRequest.Amount = 1
-	_, err = bi.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)
+	_, err = bi.WithdrawCryptocurrencyFunds(t.Context(), &withdrawCryptoRequest)
 	if err != nil && !strings.Contains(err.Error(), "You are not authorized to execute this request.") {
 		t.Error("Binanceus WithdrawCryptocurrencyFunds() error", err)
 	}
@@ -358,7 +357,7 @@ func TestGetFee(t *testing.T) {
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
 	}
-	_, er := bi.GetFeeByType(context.Background(), feeBuilder)
+	_, er := bi.GetFeeByType(t.Context(), feeBuilder)
 	if er != nil {
 		t.Fatal("Binanceus GetFeeByType() error", er)
 	}
@@ -368,7 +367,7 @@ func TestGetFee(t *testing.T) {
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
 	}
-	_, er = bi.GetFeeByType(context.Background(), withdrawalFeeBuilder)
+	_, er = bi.GetFeeByType(t.Context(), withdrawalFeeBuilder)
 	if er != nil {
 		t.Fatal("Binanceus GetFeeByType() error", er)
 	}
@@ -378,7 +377,7 @@ func TestGetFee(t *testing.T) {
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
 	}
-	_, er = bi.GetFeeByType(context.Background(), offlineFeeTradeBuilder)
+	_, er = bi.GetFeeByType(t.Context(), offlineFeeTradeBuilder)
 	if er != nil {
 		t.Fatal("Binanceus GetFeeByType() error", er)
 	}
@@ -390,12 +389,12 @@ func TestGetHistoricCandles(t *testing.T) {
 	startTime := time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2021, 2, 15, 0, 0, 0, 0, time.UTC)
 
-	_, err := bi.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.Interval(time.Hour*5), startTime, endTime)
+	_, err := bi.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.Interval(time.Hour*5), startTime, endTime)
 	if !errors.Is(err, kline.ErrRequestExceedsExchangeLimits) {
 		t.Fatalf("received: '%v', but expected: '%v'", err, kline.ErrRequestExceedsExchangeLimits)
 	}
 
-	_, err = bi.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.OneDay, startTime, endTime)
+	_, err = bi.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.OneDay, startTime, endTime)
 	if err != nil {
 		t.Error("Binanceus GetHistoricCandles() error", err)
 	}
@@ -407,7 +406,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	startTime := time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2021, 2, 15, 0, 0, 0, 0, time.UTC)
 
-	_, err := bi.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.OneDay, startTime, endTime)
+	_, err := bi.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.OneDay, startTime, endTime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +414,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	startTime = time.Now().Add(-time.Hour * 30)
 	endTime = time.Now()
 
-	_, err = bi.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.FourHour, startTime, endTime)
+	_, err = bi.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.FourHour, startTime, endTime)
 	if err != nil {
 		t.Error("Binanceus GetHistoricCandlesExtended() error", err)
 	}
@@ -426,7 +425,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 // TestGetMostRecentTrades -- test most recent trades end-point
 func TestGetMostRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetMostRecentTrades(context.Background(), RecentTradeRequestParams{
+	_, err := bi.GetMostRecentTrades(t.Context(), RecentTradeRequestParams{
 		Symbol: currency.NewPair(currency.BTC, currency.USDT),
 		Limit:  15,
 	})
@@ -438,7 +437,7 @@ func TestGetMostRecentTrades(t *testing.T) {
 func TestGetHistoricalTrades(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, err := bi.GetHistoricalTrades(context.Background(), HistoricalTradeParams{
+	_, err := bi.GetHistoricalTrades(t.Context(), HistoricalTradeParams{
 		Symbol: "BTCUSDT",
 		Limit:  5,
 		FromID: 0,
@@ -450,7 +449,7 @@ func TestGetHistoricalTrades(t *testing.T) {
 
 func TestGetAggregateTrades(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetAggregateTrades(context.Background(),
+	_, err := bi.GetAggregateTrades(t.Context(),
 		&AggregatedTradeRequestParams{
 			Symbol: currency.NewPair(currency.BTC, currency.USDT),
 			Limit:  5,
@@ -462,7 +461,7 @@ func TestGetAggregateTrades(t *testing.T) {
 
 func TestGetOrderBookDepth(t *testing.T) {
 	t.Parallel()
-	_, er := bi.GetOrderBookDepth(context.Background(), &OrderBookDataRequestParams{
+	_, er := bi.GetOrderBookDepth(t.Context(), &OrderBookDataRequestParams{
 		Symbol: currency.NewPair(currency.BTC, currency.USDT),
 		Limit:  1000,
 	})
@@ -473,7 +472,7 @@ func TestGetOrderBookDepth(t *testing.T) {
 
 func TestGetCandlestickData(t *testing.T) {
 	t.Parallel()
-	_, er := bi.GetSpotKline(context.Background(), &KlinesRequestParams{
+	_, er := bi.GetSpotKline(t.Context(), &KlinesRequestParams{
 		Symbol:    currency.NewPair(currency.BTC, currency.USDT),
 		Interval:  kline.FiveMin.Short(),
 		Limit:     24,
@@ -487,7 +486,7 @@ func TestGetCandlestickData(t *testing.T) {
 
 func TestGetPriceDatas(t *testing.T) {
 	t.Parallel()
-	_, er := bi.GetPriceDatas(context.Background())
+	_, er := bi.GetPriceDatas(t.Context())
 	if er != nil {
 		t.Error("Binanceus GetPriceDatas() error", er)
 	}
@@ -495,7 +494,7 @@ func TestGetPriceDatas(t *testing.T) {
 
 func TestGetSinglePriceData(t *testing.T) {
 	t.Parallel()
-	_, er := bi.GetSinglePriceData(context.Background(), currency.Pair{
+	_, er := bi.GetSinglePriceData(t.Context(), currency.Pair{
 		Base:  currency.BTC,
 		Quote: currency.USDT,
 	})
@@ -506,7 +505,7 @@ func TestGetSinglePriceData(t *testing.T) {
 
 func TestGetAveragePrice(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetAveragePrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := bi.GetAveragePrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetAveragePrice() error", err)
 	}
@@ -514,7 +513,7 @@ func TestGetAveragePrice(t *testing.T) {
 
 func TestGetBestPrice(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetBestPrice(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := bi.GetBestPrice(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binanceus GetBestPrice() error", err)
 	}
@@ -522,7 +521,7 @@ func TestGetBestPrice(t *testing.T) {
 
 func TestGetPriceChangeStats(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetPriceChangeStats(context.Background(), currency.NewPair(currency.BTC, currency.USDT))
+	_, err := bi.GetPriceChangeStats(t.Context(), currency.NewPair(currency.BTC, currency.USDT))
 	if err != nil {
 		t.Error("Binance GetPriceChangeStats() error", err)
 	}
@@ -530,7 +529,7 @@ func TestGetPriceChangeStats(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	_, err := bi.GetTickers(context.Background())
+	_, err := bi.GetTickers(t.Context())
 	if err != nil {
 		t.Error("Binance TestGetTickers error", err)
 	}
@@ -539,7 +538,7 @@ func TestGetTickers(t *testing.T) {
 func TestGetAccount(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetAccount(context.Background())
+	_, er := bi.GetAccount(t.Context())
 	if er != nil {
 		t.Error("Binanceus GetAccount() error", er)
 	}
@@ -548,7 +547,7 @@ func TestGetAccount(t *testing.T) {
 func TestGetUserAccountStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetUserAccountStatus(context.Background(), 3000)
+	_, er := bi.GetUserAccountStatus(t.Context(), 3000)
 	if er != nil {
 		t.Error("Binanceus GetUserAccountStatus() error", er)
 	}
@@ -557,7 +556,7 @@ func TestGetUserAccountStatus(t *testing.T) {
 func TestGetUserAPITradingStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetUserAPITradingStatus(context.Background(), 3000)
+	_, er := bi.GetUserAPITradingStatus(t.Context(), 3000)
 	if er != nil {
 		t.Error("Binanceus GetUserAPITradingStatus() error", er)
 	}
@@ -566,7 +565,7 @@ func TestGetUserAPITradingStatus(t *testing.T) {
 func TestGetTradeFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetTradeFee(context.Background(), 3000, "BTC-USDT")
+	_, er := bi.GetTradeFee(t.Context(), 3000, "BTC-USDT")
 	if er != nil {
 		t.Error("Binanceus GetTradeFee() error", er)
 	}
@@ -575,7 +574,7 @@ func TestGetTradeFee(t *testing.T) {
 func TestGetAssetDistributionHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetAssetDistributionHistory(context.Background(), "", 0, 0, 3000)
+	_, er := bi.GetAssetDistributionHistory(t.Context(), "", 0, 0, 3000)
 	if er != nil {
 		t.Error("Binanceus GetAssetDistributionHistory() error", er)
 	}
@@ -584,7 +583,7 @@ func TestGetAssetDistributionHistory(t *testing.T) {
 func TestGetMasterAccountTotalUSDValue(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetMasterAccountTotalUSDValue(context.Background(), "", 0, 0); er != nil && !strings.Contains(er.Error(), "Sub-account function is not enabled.") {
+	if _, er := bi.GetMasterAccountTotalUSDValue(t.Context(), "", 0, 0); er != nil && !strings.Contains(er.Error(), "Sub-account function is not enabled.") {
 		t.Errorf("Binanceus GetMasterAccountTotalUSDValue() expecting %s, but found %v", "Sub-account function is not enabled.", er)
 	}
 }
@@ -592,10 +591,10 @@ func TestGetMasterAccountTotalUSDValue(t *testing.T) {
 func TestGetSubaccountStatusList(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetSubaccountStatusList(context.Background(), ""); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
+	if _, er := bi.GetSubaccountStatusList(t.Context(), ""); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
 		t.Errorf("Binanceus GetSubaccountStatusList() expecting %v, but found %v", errMissingSubAccountEmail, er)
 	}
-	if _, er := bi.GetSubaccountStatusList(context.Background(), "someone@thrasher.corp"); er != nil && !strings.Contains(er.Error(), "Sub-account function is not enabled.") {
+	if _, er := bi.GetSubaccountStatusList(t.Context(), "someone@thrasher.corp"); er != nil && !strings.Contains(er.Error(), "Sub-account function is not enabled.") {
 		t.Errorf("Binanceus GetSubaccountStatusList() expecting %s, but found %v", "Sub-account function is not enabled.", er)
 	}
 }
@@ -603,15 +602,15 @@ func TestGetSubaccountStatusList(t *testing.T) {
 func TestGetSubAccountDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetSubAccountDepositAddress(context.Background(), SubAccountDepositAddressRequestParams{}); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
+	if _, er := bi.GetSubAccountDepositAddress(t.Context(), SubAccountDepositAddressRequestParams{}); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
 		t.Errorf("Binanceus GetSubAccountDepositAddress() %v, but found %v", errMissingSubAccountEmail, er)
 	}
-	if _, er := bi.GetSubAccountDepositAddress(context.Background(), SubAccountDepositAddressRequestParams{
+	if _, er := bi.GetSubAccountDepositAddress(t.Context(), SubAccountDepositAddressRequestParams{
 		Email: "someone@thrasher.io",
 	}); er != nil && !errors.Is(er, errMissingCurrencyCoin) {
 		t.Errorf("Binanceus GetSubAccountDepositAddress() %v, but found %v", errMissingCurrencyCoin, er)
 	}
-	if _, er := bi.GetSubAccountDepositAddress(context.Background(), SubAccountDepositAddressRequestParams{
+	if _, er := bi.GetSubAccountDepositAddress(t.Context(), SubAccountDepositAddressRequestParams{
 		Email: "someone@thrasher.io",
 		Coin:  currency.BTC,
 	}); er != nil && !strings.Contains(er.Error(), "This parent sub have no relation") {
@@ -639,10 +638,10 @@ func TestGetSubAccountDepositHistory(t *testing.T) {
 		t.Error("Binanceus Decerializing to SubAccountDepositItem error", er)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetSubAccountDepositHistory(context.Background(), "", currency.BTC, 1, time.Time{}, time.Time{}, 0, 0); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
+	if _, er := bi.GetSubAccountDepositHistory(t.Context(), "", currency.BTC, 1, time.Time{}, time.Time{}, 0, 0); er != nil && !errors.Is(er, errMissingSubAccountEmail) {
 		t.Errorf("Binanceus GetSubAccountDepositHistory() expecting %v, but found %v", errMissingSubAccountEmail, er)
 	}
-	if _, er := bi.GetSubAccountDepositHistory(context.Background(), "someone@thrasher.io", currency.BTC, 1, time.Time{}, time.Time{}, 0, 0); er != nil && !strings.Contains(er.Error(), "This parent sub have no relation") {
+	if _, er := bi.GetSubAccountDepositHistory(t.Context(), "someone@thrasher.io", currency.BTC, 1, time.Time{}, time.Time{}, 0, 0); er != nil && !strings.Contains(er.Error(), "This parent sub have no relation") {
 		t.Errorf("Binanceus GetSubAccountDepositHistory() expecting %s, but found %v", "This parent sub have no relation", er)
 	}
 }
@@ -663,7 +662,7 @@ func TestGetSubaccountInformation(t *testing.T) {
 		t.Error("Binanceus decerializing to SubAccount error", er)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetSubaccountInformation(context.Background(), 1, 100, "", "")
+	_, er := bi.GetSubaccountInformation(t.Context(), 1, 100, "", "")
 	if er != nil && !strings.Contains(er.Error(), "Sub-account function is not enabled.") {
 		t.Error("Binanceus GetSubaccountInformation() error", er)
 	}
@@ -688,16 +687,16 @@ func TestGetReferralRewardHistory(t *testing.T) {
 		t.Error("Binanceus decerializing to ReferalRewardHistoryResponse error", er)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetReferralRewardHistory(context.Background(), 9, 5, 50); !errors.Is(er, errInvalidUserBusinessType) {
+	if _, er := bi.GetReferralRewardHistory(t.Context(), 9, 5, 50); !errors.Is(er, errInvalidUserBusinessType) {
 		t.Errorf("Binanceus GetReferralRewardHistory() expecting %v, but found %v", errInvalidUserBusinessType, er)
 	}
-	if _, er := bi.GetReferralRewardHistory(context.Background(), 1, 0, 50); !errors.Is(er, errMissingPageNumber) {
+	if _, er := bi.GetReferralRewardHistory(t.Context(), 1, 0, 50); !errors.Is(er, errMissingPageNumber) {
 		t.Errorf("Binanceus GetReferralRewardHistory() expecting %v, but found %v", errMissingPageNumber, er)
 	}
-	if _, er := bi.GetReferralRewardHistory(context.Background(), 1, 5, 0); !errors.Is(er, errInvalidRowNumber) {
+	if _, er := bi.GetReferralRewardHistory(t.Context(), 1, 5, 0); !errors.Is(er, errInvalidRowNumber) {
 		t.Errorf("Binanceus GetReferralRewardHistory() expecting %v, but found %v", errInvalidRowNumber, er)
 	}
-	if _, er := bi.GetReferralRewardHistory(context.Background(), 1, 5, 50); er != nil {
+	if _, er := bi.GetReferralRewardHistory(t.Context(), 1, 5, 50); er != nil {
 		t.Error("Binanceus GetReferralRewardHistory() error", er)
 	}
 }
@@ -705,23 +704,23 @@ func TestGetReferralRewardHistory(t *testing.T) {
 func TestGetSubaccountTransferHistory(t *testing.T) {
 	t.Parallel()
 
-	_, err := bi.GetSubaccountTransferHistory(context.Background(), "", 0, 0, 0, 0)
+	_, err := bi.GetSubaccountTransferHistory(t.Context(), "", 0, 0, 0, 0)
 	assert.ErrorIs(t, err, errNotValidEmailAddress)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
 
-	_, err = bi.GetSubaccountTransferHistory(context.Background(), "example@golang.org", 0, 0, 0, 0)
+	_, err = bi.GetSubaccountTransferHistory(t.Context(), "example@golang.org", 0, 0, 0, 0)
 	assert.Error(t, err, "GetSubaccountTransferHistory should return an error on a bogus email")
 }
 
 func TestExecuteSubAccountTransfer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, er := bi.ExecuteSubAccountTransfer(context.Background(), &SubAccountTransferRequestParams{})
+	_, er := bi.ExecuteSubAccountTransfer(t.Context(), &SubAccountTransferRequestParams{})
 	if !errors.Is(er, errUnacceptableSenderEmail) {
 		t.Errorf("binanceus error: expected %v, but found %v", errUnacceptableSenderEmail, er)
 	}
-	_, er = bi.ExecuteSubAccountTransfer(context.Background(), &SubAccountTransferRequestParams{
+	_, er = bi.ExecuteSubAccountTransfer(t.Context(), &SubAccountTransferRequestParams{
 		FromEmail: "fromemail@thrasher.io",
 		ToEmail:   "toemail@threasher.io",
 		Asset:     "BTC",
@@ -735,11 +734,11 @@ func TestExecuteSubAccountTransfer(t *testing.T) {
 func TestGetSubaccountAssets(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetSubaccountAssets(context.Background(), "")
+	_, er := bi.GetSubaccountAssets(t.Context(), "")
 	if !errors.Is(er, errNotValidEmailAddress) {
 		t.Errorf("Binanceus GetSubaccountAssets() expected %v, but found %v", er, errNotValidEmailAddress)
 	}
-	_, er = bi.GetSubaccountAssets(context.Background(), "subaccount@thrasher.io")
+	_, er = bi.GetSubaccountAssets(t.Context(), "subaccount@thrasher.io")
 	if er != nil && !strings.Contains(er.Error(), "This account does not exist.") {
 		t.Fatal("Binanceus GetSubaccountAssets() error", er)
 	}
@@ -748,7 +747,7 @@ func TestGetSubaccountAssets(t *testing.T) {
 func TestGetOrderRateLimits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetOrderRateLimits(context.Background(), 0)
+	_, er := bi.GetOrderRateLimits(t.Context(), 0)
 	if er != nil {
 		t.Error("Binanceus GetOrderRateLimits() error", er)
 	}
@@ -785,7 +784,7 @@ func TestNewOrderTest(t *testing.T) {
 		Quantity:    100000,
 		TimeInForce: BinanceRequestParamsTimeGTC,
 	}
-	_, err := bi.NewOrderTest(context.Background(), req)
+	_, err := bi.NewOrderTest(t.Context(), req)
 	if err != nil {
 		t.Error("Binanceus NewOrderTest() error", err)
 	}
@@ -796,7 +795,7 @@ func TestNewOrderTest(t *testing.T) {
 		Price:         0.0045,
 		QuoteOrderQty: 10,
 	}
-	_, err = bi.NewOrderTest(context.Background(), req)
+	_, err = bi.NewOrderTest(t.Context(), req)
 	if err != nil {
 		t.Error("NewOrderTest() error", err)
 	}
@@ -813,7 +812,7 @@ func TestNewOrder(t *testing.T) {
 		Quantity:    100000,
 		TimeInForce: BinanceRequestParamsTimeGTC,
 	}
-	if _, err := bi.NewOrder(context.Background(), req); err != nil && !strings.Contains(err.Error(), "Account has insufficient balance for requested action") {
+	if _, err := bi.NewOrder(t.Context(), req); err != nil && !strings.Contains(err.Error(), "Account has insufficient balance for requested action") {
 		t.Error("Binanceus NewOrder() error", err)
 	}
 }
@@ -821,11 +820,11 @@ func TestNewOrder(t *testing.T) {
 func TestGetOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetOrder(context.Background(), &OrderRequestParams{})
+	_, er := bi.GetOrder(t.Context(), &OrderRequestParams{})
 	if !errors.Is(er, errIncompleteArguments) {
 		t.Errorf("Binanceus GetOrder() error expecting %v, but found %v", errIncompleteArguments, er)
 	}
-	_, er = bi.GetOrder(context.Background(), &OrderRequestParams{
+	_, er = bi.GetOrder(t.Context(), &OrderRequestParams{
 		Symbol:            "BTCUSDT",
 		OrigClientOrderID: "something",
 	})
@@ -864,7 +863,7 @@ func TestGetAllOpenOrders(t *testing.T) {
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
 
-	_, er := bi.GetAllOpenOrders(context.Background(), "")
+	_, er := bi.GetAllOpenOrders(t.Context(), "")
 	if er != nil {
 		t.Error("Binanceus GetAllOpenOrders() error", er)
 	}
@@ -873,16 +872,16 @@ func TestGetAllOpenOrders(t *testing.T) {
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 
-	_, err := bi.CancelExistingOrder(context.Background(), &CancelOrderRequestParams{})
+	_, err := bi.CancelExistingOrder(t.Context(), &CancelOrderRequestParams{})
 	assert.ErrorIs(t, err, errMissingCurrencySymbol)
 
-	_, err = bi.CancelExistingOrder(context.Background(), &CancelOrderRequestParams{
+	_, err = bi.CancelExistingOrder(t.Context(), &CancelOrderRequestParams{
 		Symbol: currency.NewBTCUSDT(),
 	})
 	assert.ErrorIs(t, err, errEitherOrderIDOrClientOrderIDIsRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, err = bi.CancelExistingOrder(context.Background(), &CancelOrderRequestParams{
+	_, err = bi.CancelExistingOrder(t.Context(), &CancelOrderRequestParams{
 		Symbol:                currency.NewBTCUSDT(),
 		ClientSuppliedOrderID: "1234",
 	})
@@ -892,11 +891,11 @@ func TestCancelExistingOrder(t *testing.T) {
 func TestCancelOpenOrdersForSymbol(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, er := bi.CancelOpenOrdersForSymbol(context.Background(), "")
+	_, er := bi.CancelOpenOrdersForSymbol(t.Context(), "")
 	if !errors.Is(er, errMissingCurrencySymbol) {
 		t.Errorf("Binanceus CancelOpenOrdersForSymbol() error expecting %v, but found %v", errIncompleteArguments, er)
 	}
-	_, er = bi.CancelOpenOrdersForSymbol(context.Background(), "BTCUSDT")
+	_, er = bi.CancelOpenOrdersForSymbol(t.Context(), "BTCUSDT")
 	if er != nil && !strings.Contains(er.Error(), "Unknown order sent") {
 		t.Error("Binanceus CancelOpenOrdersForSymbol() error", er)
 	}
@@ -907,11 +906,11 @@ func TestCancelOpenOrdersForSymbol(t *testing.T) {
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetTrades(context.Background(), &GetTradesParams{})
+	_, er := bi.GetTrades(t.Context(), &GetTradesParams{})
 	if !errors.Is(er, errIncompleteArguments) {
 		t.Errorf(" Binanceus GetTrades() expecting error %v, but found %v", errIncompleteArguments, er)
 	}
-	_, er = bi.GetTrades(context.Background(), &GetTradesParams{Symbol: "BTCUSDT"})
+	_, er = bi.GetTrades(t.Context(), &GetTradesParams{Symbol: "BTCUSDT"})
 	if er != nil {
 		t.Error("Binanceus GetTrades() error", er)
 	}
@@ -920,7 +919,7 @@ func TestGetTrades(t *testing.T) {
 func TestCreateNewOCOOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, er := bi.CreateNewOCOOrder(context.Background(),
+	_, er := bi.CreateNewOCOOrder(t.Context(),
 		&OCOOrderInputParams{
 			StopPrice: 1000,
 			Side:      order.Buy.String(),
@@ -931,7 +930,7 @@ func TestCreateNewOCOOrder(t *testing.T) {
 		t.Errorf("Binanceus CreatenewOCOOrder() error expected %v, but found %v", errIncompleteArguments, er)
 	}
 	_, er = bi.CreateNewOCOOrder(
-		context.Background(),
+		t.Context(),
 		&OCOOrderInputParams{
 			Symbol:               "XTZUSD",
 			Price:                100,
@@ -976,11 +975,11 @@ func TestGetOCOOrder(t *testing.T) {
 		t.Error("Binanceus decerializing OCOOrderResponse error", er)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetOCOOrder(context.Background(), &GetOCOOrderRequestParams{})
+	_, er := bi.GetOCOOrder(t.Context(), &GetOCOOrderRequestParams{})
 	if !errors.Is(er, errIncompleteArguments) {
 		t.Errorf("Binanceus GetOCOOrder() error  expecting %v, but found %v", errIncompleteArguments, er)
 	}
-	_, er = bi.GetOCOOrder(context.Background(), &GetOCOOrderRequestParams{
+	_, er = bi.GetOCOOrder(t.Context(), &GetOCOOrderRequestParams{
 		OrderListID: "123445",
 	})
 	if er != nil && !strings.Contains(er.Error(), "Order list does not exist.") {
@@ -991,7 +990,7 @@ func TestGetOCOOrder(t *testing.T) {
 func TestGetAllOCOOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetAllOCOOrder(context.Background(), &OCOOrdersRequestParams{})
+	_, er := bi.GetAllOCOOrder(t.Context(), &OCOOrdersRequestParams{})
 	if er != nil {
 		t.Error("Binanceus GetAllOCOOrder() error", er)
 	}
@@ -1000,7 +999,7 @@ func TestGetAllOCOOrder(t *testing.T) {
 func TestGetOpenOCOOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetOpenOCOOrders(context.Background(), 0)
+	_, er := bi.GetOpenOCOOrders(t.Context(), 0)
 	if er != nil {
 		t.Error("Binanceus GetOpenOCOOrders() error", er)
 	}
@@ -1009,7 +1008,7 @@ func TestGetOpenOCOOrders(t *testing.T) {
 func TestCancelOCOOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, er := bi.CancelOCOOrder(context.Background(), &OCOOrdersDeleteRequestParams{})
+	_, er := bi.CancelOCOOrder(t.Context(), &OCOOrdersDeleteRequestParams{})
 	if !errors.Is(er, errIncompleteArguments) {
 		t.Errorf("Binanceus CancelOCOOrder() error expected %v, but found %v", errIncompleteArguments, er)
 	}
@@ -1019,7 +1018,7 @@ func TestCancelOCOOrder(t *testing.T) {
 func TestGetSupportedCoinPairs(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetSupportedCoinPairs(context.Background(), currency.Pair{Base: currency.BTC, Quote: currency.USDT})
+	_, er := bi.GetSupportedCoinPairs(t.Context(), currency.Pair{Base: currency.BTC, Quote: currency.USDT})
 	if er != nil {
 		t.Error("Binanceus GetSupportedCoinPairs() error", er)
 	}
@@ -1028,23 +1027,23 @@ func TestGetSupportedCoinPairs(t *testing.T) {
 func TestRequestForQuote(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.RequestForQuote(context.Background(), &RequestQuoteParams{ToCoin: "BTC", RequestCoin: "USDT", RequestAmount: 1})
+	_, er := bi.RequestForQuote(t.Context(), &RequestQuoteParams{ToCoin: "BTC", RequestCoin: "USDT", RequestAmount: 1})
 	if er != nil && !errors.Is(er, errMissingFromCoinName) {
 		t.Errorf("Binanceus RequestForQuote() expecting %v, but found %v", errMissingFromCoinName, er)
 	}
-	_, er = bi.RequestForQuote(context.Background(), &RequestQuoteParams{FromCoin: "ETH", RequestCoin: "USDT", RequestAmount: 1})
+	_, er = bi.RequestForQuote(t.Context(), &RequestQuoteParams{FromCoin: "ETH", RequestCoin: "USDT", RequestAmount: 1})
 	if er != nil && !errors.Is(er, errMissingToCoinName) {
 		t.Errorf("Binanceus RequestForQuote() expecting %v, but found %v", errMissingToCoinName, er)
 	}
-	_, er = bi.RequestForQuote(context.Background(), &RequestQuoteParams{FromCoin: "ETH", ToCoin: "BTC", RequestCoin: "USDT"})
+	_, er = bi.RequestForQuote(t.Context(), &RequestQuoteParams{FromCoin: "ETH", ToCoin: "BTC", RequestCoin: "USDT"})
 	if er != nil && !errors.Is(er, errMissingRequestAmount) {
 		t.Errorf("Binanceus RequestForQuote() expecting %v, but found %v", errMissingRequestAmount, er)
 	}
-	_, er = bi.RequestForQuote(context.Background(), &RequestQuoteParams{FromCoin: "ETH", ToCoin: "BTC", RequestAmount: 1})
+	_, er = bi.RequestForQuote(t.Context(), &RequestQuoteParams{FromCoin: "ETH", ToCoin: "BTC", RequestAmount: 1})
 	if er != nil && !errors.Is(er, errMissingRequestCoin) {
 		t.Errorf("Binanceus RequestForQuote() expecting %v, but found %v", errMissingRequestCoin, er)
 	}
-	_, er = bi.RequestForQuote(context.Background(), &RequestQuoteParams{FromCoin: "BTC", ToCoin: "USDT", RequestCoin: "BTC", RequestAmount: 1})
+	_, er = bi.RequestForQuote(t.Context(), &RequestQuoteParams{FromCoin: "BTC", ToCoin: "USDT", RequestCoin: "BTC", RequestAmount: 1})
 	if er != nil {
 		t.Error("Binanceus RequestForQuote() error", er)
 	}
@@ -1064,11 +1063,11 @@ func TestPlaceOTCTradeOrder(t *testing.T) {
 	if er != nil {
 		t.Error("Binanceus PlaceOTCTradeOrder() error", er)
 	}
-	_, er = bi.PlaceOTCTradeOrder(context.Background(), "")
+	_, er = bi.PlaceOTCTradeOrder(t.Context(), "")
 	if !errors.Is(er, errMissingQuoteID) {
 		t.Errorf("Binanceus PlaceOTCTradeOrder()  expecting %v, but found %v", errMissingQuoteID, er)
 	}
-	_, er = bi.PlaceOTCTradeOrder(context.Background(), "15848701022")
+	_, er = bi.PlaceOTCTradeOrder(t.Context(), "15848701022")
 	if er != nil && !strings.Contains(er.Error(), "-9000") {
 		t.Error("Binanceus  PlaceOTCTradeOrder() error", er)
 	}
@@ -1095,7 +1094,7 @@ func TestGetOTCTradeOrder(t *testing.T) {
 	if er != nil {
 		t.Error("Binanceus JSON GetOTCTradeOrder() error", er)
 	}
-	_, er = bi.GetOTCTradeOrder(context.Background(), 10002349)
+	_, er = bi.GetOTCTradeOrder(t.Context(), 10002349)
 	if er != nil && !strings.Contains(er.Error(), "status code: 400") {
 		t.Error("Binanceus GetOTCTradeOrder() error ", er)
 	}
@@ -1137,7 +1136,7 @@ func TestGetAllOTCTradeOrders(t *testing.T) {
 	if er != nil {
 		t.Error(er)
 	}
-	_, er = bi.GetAllOTCTradeOrders(context.Background(), &OTCTradeOrderRequestParams{})
+	_, er = bi.GetAllOTCTradeOrders(t.Context(), &OTCTradeOrderRequestParams{})
 	if er != nil {
 		t.Error("Binanceus GetAllOTCTradeOrders() error", er)
 	}
@@ -1165,7 +1164,7 @@ func TestGetAllOCBSTradeOrders(t *testing.T) {
 		t.Error("Binanceus decerializing to OCBSOrder error", er)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetAllOCBSTradeOrders(context.Background(), OCBSOrderRequestParams{}); er != nil {
+	if _, er := bi.GetAllOCBSTradeOrders(t.Context(), OCBSOrderRequestParams{}); er != nil {
 		t.Error("Binanceus GetAllOCBSTradeOrders() error", er)
 	}
 }
@@ -1173,7 +1172,7 @@ func TestGetAllOCBSTradeOrders(t *testing.T) {
 func TestGetAssetFeesAndWalletStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetAssetFeesAndWalletStatus(context.Background())
+	_, er := bi.GetAssetFeesAndWalletStatus(t.Context())
 	if er != nil {
 		t.Error("Binanceus GetAssetFeesAndWalletStatus()  error", er)
 	}
@@ -1182,11 +1181,11 @@ func TestGetAssetFeesAndWalletStatus(t *testing.T) {
 func TestWithdrawCrypto(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi, canManipulateRealOrders)
-	_, er := bi.WithdrawCrypto(context.Background(), &withdraw.Request{})
+	_, er := bi.WithdrawCrypto(t.Context(), &withdraw.Request{})
 	if !errors.Is(er, errMissingRequiredArgumentCoin) {
 		t.Errorf("Binanceus WithdrawCrypto() error expecting %v, but found %v", errMissingRequiredArgumentCoin, er)
 	}
-	if _, er = bi.WithdrawCrypto(context.Background(), &withdraw.Request{
+	if _, er = bi.WithdrawCrypto(t.Context(), &withdraw.Request{
 		Currency: currency.BTC,
 	}); !errors.Is(er, errMissingRequiredArgumentNetwork) {
 		t.Errorf("Binanceus WithdrawCrypto() expecting %v, but found %v", errMissingRequiredArgumentNetwork, er)
@@ -1195,15 +1194,15 @@ func TestWithdrawCrypto(t *testing.T) {
 		Currency: currency.BTC,
 	}
 	params.Crypto.Chain = "BSC"
-	if _, er = bi.WithdrawCrypto(context.Background(), params); !errors.Is(er, errMissingRequiredParameterAddress) {
+	if _, er = bi.WithdrawCrypto(t.Context(), params); !errors.Is(er, errMissingRequiredParameterAddress) {
 		t.Errorf("Binanceus WithdrawCrypto() expecting %v, but found %v", errMissingRequiredParameterAddress, er)
 	}
 	params.Crypto.Address = "1234567"
-	if _, er = bi.WithdrawCrypto(context.Background(), params); !errors.Is(er, errAmountValueMustBeGreaterThan0) {
+	if _, er = bi.WithdrawCrypto(t.Context(), params); !errors.Is(er, errAmountValueMustBeGreaterThan0) {
 		t.Errorf("Binanceus WithdrawCrypto() expecting %v, but found %v", errAmountValueMustBeGreaterThan0, er)
 	}
 	params.Amount = 1
-	if _, er = bi.WithdrawCrypto(context.Background(), params); er != nil && !strings.Contains(er.Error(), "You are not authorized to execute this request.") {
+	if _, er = bi.WithdrawCrypto(t.Context(), params); er != nil && !strings.Contains(er.Error(), "You are not authorized to execute this request.") {
 		t.Error("Binanceus WithdrawCrypto() error", er)
 	}
 }
@@ -1211,7 +1210,7 @@ func TestWithdrawCrypto(t *testing.T) {
 func TestFiatWithdrawalHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.FiatWithdrawalHistory(context.Background(), &FiatWithdrawalRequestParams{
+	_, er := bi.FiatWithdrawalHistory(t.Context(), &FiatWithdrawalRequestParams{
 		FiatCurrency: "USDT",
 	})
 	if er != nil {
@@ -1222,7 +1221,7 @@ func TestFiatWithdrawalHistory(t *testing.T) {
 func TestDepositHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.DepositHistory(context.Background(), currency.USD, 1, time.Time{}, time.Time{}, 0, 100)
+	_, er := bi.DepositHistory(t.Context(), currency.USD, 1, time.Time{}, time.Time{}, 0, 100)
 	if er != nil {
 		t.Error("Binanceus DepositHistory() error", er)
 	}
@@ -1231,7 +1230,7 @@ func TestDepositHistory(t *testing.T) {
 func TestFiatDepositHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.FiatDepositHistory(context.Background(), &FiatWithdrawalRequestParams{})
+	_, er := bi.FiatDepositHistory(t.Context(), &FiatWithdrawalRequestParams{})
 	if er != nil {
 		t.Error("Binanceus FiatDepositHistory() error", er)
 	}
@@ -1247,15 +1246,15 @@ func TestFiatDepositHistory(t *testing.T) {
 func TestWebsocketStreamKey(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	_, er := bi.GetWsAuthStreamKey(context.Background())
+	_, er := bi.GetWsAuthStreamKey(t.Context())
 	if er != nil {
 		t.Error("Binanceus GetWsAuthStreamKey() error", er)
 	}
-	er = bi.MaintainWsAuthStreamKey(context.Background())
+	er = bi.MaintainWsAuthStreamKey(t.Context())
 	if er != nil {
 		t.Error("Binanceus MaintainWsAuthStreamKey() error", er)
 	}
-	er = bi.CloseUserDataStream(context.Background())
+	er = bi.CloseUserDataStream(t.Context())
 	if er != nil {
 		t.Error("Binanceus CloseUserDataStream() error", er)
 	}
@@ -1779,7 +1778,7 @@ func TestWebsocketOutboundAccountPosition(t *testing.T) {
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetAvailableTransferChains(context.Background(), currency.BTC); er != nil {
+	if _, er := bi.GetAvailableTransferChains(t.Context(), currency.BTC); er != nil {
 		t.Error("Binanceus GetAvailableTransferChains() error", er)
 	}
 }
@@ -1787,7 +1786,7 @@ func TestGetAvailableTransferChains(t *testing.T) {
 func TestQuickEnableCryptoWithdrawal(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if er := bi.QuickEnableCryptoWithdrawal(context.Background()); er != nil && !strings.Contains(er.Error(), "unexpected end of JSON input") {
+	if er := bi.QuickEnableCryptoWithdrawal(t.Context()); er != nil && !strings.Contains(er.Error(), "unexpected end of JSON input") {
 		t.Errorf("Binanceus QuickEnableCryptoWithdrawal() expecting %s, but found %v", "unexpected end of JSON input", er)
 	}
 }
@@ -1795,7 +1794,7 @@ func TestQuickEnableCryptoWithdrawal(t *testing.T) {
 func TestQuickDisableCryptoWithdrawal(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if er := bi.QuickDisableCryptoWithdrawal(context.Background()); er != nil && !strings.Contains(er.Error(), "unexpected end of JSON input") {
+	if er := bi.QuickDisableCryptoWithdrawal(t.Context()); er != nil && !strings.Contains(er.Error(), "unexpected end of JSON input") {
 		t.Errorf("Binanceus QuickDisableCryptoWithdrawal() expecting %s, but found %v", "unexpected end of JSON input", er)
 	}
 }
@@ -1803,7 +1802,7 @@ func TestQuickDisableCryptoWithdrawal(t *testing.T) {
 func TestGetUsersSpotAssetSnapshot(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, bi)
-	if _, er := bi.GetUsersSpotAssetSnapshot(context.Background(), time.Time{}, time.Time{}, 10, 6); er != nil {
+	if _, er := bi.GetUsersSpotAssetSnapshot(t.Context(), time.Time{}, time.Time{}, 10, 6); er != nil {
 		t.Error("Binanceus GetUsersSpotAssetSnapshot() error", er)
 	}
 }
@@ -1815,7 +1814,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := bi.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := bi.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := bi.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -2,7 +2,6 @@ package bitfinex
 
 import (
 	"bufio"
-	"context"
 	"errors"
 	"log"
 	"os"
@@ -69,7 +68,7 @@ func TestMain(m *testing.M) {
 func TestGetV2MarginFunding(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetV2MarginFunding(context.Background(), "fUSD", "2", 2)
+	_, err := b.GetV2MarginFunding(t.Context(), "fUSD", "2", 2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -78,15 +77,15 @@ func TestGetV2MarginFunding(t *testing.T) {
 func TestGetV2MarginInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetV2MarginInfo(context.Background(), "base")
+	_, err := b.GetV2MarginInfo(t.Context(), "base")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetV2MarginInfo(context.Background(), "tBTCUSD")
+	_, err = b.GetV2MarginInfo(t.Context(), "tBTCUSD")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetV2MarginInfo(context.Background(), "sym_all")
+	_, err = b.GetV2MarginInfo(t.Context(), "sym_all")
 	if err != nil {
 		t.Error(err)
 	}
@@ -95,7 +94,7 @@ func TestGetV2MarginInfo(t *testing.T) {
 func TestGetAccountInfoV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAccountInfoV2(context.Background())
+	_, err := b.GetAccountInfoV2(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,7 +103,7 @@ func TestGetAccountInfoV2(t *testing.T) {
 func TestGetV2FundingInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetV2FundingInfo(context.Background(), "fUST")
+	_, err := b.GetV2FundingInfo(t.Context(), "fUST")
 	if err != nil {
 		t.Error(err)
 	}
@@ -113,7 +112,7 @@ func TestGetV2FundingInfo(t *testing.T) {
 func TestGetV2Balances(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetV2Balances(context.Background())
+	_, err := b.GetV2Balances(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,7 +120,7 @@ func TestGetV2Balances(t *testing.T) {
 
 func TestGetDerivativeStatusInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetDerivativeStatusInfo(context.Background(), "ALL", "", "", 0, 0)
+	_, err := b.GetDerivativeStatusInfo(t.Context(), "ALL", "", "", 0, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -130,14 +129,14 @@ func TestGetDerivativeStatusInfo(t *testing.T) {
 func TestGetPairs(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetPairs(context.Background(), asset.Binary)
+	_, err := b.GetPairs(t.Context(), asset.Binary)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
 	assets := b.GetAssetTypes(false)
 	for x := range assets {
-		_, err := b.GetPairs(context.Background(), assets[x])
+		_, err := b.GetPairs(t.Context(), assets[x])
 		if err != nil {
 			t.Error(err)
 		}
@@ -158,7 +157,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 		},
 	}
 	for assetItem, pairs := range tests {
-		if err := b.UpdateOrderExecutionLimits(context.Background(), assetItem); err != nil {
+		if err := b.UpdateOrderExecutionLimits(t.Context(), assetItem); err != nil {
 			t.Errorf("Error fetching %s pairs for test: %v", assetItem, err)
 			continue
 		}
@@ -200,7 +199,7 @@ func TestAppendOptionalDelimiter(t *testing.T) {
 
 func TestGetPlatformStatus(t *testing.T) {
 	t.Parallel()
-	result, err := b.GetPlatformStatus(context.Background())
+	result, err := b.GetPlatformStatus(t.Context())
 	if err != nil {
 		t.Errorf("TestGetPlatformStatus error: %s", err)
 	}
@@ -212,7 +211,7 @@ func TestGetPlatformStatus(t *testing.T) {
 
 func TestGetTickerBatch(t *testing.T) {
 	t.Parallel()
-	ticks, err := b.GetTickerBatch(context.Background())
+	ticks, err := b.GetTickerBatch(t.Context())
 	require.NoError(t, err, "GetTickerBatch should not error")
 	require.NotEmpty(t, ticks, "GetTickerBatch should return some ticks")
 	require.Contains(t, ticks, "tBTCUSD", "Ticker batch must contain tBTCUSD")
@@ -223,7 +222,7 @@ func TestGetTickerBatch(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	tick, err := b.GetTicker(context.Background(), "tBTCUSD")
+	tick, err := b.GetTicker(t.Context(), "tBTCUSD")
 	require.NoError(t, err, "GetTicker should not error")
 	checkTradeTick(t, tick)
 }
@@ -288,7 +287,7 @@ func TestTickerFromFundingResp(t *testing.T) {
 
 func TestGetTickerFunding(t *testing.T) {
 	t.Parallel()
-	tick, err := b.GetTicker(context.Background(), "fUSD")
+	tick, err := b.GetTicker(t.Context(), "fUSD")
 	require.NoError(t, err, "GetTicker should not error")
 	checkFundingTick(t, tick)
 }
@@ -319,7 +318,7 @@ func checkFundingTick(tb testing.TB, tick *Ticker) {
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetTrades(context.Background(), "tBTCUSD", 5, 0, 0, false)
+	_, err := b.GetTrades(t.Context(), "tBTCUSD", 5, 0, 0, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -327,27 +326,27 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderbook(context.Background(), "tBTCUSD", "R0", 1)
+	_, err := b.GetOrderbook(t.Context(), "tBTCUSD", "R0", 1)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetOrderbook(context.Background(), "fUSD", "R0", 1)
+	_, err = b.GetOrderbook(t.Context(), "fUSD", "R0", 1)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetOrderbook(context.Background(), "tBTCUSD", "P0", 1)
+	_, err = b.GetOrderbook(t.Context(), "tBTCUSD", "P0", 1)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetOrderbook(context.Background(), "fUSD", "P0", 1)
+	_, err = b.GetOrderbook(t.Context(), "fUSD", "P0", 1)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetOrderbook(context.Background(), "tLINK:UST", "P0", 1)
+	_, err = b.GetOrderbook(t.Context(), "tLINK:UST", "P0", 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -355,7 +354,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetStats(context.Background(), "btcusd")
+	_, err := b.GetStats(t.Context(), "btcusd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -363,7 +362,7 @@ func TestGetStats(t *testing.T) {
 
 func TestGetFundingBook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFundingBook(context.Background(), "usd")
+	_, err := b.GetFundingBook(t.Context(), "usd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -371,7 +370,7 @@ func TestGetFundingBook(t *testing.T) {
 
 func TestGetLends(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLends(context.Background(), "usd", nil)
+	_, err := b.GetLends(t.Context(), "usd", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -381,7 +380,7 @@ func TestGetCandles(t *testing.T) {
 	t.Parallel()
 	e := time.Now().Add(-time.Hour * 2).Truncate(time.Hour)
 	s := e.Add(-time.Hour * 4)
-	_, err := b.GetCandles(context.Background(), "fUST", "1D", s.UnixMilli(), e.UnixMilli(), 10000, true)
+	_, err := b.GetCandles(t.Context(), "fUST", "1D", s.UnixMilli(), e.UnixMilli(), 10000, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,12 +389,12 @@ func TestGetCandles(t *testing.T) {
 func TestGetLeaderboard(t *testing.T) {
 	t.Parallel()
 	// Test invalid key
-	_, err := b.GetLeaderboard(context.Background(), "", "", "", 0, 0, "", "")
+	_, err := b.GetLeaderboard(t.Context(), "", "", "", 0, 0, "", "")
 	if err == nil {
 		t.Error("an error should have been thrown for an invalid key")
 	}
 	// Test default
-	_, err = b.GetLeaderboard(context.Background(),
+	_, err = b.GetLeaderboard(t.Context(),
 		LeaderboardUnrealisedProfitInception,
 		"1M",
 		"tGLOBAL:USD",
@@ -408,7 +407,7 @@ func TestGetLeaderboard(t *testing.T) {
 	}
 	// Test params
 	var result []LeaderboardEntry
-	result, err = b.GetLeaderboard(context.Background(),
+	result, err = b.GetLeaderboard(t.Context(),
 		LeaderboardUnrealisedProfitInception,
 		"1M",
 		"tGLOBAL:USD",
@@ -428,7 +427,7 @@ func TestGetAccountFees(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := b.UpdateAccountInfo(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error("GetAccountInfo error", err)
 	}
@@ -437,7 +436,7 @@ func TestGetAccountFees(t *testing.T) {
 func TestGetWithdrawalFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWithdrawalFees(context.Background())
+	_, err := b.GetWithdrawalFees(t.Context())
 	if err != nil {
 		t.Error("GetAccountInfo error", err)
 	}
@@ -446,7 +445,7 @@ func TestGetWithdrawalFee(t *testing.T) {
 func TestGetAccountSummary(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAccountSummary(context.Background())
+	_, err := b.GetAccountSummary(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -455,17 +454,17 @@ func TestGetAccountSummary(t *testing.T) {
 func TestNewDeposit(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.NewDeposit(context.Background(), "blabla", "testwallet", 0)
+	_, err := b.NewDeposit(t.Context(), "blabla", "testwallet", 0)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.NewDeposit(context.Background(), "bitcoin", "testwallet", 0)
+	_, err = b.NewDeposit(t.Context(), "bitcoin", "testwallet", 0)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.NewDeposit(context.Background(), "ripple", "", 0)
+	_, err = b.NewDeposit(t.Context(), "ripple", "", 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -474,7 +473,7 @@ func TestNewDeposit(t *testing.T) {
 func TestGetKeyPermissions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetKeyPermissions(context.Background())
+	_, err := b.GetKeyPermissions(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +482,7 @@ func TestGetKeyPermissions(t *testing.T) {
 func TestGetMarginInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetMarginInfo(context.Background())
+	_, err := b.GetMarginInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -492,7 +491,7 @@ func TestGetMarginInfo(t *testing.T) {
 func TestGetAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAccountBalance(context.Background())
+	_, err := b.GetAccountBalance(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -501,7 +500,7 @@ func TestGetAccountBalance(t *testing.T) {
 func TestWalletTransfer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.WalletTransfer(context.Background(), 0.01, "btc", "bla", "bla")
+	_, err := b.WalletTransfer(t.Context(), 0.01, "btc", "bla", "bla")
 	if err != nil {
 		t.Error(err)
 	}
@@ -510,7 +509,7 @@ func TestWalletTransfer(t *testing.T) {
 func TestNewOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.NewOrder(context.Background(),
+	_, err := b.NewOrder(t.Context(),
 		"BTCUSD",
 		order.Limit.Lower(),
 		-1,
@@ -525,7 +524,7 @@ func TestNewOrder(t *testing.T) {
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.UpdateTicker(context.Background(), btcusdPair, asset.Spot)
+	_, err := b.UpdateTicker(t.Context(), btcusdPair, asset.Spot)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTicker may only error about locked markets")
 }
 
@@ -543,7 +542,7 @@ func TestUpdateTickers(t *testing.T) {
 		err = b.CurrencyPairs.StorePairs(a, avail, true)
 		require.NoError(t, err, "StorePairs should not error")
 
-		err = b.UpdateTickers(context.Background(), a)
+		err = b.UpdateTickers(t.Context(), a)
 		require.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 
 		// Bitfinex leaves delisted pairs in Available info/conf endpoints
@@ -578,7 +577,7 @@ func TestNewOrderMulti(t *testing.T) {
 		},
 	}
 
-	_, err := b.NewOrderMulti(context.Background(), newOrder)
+	_, err := b.NewOrderMulti(t.Context(), newOrder)
 	if err != nil {
 		t.Error(err)
 	}
@@ -587,7 +586,7 @@ func TestNewOrderMulti(t *testing.T) {
 func TestCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CancelExistingOrder(context.Background(), 1337)
+	_, err := b.CancelExistingOrder(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -596,7 +595,7 @@ func TestCancelOrder(t *testing.T) {
 func TestCancelMultipleOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CancelMultipleOrders(context.Background(), []int64{1337, 1336})
+	_, err := b.CancelMultipleOrders(t.Context(), []int64{1337, 1336})
 	if err != nil {
 		t.Error(err)
 	}
@@ -605,7 +604,7 @@ func TestCancelMultipleOrders(t *testing.T) {
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CancelAllExistingOrders(context.Background())
+	_, err := b.CancelAllExistingOrders(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -614,7 +613,7 @@ func TestCancelAllOrders(t *testing.T) {
 func TestReplaceOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.ReplaceOrder(context.Background(), 1337, "BTCUSD",
+	_, err := b.ReplaceOrder(t.Context(), 1337, "BTCUSD",
 		1, 1, true, order.Limit.Lower(), false)
 	if err != nil {
 		t.Error(err)
@@ -624,7 +623,7 @@ func TestReplaceOrder(t *testing.T) {
 func TestGetOrderStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOrderStatus(context.Background(), 1337)
+	_, err := b.GetOrderStatus(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -633,12 +632,12 @@ func TestGetOrderStatus(t *testing.T) {
 func TestGetOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOpenOrders(context.Background())
+	_, err := b.GetOpenOrders(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetOpenOrders(context.Background(), 1, 2, 3, 4)
+	_, err = b.GetOpenOrders(t.Context(), 1, 2, 3, 4)
 	if err != nil {
 		t.Error(err)
 	}
@@ -647,7 +646,7 @@ func TestGetOpenOrders(t *testing.T) {
 func TestGetActivePositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetActivePositions(context.Background())
+	_, err := b.GetActivePositions(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -656,7 +655,7 @@ func TestGetActivePositions(t *testing.T) {
 func TestClaimPosition(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.ClaimPosition(context.Background(), 1337)
+	_, err := b.ClaimPosition(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -665,7 +664,7 @@ func TestClaimPosition(t *testing.T) {
 func TestGetBalanceHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetBalanceHistory(context.Background(),
+	_, err := b.GetBalanceHistory(t.Context(),
 		"USD", time.Time{}, time.Time{}, 1, "deposit")
 	if err != nil {
 		t.Error(err)
@@ -675,7 +674,7 @@ func TestGetBalanceHistory(t *testing.T) {
 func TestGetMovementHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetMovementHistory(context.Background(), "USD", "bitcoin", time.Time{}, time.Time{}, 1)
+	_, err := b.GetMovementHistory(t.Context(), "USD", "bitcoin", time.Time{}, time.Time{}, 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -684,7 +683,7 @@ func TestGetMovementHistory(t *testing.T) {
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTradeHistory(context.Background(),
+	_, err := b.GetTradeHistory(t.Context(),
 		"BTCUSD", time.Time{}, time.Time{}, 1, 0)
 	if err != nil {
 		t.Error(err)
@@ -694,7 +693,7 @@ func TestGetTradeHistory(t *testing.T) {
 func TestNewOffer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.NewOffer(context.Background(), "BTC", 1, 1, 1, "loan")
+	_, err := b.NewOffer(t.Context(), "BTC", 1, 1, 1, "loan")
 	if err != nil {
 		t.Error(err)
 	}
@@ -703,7 +702,7 @@ func TestNewOffer(t *testing.T) {
 func TestCancelOffer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CancelOffer(context.Background(), 1337)
+	_, err := b.CancelOffer(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -712,7 +711,7 @@ func TestCancelOffer(t *testing.T) {
 func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -721,7 +720,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 func TestGetOfferStatus(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOfferStatus(context.Background(), 1337)
+	_, err := b.GetOfferStatus(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -730,7 +729,7 @@ func TestGetOfferStatus(t *testing.T) {
 func TestGetActiveCredits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetActiveCredits(context.Background())
+	_, err := b.GetActiveCredits(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -739,7 +738,7 @@ func TestGetActiveCredits(t *testing.T) {
 func TestGetActiveOffers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetActiveOffers(context.Background())
+	_, err := b.GetActiveOffers(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -748,7 +747,7 @@ func TestGetActiveOffers(t *testing.T) {
 func TestGetActiveMarginFunding(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetActiveMarginFunding(context.Background())
+	_, err := b.GetActiveMarginFunding(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -757,7 +756,7 @@ func TestGetActiveMarginFunding(t *testing.T) {
 func TestGetUnusedMarginFunds(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetUnusedMarginFunds(context.Background())
+	_, err := b.GetUnusedMarginFunds(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -766,7 +765,7 @@ func TestGetUnusedMarginFunds(t *testing.T) {
 func TestGetMarginTotalTakenFunds(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetMarginTotalTakenFunds(context.Background())
+	_, err := b.GetMarginTotalTakenFunds(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -775,7 +774,7 @@ func TestGetMarginTotalTakenFunds(t *testing.T) {
 func TestCloseMarginFunding(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CloseMarginFunding(context.Background(), 1337)
+	_, err := b.CloseMarginFunding(t.Context(), 1337)
 	if err != nil {
 		t.Error(err)
 	}
@@ -793,7 +792,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -814,7 +813,7 @@ func TestGetFee(t *testing.T) {
 
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		// CryptocurrencyTradeFee Basic
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -822,28 +821,28 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyWithdrawalFee Basic
 		feeBuilder = setFeeBuilder()
 		feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-		if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
@@ -851,7 +850,7 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -859,7 +858,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
 	feeBuilder.FiatCurrency = currency.HKD
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -867,7 +866,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.HKD
-	if _, err := b.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := b.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -890,7 +889,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(b) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
@@ -906,7 +905,7 @@ func TestGetOrderHistory(t *testing.T) {
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
 	}
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if err != nil {
 		t.Error(err)
 	}
@@ -931,7 +930,7 @@ func TestSubmitOrder(t *testing.T) {
 		Amount:    20,
 		ClientID:  "meowOrder",
 	}
-	response, err := b.SubmitOrder(context.Background(), orderSubmission)
+	response, err := b.SubmitOrder(t.Context(), orderSubmission)
 
 	if sharedtestvalues.AreAPICredentialsSet(b) && err != nil {
 		t.Fatalf("Could not place order: %v", err)
@@ -956,7 +955,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -977,7 +976,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := b.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -995,7 +994,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	_, err := b.ModifyOrder(
-		context.Background(),
+		t.Context(),
 		&order.Modify{
 			OrderID:   "1337",
 			AssetType: asset.Spot,
@@ -1021,7 +1020,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := b.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := b.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -1044,7 +1043,7 @@ func TestWithdrawFiat(t *testing.T) {
 		},
 	}
 
-	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := b.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -1074,7 +1073,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		},
 	}
 
-	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -1087,12 +1086,12 @@ func TestWithdrawInternationalBank(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(b) {
-		_, err := b.GetDepositAddress(context.Background(), currency.USDT, "", "TETHERUSE")
+		_, err := b.GetDepositAddress(t.Context(), currency.USDT, "", "TETHERUSE")
 		if err != nil {
 			t.Error("GetDepositAddress() error", err)
 		}
 	} else {
-		_, err := b.GetDepositAddress(context.Background(), currency.BTC, "deposit", "")
+		_, err := b.GetDepositAddress(t.Context(), currency.BTC, "deposit", "")
 		if err == nil {
 			t.Error("GetDepositAddress() error cannot be nil")
 		}
@@ -1567,7 +1566,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	startTime := time.Now().Add(-time.Hour * 24)
 	endTime := time.Now().Add(-time.Hour * 20)
 
-	if _, err := b.GetHistoricCandles(context.Background(), btcusdPair, asset.Spot, kline.OneHour, startTime, endTime); err != nil {
+	if _, err := b.GetHistoricCandles(t.Context(), btcusdPair, asset.Spot, kline.OneHour, startTime, endTime); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1576,7 +1575,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	startTime := time.Now().Add(-time.Hour * 24)
 	endTime := time.Now().Add(-time.Hour * 20)
 
-	if _, err := b.GetHistoricCandlesExtended(context.Background(), btcusdPair, asset.Spot, kline.OneHour, startTime, endTime); err != nil {
+	if _, err := b.GetHistoricCandlesExtended(t.Context(), btcusdPair, asset.Spot, kline.OneHour, startTime, endTime); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1757,7 +1756,7 @@ func Test_FormatExchangeKlineInterval(t *testing.T) {
 
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	if _, err := b.GetRecentTrades(context.Background(), btcusdPair, asset.Spot); err != nil {
+	if _, err := b.GetRecentTrades(t.Context(), btcusdPair, asset.Spot); err != nil {
 		t.Error(err)
 	}
 
@@ -1765,7 +1764,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetRecentTrades(context.Background(), currencyPair, asset.Margin)
+	_, err = b.GetRecentTrades(t.Context(), currencyPair, asset.Margin)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1773,13 +1772,13 @@ func TestGetRecentTrades(t *testing.T) {
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	if _, err := b.GetHistoricTrades(context.Background(),
+	if _, err := b.GetHistoricTrades(t.Context(),
 		btcusdPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now()); err != nil {
 		t.Error(err)
 	}
 
 	// longer term test
-	if _, err := b.GetHistoricTrades(context.Background(),
+	if _, err := b.GetHistoricTrades(t.Context(),
 		btcusdPair, asset.Spot,
 		time.Now().Add(-time.Hour*100),
 		time.Now().Add(-time.Hour*99)); err != nil {
@@ -1874,7 +1873,7 @@ func TestPopulateAcceptableMethods(t *testing.T) {
 			t.Error("expected false")
 		}
 	}
-	if err := b.PopulateAcceptableMethods(context.Background()); err != nil {
+	if err := b.PopulateAcceptableMethods(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if !acceptableMethods.loaded() {
@@ -1887,14 +1886,14 @@ func TestPopulateAcceptableMethods(t *testing.T) {
 		t.Error("non-existent code should return no methods")
 	}
 	// since we're already loaded, this will return nil
-	if err := b.PopulateAcceptableMethods(context.Background()); err != nil {
+	if err := b.PopulateAcceptableMethods(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	r, err := b.GetAvailableTransferChains(context.Background(), currency.USDT)
+	r, err := b.GetAvailableTransferChains(t.Context(), currency.USDT)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1933,12 +1932,12 @@ func TestAccetableMethodStore(t *testing.T) {
 func TestGetSiteListConfigData(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetSiteListConfigData(context.Background(), "")
+	_, err := b.GetSiteListConfigData(t.Context(), "")
 	if !errors.Is(err, errSetCannotBeEmpty) {
 		t.Fatalf("received: %v, expected: %v", err, errSetCannotBeEmpty)
 	}
 
-	pairs, err := b.GetSiteListConfigData(context.Background(), bitfinexSecuritiesPairs)
+	pairs, err := b.GetSiteListConfigData(t.Context(), bitfinexSecuritiesPairs)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: %v, expected: %v", err, nil)
 	}
@@ -1951,7 +1950,7 @@ func TestGetSiteListConfigData(t *testing.T) {
 func TestGetSiteInfoConfigData(t *testing.T) {
 	t.Parallel()
 	for _, assetType := range []asset.Item{asset.Spot, asset.Futures} {
-		pairs, err := b.GetSiteInfoConfigData(context.Background(), assetType)
+		pairs, err := b.GetSiteInfoConfigData(t.Context(), assetType)
 		if !errors.Is(err, nil) {
 			t.Errorf("Error from GetSiteInfoConfigData for %s type received: %v, expected: %v", assetType, err, nil)
 		}
@@ -1964,7 +1963,7 @@ func TestGetSiteInfoConfigData(t *testing.T) {
 func TestOrderUpdate(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.OrderUpdate(context.Background(), "1234", "", "", 1, 1, 1)
+	_, err := b.OrderUpdate(t.Context(), "1234", "", "", 1, 1, 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1973,12 +1972,12 @@ func TestOrderUpdate(t *testing.T) {
 func TestGetInactiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetInactiveOrders(context.Background(), "tBTCUSD")
+	_, err := b.GetInactiveOrders(t.Context(), "tBTCUSD")
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.GetInactiveOrders(context.Background(), "tBTCUSD", 1, 2, 3, 4)
+	_, err = b.GetInactiveOrders(t.Context(), "tBTCUSD", 1, 2, 3, 4)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1987,7 +1986,7 @@ func TestGetInactiveOrders(t *testing.T) {
 func TestCancelMultipleOrdersV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelMultipleOrdersV2(context.Background(), 1337, 0, 0, time.Time{}, false)
+	_, err := b.CancelMultipleOrdersV2(t.Context(), 1337, 0, 0, time.Time{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2033,7 +2032,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -38,31 +38,6 @@ const (
 	pubGetHealth           = "/gethealth"
 	pubGetChats            = "/getchats"
 
-	// Authenticated Endpoints
-	privGetPermissions             = "/me/getpermissions"
-	privGetBalance                 = "/me/getbalance"
-	privMarginStatus               = "/me/getcollateral"
-	privGetCollateralAcc           = "/me/getcollateralaccounts"
-	privGetDepositAddress          = "/me/getaddresses"
-	privDepositHistory             = "/me/getcoinins"
-	privTransactionHistory         = "/me/getcoinouts"
-	privBankAccSummary             = "/me/getbankaccounts"
-	privGetDeposits                = "/me/getdeposits"
-	privWithdraw                   = "/me/withdraw"
-	privDepositCancellationHistory = "/me/getwithdrawals"
-	privSendOrder                  = "/me/sendchildorder"
-	privCancelOrder                = "/me/cancelchildorder"
-	privParentOrder                = "/me/sendparentorder"
-	privCancelParentOrder          = "/me/cancelparentorder"
-	privCancelOrders               = "/me/cancelallchildorders"
-	privListOrders                 = "/me/getchildorders"
-	privListParentOrders           = "/me/getparentorders"
-	privParentOrderDetails         = "/me/getparentorder"
-	privExecutions                 = "/me/getexecutions"
-	privOpenInterest               = "/me/getpositions"
-	privMarginChange               = "/me/getcollateralhistory"
-	privTradingCommission          = "/me/gettradingcommission"
-
 	orders request.EndpointLimit = iota
 	lowVolume
 )

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -1,7 +1,6 @@
 package bitflyer
 
 import (
-	"context"
 	"log"
 	"os"
 	"testing"
@@ -55,7 +54,7 @@ func TestMain(m *testing.M) {
 
 func TestGetLatestBlockCA(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLatestBlockCA(context.Background())
+	_, err := b.GetLatestBlockCA(t.Context())
 	if err != nil {
 		t.Error("Bitflyer - GetLatestBlockCA() error:", err)
 	}
@@ -63,7 +62,7 @@ func TestGetLatestBlockCA(t *testing.T) {
 
 func TestGetBlockCA(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetBlockCA(context.Background(), "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
+	_, err := b.GetBlockCA(t.Context(), "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
 	if err != nil {
 		t.Error("Bitflyer - GetBlockCA() error:", err)
 	}
@@ -71,7 +70,7 @@ func TestGetBlockCA(t *testing.T) {
 
 func TestGetBlockbyHeightCA(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetBlockbyHeightCA(context.Background(), 0)
+	_, err := b.GetBlockbyHeightCA(t.Context(), 0)
 	if err != nil {
 		t.Error("Bitflyer - GetBlockbyHeightCA() error:", err)
 	}
@@ -79,7 +78,7 @@ func TestGetBlockbyHeightCA(t *testing.T) {
 
 func TestGetTransactionByHashCA(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTransactionByHashCA(context.Background(), "0562d1f063cd4127053d838b165630445af5e480ceb24e1fd9ecea52903cb772")
+	_, err := b.GetTransactionByHashCA(t.Context(), "0562d1f063cd4127053d838b165630445af5e480ceb24e1fd9ecea52903cb772")
 	if err != nil {
 		t.Error("Bitflyer - GetTransactionByHashCA() error:", err)
 	}
@@ -87,7 +86,7 @@ func TestGetTransactionByHashCA(t *testing.T) {
 
 func TestGetAddressInfoCA(t *testing.T) {
 	t.Parallel()
-	v, err := b.GetAddressInfoCA(context.Background(), core.BitcoinDonationAddress)
+	v, err := b.GetAddressInfoCA(t.Context(), core.BitcoinDonationAddress)
 	if err != nil {
 		t.Error("Bitflyer - GetAddressInfoCA() error:", err)
 	}
@@ -98,7 +97,7 @@ func TestGetAddressInfoCA(t *testing.T) {
 
 func TestGetMarkets(t *testing.T) {
 	t.Parallel()
-	markets, err := b.GetMarkets(context.Background())
+	markets, err := b.GetMarkets(t.Context())
 	if err != nil {
 		t.Error("Bitflyer - GetMarkets() error:", err)
 	}
@@ -114,7 +113,7 @@ func TestGetMarkets(t *testing.T) {
 
 func TestGetOrderBook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderBook(context.Background(), "BTC_JPY")
+	_, err := b.GetOrderBook(t.Context(), "BTC_JPY")
 	if err != nil {
 		t.Error("Bitflyer - GetOrderBook() error:", err)
 	}
@@ -122,7 +121,7 @@ func TestGetOrderBook(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTicker(context.Background(), "BTC_JPY")
+	_, err := b.GetTicker(t.Context(), "BTC_JPY")
 	if err != nil {
 		t.Error("Bitflyer - GetTicker() error:", err)
 	}
@@ -130,7 +129,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetExecutionHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetExecutionHistory(context.Background(), "BTC_JPY")
+	_, err := b.GetExecutionHistory(t.Context(), "BTC_JPY")
 	if err != nil {
 		t.Error("Bitflyer - GetExecutionHistory() error:", err)
 	}
@@ -138,7 +137,7 @@ func TestGetExecutionHistory(t *testing.T) {
 
 func TestGetExchangeStatus(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetExchangeStatus(context.Background())
+	_, err := b.GetExchangeStatus(t.Context())
 	if err != nil {
 		t.Error("Bitflyer - GetExchangeStatus() error:", err)
 	}
@@ -170,7 +169,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +265,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(b) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(b) && err == nil {
@@ -282,7 +281,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected '%v', received '%v'", common.ErrNotYetImplemented, err)
 	}
@@ -308,7 +307,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	_, err := b.SubmitOrder(context.Background(), orderSubmission)
+	_, err := b.SubmitOrder(t.Context(), orderSubmission)
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected 'Not Yet Implemented', received %v", err)
 	}
@@ -326,7 +325,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected 'Not Yet Implemented', received %v", err)
@@ -345,7 +344,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	_, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	_, err := b.CancelAllOrders(t.Context(), orderCancellation)
 
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected 'Not Yet Implemented', received %v", err)
@@ -366,7 +365,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := b.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := b.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected 'Not Yet Implemented', received %v", err)
@@ -376,7 +375,7 @@ func TestWithdraw(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ModifyOrder(context.Background(),
+	_, err := b.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
@@ -389,7 +388,7 @@ func TestWithdrawFiat(t *testing.T) {
 
 	withdrawFiatRequest := withdraw.Request{}
 
-	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := b.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrNotYetImplemented, err)
 	}
@@ -401,7 +400,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 	withdrawFiatRequest := withdraw.Request{}
 
-	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrNotYetImplemented {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrNotYetImplemented, err)
@@ -414,7 +413,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = b.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -426,7 +425,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(),
+	_, err = b.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Fatal(err)
@@ -447,7 +446,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err, "GetCurrencyTradeURL must not error")
 		assert.NotEmpty(t, resp, "GetCurrencyTradeURL should return an url")
 	}

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -217,7 +217,7 @@ func TestMarketSellOrder(t *testing.T) {
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, b.UpdateTradablePairs(t.Context(), false), "UpdateTradablePairs must not error")
+	testexch.UpdatePairsOnce(t, b)
 	tick, err := b.UpdateTicker(t.Context(), testPair, asset.Spot)
 	require.NoError(t, err, "UpdateTicker must not error")
 	assert.Positive(t, tick.High, "High should be positive")
@@ -485,7 +485,7 @@ func TestGetDepositAddress(t *testing.T) {
 
 func TestGetCandleStick(t *testing.T) {
 	t.Parallel()
-	c, err := b.GetCandleStick(t.Context(), "BTC_KRW", "1m")
+	c, err := b.GetCandleStick(t.Context(), testPair.String(), "1m")
 	require.NoError(t, err, "GetCandleStick must not error")
 	assert.NotEmpty(t, c.Status, "Status should not be empty")
 	assert.NotEmpty(t, c.Data, "Data should not be empty")

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -232,6 +232,8 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
+
+	testexch.UpdatePairsOnce(t, b)
 	err := b.UpdateTickers(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateTickers must not error")
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -67,13 +67,13 @@ func TestMain(m *testing.M) {
 
 func TestGetTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTradablePairs(context.Background())
+	_, err := b.GetTradablePairs(t.Context())
 	require.NoError(t, err, "GetTradablePairs must not error")
 }
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	tick, err := b.GetTicker(context.Background(), testCurrency)
+	tick, err := b.GetTicker(t.Context(), testCurrency)
 	require.NoError(t, err, "GetTicker must not error")
 	assert.Positive(t, tick.OpeningPrice, "OpeningPrice should be positive")
 	assert.Positive(t, tick.ClosingPrice, "ClosingPrice should be positive")
@@ -92,7 +92,7 @@ func TestGetTicker(t *testing.T) {
 // not all currencies have dates and fluctuation rates
 func TestGetAllTickers(t *testing.T) {
 	t.Parallel()
-	tick, err := b.GetAllTickers(context.Background())
+	tick, err := b.GetAllTickers(t.Context())
 	require.NoError(t, err, "GetAllTickers must not error")
 	for _, res := range tick {
 		assert.Positive(t, res.OpeningPrice, "OpeningPrice should be positive")
@@ -109,7 +109,7 @@ func TestGetAllTickers(t *testing.T) {
 
 func TestGetOrderBook(t *testing.T) {
 	t.Parallel()
-	ob, err := b.GetOrderBook(context.Background(), testCurrency)
+	ob, err := b.GetOrderBook(t.Context(), testCurrency)
 	require.NoError(t, err, "GetOrderBook must not error")
 	assert.NotEmpty(t, ob.Status, "Status should not be empty")
 	assert.NotEmpty(t, ob.Data.Timestamp, "Timestamp should not be empty")
@@ -120,7 +120,7 @@ func TestGetOrderBook(t *testing.T) {
 func TestGetTransactionHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTransactionHistory(context.Background(), testCurrency)
+	_, err := b.GetTransactionHistory(t.Context(), testCurrency)
 	require.NoError(t, err, "GetTransactionHistory must not error")
 }
 
@@ -128,12 +128,12 @@ func TestGetAccountInformation(t *testing.T) {
 	t.Parallel()
 
 	// Offline test
-	_, err := b.GetAccountInformation(context.Background(), "", "")
+	_, err := b.GetAccountInformation(t.Context(), "", "")
 	assert.Error(t, err, "expected error when no order currency is specified")
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err = b.GetAccountInformation(context.Background(),
+	_, err = b.GetAccountInformation(t.Context(),
 		testCurrency,
 		currency.KRW.String())
 	require.NoError(t, err, "GetAccountInformation should not error")
@@ -143,7 +143,7 @@ func TestGetAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetAccountBalance(context.Background(), testCurrency)
+	_, err := b.GetAccountBalance(t.Context(), testCurrency)
 	require.NoError(t, err, "GetAccountBalance must not error")
 }
 
@@ -151,7 +151,7 @@ func TestGetWalletAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	a, err := b.GetWalletAddress(context.Background(), currency.BTC)
+	a, err := b.GetWalletAddress(t.Context(), currency.BTC)
 	require.NoError(t, err, "GetWalletAddress must not error")
 	assert.NotEmpty(t, a.Data.Currency, "Currency should not be empty")
 	assert.NotEmpty(t, a.Data.Tag, "Tag should not be empty")
@@ -162,7 +162,7 @@ func TestGetLastTransaction(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetLastTransaction(context.Background())
+	_, err := b.GetLastTransaction(t.Context())
 	require.NoError(t, err, "GetLastTransaction must not error")
 }
 
@@ -170,7 +170,7 @@ func TestGetOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetOrders(context.Background(),
+	_, err := b.GetOrders(t.Context(),
 		"1337", order.Bid.Lower(), 100, time.Time{}, currency.BTC, currency.KRW)
 	require.NoError(t, err, "GetOrders must not error")
 }
@@ -179,7 +179,7 @@ func TestGetUserTransactions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetUserTransactions(context.Background(), 0, 0, 0, currency.EMPTYCODE, currency.EMPTYCODE)
+	_, err := b.GetUserTransactions(t.Context(), 0, 0, 0, currency.EMPTYCODE, currency.EMPTYCODE)
 	require.NoError(t, err, "GetUserTransactions must not error")
 }
 
@@ -187,7 +187,7 @@ func TestPlaceTrade(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.PlaceTrade(context.Background(),
+	_, err := b.PlaceTrade(t.Context(),
 		testCurrency, order.Bid.Lower(), 0, 0)
 	require.NoError(t, err, "PlaceTrade must not error")
 }
@@ -196,7 +196,7 @@ func TestGetOrderDetails(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetOrderDetails(context.Background(),
+	_, err := b.GetOrderDetails(t.Context(),
 		"1337", order.Bid.Lower(), testCurrency)
 	require.NoError(t, err, "GetOrderDetails must not error")
 }
@@ -205,7 +205,7 @@ func TestCancelTrade(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.CancelTrade(context.Background(), "", "", "")
+	_, err := b.CancelTrade(t.Context(), "", "", "")
 	require.NoError(t, err, "CancelTrade must not error")
 }
 
@@ -213,7 +213,7 @@ func TestWithdrawCrypto(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.WithdrawCrypto(context.Background(),
+	_, err := b.WithdrawCrypto(t.Context(),
 		"LQxiDhKU7idKiWQhx4ALKYkBx8xKEQVxJR", "", "ltc", 0)
 	require.NoError(t, err, "WithdrawCrypto must not error")
 }
@@ -221,7 +221,7 @@ func TestWithdrawCrypto(t *testing.T) {
 func TestRequestKRWDepositDetails(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.RequestKRWDepositDetails(context.Background())
+	_, err := b.RequestKRWDepositDetails(t.Context())
 	require.NoError(t, err, "RequestKRWDepositDetails must not error")
 }
 
@@ -229,7 +229,7 @@ func TestRequestKRWWithdraw(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.RequestKRWWithdraw(context.Background(),
+	_, err := b.RequestKRWWithdraw(t.Context(),
 		"102_bank", "1337", 1000)
 	require.NoError(t, err, "RequestKRWWithdraw must not error")
 }
@@ -239,7 +239,7 @@ func TestMarketBuyOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	p := currency.NewPair(currency.BTC, currency.KRW)
-	_, err := b.MarketBuyOrder(context.Background(), p, 0)
+	_, err := b.MarketBuyOrder(t.Context(), p, 0)
 	require.NoError(t, err, "MarketBuyOrder must not error")
 }
 
@@ -248,14 +248,14 @@ func TestMarketSellOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	p := currency.NewPair(currency.BTC, currency.KRW)
-	_, err := b.MarketSellOrder(context.Background(), p, 0)
+	_, err := b.MarketSellOrder(t.Context(), p, 0)
 	require.NoError(t, err, "MarketSellOrder must not error")
 }
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPairWithDelimiter("QTUM", "KRW", "-")
-	tick, err := b.UpdateTicker(context.Background(), cp, asset.Spot)
+	tick, err := b.UpdateTicker(t.Context(), cp, asset.Spot)
 	require.NoError(t, err, "UpdateTicker must not error")
 	assert.Positive(t, tick.High, "High should be positive")
 	assert.Positive(t, tick.Low, "Low should be positive")
@@ -269,7 +269,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTickers(context.Background(), asset.Spot)
+	err := b.UpdateTickers(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateTickers must not error")
 }
 
@@ -286,7 +286,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 
 	if !sharedtestvalues.AreAPICredentialsSet(b) {
@@ -366,7 +366,7 @@ func TestGetActiveOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	require.NoError(t, err, "GetActiveOrders must not error")
 }
 
@@ -381,7 +381,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Pairs:     currency.Pairs{currency.NewPair(currency.BTC, currency.KRW)},
 	}
 
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	require.NoError(t, err, "GetOrderHistory must not error")
 }
 
@@ -405,7 +405,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	_, err := b.SubmitOrder(context.Background(), orderSubmission)
+	_, err := b.SubmitOrder(t.Context(), orderSubmission)
 	require.NoError(t, err, "SubmitOrder must not error")
 }
 
@@ -421,7 +421,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 	require.NoError(t, err, "CancelOrder must not error")
 }
 
@@ -437,7 +437,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := b.CancelAllOrders(t.Context(), orderCancellation)
 	require.NoError(t, err, "CancelAllOrders must not error")
 
 	assert.Empty(t, resp.Status, "%v orders failed to cancel", len(resp.Status))
@@ -447,7 +447,7 @@ func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := b.UpdateAccountInfo(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateAccountInfo must not error")
 }
 
@@ -458,7 +458,7 @@ func TestModifyOrder(t *testing.T) {
 	curr, err := currency.NewPairFromString("BTCUSD")
 	require.NoError(t, err, "Issue setting currency")
 
-	_, err = b.ModifyOrder(context.Background(), &order.Modify{
+	_, err = b.ModifyOrder(t.Context(), &order.Modify{
 		OrderID:   "1337",
 		Price:     100,
 		Amount:    1000,
@@ -507,7 +507,7 @@ func TestWithdrawFiat(t *testing.T) {
 		Description: "WITHDRAW IT ALL",
 	}
 
-	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := b.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	require.NoError(t, err, "WithdrawFiatFunds must not error")
 }
 
@@ -516,7 +516,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
@@ -525,13 +525,13 @@ func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := b.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	require.NoError(t, err, "GetDepositAddress must not error")
 }
 
 func TestGetCandleStick(t *testing.T) {
 	t.Parallel()
-	c, err := b.GetCandleStick(context.Background(), "BTC_KRW", "1m")
+	c, err := b.GetCandleStick(t.Context(), "BTC_KRW", "1m")
 	require.NoError(t, err, "GetCandleStick must not error")
 	assert.NotEmpty(t, c.Status, "Status should not be empty")
 	assert.NotEmpty(t, c.Data, "Data should not be empty")
@@ -542,7 +542,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	pair, err := currency.NewPairFromString("BTCKRW")
 	require.NoError(t, err, "Issue setting currency")
 	startTime := time.Now().AddDate(0, -1, 0)
-	c, err := b.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.OneDay, startTime, time.Now())
+	c, err := b.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.OneDay, startTime, time.Now())
 	require.NoError(t, err, "GetHistoricCandles must not error")
 	assert.NotEmpty(t, c.Exchange, "Exchange should not be empty")
 	assert.NotEmpty(t, c.Candles, "Candles should not be empty")
@@ -554,7 +554,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	require.NoError(t, err, "Issue setting currency")
 
 	startTime := time.Now().Add(-time.Hour * 24)
-	_, err = b.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.OneDay, startTime, time.Now())
+	_, err = b.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.OneDay, startTime, time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
@@ -563,7 +563,7 @@ func TestGetRecentTrades(t *testing.T) {
 	currencyPair, err := currency.NewPairFromString("BTC_KRW")
 	require.NoError(t, err, "Issue setting currency")
 
-	tr, err := b.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	tr, err := b.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	require.NoError(t, err, "GetRecentTrades must not error")
 	assert.NotEmpty(t, tr, "Trades should not be empty")
 	for _, req := range tr {
@@ -580,14 +580,14 @@ func TestGetHistoricTrades(t *testing.T) {
 	currencyPair, err := currency.NewPairFromString("BTC_KRW")
 	require.NoError(t, err, "Issue setting currency")
 
-	_, err = b.GetHistoricTrades(context.Background(),
+	_, err = b.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateOrderExecutionLimits(context.Background(), asset.Empty)
+	err := b.UpdateOrderExecutionLimits(t.Context(), asset.Empty)
 	require.NoError(t, err, "UpdateOrderExecutionLimits must not error")
 
 	cp := currency.NewPair(currency.BTC, currency.KRW)
@@ -651,10 +651,10 @@ func TestGetAmountMinimum(t *testing.T) {
 
 func TestGetAssetStatus(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetAssetStatus(context.Background(), "")
+	_, err := b.GetAssetStatus(t.Context(), "")
 	assert.ErrorIs(t, err, errSymbolIsEmpty)
 
-	s, err := b.GetAssetStatus(context.Background(), "sol")
+	s, err := b.GetAssetStatus(t.Context(), "sol")
 	require.NoError(t, err, "GetAssetStatus must not error")
 	assert.NotEmpty(t, s.Status, "Status should not be empty")
 	assert.NotEmpty(t, s.Data.DepositStatus, "DepositStatus should not be empty")
@@ -663,7 +663,7 @@ func TestGetAssetStatus(t *testing.T) {
 
 func TestGetAssetStatusAll(t *testing.T) {
 	t.Parallel()
-	s, err := b.GetAssetStatusAll(context.Background())
+	s, err := b.GetAssetStatusAll(t.Context())
 	require.NoError(t, err, "GetAssetStatusAll must not error")
 	require.NoError(t, err, "GetAssetStatus must not error")
 	assert.NotEmpty(t, s.Status, "Status should not be empty")
@@ -671,7 +671,7 @@ func TestGetAssetStatusAll(t *testing.T) {
 
 func TestUpdateCurrencyStates(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateCurrencyStates(context.Background(), asset.Spot)
+	err := b.UpdateCurrencyStates(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateCurrencyStates must not error")
 }
 
@@ -679,7 +679,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	require.NoError(t, err, "TestGetWithdrawalsHistory must not error")
 }
 
@@ -687,7 +687,7 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetOrderInfo(context.Background(), "1234", currency.NewPair(currency.BTC, currency.USDT), asset.Spot)
+	_, err := b.GetOrderInfo(t.Context(), "1234", currency.NewPair(currency.BTC, currency.USDT), asset.Spot)
 	require.NoError(t, err, "GetOrderInfo must not error")
 }
 
@@ -695,7 +695,7 @@ func TestGetWithdrawalHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	require.NoError(t, err, "GetWithdrawalsHistory must not error")
 }
 
@@ -706,7 +706,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -226,13 +226,17 @@ func (b *Bithumb) UpdateTickers(ctx context.Context, a asset.Item) error {
 			return fmt.Errorf("enabled pair %s [%s] not found in returned ticker map %v",
 				pairs[i], pairs, tickers)
 		}
+		p, err := b.FormatExchangeCurrency(pairs[i], a)
+		if err != nil {
+			return err
+		}
 		err = ticker.ProcessTicker(&ticker.Price{
 			High:         t.MaxPrice,
 			Low:          t.MinPrice,
 			Volume:       t.UnitsTraded24Hr,
 			Open:         t.OpeningPrice,
 			Close:        t.ClosingPrice,
-			Pair:         pairs[i],
+			Pair:         p,
 			ExchangeName: b.Name,
 			AssetType:    a,
 		})

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -1,7 +1,6 @@
 package bitmex
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"os"
@@ -65,11 +64,11 @@ func TestMain(m *testing.M) {
 
 func TestGetFullFundingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFullFundingHistory(context.Background(),
+	_, err := b.GetFullFundingHistory(t.Context(),
 		"", "", "", "", "", true, time.Now().Add(-time.Minute), time.Now())
 	require.NoError(t, err)
 
-	_, err = b.GetFullFundingHistory(context.Background(),
+	_, err = b.GetFullFundingHistory(t.Context(),
 		"LTCUSD", "1", "", "", "", true, time.Now().Add(-time.Minute), time.Now())
 	require.NoError(t, err)
 }
@@ -77,48 +76,48 @@ func TestGetFullFundingHistory(t *testing.T) {
 func TestGetUrgentAnnouncement(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.GetUrgentAnnouncement(context.Background())
+	_, err := b.GetUrgentAnnouncement(t.Context())
 	require.Error(t, err)
 }
 
 func TestGetAPIKeys(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.GetAPIKeys(context.Background())
+	_, err := b.GetAPIKeys(t.Context())
 	require.Error(t, err)
 }
 
 func TestRemoveAPIKey(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.RemoveAPIKey(context.Background(), APIKeyParams{APIKeyID: "1337"})
+	_, err := b.RemoveAPIKey(t.Context(), APIKeyParams{APIKeyID: "1337"})
 	require.Error(t, err)
 }
 
 func TestDisableAPIKey(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.DisableAPIKey(context.Background(), APIKeyParams{APIKeyID: "1337"})
+	_, err := b.DisableAPIKey(t.Context(), APIKeyParams{APIKeyID: "1337"})
 	require.Error(t, err)
 }
 
 func TestEnableAPIKey(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.EnableAPIKey(context.Background(), APIKeyParams{APIKeyID: "1337"})
+	_, err := b.EnableAPIKey(t.Context(), APIKeyParams{APIKeyID: "1337"})
 	require.Error(t, err)
 }
 
 func TestGetTrollboxMessages(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrollboxMessages(context.Background(), ChatGetParams{Count: 1})
+	_, err := b.GetTrollboxMessages(t.Context(), ChatGetParams{Count: 1})
 	require.NoError(t, err)
 }
 
 func TestSendTrollboxMessage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.SendTrollboxMessage(context.Background(),
+	_, err := b.SendTrollboxMessage(t.Context(),
 		ChatSendParams{
 			ChannelID: 1337,
 			Message:   "Hello,World!",
@@ -128,20 +127,20 @@ func TestSendTrollboxMessage(t *testing.T) {
 
 func TestGetTrollboxChannels(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrollboxChannels(context.Background())
+	_, err := b.GetTrollboxChannels(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetTrollboxConnectedUsers(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrollboxConnectedUsers(context.Background())
+	_, err := b.GetTrollboxConnectedUsers(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetAccountExecutions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.GetAccountExecutions(context.Background(),
+	_, err := b.GetAccountExecutions(t.Context(),
 		&GenericRequestParams{})
 	require.Error(t, err)
 }
@@ -149,20 +148,20 @@ func TestGetAccountExecutions(t *testing.T) {
 func TestGetAccountExecutionTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.GetAccountExecutionTradeHistory(context.Background(),
+	_, err := b.GetAccountExecutionTradeHistory(t.Context(),
 		&GenericRequestParams{})
 	require.Error(t, err)
 }
 
 func TestGetFundingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetAccountFundingHistory(context.Background())
+	_, err := b.GetAccountFundingHistory(t.Context())
 	require.Error(t, err)
 }
 
 func TestGetInstruments(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetInstruments(context.Background(),
+	_, err := b.GetInstruments(t.Context(),
 		&GenericRequestParams{
 			Symbol: "XRPUSD",
 		})
@@ -171,58 +170,58 @@ func TestGetInstruments(t *testing.T) {
 
 func TestGetActiveInstruments(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetActiveInstruments(context.Background(),
+	_, err := b.GetActiveInstruments(t.Context(),
 		&GenericRequestParams{})
 	require.NoError(t, err)
 }
 
 func TestGetActiveAndIndexInstruments(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetActiveAndIndexInstruments(context.Background())
+	_, err := b.GetActiveAndIndexInstruments(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetActiveIntervals(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetActiveIntervals(context.Background())
+	_, err := b.GetActiveIntervals(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetCompositeIndex(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetCompositeIndex(context.Background(),
+	_, err := b.GetCompositeIndex(t.Context(),
 		".XBT", "", "", "", "", "", time.Time{}, time.Time{})
 	require.NoError(t, err)
 }
 
 func TestGetIndices(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetIndices(context.Background())
+	_, err := b.GetIndices(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetInsuranceFundHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetInsuranceFundHistory(context.Background(),
+	_, err := b.GetInsuranceFundHistory(t.Context(),
 		&GenericRequestParams{})
 	require.NoError(t, err)
 }
 
 func TestGetLeaderboard(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLeaderboard(context.Background(), LeaderboardGetParams{})
+	_, err := b.GetLeaderboard(t.Context(), LeaderboardGetParams{})
 	require.NoError(t, err)
 }
 
 func TestGetAliasOnLeaderboard(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetAliasOnLeaderboard(context.Background())
+	_, err := b.GetAliasOnLeaderboard(t.Context())
 	require.Error(t, err)
 }
 
 func TestGetLiquidationOrders(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLiquidationOrders(context.Background(),
+	_, err := b.GetLiquidationOrders(t.Context(),
 		&GenericRequestParams{})
 	require.NoError(t, err)
 }
@@ -230,21 +229,21 @@ func TestGetLiquidationOrders(t *testing.T) {
 func TestGetCurrentNotifications(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.GetCurrentNotifications(context.Background())
+	_, err := b.GetCurrentNotifications(t.Context())
 	require.Error(t, err)
 }
 
 func TestAmendOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.AmendOrder(context.Background(), &OrderAmendParams{})
+	_, err := b.AmendOrder(t.Context(), &OrderAmendParams{})
 	require.Error(t, err)
 }
 
 func TestCreateOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.CreateOrder(context.Background(),
+	_, err := b.CreateOrder(t.Context(),
 		&OrderNewParams{
 			Symbol:        "XBTM15",
 			Price:         219.0,
@@ -257,14 +256,14 @@ func TestCreateOrder(t *testing.T) {
 func TestCancelOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.CancelOrders(context.Background(), &OrderCancelParams{})
+	_, err := b.CancelOrders(t.Context(), &OrderCancelParams{})
 	require.Error(t, err)
 }
 
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.CancelAllExistingOrders(context.Background(),
+	_, err := b.CancelAllExistingOrders(t.Context(),
 		OrderCancelAllParams{})
 	require.Error(t, err)
 }
@@ -272,107 +271,107 @@ func TestCancelAllOrders(t *testing.T) {
 func TestAmendBulkOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.AmendBulkOrders(context.Background(), OrderAmendBulkParams{})
+	_, err := b.AmendBulkOrders(t.Context(), OrderAmendBulkParams{})
 	require.Error(t, err)
 }
 
 func TestCreateBulkOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.CreateBulkOrders(context.Background(), OrderNewBulkParams{})
+	_, err := b.CreateBulkOrders(t.Context(), OrderNewBulkParams{})
 	require.Error(t, err)
 }
 
 func TestCancelAllOrdersAfterTime(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.CancelAllOrdersAfterTime(context.Background(),
+	_, err := b.CancelAllOrdersAfterTime(t.Context(),
 		OrderCancelAllAfterParams{})
 	require.Error(t, err)
 }
 
 func TestClosePosition(t *testing.T) {
 	t.Parallel()
-	_, err := b.ClosePosition(context.Background(), OrderClosePositionParams{})
+	_, err := b.ClosePosition(t.Context(), OrderClosePositionParams{})
 	require.Error(t, err)
 }
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderbook(context.Background(),
+	_, err := b.GetOrderbook(t.Context(),
 		OrderBookGetL2Params{Symbol: "XBT"})
 	require.NoError(t, err)
 }
 
 func TestGetPositions(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPositions(context.Background(), PositionGetParams{})
+	_, err := b.GetPositions(t.Context(), PositionGetParams{})
 	require.Error(t, err)
 }
 
 func TestIsolatePosition(t *testing.T) {
 	t.Parallel()
-	_, err := b.IsolatePosition(context.Background(),
+	_, err := b.IsolatePosition(t.Context(),
 		PositionIsolateMarginParams{Symbol: "XBT"})
 	require.Error(t, err)
 }
 
 func TestLeveragePosition(t *testing.T) {
 	t.Parallel()
-	_, err := b.LeveragePosition(context.Background(),
+	_, err := b.LeveragePosition(t.Context(),
 		PositionUpdateLeverageParams{})
 	require.Error(t, err)
 }
 
 func TestUpdateRiskLimit(t *testing.T) {
 	t.Parallel()
-	_, err := b.UpdateRiskLimit(context.Background(),
+	_, err := b.UpdateRiskLimit(t.Context(),
 		PositionUpdateRiskLimitParams{})
 	require.Error(t, err)
 }
 
 func TestTransferMargin(t *testing.T) {
 	t.Parallel()
-	_, err := b.TransferMargin(context.Background(),
+	_, err := b.TransferMargin(t.Context(),
 		PositionTransferIsolatedMarginParams{})
 	require.Error(t, err)
 }
 
 func TestGetQuotesByBuckets(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetQuotesByBuckets(context.Background(),
+	_, err := b.GetQuotesByBuckets(t.Context(),
 		&QuoteGetBucketedParams{})
 	require.Error(t, err)
 }
 
 func TestGetSettlementHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetSettlementHistory(context.Background(),
+	_, err := b.GetSettlementHistory(t.Context(),
 		&GenericRequestParams{})
 	require.NoError(t, err)
 }
 
 func TestGetStats(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetStats(context.Background())
+	_, err := b.GetStats(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetStatsHistorical(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetStatsHistorical(context.Background())
+	_, err := b.GetStatsHistorical(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetStatSummary(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetStatSummary(context.Background())
+	_, err := b.GetStatSummary(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetTrade(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrade(context.Background(),
+	_, err := b.GetTrade(t.Context(),
 		&GenericRequestParams{
 			Symbol:    "XBT",
 			Reverse:   false,
@@ -383,7 +382,7 @@ func TestGetTrade(t *testing.T) {
 
 func TestGetPreviousTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPreviousTrades(context.Background(),
+	_, err := b.GetPreviousTrades(t.Context(),
 		&TradeGetBucketedParams{
 			Symbol:  "XBTBTC",
 			Start:   time.Now().Add(-time.Hour).Unix(),
@@ -405,7 +404,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	require.NoError(t, err)
 	if !sharedtestvalues.AreAPICredentialsSet(b) {
 		assert.Equal(t, exchange.OfflineTradeFee, feeBuilder.FeeType)
@@ -483,7 +482,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 	} else {
@@ -500,7 +499,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 	} else {
@@ -528,7 +527,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Futures,
 	}
-	response, err := b.SubmitOrder(context.Background(), orderSubmission)
+	response, err := b.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 		assert.Equal(t, order.New, response.Status)
@@ -549,7 +548,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Futures,
 	}
 
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 	} else {
@@ -569,7 +568,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Futures,
 	}
 
-	resp, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := b.CancelAllOrders(t.Context(), orderCancellation)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 		require.Empty(t, resp.Status, "CancelAllOrders must not fail to cancel orders")
@@ -581,16 +580,16 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestUpdateAccountInfo(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(b) {
-		_, err := b.UpdateAccountInfo(context.Background(), asset.Spot)
+		_, err := b.UpdateAccountInfo(t.Context(), asset.Spot)
 		require.NoError(t, err)
 
-		_, err = b.UpdateAccountInfo(context.Background(), asset.Futures)
+		_, err = b.UpdateAccountInfo(t.Context(), asset.Futures)
 		require.NoError(t, err)
 	} else {
-		_, err := b.UpdateAccountInfo(context.Background(), asset.Spot)
+		_, err := b.UpdateAccountInfo(t.Context(), asset.Spot)
 		require.Error(t, err)
 
-		_, err = b.UpdateAccountInfo(context.Background(), asset.Futures)
+		_, err = b.UpdateAccountInfo(t.Context(), asset.Futures)
 		require.Error(t, err)
 	}
 }
@@ -598,7 +597,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
-	_, err := b.ModifyOrder(context.Background(),
+	_, err := b.ModifyOrder(t.Context(),
 		&order.Modify{OrderID: "1337", AssetType: asset.Futures})
 	require.Error(t, err)
 }
@@ -618,7 +617,7 @@ func TestWithdraw(t *testing.T) {
 		OneTimePassword: 696969,
 	}
 
-	_, err := b.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)
+	_, err := b.WithdrawCryptocurrencyFunds(t.Context(), &withdrawCryptoRequest)
 	if sharedtestvalues.AreAPICredentialsSet(b) {
 		require.NoError(t, err)
 	} else {
@@ -631,7 +630,7 @@ func TestWithdrawFiat(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := b.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
@@ -640,7 +639,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, b, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
@@ -648,10 +647,10 @@ func TestWithdrawInternationalBank(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(b) {
-		_, err := b.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := b.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		require.NoError(t, err)
 	} else {
-		_, err := b.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := b.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		require.Error(t, err)
 	}
 }
@@ -667,7 +666,7 @@ func TestWsAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	go b.wsReadData()
-	err = b.websocketSendAuth(context.Background())
+	err = b.websocketSendAuth(t.Context())
 	require.NoError(t, err)
 	timer := time.NewTimer(sharedtestvalues.WebsocketResponseDefaultTimeout)
 	select {
@@ -687,7 +686,7 @@ func TestWsAuth(t *testing.T) {
 
 func TestUpdateTradablePairs(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTradablePairs(context.Background(), true)
+	err := b.UpdateTradablePairs(t.Context(), true)
 	require.NoError(t, err)
 }
 
@@ -882,32 +881,32 @@ func TestWsTrades(t *testing.T) {
 
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTradablePairs(context.Background(), false)
+	err := b.UpdateTradablePairs(t.Context(), false)
 	require.NoError(t, err)
 	currencyPair := b.CurrencyPairs.Pairs[asset.Futures].Available[0]
-	_, err = b.GetRecentTrades(context.Background(), currencyPair, asset.Futures)
+	_, err = b.GetRecentTrades(t.Context(), currencyPair, asset.Futures)
 	require.NoError(t, err)
 }
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTradablePairs(context.Background(), false)
+	err := b.UpdateTradablePairs(t.Context(), false)
 	require.NoError(t, err)
 	currencyPair := b.CurrencyPairs.Pairs[asset.Futures].Available[0]
-	_, err = b.GetHistoricTrades(context.Background(), currencyPair, asset.Futures, time.Now().Add(-time.Minute), time.Now())
+	_, err = b.GetHistoricTrades(t.Context(), currencyPair, asset.Futures, time.Now().Add(-time.Minute), time.Now())
 	require.NoError(t, err)
 }
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPair(currency.ETH, currency.USD)
-	_, err := b.UpdateTicker(context.Background(), cp, asset.PerpetualContract)
+	_, err := b.UpdateTicker(t.Context(), cp, asset.PerpetualContract)
 	require.NoError(t, err)
 }
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTickers(context.Background(), asset.PerpetualContract)
+	err := b.UpdateTickers(t.Context(), asset.PerpetualContract)
 	require.NoError(t, err)
 }
 
@@ -958,7 +957,7 @@ func TestGetActionFromString(t *testing.T) {
 func TestGetAccountFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAccountFundingHistory(context.Background())
+	_, err := b.GetAccountFundingHistory(t.Context())
 	require.NoError(t, err)
 }
 
@@ -966,7 +965,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	require.NoError(t, err)
 }
 
@@ -974,14 +973,14 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetOrderInfo(context.Background(), "1234", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
+	_, err := b.GetOrderInfo(t.Context(), "1234", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	require.NoError(t, err)
 }
 
 func TestCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelBatchOrders(context.Background(), []order.Cancel{
+	_, err := b.CancelBatchOrders(t.Context(), []order.Cancel{
 		{
 			OrderID:   "1234",
 			AssetType: asset.Spot,
@@ -993,42 +992,42 @@ func TestCancelBatchOrders(t *testing.T) {
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := b.GetFuturesContractDetails(t.Context(), asset.Spot)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
 
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.Futures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.Futures)
 	assert.NoError(t, err)
 
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.PerpetualContract)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.PerpetualContract)
 	assert.NoError(t, err)
 }
 
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
 		IncludePredictedRate: true,
 	})
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 		Pair:  currency.NewPair(currency.BTC, currency.KLAY),
 	})
 	assert.ErrorIs(t, err, futures.ErrNotPerpetualFuture)
 
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.PerpetualContract,
 	})
 	require.NoError(t, err)
 
 	cp, err := currency.NewPairFromString("ETHUSD")
 	require.NoError(t, err)
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.PerpetualContract,
 		Pair:  cp,
 	})
@@ -1052,7 +1051,7 @@ func TestGetOpenInterest(t *testing.T) {
 	cp2 := currency.NewPair(currency.DOGE, currency.USD)
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, b, asset.PerpetualContract, cp1, cp2)
 
-	resp, err := b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.XBT.Item,
 		Quote: currency.USD.Item,
 		Asset: asset.PerpetualContract,
@@ -1060,7 +1059,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background(),
+	resp, err = b.GetOpenInterest(t.Context(),
 		key.PairAsset{
 			Base:  currency.XBT.Item,
 			Quote: currency.USD.Item,
@@ -1074,11 +1073,11 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background())
+	resp, err = b.GetOpenInterest(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	_, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.Spot,
@@ -1093,7 +1092,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -1,7 +1,6 @@
 package bitstamp
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -53,7 +52,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
 	feeBuilder := setFeeBuilder()
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 	if mockTests {
 		assert.Equal(t, exchange.OfflineTradeFee, feeBuilder.FeeType, "TradeFee should be correct")
@@ -71,7 +70,7 @@ func TestGetFee(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	fee, err := b.GetFee(context.Background(), feeBuilder)
+	fee, err := b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 	if mockTests {
 		assert.NotEmpty(t, fee, "Fee should not be empty")
@@ -80,13 +79,13 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee High quantity
 	feeBuilder.Amount = 1000
 	feeBuilder.PurchasePrice = 1000
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
-	fee, err = b.GetFee(context.Background(), feeBuilder)
+	fee, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 	if mockTests {
 		assert.Positive(t, fee, "Maker fee should be positive")
@@ -95,7 +94,7 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee IsTaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = false
-	fee, err = b.GetFee(context.Background(), feeBuilder)
+	fee, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 	if mockTests {
 		assert.Positive(t, fee, "Taker fee should be positive")
@@ -104,33 +103,33 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee Negative purchase price
 	feeBuilder = setFeeBuilder()
 	feeBuilder.PurchasePrice = -1000
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 
 	// CryptocurrencyWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 
 	// InternationalBankDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
 	feeBuilder.FiatCurrency = currency.HKD
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 
 	// InternationalBankWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.HKD
-	fee, err = b.GetFee(context.Background(), feeBuilder)
+	fee, err = b.GetFee(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFee must not error")
 	assert.NotEmpty(t, fee, "Fee should not be empty")
 }
@@ -142,7 +141,7 @@ func TestGetAccountTradingFee(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
 
-	fee, err := b.GetAccountTradingFee(context.Background(), currency.NewPair(currency.LTC, currency.BTC))
+	fee, err := b.GetAccountTradingFee(t.Context(), currency.NewPair(currency.LTC, currency.BTC))
 	require.NoError(t, err, "GetAccountTradingFee must not error")
 	if mockTests {
 		assert.Positive(t, fee.Fees.Maker, "Maker should be positive")
@@ -151,7 +150,7 @@ func TestGetAccountTradingFee(t *testing.T) {
 	assert.NotEmpty(t, fee.Symbol, "Symbol should not be empty")
 	assert.Equal(t, "ltcbtc", fee.Symbol, "Symbol should be correct")
 
-	_, err = b.GetAccountTradingFee(context.Background(), currency.EMPTYPAIR)
+	_, err = b.GetAccountTradingFee(t.Context(), currency.EMPTYPAIR)
 	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "Should get back the right error")
 }
 
@@ -162,7 +161,7 @@ func TestGetAccountTradingFees(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
 
-	fees, err := b.GetAccountTradingFees(context.Background())
+	fees, err := b.GetAccountTradingFees(t.Context())
 	require.NoError(t, err, "GetAccountTradingFee must not error")
 	if assert.NotEmpty(t, fees, "Should get back multiple fees") {
 		fee := fees[0]
@@ -177,7 +176,7 @@ func TestGetAccountTradingFees(t *testing.T) {
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
 
-	tick, err := b.GetTicker(context.Background(),
+	tick, err := b.GetTicker(t.Context(),
 		currency.BTC.String()+currency.USD.String(), false)
 	require.NoError(t, err, "GetTicker must not error")
 	assert.Positive(t, tick.Ask, "Ask should be positive")
@@ -196,7 +195,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	ob, err := b.GetOrderbook(context.Background(), currency.BTC.String()+currency.USD.String())
+	ob, err := b.GetOrderbook(t.Context(), currency.BTC.String()+currency.USD.String())
 	require.NoError(t, err, "GetOrderbook must not error")
 	assert.NotEmpty(t, ob.Timestamp, "Timestamp should not be empty")
 	for i, o := range [][]OrderbookBase{ob.Asks, ob.Bids} {
@@ -212,7 +211,7 @@ func TestGetOrderbook(t *testing.T) {
 func TestGetTradingPairs(t *testing.T) {
 	t.Parallel()
 
-	p, err := b.GetTradingPairs(context.Background())
+	p, err := b.GetTradingPairs(t.Context())
 	require.NoError(t, err, "GetTradingPairs must not error")
 	assert.NotEmpty(t, p, "Pairs should not be empty")
 	for _, res := range p {
@@ -230,14 +229,14 @@ func TestGetTradingPairs(t *testing.T) {
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
 
-	p, err := b.FetchTradablePairs(context.Background(), asset.Spot)
+	p, err := b.FetchTradablePairs(t.Context(), asset.Spot)
 	require.NoError(t, err, "FetchTradablePairs must not error")
 	assert.True(t, p.Contains(currency.NewBTCUSD(), true), "Pairs should contain BTC/USD")
 }
 
 func TestUpdateTradablePairs(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTradablePairs(context.Background(), true)
+	err := b.UpdateTradablePairs(t.Context(), true)
 	require.NoError(t, err, "UpdateTradablePairs must not error")
 }
 
@@ -257,7 +256,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 		},
 	}
 	for assetItem, limitTests := range tests {
-		if err := b.UpdateOrderExecutionLimits(context.Background(), assetItem); err != nil {
+		if err := b.UpdateOrderExecutionLimits(t.Context(), assetItem); err != nil {
 			t.Errorf("Error fetching %s pairs for test: %v", assetItem, err)
 		}
 		for _, limitTest := range limitTests {
@@ -285,7 +284,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 func TestGetTransactions(t *testing.T) {
 	t.Parallel()
 
-	tr, err := b.GetTransactions(context.Background(),
+	tr, err := b.GetTransactions(t.Context(),
 		currency.BTC.String()+currency.USD.String(), "hour")
 	require.NoError(t, err, "GetTransactions must not error")
 	assert.NotEmpty(t, tr, "Transactions should not be empty")
@@ -300,7 +299,7 @@ func TestGetTransactions(t *testing.T) {
 func TestGetEURUSDConversionRate(t *testing.T) {
 	t.Parallel()
 
-	c, err := b.GetEURUSDConversionRate(context.Background())
+	c, err := b.GetEURUSDConversionRate(t.Context())
 	require.NoError(t, err, "GetEURUSDConversionRate must not error")
 	assert.Positive(t, c.Sell, "Sell should be positive")
 	assert.Positive(t, c.Buy, "Buy should be positive")
@@ -312,7 +311,7 @@ func TestGetBalance(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	bal, err := b.GetBalance(context.Background())
+	bal, err := b.GetBalance(t.Context())
 	require.NoError(t, err, "GetBalance must not error")
 	if mockTests {
 		for k, e := range map[string]Balance{
@@ -343,7 +342,7 @@ func TestGetUserTransactions(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	tr, err := b.GetUserTransactions(context.Background(), "btcusd")
+	tr, err := b.GetUserTransactions(t.Context(), "btcusd")
 	require.NoError(t, err, "GetUserTransactions must not error")
 	if mockTests {
 		assert.NotEmpty(t, tr, "Transactions should not be empty")
@@ -360,7 +359,7 @@ func TestGetOpenOrders(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	o, err := b.GetOpenOrders(context.Background(), "btcusd")
+	o, err := b.GetOpenOrders(t.Context(), "btcusd")
 	require.NoError(t, err, "GetOpenOrders must not error")
 	if mockTests {
 		assert.NotEmpty(t, o, "Orders should not be empty")
@@ -384,7 +383,7 @@ func TestGetOrderStatus(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	o, err := b.GetOrderStatus(context.Background(), 1458532827766784)
+	o, err := b.GetOrderStatus(t.Context(), 1458532827766784)
 	if !mockTests {
 		assert.ErrorContains(t, err, "Order not found")
 	} else {
@@ -411,7 +410,7 @@ func TestGetWithdrawalRequests(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	r, err := b.GetWithdrawalRequests(context.Background(), 1)
+	r, err := b.GetWithdrawalRequests(t.Context(), 1)
 	require.NoError(t, err, "GetWithdrawalRequests must not error")
 	if mockTests {
 		assert.NotEmpty(t, r, "GetWithdrawalRequests should return a withdrawal request")
@@ -436,7 +435,7 @@ func TestGetUnconfirmedBitcoinDeposits(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	d, err := b.GetUnconfirmedBitcoinDeposits(context.Background())
+	d, err := b.GetUnconfirmedBitcoinDeposits(t.Context())
 	require.NoError(t, err, "GetUnconfirmedBitcoinDeposits must not error")
 	if mockTests {
 		assert.NotEmpty(t, d, "Deposits should not be empty")
@@ -454,7 +453,7 @@ func TestTransferAccountBalance(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	err := b.TransferAccountBalance(context.Background(),
+	err := b.TransferAccountBalance(t.Context(),
 		10000, "BTC", "1234567", true)
 	if !mockTests {
 		assert.ErrorContains(t, err, "Sub account with identifier \"1234567\" does not exist.")
@@ -479,7 +478,7 @@ func TestGetActiveOrders(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	o, err := b.GetActiveOrders(context.Background(), &order.MultiOrderRequest{
+	o, err := b.GetActiveOrders(t.Context(), &order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -504,7 +503,7 @@ func TestGetOrderHistory(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	o, err := b.GetOrderHistory(context.Background(), &order.MultiOrderRequest{
+	o, err := b.GetOrderHistory(t.Context(), &order.MultiOrderRequest{
 		Type:      order.AnyType,
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
@@ -528,7 +527,7 @@ func TestSubmitOrder(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
-	o, err := b.SubmitOrder(context.Background(), &order.Submit{
+	o, err := b.SubmitOrder(t.Context(), &order.Submit{
 		Exchange: b.Name,
 		Pair: currency.Pair{
 			Base:  currency.BTC,
@@ -561,7 +560,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
-	err := b.CancelOrder(context.Background(), &order.Cancel{
+	err := b.CancelOrder(t.Context(), &order.Cancel{
 		OrderID: "1453282316578816",
 	})
 	if !mockTests {
@@ -577,7 +576,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
-	resp, err := b.CancelAllOrders(context.Background(),
+	resp, err := b.CancelAllOrders(t.Context(),
 		&order.Cancel{AssetType: asset.Spot})
 	require.NoError(t, err, "TestCancelAllExchangeOrders must not error")
 	if len(resp.Status) > 0 {
@@ -588,7 +587,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := b.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
@@ -598,7 +597,7 @@ func TestWithdraw(t *testing.T) {
 	if !mockTests {
 		t.Skip("TestWithdraw not allowed for live tests")
 	}
-	w, err := b.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	w, err := b.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange:    b.Name,
 		Amount:      6,
 		Currency:    currency.BTC,
@@ -645,7 +644,7 @@ func TestWithdrawFiat(t *testing.T) {
 		Description: "WITHDRAW IT ALL",
 	}
 
-	w, err := b.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	w, err := b.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if mockTests {
 		require.NoError(t, err, "WithdrawFiat must not error")
 		assert.Equal(t, "1", w.ID, "Withdrawal ID should be correct")
@@ -694,7 +693,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		Description: "WITHDRAW IT ALL",
 	}
 
-	w, err := b.WithdrawFiatFundsToInternationalBank(context.Background(),
+	w, err := b.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if mockTests {
 		assert.Equal(t, "1", w.ID, "Withdrawal ID should be correct")
@@ -709,7 +708,7 @@ func TestGetDepositAddress(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 	}
-	a, err := b.GetDepositAddress(context.Background(), currency.XRP, "", "")
+	a, err := b.GetDepositAddress(t.Context(), currency.XRP, "", "")
 	require.NoError(t, err, "GetDepositAddress must not error")
 	assert.NotEmpty(t, a.Address, "Address should not be empty")
 	assert.NotEmpty(t, a.Tag, "Tag should not be empty")
@@ -868,7 +867,7 @@ func TestWsRequestReconnect(t *testing.T) {
 func TestBitstamp_OHLC(t *testing.T) {
 	start := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
-	o, err := b.OHLC(context.Background(), "btcusd", start, end, "60", "10")
+	o, err := b.OHLC(t.Context(), "btcusd", start, end, "60", "10")
 	require.NoError(t, err, "TestBitstamp_OHLC must not error")
 	assert.Equal(t, "BTC/USD", o.Data.Pair, "Pair should be correct")
 	for _, req := range o.Data.OHLCV {
@@ -883,7 +882,7 @@ func TestBitstamp_OHLC(t *testing.T) {
 func TestBitstamp_GetHistoricCandles(t *testing.T) {
 	start := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
-	c, err := b.GetHistoricCandles(context.Background(), btcusdPair, asset.Spot, kline.OneDay, start, end)
+	c, err := b.GetHistoricCandles(t.Context(), btcusdPair, asset.Spot, kline.OneDay, start, end)
 	require.NoError(t, err, "GetHistoricCandles must not error")
 	assert.Equal(t, btcusdPair, c.Pair, "Pair should be correct")
 	assert.NotEmpty(t, c, "Candles should not be empty")
@@ -901,7 +900,7 @@ func TestBitstamp_GetHistoricCandlesExtended(t *testing.T) {
 	start := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
 
-	c, err := b.GetHistoricCandlesExtended(context.Background(), btcusdPair, asset.Spot, kline.OneDay, start, end)
+	c, err := b.GetHistoricCandlesExtended(t.Context(), btcusdPair, asset.Spot, kline.OneDay, start, end)
 	require.NoError(t, err, "GetHistoricCandlesExtended must not error")
 	assert.Equal(t, btcusdPair, c.Pair, "Pair should be correct")
 	assert.NotEmpty(t, c, "Candles should not be empty")
@@ -921,7 +920,7 @@ func TestGetRecentTrades(t *testing.T) {
 	currencyPair, err := currency.NewPairFromString("LTCUSD")
 	require.NoError(t, err, "NewPairFromString must not error")
 
-	tr, err := b.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	tr, err := b.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	require.NoError(t, err, "GetRecentTrades must not error")
 	assert.NotEmpty(t, tr, "Trades should not be empty")
 	for _, req := range tr {
@@ -939,7 +938,7 @@ func TestGetHistoricTrades(t *testing.T) {
 
 	currencyPair, err := currency.NewPairFromString("LTCUSD")
 	require.NoError(t, err, "NewPairFromString must not error")
-	_, err = b.GetHistoricTrades(context.Background(),
+	_, err = b.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
@@ -980,7 +979,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	h, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	h, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	require.NoError(t, err, "GetWithdrawalsHistory must not error")
 	if mockTests {
 		assert.NotEmpty(t, h, "WithdrawalHistory should not be empty")
@@ -998,7 +997,7 @@ func TestGetOrderInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	o, err := b.GetOrderInfo(context.Background(), "1458532827766784", btcusdPair, asset.Spot)
+	o, err := b.GetOrderInfo(t.Context(), "1458532827766784", btcusdPair, asset.Spot)
 	if mockTests {
 		require.NoError(t, err, "GetOrderInfo must not error")
 		assert.Equal(t, time.Date(2022, time.January, 31, 14, 43, 15, 0, time.UTC), o.Date, "Date should match")
@@ -1019,7 +1018,7 @@ func TestFetchWSAuth(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	resp, err := b.FetchWSAuth(context.TODO())
+	resp, err := b.FetchWSAuth(t.Context())
 	require.NoError(t, err, "FetchWSAuth must not error")
 	assert.NotNil(t, resp, "resp should not be nil")
 	assert.Positive(t, resp.UserID, "UserID should be positive")
@@ -1034,7 +1033,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/blackbox_test.go
+++ b/exchanges/blackbox_test.go
@@ -25,7 +25,7 @@ func TestBootstrap(t *testing.T) {
 		make(chan int, 1),
 	}
 	m.Features.Enabled.AutoPairUpdates = true
-	err := exchange.Bootstrap(context.TODO(), m)
+	err := exchange.Bootstrap(t.Context(), m)
 	assert.NoError(t, err, "Bootstrap should not error")
 	assert.Equal(t, 42, <-m.flow, "UpdateTradablePairs should be called on the exchange")
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 
 func TestGetMarkets(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarkets(context.Background())
+	_, err := b.GetMarkets(t.Context())
 	if err != nil {
 		t.Error("GetTicker() error", err)
 	}
@@ -77,7 +77,7 @@ func TestGetMarkets(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTicker(context.Background(), BTCAUD)
+	_, err := b.GetTicker(t.Context(), BTCAUD)
 	if err != nil {
 		t.Error("GetOrderbook() error", err)
 	}
@@ -85,7 +85,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrades(context.Background(), BTCAUD, 0, 0, 5)
+	_, err := b.GetTrades(t.Context(), BTCAUD, 0, 0, 5)
 	if err != nil {
 		t.Error("GetTrades() error", err)
 	}
@@ -93,7 +93,7 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderbook(context.Background(), BTCAUD, 2)
+	_, err := b.GetOrderbook(t.Context(), BTCAUD, 2)
 	if err != nil {
 		t.Error("GetTrades() error", err)
 	}
@@ -101,7 +101,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetMarketCandles(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarketCandles(context.Background(),
+	_, err := b.GetMarketCandles(t.Context(),
 		BTCAUD, "1h", time.Now().UTC().Add(-time.Hour*24), time.Now().UTC(), -1, -1, -1)
 	if err != nil {
 		t.Error(err)
@@ -114,7 +114,7 @@ func TestGetTickers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetTickers(context.Background(), temp)
+	_, err = b.GetTickers(t.Context(), temp)
 	if err != nil {
 		t.Error(err)
 	}
@@ -123,7 +123,7 @@ func TestGetTickers(t *testing.T) {
 func TestGetMultipleOrderbooks(t *testing.T) {
 	t.Parallel()
 	temp := []string{BTCAUD, LTCAUD, ETHAUD}
-	_, err := b.GetMultipleOrderbooks(context.Background(), temp)
+	_, err := b.GetMultipleOrderbooks(t.Context(), temp)
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,7 +131,7 @@ func TestGetMultipleOrderbooks(t *testing.T) {
 
 func TestGetCurrentServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetCurrentServerTime(context.Background())
+	_, err := b.GetCurrentServerTime(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -139,7 +139,7 @@ func TestGetCurrentServerTime(t *testing.T) {
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := b.GetServerTime(context.Background(), asset.Spot)
+	st, err := b.GetServerTime(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -152,7 +152,7 @@ func TestWrapperGetServerTime(t *testing.T) {
 func TestGetAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAccountBalance(context.Background())
+	_, err := b.GetAccountBalance(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +161,7 @@ func TestGetAccountBalance(t *testing.T) {
 func TestGetTradingFees(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTradingFees(context.Background())
+	_, err := b.GetTradingFees(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -170,15 +170,15 @@ func TestGetTradingFees(t *testing.T) {
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTradeHistory(context.Background(), ETHAUD, "", -1, -1, -1)
+	_, err := b.GetTradeHistory(t.Context(), ETHAUD, "", -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTradeHistory(context.Background(), BTCAUD, "", -1, -1, 1)
+	_, err = b.GetTradeHistory(t.Context(), BTCAUD, "", -1, -1, 1)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTradeHistory(context.Background(), fakePair, "", -1, -1, -1)
+	_, err = b.GetTradeHistory(t.Context(), fakePair, "", -1, -1, -1)
 	if err == nil {
 		t.Error("expected an error due to invalid trading pair")
 	}
@@ -187,7 +187,7 @@ func TestGetTradeHistory(t *testing.T) {
 func TestGetTradeByID(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTradeByID(context.Background(), "4712043732")
+	_, err := b.GetTradeByID(t.Context(), "4712043732")
 	if err != nil {
 		t.Error(err)
 	}
@@ -195,7 +195,7 @@ func TestGetTradeByID(t *testing.T) {
 
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
-	_, err := b.SubmitOrder(context.Background(), &order.Submit{
+	_, err := b.SubmitOrder(t.Context(), &order.Submit{
 		Exchange:  b.Name,
 		Price:     100,
 		Amount:    1,
@@ -208,7 +208,7 @@ func TestSubmitOrder(t *testing.T) {
 	if !errors.Is(err, order.ErrTypeIsInvalid) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, order.ErrTypeIsInvalid)
 	}
-	_, err = b.SubmitOrder(context.Background(), &order.Submit{
+	_, err = b.SubmitOrder(t.Context(), &order.Submit{
 		Exchange:  b.Name,
 		Price:     100,
 		Amount:    1,
@@ -224,7 +224,7 @@ func TestSubmitOrder(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err = b.SubmitOrder(context.Background(), &order.Submit{
+	_, err = b.SubmitOrder(t.Context(), &order.Submit{
 		Exchange:  b.Name,
 		Price:     100,
 		Amount:    1,
@@ -242,7 +242,7 @@ func TestSubmitOrder(t *testing.T) {
 func TestNewOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.NewOrder(context.Background(), 100, 1, 0, 0, BTCAUD, limit, bidSide, "", "", "", true)
+	_, err := b.NewOrder(t.Context(), 100, 1, 0, 0, BTCAUD, limit, bidSide, "", "", "", true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -251,11 +251,11 @@ func TestNewOrder(t *testing.T) {
 func TestGetOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOrders(context.Background(), "", -1, -1, 2, false)
+	_, err := b.GetOrders(t.Context(), "", -1, -1, 2, false)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrders(context.Background(), LTCAUD, -1, -1, -1, true)
+	_, err = b.GetOrders(t.Context(), LTCAUD, -1, -1, -1, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -266,12 +266,12 @@ func TestCancelOpenOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	temp := []string{BTCAUD, LTCAUD}
-	_, err := b.CancelAllOpenOrdersByPairs(context.Background(), temp)
+	_, err := b.CancelAllOpenOrdersByPairs(t.Context(), temp)
 	if err != nil {
 		t.Error(err)
 	}
 	temp = []string{BTCAUD, fakePair}
-	_, err = b.CancelAllOpenOrdersByPairs(context.Background(), temp)
+	_, err = b.CancelAllOpenOrdersByPairs(t.Context(), temp)
 	if err == nil {
 		t.Error("expected an error due to invalid marketID")
 	}
@@ -281,11 +281,11 @@ func TestFetchOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.FetchOrder(context.Background(), "4477045999")
+	_, err := b.FetchOrder(t.Context(), "4477045999")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.FetchOrder(context.Background(), "696969")
+	_, err = b.FetchOrder(t.Context(), "696969")
 	if err == nil {
 		t.Error(err)
 	}
@@ -295,7 +295,7 @@ func TestRemoveOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.RemoveOrder(context.Background(), "")
+	_, err := b.RemoveOrder(t.Context(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -305,7 +305,7 @@ func TestListWithdrawals(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.ListWithdrawals(context.Background(), -1, -1, -1)
+	_, err := b.ListWithdrawals(t.Context(), -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -315,7 +315,7 @@ func TestGetWithdrawal(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetWithdrawal(context.Background(), "4477381751")
+	_, err := b.GetWithdrawal(t.Context(), "4477381751")
 	if err != nil {
 		t.Error(err)
 	}
@@ -325,7 +325,7 @@ func TestListDeposits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.ListDeposits(context.Background(), -1, -1, -1)
+	_, err := b.ListDeposits(t.Context(), -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -335,7 +335,7 @@ func TestGetDeposit(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetDeposit(context.Background(), "4476769607")
+	_, err := b.GetDeposit(t.Context(), "4476769607")
 	if err != nil {
 		t.Error(err)
 	}
@@ -345,7 +345,7 @@ func TestListTransfers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.ListTransfers(context.Background(), -1, -1, -1)
+	_, err := b.ListTransfers(t.Context(), -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -355,11 +355,11 @@ func TestGetTransfer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetTransfer(context.Background(), "4476769607")
+	_, err := b.GetTransfer(t.Context(), "4476769607")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTransfer(context.Background(), "6969696")
+	_, err = b.GetTransfer(t.Context(), "6969696")
 	if err == nil {
 		t.Error("expected an error due to invalid transferID")
 	}
@@ -369,11 +369,11 @@ func TestFetchDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.FetchDepositAddress(context.Background(), currency.XRP, -1, -1, -1)
+	_, err := b.FetchDepositAddress(t.Context(), currency.XRP, -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.FetchDepositAddress(context.Background(), currency.NewCode("MOOCOW"), -1, -1, -1)
+	_, err = b.FetchDepositAddress(t.Context(), currency.NewCode("MOOCOW"), -1, -1, -1)
 	if err != nil {
 		t.Error("expected an error due to invalid assetID")
 	}
@@ -381,7 +381,7 @@ func TestFetchDepositAddress(t *testing.T) {
 
 func TestGetWithdrawalFees(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetWithdrawalFees(context.Background())
+	_, err := b.GetWithdrawalFees(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -391,7 +391,7 @@ func TestListAssets(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.ListAssets(context.Background())
+	_, err := b.ListAssets(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -401,7 +401,7 @@ func TestGetTransactions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetTransactions(context.Background(), "", -1, -1, -1)
+	_, err := b.GetTransactions(t.Context(), "", -1, -1, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -411,7 +411,7 @@ func TestCreateNewReport(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.CreateNewReport(context.Background(), "TransactionReport", "json")
+	_, err := b.CreateNewReport(t.Context(), "TransactionReport", "json")
 	if err != nil {
 		t.Error(err)
 	}
@@ -421,7 +421,7 @@ func TestGetReport(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetReport(context.Background(), "1kv38epne5v7lek9f18m60idg6")
+	_, err := b.GetReport(t.Context(), "1kv38epne5v7lek9f18m60idg6")
 	if err != nil {
 		t.Error(err)
 	}
@@ -431,7 +431,7 @@ func TestRequestWithdaw(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err := b.RequestWithdraw(context.Background(), "BTC", 1, "sdjflajdslfjld", "", "", "", "")
+	_, err := b.RequestWithdraw(t.Context(), "BTC", 1, "sdjflajdslfjld", "", "", "", "")
 	if err == nil {
 		t.Error("expected an error due to invalid toAddress")
 	}
@@ -449,7 +449,7 @@ func TestBatchPlaceCancelOrders(t *testing.T) {
 		OrderType: order.Limit.String(),
 		Side:      bid,
 	}
-	_, err := b.BatchPlaceCancelOrders(context.Background(), nil, append(temp, o))
+	_, err := b.BatchPlaceCancelOrders(t.Context(), nil, append(temp, o))
 	if err != nil {
 		t.Error(err)
 	}
@@ -460,7 +460,7 @@ func TestGetBatchTrades(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
 	temp := []string{"4477045999", "4477381751", "4476769607"}
-	_, err := b.GetBatchTrades(context.Background(), temp)
+	_, err := b.GetBatchTrades(t.Context(), temp)
 	if err != nil {
 		t.Error(err)
 	}
@@ -471,7 +471,7 @@ func TestCancelBatch(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	temp := []string{"4477045999", "4477381751", "4477381751"}
-	_, err := b.CancelBatch(context.Background(), temp)
+	_, err := b.CancelBatch(t.Context(), temp)
 	if err != nil {
 		t.Error(err)
 	}
@@ -481,7 +481,7 @@ func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetOrderHistory(context.Background(), &order.MultiOrderRequest{
+	_, err := b.GetOrderHistory(t.Context(), &order.MultiOrderRequest{
 		Side:      order.Buy,
 		AssetType: asset.Spot,
 		Type:      order.AnyType,
@@ -494,7 +494,7 @@ func TestGetOrderHistory(t *testing.T) {
 func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.AUD.String(), "-")
-	_, err := b.UpdateOrderbook(context.Background(), cp, asset.Spot)
+	_, err := b.UpdateOrderbook(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -503,7 +503,7 @@ func TestUpdateOrderbook(t *testing.T) {
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.AUD.String(), "-")
-	_, err := b.UpdateTicker(context.Background(), cp, asset.Spot)
+	_, err := b.UpdateTicker(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -511,7 +511,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTickers(context.Background(), asset.Spot)
+	err := b.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -521,7 +521,7 @@ func TestGetActiveOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.GetActiveOrders(context.Background(),
+	_, err := b.GetActiveOrders(t.Context(),
 		&order.MultiOrderRequest{AssetType: asset.Spot, Side: order.AnySide, Type: order.AnyType})
 	if err != nil {
 		t.Fatal(err)
@@ -783,12 +783,12 @@ func TestBTCMarkets_GetHistoricCandles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = b.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.OneHour, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC())
+	_, err = b.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.OneHour, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = b.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.FifteenMin, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC())
+	_, err = b.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.FifteenMin, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -803,7 +803,7 @@ func TestBTCMarkets_GetHistoricCandlesExtended(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = b.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.OneHour, start, end)
+	_, err = b.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.OneHour, start, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -846,7 +846,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = b.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -858,7 +858,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(),
+	_, err = b.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -1015,24 +1015,24 @@ func TestGetTimeInForce(t *testing.T) {
 
 func TestReplaceOrder(t *testing.T) {
 	t.Parallel()
-	_, err := b.ReplaceOrder(context.Background(), "", "bro", 0, 0)
+	_, err := b.ReplaceOrder(t.Context(), "", "bro", 0, 0)
 	if !errors.Is(err, errInvalidAmount) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errInvalidAmount)
 	}
 
-	_, err = b.ReplaceOrder(context.Background(), "", "bro", 1, 0)
+	_, err = b.ReplaceOrder(t.Context(), "", "bro", 1, 0)
 	if !errors.Is(err, errInvalidAmount) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errInvalidAmount)
 	}
 
-	_, err = b.ReplaceOrder(context.Background(), "", "bro", 1, 1)
+	_, err = b.ReplaceOrder(t.Context(), "", "bro", 1, 1)
 	if !errors.Is(err, errIDRequired) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errIDRequired)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	_, err = b.ReplaceOrder(context.Background(), "8207096301", "bruh", 100000, 0.001)
+	_, err = b.ReplaceOrder(t.Context(), "8207096301", "bruh", 100000, 0.001)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -1040,14 +1040,14 @@ func TestReplaceOrder(t *testing.T) {
 
 func TestWrapperModifyOrder(t *testing.T) {
 	t.Parallel()
-	_, err := b.ModifyOrder(context.Background(), &order.Modify{})
+	_, err := b.ModifyOrder(t.Context(), &order.Modify{})
 	if !errors.Is(err, order.ErrPairIsEmpty) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, order.ErrPairIsEmpty)
 	}
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	mo, err := b.ModifyOrder(context.Background(), &order.Modify{
+	mo, err := b.ModifyOrder(t.Context(), &order.Modify{
 		Pair:          currency.NewPair(currency.BTC, currency.AUD),
 		AssetType:     asset.Spot,
 		Price:         100000,
@@ -1066,12 +1066,12 @@ func TestWrapperModifyOrder(t *testing.T) {
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateOrderExecutionLimits(context.Background(), asset.Empty)
+	err := b.UpdateOrderExecutionLimits(t.Context(), asset.Empty)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, asset.ErrNotSupported)
 	}
 
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -1129,7 +1129,7 @@ func TestConvertToKlineCandle(t *testing.T) {
 func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1138,7 +1138,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 func TestCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelBatchOrders(context.Background(), []order.Cancel{
+	_, err := b.CancelBatchOrders(t.Context(), []order.Cancel{
 		{
 			OrderID:   "1234",
 			AssetType: asset.Spot,
@@ -1157,7 +1157,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -1,7 +1,6 @@
 package btse
 
 import (
-	"context"
 	"log"
 	"os"
 	"testing"
@@ -79,65 +78,65 @@ func TestUpdateTradablePairs(t *testing.T) {
 }
 
 func TestFetchFundingHistory(t *testing.T) {
-	_, err := b.FetchFundingHistory(context.Background(), "")
+	_, err := b.FetchFundingHistory(t.Context(), "")
 	assert.NoError(t, err, "FetchFundingHistory should not error")
 }
 
 func TestGetMarketsSummary(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarketSummary(context.Background(), "", true)
+	_, err := b.GetMarketSummary(t.Context(), "", true)
 	assert.NoError(t, err, "GetMarketSummary should not error")
 
-	ret, err := b.GetMarketSummary(context.Background(), spotPair.String(), true)
+	ret, err := b.GetMarketSummary(t.Context(), spotPair.String(), true)
 	assert.NoError(t, err, "GetMarketSummary should not error")
 	assert.Len(t, ret, 1, "expected only one result when requesting BTC-USD data received")
 
-	_, err = b.GetMarketSummary(context.Background(), "", false)
+	_, err = b.GetMarketSummary(t.Context(), "", false)
 	assert.NoError(t, err, "GetMarketSummary should not error")
 }
 
 func TestFetchOrderBook(t *testing.T) {
 	t.Parallel()
-	_, err := b.FetchOrderbook(context.Background(), spotPair.String(), 0, 1, 1, true)
+	_, err := b.FetchOrderbook(t.Context(), spotPair.String(), 0, 1, 1, true)
 	assert.NoError(t, err, "FetchOrderBook should not error")
 
-	_, err = b.FetchOrderbook(context.Background(), futuresPair.String(), 0, 1, 1, false)
+	_, err = b.FetchOrderbook(t.Context(), futuresPair.String(), 0, 1, 1, false)
 	assert.NoError(t, err, "FetchOrderBook should not error")
 
-	_, err = b.FetchOrderbook(context.Background(), spotPair.String(), 1, 1, 1, true)
+	_, err = b.FetchOrderbook(t.Context(), spotPair.String(), 1, 1, 1, true)
 	assert.NoError(t, err, "FetchOrderBook should not error")
 }
 
 func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := b.UpdateOrderbook(context.Background(), spotPair, asset.Spot)
+	_, err := b.UpdateOrderbook(t.Context(), spotPair, asset.Spot)
 	assert.NoError(t, err, "UpdateOrderbook should not error")
 
-	_, err = b.UpdateOrderbook(context.Background(), futuresPair, asset.Futures)
+	_, err = b.UpdateOrderbook(t.Context(), futuresPair, asset.Futures)
 	assert.NoError(t, err, "UpdateOrderbook should not error")
 }
 
 func TestFetchOrderBookL2(t *testing.T) {
 	t.Parallel()
-	_, err := b.FetchOrderbookL2(context.Background(), spotPair.String(), 20)
+	_, err := b.FetchOrderbookL2(t.Context(), spotPair.String(), 20)
 	assert.NoError(t, err, "FetchOrderBookL2 should not error")
 }
 
 func TestOHLCV(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOHLCV(context.Background(), spotPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 60, asset.Spot)
+	_, err := b.GetOHLCV(t.Context(), spotPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 60, asset.Spot)
 	assert.NoError(t, err, "GetOHLCV should not error")
 
-	_, err = b.GetOHLCV(context.Background(), spotPair.String(), time.Now(), time.Now().AddDate(0, 0, -1), 60, asset.Spot)
+	_, err = b.GetOHLCV(t.Context(), spotPair.String(), time.Now(), time.Now().AddDate(0, 0, -1), 60, asset.Spot)
 	assert.ErrorIs(t, err, common.ErrStartAfterEnd, "GetOHLCV should error if start date after end date")
 
-	_, err = b.GetOHLCV(context.Background(), futuresPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 60, asset.Futures)
+	_, err = b.GetOHLCV(t.Context(), futuresPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 60, asset.Futures)
 	assert.NoError(t, err, "GetOHLCV should not error")
 }
 
 func TestGetPrice(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPrice(context.Background(), spotPair.String())
+	_, err := b.GetPrice(t.Context(), spotPair.String())
 	assert.NoError(t, err, "GetPrice should not error")
 }
 
@@ -153,10 +152,10 @@ func TestGetHistoricCandles(t *testing.T) {
 	require.NoError(t, testexch.Setup(b), "Test exchange Setup must not error")
 	b.Requester = r
 	start := time.Now().AddDate(0, 0, -3)
-	_, err := b.GetHistoricCandles(context.Background(), spotPair, asset.Spot, kline.OneHour, start, time.Now())
+	_, err := b.GetHistoricCandles(t.Context(), spotPair, asset.Spot, kline.OneHour, start, time.Now())
 	assert.NoError(t, err, "GetHistoricCandles should not error")
 
-	_, err = b.GetHistoricCandles(context.Background(), spotPair, asset.Spot, kline.OneDay, start, time.Now())
+	_, err = b.GetHistoricCandles(t.Context(), spotPair, asset.Spot, kline.OneDay, start, time.Now())
 	assert.NoError(t, err, "GetHistoricCandles should not error")
 }
 
@@ -170,52 +169,52 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	assert.NoError(t, err, "StorePairs should not error")
 
 	start := time.Now().AddDate(0, 0, -1)
-	_, err = b.GetHistoricCandlesExtended(context.Background(), spotPair, asset.Spot, kline.OneHour, start, time.Now())
+	_, err = b.GetHistoricCandlesExtended(t.Context(), spotPair, asset.Spot, kline.OneHour, start, time.Now())
 	assert.NoError(t, err, "GetHistoricCandlesExtended should not error")
 
-	_, err = b.GetHistoricCandlesExtended(context.Background(), futuresPair, asset.Futures, kline.OneHour, start, time.Now())
+	_, err = b.GetHistoricCandlesExtended(t.Context(), futuresPair, asset.Futures, kline.OneHour, start, time.Now())
 	assert.NoError(t, err, "GetHistoricCandlesExtended should not error")
 }
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTrades(context.Background(), spotPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 0, 0, 50, false, true)
+	_, err := b.GetTrades(t.Context(), spotPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 0, 0, 50, false, true)
 	assert.NoError(t, err, "GetTrades should not error")
 
-	_, err = b.GetTrades(context.Background(), spotPair.String(), time.Now(), time.Now().AddDate(0, -1, 0), 0, 0, 50, false, true)
+	_, err = b.GetTrades(t.Context(), spotPair.String(), time.Now(), time.Now().AddDate(0, -1, 0), 0, 0, 50, false, true)
 	assert.ErrorIs(t, err, common.ErrStartAfterEnd, "GetTrades should error if start date after end date")
 
-	_, err = b.GetTrades(context.Background(), futuresPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 0, 0, 50, false, false)
+	_, err = b.GetTrades(t.Context(), futuresPair.String(), time.Now().AddDate(0, 0, -1), time.Now(), 0, 0, 50, false, false)
 	assert.NoError(t, err, "GetTrades should not error")
 }
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.UpdateTicker(context.Background(), spotPair, asset.Spot)
+	_, err := b.UpdateTicker(t.Context(), spotPair, asset.Spot)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 
-	_, err = b.UpdateTicker(context.Background(), futuresPair, asset.Futures)
+	_, err = b.UpdateTicker(t.Context(), futuresPair, asset.Futures)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 }
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateTickers(context.Background(), asset.Spot)
+	err := b.UpdateTickers(t.Context(), asset.Spot)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 
-	err = b.UpdateTickers(context.Background(), asset.Futures)
+	err = b.UpdateTickers(t.Context(), asset.Futures)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTickers may only error about locked markets")
 }
 
 func TestGetCurrentServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetCurrentServerTime(context.Background())
+	_, err := b.GetCurrentServerTime(t.Context())
 	assert.NoError(t, err, "GetCurrentServerTime should not error")
 }
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := b.GetServerTime(context.Background(), asset.Spot)
+	st, err := b.GetServerTime(t.Context(), asset.Spot)
 	assert.NoError(t, err, "GetServerTime should not error")
 	assert.WithinRange(t, st, time.Now().Add(-24*time.Hour), time.Now().Add(24*time.Hour), "Time should be within a day of now")
 }
@@ -223,63 +222,63 @@ func TestWrapperGetServerTime(t *testing.T) {
 func TestGetWalletInformation(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWalletInformation(context.Background())
+	_, err := b.GetWalletInformation(t.Context())
 	assert.NoError(t, err, "GetWalletInformation should not error")
 }
 
 func TestGetFeeInformation(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetFeeInformation(context.Background(), "")
+	_, err := b.GetFeeInformation(t.Context(), "")
 	assert.NoError(t, err, "GetFeeInformation should not error")
 }
 
 func TestGetWalletHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWalletHistory(context.Background(), spotPair.String(), time.Time{}, time.Time{}, 50)
+	_, err := b.GetWalletHistory(t.Context(), spotPair.String(), time.Time{}, time.Time{}, 50)
 	assert.NoError(t, err, "GetWalletHistory should not error")
 }
 
 func TestGetWalletAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWalletAddress(context.Background(), "XRP")
+	_, err := b.GetWalletAddress(t.Context(), "XRP")
 	assert.NoError(t, err, "GetWalletAddress should not error")
 }
 
 func TestCreateWalletAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.CreateWalletAddress(context.Background(), "XRP")
+	_, err := b.CreateWalletAddress(t.Context(), "XRP")
 	assert.NoError(t, err, "CreateWalletAddress should not error")
 }
 
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := b.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	assert.NoError(t, err, "GetDepositAddress should not error")
 }
 
 func TestCreateOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CreateOrder(context.Background(), "", 0.0, false, -1, "BUY", 100, 0, 0, spotPair.String(), "GTC", 0.0, 0.0, "LIMIT", "LIMIT")
+	_, err := b.CreateOrder(t.Context(), "", 0.0, false, -1, "BUY", 100, 0, 0, spotPair.String(), "GTC", 0.0, 0.0, "LIMIT", "LIMIT")
 	assert.NoError(t, err, "CreateOrder should not error")
 }
 
 func TestBTSEIndexOrderPeg(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.IndexOrderPeg(context.Background(), "", 0.0, false, -1, "BUY", 100, 0, 0, spotPair.String(), "GTC", 0.0, 0.0, "", "LIMIT")
+	_, err := b.IndexOrderPeg(t.Context(), "", 0.0, false, -1, "BUY", 100, 0, 0, spotPair.String(), "GTC", 0.0, 0.0, "", "LIMIT")
 	assert.NoError(t, err, "IndexOrderPeg should not error")
 }
 
 func TestGetOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOrders(context.Background(), spotPair.String(), "", "")
+	_, err := b.GetOrders(t.Context(), spotPair.String(), "", "")
 	assert.NoError(t, err, "GetOrders should not error")
 }
 
@@ -305,7 +304,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err, "GetActiveOrders should not error")
 }
 
@@ -318,7 +317,7 @@ func TestGetOrderHistory(t *testing.T) {
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
 	}
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err, "GetOrderHistory should not error")
 }
 
@@ -326,7 +325,7 @@ func TestTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 
-	_, err := b.TradeHistory(context.Background(), "", time.Time{}, time.Time{}, 0, 0, 0, false, "", "")
+	_, err := b.TradeHistory(t.Context(), "", time.Time{}, time.Time{}, 0, 0, 0, false, "", "")
 	assert.NoError(t, err, "TradeHistory should not error")
 }
 
@@ -345,7 +344,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 		PurchasePrice: 1000,
 	}
 
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	assert.NoError(t, err, "GetFeeByType should not error")
 	if !sharedtestvalues.AreAPICredentialsSet(b) {
 		assert.Equal(t, exchange.OfflineTradeFee, feeBuilder.FeeType, "FeeBuilder should give offline trade fee type")
@@ -365,35 +364,35 @@ func TestGetFee(t *testing.T) {
 		PurchasePrice: 1000,
 	}
 
-	_, err := b.GetFee(context.Background(), feeBuilder)
+	_, err := b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for maker")
 
 	feeBuilder.IsMaker = false
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for taker")
 
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for withdrawal")
 
 	feeBuilder.Pair.Base = currency.USDT
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for USDT")
 
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for International deposits")
 
 	feeBuilder.Amount = 1000000
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for a squillion")
 
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for International withdrawals")
 
 	feeBuilder.Amount = 1000
-	_, err = b.GetFee(context.Background(), feeBuilder)
+	_, err = b.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "fee builuder should not error for a fraction of a squillion")
 }
 
@@ -420,7 +419,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "",
 		AssetType: asset.Spot,
 	}
-	response, err := b.SubmitOrder(context.Background(), orderSubmission)
+	response, err := b.SubmitOrder(t.Context(), orderSubmission)
 	assert.NoError(t, err, "SubmitOrder should not error")
 	assert.Equal(t, order.New, response.Status, "Response Status should be New")
 }
@@ -429,7 +428,7 @@ func TestCancelAllAfter(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
-	err := b.CancelAllAfter(context.Background(), 1)
+	err := b.CancelAllAfter(t.Context(), 1)
 	assert.NoError(t, err, "CancelAllAfter should not error")
 }
 
@@ -444,7 +443,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		Pair:      spotPair,
 		AssetType: asset.Spot,
 	}
-	err := b.CancelOrder(context.Background(), orderCancellation)
+	err := b.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err, "CancelOrder should not error")
 }
 
@@ -453,7 +452,7 @@ func TestCancelOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
 
 	// TODO: Place an order to make sure we can cancel it
-	_, err := b.CancelExistingOrder(context.Background(), "", spotPair.String(), "")
+	_, err := b.CancelExistingOrder(t.Context(), "", spotPair.String(), "")
 	assert.NoError(t, err, "CancelExistingOrder should not error")
 }
 
@@ -467,7 +466,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		Pair:      spotPair,
 		AssetType: asset.Spot,
 	}
-	resp, err := b.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := b.CancelAllOrders(t.Context(), orderCancellation)
 
 	assert.NoError(t, err, "CancelAllOrders should not error")
 	for k, v := range resp.Status {
@@ -567,7 +566,7 @@ func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
 	assets := b.GetAssetTypes(false)
 	for i := range assets {
-		data, err := b.FetchTradablePairs(context.Background(), assets[i])
+		data, err := b.FetchTradablePairs(t.Context(), assets[i])
 		assert.NoErrorf(t, err, "FetchTradablePairs should not error for %s", assets[i])
 		assert.NotEmpty(t, data, "FetchTradablePairs should return some pairs")
 	}
@@ -593,7 +592,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, b)
 	for _, a := range b.GetAssetTypes(false) {
-		err := b.UpdateOrderExecutionLimits(context.Background(), a)
+		err := b.UpdateOrderExecutionLimits(t.Context(), a)
 		require.NoErrorf(t, err, "UpdateOrderExecutionLimits must not error for %s", a)
 
 		pairs, err := b.GetAvailablePairs(a)
@@ -614,16 +613,16 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetRecentTrades(context.Background(), spotPair, asset.Spot)
+	_, err := b.GetRecentTrades(t.Context(), spotPair, asset.Spot)
 	assert.NoError(t, err, "GetRecentTrades Should not error")
 
-	_, err = b.GetRecentTrades(context.Background(), futuresPair, asset.Futures)
+	_, err = b.GetRecentTrades(t.Context(), futuresPair, asset.Futures)
 	assert.NoError(t, err, "GetRecentTrades Should not error")
 }
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetHistoricTrades(context.Background(), spotPair, asset.Spot, time.Now().Add(-time.Minute), time.Now())
+	_, err := b.GetHistoricTrades(t.Context(), spotPair, asset.Spot, time.Now().Add(-time.Minute), time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported, "GetHistoricTrades should not be supported")
 }
 
@@ -664,31 +663,31 @@ func TestWsUnexpectedData(t *testing.T) {
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := b.GetFuturesContractDetails(t.Context(), asset.Spot)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset, "GetFuturesContractDetails should error correctly on Spot")
 
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetFuturesContractDetails should error correctly on Margin")
 
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.Futures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.Futures)
 	assert.NoError(t, err, "GetFuturesContractDetails should not error on Futures")
 }
 
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USDT),
 		IncludePredictedRate: true,
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetLatestFundingRates should error on Margin")
 
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 	})
 	assert.NoError(t, err, "GetLatestFundingRates should not error on futures")
 
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 		Pair:  futuresPair,
 	})
@@ -721,7 +720,7 @@ func TestGetOpenInterest(t *testing.T) {
 	cp2 := currency.NewPair(currency.ETH, currency.PFC)
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, b, asset.Futures, futuresPair, cp1, cp2)
 
-	resp, err := b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  cp1.Base.Item,
 		Quote: cp1.Quote.Item,
 		Asset: asset.Futures,
@@ -729,7 +728,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background(),
+	resp, err = b.GetOpenInterest(t.Context(),
 		key.PairAsset{
 			Base:  cp1.Base.Item,
 			Quote: cp1.Quote.Item,
@@ -743,11 +742,11 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background())
+	resp, err = b.GetOpenInterest(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	_, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.Spot,
@@ -762,7 +761,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -1,7 +1,6 @@
 package bybit
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -53,15 +52,15 @@ var (
 
 func TestGetInstrumentInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetInstrumentInfo(context.Background(), "spot", "", "", "", "", 0)
+	_, err := b.GetInstrumentInfo(t.Context(), "spot", "", "", "", "", 0)
 	require.NoError(t, err)
-	_, err = b.GetInstrumentInfo(context.Background(), "linear", "", "", "", "", 0)
+	_, err = b.GetInstrumentInfo(t.Context(), "linear", "", "", "", "", 0)
 	require.NoError(t, err)
-	_, err = b.GetInstrumentInfo(context.Background(), "inverse", "", "", "", "", 0)
+	_, err = b.GetInstrumentInfo(t.Context(), "inverse", "", "", "", "", 0)
 	require.NoError(t, err)
-	_, err = b.GetInstrumentInfo(context.Background(), "option", "", "", "", "", 0)
+	_, err = b.GetInstrumentInfo(t.Context(), "option", "", "", "", "", 0)
 	require.NoError(t, err)
-	payload, err := b.GetInstrumentInfo(context.Background(), "linear", "10000000AIDOGEUSDT", "", "", "", 0)
+	payload, err := b.GetInstrumentInfo(t.Context(), "linear", "10000000AIDOGEUSDT", "", "", "", 0)
 	require.NoError(t, err)
 	require.NotEmpty(t, payload.List)
 	require.NotZero(t, payload.List[0].LotSizeFilter.MinNotionalValue)
@@ -75,23 +74,23 @@ func TestGetKlines(t *testing.T) {
 		s = time.Unix(1691897100, 0).Round(kline.FiveMin.Duration())
 		e = time.Unix(1691907100, 0).Round(kline.FiveMin.Duration())
 	}
-	_, err := b.GetKlines(context.Background(), "spot", spotTradablePair.String(), kline.FiveMin, s, e, 100)
+	_, err := b.GetKlines(t.Context(), "spot", spotTradablePair.String(), kline.FiveMin, s, e, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetKlines(context.Background(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetKlines(t.Context(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetKlines(context.Background(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetKlines(t.Context(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetKlines(context.Background(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetKlines(t.Context(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetKlines(context.Background(), "option", optionsTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetKlines(t.Context(), "option", optionsTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err == nil {
 		t.Fatalf("expected 'params error: Category is invalid', but found nil")
 	}
@@ -105,19 +104,19 @@ func TestGetMarkPriceKline(t *testing.T) {
 		s = time.UnixMilli(1693077167971)
 		e = time.UnixMilli(1693080767971)
 	}
-	_, err := b.GetMarkPriceKline(context.Background(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err := b.GetMarkPriceKline(t.Context(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetMarkPriceKline(context.Background(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetMarkPriceKline(t.Context(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetMarkPriceKline(context.Background(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetMarkPriceKline(t.Context(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetMarkPriceKline(context.Background(), "option", optionsTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetMarkPriceKline(t.Context(), "option", optionsTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err == nil {
 		t.Fatalf("expected 'params error: Category is invalid', but found nil")
 	}
@@ -131,15 +130,15 @@ func TestGetIndexPriceKline(t *testing.T) {
 		s = time.UnixMilli(1693077165571)
 		e = time.UnixMilli(1693080765571)
 	}
-	_, err := b.GetIndexPriceKline(context.Background(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err := b.GetIndexPriceKline(t.Context(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetIndexPriceKline(context.Background(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetIndexPriceKline(t.Context(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetIndexPriceKline(context.Background(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
+	_, err = b.GetIndexPriceKline(t.Context(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,23 +146,23 @@ func TestGetIndexPriceKline(t *testing.T) {
 
 func TestGetOrderBook(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOrderBook(context.Background(), "spot", spotTradablePair.String(), 100)
+	_, err := b.GetOrderBook(t.Context(), "spot", spotTradablePair.String(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetOrderBook(context.Background(), "linear", usdtMarginedTradablePair.String(), 100)
+	_, err = b.GetOrderBook(t.Context(), "linear", usdtMarginedTradablePair.String(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetOrderBook(context.Background(), "linear", usdcMarginedTradablePair.String(), 100)
+	_, err = b.GetOrderBook(t.Context(), "linear", usdcMarginedTradablePair.String(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetOrderBook(context.Background(), "inverse", inverseTradablePair.String(), 100)
+	_, err = b.GetOrderBook(t.Context(), "inverse", inverseTradablePair.String(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetOrderBook(context.Background(), "option", optionsTradablePair.String(), 0)
+	_, err = b.GetOrderBook(t.Context(), "option", optionsTradablePair.String(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,23 +170,23 @@ func TestGetOrderBook(t *testing.T) {
 
 func TestGetRiskLimit(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetRiskLimit(context.Background(), "linear", usdtMarginedTradablePair.String())
+	_, err := b.GetRiskLimit(t.Context(), "linear", usdtMarginedTradablePair.String())
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetRiskLimit(context.Background(), "linear", usdcMarginedTradablePair.String())
+	_, err = b.GetRiskLimit(t.Context(), "linear", usdcMarginedTradablePair.String())
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetRiskLimit(context.Background(), "inverse", inverseTradablePair.String())
+	_, err = b.GetRiskLimit(t.Context(), "inverse", inverseTradablePair.String())
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetRiskLimit(context.Background(), "option", optionsTradablePair.String())
+	_, err = b.GetRiskLimit(t.Context(), "option", optionsTradablePair.String())
 	if !errors.Is(err, errInvalidCategory) {
 		t.Error(err)
 	}
-	_, err = b.GetRiskLimit(context.Background(), "spot", spotTradablePair.String())
+	_, err = b.GetRiskLimit(t.Context(), "spot", spotTradablePair.String())
 	if !errors.Is(err, errInvalidCategory) {
 		t.Error(err)
 	}
@@ -196,23 +195,23 @@ func TestGetRiskLimit(t *testing.T) {
 // test cases for Wrapper
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	_, err := b.UpdateTicker(context.Background(), spotTradablePair, asset.Spot)
+	_, err := b.UpdateTicker(t.Context(), spotTradablePair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateTicker(context.Background(), usdtMarginedTradablePair, asset.USDTMarginedFutures)
+	_, err = b.UpdateTicker(t.Context(), usdtMarginedTradablePair, asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateTicker(context.Background(), usdcMarginedTradablePair, asset.USDCMarginedFutures)
+	_, err = b.UpdateTicker(t.Context(), usdcMarginedTradablePair, asset.USDCMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateTicker(context.Background(), inverseTradablePair, asset.CoinMarginedFutures)
+	_, err = b.UpdateTicker(t.Context(), inverseTradablePair, asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateTicker(context.Background(), optionsTradablePair, asset.Options)
+	_, err = b.UpdateTicker(t.Context(), optionsTradablePair, asset.Options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -221,24 +220,24 @@ func TestUpdateTicker(t *testing.T) {
 func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
 	var err error
-	_, err = b.UpdateOrderbook(context.Background(), spotTradablePair, asset.Spot)
+	_, err = b.UpdateOrderbook(t.Context(), spotTradablePair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), usdcMarginedTradablePair, asset.USDCMarginedFutures)
+	_, err = b.UpdateOrderbook(t.Context(), usdcMarginedTradablePair, asset.USDCMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), usdtMarginedTradablePair, asset.USDTMarginedFutures)
+	_, err = b.UpdateOrderbook(t.Context(), usdtMarginedTradablePair, asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = b.UpdateOrderbook(context.Background(), inverseTradablePair, asset.CoinMarginedFutures)
+	_, err = b.UpdateOrderbook(t.Context(), inverseTradablePair, asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.UpdateOrderbook(context.Background(), optionsTradablePair, asset.Options)
+	_, err = b.UpdateOrderbook(t.Context(), optionsTradablePair, asset.Options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -260,11 +259,11 @@ func TestSubmitOrder(t *testing.T) {
 		ClientOrderID: "1234",
 		AssetType:     asset.Spot,
 	}
-	_, err := b.SubmitOrder(context.Background(), orderSubmission)
+	_, err := b.SubmitOrder(t.Context(), orderSubmission)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.SubmitOrder(context.Background(), &order.Submit{
+	_, err = b.SubmitOrder(t.Context(), &order.Submit{
 		Exchange:      b.GetName(),
 		AssetType:     asset.Options,
 		Pair:          optionsTradablePair,
@@ -286,7 +285,7 @@ func TestModifyOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ModifyOrder(context.Background(), &order.Modify{
+	_, err := b.ModifyOrder(t.Context(), &order.Modify{
 		OrderID:      "1234",
 		Type:         order.Limit,
 		Side:         order.Buy,
@@ -315,23 +314,23 @@ func TestGetHistoricCandles(t *testing.T) {
 		start = time.UnixMilli(1692748800000)
 		end = time.UnixMilli(1693094400000)
 	}
-	_, err := b.GetHistoricCandles(context.Background(), spotTradablePair, asset.Spot, kline.OneDay, start, end)
+	_, err := b.GetHistoricCandles(t.Context(), spotTradablePair, asset.Spot, kline.OneDay, start, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandles(context.Background(), usdtMarginedTradablePair, asset.USDTMarginedFutures, kline.OneDay, start, end)
+	_, err = b.GetHistoricCandles(t.Context(), usdtMarginedTradablePair, asset.USDTMarginedFutures, kline.OneDay, start, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandles(context.Background(), usdcMarginedTradablePair, asset.USDCMarginedFutures, kline.OneDay, start, end)
+	_, err = b.GetHistoricCandles(t.Context(), usdcMarginedTradablePair, asset.USDCMarginedFutures, kline.OneDay, start, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandles(context.Background(), inverseTradablePair, asset.CoinMarginedFutures, kline.OneHour, start, end)
+	_, err = b.GetHistoricCandles(t.Context(), inverseTradablePair, asset.CoinMarginedFutures, kline.OneHour, start, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandles(context.Background(), optionsTradablePair, asset.Options, kline.OneHour, start, end)
+	_, err = b.GetHistoricCandles(t.Context(), optionsTradablePair, asset.Options, kline.OneHour, start, end)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
@@ -345,19 +344,19 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 		startTime = time.UnixMilli(1692889428738)
 		end = time.UnixMilli(1693145028738)
 	}
-	_, err := b.GetHistoricCandlesExtended(context.Background(), spotTradablePair, asset.Spot, kline.OneMin, startTime, end)
+	_, err := b.GetHistoricCandlesExtended(t.Context(), spotTradablePair, asset.Spot, kline.OneMin, startTime, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandlesExtended(context.Background(), inverseTradablePair, asset.CoinMarginedFutures, kline.OneHour, startTime, end)
+	_, err = b.GetHistoricCandlesExtended(t.Context(), inverseTradablePair, asset.CoinMarginedFutures, kline.OneHour, startTime, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandlesExtended(context.Background(), usdtMarginedTradablePair, asset.USDTMarginedFutures, kline.OneDay, time.UnixMilli(1692889428738), time.UnixMilli(1693145028738))
+	_, err = b.GetHistoricCandlesExtended(t.Context(), usdtMarginedTradablePair, asset.USDTMarginedFutures, kline.OneDay, time.UnixMilli(1692889428738), time.UnixMilli(1693145028738))
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricCandlesExtended(context.Background(), optionsTradablePair, asset.Options, kline.FiveMin, startTime, end)
+	_, err = b.GetHistoricCandlesExtended(t.Context(), optionsTradablePair, asset.Options, kline.FiveMin, startTime, end)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("found '%v', expected '%v'", err, asset.ErrNotSupported)
 	}
@@ -369,7 +368,7 @@ func TestCancelOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.CancelOrder(context.Background(), &order.Cancel{
+	err := b.CancelOrder(t.Context(), &order.Cancel{
 		Exchange:  b.Name,
 		AssetType: asset.Spot,
 		Pair:      spotTradablePair,
@@ -378,7 +377,7 @@ func TestCancelOrder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.CancelOrder(context.Background(), &order.Cancel{
+	err = b.CancelOrder(t.Context(), &order.Cancel{
 		Exchange:  b.Name,
 		AssetType: asset.USDTMarginedFutures,
 		Pair:      usdtMarginedTradablePair,
@@ -388,7 +387,7 @@ func TestCancelOrder(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = b.CancelOrder(context.Background(), &order.Cancel{
+	err = b.CancelOrder(t.Context(), &order.Cancel{
 		Exchange:  b.Name,
 		AssetType: asset.CoinMarginedFutures,
 		Pair:      inverseTradablePair,
@@ -397,7 +396,7 @@ func TestCancelOrder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.CancelOrder(context.Background(), &order.Cancel{
+	err = b.CancelOrder(t.Context(), &order.Cancel{
 		Exchange:  b.Name,
 		AssetType: asset.Options,
 		Pair:      optionsTradablePair,
@@ -414,23 +413,23 @@ func TestCancelAllOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelAllOrders(context.Background(), &order.Cancel{AssetType: asset.Spot, Pair: spotTradablePair})
+	_, err := b.CancelAllOrders(t.Context(), &order.Cancel{AssetType: asset.Spot, Pair: spotTradablePair})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.CancelAllOrders(context.Background(), &order.Cancel{Exchange: b.Name, AssetType: asset.USDTMarginedFutures, Pair: usdtMarginedTradablePair})
+	_, err = b.CancelAllOrders(t.Context(), &order.Cancel{Exchange: b.Name, AssetType: asset.USDTMarginedFutures, Pair: usdtMarginedTradablePair})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.CancelAllOrders(context.Background(), &order.Cancel{Exchange: b.Name, AssetType: asset.CoinMarginedFutures, Pair: inverseTradablePair})
+	_, err = b.CancelAllOrders(t.Context(), &order.Cancel{Exchange: b.Name, AssetType: asset.CoinMarginedFutures, Pair: inverseTradablePair})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.CancelAllOrders(context.Background(), &order.Cancel{Exchange: b.Name, AssetType: asset.Options, Pair: optionsTradablePair})
+	_, err = b.CancelAllOrders(t.Context(), &order.Cancel{Exchange: b.Name, AssetType: asset.Options, Pair: optionsTradablePair})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.CancelAllOrders(context.Background(), &order.Cancel{Exchange: b.Name, AssetType: asset.Futures, Pair: spotTradablePair})
+	_, err = b.CancelAllOrders(t.Context(), &order.Cancel{Exchange: b.Name, AssetType: asset.Futures, Pair: spotTradablePair})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, but found %v", asset.ErrNotSupported, err)
 	}
@@ -442,22 +441,22 @@ func TestGetOrderInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetOrderInfo(context.Background(),
+	_, err := b.GetOrderInfo(t.Context(),
 		"12234", spotTradablePair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrderInfo(context.Background(),
+	_, err = b.GetOrderInfo(t.Context(),
 		"12234", usdtMarginedTradablePair, asset.USDTMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrderInfo(context.Background(),
+	_, err = b.GetOrderInfo(t.Context(),
 		"12234", inverseTradablePair, asset.CoinMarginedFutures)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOrderInfo(context.Background(),
+	_, err = b.GetOrderInfo(t.Context(),
 		"12234", optionsTradablePair, asset.Options)
 	if err != nil {
 		t.Error(err)
@@ -476,22 +475,22 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 		Type:      order.AnyType,
 	}
-	_, err := b.GetActiveOrders(context.Background(), &getOrdersRequestSpot)
+	_, err := b.GetActiveOrders(t.Context(), &getOrdersRequestSpot)
 	if err != nil {
 		t.Error(err)
 	}
 	getOrdersRequestLinear := order.MultiOrderRequest{Pairs: currency.Pairs{usdtMarginedTradablePair}, AssetType: asset.USDTMarginedFutures, Side: order.AnySide, Type: order.AnyType}
-	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestLinear)
+	_, err = b.GetActiveOrders(t.Context(), &getOrdersRequestLinear)
 	if err != nil {
 		t.Error(err)
 	}
 	getOrdersRequestInverse := order.MultiOrderRequest{Pairs: currency.Pairs{inverseTradablePair}, AssetType: asset.CoinMarginedFutures, Side: order.AnySide, Type: order.AnyType}
-	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestInverse)
+	_, err = b.GetActiveOrders(t.Context(), &getOrdersRequestInverse)
 	if err != nil {
 		t.Error(err)
 	}
 	getOrdersRequestFutures := order.MultiOrderRequest{Pairs: currency.Pairs{optionsTradablePair}, AssetType: asset.Options, Side: order.AnySide, Type: order.AnyType}
-	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestFutures)
+	_, err = b.GetActiveOrders(t.Context(), &getOrdersRequestFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -500,7 +499,7 @@ func TestGetActiveOrders(t *testing.T) {
 		t.Fatal(err)
 	}
 	getOrdersRequestSpot = order.MultiOrderRequest{Pairs: pairs, AssetType: asset.Spot, Side: order.AnySide, Type: order.AnyType}
-	_, err = b.GetActiveOrders(context.Background(), &getOrdersRequestSpot)
+	_, err = b.GetActiveOrders(t.Context(), &getOrdersRequestSpot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -518,7 +517,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 	}
-	_, err := b.GetOrderHistory(context.Background(), &getOrdersRequestSpot)
+	_, err := b.GetOrderHistory(t.Context(), &getOrdersRequestSpot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -528,13 +527,13 @@ func TestGetOrderHistory(t *testing.T) {
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 	}
-	_, err = b.GetOrderHistory(context.Background(), &getOrdersRequestUMF)
+	_, err = b.GetOrderHistory(t.Context(), &getOrdersRequestUMF)
 	if err != nil {
 		t.Error(err)
 	}
 	getOrdersRequestUMF.Pairs = currency.Pairs{usdcMarginedTradablePair}
 	getOrdersRequestUMF.AssetType = asset.USDCMarginedFutures
-	_, err = b.GetOrderHistory(context.Background(), &getOrdersRequestUMF)
+	_, err = b.GetOrderHistory(t.Context(), &getOrdersRequestUMF)
 	if err != nil {
 		t.Error(err)
 	}
@@ -544,7 +543,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 	}
-	_, err = b.GetOrderHistory(context.Background(), &getOrdersRequestCMF)
+	_, err = b.GetOrderHistory(t.Context(), &getOrdersRequestCMF)
 	if err != nil {
 		t.Error(err)
 	}
@@ -554,7 +553,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Type:      order.AnyType,
 		Side:      order.AnySide,
 	}
-	_, err = b.GetOrderHistory(context.Background(), &getOrdersRequestFutures)
+	_, err = b.GetOrderHistory(t.Context(), &getOrdersRequestFutures)
 	if err != nil {
 		t.Error(err)
 	}
@@ -566,7 +565,7 @@ func TestGetDepositAddress(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetDepositAddress(context.Background(), currency.USDT, "", currency.ETH.String())
+	_, err := b.GetDepositAddress(t.Context(), currency.USDT, "", currency.ETH.String())
 	if err != nil {
 		t.Error(err)
 	}
@@ -578,7 +577,7 @@ func TestGetAvailableTransferChains(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAvailableTransferChains(context.Background(), currency.USDT)
+	_, err := b.GetAvailableTransferChains(t.Context(), currency.USDT)
 	if err != nil {
 		t.Error(err)
 	}
@@ -590,7 +589,7 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	_, err := b.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange: "Bybit",
 		Amount:   10,
 		Currency: currency.LTC,
@@ -607,7 +606,7 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	err := b.UpdateTickers(ctx, asset.Spot)
 	if err != nil {
 		t.Fatalf("%v %v\n", asset.Spot, err)
@@ -628,43 +627,43 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestGetTickersV5(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetTickers(context.Background(), "bruh", "", "", time.Time{})
+	_, err := b.GetTickers(t.Context(), "bruh", "", "", time.Time{})
 	require.ErrorIs(t, err, errInvalidCategory)
-	_, err = b.GetTickers(context.Background(), "option", "BTC-26NOV24-92000-C", "", time.Time{})
+	_, err = b.GetTickers(t.Context(), "option", "BTC-26NOV24-92000-C", "", time.Time{})
 	require.NoError(t, err)
-	_, err = b.GetTickers(context.Background(), "spot", "", "", time.Time{})
+	_, err = b.GetTickers(t.Context(), "spot", "", "", time.Time{})
 	require.NoError(t, err)
-	_, err = b.GetTickers(context.Background(), "inverse", "", "", time.Time{})
+	_, err = b.GetTickers(t.Context(), "inverse", "", "", time.Time{})
 	require.NoError(t, err)
-	_, err = b.GetTickers(context.Background(), "linear", "", "", time.Time{})
+	_, err = b.GetTickers(t.Context(), "linear", "", "", time.Time{})
 	require.NoError(t, err)
-	_, err = b.GetTickers(context.Background(), "option", "", "BTC", time.Time{})
+	_, err = b.GetTickers(t.Context(), "option", "", "BTC", time.Time{})
 	require.NoError(t, err)
 }
 
 func TestGetFundingRateHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFundingRateHistory(context.Background(), "bruh", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetFundingRateHistory(t.Context(), "bruh", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetFundingRateHistory(context.Background(), "spot", spotTradablePair.String(), time.Time{}, time.Time{}, 100)
+	_, err = b.GetFundingRateHistory(t.Context(), "spot", spotTradablePair.String(), time.Time{}, time.Time{}, 100)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetFundingRateHistory(context.Background(), "linear", usdtMarginedTradablePair.String(), time.Time{}, time.Time{}, 100)
+	_, err = b.GetFundingRateHistory(t.Context(), "linear", usdtMarginedTradablePair.String(), time.Time{}, time.Time{}, 100)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFundingRateHistory(context.Background(), "linear", usdcMarginedTradablePair.String(), time.Time{}, time.Time{}, 100)
+	_, err = b.GetFundingRateHistory(t.Context(), "linear", usdcMarginedTradablePair.String(), time.Time{}, time.Time{}, 100)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFundingRateHistory(context.Background(), "inverse", inverseTradablePair.String(), time.Time{}, time.Time{}, 100)
+	_, err = b.GetFundingRateHistory(t.Context(), "inverse", inverseTradablePair.String(), time.Time{}, time.Time{}, 100)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetFundingRateHistory(context.Background(), "option", optionsTradablePair.String(), time.Time{}, time.Time{}, 100)
+	_, err = b.GetFundingRateHistory(t.Context(), "option", optionsTradablePair.String(), time.Time{}, time.Time{}, 100)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
@@ -672,23 +671,23 @@ func TestGetFundingRateHistory(t *testing.T) {
 
 func TestGetPublicTradingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetPublicTradingHistory(context.Background(), "spot", spotTradablePair.String(), "", "", 30)
+	_, err := b.GetPublicTradingHistory(t.Context(), "spot", spotTradablePair.String(), "", "", 30)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetPublicTradingHistory(context.Background(), "linear", usdtMarginedTradablePair.String(), "", "", 30)
+	_, err = b.GetPublicTradingHistory(t.Context(), "linear", usdtMarginedTradablePair.String(), "", "", 30)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetPublicTradingHistory(context.Background(), "linear", usdcMarginedTradablePair.String(), "", "", 30)
+	_, err = b.GetPublicTradingHistory(t.Context(), "linear", usdcMarginedTradablePair.String(), "", "", 30)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetPublicTradingHistory(context.Background(), "inverse", inverseTradablePair.String(), "", "", 30)
+	_, err = b.GetPublicTradingHistory(t.Context(), "inverse", inverseTradablePair.String(), "", "", 30)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetPublicTradingHistory(context.Background(), "option", optionsTradablePair.String(), "BTC", "", 30)
+	_, err = b.GetPublicTradingHistory(t.Context(), "option", optionsTradablePair.String(), "BTC", "", 30)
 	if err != nil {
 		t.Error(err)
 	}
@@ -696,23 +695,23 @@ func TestGetPublicTradingHistory(t *testing.T) {
 
 func TestGetOpenInterestData(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOpenInterestData(context.Background(), "spot", spotTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
+	_, err := b.GetOpenInterestData(t.Context(), "spot", spotTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetOpenInterestData(context.Background(), "linear", usdtMarginedTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
+	_, err = b.GetOpenInterestData(t.Context(), "linear", usdtMarginedTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOpenInterestData(context.Background(), "linear", usdcMarginedTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
+	_, err = b.GetOpenInterestData(t.Context(), "linear", usdcMarginedTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOpenInterestData(context.Background(), "inverse", inverseTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
+	_, err = b.GetOpenInterestData(t.Context(), "inverse", inverseTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetOpenInterestData(context.Background(), "option", optionsTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
+	_, err = b.GetOpenInterestData(t.Context(), "option", optionsTradablePair.String(), "5min", time.Time{}, time.Time{}, 0, "")
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
@@ -726,11 +725,11 @@ func TestGetHistoricalVolatility(t *testing.T) {
 		end = time.UnixMilli(1693080759395)
 		start = time.UnixMilli(1690488759395)
 	}
-	_, err := b.GetHistoricalVolatility(context.Background(), "option", "", 123, start, end)
+	_, err := b.GetHistoricalVolatility(t.Context(), "option", "", 123, start, end)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricalVolatility(context.Background(), "spot", "", 123, start, end)
+	_, err = b.GetHistoricalVolatility(t.Context(), "spot", "", 123, start, end)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, but found %v", errInvalidCategory, err)
 	}
@@ -738,7 +737,7 @@ func TestGetHistoricalVolatility(t *testing.T) {
 
 func TestGetInsurance(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetInsurance(context.Background(), "")
+	_, err := b.GetInsurance(t.Context(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -746,19 +745,19 @@ func TestGetInsurance(t *testing.T) {
 
 func TestGetDeliveryPrice(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetDeliveryPrice(context.Background(), "spot", spotTradablePair.String(), "", "", 200)
+	_, err := b.GetDeliveryPrice(t.Context(), "spot", spotTradablePair.String(), "", "", 200)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, but found %v", errInvalidCategory, err)
 	}
-	_, err = b.GetDeliveryPrice(context.Background(), "linear", "", "", "", 200)
+	_, err = b.GetDeliveryPrice(t.Context(), "linear", "", "", "", 200)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetDeliveryPrice(context.Background(), "inverse", "", "", "", 200)
+	_, err = b.GetDeliveryPrice(t.Context(), "inverse", "", "", "", 200)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetDeliveryPrice(context.Background(), "option", "", "BTC", "", 200)
+	_, err = b.GetDeliveryPrice(t.Context(), "option", "", "BTC", "", 200)
 	if err != nil {
 		t.Error(err)
 	}
@@ -766,16 +765,16 @@ func TestGetDeliveryPrice(t *testing.T) {
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := b.UpdateOrderExecutionLimits(context.Background(), asset.Futures)
+	err := b.UpdateOrderExecutionLimits(t.Context(), asset.Futures)
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.Options)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.Options)
 	assert.NoError(t, err)
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.USDCMarginedFutures)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.USDCMarginedFutures)
 	assert.NoError(t, err)
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.USDTMarginedFutures)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.USDTMarginedFutures)
 	assert.NoError(t, err)
 
-	err = b.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
+	err = b.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
 	assert.NoError(t, err)
 	availablePairs, err := b.GetAvailablePairs(asset.Spot)
 	if err != nil {
@@ -797,7 +796,7 @@ func TestPlaceOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := b.PlaceOrder(ctx, nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
@@ -853,7 +852,7 @@ func TestPlaceOrder(t *testing.T) {
 	if !errors.Is(err, errInvalidTriggerDirection) {
 		t.Fatalf("expected %v, got %v", errInvalidTriggerDirection, err)
 	}
-	_, err = b.PlaceOrder(context.Background(), &PlaceOrderParams{
+	_, err = b.PlaceOrder(t.Context(), &PlaceOrderParams{
 		Category:         "spot",
 		Symbol:           spotTradablePair,
 		Side:             "buy",
@@ -867,7 +866,7 @@ func TestPlaceOrder(t *testing.T) {
 	}
 	// Spot post only normal order
 	arg := &PlaceOrderParams{Category: "spot", Symbol: spotTradablePair, Side: "Buy", OrderType: "Limit", OrderQuantity: 0.1, Price: 15600, TimeInForce: "PostOnly", OrderLinkID: "spot-test-01", IsLeverage: 0, OrderFilter: "Order"}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -879,7 +878,7 @@ func TestPlaceOrder(t *testing.T) {
 		OrderQuantity: 0.1, Price: 15600, TriggerPrice: 15000,
 		TimeInForce: "GTC", OrderLinkID: "spot-test-02", IsLeverage: 0, OrderFilter: "tpslOrder",
 	}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -888,7 +887,7 @@ func TestPlaceOrder(t *testing.T) {
 		Category: "spot", Symbol: spotTradablePair, Side: "Buy", OrderType: "Limit",
 		OrderQuantity: 0.1, Price: 15600, TimeInForce: "IOC", OrderLinkID: "spot-test-limit", IsLeverage: 1, OrderFilter: "Order",
 	}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -899,7 +898,7 @@ func TestPlaceOrder(t *testing.T) {
 		TimeInForce: "IOC", OrderLinkID: "spot-test-04",
 		IsLeverage: 0, OrderFilter: "Order",
 	}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -908,7 +907,7 @@ func TestPlaceOrder(t *testing.T) {
 		Category: "linear",
 		Symbol:   usdcMarginedTradablePair, Side: "Buy", OrderType: "Limit", OrderQuantity: 1, Price: 25000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-01", ReduceOnly: false, TakeProfitPrice: 28000, StopLossPrice: 20000, TpslMode: "Partial", TpOrderType: "Limit", SlOrderType: "Limit", TpLimitPrice: 27500, SlLimitPrice: 20500,
 	}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -917,7 +916,7 @@ func TestPlaceOrder(t *testing.T) {
 		Category: "linear", Symbol: usdtMarginedTradablePair, Side: "Sell",
 		OrderType: "Limit", OrderQuantity: 1, Price: 3000, TimeInForce: "GTC", PositionIdx: 0, OrderLinkID: "usdt-test-02", ReduceOnly: true,
 	}
-	_, err = b.PlaceOrder(context.Background(), arg)
+	_, err = b.PlaceOrder(t.Context(), arg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -929,35 +928,35 @@ func TestAmendOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.AmendOrder(context.Background(), nil)
+	_, err := b.AmendOrder(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{})
+	_, err = b.AmendOrder(t.Context(), &AmendOrderParams{})
 	if !errors.Is(err, errEitherOrderIDOROrderLinkIDRequired) {
 		t.Fatalf("expected %v, got %v", errEitherOrderIDOROrderLinkIDRequired, err)
 	}
-	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
+	_, err = b.AmendOrder(t.Context(), &AmendOrderParams{
 		OrderID: "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 	})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
+	_, err = b.AmendOrder(t.Context(), &AmendOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category: "mycat",
 	})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
+	_, err = b.AmendOrder(t.Context(), &AmendOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category: "option",
 	})
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyPairEmpty, err)
 	}
-	_, err = b.AmendOrder(context.Background(), &AmendOrderParams{
+	_, err = b.AmendOrder(t.Context(), &AmendOrderParams{
 		OrderID:         "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category:        cSpot,
 		Symbol:          spotTradablePair,
@@ -978,35 +977,35 @@ func TestCancelTradeOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelTradeOrder(context.Background(), nil)
+	_, err := b.CancelTradeOrder(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{})
+	_, err = b.CancelTradeOrder(t.Context(), &CancelOrderParams{})
 	if !errors.Is(err, errEitherOrderIDOROrderLinkIDRequired) {
 		t.Fatalf("expected %v, got %v", errEitherOrderIDOROrderLinkIDRequired, err)
 	}
-	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
+	_, err = b.CancelTradeOrder(t.Context(), &CancelOrderParams{
 		OrderID: "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 	})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
+	_, err = b.CancelTradeOrder(t.Context(), &CancelOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category: "mycat",
 	})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
+	_, err = b.CancelTradeOrder(t.Context(), &CancelOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category: "option",
 	})
 	if !errors.Is(err, currency.ErrCurrencyPairEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyPairEmpty, err)
 	}
-	_, err = b.CancelTradeOrder(context.Background(), &CancelOrderParams{
+	_, err = b.CancelTradeOrder(t.Context(), &CancelOrderParams{
 		OrderID:  "c6f055d9-7f21-4079-913d-e6523a9cfffa",
 		Category: "option",
 		Symbol:   optionsTradablePair,
@@ -1021,11 +1020,11 @@ func TestGetOpenOrders(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetOpenOrders(context.Background(), "", "", "", "", "", "", "", "", 0, 100)
+	_, err := b.GetOpenOrders(t.Context(), "", "", "", "", "", "", "", "", 0, 100)
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.GetOpenOrders(context.Background(), "spot", "", "", "", "", "", "", "", 0, 0)
+	_, err = b.GetOpenOrders(t.Context(), "spot", "", "", "", "", "", "", "", 0, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1037,15 +1036,15 @@ func TestCancelAllTradeOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelAllTradeOrders(context.Background(), nil)
+	_, err := b.CancelAllTradeOrders(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CancelAllTradeOrders(context.Background(), &CancelAllOrdersParam{})
+	_, err = b.CancelAllTradeOrders(t.Context(), &CancelAllOrdersParam{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.CancelAllTradeOrders(context.Background(), &CancelAllOrdersParam{Category: "option"})
+	_, err = b.CancelAllTradeOrders(t.Context(), &CancelAllOrdersParam{Category: "option"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1061,11 +1060,11 @@ func TestGetTradeOrderHistory(t *testing.T) {
 	} else {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetTradeOrderHistory(context.Background(), "", "", "", "", "", "", "", "", "", start, end, 100)
+	_, err := b.GetTradeOrderHistory(t.Context(), "", "", "", "", "", "", "", "", "", start, end, 100)
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.GetTradeOrderHistory(context.Background(), "spot", spotTradablePair.String(), "", "", "BTC", "", "StopOrder", "", "", start, end, 100)
+	_, err = b.GetTradeOrderHistory(t.Context(), "spot", spotTradablePair.String(), "", "", "BTC", "", "StopOrder", "", "", start, end, 100)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1077,21 +1076,21 @@ func TestPlaceBatchOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.PlaceBatchOrder(context.Background(), nil)
+	_, err := b.PlaceBatchOrder(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.PlaceBatchOrder(context.Background(), &PlaceBatchOrderParam{})
+	_, err = b.PlaceBatchOrder(t.Context(), &PlaceBatchOrderParam{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.PlaceBatchOrder(context.Background(), &PlaceBatchOrderParam{
+	_, err = b.PlaceBatchOrder(t.Context(), &PlaceBatchOrderParam{
 		Category: "linear",
 	})
 	if !errors.Is(err, errNoOrderPassed) {
 		t.Fatalf("expected %v, got %v", errNoOrderPassed, err)
 	}
-	_, err = b.PlaceBatchOrder(context.Background(), &PlaceBatchOrderParam{
+	_, err = b.PlaceBatchOrder(t.Context(), &PlaceBatchOrderParam{
 		Category: "option",
 		Request: []BatchOrderItemParam{
 			{
@@ -1121,7 +1120,7 @@ func TestPlaceBatchOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.PlaceBatchOrder(context.Background(), &PlaceBatchOrderParam{
+	_, err = b.PlaceBatchOrder(t.Context(), &PlaceBatchOrderParam{
 		Category: "linear",
 		Request: []BatchOrderItemParam{
 			{
@@ -1159,11 +1158,11 @@ func TestBatchAmendOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.BatchAmendOrder(context.Background(), "linear", nil)
+	_, err := b.BatchAmendOrder(t.Context(), "linear", nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.BatchAmendOrder(context.Background(), "", []BatchAmendOrderParamItem{
+	_, err = b.BatchAmendOrder(t.Context(), "", []BatchAmendOrderParamItem{
 		{
 			Symbol:                 optionsTradablePair,
 			OrderImpliedVolatility: "6.8",
@@ -1173,7 +1172,7 @@ func TestBatchAmendOrder(t *testing.T) {
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.BatchAmendOrder(context.Background(), "option", []BatchAmendOrderParamItem{
+	_, err = b.BatchAmendOrder(t.Context(), "option", []BatchAmendOrderParamItem{
 		{
 			Symbol:                 optionsTradablePair,
 			OrderImpliedVolatility: "6.8",
@@ -1196,19 +1195,19 @@ func TestCancelBatchOrder(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelBatchOrder(context.Background(), nil)
+	_, err := b.CancelBatchOrder(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CancelBatchOrder(context.Background(), &CancelBatchOrder{})
+	_, err = b.CancelBatchOrder(t.Context(), &CancelBatchOrder{})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.CancelBatchOrder(context.Background(), &CancelBatchOrder{Category: cOption})
+	_, err = b.CancelBatchOrder(t.Context(), &CancelBatchOrder{Category: cOption})
 	if !errors.Is(err, errNoOrderPassed) {
 		t.Fatalf("expected %v, got %v", errNoOrderPassed, err)
 	}
-	_, err = b.CancelBatchOrder(context.Background(), &CancelBatchOrder{
+	_, err = b.CancelBatchOrder(t.Context(), &CancelBatchOrder{
 		Category: "option",
 		Request: []CancelOrderParams{
 			{
@@ -1231,19 +1230,19 @@ func TestGetBorrowQuota(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetBorrowQuota(context.Background(), "", "BTCUSDT", "Buy")
+	_, err := b.GetBorrowQuota(t.Context(), "", "BTCUSDT", "Buy")
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.GetBorrowQuota(context.Background(), "spot", "", "Buy")
+	_, err = b.GetBorrowQuota(t.Context(), "spot", "", "Buy")
 	if !errors.Is(err, errSymbolMissing) {
 		t.Fatalf("expected %v, got %v", errSymbolMissing, err)
 	}
-	_, err = b.GetBorrowQuota(context.Background(), "spot", spotTradablePair.String(), "")
+	_, err = b.GetBorrowQuota(t.Context(), "spot", spotTradablePair.String(), "")
 	if !errors.Is(err, order.ErrSideIsInvalid) {
 		t.Error(err)
 	}
-	_, err = b.GetBorrowQuota(context.Background(), "spot", spotTradablePair.String(), "Buy")
+	_, err = b.GetBorrowQuota(t.Context(), "spot", spotTradablePair.String(), "Buy")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1255,11 +1254,11 @@ func TestSetDisconnectCancelAll(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetDisconnectCancelAll(context.Background(), nil)
+	err := b.SetDisconnectCancelAll(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	err = b.SetDisconnectCancelAll(context.Background(), &SetDCPParams{TimeWindow: 300})
+	err = b.SetDisconnectCancelAll(t.Context(), &SetDCPParams{TimeWindow: 300})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1270,19 +1269,19 @@ func TestGetPositionInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetPositionInfo(context.Background(), "", "", "", "", "", 20)
+	_, err := b.GetPositionInfo(t.Context(), "", "", "", "", "", 20)
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.GetPositionInfo(context.Background(), "spot", "", "", "", "", 20)
+	_, err = b.GetPositionInfo(t.Context(), "spot", "", "", "", "", 20)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetPositionInfo(context.Background(), "linear", "BTCUSDT", "", "", "", 20)
+	_, err = b.GetPositionInfo(t.Context(), "linear", "BTCUSDT", "", "", "", 20)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetPositionInfo(context.Background(), "option", "BTC-26NOV24-92000-C", "BTC", "", "", 20)
+	_, err = b.GetPositionInfo(t.Context(), "option", "BTC-26NOV24-92000-C", "BTC", "", "", 20)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1294,27 +1293,27 @@ func TestSetLeverageLevel(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetLeverageLevel(context.Background(), nil)
+	err := b.SetLeverageLevel(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	err = b.SetLeverageLevel(context.Background(), &SetLeverageParams{})
+	err = b.SetLeverageLevel(t.Context(), &SetLeverageParams{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	err = b.SetLeverageLevel(context.Background(), &SetLeverageParams{Category: "spot"})
+	err = b.SetLeverageLevel(t.Context(), &SetLeverageParams{Category: "spot"})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	err = b.SetLeverageLevel(context.Background(), &SetLeverageParams{Category: "linear"})
+	err = b.SetLeverageLevel(t.Context(), &SetLeverageParams{Category: "linear"})
 	if !errors.Is(err, errSymbolMissing) {
 		t.Fatalf("expected %v, got %v", errSymbolMissing, err)
 	}
-	err = b.SetLeverageLevel(context.Background(), &SetLeverageParams{Category: "linear", Symbol: "BTCUSDT"})
+	err = b.SetLeverageLevel(t.Context(), &SetLeverageParams{Category: "linear", Symbol: "BTCUSDT"})
 	if !errors.Is(err, errInvalidLeverage) {
 		t.Fatalf("expected %v, got %v", errInvalidLeverage, err)
 	}
-	err = b.SetLeverageLevel(context.Background(), &SetLeverageParams{Category: "linear", Symbol: "BTCUSDT", SellLeverage: 3, BuyLeverage: 3})
+	err = b.SetLeverageLevel(t.Context(), &SetLeverageParams{Category: "linear", Symbol: "BTCUSDT", SellLeverage: 3, BuyLeverage: 3})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1326,31 +1325,31 @@ func TestSwitchTradeMode(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SwitchTradeMode(context.Background(), nil)
+	err := b.SwitchTradeMode(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{Category: "spot"})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{Category: "spot"})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{Category: "linear"})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{Category: "linear"})
 	if !errors.Is(err, errSymbolMissing) {
 		t.Fatalf("expected %v, got %v", errSymbolMissing, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{Category: "linear", Symbol: usdtMarginedTradablePair.String()})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{Category: "linear", Symbol: usdtMarginedTradablePair.String()})
 	if !errors.Is(err, errInvalidLeverage) {
 		t.Fatalf("expected %v, got %v", errInvalidLeverage, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{Category: "linear", Symbol: usdcMarginedTradablePair.String(), SellLeverage: 3, BuyLeverage: 3, TradeMode: 2})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{Category: "linear", Symbol: usdcMarginedTradablePair.String(), SellLeverage: 3, BuyLeverage: 3, TradeMode: 2})
 	if !errors.Is(err, errInvalidTradeModeValue) {
 		t.Fatalf("expected %v, got %v", errInvalidTradeModeValue, err)
 	}
-	err = b.SwitchTradeMode(context.Background(), &SwitchTradeModeParams{Category: "linear", Symbol: usdtMarginedTradablePair.String(), SellLeverage: 3, BuyLeverage: 3, TradeMode: 1})
+	err = b.SwitchTradeMode(t.Context(), &SwitchTradeModeParams{Category: "linear", Symbol: usdtMarginedTradablePair.String(), SellLeverage: 3, BuyLeverage: 3, TradeMode: 1})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1362,33 +1361,33 @@ func TestSetTakeProfitStopLossMode(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.SetTakeProfitStopLossMode(context.Background(), nil)
+	_, err := b.SetTakeProfitStopLossMode(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{})
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{
 		Category: "spot",
 	})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{Category: "spot"})
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{Category: "spot"})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{Category: "linear"})
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{Category: "linear"})
 	if !errors.Is(err, errSymbolMissing) {
 		t.Fatalf("expected %v, got %v", errSymbolMissing, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{Category: "linear", Symbol: "BTCUSDT"})
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{Category: "linear", Symbol: "BTCUSDT"})
 	if !errors.Is(err, errTakeProfitOrStopLossModeMissing) {
 		t.Fatalf("expected %v, got %v", errTakeProfitOrStopLossModeMissing, err)
 	}
-	_, err = b.SetTakeProfitStopLossMode(context.Background(), &TPSLModeParams{Category: "linear", Symbol: "BTCUSDT", TpslMode: "Partial"})
+	_, err = b.SetTakeProfitStopLossMode(t.Context(), &TPSLModeParams{Category: "linear", Symbol: "BTCUSDT", TpslMode: "Partial"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1400,19 +1399,19 @@ func TestSwitchPositionMode(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SwitchPositionMode(context.Background(), nil)
+	err := b.SwitchPositionMode(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	err = b.SwitchPositionMode(context.Background(), &SwitchPositionModeParams{})
+	err = b.SwitchPositionMode(t.Context(), &SwitchPositionModeParams{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	err = b.SwitchPositionMode(context.Background(), &SwitchPositionModeParams{Category: "linear"})
+	err = b.SwitchPositionMode(t.Context(), &SwitchPositionModeParams{Category: "linear"})
 	if !errors.Is(err, errEitherSymbolOrCoinRequired) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	err = b.SwitchPositionMode(context.Background(), &SwitchPositionModeParams{Category: "linear", Symbol: usdtMarginedTradablePair, PositionMode: 3})
+	err = b.SwitchPositionMode(t.Context(), &SwitchPositionModeParams{Category: "linear", Symbol: usdtMarginedTradablePair, PositionMode: 3})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1424,23 +1423,23 @@ func TestSetRiskLimit(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.SetRiskLimit(context.Background(), nil)
+	_, err := b.SetRiskLimit(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.SetRiskLimit(context.Background(), &SetRiskLimitParam{})
+	_, err = b.SetRiskLimit(t.Context(), &SetRiskLimitParam{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Errorf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.SetRiskLimit(context.Background(), &SetRiskLimitParam{Category: "linear", PositionMode: -2})
+	_, err = b.SetRiskLimit(t.Context(), &SetRiskLimitParam{Category: "linear", PositionMode: -2})
 	if !errors.Is(err, errInvalidPositionMode) {
 		t.Errorf("expected %v, got %v", errInvalidPositionMode, err)
 	}
-	_, err = b.SetRiskLimit(context.Background(), &SetRiskLimitParam{Category: "linear"})
+	_, err = b.SetRiskLimit(t.Context(), &SetRiskLimitParam{Category: "linear"})
 	if !errors.Is(err, errSymbolMissing) {
 		t.Errorf("expected %v, got %v", errSymbolMissing, err)
 	}
-	_, err = b.SetRiskLimit(context.Background(), &SetRiskLimitParam{
+	_, err = b.SetRiskLimit(t.Context(), &SetRiskLimitParam{
 		Category:     "linear",
 		RiskID:       1234,
 		Symbol:       usdtMarginedTradablePair,
@@ -1457,15 +1456,15 @@ func TestSetTradingStop(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetTradingStop(context.Background(), &TradingStopParams{})
+	err := b.SetTradingStop(t.Context(), &TradingStopParams{})
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Errorf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	err = b.SetTradingStop(context.Background(), &TradingStopParams{Category: "spot"})
+	err = b.SetTradingStop(t.Context(), &TradingStopParams{Category: "spot"})
 	if !errors.Is(err, errInvalidCategory) {
 		t.Errorf("expected %v, got %v", errInvalidCategory, err)
 	}
-	err = b.SetTradingStop(context.Background(), &TradingStopParams{
+	err = b.SetTradingStop(t.Context(), &TradingStopParams{
 		Category:                 "linear",
 		Symbol:                   usdtMarginedTradablePair,
 		TakeProfit:               "0.5",
@@ -1484,7 +1483,7 @@ func TestSetTradingStop(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = b.SetTradingStop(context.Background(), &TradingStopParams{
+	err = b.SetTradingStop(t.Context(), &TradingStopParams{
 		Category:                 "linear",
 		Symbol:                   usdcMarginedTradablePair,
 		TakeProfit:               "0.5",
@@ -1511,7 +1510,7 @@ func TestSetAutoAddMargin(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetAutoAddMargin(context.Background(), &AutoAddMarginParam{
+	err := b.SetAutoAddMargin(t.Context(), &AutoAddMarginParam{
 		Category:      "inverse",
 		Symbol:        inverseTradablePair,
 		AutoAddmargin: 0,
@@ -1528,7 +1527,7 @@ func TestAddOrReduceMargin(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.AddOrReduceMargin(context.Background(), &AddOrReduceMarginParam{
+	_, err := b.AddOrReduceMargin(t.Context(), &AddOrReduceMarginParam{
 		Category:      "inverse",
 		Symbol:        inverseTradablePair,
 		Margin:        -10,
@@ -1544,7 +1543,7 @@ func TestGetExecution(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetExecution(context.Background(), "spot", "", "", "", "", "Trade", "tpslOrder", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetExecution(t.Context(), "spot", "", "", "", "", "Trade", "tpslOrder", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1555,11 +1554,11 @@ func TestGetClosedPnL(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetClosedPnL(context.Background(), "spot", "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetClosedPnL(t.Context(), "spot", "", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", err, errInvalidCategory)
 	}
-	_, err = b.GetClosedPnL(context.Background(), "linear", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetClosedPnL(t.Context(), "linear", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1571,7 +1570,7 @@ func TestConfirmNewRiskLimit(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	err := b.ConfirmNewRiskLimit(context.Background(), "linear", "BTCUSDT")
+	err := b.ConfirmNewRiskLimit(t.Context(), "linear", "BTCUSDT")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1583,15 +1582,15 @@ func TestGetPreUpgradeOrderHistory(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeOrderHistory(context.Background(), "", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 100)
+	_, err := b.GetPreUpgradeOrderHistory(t.Context(), "", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 100)
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("expected %v, got %v", errCategoryNotSet, err)
 	}
-	_, err = b.GetPreUpgradeOrderHistory(context.Background(), "option", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeOrderHistory(t.Context(), "option", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errBaseNotSet) {
 		t.Fatalf("expected %v, got %v", errBaseNotSet, err)
 	}
-	_, err = b.GetPreUpgradeOrderHistory(context.Background(), "linear", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeOrderHistory(t.Context(), "linear", "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1603,15 +1602,15 @@ func TestGetPreUpgradeTradeHistory(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeTradeHistory(context.Background(), "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetPreUpgradeTradeHistory(t.Context(), "", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errCategoryNotSet) {
 		t.Fatalf("found %v, expected %v", err, errCategoryNotSet)
 	}
-	_, err = b.GetPreUpgradeTradeHistory(context.Background(), "option", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeTradeHistory(t.Context(), "option", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("found %v, expected %v", err, errInvalidCategory)
 	}
-	_, err = b.GetPreUpgradeTradeHistory(context.Background(), "linear", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeTradeHistory(t.Context(), "linear", "", "", "", "", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1623,11 +1622,11 @@ func TestGetPreUpgradeClosedPnL(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeClosedPnL(context.Background(), "option", "BTCUSDT", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetPreUpgradeClosedPnL(t.Context(), "option", "BTCUSDT", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetPreUpgradeClosedPnL(context.Background(), "linear", "BTCUSDT", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeClosedPnL(t.Context(), "linear", "BTCUSDT", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1639,11 +1638,11 @@ func TestGetPreUpgradeTransactionLog(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeTransactionLog(context.Background(), "option", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetPreUpgradeTransactionLog(t.Context(), "option", "", "", "", time.Time{}, time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("found %v, expected %v", err, errInvalidCategory)
 	}
-	_, err = b.GetPreUpgradeTransactionLog(context.Background(), "linear", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetPreUpgradeTransactionLog(t.Context(), "linear", "", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1655,11 +1654,11 @@ func TestGetPreUpgradeOptionDeliveryRecord(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeOptionDeliveryRecord(context.Background(), "linear", "", "", time.Time{}, 0)
+	_, err := b.GetPreUpgradeOptionDeliveryRecord(t.Context(), "linear", "", "", time.Time{}, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Error(err)
 	}
-	_, err = b.GetPreUpgradeOptionDeliveryRecord(context.Background(), "option", "", "", time.Time{}, 0)
+	_, err = b.GetPreUpgradeOptionDeliveryRecord(t.Context(), "option", "", "", time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1671,11 +1670,11 @@ func TestGetPreUpgradeUSDCSessionSettlement(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPreUpgradeUSDCSessionSettlement(context.Background(), "option", "", "", 10)
+	_, err := b.GetPreUpgradeUSDCSessionSettlement(t.Context(), "option", "", "", 10)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetPreUpgradeUSDCSessionSettlement(context.Background(), "linear", "", "", 10)
+	_, err = b.GetPreUpgradeUSDCSessionSettlement(t.Context(), "linear", "", "", 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1687,7 +1686,7 @@ func TestGetWalletBalance(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
 
-	r, err := b.GetWalletBalance(context.Background(), "UNIFIED", "")
+	r, err := b.GetWalletBalance(t.Context(), "UNIFIED", "")
 	require.NoError(t, err, "GetWalletBalance should not error")
 	require.NotNil(t, r, "GetWalletBalance should return a result")
 
@@ -1776,7 +1775,7 @@ func TestUpgradeToUnifiedAccount(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.UpgradeToUnifiedAccount(context.Background())
+	_, err := b.UpgradeToUnifiedAccount(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1787,7 +1786,7 @@ func TestGetBorrowHistory(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetBorrowHistory(context.Background(), "BTC", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetBorrowHistory(t.Context(), "BTC", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1799,7 +1798,7 @@ func TestSetCollateralCoin(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetCollateralCoin(context.Background(), currency.BTC, false)
+	err := b.SetCollateralCoin(t.Context(), currency.BTC, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1810,7 +1809,7 @@ func TestGetCollateralInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetCollateralInfo(context.Background(), "BTC")
+	_, err := b.GetCollateralInfo(t.Context(), "BTC")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1821,7 +1820,7 @@ func TestGetCoinGreeks(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetCoinGreeks(context.Background(), "BTC")
+	_, err := b.GetCoinGreeks(t.Context(), "BTC")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1832,11 +1831,11 @@ func TestGetFeeRate(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetFeeRate(context.Background(), "something", "", "BTC")
+	_, err := b.GetFeeRate(t.Context(), "something", "", "BTC")
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetFeeRate(context.Background(), "linear", "", "BTC")
+	_, err = b.GetFeeRate(t.Context(), "linear", "", "BTC")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1847,7 +1846,7 @@ func TestGetAccountInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetAccountInfo(context.Background())
+	_, err := b.GetAccountInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1858,11 +1857,11 @@ func TestGetTransactionLog(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetTransactionLog(context.Background(), "option", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetTransactionLog(t.Context(), "option", "", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetTransactionLog(context.Background(), "linear", "", "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetTransactionLog(t.Context(), "linear", "", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1874,7 +1873,7 @@ func TestSetMarginMode(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.SetMarginMode(context.Background(), "PORTFOLIO_MARGIN")
+	_, err := b.SetMarginMode(t.Context(), "PORTFOLIO_MARGIN")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1883,7 +1882,7 @@ func TestSetMarginMode(t *testing.T) {
 func TestSetSpotHedging(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetSpotHedging(context.Background(), true)
+	err := b.SetSpotHedging(t.Context(), true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1895,11 +1894,11 @@ func TestGetSubAccountALLAPIKeys(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetSubAccountAllAPIKeys(context.Background(), "", "", 10)
+	_, err := b.GetSubAccountAllAPIKeys(t.Context(), "", "", 10)
 	if !errors.Is(err, errMemberIDRequired) {
 		t.Errorf("expected %v, got %v", errMemberIDRequired, err)
 	}
-	_, err = b.GetSubAccountAllAPIKeys(context.Background(), "1234", "", 10)
+	_, err = b.GetSubAccountAllAPIKeys(t.Context(), "1234", "", 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1911,11 +1910,11 @@ func TestSetMMP(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.SetMMP(context.Background(), nil)
+	err := b.SetMMP(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("found %v, expected %v", err, errNilArgument)
 	}
-	err = b.SetMMP(context.Background(), &MMPRequestParam{
+	err = b.SetMMP(t.Context(), &MMPRequestParam{
 		BaseCoin:           "ETH",
 		TimeWindowMS:       5000,
 		FrozenPeriod:       100000,
@@ -1933,11 +1932,11 @@ func TestResetMMP(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.ResetMMP(context.Background(), "USDT")
+	err := b.ResetMMP(t.Context(), "USDT")
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("found %v, expected %v", err, errNilArgument)
 	}
-	err = b.ResetMMP(context.Background(), "BTC")
+	err = b.ResetMMP(t.Context(), "BTC")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1948,7 +1947,7 @@ func TestGetMMPState(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetMMPState(context.Background(), "BTC")
+	_, err := b.GetMMPState(t.Context(), "BTC")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1959,7 +1958,7 @@ func TestGetCoinExchangeRecords(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetCoinExchangeRecords(context.Background(), "", "", "", 20)
+	_, err := b.GetCoinExchangeRecords(t.Context(), "", "", "", 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1973,11 +1972,11 @@ func TestGetDeliveryRecord(t *testing.T) {
 	} else {
 		expiryTime = time.UnixMilli(1700216290093)
 	}
-	_, err := b.GetDeliveryRecord(context.Background(), "spot", "", "", expiryTime, 20)
+	_, err := b.GetDeliveryRecord(t.Context(), "spot", "", "", expiryTime, 20)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatal(err)
 	}
-	_, err = b.GetDeliveryRecord(context.Background(), "linear", "", "", expiryTime, 20)
+	_, err = b.GetDeliveryRecord(t.Context(), "linear", "", "", expiryTime, 20)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1988,11 +1987,11 @@ func TestGetUSDCSessionSettlement(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetUSDCSessionSettlement(context.Background(), "option", "", "", 10)
+	_, err := b.GetUSDCSessionSettlement(t.Context(), "option", "", "", 10)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
-	_, err = b.GetUSDCSessionSettlement(context.Background(), "linear", "", "", 10)
+	_, err = b.GetUSDCSessionSettlement(t.Context(), "linear", "", "", 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2003,11 +2002,11 @@ func TestGetAssetInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetAssetInfo(context.Background(), "", "BTC")
+	_, err := b.GetAssetInfo(t.Context(), "", "BTC")
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatal(err)
 	}
-	_, err = b.GetAssetInfo(context.Background(), "SPOT", "BTC")
+	_, err = b.GetAssetInfo(t.Context(), "SPOT", "BTC")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2018,11 +2017,11 @@ func TestGetAllCoinBalance(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetAllCoinBalance(context.Background(), "", "", "", 0)
+	_, err := b.GetAllCoinBalance(t.Context(), "", "", "", 0)
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.GetAllCoinBalance(context.Background(), "FUND", "", "", 0)
+	_, err = b.GetAllCoinBalance(t.Context(), "FUND", "", "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2033,11 +2032,11 @@ func TestGetSingleCoinBalance(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetSingleCoinBalance(context.Background(), "", "", "", 0, 0)
+	_, err := b.GetSingleCoinBalance(t.Context(), "", "", "", 0, 0)
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.GetSingleCoinBalance(context.Background(), "SPOT", currency.BTC.String(), "", 0, 0)
+	_, err = b.GetSingleCoinBalance(t.Context(), "SPOT", currency.BTC.String(), "", 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2048,7 +2047,7 @@ func TestGetTransferableCoin(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetTransferableCoin(context.Background(), "SPOT", "OPTION")
+	_, err := b.GetTransferableCoin(t.Context(), "SPOT", "OPTION")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2060,11 +2059,11 @@ func TestCreateInternalTransfer(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CreateInternalTransfer(context.Background(), nil)
+	_, err := b.CreateInternalTransfer(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{})
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{})
 	if !errors.Is(err, errMissingTransferID) {
 		t.Fatalf("expected %v, got %v", errMissingTransferID, err)
 	}
@@ -2072,18 +2071,18 @@ func TestCreateInternalTransfer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{TransferID: transferID})
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{TransferID: transferID})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC,
 	})
 	if !errors.Is(err, order.ErrAmountIsInvalid) {
 		t.Fatalf("expected %v, got %v", order.ErrAmountIsInvalid, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC,
 		Amount:     123.456,
@@ -2091,21 +2090,21 @@ func TestCreateInternalTransfer(t *testing.T) {
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456,
 	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED",
 	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateInternalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateInternalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456,
 		ToAccountType:   "CONTRACT",
@@ -2128,7 +2127,7 @@ func TestGetInternalTransferRecords(t *testing.T) {
 	} else {
 		transferIDString = "018bd458-dba0-728b-b5b6-ecd5bd296528"
 	}
-	_, err = b.GetInternalTransferRecords(context.Background(), transferIDString, currency.BTC.String(), "", "", time.Time{}, time.Time{}, 0)
+	_, err = b.GetInternalTransferRecords(t.Context(), transferIDString, currency.BTC.String(), "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2139,7 +2138,7 @@ func TestGetSubUID(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetSubUID(context.Background())
+	_, err := b.GetSubUID(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -2151,7 +2150,7 @@ func TestEnableUniversalTransferForSubUID(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.EnableUniversalTransferForSubUID(context.Background())
+	err := b.EnableUniversalTransferForSubUID(t.Context())
 	if !errors.Is(err, errMembersIDsNotSet) {
 		t.Fatalf("expected %v, got %v", errMembersIDsNotSet, err)
 	}
@@ -2163,7 +2162,7 @@ func TestEnableUniversalTransferForSubUID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = b.EnableUniversalTransferForSubUID(context.Background(), transferID1.String(), transferID2.String())
+	err = b.EnableUniversalTransferForSubUID(t.Context(), transferID1.String(), transferID2.String())
 	if err != nil {
 		t.Error(err)
 	}
@@ -2171,11 +2170,11 @@ func TestEnableUniversalTransferForSubUID(t *testing.T) {
 
 func TestCreateUniversalTransfer(t *testing.T) {
 	t.Parallel()
-	_, err := b.CreateUniversalTransfer(context.Background(), nil)
+	_, err := b.CreateUniversalTransfer(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{})
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{})
 	if !errors.Is(err, errMissingTransferID) {
 		t.Fatalf("expected %v, got %v", errMissingTransferID, err)
 	}
@@ -2183,18 +2182,18 @@ func TestCreateUniversalTransfer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{TransferID: transferID})
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{TransferID: transferID})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC,
 	})
 	if !errors.Is(err, order.ErrAmountIsInvalid) {
 		t.Fatalf("expected %v, got %v", order.ErrAmountIsInvalid, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC,
 		Amount:     123.456,
@@ -2202,21 +2201,21 @@ func TestCreateUniversalTransfer(t *testing.T) {
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456,
 	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456, FromAccountType: "UNIFIED",
 	})
 	if !errors.Is(err, errMissingAccountType) {
 		t.Fatalf("expected %v, got %v", errMissingAccountType, err)
 	}
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456,
 		ToAccountType:   "CONTRACT",
@@ -2229,7 +2228,7 @@ func TestCreateUniversalTransfer(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err = b.CreateUniversalTransfer(context.Background(), &TransferParams{
+	_, err = b.CreateUniversalTransfer(t.Context(), &TransferParams{
 		TransferID: transferID,
 		Coin:       currency.BTC, Amount: 123.456,
 		ToAccountType:   "CONTRACT",
@@ -2255,7 +2254,7 @@ func TestGetUniversalTransferRecords(t *testing.T) {
 	} else {
 		transferIDString = "018bd461-cb9c-75ce-94d4-0d3f4d84c339"
 	}
-	_, err := b.GetUniversalTransferRecords(context.Background(), transferIDString, currency.BTC.String(), "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetUniversalTransferRecords(t.Context(), transferIDString, currency.BTC.String(), "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2266,7 +2265,7 @@ func TestGetAllowedDepositCoinInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetAllowedDepositCoinInfo(context.Background(), "BTC", "", "", 0)
+	_, err := b.GetAllowedDepositCoinInfo(t.Context(), "BTC", "", "", 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2278,7 +2277,7 @@ func TestSetDepositAccount(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.SetDepositAccount(context.Background(), "FUND")
+	_, err := b.SetDepositAccount(t.Context(), "FUND")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2289,7 +2288,7 @@ func TestGetDepositRecords(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetDepositRecords(context.Background(), "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetDepositRecords(t.Context(), "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2301,7 +2300,7 @@ func TestGetSubDepositRecords(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetSubDepositRecords(context.Background(), "12345", "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetSubDepositRecords(t.Context(), "12345", "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2312,7 +2311,7 @@ func TestInternalDepositRecords(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetInternalDepositRecordsOffChain(context.Background(), currency.ETH.String(), "", time.Time{}, time.Time{}, 8)
+	_, err := b.GetInternalDepositRecordsOffChain(t.Context(), currency.ETH.String(), "", time.Time{}, time.Time{}, 8)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2323,7 +2322,7 @@ func TestGetMasterDepositAddress(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetMasterDepositAddress(context.Background(), currency.LTC, "")
+	_, err := b.GetMasterDepositAddress(t.Context(), currency.LTC, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2335,7 +2334,7 @@ func TestGetSubDepositAddress(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetSubDepositAddress(context.Background(), currency.LTC, "LTC", "12345")
+	_, err := b.GetSubDepositAddress(t.Context(), currency.LTC, "LTC", "12345")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2346,7 +2345,7 @@ func TestGetCoinInfo(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetCoinInfo(context.Background(), currency.BTC)
+	_, err := b.GetCoinInfo(t.Context(), currency.BTC)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2357,7 +2356,7 @@ func TestGetWithdrawalRecords(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetWithdrawalRecords(context.Background(), currency.LTC, "", "", "", time.Time{}, time.Time{}, 10)
+	_, err := b.GetWithdrawalRecords(t.Context(), currency.LTC, "", "", "", time.Time{}, time.Time{}, 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2368,7 +2367,7 @@ func TestGetWithdrawableAmount(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	_, err := b.GetWithdrawableAmount(context.Background(), currency.LTC)
+	_, err := b.GetWithdrawableAmount(t.Context(), currency.LTC)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2380,27 +2379,27 @@ func TestWithdrawCurrency(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.WithdrawCurrency(context.Background(), nil)
+	_, err := b.WithdrawCurrency(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.WithdrawCurrency(context.Background(), &WithdrawalParam{})
+	_, err = b.WithdrawCurrency(t.Context(), &WithdrawalParam{})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.WithdrawCurrency(context.Background(), &WithdrawalParam{Coin: currency.BTC})
+	_, err = b.WithdrawCurrency(t.Context(), &WithdrawalParam{Coin: currency.BTC})
 	if !errors.Is(err, errMissingChainInformation) {
 		t.Fatalf("expected %v, got %v", errMissingChainInformation, err)
 	}
-	_, err = b.WithdrawCurrency(context.Background(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC"})
+	_, err = b.WithdrawCurrency(t.Context(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC"})
 	if !errors.Is(err, errMissingAddressInfo) {
 		t.Fatalf("expected %v, got %v", errMissingAddressInfo, err)
 	}
-	_, err = b.WithdrawCurrency(context.Background(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC", Address: "234234234"})
+	_, err = b.WithdrawCurrency(t.Context(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC", Address: "234234234"})
 	if !errors.Is(err, order.ErrAmountBelowMin) {
 		t.Fatalf("expected %v, got %v", order.ErrAmountBelowMin, err)
 	}
-	_, err = b.WithdrawCurrency(context.Background(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC", Address: "234234234", Amount: 123})
+	_, err = b.WithdrawCurrency(t.Context(), &WithdrawalParam{Coin: currency.LTC, Chain: "LTC", Address: "234234234", Amount: 123})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2412,11 +2411,11 @@ func TestCancelWithdrawal(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.CancelWithdrawal(context.Background(), "")
+	_, err := b.CancelWithdrawal(t.Context(), "")
 	if !errors.Is(err, errMissingWithdrawalID) {
 		t.Fatalf("expected %v, got %v", errMissingWithdrawalID, err)
 	}
-	_, err = b.CancelWithdrawal(context.Background(), "12314")
+	_, err = b.CancelWithdrawal(t.Context(), "12314")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2424,15 +2423,15 @@ func TestCancelWithdrawal(t *testing.T) {
 
 func TestCreateNewSubUserID(t *testing.T) {
 	t.Parallel()
-	_, err := b.CreateNewSubUserID(context.Background(), nil)
+	_, err := b.CreateNewSubUserID(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CreateNewSubUserID(context.Background(), &CreateSubUserParams{MemberType: 1, Switch: 1, Note: "test"})
+	_, err = b.CreateNewSubUserID(t.Context(), &CreateSubUserParams{MemberType: 1, Switch: 1, Note: "test"})
 	if !errors.Is(err, errMissingUsername) {
 		t.Fatalf("expected %v, got %v", errMissingUsername, err)
 	}
-	_, err = b.CreateNewSubUserID(context.Background(), &CreateSubUserParams{Username: "Sami", Switch: 1, Note: "test"})
+	_, err = b.CreateNewSubUserID(t.Context(), &CreateSubUserParams{Username: "Sami", Switch: 1, Note: "test"})
 	if !errors.Is(err, errInvalidMemberType) {
 		t.Fatalf("expected %v, got %v", errInvalidMemberType, err)
 	}
@@ -2440,7 +2439,7 @@ func TestCreateNewSubUserID(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err = b.CreateNewSubUserID(context.Background(), &CreateSubUserParams{Username: "sami", MemberType: 1, Switch: 1, Note: "test"})
+	_, err = b.CreateNewSubUserID(t.Context(), &CreateSubUserParams{Username: "sami", MemberType: 1, Switch: 1, Note: "test"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2448,11 +2447,11 @@ func TestCreateNewSubUserID(t *testing.T) {
 
 func TestCreateSubUIDAPIKey(t *testing.T) {
 	t.Parallel()
-	_, err := b.CreateSubUIDAPIKey(context.Background(), nil)
+	_, err := b.CreateSubUIDAPIKey(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.CreateSubUIDAPIKey(context.Background(), &SubUIDAPIKeyParam{})
+	_, err = b.CreateSubUIDAPIKey(t.Context(), &SubUIDAPIKeyParam{})
 	if !errors.Is(err, errMissingUserID) {
 		t.Fatalf("expected %v, got %v", errMissingUserID, err)
 	}
@@ -2460,7 +2459,7 @@ func TestCreateSubUIDAPIKey(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err = b.CreateSubUIDAPIKey(context.Background(), &SubUIDAPIKeyParam{
+	_, err = b.CreateSubUIDAPIKey(t.Context(), &SubUIDAPIKeyParam{
 		Subuid:      53888000,
 		Note:        "testxxx",
 		ReadOnly:    0,
@@ -2477,7 +2476,7 @@ func TestGetSubUIDList(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetSubUIDList(context.Background())
+	_, err := b.GetSubUIDList(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -2489,7 +2488,7 @@ func TestFreezeSubUID(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.FreezeSubUID(context.Background(), "1234", true)
+	err := b.FreezeSubUID(t.Context(), "1234", true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2501,7 +2500,7 @@ func TestGetAPIKeyInformation(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAPIKeyInformation(context.Background())
+	_, err := b.GetAPIKeyInformation(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -2513,7 +2512,7 @@ func TestGetUIDWalletType(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetUIDWalletType(context.Background(), "234234")
+	_, err := b.GetUIDWalletType(t.Context(), "234234")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2525,11 +2524,11 @@ func TestModifyMasterAPIKey(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ModifyMasterAPIKey(context.Background(), &SubUIDAPIKeyUpdateParam{})
+	_, err := b.ModifyMasterAPIKey(t.Context(), &SubUIDAPIKeyUpdateParam{})
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.ModifyMasterAPIKey(context.Background(), &SubUIDAPIKeyUpdateParam{
+	_, err = b.ModifyMasterAPIKey(t.Context(), &SubUIDAPIKeyUpdateParam{
 		ReadOnly: 0,
 		IPs:      "*",
 		Permissions: PermissionsList{
@@ -2552,11 +2551,11 @@ func TestModifySubAPIKey(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ModifySubAPIKey(context.Background(), &SubUIDAPIKeyUpdateParam{})
+	_, err := b.ModifySubAPIKey(t.Context(), &SubUIDAPIKeyUpdateParam{})
 	if !errors.Is(err, errNilArgument) {
 		t.Fatalf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.ModifySubAPIKey(context.Background(), &SubUIDAPIKeyUpdateParam{
+	_, err = b.ModifySubAPIKey(t.Context(), &SubUIDAPIKeyUpdateParam{
 		APIKey:   "lnqQ8ACaoMLi4168He",
 		ReadOnly: 0,
 		IPs:      "*",
@@ -2580,11 +2579,11 @@ func TestDeleteSubUID(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	err := b.DeleteSubUID(context.Background(), "")
+	err := b.DeleteSubUID(t.Context(), "")
 	if !errors.Is(err, errMemberIDRequired) {
 		t.Errorf("expected %v, got %v", errMemberIDRequired, err)
 	}
-	err = b.DeleteSubUID(context.Background(), "1234")
+	err = b.DeleteSubUID(t.Context(), "1234")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2596,7 +2595,7 @@ func TestDeleteMasterAPIKey(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.DeleteMasterAPIKey(context.Background())
+	err := b.DeleteMasterAPIKey(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -2608,7 +2607,7 @@ func TestDeleteSubAPIKey(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	err := b.DeleteSubAccountAPIKey(context.Background(), "12434")
+	err := b.DeleteSubAccountAPIKey(t.Context(), "12434")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2620,7 +2619,7 @@ func TestGetAffiliateUserInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetAffiliateUserInfo(context.Background(), "1234")
+	_, err := b.GetAffiliateUserInfo(t.Context(), "1234")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2632,7 +2631,7 @@ func TestGetLeverageTokenInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetLeverageTokenInfo(context.Background(), currency.NewCode("BTC3L"))
+	_, err := b.GetLeverageTokenInfo(t.Context(), currency.NewCode("BTC3L"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -2644,11 +2643,11 @@ func TestGetLeveragedTokenMarket(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetLeveragedTokenMarket(context.Background(), currency.EMPTYCODE)
+	_, err := b.GetLeveragedTokenMarket(t.Context(), currency.EMPTYCODE)
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Fatalf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.GetLeveragedTokenMarket(context.Background(), currency.NewCode("BTC3L"))
+	_, err = b.GetLeveragedTokenMarket(t.Context(), currency.NewCode("BTC3L"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -2660,7 +2659,7 @@ func TestPurchaseLeverageToken(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.PurchaseLeverageToken(context.Background(), currency.BTC3L, 100, "")
+	_, err := b.PurchaseLeverageToken(t.Context(), currency.BTC3L, 100, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2672,7 +2671,7 @@ func TestRedeemLeverageToken(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.RedeemLeverageToken(context.Background(), currency.BTC3L, 100, "")
+	_, err := b.RedeemLeverageToken(t.Context(), currency.BTC3L, 100, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2684,7 +2683,7 @@ func TestGetPurchaseAndRedemptionRecords(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetPurchaseAndRedemptionRecords(context.Background(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{}, 0, 0)
+	_, err := b.GetPurchaseAndRedemptionRecords(t.Context(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{}, 0, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2696,7 +2695,7 @@ func TestToggleMarginTrade(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.ToggleMarginTrade(context.Background(), true)
+	_, err := b.ToggleMarginTrade(t.Context(), true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2708,7 +2707,7 @@ func TestSetSpotMarginTradeLeverage(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	err := b.SetSpotMarginTradeLeverage(context.Background(), 3)
+	err := b.SetSpotMarginTradeLeverage(t.Context(), 3)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2716,7 +2715,7 @@ func TestSetSpotMarginTradeLeverage(t *testing.T) {
 
 func TestGetMarginCoinInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetMarginCoinInfo(context.Background(), currency.BTC)
+	_, err := b.GetMarginCoinInfo(t.Context(), currency.BTC)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2724,7 +2723,7 @@ func TestGetMarginCoinInfo(t *testing.T) {
 
 func TestGetVIPMarginData(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetVIPMarginData(context.Background(), "", "")
+	_, err := b.GetVIPMarginData(t.Context(), "", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2732,7 +2731,7 @@ func TestGetVIPMarginData(t *testing.T) {
 
 func TestGetBorrowableCoinInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetBorrowableCoinInfo(context.Background(), currency.EMPTYCODE)
+	_, err := b.GetBorrowableCoinInfo(t.Context(), currency.EMPTYCODE)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2744,11 +2743,11 @@ func TestGetInterestAndQuota(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetInterestAndQuota(context.Background(), currency.EMPTYCODE)
+	_, err := b.GetInterestAndQuota(t.Context(), currency.EMPTYCODE)
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.GetInterestAndQuota(context.Background(), currency.BTC)
+	_, err = b.GetInterestAndQuota(t.Context(), currency.BTC)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2760,7 +2759,7 @@ func TestGetLoanAccountInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetLoanAccountInfo(context.Background())
+	_, err := b.GetLoanAccountInfo(t.Context())
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2772,19 +2771,19 @@ func TestBorrow(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.Borrow(context.Background(), nil)
+	_, err := b.Borrow(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.Borrow(context.Background(), &LendArgument{})
+	_, err = b.Borrow(t.Context(), &LendArgument{})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.Borrow(context.Background(), &LendArgument{Coin: currency.BTC})
+	_, err = b.Borrow(t.Context(), &LendArgument{Coin: currency.BTC})
 	if !errors.Is(err, order.ErrAmountBelowMin) {
 		t.Errorf("expected %v, got %v", order.ErrAmountBelowMin, err)
 	}
-	_, err = b.Borrow(context.Background(), &LendArgument{Coin: currency.BTC, AmountToBorrow: 0.1})
+	_, err = b.Borrow(t.Context(), &LendArgument{Coin: currency.BTC, AmountToBorrow: 0.1})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2796,19 +2795,19 @@ func TestRepay(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.Repay(context.Background(), nil)
+	_, err := b.Repay(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Errorf("expected %v, got %v", errNilArgument, err)
 	}
-	_, err = b.Repay(context.Background(), &LendArgument{})
+	_, err = b.Repay(t.Context(), &LendArgument{})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.Repay(context.Background(), &LendArgument{Coin: currency.BTC})
+	_, err = b.Repay(t.Context(), &LendArgument{Coin: currency.BTC})
 	if !errors.Is(err, order.ErrAmountBelowMin) {
 		t.Errorf("expected %v, got %v", order.ErrAmountBelowMin, err)
 	}
-	_, err = b.Repay(context.Background(), &LendArgument{Coin: currency.BTC, AmountToBorrow: 0.1})
+	_, err = b.Repay(t.Context(), &LendArgument{Coin: currency.BTC, AmountToBorrow: 0.1})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2820,7 +2819,7 @@ func TestGetBorrowOrderDetail(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetBorrowOrderDetail(context.Background(), time.Time{}, time.Time{}, currency.BTC, 0, 0)
+	_, err := b.GetBorrowOrderDetail(t.Context(), time.Time{}, time.Time{}, currency.BTC, 0, 0)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2832,7 +2831,7 @@ func TestGetRepaymentOrderDetail(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetRepaymentOrderDetail(context.Background(), time.Time{}, time.Time{}, currency.BTC, 0)
+	_, err := b.GetRepaymentOrderDetail(t.Context(), time.Time{}, time.Time{}, currency.BTC, 0)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2844,7 +2843,7 @@ func TestToggleMarginTradeNormal(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.ToggleMarginTradeNormal(context.Background(), true)
+	_, err := b.ToggleMarginTradeNormal(t.Context(), true)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2852,7 +2851,7 @@ func TestToggleMarginTradeNormal(t *testing.T) {
 
 func TestGetProductInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetProductInfo(context.Background(), "")
+	_, err := b.GetProductInfo(t.Context(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2860,7 +2859,7 @@ func TestGetProductInfo(t *testing.T) {
 
 func TestGetInstitutionalLengingMarginCoinInfo(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetInstitutionalLengingMarginCoinInfo(context.Background(), "")
+	_, err := b.GetInstitutionalLengingMarginCoinInfo(t.Context(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2872,7 +2871,7 @@ func TestGetInstitutionalLoanOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetInstitutionalLoanOrders(context.Background(), "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetInstitutionalLoanOrders(t.Context(), "", time.Time{}, time.Time{}, 0)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2884,7 +2883,7 @@ func TestGetInstitutionalRepayOrders(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetInstitutionalRepayOrders(context.Background(), time.Time{}, time.Time{}, 0)
+	_, err := b.GetInstitutionalRepayOrders(t.Context(), time.Time{}, time.Time{}, 0)
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2896,7 +2895,7 @@ func TestGetLTV(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetLTV(context.Background())
+	_, err := b.GetLTV(t.Context())
 	if err != nil && !errors.Is(err, errEndpointAvailableForNormalAPIKeyHolders) {
 		t.Error(err)
 	}
@@ -2908,7 +2907,7 @@ func TestBindOrUnbindUID(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.BindOrUnbindUID(context.Background(), "12234", "0")
+	_, err := b.BindOrUnbindUID(t.Context(), "12234", "0")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2920,7 +2919,7 @@ func TestGetC2CLendingCoinInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetC2CLendingCoinInfo(context.Background(), currency.BTC)
+	_, err := b.GetC2CLendingCoinInfo(t.Context(), currency.BTC)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2932,19 +2931,19 @@ func TestC2CDepositFunds(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.C2CDepositFunds(context.Background(), nil)
+	_, err := b.C2CDepositFunds(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Error(err)
 	}
-	_, err = b.C2CDepositFunds(context.Background(), &C2CLendingFundsParams{})
+	_, err = b.C2CDepositFunds(t.Context(), &C2CLendingFundsParams{})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.C2CDepositFunds(context.Background(), &C2CLendingFundsParams{Coin: currency.BTC})
+	_, err = b.C2CDepositFunds(t.Context(), &C2CLendingFundsParams{Coin: currency.BTC})
 	if !errors.Is(err, order.ErrAmountBelowMin) {
 		t.Errorf("expected %v, got %v", order.ErrAmountBelowMin, err)
 	}
-	_, err = b.C2CDepositFunds(context.Background(), &C2CLendingFundsParams{Coin: currency.BTC, Quantity: 1232})
+	_, err = b.C2CDepositFunds(t.Context(), &C2CLendingFundsParams{Coin: currency.BTC, Quantity: 1232})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2956,19 +2955,19 @@ func TestC2CRedeemFunds(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	_, err := b.C2CRedeemFunds(context.Background(), nil)
+	_, err := b.C2CRedeemFunds(t.Context(), nil)
 	if !errors.Is(err, errNilArgument) {
 		t.Error(err)
 	}
-	_, err = b.C2CRedeemFunds(context.Background(), &C2CLendingFundsParams{})
+	_, err = b.C2CRedeemFunds(t.Context(), &C2CLendingFundsParams{})
 	if !errors.Is(err, currency.ErrCurrencyCodeEmpty) {
 		t.Errorf("expected %v, got %v", currency.ErrCurrencyCodeEmpty, err)
 	}
-	_, err = b.C2CRedeemFunds(context.Background(), &C2CLendingFundsParams{Coin: currency.BTC})
+	_, err = b.C2CRedeemFunds(t.Context(), &C2CLendingFundsParams{Coin: currency.BTC})
 	if !errors.Is(err, order.ErrAmountBelowMin) {
 		t.Errorf("expected %v, got %v", order.ErrAmountBelowMin, err)
 	}
-	_, err = b.C2CRedeemFunds(context.Background(), &C2CLendingFundsParams{Coin: currency.BTC, Quantity: 1232})
+	_, err = b.C2CRedeemFunds(t.Context(), &C2CLendingFundsParams{Coin: currency.BTC, Quantity: 1232})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2980,7 +2979,7 @@ func TestGetC2CLendingOrderRecords(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetC2CLendingOrderRecords(context.Background(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetC2CLendingOrderRecords(t.Context(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2992,7 +2991,7 @@ func TestGetC2CLendingAccountInfo(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetC2CLendingAccountInfo(context.Background(), currency.LTC)
+	_, err := b.GetC2CLendingAccountInfo(t.Context(), currency.LTC)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3004,7 +3003,7 @@ func TestGetBrokerEarning(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetBrokerEarning(context.Background(), "DERIVATIVES", "", time.Time{}, time.Time{}, 0)
+	_, err := b.GetBrokerEarning(t.Context(), "DERIVATIVES", "", time.Time{}, time.Time{}, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3016,7 +3015,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
 
-	r, err := b.UpdateAccountInfo(context.Background(), asset.Spot)
+	r, err := b.UpdateAccountInfo(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateAccountInfo should not error")
 	require.NotEmpty(t, r, "UpdateAccountInfo should return account info")
 
@@ -3055,11 +3054,11 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 		t.Skip(skipAuthenticatedFunctionsForMockTesting)
 	}
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Futures)
+	_, err := b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Futures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
-	_, err = b.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err = b.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error("GetWithdrawalsHistory()", err)
 	}
@@ -3077,17 +3076,17 @@ func TestGetRecentTrades(t *testing.T) {
 		{asset.USDTMarginedFutures, usdtMarginedTradablePair},
 		{asset.USDCMarginedFutures, usdcMarginedTradablePair},
 	} {
-		_, err := b.GetRecentTrades(context.Background(), tt.p, tt.a)
+		_, err := b.GetRecentTrades(t.Context(), tt.p, tt.a)
 		assert.NoErrorf(t, err, "GetRecentTrades should not error for %s asset", tt.a)
 	}
 
-	_, err := b.GetRecentTrades(context.Background(), spotTradablePair, asset.Futures)
+	_, err := b.GetRecentTrades(t.Context(), spotTradablePair, asset.Futures)
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 }
 
 func TestGetBybitServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetBybitServerTime(context.Background())
+	_, err := b.GetBybitServerTime(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -3095,7 +3094,7 @@ func TestGetBybitServerTime(t *testing.T) {
 
 func TestGetServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetServerTime(context.Background(), asset.Empty)
+	_, err := b.GetServerTime(t.Context(), asset.Empty)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3103,23 +3102,23 @@ func TestGetServerTime(t *testing.T) {
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetHistoricTrades(context.Background(), spotTradablePair, asset.Spot, time.Time{}, time.Time{})
+	_, err := b.GetHistoricTrades(t.Context(), spotTradablePair, asset.Spot, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(), usdtMarginedTradablePair, asset.USDTMarginedFutures, time.Time{}, time.Time{})
+	_, err = b.GetHistoricTrades(t.Context(), usdtMarginedTradablePair, asset.USDTMarginedFutures, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(), usdcMarginedTradablePair, asset.USDCMarginedFutures, time.Time{}, time.Time{})
+	_, err = b.GetHistoricTrades(t.Context(), usdcMarginedTradablePair, asset.USDCMarginedFutures, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(), inverseTradablePair, asset.CoinMarginedFutures, time.Time{}, time.Time{})
+	_, err = b.GetHistoricTrades(t.Context(), inverseTradablePair, asset.CoinMarginedFutures, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetHistoricTrades(context.Background(), optionsTradablePair, asset.Options, time.Time{}, time.Time{})
+	_, err = b.GetHistoricTrades(t.Context(), optionsTradablePair, asset.Options, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -3140,7 +3139,7 @@ func TestCancelBatchOrders(t *testing.T) {
 		Pair:      usdtMarginedTradablePair,
 		AssetType: asset.USDTMarginedFutures,
 	}}
-	_, err := b.CancelBatchOrders(context.Background(), orderCancellationParams)
+	_, err := b.CancelBatchOrders(t.Context(), orderCancellationParams)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
@@ -3154,7 +3153,7 @@ func TestCancelBatchOrders(t *testing.T) {
 		Pair:      optionsTradablePair,
 		AssetType: asset.Options,
 	}}
-	_, err = b.CancelBatchOrders(context.Background(), orderCancellationParams)
+	_, err = b.CancelBatchOrders(t.Context(), orderCancellationParams)
 	if err != nil {
 		t.Error(err)
 	}
@@ -3393,22 +3392,22 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 		FiatCurrency:        currency.USD,
 		BankTransactionType: exchange.WireTransfer,
 	}
-	_, err := b.GetFeeByType(context.Background(), feeBuilder)
+	_, err := b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
 	feeBuilder.Pair = optionsTradablePair
-	_, err = b.GetFeeByType(context.Background(), feeBuilder)
+	_, err = b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
 	feeBuilder.Pair = usdtMarginedTradablePair
-	_, err = b.GetFeeByType(context.Background(), feeBuilder)
+	_, err = b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
 	feeBuilder.Pair = inverseTradablePair
-	_, err = b.GetFeeByType(context.Background(), feeBuilder)
+	_, err = b.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3417,7 +3416,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 func TestSetLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)
-	ctx := context.Background()
+	ctx := t.Context()
 	err := b.SetLeverage(ctx, asset.USDTMarginedFutures, usdtMarginedTradablePair, margin.Multi, 5, order.Buy)
 	if err != nil {
 		t.Error(err)
@@ -3455,19 +3454,19 @@ func TestSetLeverage(t *testing.T) {
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := b.GetFuturesContractDetails(t.Context(), asset.Spot)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.CoinMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.CoinMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
-	_, err = b.GetFuturesContractDetails(context.Background(), asset.USDCMarginedFutures)
+	_, err = b.GetFuturesContractDetails(t.Context(), asset.USDCMarginedFutures)
 	if !errors.Is(err, nil) {
 		t.Error(err)
 	}
@@ -3475,27 +3474,27 @@ func TestGetFuturesContractDetails(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := b.FetchTradablePairs(context.Background(), asset.Spot)
+	_, err := b.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.FetchTradablePairs(context.Background(), asset.CoinMarginedFutures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.CoinMarginedFutures)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.FetchTradablePairs(context.Background(), asset.USDTMarginedFutures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.USDTMarginedFutures)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.FetchTradablePairs(context.Background(), asset.USDCMarginedFutures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.USDCMarginedFutures)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.FetchTradablePairs(context.Background(), asset.Options)
+	_, err = b.FetchTradablePairs(t.Context(), asset.Options)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.FetchTradablePairs(context.Background(), asset.Futures)
+	_, err = b.FetchTradablePairs(t.Context(), asset.Futures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
@@ -3522,15 +3521,15 @@ func TestDeltaUpdateOrderbook(t *testing.T) {
 
 func TestGetLongShortRatio(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLongShortRatio(context.Background(), "linear", "BTCUSDT", kline.FiveMin, 0)
+	_, err := b.GetLongShortRatio(t.Context(), "linear", "BTCUSDT", kline.FiveMin, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetLongShortRatio(context.Background(), "inverse", "BTCUSDT", kline.FiveMin, 0)
+	_, err = b.GetLongShortRatio(t.Context(), "inverse", "BTCUSDT", kline.FiveMin, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.GetLongShortRatio(context.Background(), "spot", "BTCUSDT", kline.FiveMin, 0)
+	_, err = b.GetLongShortRatio(t.Context(), "spot", "BTCUSDT", kline.FiveMin, 0)
 	if !errors.Is(err, errInvalidCategory) {
 		t.Fatalf("expected %v, got %v", errInvalidCategory, err)
 	}
@@ -3585,7 +3584,7 @@ func TestFetchAccountType(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	val, err := b.FetchAccountType(context.Background())
+	val, err := b.FetchAccountType(t.Context())
 	require.NoError(t, err)
 	require.NotZero(t, val)
 }
@@ -3603,44 +3602,44 @@ func TestRequiresUnifiedAccount(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
 	}
-	err := b.RequiresUnifiedAccount(context.Background())
+	err := b.RequiresUnifiedAccount(t.Context())
 	require.NoError(t, err)
 	b := &Bybit{} //nolint:govet // Intentional shadow to avoid future copy/paste mistakes. Also stops race below.
 	b.account.accountType = accountTypeNormal
-	err = b.RequiresUnifiedAccount(context.Background())
+	err = b.RequiresUnifiedAccount(t.Context())
 	require.ErrorIs(t, err, errAPIKeyIsNotUnified)
 }
 
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 		Pair:  usdtMarginedTradablePair,
 	})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Spot,
 		Pair:  spotTradablePair,
 	})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Options,
 		Pair:  optionsTradablePair,
 	})
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Errorf("expected %v, got %v", asset.ErrNotSupported, err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.USDTMarginedFutures,
 	})
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = b.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = b.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.USDCMarginedFutures,
 		Pair:  usdcMarginedTradablePair,
 	})
@@ -3673,14 +3672,14 @@ func TestConstructOrderDetails(t *testing.T) {
 
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
-	_, err := b.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err := b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.ETH.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.Spot,
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 
-	resp, err := b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  usdcMarginedTradablePair.Base.Item,
 		Quote: usdcMarginedTradablePair.Quote.Item,
 		Asset: asset.USDCMarginedFutures,
@@ -3688,7 +3687,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  usdtMarginedTradablePair.Base.Item,
 		Quote: usdtMarginedTradablePair.Quote.Item,
 		Asset: asset.USDTMarginedFutures,
@@ -3696,7 +3695,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err = b.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  inverseTradablePair.Base.Item,
 		Quote: inverseTradablePair.Quote.Item,
 		Asset: asset.CoinMarginedFutures,
@@ -3704,7 +3703,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = b.GetOpenInterest(context.Background())
+	resp, err = b.GetOpenInterest(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -3736,7 +3735,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := b.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := b.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := b.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -1,7 +1,6 @@
 package coinbasepro
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -45,32 +44,32 @@ func TestMain(_ *testing.M) {
 }
 
 func TestGetProducts(t *testing.T) {
-	_, err := c.GetProducts(context.Background())
+	_, err := c.GetProducts(t.Context())
 	if err != nil {
 		t.Errorf("Coinbase, GetProducts() Error: %s", err)
 	}
 }
 
 func TestGetOrderbook(t *testing.T) {
-	_, err := c.GetOrderbook(context.Background(), testPair.String(), 2)
+	_, err := c.GetOrderbook(t.Context(), testPair.String(), 2)
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = c.GetOrderbook(context.Background(), testPair.String(), 3)
+	_, err = c.GetOrderbook(t.Context(), testPair.String(), 3)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestGetTicker(t *testing.T) {
-	_, err := c.GetTicker(context.Background(), testPair.String())
+	_, err := c.GetTicker(t.Context(), testPair.String())
 	if err != nil {
 		t.Error("GetTicker() error", err)
 	}
 }
 
 func TestGetTrades(t *testing.T) {
-	_, err := c.GetTrades(context.Background(), testPair.String())
+	_, err := c.GetTrades(t.Context(), testPair.String())
 	if err != nil {
 		t.Error("GetTrades() error", err)
 	}
@@ -79,7 +78,7 @@ func TestGetTrades(t *testing.T) {
 func TestGetHistoricRatesGranularityCheck(t *testing.T) {
 	end := time.Now()
 	start := end.Add(-time.Hour * 2)
-	_, err := c.GetHistoricCandles(context.Background(),
+	_, err := c.GetHistoricCandles(t.Context(),
 		testPair, asset.Spot, kline.OneHour, start, end)
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +89,7 @@ func TestCoinbasePro_GetHistoricCandlesExtended(t *testing.T) {
 	start := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
 
-	_, err := c.GetHistoricCandlesExtended(context.Background(),
+	_, err := c.GetHistoricCandlesExtended(t.Context(),
 		testPair, asset.Spot, kline.OneDay, start, end)
 	if err != nil {
 		t.Fatal(err)
@@ -98,21 +97,21 @@ func TestCoinbasePro_GetHistoricCandlesExtended(t *testing.T) {
 }
 
 func TestGetStats(t *testing.T) {
-	_, err := c.GetStats(context.Background(), testPair.String())
+	_, err := c.GetStats(t.Context(), testPair.String())
 	if err != nil {
 		t.Error("GetStats() error", err)
 	}
 }
 
 func TestGetCurrencies(t *testing.T) {
-	_, err := c.GetCurrencies(context.Background())
+	_, err := c.GetCurrencies(t.Context())
 	if err != nil {
 		t.Error("GetCurrencies() error", err)
 	}
 }
 
 func TestGetCurrentServerTime(t *testing.T) {
-	_, err := c.GetCurrentServerTime(context.Background())
+	_, err := c.GetCurrentServerTime(t.Context())
 	if err != nil {
 		t.Error("GetServerTime() error", err)
 	}
@@ -120,7 +119,7 @@ func TestGetCurrentServerTime(t *testing.T) {
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := c.GetServerTime(context.Background(), asset.Spot)
+	st, err := c.GetServerTime(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -134,11 +133,11 @@ func TestAuthRequests(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, c)
 
-	_, err := c.GetAccounts(context.Background())
+	_, err := c.GetAccounts(t.Context())
 	if err != nil {
 		t.Error("GetAccounts() error", err)
 	}
-	accountResponse, err := c.GetAccount(context.Background(),
+	accountResponse, err := c.GetAccount(t.Context(),
 		"13371337-1337-1337-1337-133713371337")
 	if accountResponse.ID != "" {
 		t.Error("Expecting no data returned")
@@ -146,7 +145,7 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	accountHistoryResponse, err := c.GetAccountHistory(context.Background(),
+	accountHistoryResponse, err := c.GetAccountHistory(t.Context(),
 		"13371337-1337-1337-1337-133713371337")
 	if len(accountHistoryResponse) > 0 {
 		t.Error("Expecting no data returned")
@@ -154,7 +153,7 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	getHoldsResponse, err := c.GetHolds(context.Background(),
+	getHoldsResponse, err := c.GetHolds(t.Context(),
 		"13371337-1337-1337-1337-133713371337")
 	if len(getHoldsResponse) > 0 {
 		t.Error("Expecting no data returned")
@@ -162,7 +161,7 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	orderResponse, err := c.PlaceLimitOrder(context.Background(),
+	orderResponse, err := c.PlaceLimitOrder(t.Context(),
 		"", 0.001, 0.001,
 		order.Buy.Lower(), "", "", testPair.String(), "", false)
 	if orderResponse != "" {
@@ -171,7 +170,7 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	marketOrderResponse, err := c.PlaceMarketOrder(context.Background(),
+	marketOrderResponse, err := c.PlaceMarketOrder(t.Context(),
 		"", 1, 0,
 		order.Buy.Lower(), testPair.String(), "")
 	if marketOrderResponse != "" {
@@ -180,7 +179,7 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	fillsResponse, err := c.GetFills(context.Background(),
+	fillsResponse, err := c.GetFills(t.Context(),
 		"1337", testPair.String())
 	if len(fillsResponse) > 0 {
 		t.Error("Expecting no data returned")
@@ -188,11 +187,11 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	_, err = c.GetFills(context.Background(), "", "")
+	_, err = c.GetFills(t.Context(), "", "")
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	marginTransferResponse, err := c.MarginTransfer(context.Background(),
+	marginTransferResponse, err := c.MarginTransfer(t.Context(),
 		1, "withdraw", "13371337-1337-1337-1337-133713371337", "BTC")
 	if marginTransferResponse.ID != "" {
 		t.Error("Expecting no data returned")
@@ -200,19 +199,19 @@ func TestAuthRequests(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	_, err = c.GetPosition(context.Background())
+	_, err = c.GetPosition(t.Context())
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	_, err = c.ClosePosition(context.Background(), false)
+	_, err = c.ClosePosition(t.Context(), false)
 	if err == nil {
 		t.Error("Expecting error")
 	}
-	_, err = c.GetPayMethods(context.Background())
+	_, err = c.GetPayMethods(t.Context())
 	if err != nil {
 		t.Error("GetPayMethods() error", err)
 	}
-	_, err = c.GetCoinbaseAccounts(context.Background())
+	_, err = c.GetCoinbaseAccounts(t.Context())
 	if err != nil {
 		t.Error("GetCoinbaseAccounts() error", err)
 	}
@@ -230,7 +229,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := c.GetFeeByType(context.Background(), feeBuilder)
+	_, err := c.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +249,7 @@ func TestGetFee(t *testing.T) {
 
 	if sharedtestvalues.AreAPICredentialsSet(c) {
 		// CryptocurrencyTradeFee Basic
-		if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -258,21 +257,21 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
@@ -280,14 +279,14 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -295,7 +294,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
 	feeBuilder.FiatCurrency = currency.EUR
-	if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -303,7 +302,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.USD
-	if _, err := c.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := c.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -411,7 +410,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := c.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := c.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -427,7 +426,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := c.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -435,7 +434,7 @@ func TestGetOrderHistory(t *testing.T) {
 	}
 
 	getOrdersRequest.Pairs = []currency.Pair{}
-	_, err = c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err = c.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -443,7 +442,7 @@ func TestGetOrderHistory(t *testing.T) {
 	}
 
 	getOrdersRequest.Pairs = nil
-	_, err = c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err = c.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -473,7 +472,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	response, err := c.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(c) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -494,7 +493,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err = c.SubmitOrder(context.Background(), orderSubmission)
+	response, err = c.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(c) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -515,7 +514,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:    "meowOrder",
 		AssetType:   asset.Spot,
 	}
-	response, err = c.SubmitOrder(context.Background(), orderSubmission)
+	response, err = c.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(c) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -534,7 +533,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := c.CancelOrder(context.Background(), orderCancellation)
+	err := c.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -554,7 +553,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := c.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := c.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -572,7 +571,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	_, err := c.ModifyOrder(context.Background(),
+	_, err := c.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
@@ -593,7 +592,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := c.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := c.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -617,7 +616,7 @@ func TestWithdrawFiat(t *testing.T) {
 		},
 	}
 
-	_, err := c.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := c.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -640,7 +639,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		},
 	}
 
-	_, err := c.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := c.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -651,7 +650,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 }
 
 func TestGetDepositAddress(t *testing.T) {
-	_, err := c.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := c.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	if err == nil {
 		t.Error("GetDepositAddress() error", err)
 	}
@@ -1003,7 +1002,7 @@ func TestParseTime(t *testing.T) {
 
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := c.GetRecentTrades(context.Background(), testPair, asset.Spot)
+	_, err := c.GetRecentTrades(t.Context(), testPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1011,7 +1010,7 @@ func TestGetRecentTrades(t *testing.T) {
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	_, err := c.GetHistoricTrades(context.Background(),
+	_, err := c.GetHistoricTrades(t.Context(),
 		testPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -1021,7 +1020,7 @@ func TestGetHistoricTrades(t *testing.T) {
 func TestGetTransfers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, c)
-	_, err := c.GetTransfers(context.Background(), "", "", 100, time.Time{}, time.Time{})
+	_, err := c.GetTransfers(t.Context(), "", "", 100, time.Time{}, time.Time{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1034,7 +1033,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := c.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := c.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := c.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -83,7 +83,7 @@ func setupWSTestAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	go c.wsReadData()
-	err = c.wsAuthenticate(context.Background())
+	err = c.wsAuthenticate(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -95,14 +95,14 @@ func setupWSTestAuth(t *testing.T) {
 }
 
 func TestGetInstruments(t *testing.T) {
-	_, err := c.GetInstruments(context.Background())
+	_, err := c.GetInstruments(t.Context())
 	if err != nil {
 		t.Error("GetInstruments() error", err)
 	}
 }
 
 func TestSeedInstruments(t *testing.T) {
-	err := c.SeedInstruments(context.Background())
+	err := c.SeedInstruments(t.Context())
 	if err != nil {
 		// No point checking the next condition
 		t.Fatal(err)
@@ -125,7 +125,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := c.GetFeeByType(context.Background(), feeBuilder)
+	_, err := c.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestGetActiveOrders(t *testing.T) {
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
 	}
-	_, err := c.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := c.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	}
@@ -273,7 +273,7 @@ func TestGetOrderHistoryWrapper(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := c.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := c.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(c) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	}
@@ -299,7 +299,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "123",
 		AssetType: asset.Spot,
 	}
-	response, err := c.SubmitOrder(context.Background(), orderSubmission)
+	response, err := c.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(c) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
@@ -319,7 +319,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := c.CancelOrder(context.Background(), orderCancellation)
+	err := c.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -340,7 +340,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := c.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := c.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(c) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -357,12 +357,12 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	if apiKey != "" || clientID != "" {
-		_, err := c.UpdateAccountInfo(context.Background(), asset.Spot)
+		_, err := c.UpdateAccountInfo(t.Context(), asset.Spot)
 		if err != nil {
 			t.Error("GetAccountInfo() error", err)
 		}
 	} else {
-		_, err := c.UpdateAccountInfo(context.Background(), asset.Spot)
+		_, err := c.UpdateAccountInfo(t.Context(), asset.Spot)
 		if err == nil {
 			t.Error("GetAccountInfo() Expected error")
 		}
@@ -373,7 +373,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
-	_, err := c.ModifyOrder(context.Background(),
+	_, err := c.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
@@ -394,7 +394,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := c.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := c.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected 'Not supported', received %v", err)
@@ -406,7 +406,7 @@ func TestWithdrawFiat(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := c.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := c.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
 	}
@@ -417,7 +417,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, c, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := c.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := c.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -425,7 +425,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 }
 
 func TestGetDepositAddress(t *testing.T) {
-	_, err := c.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := c.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	if err == nil {
 		t.Error("GetDepositAddress() function unsupported cannot be nil")
 	}
@@ -517,7 +517,7 @@ func TestWsAuthCancelOrdersWrapper(t *testing.T) {
 	orderDetails := order.Cancel{
 		Pair: currency.NewPair(currency.LTC, currency.BTC),
 	}
-	_, err := c.CancelAllOrders(context.Background(), &orderDetails)
+	_, err := c.CancelAllOrders(t.Context(), &orderDetails)
 	if err != nil {
 		t.Error(err)
 	}
@@ -645,7 +645,7 @@ func TestWsOrderbook(t *testing.T) {
   "reply": "inst_order_book",
   "status": [ "OK" ]
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -659,7 +659,7 @@ func TestWsOrderbook(t *testing.T) {
   "side": "BUY",
   "trans_id": 169384
 }`)
-	err = c.wsHandleData(context.Background(), pressXToJSON)
+	err = c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -677,7 +677,7 @@ func TestWsTicker(t *testing.T) {
   "volume": "0.07650000",
   "volume24": "56.07650000"
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -709,7 +709,7 @@ func TestWsGetInstruments(t *testing.T) {
       "OK"
    ]
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -756,7 +756,7 @@ func TestWsTrades(t *testing.T) {
       "trans_id": 169502
     }]
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -769,7 +769,7 @@ func TestWsTrades(t *testing.T) {
   "timestamp": 0,
   "trans_id": 169478
 }`)
-	err = c.wsHandleData(context.Background(), pressXToJSON)
+	err = c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -799,7 +799,7 @@ func TestWsLogin(t *testing.T) {
    "unverified_email":"",
    "username":"test"
 }`)
-	ctx := account.DeployCredentialsToContext(context.Background(),
+	ctx := account.DeployCredentialsToContext(t.Context(),
 		&account.Credentials{Key: "b46e658f-d4c4-433c-b032-093423b1aaa4", ClientID: "dummy"})
 	err := c.wsHandleData(ctx, pressXToJSON)
 	if err != nil {
@@ -825,7 +825,7 @@ func TestWsAccountBalance(t *testing.T) {
   "reply": "user_balance",
   "trans_id": 15159032
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -847,7 +847,7 @@ func TestWsOrder(t *testing.T) {
       "side":"SELL",
       "trans_id":127303
    }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -877,7 +877,7 @@ func TestWsOrder(t *testing.T) {
     "timestamp": 1482903034617491,
     "trans_id": 20859252
   }`)
-	err = c.wsHandleData(context.Background(), pressXToJSON)
+	err = c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -901,7 +901,7 @@ func TestWsOrder(t *testing.T) {
     "side": "BUY",
     "trans_id": 3282993
 }`)
-	err = c.wsHandleData(context.Background(), pressXToJSON)
+	err = c.wsHandleData(t.Context(), pressXToJSON)
 	if err == nil {
 		t.Error("Expected not enough balance error")
 	}
@@ -942,7 +942,7 @@ func TestWsOrders(t *testing.T) {
     "trans_id": 15155497
   }
 ]`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -978,7 +978,7 @@ func TestWsOpenOrders(t *testing.T) {
         }
     ]
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -994,7 +994,7 @@ func TestWsCancelOrder(t *testing.T) {
       "OK"
     ]
   }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1023,7 +1023,7 @@ func TestWsCancelOrders(t *testing.T) {
   ],
   "trans_id": 15166063
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1080,7 +1080,7 @@ func TestWsOrderHistory(t *testing.T) {
     }
   ]
 }`)
-	err := c.wsHandleData(context.Background(), pressXToJSON)
+	err := c.wsHandleData(t.Context(), pressXToJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1113,7 +1113,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = c.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = c.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1125,7 +1125,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = c.GetHistoricTrades(context.Background(),
+	_, err = c.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -1135,7 +1135,7 @@ func TestGetHistoricTrades(t *testing.T) {
 func TestCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, c, canManipulateRealOrders)
-	_, err := c.CancelBatchOrders(context.Background(), []order.Cancel{
+	_, err := c.CancelBatchOrders(t.Context(), []order.Cancel{
 		{
 			OrderID:   "1234",
 			AssetType: asset.Spot,
@@ -1154,7 +1154,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := c.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := c.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := c.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/credentials_test.go
+++ b/exchanges/credentials_test.go
@@ -12,27 +12,27 @@ import (
 func TestGetCredentials(t *testing.T) {
 	t.Parallel()
 	var b Base
-	_, err := b.GetCredentials(context.Background())
+	_, err := b.GetCredentials(t.Context())
 	if !errors.Is(err, ErrCredentialsAreEmpty) {
 		t.Fatalf("received: %v but expected: %v", err, ErrCredentialsAreEmpty)
 	}
 
 	b.API.CredentialsValidator.RequiresKey = true
-	ctx := account.DeployCredentialsToContext(context.Background(), &account.Credentials{Secret: "wow"})
+	ctx := account.DeployCredentialsToContext(t.Context(), &account.Credentials{Secret: "wow"})
 	_, err = b.GetCredentials(ctx)
 	if !errors.Is(err, errRequiresAPIKey) {
 		t.Fatalf("received: %v but expected: %v", err, errRequiresAPIKey)
 	}
 
 	b.API.CredentialsValidator.RequiresSecret = true
-	ctx = account.DeployCredentialsToContext(context.Background(), &account.Credentials{Key: "wow"})
+	ctx = account.DeployCredentialsToContext(t.Context(), &account.Credentials{Key: "wow"})
 	_, err = b.GetCredentials(ctx)
 	if !errors.Is(err, errRequiresAPISecret) {
 		t.Fatalf("received: %v but expected: %v", err, errRequiresAPISecret)
 	}
 
 	b.API.CredentialsValidator.RequiresBase64DecodeSecret = true
-	ctx = account.DeployCredentialsToContext(context.Background(), &account.Credentials{
+	ctx = account.DeployCredentialsToContext(t.Context(), &account.Credentials{
 		Key:    "meow",
 		Secret: "invalidb64",
 	})
@@ -41,7 +41,7 @@ func TestGetCredentials(t *testing.T) {
 	}
 
 	const expectedBase64DecodedOutput = "hello world"
-	ctx = account.DeployCredentialsToContext(context.Background(), &account.Credentials{
+	ctx = account.DeployCredentialsToContext(t.Context(), &account.Credentials{
 		Key:    "meow",
 		Secret: "aGVsbG8gd29ybGQ=",
 	})
@@ -53,7 +53,7 @@ func TestGetCredentials(t *testing.T) {
 		t.Fatalf("received: %v but expected: %v", creds.Secret, expectedBase64DecodedOutput)
 	}
 
-	ctx = context.WithValue(context.Background(), account.ContextCredentialsFlag, "pewpew")
+	ctx = context.WithValue(t.Context(), account.ContextCredentialsFlag, "pewpew")
 	_, err = b.GetCredentials(ctx)
 	if !errors.Is(err, errContextCredentialsFailure) {
 		t.Fatalf("received: %v but expected: %v", err, errContextCredentialsFailure)
@@ -69,7 +69,7 @@ func TestGetCredentials(t *testing.T) {
 		OneTimePassword: "superOneTimePasssssss",
 	}
 
-	ctx = account.DeployCredentialsToContext(context.Background(), fullCred)
+	ctx = account.DeployCredentialsToContext(t.Context(), fullCred)
 	creds, err = b.GetCredentials(ctx)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: %v but expected: %v", err, nil)
@@ -92,7 +92,7 @@ func TestGetCredentials(t *testing.T) {
 		OneTimePassword: "superOneTimePasssssss",
 	}
 
-	ctx = account.DeployCredentialsToContext(context.Background(), lonelyCred)
+	ctx = account.DeployCredentialsToContext(t.Context(), lonelyCred)
 	b.API.CredentialsValidator.RequiresClientID = true
 	_, err = b.GetCredentials(ctx)
 	if !errors.Is(err, errRequiresAPIClientID) {
@@ -103,7 +103,7 @@ func TestGetCredentials(t *testing.T) {
 	b.API.SetSecret("sir")
 	b.API.SetClientID("1337")
 
-	ctx = context.WithValue(context.Background(), account.ContextSubAccountFlag, "superaccount")
+	ctx = context.WithValue(t.Context(), account.ContextSubAccountFlag, "superaccount")
 	overridedSA, err := b.GetCredentials(ctx)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: %v but expected: %v", err, nil)
@@ -116,7 +116,7 @@ func TestGetCredentials(t *testing.T) {
 		t.Fatal("unexpected values")
 	}
 
-	notOverrided, err := b.GetCredentials(context.Background())
+	notOverrided, err := b.GetCredentials(t.Context())
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: %v but expected: %v", err, nil)
 	}
@@ -132,10 +132,10 @@ func TestGetCredentials(t *testing.T) {
 func TestAreCredentialsValid(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if b.AreCredentialsValid(context.Background()) {
+	if b.AreCredentialsValid(t.Context()) {
 		t.Fatal("should not be valid")
 	}
-	ctx := account.DeployCredentialsToContext(context.Background(), &account.Credentials{Key: "hello"})
+	ctx := account.DeployCredentialsToContext(t.Context(), &account.Credentials{Key: "hello"})
 	if !b.AreCredentialsValid(ctx) {
 		t.Fatal("should be valid")
 	}

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -1664,7 +1664,7 @@ func TestGetSubscriptions(t *testing.T) {
 
 func TestAuthenticateWebsocket(t *testing.T) {
 	b := Base{}
-	if err := b.AuthenticateWebsocket(context.Background()); err == nil {
+	if err := b.AuthenticateWebsocket(t.Context()); err == nil {
 		t.Fatal("error cannot be nil")
 	}
 }
@@ -1983,7 +1983,7 @@ func TestGetGetURLTypeFromString(t *testing.T) {
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetAvailableTransferChains(context.Background(), currency.BTC); !errors.Is(err, common.ErrFunctionNotSupported) {
+	if _, err := b.GetAvailableTransferChains(t.Context(), currency.BTC); !errors.Is(err, common.ErrFunctionNotSupported) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrFunctionNotSupported)
 	}
 }
@@ -1991,7 +1991,7 @@ func TestGetAvailableTransferChains(t *testing.T) {
 func TestCalculatePNL(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.CalculatePNL(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.CalculatePNL(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -1999,7 +1999,7 @@ func TestCalculatePNL(t *testing.T) {
 func TestScaleCollateral(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.ScaleCollateral(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.ScaleCollateral(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2007,7 +2007,7 @@ func TestScaleCollateral(t *testing.T) {
 func TestCalculateTotalCollateral(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.CalculateTotalCollateral(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.CalculateTotalCollateral(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2015,7 +2015,7 @@ func TestCalculateTotalCollateral(t *testing.T) {
 func TestUpdateCurrencyStates(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if err := b.UpdateCurrencyStates(context.Background(), asset.Spot); !errors.Is(err, common.ErrNotYetImplemented) {
+	if err := b.UpdateCurrencyStates(t.Context(), asset.Spot); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2059,7 +2059,7 @@ func TestSetFillsFeedStatus(t *testing.T) {
 func TestGetMarginRateHistory(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetMarginRatesHistory(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.GetMarginRatesHistory(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2067,7 +2067,7 @@ func TestGetMarginRateHistory(t *testing.T) {
 func TestGetPositionSummary(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetFuturesPositionSummary(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.GetFuturesPositionSummary(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2075,7 +2075,7 @@ func TestGetPositionSummary(t *testing.T) {
 func TestGetFuturesPositions(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetFuturesPositionOrders(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.GetFuturesPositionOrders(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2083,7 +2083,7 @@ func TestGetFuturesPositions(t *testing.T) {
 func TestGetHistoricalFundingRates(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetHistoricalFundingRates(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.GetHistoricalFundingRates(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2091,7 +2091,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 func TestGetFundingRates(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetHistoricalFundingRates(context.Background(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
+	if _, err := b.GetHistoricalFundingRates(t.Context(), nil); !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrNotYetImplemented)
 	}
 }
@@ -2507,7 +2507,7 @@ func TestGetKlineExtendedRequest(t *testing.T) {
 func TestSetCollateralMode(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	err := b.SetCollateralMode(context.Background(), asset.Spot, collateral.SingleMode)
+	err := b.SetCollateralMode(t.Context(), asset.Spot, collateral.SingleMode)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2516,7 +2516,7 @@ func TestSetCollateralMode(t *testing.T) {
 func TestGetCollateralMode(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	_, err := b.GetCollateralMode(context.Background(), asset.Spot)
+	_, err := b.GetCollateralMode(t.Context(), asset.Spot)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2525,7 +2525,7 @@ func TestGetCollateralMode(t *testing.T) {
 func TestSetMarginType(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	err := b.SetMarginType(context.Background(), asset.Spot, currency.NewBTCUSD(), margin.Multi)
+	err := b.SetMarginType(t.Context(), asset.Spot, currency.NewBTCUSD(), margin.Multi)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2534,7 +2534,7 @@ func TestSetMarginType(t *testing.T) {
 func TestChangePositionMargin(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	_, err := b.ChangePositionMargin(context.Background(), nil)
+	_, err := b.ChangePositionMargin(t.Context(), nil)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2543,7 +2543,7 @@ func TestChangePositionMargin(t *testing.T) {
 func TestSetLeverage(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	err := b.SetLeverage(context.Background(), asset.Spot, currency.NewBTCUSD(), margin.Multi, 1, order.UnknownSide)
+	err := b.SetLeverage(t.Context(), asset.Spot, currency.NewBTCUSD(), margin.Multi, 1, order.UnknownSide)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2552,7 +2552,7 @@ func TestSetLeverage(t *testing.T) {
 func TestGetLeverage(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	_, err := b.GetLeverage(context.Background(), asset.Spot, currency.NewBTCUSD(), margin.Multi, order.UnknownSide)
+	_, err := b.GetLeverage(t.Context(), asset.Spot, currency.NewBTCUSD(), margin.Multi, order.UnknownSide)
 	if !errors.Is(err, common.ErrNotYetImplemented) {
 		t.Error(err)
 	}
@@ -2777,7 +2777,7 @@ func TestIsPairEnabled(t *testing.T) {
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
 	var b Base
-	if _, err := b.GetOpenInterest(context.Background()); !errors.Is(err, common.ErrFunctionNotSupported) {
+	if _, err := b.GetOpenInterest(t.Context()); !errors.Is(err, common.ErrFunctionNotSupported) {
 		t.Errorf("received: %v, expected: %v", err, common.ErrFunctionNotSupported)
 	}
 }
@@ -2788,7 +2788,7 @@ func TestGetCachedOpenInterest(t *testing.T) {
 	b.Features.Supports.FuturesCapabilities.OpenInterest = OpenInterestSupport{
 		Supported: true,
 	}
-	_, err := b.GetCachedOpenInterest(context.Background())
+	_, err := b.GetCachedOpenInterest(t.Context())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 	b.Features.Supports.FuturesCapabilities.OpenInterest.SupportedViaTicker = true
 	b.Name = "test"
@@ -2800,10 +2800,10 @@ func TestGetCachedOpenInterest(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = b.GetCachedOpenInterest(context.Background())
+	_, err = b.GetCachedOpenInterest(t.Context())
 	assert.NoError(t, err)
 
-	_, err = b.GetCachedOpenInterest(context.Background(), key.PairAsset{
+	_, err = b.GetCachedOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.BONK.Item,
 		Asset: asset.Futures,
@@ -2874,10 +2874,10 @@ func TestGetDefaultConfig(t *testing.T) {
 
 	exch := &FakeBase{}
 
-	_, err := GetDefaultConfig(context.Background(), nil)
+	_, err := GetDefaultConfig(t.Context(), nil)
 	assert.ErrorIs(t, err, errExchangeIsNil)
 
-	c, err := GetDefaultConfig(context.Background(), exch)
+	c, err := GetDefaultConfig(t.Context(), exch)
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", c.Name)
@@ -2885,7 +2885,7 @@ func TestGetDefaultConfig(t *testing.T) {
 
 	// Test below demonstrates that the requester is not overwritten so that
 	// SetDefaults is not called twice.
-	c, err = GetDefaultConfig(context.Background(), exch)
+	c, err = GetDefaultConfig(t.Context(), exch)
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", c.Name)
@@ -2941,7 +2941,7 @@ func TestGetCachedAccountInfo(t *testing.T) {
 		Key:    "test",
 		Secret: "test",
 	}
-	ctx := account.DeployCredentialsToContext(context.Background(), &account.Credentials{
+	ctx := account.DeployCredentialsToContext(t.Context(), &account.Credentials{
 		Key:    "test",
 		Secret: "test",
 	})
@@ -3116,7 +3116,7 @@ func (f *FakeBase) GetFuturesContractDetails(context.Context, asset.Item) ([]fut
 func TestGetCurrencyTradeURL(t *testing.T) {
 	t.Parallel()
 	b := Base{}
-	_, err := b.GetCurrencyTradeURL(context.Background(), asset.Spot, currency.NewPair(currency.BTC, currency.USDT))
+	_, err := b.GetCurrencyTradeURL(t.Context(), asset.Spot, currency.NewPair(currency.BTC, currency.USDT))
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
@@ -3146,6 +3146,6 @@ func TestSetConfigPairFormatFromExchange(t *testing.T) {
 }
 
 func TestWebsocketSubmitOrder(t *testing.T) {
-	_, err := (&Base{}).WebsocketSubmitOrder(context.Background(), nil)
+	_, err := (&Base{}).WebsocketSubmitOrder(t.Context(), nil)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -1,7 +1,6 @@
 package exmo
 
 import (
-	"context"
 	"log"
 	"os"
 	"testing"
@@ -54,7 +53,7 @@ func TestMain(m *testing.M) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetTrades(context.Background(), "BTC_USD")
+	_, err := e.GetTrades(t.Context(), "BTC_USD")
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -62,7 +61,7 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetOrderbook(context.Background(), "BTC_USD")
+	_, err := e.GetOrderbook(t.Context(), "BTC_USD")
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -70,7 +69,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetTicker(context.Background())
+	_, err := e.GetTicker(t.Context())
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -78,7 +77,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetPairSettings(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetPairSettings(context.Background())
+	_, err := e.GetPairSettings(t.Context())
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -86,7 +85,7 @@ func TestGetPairSettings(t *testing.T) {
 
 func TestGetCurrency(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetCurrency(context.Background())
+	_, err := e.GetCurrency(t.Context())
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -96,7 +95,7 @@ func TestGetUserInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 
-	_, err := e.GetUserInfo(context.Background())
+	_, err := e.GetUserInfo(t.Context())
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -106,7 +105,7 @@ func TestGetRequiredAmount(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 
-	_, err := e.GetRequiredAmount(context.Background(), "BTC_USD", 100)
+	_, err := e.GetRequiredAmount(t.Context(), "BTC_USD", 100)
 	if err != nil {
 		t.Errorf("Err: %s", err)
 	}
@@ -126,7 +125,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := e.GetFeeByType(context.Background(), feeBuilder)
+	_, err := e.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +259,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := e.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := e.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(e) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
@@ -279,7 +278,7 @@ func TestGetOrderHistory(t *testing.T) {
 	currPair.Delimiter = "_"
 	getOrdersRequest.Pairs = []currency.Pair{currPair}
 
-	_, err := e.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := e.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(e) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
@@ -308,7 +307,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := e.SubmitOrder(context.Background(), orderSubmission)
+	response, err := e.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(e) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
@@ -328,7 +327,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := e.CancelOrder(context.Background(), orderCancellation)
+	err := e.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -349,7 +348,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := e.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := e.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -367,7 +366,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
-	_, err := e.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := e.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
 	}
@@ -387,7 +386,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := e.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := e.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(e) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -402,7 +401,7 @@ func TestWithdrawFiat(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := e.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := e.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
 	}
@@ -413,7 +412,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, e, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := e.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := e.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -422,12 +421,12 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	if sharedtestvalues.AreAPICredentialsSet(e) {
-		_, err := e.GetDepositAddress(context.Background(), currency.USDT, "", "ERC20")
+		_, err := e.GetDepositAddress(t.Context(), currency.USDT, "", "ERC20")
 		if err != nil {
 			t.Error("GetDepositAddress() error", err)
 		}
 	} else {
-		_, err := e.GetDepositAddress(context.Background(), currency.LTC, "", "")
+		_, err := e.GetDepositAddress(t.Context(), currency.LTC, "", "")
 		if err == nil {
 			t.Error("GetDepositAddress() error cannot be nil")
 		}
@@ -437,7 +436,7 @@ func TestGetDepositAddress(t *testing.T) {
 func TestGetCryptoDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err := e.GetCryptoDepositAddress(context.Background())
+	_, err := e.GetCryptoDepositAddress(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -449,7 +448,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = e.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = e.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -461,7 +460,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = e.GetHistoricTrades(context.Background(),
+	_, err = e.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -474,7 +473,7 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = e.UpdateTicker(context.Background(), cp, asset.Spot)
+	_, err = e.UpdateTicker(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +482,7 @@ func TestUpdateTicker(t *testing.T) {
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 
-	err := e.UpdateTickers(context.Background(), asset.Spot)
+	err := e.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -503,7 +502,7 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestGetCryptoPaymentProvidersList(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetCryptoPaymentProvidersList(context.Background())
+	_, err := e.GetCryptoPaymentProvidersList(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +510,7 @@ func TestGetCryptoPaymentProvidersList(t *testing.T) {
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetAvailableTransferChains(context.Background(), currency.USDT)
+	_, err := e.GetAvailableTransferChains(t.Context(), currency.USDT)
 	if err != nil {
 		t.Error(err)
 	}
@@ -520,7 +519,7 @@ func TestGetAvailableTransferChains(t *testing.T) {
 func TestGetAccountFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err := e.GetAccountFundingHistory(context.Background())
+	_, err := e.GetAccountFundingHistory(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -530,7 +529,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 
-	_, err := e.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := e.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -543,7 +542,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := e.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := e.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := e.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/futures/futures_test.go
+++ b/exchanges/futures/futures_test.go
@@ -848,16 +848,16 @@ func TestSetupPositionTracker(t *testing.T) {
 func TestCalculatePNL(t *testing.T) {
 	t.Parallel()
 	p := &PNLCalculator{}
-	_, err := p.CalculatePNL(context.Background(), nil)
+	_, err := p.CalculatePNL(t.Context(), nil)
 	if !errors.Is(err, ErrNilPNLCalculator) {
 		t.Errorf("received '%v' expected '%v", err, ErrNilPNLCalculator)
 	}
-	_, err = p.CalculatePNL(context.Background(), &PNLCalculatorRequest{})
+	_, err = p.CalculatePNL(t.Context(), &PNLCalculatorRequest{})
 	if !errors.Is(err, errCannotCalculateUnrealisedPNL) {
 		t.Errorf("received '%v' expected '%v", err, errCannotCalculateUnrealisedPNL)
 	}
 
-	_, err = p.CalculatePNL(context.Background(),
+	_, err = p.CalculatePNL(t.Context(),
 		&PNLCalculatorRequest{
 			OrderDirection:   order.Short,
 			CurrentDirection: order.Long,

--- a/exchanges/gateio/gateio_websocket_delivery_futures.go
+++ b/exchanges/gateio/gateio_websocket_delivery_futures.go
@@ -23,8 +23,8 @@ const (
 	deliveryRealBTCTradingURL  = "wss://fx-ws.gateio.ws/v4/ws/delivery/btc"
 
 	// delivery testnet urls
-	deliveryTestNetBTCTradingURL  = "wss://fx-ws-testnet.gateio.ws/v4/ws/delivery/btc"
-	deliveryTestNetUSDTTradingURL = "wss://fx-ws-testnet.gateio.ws/v4/ws/delivery/usdt"
+	deliveryTestNetBTCTradingURL  = "wss://fx-ws-testnet.gateio.ws/v4/ws/delivery/btc"  //nolint:unused // Can be used for testing
+	deliveryTestNetUSDTTradingURL = "wss://fx-ws-testnet.gateio.ws/v4/ws/delivery/usdt" //nolint:unused // Can be used for testing
 )
 
 var defaultDeliveryFuturesSubscriptions = []string{

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"context"
 	"errors"
 	"net/url"
 	"strings"
@@ -39,7 +38,7 @@ var g = &Gemini{}
 
 func TestGetSymbols(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetSymbols(context.Background())
+	_, err := g.GetSymbols(t.Context())
 	if err != nil {
 		t.Error("GetSymbols() error", err)
 	}
@@ -47,7 +46,7 @@ func TestGetSymbols(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	pairs, err := g.FetchTradablePairs(context.Background(), asset.Spot)
+	pairs, err := g.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,11 +63,11 @@ func TestFetchTradablePairs(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetTicker(context.Background(), "BTCUSD")
+	_, err := g.GetTicker(t.Context(), "BTCUSD")
 	if err != nil {
 		t.Error("GetTicker() error", err)
 	}
-	_, err = g.GetTicker(context.Background(), "bla")
+	_, err = g.GetTicker(t.Context(), "bla")
 	if err == nil {
 		t.Error("GetTicker() Expected error")
 	}
@@ -76,7 +75,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetOrderbook(context.Background(), testCurrency, url.Values{})
+	_, err := g.GetOrderbook(t.Context(), testCurrency, url.Values{})
 	if err != nil {
 		t.Error("GetOrderbook() error", err)
 	}
@@ -84,7 +83,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetTrades(context.Background(), testCurrency, 0, 0, false)
+	_, err := g.GetTrades(t.Context(), testCurrency, 0, 0, false)
 	if err != nil {
 		t.Error("GetTrades() error", err)
 	}
@@ -92,7 +91,7 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetNotionalVolume(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetNotionalVolume(context.Background())
+	_, err := g.GetNotionalVolume(t.Context())
 	if err != nil && mockTests {
 		t.Error("GetNotionalVolume() error", err)
 	} else if err == nil && !mockTests {
@@ -102,7 +101,7 @@ func TestGetNotionalVolume(t *testing.T) {
 
 func TestGetAuction(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetAuction(context.Background(), testCurrency)
+	_, err := g.GetAuction(t.Context(), testCurrency)
 	if err != nil {
 		t.Error("GetAuction() error", err)
 	}
@@ -110,7 +109,7 @@ func TestGetAuction(t *testing.T) {
 
 func TestGetAuctionHistory(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetAuctionHistory(context.Background(), testCurrency, url.Values{})
+	_, err := g.GetAuctionHistory(t.Context(), testCurrency, url.Values{})
 	if err != nil {
 		t.Error("GetAuctionHistory() error", err)
 	}
@@ -118,7 +117,7 @@ func TestGetAuctionHistory(t *testing.T) {
 
 func TestNewOrder(t *testing.T) {
 	t.Parallel()
-	_, err := g.NewOrder(context.Background(),
+	_, err := g.NewOrder(t.Context(),
 		testCurrency,
 		1,
 		9000000,
@@ -133,7 +132,7 @@ func TestNewOrder(t *testing.T) {
 
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
-	_, err := g.CancelExistingOrder(context.Background(), 265555413)
+	_, err := g.CancelExistingOrder(t.Context(), 265555413)
 	if err != nil && mockTests {
 		t.Error("CancelExistingOrder() error", err)
 	} else if err == nil && !mockTests {
@@ -143,7 +142,7 @@ func TestCancelExistingOrder(t *testing.T) {
 
 func TestCancelExistingOrders(t *testing.T) {
 	t.Parallel()
-	_, err := g.CancelExistingOrders(context.Background(), false)
+	_, err := g.CancelExistingOrders(t.Context(), false)
 	if err != nil && mockTests {
 		t.Error("CancelExistingOrders() error", err)
 	} else if err == nil && !mockTests {
@@ -153,7 +152,7 @@ func TestCancelExistingOrders(t *testing.T) {
 
 func TestGetOrderStatus(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetOrderStatus(context.Background(), 265563260)
+	_, err := g.GetOrderStatus(t.Context(), 265563260)
 	if err != nil && mockTests {
 		t.Error("GetOrderStatus() error", err)
 	} else if err == nil && !mockTests {
@@ -163,7 +162,7 @@ func TestGetOrderStatus(t *testing.T) {
 
 func TestGetOrders(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetOrders(context.Background())
+	_, err := g.GetOrders(t.Context())
 	if err != nil && mockTests {
 		t.Error("GetOrders() error", err)
 	} else if err == nil && !mockTests {
@@ -173,7 +172,7 @@ func TestGetOrders(t *testing.T) {
 
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetTradeHistory(context.Background(), testCurrency, 0)
+	_, err := g.GetTradeHistory(t.Context(), testCurrency, 0)
 	if err != nil && mockTests {
 		t.Error("GetTradeHistory() error", err)
 	} else if err == nil && !mockTests {
@@ -183,7 +182,7 @@ func TestGetTradeHistory(t *testing.T) {
 
 func TestGetTradeVolume(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetTradeVolume(context.Background())
+	_, err := g.GetTradeVolume(t.Context())
 	if err != nil && mockTests {
 		t.Error("GetTradeVolume() error", err)
 	} else if err == nil && !mockTests {
@@ -193,7 +192,7 @@ func TestGetTradeVolume(t *testing.T) {
 
 func TestGetBalances(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetBalances(context.Background())
+	_, err := g.GetBalances(t.Context())
 	if err != nil && mockTests {
 		t.Error("GetBalances() error", err)
 	} else if err == nil && !mockTests {
@@ -203,7 +202,7 @@ func TestGetBalances(t *testing.T) {
 
 func TestGetCryptoDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetCryptoDepositAddress(context.Background(), "LOL123", "btc")
+	_, err := g.GetCryptoDepositAddress(t.Context(), "LOL123", "btc")
 	if err == nil {
 		t.Error("GetCryptoDepositAddress() Expected error")
 	}
@@ -211,7 +210,7 @@ func TestGetCryptoDepositAddress(t *testing.T) {
 
 func TestWithdrawCrypto(t *testing.T) {
 	t.Parallel()
-	_, err := g.WithdrawCrypto(context.Background(), "LOL123", "btc", 1)
+	_, err := g.WithdrawCrypto(t.Context(), "LOL123", "btc", 1)
 	if err == nil {
 		t.Error("WithdrawCrypto() Expected error")
 	}
@@ -219,7 +218,7 @@ func TestWithdrawCrypto(t *testing.T) {
 
 func TestPostHeartbeat(t *testing.T) {
 	t.Parallel()
-	_, err := g.PostHeartbeat(context.Background())
+	_, err := g.PostHeartbeat(t.Context())
 	if err != nil && mockTests {
 		t.Error("PostHeartbeat() error", err)
 	} else if err == nil && !mockTests {
@@ -244,7 +243,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 	feeBuilder := setFeeBuilder()
-	_, err := g.GetFeeByType(context.Background(), feeBuilder)
+	_, err := g.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +267,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
 	if sharedtestvalues.AreAPICredentialsSet(g) || mockTests {
 		// CryptocurrencyTradeFee Basic
-		if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -276,28 +275,28 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
 	// CryptocurrencyWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -305,21 +304,21 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.Pair.Base = currency.NewCode("hello")
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// InternationalBankDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
-	if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -327,7 +326,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.USD
-	if _, err := g.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := g.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -358,7 +357,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := g.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := g.GetActiveOrders(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(g) && err != nil && !mockTests:
 		t.Errorf("Could not get open orders: %s", err)
@@ -378,7 +377,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := g.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := g.GetOrderHistory(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(g) && err != nil:
 		t.Errorf("Could not get order history: %s", err)
@@ -412,7 +411,7 @@ func TestSubmitOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	response, err := g.SubmitOrder(context.Background(), orderSubmission)
+	response, err := g.SubmitOrder(t.Context(), orderSubmission)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(g) && (err != nil || response.Status != order.New):
 		t.Errorf("Order failed to be placed: %v", err)
@@ -434,7 +433,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		Pair:      currency.NewPair(currency.BTC, currency.USDT),
 	}
 
-	err := g.CancelOrder(context.Background(), orderCancellation)
+	err := g.CancelOrder(t.Context(), orderCancellation)
 	switch {
 	case !sharedtestvalues.AreAPICredentialsSet(g) && err == nil && !mockTests:
 		t.Error("Expecting an error when no keys are set")
@@ -459,7 +458,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := g.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := g.CancelAllOrders(t.Context(), orderCancellation)
 	switch {
 	case !sharedtestvalues.AreAPICredentialsSet(g) && err == nil && !mockTests:
 		t.Error("Expecting an error when no keys are set")
@@ -478,7 +477,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 
-	_, err := g.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := g.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
 	}
@@ -491,7 +490,7 @@ func TestWithdraw(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, g, canManipulateRealOrders)
 	}
 
-	_, err := g.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := g.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdraw.Request{
 			Exchange:    g.Name,
 			Amount:      -1,
@@ -519,7 +518,7 @@ func TestWithdrawFiat(t *testing.T) {
 	}
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := g.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := g.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
 			common.ErrFunctionNotSupported,
@@ -534,7 +533,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	}
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := g.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := g.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
@@ -545,7 +544,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := g.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	if err == nil {
 		t.Error("GetDepositAddress error cannot be nil")
 	}
@@ -565,7 +564,7 @@ func TestWsAuth(t *testing.T) {
 	}
 	var dialer gws.Dialer
 	go g.wsReadData()
-	err = g.WsAuth(context.Background(), &dialer)
+	err = g.WsAuth(t.Context(), &dialer)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1185,7 +1184,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = g.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = g.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1203,7 +1202,7 @@ func TestGetHistoricTrades(t *testing.T) {
 		tStart = time.Date(time.Now().Year(), time.Now().Month(), 1, 0, 0, 0, 0, time.UTC)
 		tEnd = time.Date(time.Now().Year(), time.Now().Month(), 1, 0, 15, 0, 0, time.UTC)
 	}
-	_, err = g.GetHistoricTrades(context.Background(),
+	_, err = g.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, tStart, tEnd)
 	if err != nil {
 		t.Error(err)
@@ -1214,7 +1213,7 @@ func TestTransfers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
 
-	_, err := g.Transfers(context.Background(), currency.BTC, time.Time{}, 100, "", true)
+	_, err := g.Transfers(t.Context(), currency.BTC, time.Time{}, 100, "", true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1224,7 +1223,7 @@ func TestGetAccountFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
 
-	_, err := g.GetAccountFundingHistory(context.Background())
+	_, err := g.GetAccountFundingHistory(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1234,7 +1233,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
 
-	_, err := g.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := g.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1244,7 +1243,7 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, g)
 
-	_, err := g.GetOrderInfo(context.Background(), "1234", currency.EMPTYPAIR, asset.Empty)
+	_, err := g.GetOrderInfo(t.Context(), "1234", currency.EMPTYPAIR, asset.Empty)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1252,11 +1251,11 @@ func TestGetOrderInfo(t *testing.T) {
 
 func TestGetSymbolDetails(t *testing.T) {
 	t.Parallel()
-	_, err := g.GetSymbolDetails(context.Background(), "all")
+	_, err := g.GetSymbolDetails(t.Context(), "all")
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = g.GetSymbolDetails(context.Background(), "btcusd")
+	_, err = g.GetSymbolDetails(t.Context(), "btcusd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1264,11 +1263,11 @@ func TestGetSymbolDetails(t *testing.T) {
 
 func TestSetExchangeOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := g.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
+	err := g.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = g.UpdateOrderExecutionLimits(context.Background(), asset.Futures)
+	err = g.UpdateOrderExecutionLimits(t.Context(), asset.Futures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Fatal(err)
 	}
@@ -1296,7 +1295,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := g.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := g.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := g.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -69,21 +69,21 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetOrderbook(t *testing.T) {
-	_, err := h.GetOrderbook(context.Background(), "BTCUSD", 50)
+	_, err := h.GetOrderbook(t.Context(), "BTCUSD", 50)
 	if err != nil {
 		t.Error("Test failed - HitBTC GetOrderbook() error", err)
 	}
 }
 
 func TestGetTrades(t *testing.T) {
-	_, err := h.GetTrades(context.Background(), "BTCUSD", "", "", 0, 0, 0, 0)
+	_, err := h.GetTrades(t.Context(), "BTCUSD", "", "", 0, 0, 0, 0)
 	if err != nil {
 		t.Error("Test failed - HitBTC GetTradeHistory() error", err)
 	}
 }
 
 func TestGetChartCandles(t *testing.T) {
-	_, err := h.GetCandles(context.Background(),
+	_, err := h.GetCandles(t.Context(),
 		"BTCUSD", "", "D1", time.Now().Add(-24*time.Hour), time.Now())
 	if err != nil {
 		t.Error("Test failed - HitBTC GetChartData() error", err)
@@ -99,7 +99,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	}
 	startTime := time.Now().Add(-time.Hour * 6)
 	end := time.Now()
-	_, err = h.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.OneMin, startTime, end)
+	_, err = h.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.OneMin, startTime, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,14 +113,14 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	}
 	startTime := time.Unix(1546300800, 0)
 	end := time.Unix(1577836799, 0)
-	_, err = h.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.OneHour, startTime, end)
+	_, err = h.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.OneHour, startTime, end)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestGetCurrencies(t *testing.T) {
-	_, err := h.GetCurrencies(context.Background())
+	_, err := h.GetCurrencies(t.Context())
 	if err != nil {
 		t.Error("Test failed - HitBTC GetCurrencies() error", err)
 	}
@@ -140,7 +140,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := h.GetFeeByType(context.Background(), feeBuilder)
+	_, err := h.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = h.UpdateTicker(context.Background(), pairs[0], asset.Spot)
+	_, err = h.UpdateTicker(t.Context(), pairs[0], asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -172,7 +172,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	require.NoError(t, h.UpdateTickers(context.Background(), asset.Spot))
+	require.NoError(t, h.UpdateTickers(t.Context(), asset.Spot))
 
 	enabled, err := h.GetEnabledPairs(asset.Spot)
 	require.NoError(t, err)
@@ -184,14 +184,14 @@ func TestUpdateTickers(t *testing.T) {
 }
 
 func TestGetAllTickers(t *testing.T) {
-	_, err := h.GetTickers(context.Background())
+	_, err := h.GetTickers(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestGetSingularTicker(t *testing.T) {
-	_, err := h.GetTicker(context.Background(), "BTCUSD")
+	_, err := h.GetTicker(t.Context(), "BTCUSD")
 	if err != nil {
 		t.Error(err)
 	}
@@ -201,7 +201,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		// CryptocurrencyTradeFee Basic
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -209,32 +209,32 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 		// CryptocurrencyWithdrawalFee Basic
 		feeBuilder = setFeeBuilder()
 		feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 		// CryptocurrencyWithdrawalFee Invalid currency
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Pair.Base = currency.NewCode("hello")
 		feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-		if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
@@ -244,14 +244,14 @@ func TestGetFee(t *testing.T) {
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
 	feeBuilder.Pair.Base = currency.BTC
 	feeBuilder.Pair.Quote = currency.LTC
-	if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// InternationalBankDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
-	if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -259,7 +259,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.USD
-	if _, err := h.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := h.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -281,7 +281,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := h.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := h.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(h) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
@@ -298,7 +298,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := h.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := h.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(h) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
@@ -325,7 +325,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := h.SubmitOrder(context.Background(), orderSubmission)
+	response, err := h.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(h) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
@@ -345,7 +345,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := h.CancelOrder(context.Background(), orderCancellation)
+	err := h.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -366,7 +366,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := h.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := h.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -384,7 +384,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
-	_, err := h.ModifyOrder(context.Background(),
+	_, err := h.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
@@ -405,7 +405,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := h.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := h.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(h) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -420,7 +420,7 @@ func TestWithdrawFiat(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := h.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := h.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
 	}
@@ -431,7 +431,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := h.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := h.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
@@ -441,12 +441,12 @@ func TestWithdrawInternationalBank(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(h) {
-		_, err := h.GetDepositAddress(context.Background(), currency.XRP, "", "")
+		_, err := h.GetDepositAddress(t.Context(), currency.XRP, "", "")
 		if err != nil {
 			t.Error("GetDepositAddress() error", err)
 		}
 	} else {
-		_, err := h.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := h.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		if err == nil {
 			t.Error("GetDepositAddress() error cannot be nil")
 		}
@@ -468,7 +468,7 @@ func setupWsAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	go h.wsReadData()
-	err = h.wsLogin(context.Background())
+	err = h.wsLogin(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1014,7 +1014,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = h.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = h.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1026,13 +1026,13 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = h.GetHistoricTrades(context.Background(),
+	_, err = h.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
 	}
 	// longer term
-	_, err = h.GetHistoricTrades(context.Background(),
+	_, err = h.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot,
 		time.Now().Add(-time.Minute*60*200),
 		time.Now().Add(-time.Minute*60*199))
@@ -1045,7 +1045,7 @@ func TestGetActiveOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
 
-	_, err := h.GetActiveOrderByClientOrderID(context.Background(), "1234")
+	_, err := h.GetActiveOrderByClientOrderID(t.Context(), "1234")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1055,7 +1055,7 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
 
-	_, err := h.GetOrderInfo(context.Background(), "1234", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
+	_, err := h.GetOrderInfo(t.Context(), "1234", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1063,7 +1063,7 @@ func TestGetOrderInfo(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	if _, err := h.FetchTradablePairs(context.Background(), asset.Spot); err != nil {
+	if _, err := h.FetchTradablePairs(t.Context(), asset.Spot); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1075,7 +1075,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := h.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := h.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := h.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -1,7 +1,6 @@
 package huobi
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -80,163 +79,163 @@ func TestMain(m *testing.M) {
 
 func TestGetCurrenciesIncludingChains(t *testing.T) {
 	t.Parallel()
-	r, err := h.GetCurrenciesIncludingChains(context.Background(), currency.EMPTYCODE)
+	r, err := h.GetCurrenciesIncludingChains(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 	assert.Greater(t, len(r), 1, "should get more than one currency back")
-	r, err = h.GetCurrenciesIncludingChains(context.Background(), currency.USDT)
+	r, err = h.GetCurrenciesIncludingChains(t.Context(), currency.USDT)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(r), "Should only get one currency back")
 }
 
 func TestFGetContractInfo(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetContractInfo(context.Background(), "", "", currency.EMPTYPAIR)
+	_, err := h.FGetContractInfo(t.Context(), "", "", currency.EMPTYPAIR)
 	require.NoError(t, err)
 }
 
 func TestFIndexPriceInfo(t *testing.T) {
 	t.Parallel()
-	_, err := h.FIndexPriceInfo(context.Background(), currency.BTC)
+	_, err := h.FIndexPriceInfo(t.Context(), currency.BTC)
 	require.NoError(t, err)
 }
 
 func TestFContractPriceLimitations(t *testing.T) {
 	t.Parallel()
-	_, err := h.FContractPriceLimitations(context.Background(),
+	_, err := h.FContractPriceLimitations(t.Context(),
 		"BTC", "this_week", currency.EMPTYPAIR)
 	require.NoError(t, err)
 }
 
 func TestFContractOpenInterest(t *testing.T) {
 	t.Parallel()
-	_, err := h.FContractOpenInterest(context.Background(), "BTC", "this_week", currency.EMPTYPAIR)
+	_, err := h.FContractOpenInterest(t.Context(), "BTC", "this_week", currency.EMPTYPAIR)
 	require.NoError(t, err)
 }
 
 func TestFGetEstimatedDeliveryPrice(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetEstimatedDeliveryPrice(context.Background(), currency.BTC)
+	_, err := h.FGetEstimatedDeliveryPrice(t.Context(), currency.BTC)
 	require.NoError(t, err)
 }
 
 func TestFGetMarketDepth(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetMarketDepth(context.Background(), btccwPair, "step5")
+	_, err := h.FGetMarketDepth(t.Context(), btccwPair, "step5")
 	require.NoError(t, err)
 }
 
 func TestFGetKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetKlineData(context.Background(), btccwPair, "5min", 5, time.Now().Add(-time.Minute*5), time.Now())
+	_, err := h.FGetKlineData(t.Context(), btccwPair, "5min", 5, time.Now().Add(-time.Minute*5), time.Now())
 	require.NoError(t, err)
 }
 
 func TestFGetMarketOverviewData(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetMarketOverviewData(context.Background(), btccwPair)
+	_, err := h.FGetMarketOverviewData(t.Context(), btccwPair)
 	require.NoError(t, err)
 }
 
 func TestFLastTradeData(t *testing.T) {
 	t.Parallel()
-	_, err := h.FLastTradeData(context.Background(), btccwPair)
+	_, err := h.FLastTradeData(t.Context(), btccwPair)
 	require.NoError(t, err)
 }
 
 func TestFRequestPublicBatchTrades(t *testing.T) {
 	t.Parallel()
-	_, err := h.FRequestPublicBatchTrades(context.Background(), btccwPair, 50)
+	_, err := h.FRequestPublicBatchTrades(t.Context(), btccwPair, 50)
 	require.NoError(t, err)
 }
 
 func TestFQueryTieredAdjustmentFactor(t *testing.T) {
 	t.Parallel()
-	_, err := h.FQueryTieredAdjustmentFactor(context.Background(), currency.BTC)
+	_, err := h.FQueryTieredAdjustmentFactor(t.Context(), currency.BTC)
 	require.NoError(t, err)
 }
 
 func TestFQueryHisOpenInterest(t *testing.T) {
 	t.Parallel()
-	_, err := h.FQueryHisOpenInterest(context.Background(), "BTC", "this_week", "60min", "cont", 3)
+	_, err := h.FQueryHisOpenInterest(t.Context(), "BTC", "this_week", "60min", "cont", 3)
 	require.NoError(t, err)
 }
 
 func TestFQuerySystemStatus(t *testing.T) {
 	t.Parallel()
-	_, err := h.FQuerySystemStatus(context.Background(), currency.BTC)
+	_, err := h.FQuerySystemStatus(t.Context(), currency.BTC)
 	require.NoError(t, err)
 }
 
 func TestFQueryTopAccountsRatio(t *testing.T) {
 	t.Parallel()
-	_, err := h.FQueryTopAccountsRatio(context.Background(), "BTC", "5min")
+	_, err := h.FQueryTopAccountsRatio(t.Context(), "BTC", "5min")
 	require.NoError(t, err)
 }
 
 func TestFQueryTopPositionsRatio(t *testing.T) {
 	t.Parallel()
-	_, err := h.FQueryTopPositionsRatio(context.Background(), "BTC", "5min")
+	_, err := h.FQueryTopPositionsRatio(t.Context(), "BTC", "5min")
 	require.NoError(t, err)
 }
 
 func TestFLiquidationOrders(t *testing.T) {
 	t.Parallel()
-	if _, err := h.FLiquidationOrders(context.Background(), currency.BTC, "filled", 0, 0, "", 0); err != nil {
+	if _, err := h.FLiquidationOrders(t.Context(), currency.BTC, "filled", 0, 0, "", 0); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestFIndexKline(t *testing.T) {
 	t.Parallel()
-	_, err := h.FIndexKline(context.Background(), btccwPair, "5min", 5)
+	_, err := h.FIndexKline(t.Context(), btccwPair, "5min", 5)
 	require.NoError(t, err)
 }
 
 func TestFGetBasisData(t *testing.T) {
 	t.Parallel()
-	_, err := h.FGetBasisData(context.Background(), btccwPair, "5min", "open", 3)
+	_, err := h.FGetBasisData(t.Context(), btccwPair, "5min", "open", 3)
 	require.NoError(t, err)
 }
 
 func TestFGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetAccountInfo(context.Background(), currency.EMPTYCODE)
+	_, err := h.FGetAccountInfo(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetPositionsInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetPositionsInfo(context.Background(), currency.EMPTYCODE)
+	_, err := h.FGetPositionsInfo(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetAllSubAccountAssets(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetAllSubAccountAssets(context.Background(), currency.EMPTYCODE)
+	_, err := h.FGetAllSubAccountAssets(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetSingleSubAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetSingleSubAccountInfo(context.Background(), "", "154263566")
+	_, err := h.FGetSingleSubAccountInfo(t.Context(), "", "154263566")
 	require.NoError(t, err)
 }
 
 func TestFGetSingleSubPositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetSingleSubPositions(context.Background(), "", "154263566")
+	_, err := h.FGetSingleSubPositions(t.Context(), "", "154263566")
 	require.NoError(t, err)
 }
 
 func TestFGetFinancialRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetFinancialRecords(context.Background(),
+	_, err := h.FGetFinancialRecords(t.Context(),
 		"BTC", "closeLong", 2, 0, 0)
 	require.NoError(t, err)
 }
@@ -244,7 +243,7 @@ func TestFGetFinancialRecords(t *testing.T) {
 func TestFGetSettlementRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetSettlementRecords(context.Background(),
+	_, err := h.FGetSettlementRecords(t.Context(),
 		currency.BTC, 0, 0, time.Now().Add(-48*time.Hour), time.Now())
 	require.NoError(t, err)
 }
@@ -252,56 +251,56 @@ func TestFGetSettlementRecords(t *testing.T) {
 func TestFContractTradingFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FContractTradingFee(context.Background(), currency.EMPTYCODE)
+	_, err := h.FContractTradingFee(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetTransferLimits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetTransferLimits(context.Background(), currency.EMPTYCODE)
+	_, err := h.FGetTransferLimits(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetPositionLimits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetPositionLimits(context.Background(), currency.EMPTYCODE)
+	_, err := h.FGetPositionLimits(t.Context(), currency.EMPTYCODE)
 	require.NoError(t, err)
 }
 
 func TestFGetAssetsAndPositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetAssetsAndPositions(context.Background(), currency.HT)
+	_, err := h.FGetAssetsAndPositions(t.Context(), currency.HT)
 	require.NoError(t, err)
 }
 
 func TestFTransfer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FTransfer(context.Background(), "154263566", "HT", "sub_to_master", 5)
+	_, err := h.FTransfer(t.Context(), "154263566", "HT", "sub_to_master", 5)
 	require.NoError(t, err)
 }
 
 func TestFGetTransferRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetTransferRecords(context.Background(), "HT", "master_to_sub", 90, 0, 0)
+	_, err := h.FGetTransferRecords(t.Context(), "HT", "master_to_sub", 90, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestFGetAvailableLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetAvailableLeverage(context.Background(), currency.BTC)
+	_, err := h.FGetAvailableLeverage(t.Context(), currency.BTC)
 	require.NoError(t, err)
 }
 
 func TestFOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FOrder(context.Background(), currency.EMPTYPAIR, "BTC", "quarter", "123", "BUY", "open", "limit", 1, 1, 1)
+	_, err := h.FOrder(t.Context(), currency.EMPTYPAIR, "BTC", "quarter", "123", "BUY", "open", "limit", 1, 1, 1)
 	require.NoError(t, err)
 }
 
@@ -332,14 +331,14 @@ func TestFPlaceBatchOrder(t *testing.T) {
 		OrderPriceType: "limit",
 	}
 	req = append(req, order1, order2)
-	_, err := h.FPlaceBatchOrder(context.Background(), req)
+	_, err := h.FPlaceBatchOrder(t.Context(), req)
 	require.NoError(t, err)
 }
 
 func TestFCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FCancelOrder(context.Background(), currency.BTC, "123", "")
+	_, err := h.FCancelOrder(t.Context(), currency.BTC, "123", "")
 	require.NoError(t, err)
 }
 
@@ -347,14 +346,14 @@ func TestFCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
 	updatePairsOnce(t, h)
-	_, err := h.FCancelAllOrders(context.Background(), btcFutureDatedPair, "", "")
+	_, err := h.FCancelAllOrders(t.Context(), btcFutureDatedPair, "", "")
 	require.NoError(t, err)
 }
 
 func TestFFlashCloseOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FFlashCloseOrder(context.Background(),
+	_, err := h.FFlashCloseOrder(t.Context(),
 		currency.EMPTYPAIR, "BTC", "quarter", "BUY", "lightning", "", 1)
 	require.NoError(t, err)
 }
@@ -362,28 +361,28 @@ func TestFFlashCloseOrder(t *testing.T) {
 func TestFGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetOrderInfo(context.Background(), "BTC", "", "123")
+	_, err := h.FGetOrderInfo(t.Context(), "BTC", "", "123")
 	require.NoError(t, err)
 }
 
 func TestFOrderDetails(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FOrderDetails(context.Background(), "BTC", "123", "quotation", time.Now().Add(-1*time.Hour), 0, 0)
+	_, err := h.FOrderDetails(t.Context(), "BTC", "123", "quotation", time.Now().Add(-1*time.Hour), 0, 0)
 	require.NoError(t, err)
 }
 
 func TestFGetOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetOpenOrders(context.Background(), currency.BTC, 1, 2)
+	_, err := h.FGetOpenOrders(t.Context(), currency.BTC, 1, 2)
 	require.NoError(t, err)
 }
 
 func TestFGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FGetOrderHistory(context.Background(),
+	_, err := h.FGetOrderHistory(t.Context(),
 		currency.EMPTYPAIR, "BTC",
 		"all", "all", "limit",
 		[]order.Status{},
@@ -394,90 +393,90 @@ func TestFGetOrderHistory(t *testing.T) {
 func TestFTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.FTradeHistory(context.Background(), currency.EMPTYPAIR, "BTC", "all", 10, 0, 0)
+	_, err := h.FTradeHistory(t.Context(), currency.EMPTYPAIR, "BTC", "all", 10, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestFPlaceTriggerOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FPlaceTriggerOrder(context.Background(), currency.EMPTYPAIR, "EOS", "quarter", "greaterOrEqual", "limit", "buy", "close", 1.1, 1.05, 5, 2)
+	_, err := h.FPlaceTriggerOrder(t.Context(), currency.EMPTYPAIR, "EOS", "quarter", "greaterOrEqual", "limit", "buy", "close", 1.1, 1.05, 5, 2)
 	require.NoError(t, err)
 }
 
 func TestFCancelTriggerOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FCancelTriggerOrder(context.Background(), "ETH", "123")
+	_, err := h.FCancelTriggerOrder(t.Context(), "ETH", "123")
 	require.NoError(t, err)
 }
 
 func TestFCancelAllTriggerOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FCancelAllTriggerOrders(context.Background(), currency.EMPTYPAIR, "BTC", "this_week")
+	_, err := h.FCancelAllTriggerOrders(t.Context(), currency.EMPTYPAIR, "BTC", "this_week")
 	require.NoError(t, err)
 }
 
 func TestFQueryTriggerOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FQueryTriggerOpenOrders(context.Background(), currency.EMPTYPAIR, "BTC", 0, 0)
+	_, err := h.FQueryTriggerOpenOrders(t.Context(), currency.EMPTYPAIR, "BTC", 0, 0)
 	require.NoError(t, err)
 }
 
 func TestFQueryTriggerOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.FQueryTriggerOrderHistory(context.Background(), currency.EMPTYPAIR, "EOS", "all", "all", 10, 0, 0)
+	_, err := h.FQueryTriggerOrderHistory(t.Context(), currency.EMPTYPAIR, "EOS", "all", "all", 10, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := h.FetchTradablePairs(context.Background(), asset.Futures)
+	_, err := h.FetchTradablePairs(t.Context(), asset.Futures)
 	require.NoError(t, err)
 }
 
 func TestUpdateTickerSpot(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateTicker(context.Background(), currency.NewPairWithDelimiter("INV", "ALID", "-"), asset.Spot)
+	_, err := h.UpdateTicker(t.Context(), currency.NewPairWithDelimiter("INV", "ALID", "-"), asset.Spot)
 	assert.ErrorContains(t, err, "invalid symbol")
-	_, err = h.UpdateTicker(context.Background(), currency.NewPairWithDelimiter("BTC", "USDT", "_"), asset.Spot)
+	_, err = h.UpdateTicker(t.Context(), currency.NewPairWithDelimiter("BTC", "USDT", "_"), asset.Spot)
 	require.NoError(t, err)
 }
 
 func TestUpdateTickerCMF(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateTicker(context.Background(), currency.NewPairWithDelimiter("INV", "ALID", "_"), asset.CoinMarginedFutures)
+	_, err := h.UpdateTicker(t.Context(), currency.NewPairWithDelimiter("INV", "ALID", "_"), asset.CoinMarginedFutures)
 	assert.ErrorContains(t, err, "symbol data error")
-	_, err = h.UpdateTicker(context.Background(), currency.NewPairWithDelimiter("BTC", "USD", "_"), asset.CoinMarginedFutures)
+	_, err = h.UpdateTicker(t.Context(), currency.NewPairWithDelimiter("BTC", "USD", "_"), asset.CoinMarginedFutures)
 	require.NoError(t, err)
 }
 
 func TestUpdateTickerFutures(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateTicker(context.Background(), btccwPair, asset.Futures)
+	_, err := h.UpdateTicker(t.Context(), btccwPair, asset.Futures)
 	require.NoError(t, err)
 }
 
 func TestUpdateOrderbookSpot(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateOrderbook(context.Background(), btcusdtPair, asset.Spot)
+	_, err := h.UpdateOrderbook(t.Context(), btcusdtPair, asset.Spot)
 	require.NoError(t, err)
 }
 
 func TestUpdateOrderbookCMF(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateOrderbook(context.Background(), btcusdPair, asset.CoinMarginedFutures)
+	_, err := h.UpdateOrderbook(t.Context(), btcusdPair, asset.CoinMarginedFutures)
 	require.NoError(t, err)
 }
 
 func TestUpdateOrderbookFuture(t *testing.T) {
 	t.Parallel()
-	_, err := h.UpdateOrderbook(context.Background(), btccwPair, asset.Futures)
+	_, err := h.UpdateOrderbook(t.Context(), btccwPair, asset.Futures)
 	require.NoError(t, err)
-	_, err = h.UpdateOrderbook(context.Background(), btcusdPair, asset.CoinMarginedFutures)
+	_, err = h.UpdateOrderbook(t.Context(), btcusdPair, asset.CoinMarginedFutures)
 	require.NoError(t, err)
 }
 
@@ -491,246 +490,246 @@ func TestGetOrderHistory(t *testing.T) {
 		AssetType: asset.Spot,
 		Side:      order.AnySide,
 	}
-	_, err := h.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := h.GetOrderHistory(t.Context(), &getOrdersRequest)
 	require.NoError(t, err)
 
 	cp1, err := currency.NewPairFromString("ADA-USD")
 	require.NoError(t, err)
 	getOrdersRequest.Pairs = []currency.Pair{cp1}
 	getOrdersRequest.AssetType = asset.CoinMarginedFutures
-	_, err = h.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err = h.GetOrderHistory(t.Context(), &getOrdersRequest)
 	require.NoError(t, err)
 	getOrdersRequest.Pairs = []currency.Pair{btcFutureDatedPair}
 	getOrdersRequest.AssetType = asset.Futures
-	_, err = h.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err = h.GetOrderHistory(t.Context(), &getOrdersRequest)
 	require.NoError(t, err)
 }
 
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelAllOrders(context.Background(), &order.Cancel{AssetType: asset.Futures})
+	_, err := h.CancelAllOrders(t.Context(), &order.Cancel{AssetType: asset.Futures})
 	require.NoError(t, err)
 }
 
 func TestQuerySwapIndexPriceInfo(t *testing.T) {
 	t.Parallel()
-	_, err := h.QuerySwapIndexPriceInfo(context.Background(), btcusdPair)
+	_, err := h.QuerySwapIndexPriceInfo(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestSwapOpenInterestInformation(t *testing.T) {
 	t.Parallel()
-	_, err := h.SwapOpenInterestInformation(context.Background(), btcusdPair)
+	_, err := h.SwapOpenInterestInformation(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapMarketDepth(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapMarketDepth(context.Background(), btcusdPair, "step0")
+	_, err := h.GetSwapMarketDepth(t.Context(), btcusdPair, "step0")
 	require.NoError(t, err)
 }
 
 func TestGetSwapKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapKlineData(context.Background(), btcusdPair, "5min", 5, time.Now().Add(-time.Hour), time.Now())
+	_, err := h.GetSwapKlineData(t.Context(), btcusdPair, "5min", 5, time.Now().Add(-time.Hour), time.Now())
 	require.NoError(t, err)
 }
 
 func TestGetSwapMarketOverview(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapMarketOverview(context.Background(), btcusdPair)
+	_, err := h.GetSwapMarketOverview(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetLastTrade(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetLastTrade(context.Background(), btcusdPair)
+	_, err := h.GetLastTrade(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetBatchTrades(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetBatchTrades(context.Background(), btcusdPair, 5)
+	_, err := h.GetBatchTrades(t.Context(), btcusdPair, 5)
 	require.NoError(t, err)
 }
 
 func TestGetTieredAjustmentFactorInfo(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTieredAjustmentFactorInfo(context.Background(), btcusdPair)
+	_, err := h.GetTieredAjustmentFactorInfo(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetOpenInterestInfo(t *testing.T) {
 	t.Parallel()
 	updatePairsOnce(t, h)
-	_, err := h.GetOpenInterestInfo(context.Background(), btcusdPair, "5min", "cryptocurrency", 50)
+	_, err := h.GetOpenInterestInfo(t.Context(), btcusdPair, "5min", "cryptocurrency", 50)
 	require.NoError(t, err)
 }
 
 func TestGetTraderSentimentIndexAccount(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTraderSentimentIndexAccount(context.Background(), btcusdPair, "5min")
+	_, err := h.GetTraderSentimentIndexAccount(t.Context(), btcusdPair, "5min")
 	require.NoError(t, err)
 }
 
 func TestGetTraderSentimentIndexPosition(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTraderSentimentIndexPosition(context.Background(), btcusdPair, "5min")
+	_, err := h.GetTraderSentimentIndexPosition(t.Context(), btcusdPair, "5min")
 	require.NoError(t, err)
 }
 
 func TestGetLiquidationOrders(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetLiquidationOrders(context.Background(), btcusdPair, "closed", 0, 0, "", 0)
+	_, err := h.GetLiquidationOrders(t.Context(), btcusdPair, "closed", 0, 0, "", 0)
 	require.NoError(t, err)
 }
 
 func TestGetHistoricalFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetHistoricalFundingRatesForPair(context.Background(), btcusdPair, 0, 0)
+	_, err := h.GetHistoricalFundingRatesForPair(t.Context(), btcusdPair, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetPremiumIndexKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetPremiumIndexKlineData(context.Background(), btcusdPair, "5min", 15)
+	_, err := h.GetPremiumIndexKlineData(t.Context(), btcusdPair, "5min", 15)
 	require.NoError(t, err)
 }
 
 func TestGetEstimatedFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetPremiumIndexKlineData(context.Background(), btcusdPair, "5min", 15)
+	_, err := h.GetPremiumIndexKlineData(t.Context(), btcusdPair, "5min", 15)
 	require.NoError(t, err)
 }
 
 func TestGetBasisData(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetBasisData(context.Background(), btcusdPair, "5min", "close", 5)
+	_, err := h.GetBasisData(t.Context(), btcusdPair, "5min", "close", 5)
 	require.NoError(t, err)
 }
 
 func TestGetSystemStatusInfo(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSystemStatusInfo(context.Background(), btcusdPair)
+	_, err := h.GetSystemStatusInfo(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapPriceLimits(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapPriceLimits(context.Background(), btcusdPair)
+	_, err := h.GetSwapPriceLimits(t.Context(), btcusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetMarginRates(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetMarginRates(context.Background(), btcusdtPair)
+	_, err := h.GetMarginRates(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapAccountInfo(context.Background(), ethusdPair)
+	_, err := h.GetSwapAccountInfo(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapPositionsInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapPositionsInfo(context.Background(), ethusdPair)
+	_, err := h.GetSwapPositionsInfo(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapAssetsAndPositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapAssetsAndPositions(context.Background(), ethusdPair)
+	_, err := h.GetSwapAssetsAndPositions(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapAllSubAccAssets(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapAllSubAccAssets(context.Background(), ethusdPair)
+	_, err := h.GetSwapAllSubAccAssets(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSubAccPositionInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSubAccPositionInfo(context.Background(), ethusdPair, 0)
+	_, err := h.GetSubAccPositionInfo(t.Context(), ethusdPair, 0)
 	require.NoError(t, err)
 }
 
 func TestGetAccountFinancialRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetAccountFinancialRecords(context.Background(), ethusdPair, "3,4", 15, 0, 0)
+	_, err := h.GetAccountFinancialRecords(t.Context(), ethusdPair, "3,4", 15, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetSwapSettlementRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapSettlementRecords(context.Background(), ethusdPair, time.Time{}, time.Time{}, 0, 0)
+	_, err := h.GetSwapSettlementRecords(t.Context(), ethusdPair, time.Time{}, time.Time{}, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetAvailableLeverage(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetAvailableLeverage(context.Background(), ethusdPair)
+	_, err := h.GetAvailableLeverage(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapOrderLimitInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapOrderLimitInfo(context.Background(), ethusdPair, "limit")
+	_, err := h.GetSwapOrderLimitInfo(t.Context(), ethusdPair, "limit")
 	require.NoError(t, err)
 }
 
 func TestGetSwapTradingFeeInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapTradingFeeInfo(context.Background(), ethusdPair)
+	_, err := h.GetSwapTradingFeeInfo(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapTransferLimitInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapTransferLimitInfo(context.Background(), ethusdPair)
+	_, err := h.GetSwapTransferLimitInfo(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapPositionLimitInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapPositionLimitInfo(context.Background(), ethusdPair)
+	_, err := h.GetSwapPositionLimitInfo(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestAccountTransferData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.AccountTransferData(context.Background(), ethusdPair, "123", "master_to_sub", 15)
+	_, err := h.AccountTransferData(t.Context(), ethusdPair, "123", "master_to_sub", 15)
 	require.NoError(t, err)
 }
 
 func TestAccountTransferRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.AccountTransferRecords(context.Background(), ethusdPair, "master_to_sub", 12, 0, 0)
+	_, err := h.AccountTransferRecords(t.Context(), ethusdPair, "master_to_sub", 12, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestPlaceSwapOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.PlaceSwapOrders(context.Background(), ethusdPair, "", "buy", "open", "limit", 0.01, 1, 1)
+	_, err := h.PlaceSwapOrders(t.Context(), ethusdPair, "", "buy", "open", "limit", 0.01, 1, 1)
 	require.NoError(t, err)
 }
 
@@ -760,103 +759,103 @@ func TestPlaceSwapBatchOrders(t *testing.T) {
 	}
 	req.Data = append(req.Data, order1, order2)
 
-	_, err := h.PlaceSwapBatchOrders(context.Background(), req)
+	_, err := h.PlaceSwapBatchOrders(t.Context(), req)
 	require.NoError(t, err)
 }
 
 func TestCancelSwapOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelSwapOrder(context.Background(), "test123", "", ethusdPair)
+	_, err := h.CancelSwapOrder(t.Context(), "test123", "", ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestCancelAllSwapOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelAllSwapOrders(context.Background(), ethusdPair)
+	_, err := h.CancelAllSwapOrders(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestPlaceLightningCloseOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.PlaceLightningCloseOrder(context.Background(), ethusdPair, "buy", "lightning", 5, 1)
+	_, err := h.PlaceLightningCloseOrder(t.Context(), ethusdPair, "buy", "lightning", 5, 1)
 	require.NoError(t, err)
 }
 
 func TestGetSwapOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapOrderInfo(context.Background(), ethusdPair, "123", "")
+	_, err := h.GetSwapOrderInfo(t.Context(), ethusdPair, "123", "")
 	require.NoError(t, err)
 }
 
 func TestGetSwapOrderDetails(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapOrderDetails(context.Background(), ethusdPair, "123", "10", "cancelledOrder", 0, 0)
+	_, err := h.GetSwapOrderDetails(t.Context(), ethusdPair, "123", "10", "cancelledOrder", 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetSwapOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapOpenOrders(context.Background(), ethusdPair, 0, 0)
+	_, err := h.GetSwapOpenOrders(t.Context(), ethusdPair, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetSwapOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapOrderHistory(context.Background(), ethusdPair, "all", "all", []order.Status{order.PartiallyCancelled, order.Active}, 25, 0, 0)
+	_, err := h.GetSwapOrderHistory(t.Context(), ethusdPair, "all", "all", []order.Status{order.PartiallyCancelled, order.Active}, 25, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetSwapTradeHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapTradeHistory(context.Background(), ethusdPair, "liquidateShort", 10, 0, 0)
+	_, err := h.GetSwapTradeHistory(t.Context(), ethusdPair, "liquidateShort", 10, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestPlaceSwapTriggerOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.PlaceSwapTriggerOrder(context.Background(), ethusdPair, "greaterOrEqual", "buy", "open", "optimal_5", 5, 3, 1, 1)
+	_, err := h.PlaceSwapTriggerOrder(t.Context(), ethusdPair, "greaterOrEqual", "buy", "open", "optimal_5", 5, 3, 1, 1)
 	require.NoError(t, err)
 }
 
 func TestCancelSwapTriggerOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelSwapTriggerOrder(context.Background(), ethusdPair, "test123")
+	_, err := h.CancelSwapTriggerOrder(t.Context(), ethusdPair, "test123")
 	require.NoError(t, err)
 }
 
 func TestCancelAllSwapTriggerOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelAllSwapTriggerOrders(context.Background(), ethusdPair)
+	_, err := h.CancelAllSwapTriggerOrders(t.Context(), ethusdPair)
 	require.NoError(t, err)
 }
 
 func TestGetSwapTriggerOrderHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapTriggerOrderHistory(context.Background(), ethusdPair, "open", "all", 15, 0, 0)
+	_, err := h.GetSwapTriggerOrderHistory(t.Context(), ethusdPair, "open", "all", 15, 0, 0)
 	require.NoError(t, err)
 }
 
 func TestGetSwapMarkets(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapMarkets(context.Background(), currency.EMPTYPAIR)
+	_, err := h.GetSwapMarkets(t.Context(), currency.EMPTYPAIR)
 	require.NoError(t, err)
 }
 
 func TestGetSpotKline(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSpotKline(context.Background(), KlinesRequestParams{Symbol: btcusdtPair, Period: "1min"})
+	_, err := h.GetSpotKline(t.Context(), KlinesRequestParams{Symbol: btcusdtPair, Period: "1min"})
 	require.NoError(t, err)
 }
 
@@ -868,16 +867,16 @@ func TestGetHistoricCandles(t *testing.T) {
 	updatePairsOnce(t, h)
 
 	endTime := time.Now().Add(-time.Hour).Truncate(time.Hour)
-	_, err := h.GetHistoricCandles(context.Background(), btcusdtPair, asset.Spot, kline.OneMin, endTime.Add(-time.Hour), endTime)
+	_, err := h.GetHistoricCandles(t.Context(), btcusdtPair, asset.Spot, kline.OneMin, endTime.Add(-time.Hour), endTime)
 	require.NoError(t, err)
 
-	_, err = h.GetHistoricCandles(context.Background(), btcusdtPair, asset.Spot, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
+	_, err = h.GetHistoricCandles(t.Context(), btcusdtPair, asset.Spot, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
 	require.NoError(t, err)
 
-	_, err = h.GetHistoricCandles(context.Background(), btcFutureDatedPair, asset.Futures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
+	_, err = h.GetHistoricCandles(t.Context(), btcFutureDatedPair, asset.Futures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
 	require.NoError(t, err)
 
-	_, err = h.GetHistoricCandles(context.Background(), btcusdPair, asset.CoinMarginedFutures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
+	_, err = h.GetHistoricCandles(t.Context(), btcusdPair, asset.CoinMarginedFutures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
 	require.NoError(t, err)
 }
 
@@ -889,32 +888,32 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	updatePairsOnce(t, h)
 
 	endTime := time.Now().Add(-time.Hour).Truncate(time.Hour)
-	_, err := h.GetHistoricCandlesExtended(context.Background(), btcusdtPair, asset.Spot, kline.OneMin, endTime.Add(-time.Hour), endTime)
+	_, err := h.GetHistoricCandlesExtended(t.Context(), btcusdtPair, asset.Spot, kline.OneMin, endTime.Add(-time.Hour), endTime)
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 
-	_, err = h.GetHistoricCandlesExtended(context.Background(), btcFutureDatedPair, asset.Futures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
+	_, err = h.GetHistoricCandlesExtended(t.Context(), btcFutureDatedPair, asset.Futures, kline.OneDay, endTime.AddDate(0, 0, -7), endTime)
 	require.NoError(t, err)
 
 	// demonstrate that adjusting time doesn't wreck non-day intervals
-	_, err = h.GetHistoricCandlesExtended(context.Background(), btcFutureDatedPair, asset.Futures, kline.OneHour, endTime.AddDate(0, 0, -1), endTime)
+	_, err = h.GetHistoricCandlesExtended(t.Context(), btcFutureDatedPair, asset.Futures, kline.OneHour, endTime.AddDate(0, 0, -1), endTime)
 	require.NoError(t, err)
 
-	_, err = h.GetHistoricCandlesExtended(context.Background(), btcusdPair, asset.CoinMarginedFutures, kline.OneDay, endTime.AddDate(0, 0, -7), time.Now())
+	_, err = h.GetHistoricCandlesExtended(t.Context(), btcusdPair, asset.CoinMarginedFutures, kline.OneDay, endTime.AddDate(0, 0, -7), time.Now())
 	require.NoError(t, err)
 
-	_, err = h.GetHistoricCandlesExtended(context.Background(), btcusdPair, asset.CoinMarginedFutures, kline.OneHour, endTime.AddDate(0, 0, -1), time.Now())
+	_, err = h.GetHistoricCandlesExtended(t.Context(), btcusdPair, asset.CoinMarginedFutures, kline.OneHour, endTime.AddDate(0, 0, -1), time.Now())
 	require.NoError(t, err)
 }
 
 func TestGetMarketDetailMerged(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetMarketDetailMerged(context.Background(), btcusdtPair)
+	_, err := h.GetMarketDetailMerged(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestGetDepth(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetDepth(context.Background(),
+	_, err := h.GetDepth(t.Context(),
 		&OrderBookDataRequestParams{
 			Symbol: btcusdtPair,
 			Type:   OrderBookDataRequestParamsTypeStep1,
@@ -924,37 +923,37 @@ func TestGetDepth(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTrades(context.Background(), btcusdtPair)
+	_, err := h.GetTrades(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestGetLatestSpotPrice(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetLatestSpotPrice(context.Background(), btcusdtPair)
+	_, err := h.GetLatestSpotPrice(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTradeHistory(context.Background(), btcusdtPair, 50)
+	_, err := h.GetTradeHistory(t.Context(), btcusdtPair, 50)
 	require.NoError(t, err)
 }
 
 func TestGetMarketDetail(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetMarketDetail(context.Background(), btcusdtPair)
+	_, err := h.GetMarketDetail(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestGetSymbols(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSymbols(context.Background())
+	_, err := h.GetSymbols(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetCurrencies(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetCurrencies(context.Background())
+	_, err := h.GetCurrencies(t.Context())
 	require.NoError(t, err)
 }
 
@@ -962,26 +961,26 @@ func TestGet24HrMarketSummary(t *testing.T) {
 	t.Parallel()
 	cp, err := currency.NewPairFromString("ethusdt")
 	require.NoError(t, err)
-	_, err = h.Get24HrMarketSummary(context.Background(), cp)
+	_, err = h.Get24HrMarketSummary(t.Context(), cp)
 	require.NoError(t, err)
 }
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetTickers(context.Background())
+	_, err := h.GetTickers(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetTimestamp(t *testing.T) {
 	t.Parallel()
-	st, err := h.GetCurrentServerTime(context.Background())
+	st, err := h.GetCurrentServerTime(t.Context())
 	require.NoError(t, err)
 	assert.NotEmpty(t, st, "GetCurrentServerTime should return a time")
 }
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := h.GetServerTime(context.Background(), asset.Spot)
+	st, err := h.GetServerTime(t.Context(), asset.Spot)
 	require.NoError(t, err)
 	assert.NotEmpty(t, st, "GetServerTime should return a time")
 }
@@ -989,25 +988,25 @@ func TestWrapperGetServerTime(t *testing.T) {
 func TestGetAccounts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.GetAccounts(context.Background())
+	_, err := h.GetAccounts(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	result, err := h.GetAccounts(context.Background())
+	result, err := h.GetAccounts(t.Context())
 	require.NoError(t, err, "GetAccounts must not error")
 
 	userID := strconv.FormatInt(result[0].ID, 10)
-	_, err = h.GetAccountBalance(context.Background(), userID)
+	_, err = h.GetAccountBalance(t.Context(), userID)
 	require.NoError(t, err, "GetAccountBalance must not error")
 }
 
 func TestGetAggregatedBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetAggregatedBalance(context.Background())
+	_, err := h.GetAggregatedBalance(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1022,42 +1021,42 @@ func TestSpotNewOrder(t *testing.T) {
 		Type:      SpotNewOrderRequestTypeBuyLimit,
 	}
 
-	_, err := h.SpotNewOrder(context.Background(), &arg)
+	_, err := h.SpotNewOrder(t.Context(), &arg)
 	require.NoError(t, err)
 }
 
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelExistingOrder(context.Background(), 1337)
+	_, err := h.CancelExistingOrder(t.Context(), 1337)
 	assert.Error(t, err)
 }
 
 func TestGetOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.GetOrder(context.Background(), 1337)
+	_, err := h.GetOrder(t.Context(), 1337)
 	require.NoError(t, err)
 }
 
 func TestGetMarginLoanOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetMarginLoanOrders(context.Background(), btcusdtPair, "", "", "", "", "", "", "")
+	_, err := h.GetMarginLoanOrders(t.Context(), btcusdtPair, "", "", "", "", "", "", "")
 	require.NoError(t, err)
 }
 
 func TestGetMarginAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetMarginAccountBalance(context.Background(), btcusdtPair)
+	_, err := h.GetMarginAccountBalance(t.Context(), btcusdtPair)
 	require.NoError(t, err)
 }
 
 func TestCancelWithdraw(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelWithdraw(context.Background(), 1337)
+	_, err := h.CancelWithdraw(t.Context(), 1337)
 	require.Error(t, err)
 }
 
@@ -1077,7 +1076,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := h.GetFeeByType(context.Background(), feeBuilder)
+	_, err := h.GetFeeByType(t.Context(), feeBuilder)
 	require.NoError(t, err)
 	if !sharedtestvalues.AreAPICredentialsSet(h) {
 		assert.Equal(t, exchange.OfflineTradeFee, feeBuilder.FeeType)
@@ -1161,7 +1160,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := h.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := h.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		require.NoError(t, err)
 	} else {
@@ -1174,7 +1173,7 @@ func TestGetActiveOrders(t *testing.T) {
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	accounts, err := h.GetAccounts(context.Background())
+	accounts, err := h.GetAccounts(t.Context())
 	require.NoError(t, err, "GetAccounts must not error")
 
 	orderSubmission := &order.Submit{
@@ -1190,7 +1189,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  strconv.FormatInt(accounts[0].ID, 10),
 		AssetType: asset.Spot,
 	}
-	response, err := h.SubmitOrder(context.Background(), orderSubmission)
+	response, err := h.SubmitOrder(t.Context(), orderSubmission)
 	require.NoError(t, err)
 	assert.Equal(t, order.New, response.Status, "response status should be correct")
 }
@@ -1205,7 +1204,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := h.CancelOrder(context.Background(), orderCancellation)
+	err := h.CancelOrder(t.Context(), orderCancellation)
 	require.NoError(t, err)
 }
 
@@ -1220,7 +1219,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	_, err := h.CancelAllOrders(context.Background(), &orderCancellation)
+	_, err := h.CancelAllOrders(t.Context(), &orderCancellation)
 	require.NoError(t, err)
 }
 
@@ -1228,7 +1227,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
 	for _, a := range []asset.Item{asset.Spot, asset.CoinMarginedFutures, asset.Futures} {
-		_, err := h.UpdateAccountInfo(context.Background(), a)
+		_, err := h.UpdateAccountInfo(t.Context(), a)
 		assert.NoErrorf(t, err, "UpdateAccountInfo should not error for asset %s", a)
 	}
 }
@@ -1236,7 +1235,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, h, canManipulateRealOrders)
-	_, err := h.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := h.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	require.Error(t, err, "ModifyOrder must error without any order details")
 }
 
@@ -1254,25 +1253,25 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := h.WithdrawCryptocurrencyFunds(context.Background(), &withdrawCryptoRequest)
+	_, err := h.WithdrawCryptocurrencyFunds(t.Context(), &withdrawCryptoRequest)
 	require.ErrorContains(t, err, withdraw.ErrStrAmountMustBeGreaterThanZero)
 }
 
 func TestWithdrawFiat(t *testing.T) {
 	t.Parallel()
-	_, err := h.WithdrawFiatFunds(context.Background(), &withdraw.Request{})
+	_, err := h.WithdrawFiatFunds(t.Context(), &withdraw.Request{})
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
 func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
-	_, err := h.WithdrawFiatFundsToInternationalBank(context.Background(), &withdraw.Request{})
+	_, err := h.WithdrawFiatFundsToInternationalBank(t.Context(), &withdraw.Request{})
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
 func TestQueryDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := h.QueryDepositAddress(context.Background(), currency.USDT)
+	_, err := h.QueryDepositAddress(t.Context(), currency.USDT)
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		require.NoError(t, err)
 	} else {
@@ -1282,7 +1281,7 @@ func TestQueryDepositAddress(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetDepositAddress(context.Background(), currency.USDT, "", "uSdTeRc20")
+	_, err := h.GetDepositAddress(t.Context(), currency.USDT, "", "uSdTeRc20")
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		require.NoError(t, err)
 	} else {
@@ -1292,7 +1291,7 @@ func TestGetDepositAddress(t *testing.T) {
 
 func TestQueryWithdrawQuota(t *testing.T) {
 	t.Parallel()
-	_, err := h.QueryWithdrawQuotas(context.Background(), currency.BTC.Lower().String())
+	_, err := h.QueryWithdrawQuotas(t.Context(), currency.BTC.Lower().String())
 	if sharedtestvalues.AreAPICredentialsSet(h) {
 		require.NoError(t, err)
 	} else {
@@ -1641,23 +1640,23 @@ func Test_FormatExchangeKlineInterval(t *testing.T) {
 
 func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetRecentTrades(context.Background(), btcusdtPair, asset.Spot)
+	_, err := h.GetRecentTrades(t.Context(), btcusdtPair, asset.Spot)
 	require.NoError(t, err)
-	_, err = h.GetRecentTrades(context.Background(), btccwPair, asset.Futures)
+	_, err = h.GetRecentTrades(t.Context(), btccwPair, asset.Futures)
 	require.NoError(t, err)
-	_, err = h.GetRecentTrades(context.Background(), btcusdPair, asset.CoinMarginedFutures)
+	_, err = h.GetRecentTrades(t.Context(), btcusdPair, asset.CoinMarginedFutures)
 	require.NoError(t, err)
 }
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetHistoricTrades(context.Background(), btcusdtPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
+	_, err := h.GetHistoricTrades(t.Context(), btcusdtPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	require.ErrorIs(t, err, common.ErrFunctionNotSupported)
 }
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	c, err := h.GetAvailableTransferChains(context.Background(), currency.USDT)
+	c, err := h.GetAvailableTransferChains(t.Context(), currency.USDT)
 	require.NoError(t, err)
 	require.Greater(t, len(c), 2, "Must get more than 2 chains")
 }
@@ -1689,21 +1688,21 @@ func TestFormatFuturesPair(t *testing.T) {
 func TestSearchForExistedWithdrawsAndDeposits(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.SearchForExistedWithdrawsAndDeposits(context.Background(), currency.BTC, "deposit", "", 0, 100)
+	_, err := h.SearchForExistedWithdrawsAndDeposits(t.Context(), currency.BTC, "deposit", "", 0, 100)
 	require.NoError(t, err)
 }
 
 func TestCancelOrderBatch(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelOrderBatch(context.Background(), []string{"1234"}, nil)
+	_, err := h.CancelOrderBatch(t.Context(), []string{"1234"}, nil)
 	require.NoError(t, err)
 }
 
 func TestCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h, canManipulateRealOrders)
-	_, err := h.CancelBatchOrders(context.Background(), []order.Cancel{
+	_, err := h.CancelBatchOrders(t.Context(), []order.Cancel{
 		{
 			OrderID:   "1234",
 			AssetType: asset.Spot,
@@ -1716,20 +1715,20 @@ func TestCancelBatchOrders(t *testing.T) {
 func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := h.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	require.NoError(t, err)
 }
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := h.GetFuturesContractDetails(t.Context(), asset.Spot)
 	require.ErrorIs(t, err, futures.ErrNotFuturesAsset)
-	_, err = h.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = h.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
-	_, err = h.GetFuturesContractDetails(context.Background(), asset.CoinMarginedFutures)
+	_, err = h.GetFuturesContractDetails(t.Context(), asset.CoinMarginedFutures)
 	require.NoError(t, err)
-	_, err = h.GetFuturesContractDetails(context.Background(), asset.Futures)
+	_, err = h.GetFuturesContractDetails(t.Context(), asset.Futures)
 	require.NoError(t, err)
 }
 
@@ -1739,14 +1738,14 @@ func TestGetLatestFundingRates(t *testing.T) {
 	require.NoError(t, testexch.Setup(h), "Test Instance Setup must not fail")
 	updatePairsOnce(t, h)
 
-	_, err := h.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := h.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USD),
 		IncludePredictedRate: true,
 	})
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
-	_, err = h.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = h.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.CoinMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USD),
 		IncludePredictedRate: true,
@@ -1756,7 +1755,7 @@ func TestGetLatestFundingRates(t *testing.T) {
 	err = h.CurrencyPairs.EnablePair(asset.CoinMarginedFutures, currency.NewPair(currency.BTC, currency.USD))
 	require.ErrorIs(t, err, currency.ErrPairAlreadyEnabled)
 
-	_, err = h.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = h.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.CoinMarginedFutures,
 		IncludePredictedRate: true,
 	})
@@ -1776,27 +1775,27 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 
 func TestGetSwapFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapFundingRates(context.Background())
+	_, err := h.GetSwapFundingRates(t.Context())
 	require.NoError(t, err)
 }
 
 func TestGetBatchCoinMarginSwapContracts(t *testing.T) {
 	t.Parallel()
-	resp, err := h.GetBatchCoinMarginSwapContracts(context.Background())
+	resp, err := h.GetBatchCoinMarginSwapContracts(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
 
 func TestGetBatchLinearSwapContracts(t *testing.T) {
 	t.Parallel()
-	resp, err := h.GetBatchLinearSwapContracts(context.Background())
+	resp, err := h.GetBatchLinearSwapContracts(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
 
 func TestGetBatchFuturesContracts(t *testing.T) {
 	t.Parallel()
-	resp, err := h.GetBatchFuturesContracts(context.Background())
+	resp, err := h.GetBatchFuturesContracts(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -1805,7 +1804,7 @@ func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 	updatePairsOnce(t, h)
 	for _, a := range h.GetAssetTypes(false) {
-		err := h.UpdateTickers(context.Background(), a)
+		err := h.UpdateTickers(t.Context(), a)
 		require.NoErrorf(t, err, "asset %s", a)
 		avail, err := h.GetAvailablePairs(a)
 		require.NoError(t, err)
@@ -1822,7 +1821,7 @@ func TestPairFromContractExpiryCode(t *testing.T) {
 	h := new(HUOBI) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(h), "Test Instance Setup must not fail")
 
-	_, err := h.FetchTradablePairs(context.Background(), asset.Futures)
+	_, err := h.FetchTradablePairs(t.Context(), asset.Futures)
 	require.NoError(t, err)
 
 	tz, err := time.LoadLocation("Asia/Singapore") // Huobi HQ and apparent local time for when codes become effective
@@ -1863,14 +1862,14 @@ func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
 	updatePairsOnce(t, h)
 
-	_, err := h.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err := h.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.ETH.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.USDTMarginedFutures,
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported)
 
-	resp, err := h.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := h.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.BTC.Item,
 		Quote: currency.USD.Item,
 		Asset: asset.CoinMarginedFutures,
@@ -1878,7 +1877,7 @@ func TestGetOpenInterest(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = h.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err = h.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  btccwPair.Base.Item,
 		Quote: btccwPair.Quote.Item,
 		Asset: asset.Futures,
@@ -1886,31 +1885,31 @@ func TestGetOpenInterest(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = h.GetOpenInterest(context.Background())
+	resp, err = h.GetOpenInterest(t.Context())
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
 
 func TestContractOpenInterestUSDT(t *testing.T) {
 	t.Parallel()
-	resp, err := h.ContractOpenInterestUSDT(context.Background(), currency.EMPTYPAIR, currency.EMPTYPAIR, "", "")
+	resp, err := h.ContractOpenInterestUSDT(t.Context(), currency.EMPTYPAIR, currency.EMPTYPAIR, "", "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
 	cp := currency.NewPair(currency.BTC, currency.USDT)
-	resp, err = h.ContractOpenInterestUSDT(context.Background(), cp, currency.EMPTYPAIR, "", "")
+	resp, err = h.ContractOpenInterestUSDT(t.Context(), cp, currency.EMPTYPAIR, "", "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = h.ContractOpenInterestUSDT(context.Background(), currency.EMPTYPAIR, cp, "", "")
+	resp, err = h.ContractOpenInterestUSDT(t.Context(), currency.EMPTYPAIR, cp, "", "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = h.ContractOpenInterestUSDT(context.Background(), cp, currency.EMPTYPAIR, "this_week", "")
+	resp, err = h.ContractOpenInterestUSDT(t.Context(), cp, currency.EMPTYPAIR, "this_week", "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = h.ContractOpenInterestUSDT(context.Background(), currency.EMPTYPAIR, currency.EMPTYPAIR, "", "swap")
+	resp, err = h.ContractOpenInterestUSDT(t.Context(), currency.EMPTYPAIR, currency.EMPTYPAIR, "", "swap")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -1922,7 +1921,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := h.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := h.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := h.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		if (a == asset.Futures || a == asset.CoinMarginedFutures) && !pairs[0].Quote.Equal(currency.USD) && !pairs[0].Quote.Equal(currency.USDT) {
 			require.ErrorIs(t, err, common.ErrNotYetImplemented)
 		} else {
@@ -2063,13 +2062,13 @@ func TestBootstrap(t *testing.T) {
 	h := new(HUOBI)
 	require.NoError(t, testexch.Setup(h), "Test Instance Setup must not fail")
 
-	c, err := h.Bootstrap(context.Background())
+	c, err := h.Bootstrap(t.Context())
 	require.NoError(t, err)
 	assert.True(t, c, "Bootstrap should return true to continue")
 
 	h.futureContractCodes = nil
 	h.Features.Enabled.AutoPairUpdates = false
-	_, err = h.Bootstrap(context.Background())
+	_, err = h.Bootstrap(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, h.futureContractCodes)
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,7 +1,6 @@
 package kraken
 
 import (
-	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -66,13 +65,13 @@ func TestUpdateTradablePairs(t *testing.T) {
 
 func TestGetCurrentServerTime(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetCurrentServerTime(context.Background())
+	_, err := k.GetCurrentServerTime(t.Context())
 	assert.NoError(t, err, "GetCurrentServerTime should not error")
 }
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := k.GetServerTime(context.Background(), asset.Spot)
+	st, err := k.GetServerTime(t.Context(), asset.Spot)
 	require.NoError(t, err, "GetServerTime should not error")
 	assert.WithinRange(t, st, time.Now().Add(-24*time.Hour), time.Now().Add(24*time.Hour), "ServerTime should be within a day of now")
 }
@@ -81,7 +80,7 @@ func TestWrapperGetServerTime(t *testing.T) {
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
 
-	err := k.UpdateOrderExecutionLimits(context.Background(), asset.Spot)
+	err := k.UpdateOrderExecutionLimits(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateOrderExecutionLimits must not error")
 	for _, p := range []currency.Pair{
 		currency.NewPair(currency.ETH, currency.USDT),
@@ -96,17 +95,17 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := k.FetchTradablePairs(context.Background(), asset.Futures)
+	_, err := k.FetchTradablePairs(t.Context(), asset.Futures)
 	assert.NoError(t, err, "FetchTradablePairs should not error")
 }
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, k)
-	_, err := k.UpdateTicker(context.Background(), spotTestPair, asset.Spot)
+	_, err := k.UpdateTicker(t.Context(), spotTestPair, asset.Spot)
 	assert.NoError(t, err, "UpdateTicker spot asset should not error")
 
-	_, err = k.UpdateTicker(context.Background(), futuresTestPair, asset.Futures)
+	_, err = k.UpdateTicker(t.Context(), futuresTestPair, asset.Futures)
 	assert.NoError(t, err, "UpdateTicker futures asset should not error")
 }
 
@@ -118,7 +117,7 @@ func TestUpdateTickers(t *testing.T) {
 
 	testexch.UpdatePairsOnce(t, k)
 
-	err := k.UpdateTickers(context.Background(), asset.Spot)
+	err := k.UpdateTickers(t.Context(), asset.Spot)
 	require.NoError(t, err, "UpdateTickers must not error")
 
 	ap, err := k.GetAvailablePairs(asset.Spot)
@@ -132,7 +131,7 @@ func TestUpdateTickers(t *testing.T) {
 	ap, err = k.GetAvailablePairs(asset.Futures)
 
 	require.NoError(t, err, "GetAvailablePairs must not error")
-	err = k.UpdateTickers(context.Background(), asset.Futures)
+	err = k.UpdateTickers(t.Context(), asset.Futures)
 	require.NoError(t, err, "UpdateTickers must not error")
 
 	for i := range ap {
@@ -140,15 +139,15 @@ func TestUpdateTickers(t *testing.T) {
 		assert.NoErrorf(t, err, "GetTicker should not error for %s", ap[i])
 	}
 
-	err = k.UpdateTickers(context.Background(), asset.Index)
+	err = k.UpdateTickers(t.Context(), asset.Index)
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "UpdateTickers should error correctly for asset.Index")
 }
 
 func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := k.UpdateOrderbook(context.Background(), spotTestPair, asset.Spot)
+	_, err := k.UpdateOrderbook(t.Context(), spotTestPair, asset.Spot)
 	assert.NoError(t, err, "UpdateOrderbook spot asset should not error")
-	_, err = k.UpdateOrderbook(context.Background(), futuresTestPair, asset.Futures)
+	_, err = k.UpdateOrderbook(t.Context(), futuresTestPair, asset.Futures)
 	assert.NoError(t, err, "UpdateOrderbook futures asset should not error")
 }
 
@@ -160,13 +159,13 @@ func TestFuturesBatchOrder(t *testing.T) {
 	tempData.OrderID = "test123"
 	tempData.Symbol = futuresTestPair.Lower().String()
 	data = append(data, tempData)
-	_, err := k.FuturesBatchOrder(context.Background(), data)
+	_, err := k.FuturesBatchOrder(t.Context(), data)
 	assert.ErrorIs(t, err, errInvalidBatchOrderType, "FuturesBatchOrder should error correctly")
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
 	data[0].PlaceOrderType = "cancel"
-	_, err = k.FuturesBatchOrder(context.Background(), data)
+	_, err = k.FuturesBatchOrder(t.Context(), data)
 	assert.NoError(t, err, "FuturesBatchOrder should not error")
 }
 
@@ -174,7 +173,7 @@ func TestFuturesEditOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesEditOrder(context.Background(), "test123", "", 5.2, 1, 0)
+	_, err := k.FuturesEditOrder(t.Context(), "test123", "", 5.2, 1, 0)
 	assert.NoError(t, err, "FuturesEditOrder should not error")
 }
 
@@ -182,7 +181,7 @@ func TestFuturesSendOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesSendOrder(context.Background(), order.Limit, futuresTestPair, "buy", "", "", "", true, 1, 1, 0.9)
+	_, err := k.FuturesSendOrder(t.Context(), order.Limit, futuresTestPair, "buy", "", "", "", true, 1, 1, 0.9)
 	assert.NoError(t, err, "FuturesSendOrder should not error")
 }
 
@@ -190,7 +189,7 @@ func TestFuturesCancelOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesCancelOrder(context.Background(), "test123", "")
+	_, err := k.FuturesCancelOrder(t.Context(), "test123", "")
 	assert.NoError(t, err, "FuturesCancelOrder should not error")
 }
 
@@ -198,7 +197,7 @@ func TestFuturesGetFills(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesGetFills(context.Background(), time.Now().Add(-time.Hour*24))
+	_, err := k.FuturesGetFills(t.Context(), time.Now().Add(-time.Hour*24))
 	assert.NoError(t, err, "FuturesGetFills should not error")
 }
 
@@ -206,7 +205,7 @@ func TestFuturesTransfer(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesTransfer(context.Background(), "cash", "futures", "btc", 2)
+	_, err := k.FuturesTransfer(t.Context(), "cash", "futures", "btc", 2)
 	assert.NoError(t, err, "FuturesTransfer should not error")
 }
 
@@ -214,7 +213,7 @@ func TestFuturesGetOpenPositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesGetOpenPositions(context.Background())
+	_, err := k.FuturesGetOpenPositions(t.Context())
 	assert.NoError(t, err, "FuturesGetOpenPositions should not error")
 }
 
@@ -222,7 +221,7 @@ func TestFuturesNotifications(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesNotifications(context.Background())
+	_, err := k.FuturesNotifications(t.Context())
 	assert.NoError(t, err, "FuturesNotifications should not error")
 }
 
@@ -230,7 +229,7 @@ func TestFuturesCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesCancelAllOrders(context.Background(), futuresTestPair)
+	_, err := k.FuturesCancelAllOrders(t.Context(), futuresTestPair)
 	assert.NoError(t, err, "FuturesCancelAllOrders should not error")
 }
 
@@ -238,7 +237,7 @@ func TestGetFuturesAccountData(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.GetFuturesAccountData(context.Background())
+	_, err := k.GetFuturesAccountData(t.Context())
 	assert.NoError(t, err, "GetFuturesAccountData should not error")
 }
 
@@ -246,7 +245,7 @@ func TestFuturesCancelAllOrdersAfter(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesCancelAllOrdersAfter(context.Background(), 50)
+	_, err := k.FuturesCancelAllOrdersAfter(t.Context(), 50)
 	assert.NoError(t, err, "FuturesCancelAllOrdersAfter should not error")
 }
 
@@ -254,7 +253,7 @@ func TestFuturesOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesOpenOrders(context.Background())
+	_, err := k.FuturesOpenOrders(t.Context())
 	assert.NoError(t, err, "FuturesOpenOrders should not error")
 }
 
@@ -262,7 +261,7 @@ func TestFuturesRecentOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.FuturesRecentOrders(context.Background(), futuresTestPair)
+	_, err := k.FuturesRecentOrders(t.Context(), futuresTestPair)
 	assert.NoError(t, err, "FuturesRecentOrders should not error")
 }
 
@@ -270,7 +269,7 @@ func TestFuturesWithdrawToSpotWallet(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesWithdrawToSpotWallet(context.Background(), "xbt", 5)
+	_, err := k.FuturesWithdrawToSpotWallet(t.Context(), "xbt", 5)
 	assert.NoError(t, err, "FuturesWithdrawToSpotWallet should not error")
 }
 
@@ -278,45 +277,45 @@ func TestFuturesGetTransfers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
 
-	_, err := k.FuturesGetTransfers(context.Background(), time.Now().Add(-time.Hour*24))
+	_, err := k.FuturesGetTransfers(t.Context(), time.Now().Add(-time.Hour*24))
 	assert.NoError(t, err, "FuturesGetTransfers should not error")
 }
 
 func TestGetFuturesOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetFuturesOrderbook(context.Background(), futuresTestPair)
+	_, err := k.GetFuturesOrderbook(t.Context(), futuresTestPair)
 	assert.NoError(t, err, "GetFuturesOrderbook should not error")
 }
 
 func TestGetFuturesMarkets(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetInstruments(context.Background())
+	_, err := k.GetInstruments(t.Context())
 	assert.NoError(t, err, "GetInstruments should not error")
 }
 
 func TestGetFuturesTickers(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetFuturesTickers(context.Background())
+	_, err := k.GetFuturesTickers(t.Context())
 	assert.NoError(t, err, "GetFuturesTickers should not error")
 }
 
 func TestGetFuturesTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetFuturesTradeHistory(context.Background(), futuresTestPair, time.Now().Add(-time.Hour*24))
+	_, err := k.GetFuturesTradeHistory(t.Context(), futuresTestPair, time.Now().Add(-time.Hour*24))
 	assert.NoError(t, err, "GetFuturesTradeHistory should not error")
 }
 
 // TestGetAssets API endpoint test
 func TestGetAssets(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetAssets(context.Background())
+	_, err := k.GetAssets(t.Context())
 	assert.NoError(t, err, "GetAssets should not error")
 }
 
 func TestSeedAssetTranslator(t *testing.T) {
 	t.Parallel()
 
-	err := k.SeedAssets(context.TODO())
+	err := k.SeedAssets(t.Context())
 	require.NoError(t, err, "SeedAssets must not error")
 
 	for from, to := range map[string]string{"XBTUSD": "XXBTZUSD", "USD": "ZUSD", "XBT": "XXBT"} {
@@ -348,7 +347,7 @@ func TestLookupCurrency(t *testing.T) {
 func TestGetAssetPairs(t *testing.T) {
 	t.Parallel()
 	for _, v := range []string{"fees", "leverage", "margin", ""} {
-		_, err := k.GetAssetPairs(context.Background(), []string{}, v)
+		_, err := k.GetAssetPairs(t.Context(), []string{}, v)
 		require.NoErrorf(t, err, "GetAssetPairs %s must not error", v)
 	}
 }
@@ -356,28 +355,28 @@ func TestGetAssetPairs(t *testing.T) {
 // TestGetTicker API endpoint test
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetTicker(context.Background(), spotTestPair)
+	_, err := k.GetTicker(t.Context(), spotTestPair)
 	assert.NoError(t, err, "GetTicker should not error")
 }
 
 // TestGetTickers API endpoint test
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetTickers(context.Background(), "LTCUSD,ETCUSD")
+	_, err := k.GetTickers(t.Context(), "LTCUSD,ETCUSD")
 	assert.NoError(t, err, "GetTickers should not error")
 }
 
 // TestGetOHLC API endpoint test
 func TestGetOHLC(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetOHLC(context.Background(), currency.NewPairWithDelimiter("XXBT", "ZUSD", ""), "1440")
+	_, err := k.GetOHLC(t.Context(), currency.NewPairWithDelimiter("XXBT", "ZUSD", ""), "1440")
 	assert.NoError(t, err, "GetOHLC should not error")
 }
 
 // TestGetDepth API endpoint test
 func TestGetDepth(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetDepth(context.Background(), spotTestPair)
+	_, err := k.GetDepth(t.Context(), spotTestPair)
 	assert.NoError(t, err, "GetDepth should not error")
 }
 
@@ -385,17 +384,17 @@ func TestGetDepth(t *testing.T) {
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, k)
-	_, err := k.GetTrades(context.Background(), spotTestPair)
+	_, err := k.GetTrades(t.Context(), spotTestPair)
 	assert.NoError(t, err, "GetTrades should not error")
 
-	_, err = k.GetTrades(context.Background(), currency.NewPairWithDelimiter("XXX", "XXX", ""))
+	_, err = k.GetTrades(t.Context(), currency.NewPairWithDelimiter("XXX", "XXX", ""))
 	assert.ErrorContains(t, err, "Unknown asset pair", "GetDepth should error correctly")
 }
 
 // TestGetSpread API endpoint test
 func TestGetSpread(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetSpread(context.Background(), currency.NewPair(currency.BCH, currency.EUR)) // XBTUSD not in spread data
+	_, err := k.GetSpread(t.Context(), currency.NewPair(currency.BCH, currency.EUR)) // XBTUSD not in spread data
 	assert.NoError(t, err, "GetSpread should not error")
 }
 
@@ -403,7 +402,7 @@ func TestGetSpread(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.GetBalance(context.Background())
+	_, err := k.GetBalance(t.Context())
 	assert.NoError(t, err, "GetBalance should not error")
 }
 
@@ -411,7 +410,7 @@ func TestGetBalance(t *testing.T) {
 func TestGetDepositMethods(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.GetDepositMethods(context.Background(), "USDT")
+	_, err := k.GetDepositMethods(t.Context(), "USDT")
 	assert.NoError(t, err, "GetDepositMethods should not error")
 }
 
@@ -420,7 +419,7 @@ func TestGetTradeBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 	args := TradeBalanceOptions{Asset: "ZEUR"}
-	_, err := k.GetTradeBalance(context.Background(), args)
+	_, err := k.GetTradeBalance(t.Context(), args)
 	assert.NoError(t, err)
 }
 
@@ -429,7 +428,7 @@ func TestGetOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 	args := OrderInfoOptions{Trades: true}
-	_, err := k.GetOpenOrders(context.Background(), args)
+	_, err := k.GetOpenOrders(t.Context(), args)
 	assert.NoError(t, err)
 }
 
@@ -438,7 +437,7 @@ func TestGetClosedOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 	args := GetClosedOrdersOptions{Trades: true, Start: "OE4KV4-4FVQ5-V7XGPU"}
-	_, err := k.GetClosedOrders(context.Background(), args)
+	_, err := k.GetClosedOrders(t.Context(), args)
 	assert.NoError(t, err)
 }
 
@@ -447,7 +446,7 @@ func TestQueryOrdersInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 	args := OrderInfoOptions{Trades: true}
-	_, err := k.QueryOrdersInfo(context.Background(), args, "OR6ZFV-AA6TT-CKFFIW", "OAMUAJ-HLVKG-D3QJ5F")
+	_, err := k.QueryOrdersInfo(t.Context(), args, "OR6ZFV-AA6TT-CKFFIW", "OAMUAJ-HLVKG-D3QJ5F")
 	assert.NoError(t, err)
 }
 
@@ -456,7 +455,7 @@ func TestGetTradesHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 	args := GetTradesHistoryOptions{Trades: true, Start: "TMZEDR-VBJN2-NGY6DX", End: "TVRXG2-R62VE-RWP3UW"}
-	_, err := k.GetTradesHistory(context.Background(), args)
+	_, err := k.GetTradesHistory(t.Context(), args)
 	assert.NoError(t, err)
 }
 
@@ -464,7 +463,7 @@ func TestGetTradesHistory(t *testing.T) {
 func TestQueryTrades(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.QueryTrades(context.Background(), true, "TMZEDR-VBJN2-NGY6DX", "TFLWIB-KTT7L-4TWR3L", "TDVRAH-2H6OS-SLSXRX")
+	_, err := k.QueryTrades(t.Context(), true, "TMZEDR-VBJN2-NGY6DX", "TFLWIB-KTT7L-4TWR3L", "TDVRAH-2H6OS-SLSXRX")
 	assert.NoError(t, err)
 }
 
@@ -472,7 +471,7 @@ func TestQueryTrades(t *testing.T) {
 func TestOpenPositions(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.OpenPositions(context.Background(), false)
+	_, err := k.OpenPositions(t.Context(), false)
 	assert.NoError(t, err)
 }
 
@@ -483,7 +482,7 @@ func TestGetLedgers(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
 	args := GetLedgersOptions{Start: "LRUHXI-IWECY-K4JYGO", End: "L5NIY7-JZQJD-3J4M2V", Ofs: 15}
-	_, err := k.GetLedgers(context.Background(), args)
+	_, err := k.GetLedgers(t.Context(), args)
 	assert.ErrorContains(t, err, "EQuery:Unknown asset pair", "GetLedger should error on imaginary ledgers")
 }
 
@@ -491,7 +490,7 @@ func TestGetLedgers(t *testing.T) {
 func TestQueryLedgers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.QueryLedgers(context.Background(), "LVTSFS-NHZVM-EXNZ5M")
+	_, err := k.QueryLedgers(t.Context(), "LVTSFS-NHZVM-EXNZ5M")
 	assert.NoError(t, err)
 }
 
@@ -499,7 +498,7 @@ func TestQueryLedgers(t *testing.T) {
 func TestGetTradeVolume(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.GetTradeVolume(context.Background(), true, spotTestPair)
+	_, err := k.GetTradeVolume(t.Context(), true, spotTestPair)
 	assert.NoError(t, err, "GetTradeVolume should not error")
 }
 
@@ -511,7 +510,7 @@ func TestOrders(t *testing.T) {
 	args := AddOrderOptions{OrderFlags: "fcib"}
 	cp, err := currency.NewPairFromString("XXBTZUSD")
 	assert.NoError(t, err, "NewPairFromString should not error")
-	resp, err := k.AddOrder(context.Background(),
+	resp, err := k.AddOrder(t.Context(),
 		cp,
 		order.Buy.Lower(), order.Limit.Lower(),
 		0.0001, 9000, 9000, 0, &args)
@@ -519,7 +518,7 @@ func TestOrders(t *testing.T) {
 	if assert.NoError(t, err, "AddOrder should not error") {
 		if assert.Len(t, resp.TransactionIDs, 1, "One TransactionId should be returned") {
 			id := resp.TransactionIDs[0]
-			_, err = k.CancelExistingOrder(context.Background(), id)
+			_, err = k.CancelExistingOrder(t.Context(), id)
 			assert.NoErrorf(t, err, "CancelExistingOrder should not error, Please ensure order %s is cancelled manually", id)
 		}
 	}
@@ -529,7 +528,7 @@ func TestOrders(t *testing.T) {
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k, canManipulateRealOrders)
-	_, err := k.CancelExistingOrder(context.Background(), "OAVY7T-MV5VK-KHDF5X")
+	_, err := k.CancelExistingOrder(t.Context(), "OAVY7T-MV5VK-KHDF5X")
 	if assert.Error(t, err, "Cancel with imaginary order-id should error") {
 		assert.ErrorContains(t, err, "EOrder:Unknown order", "Cancel with imaginary order-id should error Unknown Order")
 	}
@@ -550,7 +549,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 	feeBuilder := setFeeBuilder()
-	f, err := k.GetFeeByType(context.Background(), feeBuilder)
+	f, err := k.GetFeeByType(t.Context(), feeBuilder)
 	require.NoError(t, err, "GetFeeByType must not error")
 	assert.Positive(t, f, "GetFeeByType should return a positive value")
 	if !sharedtestvalues.AreAPICredentialsSet(k) {
@@ -566,52 +565,52 @@ func TestGetFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
 
 	if sharedtestvalues.AreAPICredentialsSet(k) {
-		_, err := k.GetFee(context.Background(), feeBuilder)
+		_, err := k.GetFee(t.Context(), feeBuilder)
 		assert.NoError(t, err, "CryptocurrencyTradeFee Basic GetFee should not error")
 
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		_, err = k.GetFee(context.Background(), feeBuilder)
+		_, err = k.GetFee(t.Context(), feeBuilder)
 		assert.NoError(t, err, "CryptocurrencyTradeFee High quantity GetFee should not error")
 
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
-		_, err = k.GetFee(context.Background(), feeBuilder)
+		_, err = k.GetFee(t.Context(), feeBuilder)
 		assert.NoError(t, err, "CryptocurrencyTradeFee IsMaker GetFee should not error")
 
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		_, err = k.GetFee(context.Background(), feeBuilder)
+		_, err = k.GetFee(t.Context(), feeBuilder)
 		assert.NoError(t, err, "CryptocurrencyTradeFee Negative purchase price GetFee should not error")
 
 		feeBuilder = setFeeBuilder()
 		feeBuilder.FeeType = exchange.InternationalBankDepositFee
-		_, err = k.GetFee(context.Background(), feeBuilder)
+		_, err = k.GetFee(t.Context(), feeBuilder)
 		assert.NoError(t, err, "InternationalBankDepositFee Basic GetFee should not error")
 	}
 
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
 	feeBuilder.Pair.Base = currency.XXBT
-	_, err := k.GetFee(context.Background(), feeBuilder)
+	_, err := k.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "CryptocurrencyDepositFee Basic GetFee should not error")
 
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	_, err = k.GetFee(context.Background(), feeBuilder)
+	_, err = k.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "CryptocurrencyWithdrawalFee Basic GetFee should not error")
 
 	feeBuilder = setFeeBuilder()
 	feeBuilder.Pair.Base = currency.NewCode("hello")
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	_, err = k.GetFee(context.Background(), feeBuilder)
+	_, err = k.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "CryptocurrencyWithdrawalFee Invalid currency GetFee should not error")
 
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.USD
-	_, err = k.GetFee(context.Background(), feeBuilder)
+	_, err = k.GetFee(t.Context(), feeBuilder)
 	assert.NoError(t, err, "InternationalBankWithdrawalFee Basic GetFee should not error")
 }
 
@@ -635,7 +634,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := k.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := k.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err, "GetActiveOrders should not error")
 }
 
@@ -650,7 +649,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := k.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := k.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 }
 
@@ -658,7 +657,7 @@ func TestGetOrderHistory(t *testing.T) {
 func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
-	_, err := k.GetOrderInfo(context.Background(), "OZPTPJ-HVYHF-EDIGXS", currency.EMPTYPAIR, asset.Spot)
+	_, err := k.GetOrderInfo(t.Context(), "OZPTPJ-HVYHF-EDIGXS", currency.EMPTYPAIR, asset.Spot)
 	assert.ErrorContains(t, err, "order OZPTPJ-HVYHF-EDIGXS not found in response", "Should error that order was not found in response")
 }
 
@@ -680,7 +679,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := k.SubmitOrder(context.Background(), orderSubmission)
+	response, err := k.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(k) {
 		assert.NoError(t, err, "SubmitOrder should not error")
 		assert.Equal(t, order.New, response.Status, "SubmitOrder should return a New order status")
@@ -693,7 +692,7 @@ func TestSubmitOrder(t *testing.T) {
 func TestCancelExchangeOrder(t *testing.T) {
 	t.Parallel()
 
-	err := k.CancelOrder(context.Background(), &order.Cancel{
+	err := k.CancelOrder(t.Context(), &order.Cancel{
 		AssetType: asset.Options,
 		OrderID:   "1337",
 	})
@@ -706,7 +705,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err = k.CancelOrder(context.Background(), orderCancellation)
+	err = k.CancelOrder(t.Context(), orderCancellation)
 	if sharedtestvalues.AreAPICredentialsSet(k) {
 		assert.NoError(t, err, "CancelOrder should not error")
 	} else {
@@ -726,7 +725,7 @@ func TestCancelBatchExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	})
 
-	_, err := k.CancelBatchOrders(context.Background(), ordersCancellation)
+	_, err := k.CancelBatchOrders(t.Context(), ordersCancellation)
 	if sharedtestvalues.AreAPICredentialsSet(k) {
 		assert.NoError(t, err, "CancelBatchOrder should not error")
 	} else {
@@ -739,7 +738,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, k, canManipulateRealOrders)
 
-	resp, err := k.CancelAllOrders(context.Background(), &order.Cancel{AssetType: asset.Spot})
+	resp, err := k.CancelAllOrders(t.Context(), &order.Cancel{AssetType: asset.Spot})
 
 	if sharedtestvalues.AreAPICredentialsSet(k) {
 		assert.NoError(t, err, "CancelAllOrders should not error")
@@ -755,7 +754,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 	t.Parallel()
 
 	for _, a := range []asset.Item{asset.Spot, asset.Futures} {
-		_, err := k.UpdateAccountInfo(context.Background(), a)
+		_, err := k.UpdateAccountInfo(t.Context(), a)
 
 		if sharedtestvalues.AreAPICredentialsSet(k) {
 			assert.NoErrorf(t, err, "UpdateAccountInfo should not error for asset %s", a) // Note Well: Spot and Futures have separate api keys
@@ -769,7 +768,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 
-	_, err := k.ModifyOrder(context.Background(), &order.Modify{AssetType: asset.Spot})
+	_, err := k.ModifyOrder(t.Context(), &order.Modify{AssetType: asset.Spot})
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported, "ModifyOrder should error correctly")
 }
 
@@ -789,7 +788,7 @@ func TestWithdraw(t *testing.T) {
 		TradePassword: "Key",
 	}
 
-	_, err := k.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := k.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(k) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -811,7 +810,7 @@ func TestWithdrawFiat(t *testing.T) {
 		TradePassword: "someBank",
 	}
 
-	_, err := k.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := k.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(k) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -832,7 +831,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 		TradePassword: "someBank",
 	}
 
-	_, err := k.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := k.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(k) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -846,14 +845,14 @@ func TestGetCryptoDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, k)
 
-	_, err := k.GetCryptoDepositAddress(context.Background(), "Bitcoin", "XBT", false)
+	_, err := k.GetCryptoDepositAddress(t.Context(), "Bitcoin", "XBT", false)
 	if err != nil {
 		t.Error(err)
 	}
 	if !canManipulateRealOrders {
 		t.Skip("canManipulateRealOrders not set, skipping test")
 	}
-	_, err = k.GetCryptoDepositAddress(context.Background(), "Bitcoin", "XBT", true)
+	_, err = k.GetCryptoDepositAddress(t.Context(), "Bitcoin", "XBT", true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -863,12 +862,12 @@ func TestGetCryptoDepositAddress(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(k) {
-		_, err := k.GetDepositAddress(context.Background(), currency.USDT, "", "")
+		_, err := k.GetDepositAddress(t.Context(), currency.USDT, "", "")
 		if err != nil {
 			t.Error("GetDepositAddress() error", err)
 		}
 	} else {
-		_, err := k.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := k.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		if err == nil {
 			t.Error("GetDepositAddress() error can not be nil")
 		}
@@ -879,12 +878,12 @@ func TestGetDepositAddress(t *testing.T) {
 func TestWithdrawStatus(t *testing.T) {
 	t.Parallel()
 	if sharedtestvalues.AreAPICredentialsSet(k) {
-		_, err := k.WithdrawStatus(context.Background(), currency.BTC, "")
+		_, err := k.WithdrawStatus(t.Context(), currency.BTC, "")
 		if err != nil {
 			t.Error("WithdrawStatus() error", err)
 		}
 	} else {
-		_, err := k.WithdrawStatus(context.Background(), currency.BTC, "")
+		_, err := k.WithdrawStatus(t.Context(), currency.BTC, "")
 		if err == nil {
 			t.Error("GetDepositAddress() error can not be nil")
 		}
@@ -894,7 +893,7 @@ func TestWithdrawStatus(t *testing.T) {
 // TestWithdrawCancel wrapper test
 func TestWithdrawCancel(t *testing.T) {
 	t.Parallel()
-	_, err := k.WithdrawCancel(context.Background(), currency.BTC, "")
+	_, err := k.WithdrawCancel(t.Context(), currency.BTC, "")
 	if sharedtestvalues.AreAPICredentialsSet(k) && err == nil {
 		t.Error("WithdrawCancel() error cannot be nil")
 	} else if !sharedtestvalues.AreAPICredentialsSet(k) && err == nil {
@@ -1161,7 +1160,7 @@ func TestGetWSToken(t *testing.T) {
 	require.NoError(t, testexch.Setup(k), "Setup Instance must not error")
 	testexch.SetupWs(t, k)
 
-	resp, err := k.GetWebsocketToken(context.Background())
+	resp, err := k.GetWebsocketToken(t.Context())
 	require.NoError(t, err, "GetWebsocketToken must not error")
 	assert.NotEmpty(t, resp, "Token should not be empty")
 }
@@ -1327,16 +1326,16 @@ func TestGetHistoricCandles(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, k)
 
-	_, err := k.GetHistoricCandles(context.Background(), spotTestPair, asset.Spot, kline.OneHour, time.Now().Add(-time.Hour*12), time.Now())
+	_, err := k.GetHistoricCandles(t.Context(), spotTestPair, asset.Spot, kline.OneHour, time.Now().Add(-time.Hour*12), time.Now())
 	assert.NoError(t, err, "GetHistoricCandles should not error")
 
-	_, err = k.GetHistoricCandles(context.Background(), futuresTestPair, asset.Futures, kline.OneHour, time.Now().Add(-time.Hour*12), time.Now())
+	_, err = k.GetHistoricCandles(t.Context(), futuresTestPair, asset.Futures, kline.OneHour, time.Now().Add(-time.Hour*12), time.Now())
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetHistoricCandles should error with asset.ErrNotSupported")
 }
 
 func TestGetHistoricCandlesExtended(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetHistoricCandlesExtended(context.Background(), futuresTestPair, asset.Spot, kline.OneMin, time.Now().Add(-time.Minute*3), time.Now())
+	_, err := k.GetHistoricCandlesExtended(t.Context(), futuresTestPair, asset.Spot, kline.OneMin, time.Now().Add(-time.Minute*3), time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported, "GetHistoricCandlesExtended should error correctly")
 }
 
@@ -1357,16 +1356,16 @@ func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, k)
 
-	_, err := k.GetRecentTrades(context.Background(), spotTestPair, asset.Spot)
+	_, err := k.GetRecentTrades(t.Context(), spotTestPair, asset.Spot)
 	assert.NoError(t, err, "GetRecentTrades should not error")
 
-	_, err = k.GetRecentTrades(context.Background(), futuresTestPair, asset.Futures)
+	_, err = k.GetRecentTrades(t.Context(), futuresTestPair, asset.Futures)
 	assert.NoError(t, err, "GetRecentTrades should not error")
 }
 
 func TestGetHistoricTrades(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetHistoricTrades(context.Background(), spotTestPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
+	_, err := k.GetHistoricTrades(t.Context(), spotTestPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	assert.ErrorIs(t, err, common.ErrFunctionNotSupported, "GetHistoricTrades should error")
 }
 
@@ -1420,21 +1419,21 @@ func TestChecksumCalculation(t *testing.T) {
 
 func TestGetCharts(t *testing.T) {
 	t.Parallel()
-	resp, err := k.GetFuturesCharts(context.Background(), "1d", "spot", futuresTestPair, time.Time{}, time.Time{})
+	resp, err := k.GetFuturesCharts(t.Context(), "1d", "spot", futuresTestPair, time.Time{}, time.Time{})
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Candles)
 
 	end := time.UnixMilli(resp.Candles[0].Time)
-	_, err = k.GetFuturesCharts(context.Background(), "1d", "spot", futuresTestPair, end.Add(-time.Hour*24*7), end)
+	_, err = k.GetFuturesCharts(t.Context(), "1d", "spot", futuresTestPair, end.Add(-time.Hour*24*7), end)
 	require.NoError(t, err)
 }
 
 func TestGetFuturesTrades(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetFuturesTrades(context.Background(), futuresTestPair, time.Time{}, time.Time{})
+	_, err := k.GetFuturesTrades(t.Context(), futuresTestPair, time.Time{}, time.Time{})
 	assert.NoError(t, err, "GetFuturesTrades should not error")
 
-	_, err = k.GetFuturesTrades(context.Background(), futuresTestPair, time.Now().Add(-time.Hour), time.Now())
+	_, err = k.GetFuturesTrades(t.Context(), futuresTestPair, time.Now().Add(-time.Hour), time.Now())
 	assert.NoError(t, err, "GetFuturesTrades should not error")
 }
 
@@ -1510,36 +1509,36 @@ func TestWsOrderbookMax10Depth(t *testing.T) {
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := k.GetFuturesContractDetails(t.Context(), asset.Spot)
 	if !errors.Is(err, futures.ErrNotFuturesAsset) {
 		t.Error(err)
 	}
-	_, err = k.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = k.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	if !errors.Is(err, asset.ErrNotSupported) {
 		t.Error(err)
 	}
 
-	_, err = k.GetFuturesContractDetails(context.Background(), asset.Futures)
+	_, err = k.GetFuturesContractDetails(t.Context(), asset.Futures)
 	assert.NoError(t, err, "GetFuturesContractDetails should not error")
 }
 
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err := k.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.USDTMarginedFutures,
 		Pair:                 currency.NewPair(currency.BTC, currency.USD),
 		IncludePredictedRate: true,
 	})
 	assert.ErrorIs(t, err, asset.ErrNotSupported, "GetLatestFundingRates should error")
 
-	_, err = k.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = k.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 	})
 	assert.NoError(t, err, "GetLatestFundingRates should not error")
 
 	err = k.CurrencyPairs.EnablePair(asset.Futures, futuresTestPair)
 	assert.True(t, err == nil || errors.Is(err, currency.ErrPairAlreadyEnabled), "EnablePair should not error")
-	_, err = k.GetLatestFundingRates(context.Background(), &fundingrate.LatestRateRequest{
+	_, err = k.GetLatestFundingRates(t.Context(), &fundingrate.LatestRateRequest{
 		Asset:                asset.Futures,
 		Pair:                 futuresTestPair,
 		IncludePredictedRate: true,
@@ -1567,7 +1566,7 @@ func TestGetOpenInterest(t *testing.T) {
 	k := new(Kraken) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
 	require.NoError(t, testexch.Setup(k), "Test instance Setup must not error")
 
-	_, err := k.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err := k.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.ETH.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.USDTMarginedFutures,
@@ -1578,7 +1577,7 @@ func TestGetOpenInterest(t *testing.T) {
 	cp2 := currency.NewPair(currency.PF, currency.NewCode("ETHUSD"))
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, k, asset.Futures, cp1, cp2)
 
-	resp, err := k.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := k.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  cp1.Base.Item,
 		Quote: cp1.Quote.Item,
 		Asset: asset.Futures,
@@ -1586,7 +1585,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = k.GetOpenInterest(context.Background(),
+	resp, err = k.GetOpenInterest(t.Context(),
 		key.PairAsset{
 			Base:  cp1.Base.Item,
 			Quote: cp1.Quote.Item,
@@ -1600,7 +1599,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = k.GetOpenInterest(context.Background())
+	resp, err = k.GetOpenInterest(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -1627,7 +1626,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 			continue
 		}
 		require.NoError(t, err, "cannot get pairs for %s", a)
-		resp, err := k.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := k.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		if a != asset.Spot && a != asset.Futures {
 			assert.ErrorIs(t, err, asset.ErrNotSupported)
 			continue

--- a/exchanges/kucoin/kucoin_ratelimit_test.go
+++ b/exchanges/kucoin/kucoin_ratelimit_test.go
@@ -1,7 +1,6 @@
 package kucoin
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -193,7 +192,7 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if err := rl.InitiateRateLimit(context.Background(), tt); err != nil {
+			if err := rl.InitiateRateLimit(t.Context(), tt); err != nil {
 				t.Fatalf("error applying rate limit: %v", err)
 			}
 		})

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -78,35 +78,35 @@ func TestMain(m *testing.M) {
 // Spot asset test cases starts from here
 func TestGetSymbols(t *testing.T) {
 	t.Parallel()
-	symbols, err := ku.GetSymbols(context.Background(), "")
+	symbols, err := ku.GetSymbols(t.Context(), "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, symbols)
 	// Using market string reduces the scope of what is returned.
-	symbols, err = ku.GetSymbols(context.Background(), "ETF")
+	symbols, err = ku.GetSymbols(t.Context(), "ETF")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, symbols, "should return all available ETF symbols")
 }
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetTicker(context.Background(), "")
+	_, err := ku.GetTicker(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetTicker(context.Background(), spotTradablePair.String())
+	result, err := ku.GetTicker(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetAllTickers(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetTickers(context.Background())
+	result, err := ku.GetTickers(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesTickers(t *testing.T) {
 	t.Parallel()
-	tickers, err := ku.GetFuturesTickers(context.Background())
+	tickers, err := ku.GetFuturesTickers(t.Context())
 	assert.NoError(t, err)
 	for i := range tickers {
 		assert.Positive(t, tickers[i].Last, "Last should be positive")
@@ -121,100 +121,100 @@ func TestGetFuturesTickers(t *testing.T) {
 
 func TestGet24hrStats(t *testing.T) {
 	t.Parallel()
-	_, err := ku.Get24hrStats(context.Background(), "")
+	_, err := ku.Get24hrStats(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.Get24hrStats(context.Background(), spotTradablePair.String())
+	result, err := ku.Get24hrStats(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarketList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarketList(context.Background())
+	_, err := ku.GetMarketList(t.Context())
 	assert.NoError(t, err)
 }
 
 func TestGetPartOrderbook20(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetPartOrderbook20(context.Background(), "")
+	_, err := ku.GetPartOrderbook20(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetPartOrderbook20(context.Background(), spotTradablePair.String())
+	result, err := ku.GetPartOrderbook20(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetPartOrderbook100(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetPartOrderbook100(context.Background(), "")
+	_, err := ku.GetPartOrderbook100(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetPartOrderbook100(context.Background(), spotTradablePair.String())
+	result, err := ku.GetPartOrderbook100(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOrderbook(context.Background(), "")
+	_, err := ku.GetOrderbook(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetOrderbook(context.Background(), spotTradablePair.String())
+	_, err = ku.GetOrderbook(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 }
 
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetTradeHistory(context.Background(), "")
+	_, err := ku.GetTradeHistory(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	_, err = ku.GetTradeHistory(context.Background(), spotTradablePair.String())
+	_, err = ku.GetTradeHistory(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 }
 
 func TestGetKlines(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetKlines(context.Background(), "", "1week", time.Time{}, time.Time{})
+	_, err := ku.GetKlines(t.Context(), "", "1week", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.GetKlines(context.Background(), spotTradablePair.String(), "invalid-period", time.Time{}, time.Time{})
+	_, err = ku.GetKlines(t.Context(), spotTradablePair.String(), "invalid-period", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, errInvalidPeriod)
 
-	result, err := ku.GetKlines(context.Background(), spotTradablePair.String(), "1week", time.Time{}, time.Time{})
+	result, err := ku.GetKlines(t.Context(), spotTradablePair.String(), "1week", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	result, err = ku.GetKlines(context.Background(), spotTradablePair.String(), "5min", time.Now().Add(-time.Hour*1), time.Now())
+	result, err = ku.GetKlines(t.Context(), spotTradablePair.String(), "5min", time.Now().Add(-time.Hour*1), time.Now())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetCurrenciesV3(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetCurrenciesV3(context.Background())
+	_, err := ku.GetCurrenciesV3(t.Context())
 	assert.NoError(t, err)
 }
 
 func TestGetCurrencyV3(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetCurrencyDetailV3(context.Background(), currency.EMPTYCODE, "")
+	_, err := ku.GetCurrencyDetailV3(t.Context(), currency.EMPTYCODE, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	result, err := ku.GetCurrencyDetailV3(context.Background(), currency.BTC, "")
+	result, err := ku.GetCurrencyDetailV3(t.Context(), currency.BTC, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetCurrencyDetailV3(context.Background(), currency.BTC, "ETH")
+	result, err = ku.GetCurrencyDetailV3(t.Context(), currency.BTC, "ETH")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFiatPrice(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetFiatPrice(context.Background(), "", "")
+	result, err := ku.GetFiatPrice(t.Context(), "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetFiatPrice(context.Background(), "EUR", "ETH,BTC")
+	result, err = ku.GetFiatPrice(t.Context(), "EUR", "ETH,BTC")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -222,31 +222,31 @@ func TestGetFiatPrice(t *testing.T) {
 func TestGetLeveragedTokenInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetLeveragedTokenInfo(context.Background(), currency.BTC)
+	result, err := ku.GetLeveragedTokenInfo(t.Context(), currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarkPrice(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarkPrice(context.Background(), "")
+	_, err := ku.GetMarkPrice(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetMarkPrice(context.Background(), marginTradablePair.String())
+	result, err := ku.GetMarkPrice(t.Context(), marginTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetAllMarginTradingPairsMarkPrices(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetAllMarginTradingPairsMarkPrices(context.Background())
+	result, err := ku.GetAllMarginTradingPairsMarkPrices(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarginConfiguration(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetMarginConfiguration(context.Background())
+	result, err := ku.GetMarginConfiguration(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -254,7 +254,7 @@ func TestGetMarginConfiguration(t *testing.T) {
 func TestGetMarginAccount(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetMarginAccount(context.Background())
+	result, err := ku.GetMarginAccount(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -262,7 +262,7 @@ func TestGetMarginAccount(t *testing.T) {
 func TestGetCrossMarginRiskLimitCurrencyConfig(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetCrossMarginRiskLimitCurrencyConfig(context.Background(), "", currency.BTC)
+	result, err := ku.GetCrossMarginRiskLimitCurrencyConfig(t.Context(), "", currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -270,23 +270,23 @@ func TestGetCrossMarginRiskLimitCurrencyConfig(t *testing.T) {
 func TestGetIsolatedMarginRiskLimitCurrencyConfig(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetIsolatedMarginRiskLimitCurrencyConfig(context.Background(), "", currency.BTC)
+	result, err := ku.GetIsolatedMarginRiskLimitCurrencyConfig(t.Context(), "", currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestPostBorrowOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PostMarginBorrowOrder(context.Background(), &MarginBorrowParam{})
+	_, err := ku.PostMarginBorrowOrder(t.Context(), &MarginBorrowParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
-	_, err = ku.PostMarginBorrowOrder(context.Background(), &MarginBorrowParam{IsIsolated: true})
+	_, err = ku.PostMarginBorrowOrder(t.Context(), &MarginBorrowParam{IsIsolated: true})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
-	_, err = ku.PostMarginBorrowOrder(context.Background(), &MarginBorrowParam{IsIsolated: true, Currency: currency.BTC})
+	_, err = ku.PostMarginBorrowOrder(t.Context(), &MarginBorrowParam{IsIsolated: true, Currency: currency.BTC})
 	require.ErrorIs(t, err, errTimeInForceRequired)
 
-	_, err = ku.PostMarginBorrowOrder(context.Background(),
+	_, err = ku.PostMarginBorrowOrder(t.Context(),
 		&MarginBorrowParam{
 			Currency:    currency.USDT,
 			TimeInForce: "FOK",
@@ -294,7 +294,7 @@ func TestPostBorrowOrder(t *testing.T) {
 		})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostMarginBorrowOrder(context.Background(),
+	result, err := ku.PostMarginBorrowOrder(t.Context(),
 		&MarginBorrowParam{
 			Currency:    currency.USDT,
 			TimeInForce: "IOC",
@@ -306,27 +306,27 @@ func TestPostBorrowOrder(t *testing.T) {
 
 func TestGetMarginBorrowingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarginBorrowingHistory(context.Background(), currency.EMPTYCODE, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err := ku.GetMarginBorrowingHistory(t.Context(), currency.EMPTYCODE, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.GetMarginBorrowingHistory(context.Background(), currency.BTC, true, "", "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err = ku.GetMarginBorrowingHistory(t.Context(), currency.BTC, true, "", "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetMarginBorrowingHistory(context.Background(), currency.BTC, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err = ku.GetMarginBorrowingHistory(t.Context(), currency.BTC, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	assert.NoError(t, err)
 }
 
 func TestPostRepayment(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PostRepayment(context.Background(), &RepayParam{})
+	_, err := ku.PostRepayment(t.Context(), &RepayParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = ku.PostRepayment(context.Background(), &RepayParam{Size: 0.05})
+	_, err = ku.PostRepayment(t.Context(), &RepayParam{Size: 0.05})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.PostRepayment(context.Background(), &RepayParam{Currency: currency.ETH})
+	_, err = ku.PostRepayment(t.Context(), &RepayParam{Currency: currency.ETH})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostRepayment(context.Background(), &RepayParam{
+	result, err := ku.PostRepayment(t.Context(), &RepayParam{
 		Currency: currency.USDT,
 		Size:     0.05,
 	})
@@ -337,18 +337,18 @@ func TestPostRepayment(t *testing.T) {
 func TestGetCrossIsolatedMarginInterestRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetCrossIsolatedMarginInterestRecords(context.Background(), false, "", currency.BTC, time.Now().Add(-time.Hour*50), time.Now(), 0, 0)
+	result, err := ku.GetCrossIsolatedMarginInterestRecords(t.Context(), false, "", currency.BTC, time.Now().Add(-time.Hour*50), time.Now(), 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetRepaymentHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetRepaymentHistory(context.Background(), currency.EMPTYCODE, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err := ku.GetRepaymentHistory(t.Context(), currency.EMPTYCODE, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetRepaymentHistory(context.Background(), currency.BTC, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	result, err := ku.GetRepaymentHistory(t.Context(), currency.BTC, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -356,7 +356,7 @@ func TestGetRepaymentHistory(t *testing.T) {
 func TestGetIsolatedMarginPairConfig(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetIsolatedMarginPairConfig(context.Background())
+	result, err := ku.GetIsolatedMarginPairConfig(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -364,35 +364,35 @@ func TestGetIsolatedMarginPairConfig(t *testing.T) {
 func TestGetIsolatedMarginAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetIsolatedMarginAccountInfo(context.Background(), "")
+	result, err := ku.GetIsolatedMarginAccountInfo(t.Context(), "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	result, err = ku.GetIsolatedMarginAccountInfo(context.Background(), "USDT")
+	result, err = ku.GetIsolatedMarginAccountInfo(t.Context(), "USDT")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetSingleIsolatedMarginAccountInfo(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetSingleIsolatedMarginAccountInfo(context.Background(), "")
+	_, err := ku.GetSingleIsolatedMarginAccountInfo(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetSingleIsolatedMarginAccountInfo(context.Background(), spotTradablePair.String())
+	result, err := ku.GetSingleIsolatedMarginAccountInfo(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetCurrentServerTime(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetCurrentServerTime(context.Background())
+	result, err := ku.GetCurrentServerTime(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetServiceStatus(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetServiceStatus(context.Background())
+	result, err := ku.GetServiceStatus(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -401,7 +401,7 @@ func TestPostOrder(t *testing.T) {
 	t.Parallel()
 
 	// default order type is limit
-	_, err := ku.PostOrder(context.Background(), &SpotOrderParam{
+	_, err := ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: "",
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
@@ -409,31 +409,31 @@ func TestPostOrder(t *testing.T) {
 	customID, err := uuid.NewV4()
 	assert.NoError(t, err)
 
-	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
 		Size: 0.1, Side: "buy", Price: 234565,
 	})
 
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
-	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.PostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostOrder(context.Background(), &SpotOrderParam{
+	result, err := ku.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(),
 		Side:          "buy",
 		Symbol:        spotTradablePair,
@@ -449,7 +449,7 @@ func TestPostOrderTest(t *testing.T) {
 	t.Parallel()
 
 	// default order type is limit
-	_, err := ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	_, err := ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: "",
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
@@ -457,31 +457,31 @@ func TestPostOrderTest(t *testing.T) {
 	customID, err := uuid.NewV4()
 	assert.NoError(t, err)
 
-	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
 		Size: 0.1, Side: "buy", Price: 234565,
 	})
 
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
-	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	_, err = ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.PostOrderTest(context.Background(), &SpotOrderParam{
+	result, err := ku.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(),
 		Side:          "buy",
 		Symbol:        spotTradablePair,
@@ -496,7 +496,7 @@ func TestPostOrderTest(t *testing.T) {
 func TestHandlePostOrder(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
-	_, err := ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err := ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: "",
 	}, "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
@@ -504,46 +504,46 @@ func TestHandlePostOrder(t *testing.T) {
 	customID, err := uuid.NewV4()
 	assert.NoError(t, err)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair,
 		OrderType: "",
 	}, "")
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: currency.EMPTYPAIR,
 		Size: 0.1, Side: "buy", Price: 234565,
 	}, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "OCO", Size: 0.1,
 	}, "")
 	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "limit", Size: 0.1,
 	}, "")
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "limit", Size: 0, Price: 1000,
 	}, "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
 		Symbol:    spotTradablePair,
 		OrderType: "limit", Size: .1, Price: 1000, VisibleSize: -1,
 	}, "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
-	_, err = ku.HandlePostOrder(context.Background(), &SpotOrderParam{
+	_, err = ku.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
 		OrderType: "market", Price: 234565,
 	}, "")
@@ -553,27 +553,27 @@ func TestHandlePostOrder(t *testing.T) {
 func TestPostMarginOrder(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
-	_, err := ku.PostMarginOrder(context.Background(), &MarginOrderParam{
+	_, err := ku.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "",
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: currency.EMPTYPAIR,
 		Size: 0.1, Side: "buy", Price: 234565,
 	})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
 		Symbol:    marginTradablePair,
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.PostMarginOrder(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
@@ -581,7 +581,7 @@ func TestPostMarginOrder(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	// default order type is limit and margin mode is cross
-	result, err := ku.PostMarginOrder(context.Background(),
+	result, err := ku.PostMarginOrder(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
@@ -591,7 +591,7 @@ func TestPostMarginOrder(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// market isolated order
-	result, err = ku.PostMarginOrder(context.Background(),
+	result, err = ku.PostMarginOrder(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
@@ -605,27 +605,27 @@ func TestPostMarginOrder(t *testing.T) {
 func TestPostMarginOrderTest(t *testing.T) {
 	t.Parallel()
 	// default order type is limit
-	_, err := ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
+	_, err := ku.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "",
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: currency.EMPTYPAIR,
 		Size: 0.1, Side: "buy", Price: 234565,
 	})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
 		Symbol:    marginTradablePair,
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.PostMarginOrderTest(context.Background(), &MarginOrderParam{
+	_, err = ku.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
@@ -633,7 +633,7 @@ func TestPostMarginOrderTest(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	// default order type is limit and margin mode is cross
-	result, err := ku.PostMarginOrderTest(context.Background(),
+	result, err := ku.PostMarginOrderTest(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
@@ -643,7 +643,7 @@ func TestPostMarginOrderTest(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// market isolated order
-	result, err = ku.PostMarginOrderTest(context.Background(),
+	result, err = ku.PostMarginOrderTest(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
 			Side:          "buy", Symbol: marginTradablePair,
@@ -656,32 +656,32 @@ func TestPostMarginOrderTest(t *testing.T) {
 
 func TestPostBulkOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PostBulkOrder(context.Background(), "", []OrderRequest{})
+	_, err := ku.PostBulkOrder(t.Context(), "", []OrderRequest{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{})
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{})
 	require.ErrorIs(t, err, common.ErrEmptyParams)
 
 	arg := OrderRequest{
 		Size: 0.01,
 	}
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	arg.ClientOID = "3d07008668054da6b3cb12e432c2b13a"
 	arg.Size = 0
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 
 	arg.Side = "Sell"
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	arg.Price = 1000
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	_, err = ku.PostBulkOrder(context.Background(), spotTradablePair.String(), []OrderRequest{
+	_, err = ku.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{
 		{
 			ClientOID: "3d07008668054da6b3cb12e432c2b13a",
 			Side:      "buy",
@@ -702,22 +702,22 @@ func TestPostBulkOrder(t *testing.T) {
 
 func TestCancelSingleOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelSingleOrder(context.Background(), "")
+	_, err := ku.CancelSingleOrder(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelSingleOrder(context.Background(), "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelSingleOrder(t.Context(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelOrderByClientOID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelOrderByClientOID(context.Background(), "")
+	_, err := ku.CancelOrderByClientOID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelOrderByClientOID(context.Background(), "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelOrderByClientOID(t.Context(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -725,7 +725,7 @@ func TestCancelOrderByClientOID(t *testing.T) {
 func TestCancelAllOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllOpenOrders(context.Background(), "", "")
+	result, err := ku.CancelAllOpenOrders(t.Context(), "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -739,7 +739,7 @@ func TestGetOrders(t *testing.T) {
 	assert.NoError(t, err)
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 
-	result, err := ku.ListOrders(context.Background(), "", "", "", "", "", time.Time{}, time.Time{})
+	result, err := ku.ListOrders(t.Context(), "", "", "", "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -747,29 +747,29 @@ func TestGetOrders(t *testing.T) {
 func TestGetRecentOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetRecentOrders(context.Background())
+	result, err := ku.GetRecentOrders(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOrderByID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOrderByID(context.Background(), "")
+	_, err := ku.GetOrderByID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetOrderByID(context.Background(), "5c35c02703aa673ceec2a168")
+	result, err := ku.GetOrderByID(t.Context(), "5c35c02703aa673ceec2a168")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOrderByClientOID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOrderByClientSuppliedOrderID(context.Background(), "")
+	_, err := ku.GetOrderByClientSuppliedOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetOrderByClientSuppliedOrderID(context.Background(), "6d539dc614db312")
+	result, err := ku.GetOrderByClientSuppliedOrderID(t.Context(), "6d539dc614db312")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -777,11 +777,11 @@ func TestGetOrderByClientOID(t *testing.T) {
 func TestGetFills(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFills(context.Background(), "", "", "", "", "", time.Time{}, time.Time{})
+	result, err := ku.GetFills(t.Context(), "", "", "", "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetFills(context.Background(), "5c35c02703aa673ceec2a168", spotTradablePair.String(), "buy", "limit", SpotTradeType, time.Now().Add(-time.Hour*12), time.Now())
+	result, err = ku.GetFills(t.Context(), "5c35c02703aa673ceec2a168", spotTradablePair.String(), "buy", "limit", SpotTradeType, time.Now().Add(-time.Hour*12), time.Now())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -795,44 +795,44 @@ func TestGetRecentFills(t *testing.T) {
 	assert.NoError(t, err)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetRecentFills(context.Background())
+	result, err := ku.GetRecentFills(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestPostStopOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PostStopOrder(context.Background(), "", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	_, err := ku.PostStopOrder(t.Context(), "", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.PostStopOrder(context.Background(), "5bd6e9286d99522a52e458de", "", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	_, err = ku.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostStopOrder(context.Background(), "5bd6e9286d99522a52e458de", "buy", "", "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	_, err = ku.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "buy", "", "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostStopOrder(context.Background(), "5bd6e9286d99522a52e458de", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	result, err := ku.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelStopOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelStopOrder(context.Background(), "")
+	_, err := ku.CancelStopOrder(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelStopOrder(context.Background(), "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelStopOrder(t.Context(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelStopOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelStopOrderByClientOrderID(context.Background(), "", spotTradablePair.String())
+	_, err := ku.CancelStopOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelStopOrderByClientOrderID(context.Background(), "5bd6e9286d99522a52e458de", spotTradablePair.String())
+	result, err := ku.CancelStopOrderByClientOrderID(t.Context(), "5bd6e9286d99522a52e458de", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -840,7 +840,7 @@ func TestCancelStopOrderByClientOrderID(t *testing.T) {
 func TestCancelAllStopOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelStopOrders(context.Background(), "", "", []string{})
+	result, err := ku.CancelStopOrders(t.Context(), "", "", []string{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -852,11 +852,11 @@ func TestGetStopOrder(t *testing.T) {
 	var resp *StopOrder
 	err := json.Unmarshal([]byte(stopOrderResponseJSON), &resp)
 	assert.NoError(t, err)
-	_, err = ku.GetStopOrder(context.Background(), "")
+	_, err = ku.GetStopOrder(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetStopOrder(context.Background(), "5bd6e9286d99522a52e458de")
+	result, err := ku.GetStopOrder(t.Context(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -864,29 +864,29 @@ func TestGetStopOrder(t *testing.T) {
 func TestGetAllStopOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.ListStopOrders(context.Background(), "", "", "", "", []string{}, time.Time{}, time.Time{}, 0, 0)
+	result, err := ku.ListStopOrders(t.Context(), "", "", "", "", []string{}, time.Time{}, time.Time{}, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetStopOrderByClientID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetStopOrderByClientID(context.Background(), "", "")
+	_, err := ku.GetStopOrderByClientID(t.Context(), "", "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetStopOrderByClientID(context.Background(), "", "5bd6e9286d99522a52e458de")
+	result, err := ku.GetStopOrderByClientID(t.Context(), "", "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelStopOrderByClientID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelStopOrderByClientID(context.Background(), "", "")
+	_, err := ku.CancelStopOrderByClientID(t.Context(), "", "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelStopOrderByClientID(context.Background(), "", "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelStopOrderByClientID(t.Context(), "", "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -894,18 +894,18 @@ func TestCancelStopOrderByClientID(t *testing.T) {
 func TestGetAllAccounts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAllAccounts(context.Background(), currency.EMPTYCODE, "")
+	result, err := ku.GetAllAccounts(t.Context(), currency.EMPTYCODE, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetAccount(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetAccountDetail(context.Background(), "")
+	_, err := ku.GetAccountDetail(t.Context(), "")
 	require.ErrorIs(t, err, errAccountIDMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAccountDetail(context.Background(), "62fcd1969474ea0001fd20e4")
+	result, err := ku.GetAccountDetail(t.Context(), "62fcd1969474ea0001fd20e4")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -913,7 +913,7 @@ func TestGetAccount(t *testing.T) {
 func TestGetCrossMarginAccountsDetail(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetCrossMarginAccountsDetail(context.Background(), "KCS", "MARGIN_V2")
+	result, err := ku.GetCrossMarginAccountsDetail(t.Context(), "KCS", "MARGIN_V2")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -921,7 +921,7 @@ func TestGetCrossMarginAccountsDetail(t *testing.T) {
 func TestGetIsolatedMarginAccountDetail(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetIsolatedMarginAccountDetail(context.Background(), marginTradablePair.String(), "BTC", "")
+	result, err := ku.GetIsolatedMarginAccountDetail(t.Context(), marginTradablePair.String(), "BTC", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -929,18 +929,18 @@ func TestGetIsolatedMarginAccountDetail(t *testing.T) {
 func TestGetFuturesAccountDetail(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesAccountDetail(context.Background(), currency.USDT)
+	result, err := ku.GetFuturesAccountDetail(t.Context(), currency.USDT)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetSubAccounts(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetSubAccounts(context.Background(), "", false)
+	_, err := ku.GetSubAccounts(t.Context(), "", false)
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetSubAccounts(context.Background(), "5caefba7d9575a0688f83c45", false)
+	result, err := ku.GetSubAccounts(t.Context(), "5caefba7d9575a0688f83c45", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -948,7 +948,7 @@ func TestGetSubAccounts(t *testing.T) {
 func TestGetAllFuturesSubAccountBalances(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAllFuturesSubAccountBalances(context.Background(), currency.BTC)
+	result, err := ku.GetAllFuturesSubAccountBalances(t.Context(), currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -961,11 +961,11 @@ func TestGetAccountLedgers(t *testing.T) {
 	err := json.Unmarshal([]byte(accountLedgerResponseJSON), &resp)
 	assert.NoError(t, err)
 
-	_, err = ku.GetAccountLedgers(context.Background(), currency.EMPTYCODE, "", "", time.Now(), time.Now().Add(-time.Hour*24*10))
+	_, err = ku.GetAccountLedgers(t.Context(), currency.EMPTYCODE, "", "", time.Now(), time.Now().Add(-time.Hour*24*10))
 	require.ErrorIs(t, err, common.ErrStartAfterEnd)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAccountLedgers(context.Background(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{})
+	result, err := ku.GetAccountLedgers(t.Context(), currency.EMPTYCODE, "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -973,14 +973,14 @@ func TestGetAccountLedgers(t *testing.T) {
 func TestGetAccountLedgersHFTrade(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err := ku.GetAccountLedgersHFTrade(context.Background(), currency.BTC, "", "", 0, 10, time.Time{}, time.Now())
+	_, err := ku.GetAccountLedgersHFTrade(t.Context(), currency.BTC, "", "", 0, 10, time.Time{}, time.Now())
 	assert.NoError(t, err)
 }
 
 func TestGetAccountLedgerHFMargin(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAccountLedgerHFMargin(context.Background(), currency.BTC, "", "", 0, 0, time.Time{}, time.Time{})
+	result, err := ku.GetAccountLedgerHFMargin(t.Context(), currency.BTC, "", "", 0, 0, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -988,7 +988,7 @@ func TestGetAccountLedgerHFMargin(t *testing.T) {
 func TestGetFuturesAccountLedgers(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesAccountLedgers(context.Background(), currency.BTC, true, time.Time{}, time.Now(), 0, 100)
+	result, err := ku.GetFuturesAccountLedgers(t.Context(), currency.BTC, true, time.Time{}, time.Now(), 0, 100)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -996,7 +996,7 @@ func TestGetFuturesAccountLedgers(t *testing.T) {
 func TestGetAllSubAccountsInfoV1(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAllSubAccountsInfoV1(context.Background())
+	result, err := ku.GetAllSubAccountsInfoV1(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1004,7 +1004,7 @@ func TestGetAllSubAccountsInfoV1(t *testing.T) {
 func TestGetAllSubAccountsInfoV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAllSubAccountsInfoV2(context.Background(), 0, 30)
+	result, err := ku.GetAllSubAccountsInfoV2(t.Context(), 0, 30)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1012,7 +1012,7 @@ func TestGetAllSubAccountsInfoV2(t *testing.T) {
 func TestGetAccountSummaryInformation(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAccountSummaryInformation(context.Background())
+	result, err := ku.GetAccountSummaryInformation(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1020,7 +1020,7 @@ func TestGetAccountSummaryInformation(t *testing.T) {
 func TestGetAggregatedSubAccountBalance(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAggregatedSubAccountBalance(context.Background())
+	result, err := ku.GetAggregatedSubAccountBalance(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1028,7 +1028,7 @@ func TestGetAggregatedSubAccountBalance(t *testing.T) {
 func TestGetAllSubAccountsBalanceV2(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAllSubAccountsBalanceV2(context.Background())
+	result, err := ku.GetAllSubAccountsBalanceV2(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1036,53 +1036,53 @@ func TestGetAllSubAccountsBalanceV2(t *testing.T) {
 func TestGetPaginatedSubAccountInformation(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetPaginatedSubAccountInformation(context.Background(), 0, 10)
+	result, err := ku.GetPaginatedSubAccountInformation(t.Context(), 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetTransferableBalance(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetTransferableBalance(context.Background(), currency.EMPTYCODE, "MAIN", "")
+	_, err := ku.GetTransferableBalance(t.Context(), currency.EMPTYCODE, "MAIN", "")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.GetTransferableBalance(context.Background(), currency.BTC, "", "")
+	_, err = ku.GetTransferableBalance(t.Context(), currency.BTC, "", "")
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetTransferableBalance(context.Background(), currency.BTC, "MAIN", "")
+	result, err := ku.GetTransferableBalance(t.Context(), currency.BTC, "MAIN", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetUniversalTransfer(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetUniversalTransfer(context.Background(), &UniversalTransferParam{})
+	_, err := ku.GetUniversalTransfer(t.Context(), &UniversalTransferParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	arg := &UniversalTransferParam{
 		ToAccountTag: "1234",
 	}
-	_, err = ku.GetUniversalTransfer(context.Background(), arg)
+	_, err = ku.GetUniversalTransfer(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	arg.ClientSuppliedOrderID = "64ccc0f164781800010d8c09"
-	_, err = ku.GetUniversalTransfer(context.Background(), arg)
+	_, err = ku.GetUniversalTransfer(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	arg.Amount = 1
-	_, err = ku.GetUniversalTransfer(context.Background(), arg)
+	_, err = ku.GetUniversalTransfer(t.Context(), arg)
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	arg.FromAccountType = "MAIN"
-	_, err = ku.GetUniversalTransfer(context.Background(), arg)
+	_, err = ku.GetUniversalTransfer(t.Context(), arg)
 	require.ErrorIs(t, err, errTransferTypeMissing)
 
 	arg.TransferType = "INTERNAL"
-	_, err = ku.GetUniversalTransfer(context.Background(), arg)
+	_, err = ku.GetUniversalTransfer(t.Context(), arg)
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.GetUniversalTransfer(context.Background(), &UniversalTransferParam{
+	result, err := ku.GetUniversalTransfer(t.Context(), &UniversalTransferParam{
 		ClientSuppliedOrderID: "64ccc0f164781800010d8c09",
 		TransferType:          "INTERNAL",
 		Currency:              currency.BTC,
@@ -1093,7 +1093,7 @@ func TestGetUniversalTransfer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetUniversalTransfer(context.Background(), &UniversalTransferParam{
+	result, err = ku.GetUniversalTransfer(t.Context(), &UniversalTransferParam{
 		ClientSuppliedOrderID: "64ccc0f164781800010d8c09",
 		TransferType:          "PARENT_TO_SUB",
 		Currency:              currency.BTC,
@@ -1108,53 +1108,53 @@ func TestGetUniversalTransfer(t *testing.T) {
 
 func TestTransferMainToSubAccount(t *testing.T) {
 	t.Parallel()
-	_, err := ku.TransferMainToSubAccount(context.Background(), currency.EMPTYCODE, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
+	_, err := ku.TransferMainToSubAccount(t.Context(), currency.EMPTYCODE, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.TransferMainToSubAccount(context.Background(), currency.BTC, 1, "", "OUT", "", "", "5caefba7d9575a0688f83c45")
+	_, err = ku.TransferMainToSubAccount(t.Context(), currency.BTC, 1, "", "OUT", "", "", "5caefba7d9575a0688f83c45")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.TransferMainToSubAccount(context.Background(), currency.BTC, 0, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
+	_, err = ku.TransferMainToSubAccount(t.Context(), currency.BTC, 0, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.TransferMainToSubAccount(context.Background(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "", "", "", "5caefba7d9575a0688f83c45")
+	_, err = ku.TransferMainToSubAccount(t.Context(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "", "", "", "5caefba7d9575a0688f83c45")
 	require.ErrorIs(t, err, errTransferDirectionRequired)
-	_, err = ku.TransferMainToSubAccount(context.Background(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "")
+	_, err = ku.TransferMainToSubAccount(t.Context(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "")
 	require.ErrorIs(t, err, errSubUserIDRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.TransferMainToSubAccount(context.Background(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
+	result, err := ku.TransferMainToSubAccount(t.Context(), currency.BTC, 1, "62fcd1969474ea0001fd20e4", "OUT", "", "", "5caefba7d9575a0688f83c45")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestMakeInnerTransfer(t *testing.T) {
 	t.Parallel()
-	_, err := ku.MakeInnerTransfer(context.Background(), 0, currency.EMPTYCODE, "62fcd1969474ea0001fd20e4", "trade", "main", "1", "")
+	_, err := ku.MakeInnerTransfer(t.Context(), 0, currency.EMPTYCODE, "62fcd1969474ea0001fd20e4", "trade", "main", "1", "")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.MakeInnerTransfer(context.Background(), 0, currency.USDT, "", "trade", "main", "1", "")
+	_, err = ku.MakeInnerTransfer(t.Context(), 0, currency.USDT, "", "trade", "main", "1", "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.MakeInnerTransfer(context.Background(), 0, currency.USDT, "62fcd1969474ea0001fd20e4", "", "main", "", "")
+	_, err = ku.MakeInnerTransfer(t.Context(), 0, currency.USDT, "62fcd1969474ea0001fd20e4", "", "main", "", "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.MakeInnerTransfer(context.Background(), 1, currency.USDT, "62fcd1969474ea0001fd20e4", "", "main", "", "")
+	_, err = ku.MakeInnerTransfer(t.Context(), 1, currency.USDT, "62fcd1969474ea0001fd20e4", "", "main", "", "")
 	require.ErrorIs(t, err, errAccountTypeMissing)
-	_, err = ku.MakeInnerTransfer(context.Background(), 5, currency.USDT, "62fcd1969474ea0001fd20e4", "margin_hf", "", "", "")
+	_, err = ku.MakeInnerTransfer(t.Context(), 5, currency.USDT, "62fcd1969474ea0001fd20e4", "margin_hf", "", "", "")
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.MakeInnerTransfer(context.Background(), 10, currency.USDT, "62fcd1969474ea0001fd20e4", "main", "trade_hf", "", "")
+	result, err := ku.MakeInnerTransfer(t.Context(), 10, currency.USDT, "62fcd1969474ea0001fd20e4", "main", "trade_hf", "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestTransferToMainOrTradeAccount(t *testing.T) {
 	t.Parallel()
-	_, err := ku.TransferToMainOrTradeAccount(context.Background(), &FundTransferFuturesParam{})
+	_, err := ku.TransferToMainOrTradeAccount(t.Context(), &FundTransferFuturesParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = ku.TransferToMainOrTradeAccount(context.Background(), &FundTransferFuturesParam{RecieveAccountType: "MAIN"})
+	_, err = ku.TransferToMainOrTradeAccount(t.Context(), &FundTransferFuturesParam{RecieveAccountType: "MAIN"})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.TransferToMainOrTradeAccount(context.Background(), &FundTransferFuturesParam{Amount: 1, RecieveAccountType: "MAIN"})
+	_, err = ku.TransferToMainOrTradeAccount(t.Context(), &FundTransferFuturesParam{Amount: 1, RecieveAccountType: "MAIN"})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.TransferToMainOrTradeAccount(context.Background(), &FundTransferFuturesParam{
+	result, err := ku.TransferToMainOrTradeAccount(t.Context(), &FundTransferFuturesParam{
 		Amount:             1,
 		Currency:           currency.USDT,
 		RecieveAccountType: SpotTradeType,
@@ -1165,15 +1165,15 @@ func TestTransferToMainOrTradeAccount(t *testing.T) {
 
 func TestTransferToFuturesAccount(t *testing.T) {
 	t.Parallel()
-	_, err := ku.TransferToFuturesAccount(context.Background(), &FundTransferToFuturesParam{})
+	_, err := ku.TransferToFuturesAccount(t.Context(), &FundTransferToFuturesParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = ku.TransferToFuturesAccount(context.Background(), &FundTransferToFuturesParam{PaymentAccountType: "Main"})
+	_, err = ku.TransferToFuturesAccount(t.Context(), &FundTransferToFuturesParam{PaymentAccountType: "Main"})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.TransferToFuturesAccount(context.Background(), &FundTransferToFuturesParam{PaymentAccountType: "Main", Amount: 12})
+	_, err = ku.TransferToFuturesAccount(t.Context(), &FundTransferToFuturesParam{PaymentAccountType: "Main", Amount: 12})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.TransferToFuturesAccount(context.Background(), &FundTransferToFuturesParam{
+	result, err := ku.TransferToFuturesAccount(t.Context(), &FundTransferToFuturesParam{
 		Amount:             60,
 		Currency:           currency.USDT,
 		PaymentAccountType: SpotTradeType,
@@ -1185,24 +1185,24 @@ func TestTransferToFuturesAccount(t *testing.T) {
 func TestGetFuturesTransferOutRequestRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesTransferOutRequestRecords(context.Background(), time.Time{}, time.Now(), "", "", currency.BTC, 0, 10)
+	result, err := ku.GetFuturesTransferOutRequestRecords(t.Context(), time.Time{}, time.Now(), "", "", currency.BTC, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCreateDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CreateDepositAddress(context.Background(), &DepositAddressParams{})
+	_, err := ku.CreateDepositAddress(t.Context(), &DepositAddressParams{})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CreateDepositAddress(context.Background(), &DepositAddressParams{
+	result, err := ku.CreateDepositAddress(t.Context(), &DepositAddressParams{
 		Currency: currency.BTC,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.CreateDepositAddress(context.Background(),
+	result, err = ku.CreateDepositAddress(t.Context(),
 		&DepositAddressParams{
 			Currency: currency.USDT,
 			Chain:    "TRC20",
@@ -1213,22 +1213,22 @@ func TestCreateDepositAddress(t *testing.T) {
 
 func TestGetDepositAddressV2(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetDepositAddressesV2(context.Background(), currency.EMPTYCODE)
+	_, err := ku.GetDepositAddressesV2(t.Context(), currency.EMPTYCODE)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetDepositAddressesV2(context.Background(), currency.BTC)
+	result, err := ku.GetDepositAddressesV2(t.Context(), currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetDepositAddressesV1(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetDepositAddressV1(context.Background(), currency.EMPTYCODE, "")
+	_, err := ku.GetDepositAddressV1(t.Context(), currency.EMPTYCODE, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetDepositAddressV1(context.Background(), currency.BTC, "")
+	result, err := ku.GetDepositAddressV1(t.Context(), currency.BTC, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1242,7 +1242,7 @@ func TestGetDepositList(t *testing.T) {
 	assert.NoError(t, err)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetDepositList(context.Background(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
+	result, err := ku.GetDepositList(t.Context(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1256,7 +1256,7 @@ func TestGetHistoricalDepositList(t *testing.T) {
 	assert.NoError(t, err)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHistoricalDepositList(context.Background(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
+	result, err := ku.GetHistoricalDepositList(t.Context(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1264,7 +1264,7 @@ func TestGetHistoricalDepositList(t *testing.T) {
 func TestGetWithdrawalList(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetWithdrawalList(context.Background(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
+	result, err := ku.GetWithdrawalList(t.Context(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1272,58 +1272,58 @@ func TestGetWithdrawalList(t *testing.T) {
 func TestGetHistoricalWithdrawalList(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHistoricalWithdrawalList(context.Background(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
+	result, err := ku.GetHistoricalWithdrawalList(t.Context(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetWithdrawalQuotas(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetWithdrawalQuotas(context.Background(), currency.EMPTYCODE, "")
+	_, err := ku.GetWithdrawalQuotas(t.Context(), currency.EMPTYCODE, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetWithdrawalQuotas(context.Background(), currency.BTC, "")
+	result, err := ku.GetWithdrawalQuotas(t.Context(), currency.BTC, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestApplyWithdrawal(t *testing.T) {
 	t.Parallel()
-	_, err := ku.ApplyWithdrawal(context.Background(), currency.EMPTYCODE, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 1)
+	_, err := ku.ApplyWithdrawal(t.Context(), currency.EMPTYCODE, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 1)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.ApplyWithdrawal(context.Background(), currency.ETH, "", "", "", "", "", false, 1)
+	_, err = ku.ApplyWithdrawal(t.Context(), currency.ETH, "", "", "", "", "", false, 1)
 	require.ErrorIs(t, err, errAddressRequired)
-	_, err = ku.ApplyWithdrawal(context.Background(), currency.ETH, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 0)
+	_, err = ku.ApplyWithdrawal(t.Context(), currency.ETH, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 0)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.ApplyWithdrawal(context.Background(), currency.ETH, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 1)
+	result, err := ku.ApplyWithdrawal(t.Context(), currency.ETH, "0x597873884BC3a6C10cB6Eb7C69172028Fa85B25A", "", "", "", "", false, 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelWithdrawal(t *testing.T) {
 	t.Parallel()
-	err := ku.CancelWithdrawal(context.Background(), "")
+	err := ku.CancelWithdrawal(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	err = ku.CancelWithdrawal(context.Background(), "5bffb63303aa675e8bbe18f9")
+	err = ku.CancelWithdrawal(t.Context(), "5bffb63303aa675e8bbe18f9")
 	assert.NoError(t, err)
 }
 
 func TestGetBasicFee(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetBasicFee(context.Background(), "1")
+	result, err := ku.GetBasicFee(t.Context(), "1")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetTradingFee(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetTradingFee(context.Background(), nil)
+	_, err := ku.GetTradingFee(t.Context(), nil)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairsEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
@@ -1332,7 +1332,7 @@ func TestGetTradingFee(t *testing.T) {
 	assert.NotEmpty(t, avail)
 
 	pairs := currency.Pairs{avail[0]}
-	btcusdTradingFee, err := ku.GetTradingFee(context.Background(), pairs)
+	btcusdTradingFee, err := ku.GetTradingFee(t.Context(), pairs)
 	assert.NoErrorf(t, err, "received %v, expected %v", err, nil)
 	assert.Len(t, btcusdTradingFee, 1)
 
@@ -1340,11 +1340,11 @@ func TestGetTradingFee(t *testing.T) {
 	// the allowed pairs. If this does not error then this endpoint will allow
 	// more items to be requested.
 	pairs = append(pairs, avail[1:10]...)
-	result, err := ku.GetTradingFee(context.Background(), pairs)
+	result, err := ku.GetTradingFee(t.Context(), pairs)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	got, err := ku.GetTradingFee(context.Background(), pairs[:10])
+	got, err := ku.GetTradingFee(t.Context(), pairs[:10])
 	assert.NoError(t, err)
 	assert.Len(t, got, 10)
 }
@@ -1352,27 +1352,27 @@ func TestGetTradingFee(t *testing.T) {
 // futures
 func TestGetFuturesOpenContracts(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetFuturesOpenContracts(context.Background())
+	result, err := ku.GetFuturesOpenContracts(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesContract(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesContract(context.Background(), "")
+	_, err := ku.GetFuturesContract(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesContract(context.Background(), "XBTUSDTM")
+	result, err := ku.GetFuturesContract(t.Context(), "XBTUSDTM")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesTicker(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesTicker(context.Background(), "")
+	_, err := ku.GetFuturesTicker(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	tick, err := ku.GetFuturesTicker(context.Background(), "XBTUSDTM")
+	tick, err := ku.GetFuturesTicker(t.Context(), "XBTUSDTM")
 	if assert.NoError(t, err) {
 		assert.Positive(t, tick.Sequence, "Sequence should be positive")
 		assert.Equal(t, "XBTUSDTM", tick.Symbol)
@@ -1390,78 +1390,78 @@ func TestGetFuturesTicker(t *testing.T) {
 
 func TestGetFuturesOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesOrderbook(context.Background(), "")
+	_, err := ku.GetFuturesOrderbook(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesOrderbook(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesOrderbook(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPartOrderbook20(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPartOrderbook20(context.Background(), "")
+	_, err := ku.GetFuturesPartOrderbook20(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesPartOrderbook20(context.Background(), "XBTUSDTM")
+	result, err := ku.GetFuturesPartOrderbook20(t.Context(), "XBTUSDTM")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPartOrderbook100(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPartOrderbook100(context.Background(), "")
+	_, err := ku.GetFuturesPartOrderbook100(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesPartOrderbook100(context.Background(), "XBTUSDTM")
+	result, err := ku.GetFuturesPartOrderbook100(t.Context(), "XBTUSDTM")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesTradeHistory(context.Background(), "")
+	_, err := ku.GetFuturesTradeHistory(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesTradeHistory(context.Background(), "XBTUSDTM")
+	result, err := ku.GetFuturesTradeHistory(t.Context(), "XBTUSDTM")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesInterestRate(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesInterestRate(context.Background(), "", time.Time{}, time.Time{}, false, false, 0, 0)
+	_, err := ku.GetFuturesInterestRate(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	result, err := ku.GetFuturesInterestRate(context.Background(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
+	result, err := ku.GetFuturesInterestRate(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesIndexList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesIndexList(context.Background(), "", time.Time{}, time.Time{}, false, false, 0, 10)
+	_, err := ku.GetFuturesIndexList(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 10)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	result, err := ku.GetFuturesIndexList(context.Background(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 10)
+	result, err := ku.GetFuturesIndexList(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesCurrentMarkPrice(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesCurrentMarkPrice(context.Background(), "")
+	_, err := ku.GetFuturesCurrentMarkPrice(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesCurrentMarkPrice(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesCurrentMarkPrice(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPremiumIndex(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPremiumIndex(context.Background(), "", time.Time{}, time.Time{}, false, false, 0, 0)
+	_, err := ku.GetFuturesPremiumIndex(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesPremiumIndex(context.Background(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
+	result, err := ku.GetFuturesPremiumIndex(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1469,85 +1469,85 @@ func TestGetFuturesPremiumIndex(t *testing.T) {
 func TestGet24HourFuturesTransactionVolume(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	resp, err := ku.Get24HourFuturesTransactionVolume(context.Background())
+	resp, err := ku.Get24HourFuturesTransactionVolume(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 }
 
 func TestGetFuturesCurrentFundingRate(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesCurrentFundingRate(context.Background(), "")
+	_, err := ku.GetFuturesCurrentFundingRate(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesCurrentFundingRate(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesCurrentFundingRate(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetPublicFundingRate(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetPublicFundingRate(context.Background(), "", time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
+	_, err := ku.GetPublicFundingRate(t.Context(), "", time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetPublicFundingRate(context.Background(), futuresTradablePair.String(), time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
+	result, err := ku.GetPublicFundingRate(t.Context(), futuresTradablePair.String(), time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesServerTime(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetFuturesServerTime(context.Background())
+	result, err := ku.GetFuturesServerTime(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesServiceStatus(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetFuturesServiceStatus(context.Background())
+	result, err := ku.GetFuturesServiceStatus(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesKline(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesKline(context.Background(), 0, "XBTUSDTM", time.Time{}, time.Time{})
+	_, err := ku.GetFuturesKline(t.Context(), 0, "XBTUSDTM", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, kline.ErrInvalidInterval)
-	_, err = ku.GetFuturesKline(context.Background(), int64(kline.ThirtyMin.Duration().Seconds()), futuresTradablePair.String(), time.Time{}, time.Time{})
+	_, err = ku.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Seconds()), futuresTradablePair.String(), time.Time{}, time.Time{})
 	require.ErrorIs(t, err, kline.ErrUnsupportedInterval)
-	_, err = ku.GetFuturesKline(context.Background(), int64(kline.ThirtyMin.Duration().Minutes()), "", time.Time{}, time.Time{})
+	_, err = ku.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Minutes()), "", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := ku.GetFuturesKline(context.Background(), int64(kline.ThirtyMin.Duration().Minutes()), futuresTradablePair.String(), time.Time{}, time.Time{})
+	result, err := ku.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Minutes()), futuresTradablePair.String(), time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestPostFuturesOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy"})
+	_, err := ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy"})
 	require.ErrorIs(t, err, errInvalidLeverage)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{Side: "buy", Leverage: 1})
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{Side: "buy", Leverage: 1})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Leverage: 1})
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Leverage: 1})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Leverage: 1})
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Leverage: 1})
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	// With Stop order configuration
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, errInvalidStopPriceType)
 
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	result, err := ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
@@ -1555,14 +1555,14 @@ func TestPostFuturesOrder(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// Limit Orders
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
 		OrderType: "limit", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	result, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	result, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
 		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
@@ -1570,18 +1570,18 @@ func TestPostFuturesOrder(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// Market Orders
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
 		OrderType: "market", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	_, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
 		Size: 1, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
-	result, err = ku.PostFuturesOrder(context.Background(), &FuturesOrderParam{
+	result, err = ku.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de",
 		Side:          "buy",
 		Symbol:        futuresTradablePair,
@@ -1677,7 +1677,7 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 func TestPostFuturesOrderTest(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	response, err := ku.PostFuturesOrderTest(context.Background(), &FuturesOrderParam{
+	response, err := ku.PostFuturesOrderTest(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de",
 		Side:          "buy",
 		Symbol:        futuresTradablePair,
@@ -1697,11 +1697,11 @@ func TestPostFuturesOrderTest(t *testing.T) {
 
 func TestPlaceMultipleFuturesOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PlaceMultipleFuturesOrders(context.Background(), []FuturesOrderParam{})
+	_, err := ku.PlaceMultipleFuturesOrders(t.Context(), []FuturesOrderParam{})
 	require.ErrorIs(t, err, common.ErrEmptyParams)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PlaceMultipleFuturesOrders(context.Background(), []FuturesOrderParam{
+	result, err := ku.PlaceMultipleFuturesOrders(t.Context(), []FuturesOrderParam{
 		{
 			ClientOrderID: "5c52e11203aa677f33e491",
 			Side:          "buy",
@@ -1727,24 +1727,24 @@ func TestPlaceMultipleFuturesOrders(t *testing.T) {
 
 func TestCancelFuturesOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelFuturesOrderByOrderID(context.Background(), "")
+	_, err := ku.CancelFuturesOrderByOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelFuturesOrderByOrderID(context.Background(), "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelFuturesOrderByOrderID(t.Context(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelFuturesOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelFuturesOrderByClientOrderID(context.Background(), "", "")
+	_, err := ku.CancelFuturesOrderByClientOrderID(t.Context(), "", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.CancelFuturesOrderByClientOrderID(context.Background(), futuresTradablePair.String(), "")
+	_, err = ku.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair.String(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelFuturesOrderByClientOrderID(context.Background(), futuresTradablePair.String(), "5bd6e9286d99522a52e458de")
+	result, err := ku.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair.String(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1752,7 +1752,7 @@ func TestCancelFuturesOrderByClientOrderID(t *testing.T) {
 func TestCancelAllFuturesOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelMultipleFuturesLimitOrders(context.Background(), futuresTradablePair.String())
+	result, err := ku.CancelMultipleFuturesLimitOrders(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1760,7 +1760,7 @@ func TestCancelAllFuturesOpenOrders(t *testing.T) {
 func TestCancelAllFuturesStopOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllFuturesStopOrders(context.Background(), futuresTradablePair.String())
+	result, err := ku.CancelAllFuturesStopOrders(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1768,7 +1768,7 @@ func TestCancelAllFuturesStopOrders(t *testing.T) {
 func TestGetFuturesOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesOrders(context.Background(), "", "", "", "", time.Time{}, time.Time{})
+	result, err := ku.GetFuturesOrders(t.Context(), "", "", "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1776,7 +1776,7 @@ func TestGetFuturesOrders(t *testing.T) {
 func TestGetUntriggeredFuturesStopOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetUntriggeredFuturesStopOrders(context.Background(), "", "", "", time.Time{}, time.Time{})
+	result, err := ku.GetUntriggeredFuturesStopOrders(t.Context(), "", "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1784,29 +1784,29 @@ func TestGetUntriggeredFuturesStopOrders(t *testing.T) {
 func TestGetFuturesRecentCompletedOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesRecentCompletedOrders(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesRecentCompletedOrders(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesOrderDetails(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesOrderDetails(context.Background(), "", "")
+	_, err := ku.GetFuturesOrderDetails(t.Context(), "", "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesOrderDetails(context.Background(), "5cdfc138b21023a909e5ad55", "2212332")
+	result, err := ku.GetFuturesOrderDetails(t.Context(), "5cdfc138b21023a909e5ad55", "2212332")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesOrderDetailsByClientID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesOrderDetailsByClientOrderID(context.Background(), "")
+	_, err := ku.GetFuturesOrderDetailsByClientOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesOrderDetailsByClientOrderID(context.Background(), "eresc138b21023a909e5ad59")
+	result, err := ku.GetFuturesOrderDetailsByClientOrderID(t.Context(), "eresc138b21023a909e5ad59")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1814,7 +1814,7 @@ func TestGetFuturesOrderDetailsByClientID(t *testing.T) {
 func TestGetFuturesFills(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesFills(context.Background(), "", "", "", "", time.Time{}, time.Time{})
+	result, err := ku.GetFuturesFills(t.Context(), "", "", "", "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1822,29 +1822,29 @@ func TestGetFuturesFills(t *testing.T) {
 func TestGetFuturesRecentFills(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesRecentFills(context.Background())
+	result, err := ku.GetFuturesRecentFills(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesOpenOrderStats(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesOpenOrderStats(context.Background(), "")
+	_, err := ku.GetFuturesOpenOrderStats(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesOpenOrderStats(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesOpenOrderStats(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPosition(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPosition(context.Background(), "")
+	_, err := ku.GetFuturesPosition(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesPosition(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesPosition(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1852,44 +1852,44 @@ func TestGetFuturesPosition(t *testing.T) {
 func TestGetFuturesPositionList(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesPositionList(context.Background())
+	result, err := ku.GetFuturesPositionList(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSetAutoDepositMargin(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SetAutoDepositMargin(context.Background(), "", true)
+	_, err := ku.SetAutoDepositMargin(t.Context(), "", true)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SetAutoDepositMargin(context.Background(), futuresTradablePair.String(), true)
+	result, err := ku.SetAutoDepositMargin(t.Context(), futuresTradablePair.String(), true)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMaxWithdrawMargin(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMaxWithdrawMargin(context.Background(), "")
+	_, err := ku.GetMaxWithdrawMargin(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetMaxWithdrawMargin(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetMaxWithdrawMargin(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestRemoveMarginManually(t *testing.T) {
 	t.Parallel()
-	_, err := ku.RemoveMarginManually(context.Background(), &WithdrawMarginResponse{})
+	_, err := ku.RemoveMarginManually(t.Context(), &WithdrawMarginResponse{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
-	_, err = ku.RemoveMarginManually(context.Background(), &WithdrawMarginResponse{
+	_, err = ku.RemoveMarginManually(t.Context(), &WithdrawMarginResponse{
 		WithdrawAmount: 1,
 	})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.RemoveMarginManually(context.Background(), &WithdrawMarginResponse{
+	result, err := ku.RemoveMarginManually(t.Context(), &WithdrawMarginResponse{
 		Symbol:         "ADAUSDTM",
 		WithdrawAmount: 1,
 	})
@@ -1899,44 +1899,44 @@ func TestRemoveMarginManually(t *testing.T) {
 
 func TestAddMargin(t *testing.T) {
 	t.Parallel()
-	_, err := ku.AddMargin(context.Background(), "", "6200c9b83aecfb000152dasfdee", 1)
+	_, err := ku.AddMargin(t.Context(), "", "6200c9b83aecfb000152dasfdee", 1)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.AddMargin(context.Background(), futuresTradablePair.String(), "6200c9b83aecfb000152dasfdee", 1)
+	result, err := ku.AddMargin(t.Context(), futuresTradablePair.String(), "6200c9b83aecfb000152dasfdee", 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesRiskLimitLevel(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesRiskLimitLevel(context.Background(), "")
+	_, err := ku.GetFuturesRiskLimitLevel(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesRiskLimitLevel(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesRiskLimitLevel(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestUpdateRiskLmitLevel(t *testing.T) {
 	t.Parallel()
-	_, err := ku.FuturesUpdateRiskLmitLevel(context.Background(), "", 2)
+	_, err := ku.FuturesUpdateRiskLmitLevel(t.Context(), "", 2)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.FuturesUpdateRiskLmitLevel(context.Background(), futuresTradablePair.String(), 2)
+	result, err := ku.FuturesUpdateRiskLmitLevel(t.Context(), futuresTradablePair.String(), 2)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesFundingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesFundingHistory(context.Background(), "", 0, 0, true, true, time.Time{}, time.Time{})
+	_, err := ku.GetFuturesFundingHistory(t.Context(), "", 0, 0, true, true, time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesFundingHistory(context.Background(), futuresTradablePair.String(), 0, 0, true, true, time.Time{}, time.Time{})
+	result, err := ku.GetFuturesFundingHistory(t.Context(), futuresTradablePair.String(), 0, 0, true, true, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1944,7 +1944,7 @@ func TestGetFuturesFundingHistory(t *testing.T) {
 func TestGetFuturesAccountOverview(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesAccountOverview(context.Background(), "BTC")
+	result, err := ku.GetFuturesAccountOverview(t.Context(), "BTC")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1952,22 +1952,22 @@ func TestGetFuturesAccountOverview(t *testing.T) {
 func TestGetFuturesTransactionHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesTransactionHistory(context.Background(), currency.EMPTYCODE, "", 0, 0, true, time.Time{}, time.Time{})
+	result, err := ku.GetFuturesTransactionHistory(t.Context(), currency.EMPTYCODE, "", 0, 0, true, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCreateFuturesSubAccountAPIKey(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CreateFuturesSubAccountAPIKey(context.Background(), "", "passphrase", "", "", "subAccName")
+	_, err := ku.CreateFuturesSubAccountAPIKey(t.Context(), "", "passphrase", "", "", "subAccName")
 	require.ErrorIs(t, err, errRemarkIsRequired)
-	_, err = ku.CreateFuturesSubAccountAPIKey(context.Background(), "", "passphrase", "", "remark", "")
+	_, err = ku.CreateFuturesSubAccountAPIKey(t.Context(), "", "passphrase", "", "remark", "")
 	require.ErrorIs(t, err, errInvalidSubAccountName)
-	_, err = ku.CreateFuturesSubAccountAPIKey(context.Background(), "", "", "", "remark", "subAccName")
+	_, err = ku.CreateFuturesSubAccountAPIKey(t.Context(), "", "", "", "remark", "subAccName")
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CreateFuturesSubAccountAPIKey(context.Background(), "", "passphrase", "", "remark", "subAccName")
+	result, err := ku.CreateFuturesSubAccountAPIKey(t.Context(), "", "passphrase", "", "remark", "subAccName")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1978,40 +1978,40 @@ func TestTransferFuturesFundsToMainAccount(t *testing.T) {
 	err := json.Unmarshal([]byte(transferFuturesFundsResponseJSON), &resp)
 	assert.NoError(t, err)
 
-	_, err = ku.TransferFuturesFundsToMainAccount(context.Background(), 0, currency.USDT, "MAIN")
+	_, err = ku.TransferFuturesFundsToMainAccount(t.Context(), 0, currency.USDT, "MAIN")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.TransferFuturesFundsToMainAccount(context.Background(), 1, currency.EMPTYCODE, "MAIN")
+	_, err = ku.TransferFuturesFundsToMainAccount(t.Context(), 1, currency.EMPTYCODE, "MAIN")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.TransferFuturesFundsToMainAccount(context.Background(), 1, currency.ETH, "")
+	_, err = ku.TransferFuturesFundsToMainAccount(t.Context(), 1, currency.ETH, "")
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.TransferFuturesFundsToMainAccount(context.Background(), 1, currency.USDT, "MAIN")
+	result, err := ku.TransferFuturesFundsToMainAccount(t.Context(), 1, currency.USDT, "MAIN")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestTransferFundsToFuturesAccount(t *testing.T) {
 	t.Parallel()
-	err := ku.TransferFundsToFuturesAccount(context.Background(), 0, currency.USDT, "MAIN")
+	err := ku.TransferFundsToFuturesAccount(t.Context(), 0, currency.USDT, "MAIN")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	err = ku.TransferFundsToFuturesAccount(context.Background(), 1, currency.EMPTYCODE, "MAIN")
+	err = ku.TransferFundsToFuturesAccount(t.Context(), 1, currency.EMPTYCODE, "MAIN")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	err = ku.TransferFundsToFuturesAccount(context.Background(), 1, currency.USDT, "")
+	err = ku.TransferFundsToFuturesAccount(t.Context(), 1, currency.USDT, "")
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	err = ku.TransferFundsToFuturesAccount(context.Background(), 1, currency.USDT, "MAIN")
+	err = ku.TransferFundsToFuturesAccount(t.Context(), 1, currency.USDT, "MAIN")
 	assert.NoError(t, err)
 }
 
 func TestGetFuturesTransferOutList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesTransferOutList(context.Background(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
+	_, err := ku.GetFuturesTransferOutList(t.Context(), currency.EMPTYCODE, "", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesTransferOutList(context.Background(), currency.USDT, "", time.Time{}, time.Time{})
+	result, err := ku.GetFuturesTransferOutList(t.Context(), currency.USDT, "", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2020,7 +2020,7 @@ func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
 	assetTypes := ku.GetAssetTypes(true)
 	for _, assetType := range assetTypes {
-		result, err := ku.FetchTradablePairs(context.Background(), assetType)
+		result, err := ku.FetchTradablePairs(t.Context(), assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2031,7 +2031,7 @@ func TestUpdateOrderbook(t *testing.T) {
 	var result *orderbook.Base
 	var err error
 	for assetType, tp := range assertToTradablePairMap {
-		result, err = ku.UpdateOrderbook(context.Background(), tp, assetType)
+		result, err = ku.UpdateOrderbook(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2040,7 +2040,7 @@ func TestUpdateOrderbook(t *testing.T) {
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
 	for _, a := range ku.GetAssetTypes(true) {
-		err := ku.UpdateTickers(context.Background(), a)
+		err := ku.UpdateTickers(t.Context(), a)
 		assert.NoError(t, err)
 
 		pairs, err := ku.GetEnabledPairs(a)
@@ -2065,7 +2065,7 @@ func TestUpdateTicker(t *testing.T) {
 	var result *ticker.Price
 	var err error
 	for assetType, tp := range assertToTradablePairMap {
-		result, err = ku.UpdateTicker(context.Background(), tp, assetType)
+		result, err = ku.UpdateTicker(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2077,7 +2077,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	var result *kline.Item
 	var err error
 	for assetType, tp := range assertToTradablePairMap {
-		result, err = ku.GetHistoricCandles(context.Background(), tp, assetType, kline.OneHour, startTime, endTime)
+		result, err = ku.GetHistoricCandles(t.Context(), tp, assetType, kline.OneHour, startTime, endTime)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2086,15 +2086,15 @@ func TestGetHistoricCandles(t *testing.T) {
 func TestGetHistoricCandlesExtended(t *testing.T) {
 	startTime := time.Now().Add(-time.Hour * 48 * 10)
 	endTime := time.Now().Add(-time.Hour * 1)
-	result, err := ku.GetHistoricCandlesExtended(context.Background(), futuresTradablePair, asset.Futures, kline.FifteenMin, startTime, endTime)
+	result, err := ku.GetHistoricCandlesExtended(t.Context(), futuresTradablePair, asset.Futures, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetHistoricCandlesExtended(context.Background(), spotTradablePair, asset.Spot, kline.FifteenMin, startTime, endTime)
+	result, err = ku.GetHistoricCandlesExtended(t.Context(), spotTradablePair, asset.Spot, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetHistoricCandlesExtended(context.Background(), marginTradablePair, asset.Margin, kline.FifteenMin, startTime, endTime)
+	result, err = ku.GetHistoricCandlesExtended(t.Context(), marginTradablePair, asset.Margin, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2102,7 +2102,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 func TestGetServerTime(t *testing.T) {
 	t.Parallel()
 	for _, a := range []asset.Item{asset.Spot, asset.Futures, asset.Margin} {
-		result, err := ku.GetServerTime(context.Background(), a)
+		result, err := ku.GetServerTime(t.Context(), a)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2113,7 +2113,7 @@ func TestGetRecentTrades(t *testing.T) {
 	var result []trade.Data
 	var err error
 	for assetType, tp := range assertToTradablePairMap {
-		result, err = ku.GetRecentTrades(context.Background(), tp, assetType)
+		result, err = ku.GetRecentTrades(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -2127,52 +2127,52 @@ func TestGetOrderHistory(t *testing.T) {
 		AssetType: asset.Binary,
 		Side:      order.AnySide,
 	}
-	_, err := ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	getOrdersRequest.AssetType = asset.Futures
-	result, err := ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err := ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.AssetType = asset.Spot
 	getOrdersRequest.Pairs = []currency.Pair{}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.Type = order.OCO
 	getOrdersRequest.Pairs = []currency.Pair{}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.AssetType = asset.Margin
 	getOrdersRequest.Type = order.Stop
 	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.Pairs = []currency.Pair{}
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.Type = order.StopLimit
 	getOrdersRequest.MarginType = margin.Multi
-	result, err = ku.GetOrderHistory(context.Background(), &getOrdersRequest)
+	result, err = ku.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2190,20 +2190,20 @@ func TestGetActiveOrders(t *testing.T) {
 	}
 
 	getOrdersRequest.Type = order.OptimalLimitIOC
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	require.ErrorIs(t, err, order.ErrUnsupportedOrderType)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	getOrdersRequest.Type = order.Limit
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Pairs = []currency.Pair{}
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.Market
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	enabledPairs, err = ku.GetEnabledPairs(asset.Spot)
@@ -2215,27 +2215,27 @@ func TestGetActiveOrders(t *testing.T) {
 		AssetType: asset.Margin,
 		Side:      order.Buy,
 	}
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Pairs = []currency.Pair{}
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.Market
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.OCO
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.StopMarket
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.Stop
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	enabledPairs, err = ku.GetEnabledPairs(asset.Futures)
@@ -2247,22 +2247,22 @@ func TestGetActiveOrders(t *testing.T) {
 		AssetType: asset.Futures,
 		Side:      order.Buy,
 	}
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Pairs = []currency.Pair{}
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 
 	getOrdersRequest.Type = order.StopLimit
-	_, err = ku.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err = ku.GetActiveOrders(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 }
 
 func TestGetFeeByType(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFeeByType(context.Background(), &exchange.FeeBuilder{
+	result, err := ku.GetFeeByType(t.Context(), &exchange.FeeBuilder{
 		Amount:              1,
 		FeeType:             exchange.CryptocurrencyTradeFee,
 		Pair:                currency.NewPairWithDelimiter(currency.BTC.String(), currency.USDT.String(), currency.DashDelimiter),
@@ -2279,14 +2279,14 @@ func TestValidateCredentials(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	assetTypes := ku.CurrencyPairs.GetAssetTypes(true)
 	for _, at := range assetTypes {
-		err := ku.ValidateCredentials(context.Background(), at)
+		err := ku.ValidateCredentials(t.Context(), at)
 		assert.NoError(t, err)
 	}
 }
 
 func TestGetInstanceServers(t *testing.T) {
 	t.Parallel()
-	result, err := ku.GetInstanceServers(context.Background())
+	result, err := ku.GetInstanceServers(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2294,7 +2294,7 @@ func TestGetInstanceServers(t *testing.T) {
 func TestGetAuthenticatedServersInstances(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAuthenticatedInstanceServers(context.Background())
+	result, err := ku.GetAuthenticatedInstanceServers(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2482,21 +2482,21 @@ func TestCheckSubscriptions(t *testing.T) {
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAvailableTransferChains(context.Background(), currency.BTC)
+	result, err := ku.GetAvailableTransferChains(t.Context(), currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Options)
+	_, err := ku.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Options)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Futures)
+	result, err := ku.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Futures)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	result, err = ku.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	result, err = ku.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2506,15 +2506,15 @@ func TestGetOrderInfo(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	var result *order.Detail
 	var err error
-	result, err = ku.GetOrderInfo(context.Background(), "54541241349183409134134133", futuresTradablePair, asset.Futures)
+	result, err = ku.GetOrderInfo(t.Context(), "54541241349183409134134133", futuresTradablePair, asset.Futures)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetOrderInfo(context.Background(), "54541241349183409134134133", spotTradablePair, asset.Spot)
+	result, err = ku.GetOrderInfo(t.Context(), "54541241349183409134134133", spotTradablePair, asset.Spot)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.GetOrderInfo(context.Background(), "54541241349183409134134133", marginTradablePair, asset.Margin)
+	result, err = ku.GetOrderInfo(t.Context(), "54541241349183409134134133", marginTradablePair, asset.Margin)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2522,13 +2522,13 @@ func TestGetOrderInfo(t *testing.T) {
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err := ku.GetDepositAddress(context.Background(), currency.BTC, "", "")
+	_, err := ku.GetDepositAddress(t.Context(), currency.BTC, "", "")
 	assert.True(t, err == nil || errors.Is(err, errNoDepositAddress), err)
 }
 
 func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 	t.Parallel()
-	_, err := ku.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	_, err := ku.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange: ku.Name,
 		Amount:   0.00000000001,
 		Crypto: withdraw.CryptoRequest{
@@ -2536,14 +2536,14 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 		},
 	})
 	assert.ErrorContains(t, err, withdraw.ErrStrNoCurrencySet)
-	_, err = ku.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	_, err = ku.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange: ku.Name,
 		Amount:   0.00000000001,
 		Currency: currency.BTC,
 		Crypto:   withdraw.CryptoRequest{},
 	})
 	assert.ErrorContains(t, err, "address cannot be empty")
-	_, err = ku.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	_, err = ku.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange: ku.Name,
 		Currency: currency.BTC,
 		Crypto: withdraw.CryptoRequest{
@@ -2553,7 +2553,7 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 	assert.ErrorContains(t, err, withdraw.ErrStrAmountMustBeGreaterThanZero)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.WithdrawCryptocurrencyFunds(context.Background(), &withdraw.Request{
+	result, err := ku.WithdrawCryptocurrencyFunds(t.Context(), &withdraw.Request{
 		Exchange: ku.Name,
 		Amount:   0.00000000001,
 		Currency: currency.BTC,
@@ -2577,20 +2577,20 @@ func TestSubmitOrder(t *testing.T) {
 		ClientOrderID: "myOrder",
 		AssetType:     asset.Options,
 	}
-	_, err := ku.SubmitOrder(context.Background(), orderSubmission)
+	_, err := ku.SubmitOrder(t.Context(), orderSubmission)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	orderSubmission.AssetType = asset.Futures
 	orderSubmission.Pair = futuresTradablePair
-	result, err := ku.SubmitOrder(context.Background(), orderSubmission)
+	result, err := ku.SubmitOrder(t.Context(), orderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	orderSubmission.Type = order.OCO
 	orderSubmission.TriggerPrice = 50000
 	orderSubmission.TriggerPriceType = order.LastPrice
-	_, err = ku.SubmitOrder(context.Background(), orderSubmission)
+	_, err = ku.SubmitOrder(t.Context(), orderSubmission)
 	require.ErrorIs(t, err, order.ErrUnsupportedOrderType)
 
 	// Spot order creation tests
@@ -2603,7 +2603,7 @@ func TestSubmitOrder(t *testing.T) {
 		Amount:        100000,
 		ClientOrderID: "myOrder",
 	}
-	result, err = ku.SubmitOrder(context.Background(), spotOrderSubmission)
+	result, err = ku.SubmitOrder(t.Context(), spotOrderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
@@ -2615,7 +2615,7 @@ func TestSubmitOrder(t *testing.T) {
 			TriggerPriceType: order.LastPrice,
 		},
 	}
-	result, err = ku.SubmitOrder(context.Background(), spotOrderSubmission)
+	result, err = ku.SubmitOrder(t.Context(), spotOrderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
@@ -2631,12 +2631,12 @@ func TestSubmitOrder(t *testing.T) {
 		Price:            1234,
 		TriggerPriceType: order.LastPrice,
 	}
-	result, err = ku.SubmitOrder(context.Background(), spotOrderSubmission)
+	result, err = ku.SubmitOrder(t.Context(), spotOrderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	spotOrderSubmission.Type = order.ConditionalStop
-	_, err = ku.SubmitOrder(context.Background(), spotOrderSubmission)
+	_, err = ku.SubmitOrder(t.Context(), spotOrderSubmission)
 	require.ErrorIs(t, err, order.ErrUnsupportedOrderType)
 
 	// Margin order creation tests
@@ -2649,7 +2649,7 @@ func TestSubmitOrder(t *testing.T) {
 		Amount:        100000,
 		ClientOrderID: "myOrder",
 	}
-	result, err = ku.SubmitOrder(context.Background(), marginOrderSubmission)
+	result, err = ku.SubmitOrder(t.Context(), marginOrderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2663,97 +2663,97 @@ func TestCancelOrder(t *testing.T) {
 		Pair:      futuresTradablePair,
 		AssetType: asset.Options,
 	}
-	err := ku.CancelOrder(context.Background(), orderCancellation)
+	err := ku.CancelOrder(t.Context(), orderCancellation)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	orderCancellation.AssetType = asset.Futures
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.OrderID = ""
 	orderCancellation.ClientOrderID = "12345"
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.Pair = currency.EMPTYPAIR
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	orderCancellation.AssetType = asset.Spot
 	orderCancellation.Pair = spotTradablePair
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.Type = order.OCO
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.OrderID = "12345"
 	orderCancellation.ClientOrderID = ""
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.Type = order.Stop
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.OrderID = ""
 	orderCancellation.ClientOrderID = "12345"
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.Type = order.Limit
 	orderCancellation.AssetType = asset.Margin
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.ClientOrderID = ""
 	orderCancellation.OrderID = "12345"
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.AssetType = asset.Margin
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
 	orderCancellation.ClientOrderID = ""
 	orderCancellation.OrderID = "12345"
 	orderCancellation.AssetType = asset.Margin
-	err = ku.CancelOrder(context.Background(), orderCancellation)
+	err = ku.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 }
 
 func TestCancelAllOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllOrders(context.Background(), &order.Cancel{
+	result, err := ku.CancelAllOrders(t.Context(), &order.Cancel{
 		AssetType:  asset.Futures,
 		MarginType: margin.Isolated,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	_, err = ku.CancelAllOrders(context.Background(), &order.Cancel{
+	_, err = ku.CancelAllOrders(t.Context(), &order.Cancel{
 		AssetType:  asset.Margin,
 		MarginType: margin.Isolated,
 	})
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
-	result, err = ku.CancelAllOrders(context.Background(), &order.Cancel{
+	result, err = ku.CancelAllOrders(t.Context(), &order.Cancel{
 		AssetType: asset.Spot,
 		Type:      order.OCO,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.CancelAllOrders(context.Background(), &order.Cancel{
+	result, err = ku.CancelAllOrders(t.Context(), &order.Cancel{
 		AssetType: asset.Spot,
 		Type:      order.Stop,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.CancelAllOrders(context.Background(), &order.Cancel{
+	result, err = ku.CancelAllOrders(t.Context(), &order.Cancel{
 		AssetType: asset.Spot,
 		Type:      order.StopLimit,
 	})
@@ -2772,43 +2772,43 @@ func TestCreateSubUser(t *testing.T) {
 	var resp *SubAccount
 	err := json.Unmarshal([]byte(subUserResponseJSON), &resp)
 	assert.NoError(t, err)
-	_, err = ku.CreateSubUser(context.Background(), "", "Subaccount-1", "", "")
+	_, err = ku.CreateSubUser(t.Context(), "", "Subaccount-1", "", "")
 	require.ErrorIs(t, err, errInvalidSubAccountName)
-	_, err = ku.CreateSubUser(context.Background(), "Subaccount-2", "", "", "")
+	_, err = ku.CreateSubUser(t.Context(), "Subaccount-2", "", "", "")
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CreateSubUser(context.Background(), "Subaccount-2", "Subaccount-1", "", "")
+	result, err := ku.CreateSubUser(t.Context(), "Subaccount-2", "Subaccount-1", "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetSubAccountSpotAPIList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetSubAccountSpotAPIList(context.Background(), "", "")
+	_, err := ku.GetSubAccountSpotAPIList(t.Context(), "", "")
 	require.ErrorIs(t, err, errInvalidSubAccountName)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetSubAccountSpotAPIList(context.Background(), "Sam", "")
+	result, err := ku.GetSubAccountSpotAPIList(t.Context(), "Sam", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCreateSpotAPIsForSubAccount(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CreateSpotAPIsForSubAccount(context.Background(), &SpotAPISubAccountParams{
+	_, err := ku.CreateSpotAPIsForSubAccount(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "",
 		Passphrase:     "mysecretPassphrase123",
 		Remark:         "the-remark",
 	})
 	require.ErrorIs(t, err, errInvalidSubAccountName)
-	_, err = ku.CreateSpotAPIsForSubAccount(context.Background(), &SpotAPISubAccountParams{
+	_, err = ku.CreateSpotAPIsForSubAccount(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "gocryptoTrader1",
 		Passphrase:     "",
 		Remark:         "the-remark",
 	})
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
-	_, err = ku.CreateSpotAPIsForSubAccount(context.Background(), &SpotAPISubAccountParams{
+	_, err = ku.CreateSpotAPIsForSubAccount(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "gocryptoTrader1",
 		Passphrase:     "mysecretPassphrase123",
 		Remark:         "",
@@ -2816,7 +2816,7 @@ func TestCreateSpotAPIsForSubAccount(t *testing.T) {
 	require.ErrorIs(t, err, errRemarkIsRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CreateSpotAPIsForSubAccount(context.Background(), &SpotAPISubAccountParams{
+	result, err := ku.CreateSpotAPIsForSubAccount(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "gocryptoTrader1",
 		Passphrase:     "mysecretPassphrase123",
 		Remark:         "the-remark",
@@ -2830,21 +2830,21 @@ func TestModifySubAccountSpotAPIs(t *testing.T) {
 	var resp SpotAPISubAccount
 	err := json.Unmarshal([]byte(modifySubAccountSpotAPIs), &resp)
 	assert.NoError(t, err)
-	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
+	_, err = ku.ModifySubAccountSpotAPIs(t.Context(), &SpotAPISubAccountParams{
 		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "", Passphrase: "mysecretPassphrase123",
 	})
 	require.ErrorIs(t, err, errInvalidSubAccountName)
-	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
+	_, err = ku.ModifySubAccountSpotAPIs(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "gocryptoTrader1", Passphrase: "mysecretPassphrase123",
 	})
 	require.ErrorIs(t, err, errAPIKeyRequired)
-	_, err = ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
+	_, err = ku.ModifySubAccountSpotAPIs(t.Context(), &SpotAPISubAccountParams{
 		APIKey: "65e7f22077172b0001f9ee41", SubAccountName: "gocryptoTrader1", Passphrase: "",
 	})
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.ModifySubAccountSpotAPIs(context.Background(), &SpotAPISubAccountParams{
+	result, err := ku.ModifySubAccountSpotAPIs(t.Context(), &SpotAPISubAccountParams{
 		SubAccountName: "gocryptoTrader1",
 		Passphrase:     "mysecretPassphrase123",
 		APIKey:         apiKey,
@@ -2855,15 +2855,15 @@ func TestModifySubAccountSpotAPIs(t *testing.T) {
 
 func TestDeleteSubAccountSpotAPI(t *testing.T) {
 	t.Parallel()
-	_, err := ku.DeleteSubAccountSpotAPI(context.Background(), "65e7f22077172b0001f9ee41", "", "the-passphrase")
+	_, err := ku.DeleteSubAccountSpotAPI(t.Context(), "65e7f22077172b0001f9ee41", "", "the-passphrase")
 	require.ErrorIs(t, err, errInvalidSubAccountName)
-	_, err = ku.DeleteSubAccountSpotAPI(context.Background(), "", "gocryptoTrader1", "the-passphrase")
+	_, err = ku.DeleteSubAccountSpotAPI(t.Context(), "", "gocryptoTrader1", "the-passphrase")
 	require.ErrorIs(t, err, errAPIKeyRequired)
-	_, err = ku.DeleteSubAccountSpotAPI(context.Background(), "65e7f22077172b0001f9ee41", "gocryptoTrader1", "")
+	_, err = ku.DeleteSubAccountSpotAPI(t.Context(), "65e7f22077172b0001f9ee41", "gocryptoTrader1", "")
 	require.ErrorIs(t, err, errInvalidPassPhraseInstance)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.DeleteSubAccountSpotAPI(context.Background(), apiKey, "gocryptoTrader1", "the-passphrase")
+	result, err := ku.DeleteSubAccountSpotAPI(t.Context(), apiKey, "gocryptoTrader1", "the-passphrase")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2871,7 +2871,7 @@ func TestDeleteSubAccountSpotAPI(t *testing.T) {
 func TestGetUserInfoOfAllSubAccounts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetUserInfoOfAllSubAccounts(context.Background())
+	result, err := ku.GetUserInfoOfAllSubAccounts(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2879,7 +2879,7 @@ func TestGetUserInfoOfAllSubAccounts(t *testing.T) {
 func TestGetPaginatedListOfSubAccounts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetPaginatedListOfSubAccounts(context.Background(), 1, 100)
+	result, err := ku.GetPaginatedListOfSubAccounts(t.Context(), 1, 100)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2887,7 +2887,7 @@ func TestGetPaginatedListOfSubAccounts(t *testing.T) {
 func TestGetFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAccountFundingHistory(context.Background())
+	result, err := ku.GetAccountFundingHistory(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2919,7 +2919,7 @@ func TestUpdateAccountInfo(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
 	assetTypes := ku.GetAssetTypes(true)
 	for _, assetType := range assetTypes {
-		result, err := ku.UpdateAccountInfo(context.Background(), assetType)
+		result, err := ku.UpdateAccountInfo(t.Context(), assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	}
@@ -3086,40 +3086,40 @@ func TestSubscribeTickerAll(t *testing.T) {
 
 func TestSeedLocalCache(t *testing.T) {
 	t.Parallel()
-	err := ku.SeedLocalCache(context.Background(), marginTradablePair, asset.Margin)
+	err := ku.SeedLocalCache(t.Context(), marginTradablePair, asset.Margin)
 	assert.NoError(t, err)
 }
 
 func TestGetFuturesContractDetails(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesContractDetails(context.Background(), asset.Spot)
+	_, err := ku.GetFuturesContractDetails(t.Context(), asset.Spot)
 	require.ErrorIs(t, err, futures.ErrNotFuturesAsset)
 
-	_, err = ku.GetFuturesContractDetails(context.Background(), asset.USDTMarginedFutures)
+	_, err = ku.GetFuturesContractDetails(t.Context(), asset.USDTMarginedFutures)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
-	result, err := ku.GetFuturesContractDetails(context.Background(), asset.Futures)
+	result, err := ku.GetFuturesContractDetails(t.Context(), asset.Futures)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetLatestFundingRates(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetLatestFundingRates(context.Background(), nil)
+	_, err := ku.GetLatestFundingRates(t.Context(), nil)
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 		Pair:  currency.NewPair(currency.BTC, currency.USD),
 	}
-	_, err = ku.GetLatestFundingRates(context.Background(), req)
+	_, err = ku.GetLatestFundingRates(t.Context(), req)
 	require.ErrorIs(t, err, futures.ErrNotPerpetualFuture)
 
 	req = &fundingrate.LatestRateRequest{
 		Asset: asset.Futures,
 		Pair:  currency.NewPair(currency.XBT, currency.USDTM),
 	}
-	resp, err := ku.GetLatestFundingRates(context.Background(), req)
+	resp, err := ku.GetLatestFundingRates(t.Context(), req)
 	assert.NoError(t, err)
 	assert.Len(t, resp, 1)
 
@@ -3127,7 +3127,7 @@ func TestGetLatestFundingRates(t *testing.T) {
 		Asset: asset.Futures,
 		Pair:  currency.EMPTYPAIR,
 	}
-	resp, err = ku.GetLatestFundingRates(context.Background(), req)
+	resp, err = ku.GetLatestFundingRates(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -3153,96 +3153,96 @@ func TestIsPerpetualFutureCurrency(t *testing.T) {
 
 func TestChangePositionMargin(t *testing.T) {
 	t.Parallel()
-	_, err := ku.ChangePositionMargin(context.Background(), nil)
+	_, err := ku.ChangePositionMargin(t.Context(), nil)
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &margin.PositionChangeRequest{}
-	_, err = ku.ChangePositionMargin(context.Background(), req)
+	_, err = ku.ChangePositionMargin(t.Context(), req)
 	require.ErrorIs(t, err, futures.ErrNotFuturesAsset)
 
 	req.Asset = asset.Futures
-	_, err = ku.ChangePositionMargin(context.Background(), req)
+	_, err = ku.ChangePositionMargin(t.Context(), req)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	req.Pair = currency.NewPair(currency.XBT, currency.USDTM)
-	_, err = ku.ChangePositionMargin(context.Background(), req)
+	_, err = ku.ChangePositionMargin(t.Context(), req)
 	require.ErrorIs(t, err, margin.ErrMarginTypeUnsupported)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	req.MarginType = margin.Isolated
-	result, err := ku.ChangePositionMargin(context.Background(), req)
+	result, err := ku.ChangePositionMargin(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	req.NewAllocatedMargin = 1337
-	result, err = ku.ChangePositionMargin(context.Background(), req)
+	result, err = ku.ChangePositionMargin(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPositionSummary(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPositionSummary(context.Background(), nil)
+	_, err := ku.GetFuturesPositionSummary(t.Context(), nil)
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &futures.PositionSummaryRequest{}
-	_, err = ku.GetFuturesPositionSummary(context.Background(), req)
+	_, err = ku.GetFuturesPositionSummary(t.Context(), req)
 	require.ErrorIs(t, err, futures.ErrNotPerpetualFuture)
 
 	req.Asset = asset.Futures
-	_, err = ku.GetFuturesPositionSummary(context.Background(), req)
+	_, err = ku.GetFuturesPositionSummary(t.Context(), req)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	req.Pair = currency.NewPair(currency.XBT, currency.USDTM)
-	result, err := ku.GetFuturesPositionSummary(context.Background(), req)
+	result, err := ku.GetFuturesPositionSummary(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesPositionOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesPositionOrders(context.Background(), nil)
+	_, err := ku.GetFuturesPositionOrders(t.Context(), nil)
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	req := &futures.PositionsRequest{}
-	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
+	_, err = ku.GetFuturesPositionOrders(t.Context(), req)
 	require.ErrorIs(t, err, futures.ErrNotPerpetualFuture)
 
 	req.Asset = asset.Futures
-	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
+	_, err = ku.GetFuturesPositionOrders(t.Context(), req)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	req.Pairs = currency.Pairs{
 		currency.NewPair(currency.XBT, currency.USDTM),
 	}
-	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
+	_, err = ku.GetFuturesPositionOrders(t.Context(), req)
 	require.ErrorIs(t, err, common.ErrDateUnset)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
 	req.EndDate = time.Now()
 	req.StartDate = req.EndDate.Add(-time.Hour * 24 * 7)
-	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
+	_, err = ku.GetFuturesPositionOrders(t.Context(), req)
 	assert.NoError(t, err)
 
 	req.StartDate = req.EndDate.Add(-time.Hour * 24 * 30)
-	_, err = ku.GetFuturesPositionOrders(context.Background(), req)
+	_, err = ku.GetFuturesPositionOrders(t.Context(), req)
 	require.ErrorIs(t, err, futures.ErrOrderHistoryTooLarge)
 
 	req.RespectOrderHistoryLimits = true
-	result, err := ku.GetFuturesPositionOrders(context.Background(), req)
+	result, err := ku.GetFuturesPositionOrders(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestUpdateOrderExecutionLimits(t *testing.T) {
 	t.Parallel()
-	err := ku.UpdateOrderExecutionLimits(context.Background(), asset.Binary)
+	err := ku.UpdateOrderExecutionLimits(t.Context(), asset.Binary)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	assets := []asset.Item{asset.Spot, asset.Futures, asset.Margin}
 	for x := range assets {
-		err = ku.UpdateOrderExecutionLimits(context.Background(), assets[x])
+		err = ku.UpdateOrderExecutionLimits(t.Context(), assets[x])
 		assert.NoError(t, err)
 
 		enabled, err := ku.GetEnabledPairs(assets[x])
@@ -3267,14 +3267,14 @@ func BenchmarkIntervalToString(b *testing.B) {
 func TestGetOpenInterest(t *testing.T) {
 	t.Parallel()
 	ku := testInstance(t) //nolint:govet // Intentional shadow to avoid future copy/paste mistakes
-	_, err := ku.GetOpenInterest(context.Background(), key.PairAsset{
+	_, err := ku.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  currency.ETH.Item,
 		Quote: currency.USDT.Item,
 		Asset: asset.USDTMarginedFutures,
 	})
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
-	resp, err := ku.GetOpenInterest(context.Background(), key.PairAsset{
+	resp, err := ku.GetOpenInterest(t.Context(), key.PairAsset{
 		Base:  futuresTradablePair.Base.Item,
 		Quote: futuresTradablePair.Quote.Item,
 		Asset: asset.Futures,
@@ -3285,7 +3285,7 @@ func TestGetOpenInterest(t *testing.T) {
 	cp1 := currency.NewPair(currency.ETH, currency.USDTM)
 
 	sharedtestvalues.SetupCurrencyPairsForExchangeAsset(t, ku, asset.Futures, cp1)
-	resp, err = ku.GetOpenInterest(context.Background(),
+	resp, err = ku.GetOpenInterest(t.Context(),
 		key.PairAsset{
 			Base:  futuresTradablePair.Base.Item,
 			Quote: futuresTradablePair.Quote.Item,
@@ -3300,7 +3300,7 @@ func TestGetOpenInterest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 
-	resp, err = ku.GetOpenInterest(context.Background())
+	resp, err = ku.GetOpenInterest(t.Context())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp)
 }
@@ -3333,11 +3333,11 @@ func TestValidatePlaceOrderParams(t *testing.T) {
 
 func TestSpotHFPlaceOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.HFSpotPlaceOrder(context.Background(), &PlaceHFParam{})
+	_, err := ku.HFSpotPlaceOrder(t.Context(), &PlaceHFParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.HFSpotPlaceOrder(context.Background(), &PlaceHFParam{
+	result, err := ku.HFSpotPlaceOrder(t.Context(), &PlaceHFParam{
 		TimeInForce: "GTT",
 		Symbol:      spotTradablePair,
 		OrderType:   "limit",
@@ -3351,11 +3351,11 @@ func TestSpotHFPlaceOrder(t *testing.T) {
 
 func TestSpotPlaceHFOrderTest(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SpotPlaceHFOrderTest(context.Background(), &PlaceHFParam{})
+	_, err := ku.SpotPlaceHFOrderTest(t.Context(), &PlaceHFParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SpotPlaceHFOrderTest(context.Background(), &PlaceHFParam{
+	result, err := ku.SpotPlaceHFOrderTest(t.Context(), &PlaceHFParam{
 		TimeInForce: "GTT",
 		Symbol:      spotTradablePair,
 		OrderType:   "limit",
@@ -3369,11 +3369,11 @@ func TestSpotPlaceHFOrderTest(t *testing.T) {
 
 func TestSyncPlaceHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SyncPlaceHFOrder(context.Background(), &PlaceHFParam{})
+	_, err := ku.SyncPlaceHFOrder(t.Context(), &PlaceHFParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SyncPlaceHFOrder(context.Background(), &PlaceHFParam{
+	result, err := ku.SyncPlaceHFOrder(t.Context(), &PlaceHFParam{
 		TimeInForce: "GTT",
 		Symbol:      currency.Pair{Base: currency.ETH, Delimiter: "-", Quote: currency.BTC},
 		OrderType:   "limit",
@@ -3388,7 +3388,7 @@ func TestSyncPlaceHFOrder(t *testing.T) {
 func TestPlaceMultipleOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PlaceMultipleOrders(context.Background(), []PlaceHFParam{
+	result, err := ku.PlaceMultipleOrders(t.Context(), []PlaceHFParam{
 		{
 			TimeInForce: "GTT",
 			Symbol:      spotTradablePair,
@@ -3421,7 +3421,7 @@ func TestPlaceMultipleOrders(t *testing.T) {
 func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SyncPlaceMultipleHFOrders(context.Background(), []PlaceHFParam{
+	result, err := ku.SyncPlaceMultipleHFOrders(t.Context(), []PlaceHFParam{
 		{
 			TimeInForce: "GTT",
 			Symbol:      spotTradablePair,
@@ -3453,14 +3453,14 @@ func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 
 func TestModifyHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.ModifyHFOrder(context.Background(), &ModifyHFOrderParam{})
+	_, err := ku.ModifyHFOrder(t.Context(), &ModifyHFOrderParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
-	_, err = ku.ModifyHFOrder(context.Background(), &ModifyHFOrderParam{OrderID: "1234"})
+	_, err = ku.ModifyHFOrder(t.Context(), &ModifyHFOrderParam{OrderID: "1234"})
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.ModifyHFOrder(context.Background(), &ModifyHFOrderParam{
+	result, err := ku.ModifyHFOrder(t.Context(), &ModifyHFOrderParam{
 		Symbol:        spotTradablePair,
 		ClientOrderID: "4314oiu5345u2y554x",
 		OrderID:       "4314oiu5345u2y554x",
@@ -3473,78 +3473,78 @@ func TestModifyHFOrder(t *testing.T) {
 
 func TestCancelHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelHFOrder(context.Background(), "", spotTradablePair.String())
+	_, err := ku.CancelHFOrder(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.CancelHFOrder(context.Background(), "630625dbd9180300014c8d52", "")
+	_, err = ku.CancelHFOrder(t.Context(), "630625dbd9180300014c8d52", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelHFOrder(context.Background(), "630625dbd9180300014c8d52", spotTradablePair.String())
+	result, err := ku.CancelHFOrder(t.Context(), "630625dbd9180300014c8d52", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSyncCancelHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SyncCancelHFOrder(context.Background(), "", spotTradablePair.String())
+	_, err := ku.SyncCancelHFOrder(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.SyncCancelHFOrder(context.Background(), "12312312", "")
+	_, err = ku.SyncCancelHFOrder(t.Context(), "12312312", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SyncCancelHFOrder(context.Background(), "641d67ea162d47000160bfb8", spotTradablePair.String())
+	result, err := ku.SyncCancelHFOrder(t.Context(), "641d67ea162d47000160bfb8", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSyncCancelHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SyncCancelHFOrderByClientOrderID(context.Background(), "", spotTradablePair.String())
+	_, err := ku.SyncCancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.SyncCancelHFOrderByClientOrderID(context.Background(), "cliend-order-id", "")
+	_, err = ku.SyncCancelHFOrderByClientOrderID(t.Context(), "cliend-order-id", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SyncCancelHFOrderByClientOrderID(context.Background(), "client-order-id", spotTradablePair.String())
+	result, err := ku.SyncCancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelHFOrderByClientOrderID(context.Background(), "", spotTradablePair.String())
+	_, err := ku.CancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = ku.CancelHFOrderByClientOrderID(context.Background(), "cliend-order-id", "")
+	_, err = ku.CancelHFOrderByClientOrderID(t.Context(), "cliend-order-id", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelHFOrderByClientOrderID(context.Background(), "client-order-id", spotTradablePair.String())
+	result, err := ku.CancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelSpecifiedNumberHFOrdersByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelSpecifiedNumberHFOrdersByOrderID(context.Background(), "", spotTradablePair.String(), 10.0)
+	_, err := ku.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "", spotTradablePair.String(), 10.0)
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.CancelSpecifiedNumberHFOrdersByOrderID(context.Background(), "1", "", 10.0)
+	_, err = ku.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", "", 10.0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.CancelSpecifiedNumberHFOrdersByOrderID(context.Background(), "1", spotTradablePair.String(), 0)
+	_, err = ku.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair.String(), 0)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelSpecifiedNumberHFOrdersByOrderID(context.Background(), "1", spotTradablePair.String(), 10.0)
+	result, err := ku.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair.String(), 10.0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelAllHFOrdersBySymbol(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelAllHFOrdersBySymbol(context.Background(), "")
+	_, err := ku.CancelAllHFOrdersBySymbol(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllHFOrdersBySymbol(context.Background(), spotTradablePair.String())
+	result, err := ku.CancelAllHFOrdersBySymbol(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3552,75 +3552,75 @@ func TestCancelAllHFOrdersBySymbol(t *testing.T) {
 func TestCancelAllHFOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllHFOrders(context.Background())
+	result, err := ku.CancelAllHFOrders(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetActiveHFOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetActiveHFOrders(context.Background(), "")
+	_, err := ku.GetActiveHFOrders(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	_, err = ku.GetActiveHFOrders(context.Background(), "")
+	_, err = ku.GetActiveHFOrders(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetActiveHFOrders(context.Background(), spotTradablePair.String())
+	_, err = ku.GetActiveHFOrders(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 }
 
 func TestGetSymbolsWithActiveHFOrderList(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err := ku.GetSymbolsWithActiveHFOrderList(context.Background())
+	_, err := ku.GetSymbolsWithActiveHFOrderList(t.Context())
 	assert.NoError(t, err)
 }
 
 func TestGetHFCompletedOrderList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetHFCompletedOrderList(context.Background(), "", "sell", "limit", "", time.Time{}, time.Now(), 0)
+	_, err := ku.GetHFCompletedOrderList(t.Context(), "", "sell", "limit", "", time.Time{}, time.Now(), 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHFCompletedOrderList(context.Background(), spotTradablePair.String(), "sell", "limit", "", time.Time{}, time.Now(), 0)
+	result, err := ku.GetHFCompletedOrderList(t.Context(), spotTradablePair.String(), "sell", "limit", "", time.Time{}, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetHFOrderDetailsByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetHFOrderDetailsByOrderID(context.Background(), "", spotTradablePair.String())
+	_, err := ku.GetHFOrderDetailsByOrderID(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.GetHFOrderDetailsByOrderID(context.Background(), "1234567", "")
+	_, err = ku.GetHFOrderDetailsByOrderID(t.Context(), "1234567", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHFOrderDetailsByOrderID(context.Background(), "1234567", spotTradablePair.String())
+	result, err := ku.GetHFOrderDetailsByOrderID(t.Context(), "1234567", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetHFOrderDetailsByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetHFOrderDetailsByClientOrderID(context.Background(), "", spotTradablePair.String())
+	_, err := ku.GetHFOrderDetailsByClientOrderID(t.Context(), "", spotTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.GetHFOrderDetailsByClientOrderID(context.Background(), "1234567", "")
+	_, err = ku.GetHFOrderDetailsByClientOrderID(t.Context(), "1234567", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHFOrderDetailsByClientOrderID(context.Background(), "6d539dc614db312", spotTradablePair.String())
+	result, err := ku.GetHFOrderDetailsByClientOrderID(t.Context(), "6d539dc614db312", spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestAutoCancelHFOrderSetting(t *testing.T) {
 	t.Parallel()
-	_, err := ku.AutoCancelHFOrderSetting(context.Background(), 0, []string{})
+	_, err := ku.AutoCancelHFOrderSetting(t.Context(), 0, []string{})
 	require.ErrorIs(t, err, errTimeoutRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.AutoCancelHFOrderSetting(context.Background(), 450, []string{})
+	result, err := ku.AutoCancelHFOrderSetting(t.Context(), 450, []string{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3628,60 +3628,60 @@ func TestAutoCancelHFOrderSetting(t *testing.T) {
 func TestAutoCancelHFOrderSettingQuery(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.AutoCancelHFOrderSettingQuery(context.Background())
+	result, err := ku.AutoCancelHFOrderSettingQuery(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetHFFilledList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetHFFilledList(context.Background(), "", "", "sell", "market", "", time.Time{}, time.Now(), 0)
+	_, err := ku.GetHFFilledList(t.Context(), "", "", "sell", "market", "", time.Time{}, time.Now(), 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetHFFilledList(context.Background(), "", spotTradablePair.String(), "sell", "market", "", time.Time{}, time.Now(), 0)
+	result, err := ku.GetHFFilledList(t.Context(), "", spotTradablePair.String(), "sell", "market", "", time.Time{}, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestPlaceOCOOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PlaceOCOOrder(context.Background(), &OCOOrderParams{})
+	_, err := ku.PlaceOCOOrder(t.Context(), &OCOOrderParams{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	arg := &OCOOrderParams{Remark: "oco-new-order"}
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	arg.Symbol = spotTradablePair
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 
 	arg.Side = "Sell"
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	arg.Price = 1000
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	arg.Size = .1
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	arg.StopPrice = .1
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	arg.LimitPrice = .1
-	_, err = ku.PlaceOCOOrder(context.Background(), arg)
+	_, err = ku.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
-	cpDetail, err := ku.GetTicker(context.Background(), spotTradablePair.String())
+	cpDetail, err := ku.GetTicker(t.Context(), spotTradablePair.String())
 	assert.NoError(t, err)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.PlaceOCOOrder(context.Background(), &OCOOrderParams{
+	result, err := ku.PlaceOCOOrder(t.Context(), &OCOOrderParams{
 		Symbol:        spotTradablePair,
 		Side:          order.Buy.String(),
 		Price:         cpDetail.Price - 3,
@@ -3697,22 +3697,22 @@ func TestPlaceOCOOrder(t *testing.T) {
 
 func TestCancelOrderByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelOCOOrderByOrderID(context.Background(), "")
+	_, err := ku.CancelOCOOrderByOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelOCOOrderByOrderID(context.Background(), "6572fdd65723280007deb5e0")
+	result, err := ku.CancelOCOOrderByOrderID(t.Context(), "6572fdd65723280007deb5e0")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelOCOOrderByClientOrderID(context.Background(), "")
+	_, err := ku.CancelOCOOrderByClientOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelOCOOrderByClientOrderID(context.Background(), "6572fdd65723280007deb5e0")
+	result, err := ku.CancelOCOOrderByClientOrderID(t.Context(), "6572fdd65723280007deb5e0")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3720,89 +3720,89 @@ func TestCancelOrderByClientOrderID(t *testing.T) {
 func TestCancelMultipleOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelOCOMultipleOrders(context.Background(), []string{}, spotTradablePair.String())
+	result, err := ku.CancelOCOMultipleOrders(t.Context(), []string{}, spotTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOrderInfoByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOCOOrderInfoByOrderID(context.Background(), "")
+	_, err := ku.GetOCOOrderInfoByOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetOCOOrderInfoByOrderID(context.Background(), "order-id-here")
+	result, err := ku.GetOCOOrderInfoByOrderID(t.Context(), "order-id-here")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOrderInfoByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOCOOrderInfoByClientOrderID(context.Background(), "")
+	_, err := ku.GetOCOOrderInfoByClientOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetOCOOrderInfoByClientOrderID(context.Background(), "client-order-id-here")
+	_, err = ku.GetOCOOrderInfoByClientOrderID(t.Context(), "client-order-id-here")
 	assert.NoError(t, err)
 }
 
 func TestGetOrderDetailsByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOCOOrderDetailsByOrderID(context.Background(), "")
+	_, err := ku.GetOCOOrderDetailsByOrderID(t.Context(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetOCOOrderDetailsByOrderID(context.Background(), "order-id-here")
+	result, err := ku.GetOCOOrderDetailsByOrderID(t.Context(), "order-id-here")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetOCOOrderList(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetOCOOrderList(context.Background(), 9, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	_, err := ku.GetOCOOrderList(t.Context(), 9, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
 	require.ErrorIs(t, err, errPageSizeRequired)
-	_, err = ku.GetOCOOrderList(context.Background(), 10, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	_, err = ku.GetOCOOrderList(t.Context(), 10, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
 	require.ErrorIs(t, err, errCurrentPageRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetOCOOrderList(context.Background(), 10, 2, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	result, err := ku.GetOCOOrderList(t.Context(), 10, 2, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSendPlaceMarginHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SendPlaceMarginHFOrder(context.Background(), &PlaceMarginHFOrderParam{}, "")
+	_, err := ku.SendPlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{}, "")
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	arg := &PlaceMarginHFOrderParam{PostOnly: true}
-	_, err = ku.SendPlaceMarginHFOrder(context.Background(), arg, "")
+	_, err = ku.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, order.ErrClientOrderIDNotSupported)
 
 	arg.ClientOrderID = "first-order"
-	_, err = ku.SendPlaceMarginHFOrder(context.Background(), arg, "")
+	_, err = ku.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 
 	arg.Side = "Sell"
-	_, err = ku.SendPlaceMarginHFOrder(context.Background(), arg, "")
+	_, err = ku.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	arg.Symbol = marginTradablePair
-	_, err = ku.SendPlaceMarginHFOrder(context.Background(), arg, "")
+	_, err = ku.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
 
 	arg.Price = 1000
-	_, err = ku.SendPlaceMarginHFOrder(context.Background(), arg, "")
+	_, err = ku.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 }
 
 func TestPlaceMarginHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PlaceMarginHFOrder(context.Background(), &PlaceMarginHFOrderParam{})
+	_, err := ku.PlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.PlaceMarginHFOrder(context.Background(), &PlaceMarginHFOrderParam{
+	result, err := ku.PlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{
 		ClientOrderID:       "first-order",
 		Side:                "sell",
 		Symbol:              marginTradablePair,
@@ -3817,11 +3817,11 @@ func TestPlaceMarginHFOrder(t *testing.T) {
 
 func TestPlaceMarginHFOrderTest(t *testing.T) {
 	t.Parallel()
-	_, err := ku.PlaceMarginHFOrderTest(context.Background(), &PlaceMarginHFOrderParam{})
+	_, err := ku.PlaceMarginHFOrderTest(t.Context(), &PlaceMarginHFOrderParam{})
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.PlaceMarginHFOrderTest(context.Background(), &PlaceMarginHFOrderParam{
+	result, err := ku.PlaceMarginHFOrderTest(t.Context(), &PlaceMarginHFOrderParam{
 		ClientOrderID:       "first-order",
 		Side:                "sell",
 		Symbol:              marginTradablePair,
@@ -3836,43 +3836,43 @@ func TestPlaceMarginHFOrderTest(t *testing.T) {
 
 func TestCancelMarginHFOrderByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelMarginHFOrderByOrderID(context.Background(), "", marginTradablePair.String())
+	_, err := ku.CancelMarginHFOrderByOrderID(t.Context(), "", marginTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.CancelMarginHFOrderByOrderID(context.Background(), "order-id-here", "")
+	_, err = ku.CancelMarginHFOrderByOrderID(t.Context(), "order-id-here", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelMarginHFOrderByOrderID(context.Background(), "order-id-here", marginTradablePair.String())
+	result, err := ku.CancelMarginHFOrderByOrderID(t.Context(), "order-id-here", marginTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelMarginHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelMarginHFOrderByClientOrderID(context.Background(), "", marginTradablePair.String())
+	_, err := ku.CancelMarginHFOrderByClientOrderID(t.Context(), "", marginTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.CancelMarginHFOrderByClientOrderID(context.Background(), "order-id-here", "")
+	_, err = ku.CancelMarginHFOrderByClientOrderID(t.Context(), "order-id-here", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelMarginHFOrderByClientOrderID(context.Background(), "order-id-here", marginTradablePair.String())
+	result, err := ku.CancelMarginHFOrderByClientOrderID(t.Context(), "order-id-here", marginTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelAllMarginHFOrdersBySymbol(t *testing.T) {
 	t.Parallel()
-	_, err := ku.CancelAllMarginHFOrdersBySymbol(context.Background(), "", "MARGIN_TRADE")
+	_, err := ku.CancelAllMarginHFOrdersBySymbol(t.Context(), "", "MARGIN_TRADE")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.CancelAllMarginHFOrdersBySymbol(context.Background(), marginTradablePair.String(), "")
+	_, err = ku.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "")
 	require.ErrorIs(t, err, errTradeTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.CancelAllMarginHFOrdersBySymbol(context.Background(), marginTradablePair.String(), "MARGIN_TRADE")
+	result, err := ku.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "MARGIN_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = ku.CancelAllMarginHFOrdersBySymbol(context.Background(), marginTradablePair.String(), "MARGIN_ISOLATED_TRADE")
+	result, err = ku.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "MARGIN_ISOLATED_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3880,143 +3880,143 @@ func TestCancelAllMarginHFOrdersBySymbol(t *testing.T) {
 func TestGetActiveMarginHFOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetActiveMarginHFOrders(context.Background(), marginTradablePair.String(), "MARGIN_TRADE")
+	result, err := ku.GetActiveMarginHFOrders(t.Context(), marginTradablePair.String(), "MARGIN_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFilledHFMarginOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFilledHFMarginOrders(context.Background(), spotTradablePair.String(), "", "sell", "limit", time.Time{}, time.Now(), 0, 20)
+	_, err := ku.GetFilledHFMarginOrders(t.Context(), spotTradablePair.String(), "", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	require.ErrorIs(t, err, errTradeTypeMissing)
-	_, err = ku.GetFilledHFMarginOrders(context.Background(), "", "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
+	_, err = ku.GetFilledHFMarginOrders(t.Context(), "", "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetFilledHFMarginOrders(context.Background(), marginTradablePair.String(), "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
+	_, err = ku.GetFilledHFMarginOrders(t.Context(), marginTradablePair.String(), "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	assert.NoError(t, err)
 }
 
 func TestGetMarginHFOrderDetailByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarginHFOrderDetailByOrderID(context.Background(), "", marginTradablePair.String())
+	_, err := ku.GetMarginHFOrderDetailByOrderID(t.Context(), "", marginTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetMarginHFOrderDetailByOrderID(context.Background(), "243432432423the-order-id", marginTradablePair.String())
+	_, err = ku.GetMarginHFOrderDetailByOrderID(t.Context(), "243432432423the-order-id", marginTradablePair.String())
 	assert.True(t, errors.Is(err, order.ErrOrderNotFound) || err == nil)
 }
 
 func TestGetMarginHFOrderDetailByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarginHFOrderDetailByClientOrderID(context.Background(), "", marginTradablePair.String())
+	_, err := ku.GetMarginHFOrderDetailByClientOrderID(t.Context(), "", marginTradablePair.String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetMarginHFOrderDetailByClientOrderID(context.Background(), "the-client-order-id", marginTradablePair.String())
+	result, err := ku.GetMarginHFOrderDetailByClientOrderID(t.Context(), "the-client-order-id", marginTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarginHFTradeFills(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarginHFTradeFills(context.Background(), "", marginTradablePair.String(), "", "sell", "", time.Time{}, time.Now(), 0, 30)
+	_, err := ku.GetMarginHFTradeFills(t.Context(), "", marginTradablePair.String(), "", "sell", "", time.Time{}, time.Now(), 0, 30)
 	require.ErrorIs(t, err, errTradeTypeMissing)
 
-	_, err = ku.GetMarginHFTradeFills(context.Background(), "", "", "MARGIN_TRADE", "sell", "", time.Time{}, time.Now(), 0, 30)
+	_, err = ku.GetMarginHFTradeFills(t.Context(), "", "", "MARGIN_TRADE", "sell", "", time.Time{}, time.Now(), 0, 30)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetMarginHFTradeFills(context.Background(), "12312312", marginTradablePair.String(), "MARGIN_TRADE", "sell", "market", time.Time{}, time.Now(), 0, 30)
+	_, err = ku.GetMarginHFTradeFills(t.Context(), "12312312", marginTradablePair.String(), "MARGIN_TRADE", "sell", "market", time.Time{}, time.Now(), 0, 30)
 	assert.NoError(t, err)
 }
 
 func TestGetLendingCurrencyInformation(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetLendingCurrencyInformation(context.Background(), currency.ETH)
+	result, err := ku.GetLendingCurrencyInformation(t.Context(), currency.ETH)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetInterestRate(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetInterestRate(context.Background(), currency.EMPTYCODE)
+	_, err := ku.GetInterestRate(t.Context(), currency.EMPTYCODE)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetInterestRate(context.Background(), currency.ETH)
+	result, err := ku.GetInterestRate(t.Context(), currency.ETH)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestMarginLendingSubscription(t *testing.T) {
 	t.Parallel()
-	_, err := ku.MarginLendingSubscription(context.Background(), currency.EMPTYCODE, 1, 0.22)
+	_, err := ku.MarginLendingSubscription(t.Context(), currency.EMPTYCODE, 1, 0.22)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.MarginLendingSubscription(context.Background(), currency.ETH, 0, 0.22)
+	_, err = ku.MarginLendingSubscription(t.Context(), currency.ETH, 0, 0.22)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.MarginLendingSubscription(context.Background(), currency.ETH, 1, 0)
+	_, err = ku.MarginLendingSubscription(t.Context(), currency.ETH, 1, 0)
 	require.ErrorIs(t, err, errMissingInterestRate)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.MarginLendingSubscription(context.Background(), currency.ETH, 1, 0.22)
+	result, err := ku.MarginLendingSubscription(t.Context(), currency.ETH, 1, 0.22)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestRedemption(t *testing.T) {
 	t.Parallel()
-	_, err := ku.Redemption(context.Background(), currency.EMPTYCODE, 1, "1245")
+	_, err := ku.Redemption(t.Context(), currency.EMPTYCODE, 1, "1245")
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.Redemption(context.Background(), currency.ETH, 0, "1245")
+	_, err = ku.Redemption(t.Context(), currency.ETH, 0, "1245")
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.Redemption(context.Background(), currency.ETH, 1, "")
+	_, err = ku.Redemption(t.Context(), currency.ETH, 1, "")
 	require.ErrorIs(t, err, errMissingPurchaseOrderNumber)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.Redemption(context.Background(), currency.ETH, 1, "1245")
+	result, err := ku.Redemption(t.Context(), currency.ETH, 1, "1245")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestModifySubscriptionOrder(t *testing.T) {
 	t.Parallel()
-	_, err := ku.ModifySubscriptionOrder(context.Background(), currency.EMPTYCODE, "12345", 1.23)
+	_, err := ku.ModifySubscriptionOrder(t.Context(), currency.EMPTYCODE, "12345", 1.23)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.ModifySubscriptionOrder(context.Background(), currency.ETH, "12345", 0)
+	_, err = ku.ModifySubscriptionOrder(t.Context(), currency.ETH, "12345", 0)
 	require.ErrorIs(t, err, errMissingInterestRate)
-	_, err = ku.ModifySubscriptionOrder(context.Background(), currency.ETH, "", 1.23)
+	_, err = ku.ModifySubscriptionOrder(t.Context(), currency.ETH, "", 1.23)
 	require.ErrorIs(t, err, errMissingPurchaseOrderNumber)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.ModifySubscriptionOrder(context.Background(), currency.ETH, "12345", 1.23)
+	result, err := ku.ModifySubscriptionOrder(t.Context(), currency.ETH, "12345", 1.23)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetRedemptionOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetRedemptionOrders(context.Background(), currency.EMPTYCODE, "DONE", "2234", 0, 20)
+	_, err := ku.GetRedemptionOrders(t.Context(), currency.EMPTYCODE, "DONE", "2234", 0, 20)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.GetRedemptionOrders(context.Background(), currency.ETH, "", "", 0, 20)
+	_, err = ku.GetRedemptionOrders(t.Context(), currency.ETH, "", "", 0, 20)
 	require.ErrorIs(t, err, errStatusMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetRedemptionOrders(context.Background(), currency.BTC, "2234", "PENDING", 0, 20)
+	result, err := ku.GetRedemptionOrders(t.Context(), currency.BTC, "2234", "PENDING", 0, 20)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetSubscriptionOrders(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetSubscriptionOrders(context.Background(), currency.EMPTYCODE, "2234", "DONE", 0, 20)
+	_, err := ku.GetSubscriptionOrders(t.Context(), currency.EMPTYCODE, "2234", "DONE", 0, 20)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	_, err = ku.GetSubscriptionOrders(context.Background(), currency.ETH, "", "", 0, 20)
+	_, err = ku.GetSubscriptionOrders(t.Context(), currency.ETH, "", "", 0, 20)
 	require.ErrorIs(t, err, errStatusMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetSubscriptionOrders(context.Background(), currency.BTC, "2234", "DONE", 0, 20)
+	result, err := ku.GetSubscriptionOrders(t.Context(), currency.BTC, "2234", "DONE", 0, 20)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4029,7 +4029,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		assert.NoError(t, err, "cannot get pairs for %s", a)
 		assert.NotEmpty(t, pairs, "no pairs for %s", a)
 
-		resp, err := ku.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := ku.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		assert.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}
@@ -4050,44 +4050,44 @@ func testInstance(tb testing.TB) *Kucoin {
 func TestGetTradingPairActualFees(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetTradingPairActualFees(context.Background(), []string{spotTradablePair.String()})
+	result, err := ku.GetTradingPairActualFees(t.Context(), []string{spotTradablePair.String()})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFuturesTradingPairsActualFees(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetFuturesTradingPairsActualFees(context.Background(), "")
+	_, err := ku.GetFuturesTradingPairsActualFees(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetFuturesTradingPairsActualFees(context.Background(), futuresTradablePair.String())
+	result, err := ku.GetFuturesTradingPairsActualFees(t.Context(), futuresTradablePair.String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetPositionHistory(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetPositionHistory(context.Background(), futuresTradablePair.String(), time.Now(), time.Now().Add(-time.Hour*5), 0, 10)
+	_, err := ku.GetPositionHistory(t.Context(), futuresTradablePair.String(), time.Now(), time.Now().Add(-time.Hour*5), 0, 10)
 	require.ErrorIs(t, err, common.ErrStartAfterEnd)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetPositionHistory(context.Background(), futuresTradablePair.String(), time.Time{}, time.Time{}, 0, 10)
+	result, err := ku.GetPositionHistory(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMaximumOpenPositionSize(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMaximumOpenPositionSize(context.Background(), "", 1, 1)
+	_, err := ku.GetMaximumOpenPositionSize(t.Context(), "", 1, 1)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = ku.GetMaximumOpenPositionSize(context.Background(), futuresTradablePair.String(), 0., 1)
+	_, err = ku.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 0., 1)
 	require.ErrorIs(t, err, order.ErrPriceBelowMin)
-	_, err = ku.GetMaximumOpenPositionSize(context.Background(), futuresTradablePair.String(), 1, 0)
+	_, err = ku.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 1, 0)
 	require.ErrorIs(t, err, errInvalidLeverage)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetMaximumOpenPositionSize(context.Background(), futuresTradablePair.String(), 1, 1)
+	result, err := ku.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 1, 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4095,46 +4095,46 @@ func TestGetMaximumOpenPositionSize(t *testing.T) {
 func TestGetLatestTickersForAllContracts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetLatestTickersForAllContracts(context.Background())
+	result, err := ku.GetLatestTickersForAllContracts(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSubscribeToEarnFixedIncomeProduct(t *testing.T) {
 	t.Parallel()
-	_, err := ku.SubscribeToEarnFixedIncomeProduct(context.Background(), "", "MAIN", 12.2)
+	_, err := ku.SubscribeToEarnFixedIncomeProduct(t.Context(), "", "MAIN", 12.2)
 	require.ErrorIs(t, err, errProductIDMissing)
-	_, err = ku.SubscribeToEarnFixedIncomeProduct(context.Background(), "1232412", "MAIN", 0)
+	_, err = ku.SubscribeToEarnFixedIncomeProduct(t.Context(), "1232412", "MAIN", 0)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
-	_, err = ku.SubscribeToEarnFixedIncomeProduct(context.Background(), "1232412", "", 12.2)
+	_, err = ku.SubscribeToEarnFixedIncomeProduct(t.Context(), "1232412", "", 12.2)
 	require.ErrorIs(t, err, errAccountTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.SubscribeToEarnFixedIncomeProduct(context.Background(), "1232412", "MAIN", 12.2)
+	result, err := ku.SubscribeToEarnFixedIncomeProduct(t.Context(), "1232412", "MAIN", 12.2)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestRedeemByEarnHoldingID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.RedeemByEarnHoldingID(context.Background(), "", SpotTradeType, "1", 1)
+	_, err := ku.RedeemByEarnHoldingID(t.Context(), "", SpotTradeType, "1", 1)
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
-	_, err = ku.RedeemByEarnHoldingID(context.Background(), "123231", "Main", "1", 0)
+	_, err = ku.RedeemByEarnHoldingID(t.Context(), "123231", "Main", "1", 0)
 	require.ErrorIs(t, err, order.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	result, err := ku.RedeemByEarnHoldingID(context.Background(), "123231", SpotTradeType, "1", 1)
+	result, err := ku.RedeemByEarnHoldingID(t.Context(), "123231", SpotTradeType, "1", 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetEarnRedeemPreviewByHoldingID(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetEarnRedeemPreviewByHoldingID(context.Background(), "", "MAIN")
+	_, err := ku.GetEarnRedeemPreviewByHoldingID(t.Context(), "", "MAIN")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnRedeemPreviewByHoldingID(context.Background(), "12345", "MAIN")
+	result, err := ku.GetEarnRedeemPreviewByHoldingID(t.Context(), "12345", "MAIN")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4142,7 +4142,7 @@ func TestGetEarnRedeemPreviewByHoldingID(t *testing.T) {
 func TestGetEarnSavingsProducts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnSavingsProducts(context.Background(), currency.EMPTYCODE)
+	result, err := ku.GetEarnSavingsProducts(t.Context(), currency.EMPTYCODE)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4150,7 +4150,7 @@ func TestGetEarnSavingsProducts(t *testing.T) {
 func TestGetEarnFixedIncomeCurrentHoldings(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnFixedIncomeCurrentHoldings(context.Background(), "12312", "", currency.EMPTYCODE, 0, 10)
+	result, err := ku.GetEarnFixedIncomeCurrentHoldings(t.Context(), "12312", "", currency.EMPTYCODE, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4158,7 +4158,7 @@ func TestGetEarnFixedIncomeCurrentHoldings(t *testing.T) {
 func TestGetLimitedTimePromotionProducts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetLimitedTimePromotionProducts(context.Background(), currency.BTC)
+	result, err := ku.GetLimitedTimePromotionProducts(t.Context(), currency.BTC)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4166,7 +4166,7 @@ func TestGetLimitedTimePromotionProducts(t *testing.T) {
 func TestGetEarnKCSStakingProducts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnKCSStakingProducts(context.Background(), currency.EMPTYCODE)
+	result, err := ku.GetEarnKCSStakingProducts(t.Context(), currency.EMPTYCODE)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4174,7 +4174,7 @@ func TestGetEarnKCSStakingProducts(t *testing.T) {
 func TestGetEarnStakingProducts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnStakingProducts(context.Background(), currency.EMPTYCODE)
+	result, err := ku.GetEarnStakingProducts(t.Context(), currency.EMPTYCODE)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4182,7 +4182,7 @@ func TestGetEarnStakingProducts(t *testing.T) {
 func TestGetEarnETHStakingProducts(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetEarnETHStakingProducts(context.Background())
+	result, err := ku.GetEarnETHStakingProducts(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4190,7 +4190,7 @@ func TestGetEarnETHStakingProducts(t *testing.T) {
 func TestGetInformationOnOffExchangeFundingAndLoans(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetInformationOnOffExchangeFundingAndLoans(context.Background())
+	result, err := ku.GetInformationOnOffExchangeFundingAndLoans(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4198,44 +4198,44 @@ func TestGetInformationOnOffExchangeFundingAndLoans(t *testing.T) {
 func TestGetInformationOnAccountInvolvedInOffExchangeLoans(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetInformationOnAccountInvolvedInOffExchangeLoans(context.Background())
+	result, err := ku.GetInformationOnAccountInvolvedInOffExchangeLoans(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetAffilateUserRebateInformation(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetAffilateUserRebateInformation(context.Background(), time.Time{}, "1234", 0)
+	_, err := ku.GetAffilateUserRebateInformation(t.Context(), time.Time{}, "1234", 0)
 	require.ErrorIs(t, err, errQueryDateIsRequired)
-	_, err = ku.GetAffilateUserRebateInformation(context.Background(), time.Now(), "", 0)
+	_, err = ku.GetAffilateUserRebateInformation(t.Context(), time.Now(), "", 0)
 	require.ErrorIs(t, err, errOffsetIsRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetAffilateUserRebateInformation(context.Background(), time.Now(), "1234", 0)
+	result, err := ku.GetAffilateUserRebateInformation(t.Context(), time.Now(), "1234", 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarginPairsConfigurations(t *testing.T) {
 	t.Parallel()
-	_, err := ku.GetMarginPairsConfigurations(context.Background(), "")
+	_, err := ku.GetMarginPairsConfigurations(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	_, err = ku.GetMarginPairsConfigurations(context.Background(), marginTradablePair.String())
+	_, err = ku.GetMarginPairsConfigurations(t.Context(), marginTradablePair.String())
 	assert.NoError(t, err)
 }
 
 func TestModifyLeverageMultiplier(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku, canManipulateRealOrders)
-	err := ku.ModifyLeverageMultiplier(context.Background(), spotTradablePair.String(), 1, true)
+	err := ku.ModifyLeverageMultiplier(t.Context(), spotTradablePair.String(), 1, true)
 	assert.NoError(t, err)
 }
 
 func TestGetActiveHFOrderSymbols(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, ku)
-	result, err := ku.GetActiveHFOrderSymbols(context.Background(), "MARGIN_TRADE")
+	result, err := ku.GetActiveHFOrderSymbols(t.Context(), "MARGIN_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4370,16 +4370,16 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 		StartDate: time.Now().Add(-time.Hour * 24 * 2),
 		EndDate:   time.Now(),
 	}
-	_, err := ku.GetHistoricalFundingRates(context.Background(), r)
+	_, err := ku.GetHistoricalFundingRates(t.Context(), r)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	r.Pair = currency.EMPTYPAIR
-	_, err = ku.GetHistoricalFundingRates(context.Background(), r)
+	_, err = ku.GetHistoricalFundingRates(t.Context(), r)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	r.Asset = asset.Futures
 	r.Pair = futuresTradablePair
-	result, err := ku.GetHistoricalFundingRates(context.Background(), r)
+	result, err := ku.GetHistoricalFundingRates(t.Context(), r)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -4394,29 +4394,29 @@ func TestProcessFuturesKline(t *testing.T) {
 func TestWithdrawInternationalBank(t *testing.T) {
 	t.Parallel()
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := ku.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := ku.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
 
 func TestWithdrawFiatFunds(t *testing.T) {
 	t.Parallel()
-	_, err := ku.WithdrawFiatFunds(context.Background(), &withdraw.Request{})
+	_, err := ku.WithdrawFiatFunds(t.Context(), &withdraw.Request{})
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := ku.ModifyOrder(context.Background(), &order.Modify{})
+	_, err := ku.ModifyOrder(t.Context(), &order.Modify{})
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
 
 func TestGetHistoricTrades(t *testing.T) {
-	_, err := ku.GetHistoricTrades(context.Background(), currency.EMPTYPAIR, asset.Spot, time.Time{}, time.Time{})
+	_, err := ku.GetHistoricTrades(t.Context(), currency.EMPTYPAIR, asset.Spot, time.Time{}, time.Time{})
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
 
 func TestCancelBatchOrders(t *testing.T) {
-	_, err := ku.CancelBatchOrders(context.Background(), nil)
+	_, err := ku.CancelBatchOrders(t.Context(), nil)
 	assert.ErrorIs(t, common.ErrFunctionNotSupported, err)
 }
 

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetTicker(context.Background(), testCurrencyPair)
+	_, err := l.GetTicker(t.Context(), testCurrencyPair)
 	if err != nil {
 		t.Error(err)
 	}
@@ -74,7 +74,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
-	tickers, err := l.GetTickers(context.Background())
+	tickers, err := l.GetTickers(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestGetTickers(t *testing.T) {
 
 func TestGetCurrencyPairs(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetCurrencyPairs(context.Background())
+	_, err := l.GetCurrencyPairs(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -93,11 +93,11 @@ func TestGetCurrencyPairs(t *testing.T) {
 
 func TestGetMarketDepths(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetMarketDepths(context.Background(), testCurrencyPair, "600", "1")
+	_, err := l.GetMarketDepths(t.Context(), testCurrencyPair, "600", "1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	a, _ := l.GetMarketDepths(context.Background(), testCurrencyPair, "4", "0")
+	a, _ := l.GetMarketDepths(t.Context(), testCurrencyPair, "4", "0")
 	if len(a.Data.Asks) != 4 {
 		t.Errorf("asks length requested doesn't match the output")
 	}
@@ -105,11 +105,11 @@ func TestGetMarketDepths(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetTrades(context.Background(), testCurrencyPair, 600, time.Now().Unix())
+	_, err := l.GetTrades(t.Context(), testCurrencyPair, 600, time.Now().Unix())
 	if err != nil {
 		t.Error(err)
 	}
-	a, err := l.GetTrades(context.Background(), testCurrencyPair, 600, 0)
+	a, err := l.GetTrades(t.Context(), testCurrencyPair, 600, 0)
 	if len(a) != 600 && err != nil {
 		t.Error(err)
 	}
@@ -117,7 +117,7 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetKlines(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetKlines(context.Background(),
+	_, err := l.GetKlines(t.Context(),
 		testCurrencyPair, "600", "minute1",
 		strconv.FormatInt(time.Now().Unix(), 10))
 	if err != nil {
@@ -133,7 +133,7 @@ func TestUpdateOrderbook(t *testing.T) {
 		Quote:     currency.BTC,
 	}
 
-	_, err := l.UpdateOrderbook(context.Background(), p.Lower(), asset.Spot)
+	_, err := l.UpdateOrderbook(t.Context(), p.Lower(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -143,7 +143,7 @@ func TestGetUserInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.GetUserInfo(context.Background())
+	_, err := l.GetUserInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -154,19 +154,19 @@ func TestCreateOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l, canManipulateRealOrders)
 
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.USDT.String(), "_")
-	_, err := l.CreateOrder(context.Background(), cp.Lower().String(), "what", 1231, 12314)
+	_, err := l.CreateOrder(t.Context(), cp.Lower().String(), "what", 1231, 12314)
 	if err == nil {
 		t.Error("CreateOrder error cannot be nil")
 	}
-	_, err = l.CreateOrder(context.Background(), cp.Lower().String(), order.Buy.Lower(), 0, 0)
+	_, err = l.CreateOrder(t.Context(), cp.Lower().String(), order.Buy.Lower(), 0, 0)
 	if err == nil {
 		t.Error("CreateOrder error cannot be nil")
 	}
-	_, err = l.CreateOrder(context.Background(), cp.Lower().String(), order.Sell.Lower(), 1231, 0)
+	_, err = l.CreateOrder(t.Context(), cp.Lower().String(), order.Sell.Lower(), 1231, 0)
 	if err == nil {
 		t.Error("CreateOrder error cannot be nil")
 	}
-	_, err = l.CreateOrder(context.Background(), cp.Lower().String(), order.Buy.Lower(), 58, 681)
+	_, err = l.CreateOrder(t.Context(), cp.Lower().String(), order.Buy.Lower(), 58, 681)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestRemoveOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l, canManipulateRealOrders)
 
 	cp := currency.NewPairWithDelimiter(currency.ETH.String(), currency.BTC.String(), "_")
-	_, err := l.RemoveOrder(context.Background(),
+	_, err := l.RemoveOrder(t.Context(),
 		cp.Lower().String(), "24f7ce27-af1d-4dca-a8c1-ef1cbeec1b23")
 	if err != nil {
 		t.Error(err)
@@ -189,7 +189,7 @@ func TestQueryOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.USDT.String(), "_")
-	_, err := l.QueryOrder(context.Background(), cp.Lower().String(), "1")
+	_, err := l.QueryOrder(t.Context(), cp.Lower().String(), "1")
 	if err != nil {
 		t.Error(err)
 	}
@@ -200,7 +200,7 @@ func TestQueryOrderHistory(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.USDT.String(), "_")
-	_, err := l.QueryOrderHistory(context.Background(),
+	_, err := l.QueryOrderHistory(t.Context(),
 		cp.Lower().String(), "1", "100")
 	if err != nil {
 		t.Error(err)
@@ -209,7 +209,7 @@ func TestQueryOrderHistory(t *testing.T) {
 
 func TestGetPairInfo(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetPairInfo(context.Background())
+	_, err := l.GetPairInfo(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -219,7 +219,7 @@ func TestOrderTransactionDetails(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.OrderTransactionDetails(context.Background(),
+	_, err := l.OrderTransactionDetails(t.Context(),
 		testCurrencyPair, "24f7ce27-af1d-4dca-a8c1-ef1cbeec1b23")
 	if err != nil {
 		t.Error(err)
@@ -230,7 +230,7 @@ func TestTransactionHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.TransactionHistory(context.Background(),
+	_, err := l.TransactionHistory(t.Context(),
 		testCurrencyPair, "", "", "", "", "", "")
 	if err != nil {
 		t.Error(err)
@@ -242,7 +242,7 @@ func TestGetOpenOrders(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
 	cp := currency.NewPairWithDelimiter(currency.BTC.String(), currency.USDT.String(), "_")
-	_, err := l.GetOpenOrders(context.Background(), cp.Lower().String(), "1", "50")
+	_, err := l.GetOpenOrders(t.Context(), cp.Lower().String(), "1", "50")
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,7 +250,7 @@ func TestGetOpenOrders(t *testing.T) {
 
 func TestUSD2RMBRate(t *testing.T) {
 	t.Parallel()
-	_, err := l.USD2RMBRate(context.Background())
+	_, err := l.USD2RMBRate(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -258,7 +258,7 @@ func TestUSD2RMBRate(t *testing.T) {
 
 func TestGetWithdrawConfig(t *testing.T) {
 	t.Parallel()
-	_, err := l.GetWithdrawConfig(context.Background(),
+	_, err := l.GetWithdrawConfig(t.Context(),
 		currency.ETH.Lower().String())
 	if err != nil {
 		t.Error(err)
@@ -269,7 +269,7 @@ func TestWithdraw(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l, canManipulateRealOrders)
 
-	_, err := l.Withdraw(context.Background(), "", "", "", "", "", "")
+	_, err := l.Withdraw(t.Context(), "", "", "", "", "", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -279,7 +279,7 @@ func TestGetWithdrawRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.GetWithdrawalRecords(context.Background(), currency.ETH.Lower().String(), 0, 1, 20)
+	_, err := l.GetWithdrawalRecords(t.Context(), currency.ETH.Lower().String(), 0, 1, 20)
 	if err != nil {
 		t.Error(err)
 	}
@@ -289,12 +289,12 @@ func TestLoadPrivKey(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	err := l.loadPrivKey(context.Background())
+	err := l.loadPrivKey(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
 
-	ctx := account.DeployCredentialsToContext(context.Background(),
+	ctx := account.DeployCredentialsToContext(t.Context(),
 		&account.Credentials{Secret: "errortest"})
 	err = l.loadPrivKey(ctx)
 	if err == nil {
@@ -306,7 +306,7 @@ func TestSign(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	err := l.loadPrivKey(context.Background())
+	err := l.loadPrivKey(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +334,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := l.SubmitOrder(context.Background(), orderSubmission)
+	response, err := l.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(l) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(l) && err == nil {
@@ -351,7 +351,7 @@ func TestCancelOrder(t *testing.T) {
 	a.Pair = cp
 	a.AssetType = asset.Spot
 	a.OrderID = "24f7ce27-af1d-4dca-a8c1-ef1cbeec1b23"
-	err := l.CancelOrder(context.Background(), &a)
+	err := l.CancelOrder(t.Context(), &a)
 	if err != nil {
 		t.Error(err)
 	}
@@ -361,7 +361,7 @@ func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.GetOrderInfo(context.Background(),
+	_, err := l.GetOrderInfo(t.Context(),
 		"9ead39f5-701a-400b-b635-d7349eb0f6b", currency.EMPTYPAIR, asset.Spot)
 	if err != nil {
 		t.Error(err)
@@ -372,7 +372,7 @@ func TestGetAllOpenOrderID(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.getAllOpenOrderID(context.Background())
+	_, err := l.getAllOpenOrderID(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -385,7 +385,7 @@ func TestGetFeeByType(t *testing.T) {
 	input.Amount = 2
 	input.FeeType = exchange.CryptocurrencyWithdrawalFee
 	input.Pair = cp
-	_, err := l.GetFeeByType(context.Background(), &input)
+	_, err := l.GetFeeByType(t.Context(), &input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -395,7 +395,7 @@ func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := l.UpdateAccountInfo(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -410,7 +410,7 @@ func TestGetActiveOrders(t *testing.T) {
 	input.AssetType = asset.Spot
 	input.Type = order.AnyType
 	input.Side = order.AnySide
-	_, err := l.GetActiveOrders(context.Background(), &input)
+	_, err := l.GetActiveOrders(t.Context(), &input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -425,7 +425,7 @@ func TestGetOrderHistory(t *testing.T) {
 	input.AssetType = asset.Spot
 	input.Type = order.AnyType
 	input.Side = order.AnySide
-	_, err := l.GetOrderHistory(context.Background(), &input)
+	_, err := l.GetOrderHistory(t.Context(), &input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -437,12 +437,12 @@ func TestGetHistoricCandles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = l.GetHistoricCandles(context.Background(), cp, asset.Spot, kline.OneMin, time.Now().Add(-24*time.Hour), time.Now())
+	_, err = l.GetHistoricCandles(t.Context(), cp, asset.Spot, kline.OneMin, time.Now().Add(-24*time.Hour), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = l.GetHistoricCandles(context.Background(), cp, asset.Spot, kline.OneHour, time.Now().Add(-24*time.Hour), time.Now())
+	_, err = l.GetHistoricCandles(t.Context(), cp, asset.Spot, kline.OneHour, time.Now().Add(-24*time.Hour), time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +456,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = l.GetHistoricCandlesExtended(context.Background(), cp, asset.Spot, kline.OneMin, startTime, end)
+	_, err = l.GetHistoricCandlesExtended(t.Context(), cp, asset.Spot, kline.OneMin, startTime, end)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +516,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = l.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = l.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -528,13 +528,13 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = l.GetHistoricTrades(context.Background(),
+	_, err = l.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil {
 		t.Error(err)
 	}
 	// longer term
-	_, err = l.GetHistoricTrades(context.Background(),
+	_, err = l.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*60*200), time.Now().Add(-time.Minute*60*199))
 	if err != nil {
 		t.Error(err)
@@ -547,7 +547,7 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = l.UpdateTicker(context.Background(), cp, asset.Spot)
+	_, err = l.UpdateTicker(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -555,7 +555,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := l.UpdateTickers(context.Background(), asset.Spot)
+	err := l.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -586,7 +586,7 @@ func TestGetStatus(t *testing.T) {
 
 func TestGetTimestamp(t *testing.T) {
 	t.Parallel()
-	tt, err := l.GetTimestamp(context.Background())
+	tt, err := l.GetTimestamp(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -597,7 +597,7 @@ func TestGetTimestamp(t *testing.T) {
 
 func TestGetServerTime(t *testing.T) {
 	t.Parallel()
-	tt, err := l.GetServerTime(context.Background(), asset.Spot)
+	tt, err := l.GetServerTime(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -610,7 +610,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, l)
 
-	_, err := l.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := l.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -623,7 +623,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := l.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := l.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := l.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/mock/server_test.go
+++ b/exchanges/mock/server_test.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"os"
 	"strings"
@@ -66,7 +65,7 @@ func TestNewVCRServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = common.SendHTTPRequest(context.Background(),
+	_, err = common.SendHTTPRequest(t.Context(),
 		http.MethodGet,
 		"http://localhost:300/somethingElse?"+queryString,
 		nil,
@@ -76,7 +75,7 @@ func TestNewVCRServer(t *testing.T) {
 	}
 
 	// Expected good outcome
-	r, err := common.SendHTTPRequest(context.Background(),
+	r, err := common.SendHTTPRequest(t.Context(),
 		http.MethodGet,
 		deets,
 		nil,
@@ -89,7 +88,7 @@ func TestNewVCRServer(t *testing.T) {
 		t.Error("Was not expecting any value returned:", r)
 	}
 
-	r, err = common.SendHTTPRequest(context.Background(),
+	r, err = common.SendHTTPRequest(t.Context(),
 		http.MethodGet,
 		deets+"/test?"+queryString,
 		nil,

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -4983,7 +4983,7 @@ func TestGetFuturesContractDetails(t *testing.T) {
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	for _, a := range []asset.Item{asset.Futures, asset.PerpetualSwap, asset.Spread} {
-		result, err := ok.GetFuturesContractDetails(context.Background(), a)
+		result, err := ok.GetFuturesContractDetails(t.Context(), a)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 	}

--- a/exchanges/okx/ratelimiter_test.go
+++ b/exchanges/okx/ratelimiter_test.go
@@ -1,7 +1,6 @@
 package okx
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -275,7 +274,7 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if err := rl.InitiateRateLimit(context.Background(), tt); err != nil {
+			if err := rl.InitiateRateLimit(t.Context(), tt); err != nil {
 				t.Fatalf("error applying rate limit: %v", err)
 			}
 		})

--- a/exchanges/orderbook/simulator/simulator_test.go
+++ b/exchanges/orderbook/simulator/simulator_test.go
@@ -1,7 +1,6 @@
 package simulator
 
 import (
-	"context"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -24,7 +23,7 @@ func TestSimulate(t *testing.T) {
 			},
 		},
 	}
-	o, err := b.UpdateOrderbook(context.Background(),
+	o, err := b.UpdateOrderbook(t.Context(),
 		currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	if err != nil {
 		t.Fatal(err)

--- a/exchanges/poloniex/currency_details_test.go
+++ b/exchanges/poloniex/currency_details_test.go
@@ -1,7 +1,6 @@
 package poloniex
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -65,7 +64,7 @@ func TestWsCurrencyMap(t *testing.T) {
 		t.Fatalf("expected: %v but received: %v", errCodeMapIsNil, err)
 	}
 
-	c, err := p.GetCurrencies(context.Background())
+	c, err := p.GetCurrencies(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +74,7 @@ func TestWsCurrencyMap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tick, err := p.GetTicker(context.Background())
+	tick, err := p.GetTicker(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -1,7 +1,6 @@
 package poloniex
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -35,7 +34,7 @@ var p = &Poloniex{}
 
 func TestTimestamp(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetTimestamp(context.Background())
+	_, err := p.GetTimestamp(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -43,7 +42,7 @@ func TestTimestamp(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetTicker(context.Background())
+	_, err := p.GetTicker(t.Context())
 	if err != nil {
 		t.Error("Poloniex GetTicker() error", err)
 	}
@@ -51,7 +50,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetVolume(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetVolume(context.Background())
+	_, err := p.GetVolume(t.Context())
 	if err != nil {
 		t.Error("Test failed - Poloniex GetVolume() error")
 	}
@@ -59,7 +58,7 @@ func TestGetVolume(t *testing.T) {
 
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetOrderbook(context.Background(), "BTC_XMR", 50)
+	_, err := p.GetOrderbook(t.Context(), "BTC_XMR", 50)
 	if err != nil {
 		t.Error("Test failed - Poloniex GetOrderbook() error", err)
 	}
@@ -67,7 +66,7 @@ func TestGetOrderbook(t *testing.T) {
 
 func TestGetTradeHistory(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetTradeHistory(context.Background(), "BTC_XMR", 0, 0)
+	_, err := p.GetTradeHistory(t.Context(), "BTC_XMR", 0, 0)
 	if err != nil {
 		t.Error("Test failed - Poloniex GetTradeHistory() error", err)
 	}
@@ -75,7 +74,7 @@ func TestGetTradeHistory(t *testing.T) {
 
 func TestGetChartData(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetChartData(context.Background(),
+	_, err := p.GetChartData(t.Context(),
 		"BTC_XMR",
 		time.Unix(1405699200, 0), time.Unix(1405699400, 0), "300")
 	if err != nil {
@@ -85,7 +84,7 @@ func TestGetChartData(t *testing.T) {
 
 func TestGetCurrencies(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetCurrencies(context.Background())
+	_, err := p.GetCurrencies(t.Context())
 	if err != nil {
 		t.Error("Test failed - Poloniex GetCurrencies() error", err)
 	}
@@ -93,7 +92,7 @@ func TestGetCurrencies(t *testing.T) {
 
 func TestGetLoanOrders(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetLoanOrders(context.Background(), "BTC")
+	_, err := p.GetLoanOrders(t.Context(), "BTC")
 	if err != nil {
 		t.Error("Test failed - Poloniex GetLoanOrders() error", err)
 	}
@@ -117,7 +116,7 @@ func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	t.Parallel()
 
 	feeBuilder := setFeeBuilder()
-	_, err := p.GetFeeByType(context.Background(), feeBuilder)
+	_, err := p.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func TestGetFee(t *testing.T) {
 
 	if sharedtestvalues.AreAPICredentialsSet(p) || mockTests {
 		// CryptocurrencyTradeFee Basic
-		if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
@@ -150,21 +149,21 @@ func TestGetFee(t *testing.T) {
 		feeBuilder = setFeeBuilder()
 		feeBuilder.Amount = 1000
 		feeBuilder.PurchasePrice = 1000
-		if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 
 		// CryptocurrencyTradeFee Negative purchase price
 		feeBuilder = setFeeBuilder()
 		feeBuilder.PurchasePrice = -1000
-		if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+		if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 			t.Error(err)
 		}
 	}
 	// CryptocurrencyWithdrawalFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -172,21 +171,21 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.Pair.Base = currency.NewCode("hello")
 	feeBuilder.FeeType = exchange.CryptocurrencyWithdrawalFee
-	if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// CryptocurrencyDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.CryptocurrencyDepositFee
-	if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
 	// InternationalBankDepositFee Basic
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankDepositFee
-	if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 
@@ -194,7 +193,7 @@ func TestGetFee(t *testing.T) {
 	feeBuilder = setFeeBuilder()
 	feeBuilder.FeeType = exchange.InternationalBankWithdrawalFee
 	feeBuilder.FiatCurrency = currency.USD
-	if _, err := p.GetFee(context.Background(), feeBuilder); err != nil {
+	if _, err := p.GetFee(t.Context(), feeBuilder); err != nil {
 		t.Error(err)
 	}
 }
@@ -220,7 +219,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := p.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := p.GetActiveOrders(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
 		t.Error("GetActiveOrders() error", err)
@@ -239,7 +238,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := p.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := p.GetOrderHistory(t.Context(), &getOrdersRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
 		t.Errorf("Could not get order history: %s", err)
@@ -283,7 +282,7 @@ func TestGetOrderStatus(t *testing.T) {
 				t.Skip("mock mismatch, skipping")
 			}
 
-			_, err := p.GetAuthenticatedOrderStatus(context.Background(),
+			_, err := p.GetAuthenticatedOrderStatus(t.Context(),
 				tt.orderID)
 			switch {
 			case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
@@ -338,7 +337,7 @@ func TestGetOrderTrades(t *testing.T) {
 				t.Skip("mock mismatch, skipping")
 			}
 
-			_, err := p.GetAuthenticatedOrderTrades(context.Background(), tt.orderID)
+			_, err := p.GetAuthenticatedOrderTrades(t.Context(), tt.orderID)
 			switch {
 			case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
 				t.Errorf("Could not get order trades: %s", err)
@@ -375,7 +374,7 @@ func TestSubmitOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	response, err := p.SubmitOrder(context.Background(), orderSubmission)
+	response, err := p.SubmitOrder(t.Context(), orderSubmission)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(p) && (err != nil || response.Status != order.Filled):
 		t.Errorf("Order failed to be placed: %v", err)
@@ -398,7 +397,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := p.CancelOrder(context.Background(), orderCancellation)
+	err := p.CancelOrder(t.Context(), orderCancellation)
 	switch {
 	case !sharedtestvalues.AreAPICredentialsSet(p) && !mockTests && err == nil:
 		t.Error("Expecting an error when no keys are set")
@@ -423,7 +422,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := p.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := p.CancelAllOrders(t.Context(), orderCancellation)
 	switch {
 	case !sharedtestvalues.AreAPICredentialsSet(p) && !mockTests && err == nil:
 		t.Error("Expecting an error when no keys are set")
@@ -443,7 +442,7 @@ func TestModifyOrder(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, p, canManipulateRealOrders)
 	}
 
-	_, err := p.ModifyOrder(context.Background(), &order.Modify{
+	_, err := p.ModifyOrder(t.Context(), &order.Modify{
 		OrderID:   "1337",
 		Price:     1337,
 		AssetType: asset.Spot,
@@ -476,7 +475,7 @@ func TestWithdraw(t *testing.T) {
 		sharedtestvalues.SkipTestIfCannotManipulateOrders(t, p, canManipulateRealOrders)
 	}
 
-	_, err := p.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := p.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
@@ -495,7 +494,7 @@ func TestWithdrawFiat(t *testing.T) {
 	}
 
 	var withdrawFiatRequest withdraw.Request
-	_, err := p.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := p.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
 			common.ErrFunctionNotSupported, err)
@@ -509,7 +508,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	}
 
 	var withdrawFiatRequest withdraw.Request
-	_, err := p.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := p.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
@@ -519,7 +518,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetDepositAddress(context.Background(), currency.USDT, "", "USDTETH")
+	_, err := p.GetDepositAddress(t.Context(), currency.USDT, "", "USDTETH")
 	switch {
 	case sharedtestvalues.AreAPICredentialsSet(p) && err != nil:
 		t.Error("GetDepositAddress()", err)
@@ -534,7 +533,7 @@ func TestGenerateNewAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
 
-	_, err := p.GenerateNewAddress(context.Background(), currency.XRP.String())
+	_, err := p.GenerateNewAddress(t.Context(), currency.XRP.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +552,7 @@ func TestWsAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	go p.wsReadData()
-	creds, err := p.GetCredentials(context.Background())
+	creds, err := p.GetCredentials(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +578,7 @@ func TestWsSubAck(t *testing.T) {
 }
 
 func TestWsTicker(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -591,7 +590,7 @@ func TestWsTicker(t *testing.T) {
 }
 
 func TestWsExchangeVolume(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -604,7 +603,7 @@ func TestWsExchangeVolume(t *testing.T) {
 
 func TestWsTrades(t *testing.T) {
 	p.SetSaveTradeDataStatus(true)
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -616,7 +615,7 @@ func TestWsTrades(t *testing.T) {
 }
 
 func TestWsPriceAggregateOrderbook(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -641,7 +640,7 @@ func TestGetHistoricCandles(t *testing.T) {
 		t.Fatal(err)
 	}
 	start := time.Unix(1588741402, 0)
-	_, err = p.GetHistoricCandles(context.Background(), pair, asset.Spot, kline.FiveMin, start, time.Unix(1588745003, 0))
+	_, err = p.GetHistoricCandles(t.Context(), pair, asset.Spot, kline.FiveMin, start, time.Unix(1588745003, 0))
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -655,7 +654,7 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = p.GetHistoricCandlesExtended(context.Background(), pair, asset.Spot, kline.FiveMin, time.Unix(1588741402, 0), time.Unix(1588745003, 0))
+	_, err = p.GetHistoricCandlesExtended(t.Context(), pair, asset.Spot, kline.FiveMin, time.Unix(1588741402, 0), time.Unix(1588745003, 0))
 	if !errors.Is(err, nil) {
 		t.Fatal(err)
 	}
@@ -670,7 +669,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if mockTests {
 		t.Skip("relies on time.Now()")
 	}
-	_, err = p.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = p.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -689,7 +688,7 @@ func TestGetHistoricTrades(t *testing.T) {
 		tStart = time.Date(tmNow.Year(), tmNow.Month()-3, 6, 0, 0, 0, 0, time.UTC)
 		tEnd = time.Date(tmNow.Year(), tmNow.Month()-3, 7, 0, 0, 0, 0, time.UTC)
 	}
-	_, err = p.GetHistoricTrades(context.Background(),
+	_, err = p.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, tStart, tEnd)
 	if err != nil {
 		t.Error(err)
@@ -697,7 +696,7 @@ func TestGetHistoricTrades(t *testing.T) {
 }
 
 func TestProcessAccountMarginPosition(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -734,7 +733,7 @@ func TestProcessAccountMarginPosition(t *testing.T) {
 }
 
 func TestProcessAccountPendingOrder(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -846,7 +845,7 @@ func TestProcessAccountOrderUpdate(t *testing.T) {
 }
 
 func TestProcessAccountOrderLimit(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -907,7 +906,7 @@ func TestProcessAccountOrderLimit(t *testing.T) {
 }
 
 func TestProcessAccountBalanceUpdate(t *testing.T) {
-	err := p.loadCurrencyDetails(context.Background())
+	err := p.loadCurrencyDetails(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1018,7 +1017,7 @@ func TestGetCompleteBalances(t *testing.T) {
 	if !mockTests {
 		sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
 	}
-	_, err := p.GetCompleteBalances(context.Background())
+	_, err := p.GetCompleteBalances(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1030,7 +1029,7 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = p.UpdateTicker(context.Background(), cp, asset.Spot)
+	_, err = p.UpdateTicker(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1038,7 +1037,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := p.UpdateTickers(context.Background(), asset.Spot)
+	err := p.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1046,7 +1045,7 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestGetAvailableTransferChains(t *testing.T) {
 	t.Parallel()
-	_, err := p.GetAvailableTransferChains(context.Background(), currency.USDT)
+	_, err := p.GetAvailableTransferChains(t.Context(), currency.USDT)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1056,7 +1055,7 @@ func TestWalletActivity(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
 
-	_, err := p.WalletActivity(context.Background(), time.Now().Add(-time.Minute), time.Now(), "")
+	_, err := p.WalletActivity(t.Context(), time.Now().Add(-time.Minute), time.Now(), "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1065,7 +1064,7 @@ func TestWalletActivity(t *testing.T) {
 func TestCancelMultipleOrdersByIDs(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
-	_, err := p.CancelMultipleOrdersByIDs(context.Background(), []string{"1234"}, []string{"5678"})
+	_, err := p.CancelMultipleOrdersByIDs(t.Context(), []string{"1234"}, []string{"5678"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -1074,7 +1073,7 @@ func TestCancelMultipleOrdersByIDs(t *testing.T) {
 func TestGetAccountFundingHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
-	_, err := p.GetAccountFundingHistory(context.Background())
+	_, err := p.GetAccountFundingHistory(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -1084,7 +1083,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p)
 
-	_, err := p.GetWithdrawalsHistory(context.Background(), currency.BTC, asset.Spot)
+	_, err := p.GetWithdrawalsHistory(t.Context(), currency.BTC, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1093,7 +1092,7 @@ func TestGetWithdrawalsHistory(t *testing.T) {
 func TestCancelBatchOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, p, canManipulateRealOrders)
-	_, err := p.CancelBatchOrders(context.Background(), []order.Cancel{
+	_, err := p.CancelBatchOrders(t.Context(), []order.Cancel{
 		{
 			OrderID:   "1234",
 			AssetType: asset.Spot,
@@ -1107,7 +1106,7 @@ func TestCancelBatchOrders(t *testing.T) {
 
 func TestGetTimestamp(t *testing.T) {
 	t.Parallel()
-	st, err := p.GetTimestamp(context.Background())
+	st, err := p.GetTimestamp(t.Context())
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -1119,7 +1118,7 @@ func TestGetTimestamp(t *testing.T) {
 
 func TestGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := p.GetServerTime(context.Background(), asset.Spot)
+	st, err := p.GetServerTime(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -1131,7 +1130,7 @@ func TestGetServerTime(t *testing.T) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := p.FetchTradablePairs(context.Background(), asset.Spot)
+	_, err := p.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1144,7 +1143,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := p.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := p.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := p.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -3,6 +3,7 @@ package request
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"math"
@@ -12,8 +13,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -136,7 +135,7 @@ func TestCheckRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var check *Item
 	_, err = check.validateRequest(ctx, &Requester{})
@@ -210,29 +209,20 @@ var globalshell = RateLimitDefinitions{
 func TestDoRequest(t *testing.T) {
 	t.Parallel()
 	r, err := New("test", new(http.Client), WithLimiter(globalshell))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "New requester must not error")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err = (*Requester)(nil).SendPayload(ctx, Unset, nil, UnauthenticatedRequest)
-	if !errors.Is(ErrRequestSystemIsNil, err) {
-		t.Fatalf("expected: %v but received: %v", ErrRequestSystemIsNil, err)
-	}
+	require.ErrorIs(t, err, ErrRequestSystemIsNil)
+
 	err = r.SendPayload(ctx, Unset, nil, UnauthenticatedRequest)
-	if !errors.Is(errRequestFunctionIsNil, err) {
-		t.Fatalf("expected: %v but received: %v", errRequestFunctionIsNil, err)
-	}
+	require.ErrorIs(t, err, errRequestFunctionIsNil)
 
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) { return nil, nil }, UnauthenticatedRequest)
-	if !errors.Is(errRequestItemNil, err) {
-		t.Fatalf("expected: %v but received: %v", errRequestItemNil, err)
-	}
+	require.ErrorIs(t, err, errRequestItemNil)
 
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) { return &Item{}, nil }, UnauthenticatedRequest)
-	if !errors.Is(errInvalidPath, err) {
-		t.Fatalf("expected: %v but received: %v", errInvalidPath, err)
-	}
+	require.ErrorIs(t, err, errInvalidPath)
 
 	var nilHeader http.Header
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) {
@@ -241,15 +231,11 @@ func TestDoRequest(t *testing.T) {
 			HeaderResponse: &nilHeader,
 		}, nil
 	}, UnauthenticatedRequest)
-	if !errors.Is(errHeaderResponseMapIsNil, err) {
-		t.Fatalf("expected: %v but received: %v", errHeaderResponseMapIsNil, err)
-	}
+	require.ErrorIs(t, err, errHeaderResponseMapIsNil)
 
 	// Invalid/missing endpoint limit
 	err = r.SendPayload(ctx, Unset, func() (*Item, error) { return &Item{Path: testURL}, nil }, UnauthenticatedRequest)
-	if !errors.Is(err, errSpecificRateLimiterIsNil) {
-		t.Fatalf("expected: %v but received: %v", errSpecificRateLimiterIsNil, err)
-	}
+	require.ErrorIs(t, err, errSpecificRateLimiterIsNil)
 
 	// Force debug
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) {
@@ -263,40 +249,28 @@ func TestDoRequest(t *testing.T) {
 			Verbose:       true,
 		}, nil
 	}, UnauthenticatedRequest)
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: %v but expected: %v", err, nil)
-	}
+	require.NoError(t, err, "SendPayload must not error")
 
 	// Fail new request call
 	newError := errors.New("request item failure")
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) {
 		return nil, newError
 	}, UnauthenticatedRequest)
-	if !errors.Is(err, newError) {
-		t.Fatalf("received: %v but expected: %v", err, newError)
-	}
+	require.ErrorIs(t, err, newError)
 
 	r._HTTPClient, err = newProtectedClient(common.NewHTTPClientWithTimeout(0))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "newProtectedClient must not error")
 
 	// timeout checker
 	err = r._HTTPClient.setHTTPClientTimeout(time.Millisecond * 50)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "setHTTPClientTimeout must not error")
 	err = r.SendPayload(ctx, UnAuth, func() (*Item, error) {
 		return &Item{Path: testURL + "/timeout"}, nil
 	}, UnauthenticatedRequest)
-	if !errors.Is(err, errFailedToRetryRequest) {
-		t.Fatalf("received: %v but expected: %v", err, errFailedToRetryRequest)
-	}
+	require.ErrorIs(t, err, errFailedToRetryRequest)
 	// reset timeout
 	err = r._HTTPClient.setHTTPClientTimeout(0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "setHTTPClientTimeout must not error")
 
 	// Check JSON
 	var resp struct {
@@ -313,17 +287,10 @@ func TestDoRequest(t *testing.T) {
 			HeaderResponse: &passback,
 		}, nil
 	}, UnauthenticatedRequest)
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: %v but expected: %v", err, nil)
-	}
+	require.NoError(t, err, "SendPayload must not error")
 
-	if passback.Get("Content-Length") != "17" {
-		t.Fatal("incorrect header value")
-	}
-
-	if passback.Get("Content-Type") != "application/json" {
-		t.Fatal("incorrect header value")
-	}
+	require.Equal(t, "17", passback.Get("Content-Length"), "Content-Length must have the correct value")
+	require.Equal(t, "application/json", passback.Get("Content-Type"), "Content-Type must have the correct value")
 
 	// Check error
 	var respErr struct {
@@ -336,89 +303,76 @@ func TestDoRequest(t *testing.T) {
 			Result: &respErr,
 		}, nil
 	}, UnauthenticatedRequest)
-	if !errors.Is(err, nil) {
-		t.Fatalf("received: %v but expected: %v", err, nil)
-	}
-
-	if respErr.Error {
-		t.Fatal("unexpected value")
-	}
+	require.NoError(t, err, "SendPayload must not error")
+	require.False(t, respErr.Error, "Error must be false")
 
 	// Check client side rate limit
-	var failed int32
-	var wg sync.WaitGroup
-	wg.Add(5)
-	for range 5 {
-		go func(wg *sync.WaitGroup) {
+	const numReqs = 5
+	ec := common.CollectErrors(numReqs)
+
+	for range numReqs {
+		go func() {
+			defer ec.Wg.Done()
+
 			var resp struct {
 				Response bool `json:"response"`
 			}
-			payloadError := r.SendPayload(ctx, Auth, func() (*Item, error) {
+			if err := r.SendPayload(ctx, Auth, func() (*Item, error) {
 				return &Item{
 					Method: http.MethodGet,
 					Path:   testURL + "/rate",
 					Result: &resp,
 				}, nil
-			}, AuthenticatedRequest)
-			wg.Done()
-			if payloadError != nil {
-				atomic.StoreInt32(&failed, 1)
-				log.Fatal(payloadError)
+			}, AuthenticatedRequest); err != nil {
+				ec.C <- fmt.Errorf("SendPayload error: %w", err)
+				return
 			}
 			if !resp.Response {
-				atomic.StoreInt32(&failed, 1)
-				log.Fatal(unexpected)
+				ec.C <- fmt.Errorf("unexpected response: %+v", resp)
 			}
-		}(&wg)
+		}()
 	}
-	wg.Wait()
 
-	if failed != 0 {
-		t.Fatal("request failed")
-	}
+	require.NoError(t, ec.Collect(), "Collect must return no errors")
 }
 
 func TestDoRequest_Retries(t *testing.T) {
 	t.Parallel()
 
-	backoff := func(int) time.Duration {
-		return 0
-	}
+	backoff := func(int) time.Duration { return 0 }
 	r, err := New("test", new(http.Client), WithBackoff(backoff))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var failed int32
-	var wg sync.WaitGroup
-	wg.Add(4)
-	for range 4 {
-		go func(wg *sync.WaitGroup) {
-			defer wg.Done()
+	require.NoError(t, err, "New requester must not error")
+
+	const numReqs = 4
+
+	ec := common.CollectErrors(numReqs)
+
+	for range numReqs {
+		go func() {
+			defer ec.Wg.Done()
+
 			var resp struct {
 				Response bool `json:"response"`
 			}
-			payloadError := r.SendPayload(context.Background(), Auth, func() (*Item, error) {
+			itemFn := func() (*Item, error) {
 				return &Item{
 					Method: http.MethodGet,
 					Path:   testURL + "/rate-retry",
 					Result: &resp,
 				}, nil
-			}, AuthenticatedRequest)
-			if payloadError != nil {
-				atomic.StoreInt32(&failed, 1)
-				log.Fatal(payloadError)
+			}
+
+			if err := r.SendPayload(t.Context(), Auth, itemFn, AuthenticatedRequest); err != nil {
+				ec.C <- fmt.Errorf("SendPayload error: %w", err)
+				return
 			}
 			if !resp.Response {
-				atomic.StoreInt32(&failed, 1)
-				log.Fatal(unexpected)
+				ec.C <- fmt.Errorf("unexpected response: %+v", resp)
 			}
-		}(&wg)
+		}()
 	}
-	wg.Wait()
 
-	if failed != 0 {
-		t.Fatal("request failed")
-	}
+	require.NoError(t, ec.Collect(), "Collect must return no errors")
 }
 
 func TestDoRequest_RetryNonRecoverable(t *testing.T) {
@@ -431,7 +385,7 @@ func TestDoRequest_RetryNonRecoverable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = r.SendPayload(context.Background(), Unset, func() (*Item, error) {
+	err = r.SendPayload(t.Context(), Unset, func() (*Item, error) {
 		return &Item{
 			Method: http.MethodGet,
 			Path:   testURL + "/always-retry",
@@ -456,7 +410,7 @@ func TestDoRequest_NotRetryable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = r.SendPayload(context.Background(), Unset, func() (*Item, error) {
+	err = r.SendPayload(t.Context(), Unset, func() (*Item, error) {
 		return &Item{
 			Method: http.MethodGet,
 			Path:   testURL + "/always-retry",
@@ -535,7 +489,7 @@ func TestBasicLimiter(t *testing.T) {
 		t.Fatal(err)
 	}
 	i := Item{Path: "http://www.google.com", Method: http.MethodGet}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tn := time.Now()
 	err = r.SendPayload(ctx, Unset, func() (*Item, error) { return &i, nil }, UnauthenticatedRequest)
@@ -559,77 +513,61 @@ func TestBasicLimiter(t *testing.T) {
 }
 
 func TestEnableDisableRateLimit(t *testing.T) {
-	r, err := New("TestRequest", new(http.Client), WithLimiter(NewBasicRateLimit(time.Minute, 1, 1)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx := context.Background()
+	rl := NewBasicRateLimit(50*time.Millisecond, 1, 1)
+	r, err := New("TestRequest", http.DefaultClient, WithLimiter(rl))
+	require.NoError(t, err, "New requester must not error")
 
-	var resp any
-	err = r.SendPayload(ctx, Auth, func() (*Item, error) {
-		return &Item{
-			Method: http.MethodGet,
-			Path:   testURL,
-			Result: &resp,
-		}, nil
-	}, AuthenticatedRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.EnableRateLimiter()
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
-
-	err = r.DisableRateLimiter()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.SendPayload(ctx, Auth, func() (*Item, error) {
-		return &Item{
-			Method: http.MethodGet,
-			Path:   testURL,
-			Result: &resp,
-		}, nil
-	}, AuthenticatedRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.DisableRateLimiter()
-	if err == nil {
-		t.Fatal("error cannot be nil")
-	}
-
-	err = r.EnableRateLimiter()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ti := time.NewTicker(time.Second)
-	c := make(chan struct{})
-	go func(c chan struct{}) {
-		err = r.SendPayload(ctx, Auth, func() (*Item, error) {
+	sendIt := func() error {
+		return r.SendPayload(t.Context(), Auth, func() (*Item, error) {
 			return &Item{
 				Method: http.MethodGet,
 				Path:   testURL,
-				Result: &resp,
+				Result: new(any),
 			}, nil
 		}, AuthenticatedRequest)
-		if err != nil {
-			log.Fatal(err)
-		}
-		c <- struct{}{}
-	}(c)
-
-	select {
-	case <-c:
-		t.Fatal("rate limiting failure")
-	case <-ti.C:
-		// Correct test
 	}
+
+	t.Run("allow initial request", func(t *testing.T) {
+		require.NoError(t, sendIt(), "sendIt must not error")
+	})
+
+	t.Run("error on redundant enable", func(t *testing.T) {
+		err := r.EnableRateLimiter()
+		assert.ErrorIs(t, err, ErrRateLimiterAlreadyEnabled)
+	})
+
+	t.Run("error on redundant disable", func(t *testing.T) {
+		require.NoError(t, r.DisableRateLimiter(), "DisableRateLimiter must not error")
+		err := r.DisableRateLimiter()
+		assert.ErrorIs(t, err, ErrRateLimiterAlreadyDisabled)
+	})
+
+	t.Run("allow requests when disabled", func(t *testing.T) {
+		require.NoError(t, sendIt(), "sendIt must not error")
+	})
+
+	t.Run("allow when re-enabled", func(t *testing.T) {
+		require.NoError(t, r.EnableRateLimiter(), "EnableRateLimiter must succeed")
+		require.NoError(t, sendIt(), "sendIt must not error")
+	})
+
+	t.Run("block excess requests", func(t *testing.T) {
+		// consume the one token
+		require.NoError(t, sendIt(), "sendIt must not error")
+
+		// fire a second request and expect it to block for at least 20ms
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sendIt()
+		}()
+
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err, "Rate limiter should block until request is done")
+		case <-time.After(20 * time.Millisecond):
+			// still blocked 🌞
+		}
+	})
 }
 
 func TestSetHTTPClient(t *testing.T) {
@@ -702,12 +640,12 @@ func TestGetHTTPClientUserAgent(t *testing.T) {
 
 func TestIsVerbose(t *testing.T) {
 	t.Parallel()
-	require.False(t, IsVerbose(context.Background(), false))
-	require.True(t, IsVerbose(context.Background(), true))
-	require.True(t, IsVerbose(WithVerbose(context.Background()), false))
-	require.False(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, false), false))
-	require.False(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, "bruh"), false))
-	require.True(t, IsVerbose(context.WithValue(context.Background(), contextVerboseFlag, true), false))
+	require.False(t, IsVerbose(t.Context(), false))
+	require.True(t, IsVerbose(t.Context(), true))
+	require.True(t, IsVerbose(WithVerbose(t.Context()), false))
+	require.False(t, IsVerbose(context.WithValue(t.Context(), contextVerboseFlag, false), false))
+	require.False(t, IsVerbose(context.WithValue(t.Context(), contextVerboseFlag, "bruh"), false))
+	require.True(t, IsVerbose(context.WithValue(t.Context(), contextVerboseFlag, true), false))
 }
 
 func TestGetRateLimiterDefinitions(t *testing.T) {

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -1,7 +1,6 @@
 package yobit
 
 import (
-	"context"
 	"errors"
 	"log"
 	"math"
@@ -57,7 +56,7 @@ func TestMain(m *testing.M) {
 
 func TestFetchTradablePairs(t *testing.T) {
 	t.Parallel()
-	_, err := y.FetchTradablePairs(context.Background(), asset.Spot)
+	_, err := y.FetchTradablePairs(t.Context(), asset.Spot)
 	if err != nil {
 		t.Errorf("FetchTradablePairs err: %s", err)
 	}
@@ -65,7 +64,7 @@ func TestFetchTradablePairs(t *testing.T) {
 
 func TestGetInfo(t *testing.T) {
 	t.Parallel()
-	_, err := y.GetInfo(context.Background())
+	_, err := y.GetInfo(t.Context())
 	if err != nil {
 		t.Error("GetInfo() error")
 	}
@@ -73,7 +72,7 @@ func TestGetInfo(t *testing.T) {
 
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
-	_, err := y.GetTicker(context.Background(), "btc_usd")
+	_, err := y.GetTicker(t.Context(), "btc_usd")
 	if err != nil {
 		t.Error("GetTicker() error", err)
 	}
@@ -81,7 +80,7 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetDepth(t *testing.T) {
 	t.Parallel()
-	_, err := y.GetDepth(context.Background(), "btc_usd")
+	_, err := y.GetDepth(t.Context(), "btc_usd")
 	if err != nil {
 		t.Error("GetDepth() error", err)
 	}
@@ -89,7 +88,7 @@ func TestGetDepth(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := y.GetTrades(context.Background(), "btc_usd")
+	_, err := y.GetTrades(t.Context(), "btc_usd")
 	if err != nil {
 		t.Error("GetTrades() error", err)
 	}
@@ -97,7 +96,7 @@ func TestGetTrades(t *testing.T) {
 
 func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
-	_, err := y.UpdateAccountInfo(context.Background(), asset.Spot)
+	_, err := y.UpdateAccountInfo(t.Context(), asset.Spot)
 	if err == nil {
 		t.Error("GetAccountInfo() Expected error")
 	}
@@ -105,7 +104,7 @@ func TestGetAccountInfo(t *testing.T) {
 
 func TestGetOpenOrders(t *testing.T) {
 	t.Parallel()
-	_, err := y.GetOpenOrders(context.Background(), "")
+	_, err := y.GetOpenOrders(t.Context(), "")
 	if err == nil {
 		t.Error("GetOpenOrders() Expected error")
 	}
@@ -114,7 +113,7 @@ func TestGetOpenOrders(t *testing.T) {
 func TestGetOrderInfo(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, y)
-	_, err := y.GetOrderInfo(context.Background(), "1337", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
+	_, err := y.GetOrderInfo(t.Context(), "1337", currency.NewPair(currency.BTC, currency.USD), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +123,7 @@ func TestGetCryptoDepositAddress(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, y)
 
-	_, err := y.GetCryptoDepositAddress(context.Background(), "bTc", false)
+	_, err := y.GetCryptoDepositAddress(t.Context(), "bTc", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -132,7 +131,7 @@ func TestGetCryptoDepositAddress(t *testing.T) {
 
 func TestCancelOrder(t *testing.T) {
 	t.Parallel()
-	err := y.CancelExistingOrder(context.Background(), 1337)
+	err := y.CancelExistingOrder(t.Context(), 1337)
 	if err == nil {
 		t.Error("CancelOrder() Expected error")
 	}
@@ -140,7 +139,7 @@ func TestCancelOrder(t *testing.T) {
 
 func TestTrade(t *testing.T) {
 	t.Parallel()
-	_, err := y.Trade(context.Background(), "", order.Buy.String(), 0, 0)
+	_, err := y.Trade(t.Context(), "", order.Buy.String(), 0, 0)
 	if err == nil {
 		t.Error("Trade() Expected error")
 	}
@@ -148,7 +147,7 @@ func TestTrade(t *testing.T) {
 
 func TestWithdrawCoinsToAddress(t *testing.T) {
 	t.Parallel()
-	_, err := y.WithdrawCoinsToAddress(context.Background(), "", 0, "")
+	_, err := y.WithdrawCoinsToAddress(t.Context(), "", 0, "")
 	if err == nil {
 		t.Error("WithdrawCoinsToAddress() Expected error")
 	}
@@ -156,7 +155,7 @@ func TestWithdrawCoinsToAddress(t *testing.T) {
 
 func TestCreateYobicode(t *testing.T) {
 	t.Parallel()
-	_, err := y.CreateCoupon(context.Background(), "bla", 0)
+	_, err := y.CreateCoupon(t.Context(), "bla", 0)
 	if err == nil {
 		t.Error("CreateYobicode() Expected error")
 	}
@@ -164,7 +163,7 @@ func TestCreateYobicode(t *testing.T) {
 
 func TestRedeemYobicode(t *testing.T) {
 	t.Parallel()
-	_, err := y.RedeemCoupon(context.Background(), "bla2")
+	_, err := y.RedeemCoupon(t.Context(), "bla2")
 	if err == nil {
 		t.Error("RedeemYobicode() Expected error")
 	}
@@ -186,7 +185,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
 	feeBuilder := setFeeBuilder()
-	_, err := y.GetFeeByType(context.Background(), feeBuilder)
+	_, err := y.GetFeeByType(t.Context(), feeBuilder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +329,7 @@ func TestGetActiveOrders(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := y.GetActiveOrders(context.Background(), &getOrdersRequest)
+	_, err := y.GetActiveOrders(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(y) && err != nil {
 		t.Errorf("Could not get open orders: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
@@ -349,7 +348,7 @@ func TestGetOrderHistory(t *testing.T) {
 		Side:      order.AnySide,
 	}
 
-	_, err := y.GetOrderHistory(context.Background(), &getOrdersRequest)
+	_, err := y.GetOrderHistory(t.Context(), &getOrdersRequest)
 	if sharedtestvalues.AreAPICredentialsSet(y) && err != nil {
 		t.Errorf("Could not get order history: %s", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
@@ -377,7 +376,7 @@ func TestSubmitOrder(t *testing.T) {
 		ClientID:  "meowOrder",
 		AssetType: asset.Spot,
 	}
-	response, err := y.SubmitOrder(context.Background(), orderSubmission)
+	response, err := y.SubmitOrder(t.Context(), orderSubmission)
 	if sharedtestvalues.AreAPICredentialsSet(y) && (err != nil || response.Status != order.New) {
 		t.Errorf("Order failed to be placed: %v", err)
 	} else if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
@@ -397,7 +396,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	err := y.CancelOrder(context.Background(), orderCancellation)
+	err := y.CancelOrder(t.Context(), orderCancellation)
 	if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
@@ -418,7 +417,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 		AssetType: asset.Spot,
 	}
 
-	resp, err := y.CancelAllOrders(context.Background(), orderCancellation)
+	resp, err := y.CancelAllOrders(t.Context(), orderCancellation)
 
 	if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -436,7 +435,7 @@ func TestModifyOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
-	_, err := y.ModifyOrder(context.Background(),
+	_, err := y.ModifyOrder(t.Context(),
 		&order.Modify{AssetType: asset.Spot})
 	if err == nil {
 		t.Error("ModifyOrder() Expected error")
@@ -457,7 +456,7 @@ func TestWithdraw(t *testing.T) {
 		},
 	}
 
-	_, err := y.WithdrawCryptocurrencyFunds(context.Background(),
+	_, err := y.WithdrawCryptocurrencyFunds(t.Context(),
 		&withdrawCryptoRequest)
 	if !sharedtestvalues.AreAPICredentialsSet(y) && err == nil {
 		t.Error("Expecting an error when no keys are set")
@@ -472,7 +471,7 @@ func TestWithdrawFiat(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := y.WithdrawFiatFunds(context.Background(), &withdrawFiatRequest)
+	_, err := y.WithdrawFiatFunds(t.Context(), &withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
 			common.ErrFunctionNotSupported,
@@ -485,7 +484,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	sharedtestvalues.SkipTestIfCannotManipulateOrders(t, y, canManipulateRealOrders)
 
 	withdrawFiatRequest := withdraw.Request{}
-	_, err := y.WithdrawFiatFundsToInternationalBank(context.Background(),
+	_, err := y.WithdrawFiatFundsToInternationalBank(t.Context(),
 		&withdrawFiatRequest)
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'",
@@ -496,12 +495,12 @@ func TestWithdrawInternationalBank(t *testing.T) {
 
 func TestGetDepositAddress(t *testing.T) {
 	if sharedtestvalues.AreAPICredentialsSet(y) {
-		_, err := y.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := y.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		if err != nil {
 			t.Error(err)
 		}
 	} else {
-		_, err := y.GetDepositAddress(context.Background(), currency.BTC, "", "")
+		_, err := y.GetDepositAddress(t.Context(), currency.BTC, "", "")
 		if err == nil {
 			t.Error("GetDepositAddress() error")
 		}
@@ -513,7 +512,7 @@ func TestGetRecentTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = y.GetRecentTrades(context.Background(), currencyPair, asset.Spot)
+	_, err = y.GetRecentTrades(t.Context(), currencyPair, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -524,7 +523,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = y.GetHistoricTrades(context.Background(),
+	_, err = y.GetHistoricTrades(t.Context(),
 		currencyPair, asset.Spot, time.Now().Add(-time.Minute*15), time.Now())
 	if err != nil && err != common.ErrFunctionNotSupported {
 		t.Error(err)
@@ -537,7 +536,7 @@ func TestUpdateTicker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = y.UpdateTicker(context.Background(), cp, asset.Spot)
+	_, err = y.UpdateTicker(t.Context(), cp, asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -545,7 +544,7 @@ func TestUpdateTicker(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	err := y.UpdateTickers(context.Background(), asset.Spot)
+	err := y.UpdateTickers(t.Context(), asset.Spot)
 	if err != nil {
 		t.Error(err)
 	}
@@ -553,7 +552,7 @@ func TestUpdateTickers(t *testing.T) {
 
 func TestWrapperGetServerTime(t *testing.T) {
 	t.Parallel()
-	st, err := y.GetServerTime(context.Background(), asset.Spot)
+	st, err := y.GetServerTime(t.Context(), asset.Spot)
 	if !errors.Is(err, nil) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, nil)
 	}
@@ -570,7 +569,7 @@ func TestGetCurrencyTradeURL(t *testing.T) {
 		pairs, err := y.CurrencyPairs.GetPairs(a, false)
 		require.NoError(t, err, "cannot get pairs for %s", a)
 		require.NotEmpty(t, pairs, "no pairs for %s", a)
-		resp, err := y.GetCurrencyTradeURL(context.Background(), a, pairs[0])
+		resp, err := y.GetCurrencyTradeURL(t.Context(), a, pairs[0])
 		require.NoError(t, err)
 		assert.NotEmpty(t, resp)
 	}

--- a/gctscript/wrappers/gct/exchange/exchange_test.go
+++ b/gctscript/wrappers/gct/exchange/exchange_test.go
@@ -89,7 +89,7 @@ func TestExchange_Ticker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = exchangeTest.Ticker(context.Background(), exchName, c, assetType)
+	_, err = exchangeTest.Ticker(t.Context(), exchName, c, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestExchange_Orderbook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = exchangeTest.Orderbook(context.Background(), exchName, c, assetType)
+	_, err = exchangeTest.Orderbook(t.Context(), exchName, c, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestExchange_AccountInformation(t *testing.T) {
 	if !configureExchangeKeys() {
 		t.Skip("no exchange configured test skipped")
 	}
-	_, err := exchangeTest.AccountInformation(context.Background(),
+	_, err := exchangeTest.AccountInformation(t.Context(),
 		exchName, asset.Spot)
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +135,7 @@ func TestExchange_QueryOrder(t *testing.T) {
 		t.Skip("no exchange configured test skipped")
 	}
 	t.Parallel()
-	_, err := exchangeTest.QueryOrder(context.Background(),
+	_, err := exchangeTest.QueryOrder(t.Context(),
 		exchName, orderID, currency.EMPTYPAIR, assetType)
 	if err != nil {
 		t.Fatal(err)
@@ -162,7 +162,7 @@ func TestExchange_SubmitOrder(t *testing.T) {
 		Exchange:  exchName,
 		AssetType: asset.Spot,
 	}
-	_, err = exchangeTest.SubmitOrder(context.Background(), tempOrder)
+	_, err = exchangeTest.SubmitOrder(t.Context(), tempOrder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestExchange_CancelOrder(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPair(currency.BTC, currency.USD)
 	a := asset.Spot
-	_, err := exchangeTest.CancelOrder(context.Background(),
+	_, err := exchangeTest.CancelOrder(t.Context(),
 		exchName, orderID, cp, a)
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func TestOHLCV(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPair(currency.BTC, currency.AUD)
 	cp.Delimiter = currency.DashDelimiter
-	calvinKline, err := exchangeTest.OHLCV(context.Background(), exchName, cp, assetType, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.OneHour)
+	calvinKline, err := exchangeTest.OHLCV(t.Context(), exchName, cp, assetType, time.Now().Add(-time.Hour*24).UTC(), time.Now().UTC(), kline.OneHour)
 	if err != nil {
 		t.Error(err)
 	}

--- a/gctscript/wrappers/validator/validator_test.go
+++ b/gctscript/wrappers/validator/validator_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -64,13 +63,13 @@ func TestWrapper_IsEnabled(t *testing.T) {
 func TestWrapper_AccountInformation(t *testing.T) {
 	t.Parallel()
 
-	_, err := testWrapper.AccountInformation(context.Background(),
+	_, err := testWrapper.AccountInformation(t.Context(),
 		exchName, asset.Spot)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.AccountInformation(context.Background(),
+	_, err = testWrapper.AccountInformation(t.Context(),
 		exchError.String(), asset.Spot)
 	if err == nil {
 		t.Fatal("expected AccountInformation to return error on invalid name")
@@ -80,31 +79,31 @@ func TestWrapper_AccountInformation(t *testing.T) {
 func TestWrapper_CancelOrder(t *testing.T) {
 	t.Parallel()
 	cp := currency.NewPair(currency.BTC, currency.USD)
-	_, err := testWrapper.CancelOrder(context.Background(),
+	_, err := testWrapper.CancelOrder(t.Context(),
 		exchName, orderID, cp, assetType)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = testWrapper.CancelOrder(context.Background(),
+	_, err = testWrapper.CancelOrder(t.Context(),
 		exchError.String(), orderID, cp, assetType)
 	if err == nil {
 		t.Error("expected CancelOrder to return error on invalid name")
 	}
 
-	_, err = testWrapper.CancelOrder(context.Background(),
+	_, err = testWrapper.CancelOrder(t.Context(),
 		exchName, "", cp, assetType)
 	if err == nil {
 		t.Error("expected CancelOrder to return error on invalid name")
 	}
 
-	_, err = testWrapper.CancelOrder(context.Background(),
+	_, err = testWrapper.CancelOrder(t.Context(),
 		exchName, orderID, currency.EMPTYPAIR, assetType)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = testWrapper.CancelOrder(context.Background(),
+	_, err = testWrapper.CancelOrder(t.Context(),
 		exchName, orderID, cp, asset.Empty)
 	if err != nil {
 		t.Error(err)
@@ -129,13 +128,13 @@ func TestWrapper_Orderbook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testWrapper.Orderbook(context.Background(),
+	_, err = testWrapper.Orderbook(t.Context(),
 		exchName, c, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.Orderbook(context.Background(),
+	_, err = testWrapper.Orderbook(t.Context(),
 		exchError.String(), currencyPair, asset.Spot)
 	if err == nil {
 		t.Fatal("expected Orderbook to return error with invalid name")
@@ -162,13 +161,13 @@ func TestWrapper_Pairs(t *testing.T) {
 func TestWrapper_QueryOrder(t *testing.T) {
 	t.Parallel()
 
-	_, err := testWrapper.QueryOrder(context.Background(),
+	_, err := testWrapper.QueryOrder(t.Context(),
 		exchName, orderID, currency.EMPTYPAIR, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.QueryOrder(context.Background(),
+	_, err = testWrapper.QueryOrder(t.Context(),
 		exchError.String(), "", currency.EMPTYPAIR, assetType)
 	if err == nil {
 		t.Fatal("expected QueryOrder to return error on invalid name")
@@ -191,12 +190,12 @@ func TestWrapper_SubmitOrder(t *testing.T) {
 		Exchange:  "true",
 		AssetType: asset.Spot,
 	}
-	_, err = testWrapper.SubmitOrder(context.Background(), tempOrder)
+	_, err = testWrapper.SubmitOrder(t.Context(), tempOrder)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.SubmitOrder(context.Background(), nil)
+	_, err = testWrapper.SubmitOrder(t.Context(), nil)
 	if err == nil {
 		t.Fatal("expected SubmitOrder to return error with invalid name")
 	}
@@ -208,25 +207,25 @@ func TestWrapper_Ticker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testWrapper.Ticker(context.Background(), exchName, c, assetType)
+	_, err = testWrapper.Ticker(t.Context(), exchName, c, assetType)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = testWrapper.Ticker(context.Background(), exchError.String(), currencyPair, asset.Spot)
+	_, err = testWrapper.Ticker(t.Context(), exchError.String(), currencyPair, asset.Spot)
 	if err == nil {
 		t.Fatal("expected Ticker to return error with invalid name")
 	}
 }
 
 func TestWrapper_WithdrawalCryptoFunds(t *testing.T) {
-	_, err := testWrapper.WithdrawalCryptoFunds(context.Background(),
+	_, err := testWrapper.WithdrawalCryptoFunds(t.Context(),
 		&withdraw.Request{Exchange: exchError.String()})
 	if err == nil {
 		t.Fatal("expected WithdrawalCryptoFunds to return error with invalid name")
 	}
 
-	_, err = testWrapper.WithdrawalCryptoFunds(context.Background(),
+	_, err = testWrapper.WithdrawalCryptoFunds(t.Context(),
 		&withdraw.Request{Exchange: exchName})
 	if err != nil {
 		t.Fatal("expected WithdrawalCryptoFunds to return error with invalid name")
@@ -234,13 +233,13 @@ func TestWrapper_WithdrawalCryptoFunds(t *testing.T) {
 }
 
 func TestWrapper_WithdrawalFiatFunds(t *testing.T) {
-	_, err := testWrapper.WithdrawalFiatFunds(context.Background(),
+	_, err := testWrapper.WithdrawalFiatFunds(t.Context(),
 		"", &withdraw.Request{Exchange: exchError.String()})
 	if err == nil {
 		t.Fatal("expected WithdrawalFiatFunds to return error with invalid name")
 	}
 
-	_, err = testWrapper.WithdrawalFiatFunds(context.Background(),
+	_, err = testWrapper.WithdrawalFiatFunds(t.Context(),
 		"", &withdraw.Request{Exchange: exchName})
 	if err != nil {
 		t.Fatal("expected WithdrawalCryptoFunds to return error with invalid name")
@@ -252,12 +251,12 @@ func TestWrapper_OHLCV(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testWrapper.OHLCV(context.Background(),
+	_, err = testWrapper.OHLCV(t.Context(),
 		"test", c, asset.Spot, time.Now().Add(-24*time.Hour), time.Now(), kline.OneDay)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testWrapper.OHLCV(context.Background(),
+	_, err = testWrapper.OHLCV(t.Context(),
 		exchError.String(), c, asset.Spot,
 		time.Now().Add(-24*time.Hour),
 		time.Now(), kline.OneDay)

--- a/internal/testing/exchange/exchange.go
+++ b/internal/testing/exchange/exchange.go
@@ -2,7 +2,6 @@ package exchange
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -217,7 +216,7 @@ func UpdatePairsOnce(tb testing.TB, e exchange.IBotExchange) {
 		return
 	}
 
-	err := e.UpdateTradablePairs(context.Background(), true)
+	err := e.UpdateTradablePairs(tb.Context(), true)
 	require.NoError(tb, err, "UpdateTradablePairs must not error")
 
 	cache := new(currency.PairsManager)


### PR DESCRIPTION
# PR Description

Noticed that we're already using `t.Context` a bunch, plus comments on PR's experiencing unused vars so this automates those two checks. Also fixes some requester test log.Fatal usage.

For things that I touched, I assertified the nearby areas but this wasn't extensive. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
