### PR TITLE
buffer/orderbook: shift orderbook update logic from buffer package to orderbook package

### DIFF
--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -3357,18 +3357,15 @@ func TestGetOrderbookMovement(t *testing.T) {
 	t.Parallel()
 	em := NewExchangeManager()
 	exch, err := em.NewExchangeByName("binance")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	exch.SetDefaults()
 	b := exch.GetBase()
 	b.Name = fakeExchangeName
 	b.Enabled = true
 
 	cp, err := currency.NewPairFromString("btc-metal")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b.CurrencyPairs.Pairs = make(map[asset.Item]*currency.PairStore)
 	b.CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
@@ -3418,9 +3415,7 @@ func TestGetOrderbookMovement(t *testing.T) {
 	}
 
 	depth, err := orderbook.DeployDepth(req.Exchange, currency.NewPair(currency.BTC, currency.METAL), asset.Spot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bid := []orderbook.Tranche{
 		{Price: 10, Amount: 1},
@@ -3434,10 +3429,8 @@ func TestGetOrderbookMovement(t *testing.T) {
 		{Price: 13, Amount: 1},
 		{Price: 14, Amount: 1},
 	}
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = depth.LoadSnapshot(&orderbook.Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
+	require.NoError(t, err)
 
 	_, err = s.GetOrderbookMovement(t.Context(), req)
 	if err.Error() != "quote amount invalid" {
@@ -3470,18 +3463,15 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 	t.Parallel()
 	em := NewExchangeManager()
 	exch, err := em.NewExchangeByName("binance")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	exch.SetDefaults()
 	b := exch.GetBase()
 	b.Name = fakeExchangeName
 	b.Enabled = true
 
 	cp, err := currency.NewPairFromString("btc-meme")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b.CurrencyPairs.Pairs = make(map[asset.Item]*currency.PairStore)
 	b.CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
@@ -3531,9 +3521,7 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 	}
 
 	depth, err := orderbook.DeployDepth(req.Exchange, currency.NewPair(currency.BTC, currency.MEME), asset.Spot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bid := []orderbook.Tranche{
 		{Price: 10, Amount: 1},
@@ -3547,10 +3535,8 @@ func TestGetOrderbookAmountByNominal(t *testing.T) {
 		{Price: 13, Amount: 1},
 		{Price: 14, Amount: 1},
 	}
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = depth.LoadSnapshot(&orderbook.Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
+	require.NoError(t, err)
 
 	nominal, err := s.GetOrderbookAmountByNominal(t.Context(), req)
 	if !errors.Is(err, nil) {
@@ -3576,18 +3562,15 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 	t.Parallel()
 	em := NewExchangeManager()
 	exch, err := em.NewExchangeByName("binance")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	exch.SetDefaults()
 	b := exch.GetBase()
 	b.Name = fakeExchangeName
 	b.Enabled = true
 
 	cp, err := currency.NewPairFromString("btc-mad")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b.CurrencyPairs.Pairs = make(map[asset.Item]*currency.PairStore)
 	b.CurrencyPairs.Pairs[asset.Spot] = &currency.PairStore{
@@ -3637,9 +3620,7 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 	}
 
 	depth, err := orderbook.DeployDepth(req.Exchange, currency.NewPair(currency.BTC, currency.MAD), asset.Spot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bid := []orderbook.Tranche{
 		{Price: 10, Amount: 1},
@@ -3653,10 +3634,8 @@ func TestGetOrderbookAmountByImpact(t *testing.T) {
 		{Price: 13, Amount: 1},
 		{Price: 14, Amount: 1},
 	}
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = depth.LoadSnapshot(&orderbook.Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
+	require.NoError(t, err)
 
 	req.ImpactPercentage = 9.090909090909092
 	impact, err := s.GetOrderbookAmountByImpact(t.Context(), req)

--- a/exchange/websocket/buffer/buffer.go
+++ b/exchange/websocket/buffer/buffer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 const packageError = "websocket orderbook buffer error: %w"
@@ -20,16 +19,6 @@ var (
 	errBufferConfigNil              = errors.New("buffer config is nil")
 	errUnsetDataHandler             = errors.New("datahandler unset")
 	errIssueBufferEnabledButNoLimit = errors.New("buffer enabled but no limit set")
-	errUpdateIsNil                  = errors.New("update is nil")
-	errUpdateNoTargets              = errors.New("update bid/ask targets cannot be nil")
-	errDepthNotFound                = errors.New("orderbook depth not found")
-	errRESTOverwrite                = errors.New("orderbook has been overwritten by REST protocol")
-	errInvalidAction                = errors.New("invalid action")
-	errAmendFailure                 = errors.New("orderbook amend update failure")
-	errDeleteFailure                = errors.New("orderbook delete update failure")
-	errInsertFailure                = errors.New("orderbook insert update failure")
-	errUpdateInsertFailure          = errors.New("orderbook update/insert update failure")
-	errRESTTimerLapse               = errors.New("rest sync timer lapse with active websocket connection")
 	errOrderbookFlushed             = errors.New("orderbook flushed")
 )
 
@@ -55,250 +44,38 @@ func (w *Orderbook) Setup(exchangeConfig *config.Exchange, c *Config, dataHandle
 
 	w.sortBuffer = c.SortBuffer
 	w.sortBufferByUpdateIDs = c.SortBufferByUpdateIDs
-	w.updateEntriesByID = c.UpdateEntriesByID
 	w.exchangeName = exchangeConfig.Name
 	w.dataHandler = dataHandler
 	w.ob = make(map[key.PairAsset]*orderbookHolder)
 	w.verbose = exchangeConfig.Verbose
-	w.updateIDProgression = c.UpdateIDProgression
-	w.checksum = c.Checksum
-	return nil
-}
-
-// validate validates update against setup values
-func (w *Orderbook) validate(u *orderbook.Update) error {
-	if u == nil {
-		return fmt.Errorf(packageError, errUpdateIsNil)
-	}
-	if len(u.Bids) == 0 && len(u.Asks) == 0 {
-		return fmt.Errorf(packageError, errUpdateNoTargets)
-	}
-	return nil
-}
-
-// Update updates a stored pointer to an orderbook.Depth struct containing a
-// bid and ask Tranches, this switches between the usage of a buffered update
-func (w *Orderbook) Update(u *orderbook.Update) error {
-	if err := w.validate(u); err != nil {
-		return err
-	}
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
-	book, ok := w.ob[key.PairAsset{Base: u.Pair.Base.Item, Quote: u.Pair.Quote.Item, Asset: u.Asset}]
-	if !ok {
-		return fmt.Errorf("%w for Exchange %s CurrencyPair: %s AssetType: %s",
-			errDepthNotFound,
-			w.exchangeName,
-			u.Pair,
-			u.Asset)
-	}
-
-	// out of order update ID can be skipped
-	if w.updateIDProgression && u.UpdateID <= book.updateID {
-		if w.verbose {
-			log.Warnf(log.WebsocketMgr,
-				"Exchange %s CurrencyPair: %s AssetType: %s out of order websocket update received",
-				w.exchangeName,
-				u.Pair,
-				u.Asset)
-		}
-		return nil
-	}
-
-	// Checks for when the rest protocol overwrites a streaming dominated book
-	// will stop updating book via incremental updates. This occurs because our
-	// sync manager (engine/sync.go) timer has elapsed for streaming. Usually
-	// because the book is highly illiquid.
-	isREST, err := book.ob.IsRESTSnapshot()
-	if err != nil {
-		if !errors.Is(err, orderbook.ErrOrderbookInvalid) {
-			return err
-		}
-		// In the event a checksum or processing error invalidates the book, all
-		// updates that could be stored in the websocket buffer, skip applying
-		// until a new snapshot comes through.
-		if w.verbose {
-			log.Warnf(log.WebsocketMgr,
-				"Exchange %s CurrencyPair: %s AssetType: %s underlying book is invalid, cannot apply update.",
-				w.exchangeName,
-				u.Pair,
-				u.Asset)
-		}
-		return nil
-	}
-
-	if isREST {
-		if w.verbose {
-			log.Warnf(log.WebsocketMgr,
-				"%s for Exchange %s CurrencyPair: %s AssetType: %s consider extending synctimeoutwebsocket",
-				errRESTOverwrite,
-				w.exchangeName,
-				u.Pair,
-				u.Asset)
-		}
-		// Instance of illiquidity, this signal notifies that there is websocket
-		// activity. We can invalidate the book and request a new snapshot. All
-		// further updates through the websocket should be caught above in the
-		// IsRestSnapshot() call.
-		return book.ob.Invalidate(errRESTTimerLapse)
-	}
-
-	if w.bufferEnabled {
-		var processed bool
-		processed, err = w.processBufferUpdate(book, u)
-		if err != nil {
-			return err
-		}
-
-		if !processed {
-			return nil
-		}
-	} else {
-		err = w.processObUpdate(book, u)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Publish all state changes, disregarding verbosity or sync requirements.
-	book.ob.Publish()
-	w.dataHandler <- book.ob
-	return nil
-}
-
-// processBufferUpdate stores update into buffer, when buffer at capacity as
-// defined by w.obBufferLimit it well then sort and apply updates.
-func (w *Orderbook) processBufferUpdate(o *orderbookHolder, u *orderbook.Update) (bool, error) {
-	*o.buffer = append(*o.buffer, *u)
-	if len(*o.buffer) < w.obBufferLimit {
-		return false, nil
-	}
-
-	if w.sortBuffer {
-		// sort by last updated to ensure each update is in order
-		if w.sortBufferByUpdateIDs {
-			sort.Slice(*o.buffer, func(i, j int) bool {
-				return (*o.buffer)[i].UpdateID < (*o.buffer)[j].UpdateID
-			})
-		} else {
-			sort.Slice(*o.buffer, func(i, j int) bool {
-				return (*o.buffer)[i].UpdateTime.Before((*o.buffer)[j].UpdateTime)
-			})
-		}
-	}
-	for i := range *o.buffer {
-		err := w.processObUpdate(o, &(*o.buffer)[i])
-		if err != nil {
-			return false, err
-		}
-	}
-	// clear buffer of old updates
-	*o.buffer = nil
-	return true, nil
-}
-
-// processObUpdate processes updates either by its corresponding id or by price level
-func (w *Orderbook) processObUpdate(o *orderbookHolder, u *orderbook.Update) error {
-	// Both update methods require post processing to ensure the orderbook is in a valid state.
-	if w.updateEntriesByID {
-		if err := o.updateByIDAndAction(u); err != nil {
-			return err
-		}
-	} else {
-		if err := o.updateByPrice(u); err != nil {
-			return err
-		}
-	}
-	if w.checksum != nil {
-		compare, err := o.ob.Retrieve()
-		if err != nil {
-			return err
-		}
-		err = w.checksum(compare, u.Checksum)
-		if err != nil {
-			return o.ob.Invalidate(err)
-		}
-		o.updateID = u.UpdateID
-	} else if o.ob.VerifyOrderbook() {
-		compare, err := o.ob.Retrieve()
-		if err != nil {
-			return err
-		}
-		err = compare.Verify()
-		if err != nil {
-			return o.ob.Invalidate(err)
-		}
-	}
-	return nil
-}
-
-// updateByPrice amends amount if match occurs by price, deletes if amount is
-// zero or less and inserts if not found.
-func (o *orderbookHolder) updateByPrice(updts *orderbook.Update) error {
-	return o.ob.UpdateBidAskByPrice(updts)
-}
-
-// updateByIDAndAction will receive an action to execute against the orderbook
-// it will then match by IDs instead of price to perform the action
-func (o *orderbookHolder) updateByIDAndAction(updts *orderbook.Update) error {
-	switch updts.Action {
-	case orderbook.Amend:
-		err := o.ob.UpdateBidAskByID(updts)
-		if err != nil {
-			return fmt.Errorf("%w %w", errAmendFailure, err)
-		}
-	case orderbook.Delete:
-		// edge case for Bitfinex as their streaming endpoint duplicates deletes
-		bypassErr := o.ob.GetName() == "Bitfinex" && o.ob.IsFundingRate()
-		err := o.ob.DeleteBidAskByID(updts, bypassErr)
-		if err != nil {
-			return fmt.Errorf("%w %w", errDeleteFailure, err)
-		}
-	case orderbook.Insert:
-		err := o.ob.InsertBidAskByID(updts)
-		if err != nil {
-			return fmt.Errorf("%w %w", errInsertFailure, err)
-		}
-	case orderbook.UpdateInsert:
-		err := o.ob.UpdateInsertByID(updts)
-		if err != nil {
-			return fmt.Errorf("%w %w", errUpdateInsertFailure, err)
-		}
-	default:
-		return fmt.Errorf("%w [%d]", errInvalidAction, updts.Action)
-	}
 	return nil
 }
 
 // LoadSnapshot loads initial snapshot of orderbook data from websocket
 func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
-	// Checks if book can deploy to depth
-	err := book.Verify()
-	if err != nil {
+	if err := book.Verify(); err != nil {
 		return err
 	}
 
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
+	w.m.RLock()
 	holder, ok := w.ob[key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}]
+	w.m.RUnlock()
 	if !ok {
+		w.m.Lock()
 		// Associate orderbook pointer with local exchange depth map
-		var depth *orderbook.Depth
-		depth, err = orderbook.DeployDepth(book.Exchange, book.Pair, book.Asset)
+		depth, err := orderbook.DeployDepth(book.Exchange, book.Pair, book.Asset)
 		if err != nil {
 			return err
 		}
 		depth.AssignOptions(book)
 		buffer := make([]orderbook.Update, w.obBufferLimit)
-
 		holder = &orderbookHolder{ob: depth, buffer: &buffer}
 		w.ob[key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}] = holder
+		w.m.Unlock()
 	}
 
-	holder.updateID = book.LastUpdateID
-
-	err = holder.ob.LoadSnapshot(book.Bids, book.Asks, book.LastUpdateID, book.LastUpdated, book.UpdatePushedAt, false)
-	if err != nil {
+	book.RestSnapshot = false
+	if err := holder.ob.LoadSnapshot(book); err != nil {
 		return err
 	}
 
@@ -307,38 +84,102 @@ func (w *Orderbook) LoadSnapshot(book *orderbook.Base) error {
 	return nil
 }
 
+// Update updates a stored pointer to an orderbook.Depth struct containing bid and ask Tranches, this switches between
+// the usage of a buffered update
+func (w *Orderbook) Update(u *orderbook.Update) error {
+	w.m.RLock()
+	holder, ok := w.ob[key.PairAsset{Base: u.Pair.Base.Item, Quote: u.Pair.Quote.Item, Asset: u.Asset}]
+	w.m.RUnlock()
+	if !ok {
+		return fmt.Errorf("%w for Exchange %s CurrencyPair: %s AssetType: %s", orderbook.ErrDepthNotFound, w.exchangeName, u.Pair, u.Asset)
+	}
+
+	if w.bufferEnabled {
+		if processed, err := w.processBufferUpdate(holder, u); err != nil || !processed {
+			return err
+		}
+	} else {
+		if err := holder.ob.ProcessUpdate(u); err != nil {
+			return err
+		}
+	}
+
+	// Publish all state changes, disregarding verbosity or sync requirements.
+	holder.ob.Publish()
+	w.dataHandler <- holder.ob
+	return nil
+}
+
+// processBufferUpdate stores update into buffer, when buffer at capacity as
+// defined by w.obBufferLimit it well then sort and apply updates.
+func (w *Orderbook) processBufferUpdate(holder *orderbookHolder, u *orderbook.Update) (bool, error) {
+	*holder.buffer = append(*holder.buffer, *u)
+	if len(*holder.buffer) < w.obBufferLimit {
+		return false, nil
+	}
+
+	if w.sortBuffer {
+		// sort by last updated to ensure each update is in order
+		if w.sortBufferByUpdateIDs {
+			sort.Slice(*holder.buffer, func(i, j int) bool {
+				return (*holder.buffer)[i].UpdateID < (*holder.buffer)[j].UpdateID
+			})
+		} else {
+			sort.Slice(*holder.buffer, func(i, j int) bool {
+				return (*holder.buffer)[i].UpdateTime.Before((*holder.buffer)[j].UpdateTime)
+			})
+		}
+	}
+
+	// clear buffer of old updates on all error pathways as any error will invalidate the orderbook and will require
+	// a new snapshot to be loaded
+	defer func() { *holder.buffer = (*holder.buffer)[:0] }()
+
+	for i := range *holder.buffer {
+		if err := holder.ob.ProcessUpdate(&(*holder.buffer)[i]); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
 // GetOrderbook returns an orderbook copy as orderbook.Base
 func (w *Orderbook) GetOrderbook(p currency.Pair, a asset.Item) (*orderbook.Base, error) {
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
-	book, ok := w.ob[key.PairAsset{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
-	if !ok {
-		return nil, fmt.Errorf("%s %s %s %w", w.exchangeName, p, a, errDepthNotFound)
+	if p.IsEmpty() {
+		return nil, currency.ErrCurrencyPairEmpty
 	}
-	return book.ob.Retrieve()
-}
-
-// FlushBuffer flushes w.ob data to be garbage collected and refreshed when a
-// connection is lost and reconnected
-func (w *Orderbook) FlushBuffer() {
-	w.mtx.Lock()
-	w.ob = make(map[key.PairAsset]*orderbookHolder)
-	w.mtx.Unlock()
-}
-
-// FlushOrderbook flushes independent orderbook
-func (w *Orderbook) FlushOrderbook(p currency.Pair, a asset.Item) error {
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
-	book, ok := w.ob[key.PairAsset{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
+	if !a.IsValid() {
+		return nil, asset.ErrInvalidAsset
+	}
+	w.m.RLock()
+	holder, ok := w.ob[key.PairAsset{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
+	w.m.RUnlock()
 	if !ok {
-		return fmt.Errorf("cannot flush orderbook %s %s %s %w",
-			w.exchangeName,
-			p,
-			a,
-			errDepthNotFound)
+		return nil, fmt.Errorf("%s %w: %s.%s", w.exchangeName, orderbook.ErrDepthNotFound, a, p)
+	}
+	return holder.ob.Retrieve()
+}
+
+// FlushBuffer flushes individual orderbook buffers while keeping the orderbook lookups intact and ready for new updates
+// when a connection is re-established.
+func (w *Orderbook) FlushBuffer() {
+	w.m.Lock()
+	for _, holder := range w.ob {
+		*holder.buffer = (*holder.buffer)[:0]
+	}
+	w.m.Unlock()
+}
+
+// InvalidateOrderbook invalidates the orderbook so no trading can occur on potential corrupted data
+func (w *Orderbook) InvalidateOrderbook(p currency.Pair, a asset.Item) error {
+	w.m.RLock()
+	holder, ok := w.ob[key.PairAsset{Base: p.Base.Item, Quote: p.Quote.Item, Asset: a}]
+	w.m.RUnlock()
+	if !ok {
+		return fmt.Errorf("cannot invalidate orderbook %s %s %s %w", w.exchangeName, p, a, orderbook.ErrDepthNotFound)
 	}
 	// error not needed in this return
-	_ = book.ob.Invalidate(errOrderbookFlushed)
+	_ = holder.ob.Invalidate(errOrderbookFlushed)
 	return nil
 }

--- a/exchange/websocket/buffer/buffer_types.go
+++ b/exchange/websocket/buffer/buffer_types.go
@@ -15,14 +15,6 @@ type Config struct {
 	// SortBufferByUpdateIDs allows the sorting of the buffered updates by their
 	// corresponding update IDs.
 	SortBufferByUpdateIDs bool
-	// UpdateEntriesByID will match by IDs instead of price to perform the an
-	// action. e.g. update, delete, insert.
-	UpdateEntriesByID bool
-	// UpdateIDProgression requires that the new update ID be greater than the
-	// prior ID. This will skip processing and not error.
-	UpdateIDProgression bool
-	// Checksum is a package defined checksum calculation for updated books.
-	Checksum func(state *orderbook.Base, checksum uint32) error
 }
 
 // Orderbook defines a local cache of orderbooks for amending, appending
@@ -33,27 +25,16 @@ type Orderbook struct {
 	bufferEnabled         bool
 	sortBuffer            bool
 	sortBufferByUpdateIDs bool // When timestamps aren't provided, an id can help sort
-	updateEntriesByID     bool // Use the update IDs to match ob entries
 	exchangeName          string
 	dataHandler           chan<- any
 	verbose               bool
 
-	// updateIDProgression requires that the new update ID be greater than the
-	// prior ID. This will skip processing and not error.
-	updateIDProgression bool
-	// checksum is a package defined checksum calculation for updated books.
-	checksum func(state *orderbook.Base, checksum uint32) error
-	// TODO: sync.RWMutex. For the moment we process the orderbook in a single
-	// thread. In future when there are workers directly involved this can be
-	// can be improved with RW mechanics which will allow updates to occur at
-	// the same time on different books.
-	mtx sync.Mutex
+	m sync.RWMutex
 }
 
 // orderbookHolder defines a store of pending updates and a pointer to the
 // orderbook depth
 type orderbookHolder struct {
-	ob       *orderbook.Depth
-	buffer   *[]orderbook.Update
-	updateID int64
+	ob     *orderbook.Depth
+	buffer *[]orderbook.Update
 }

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -503,7 +503,7 @@ func (b *Binance) UpdateLocalBuffer(wsdp *WebsocketDepthStream) (bool, error) {
 
 	err = b.applyBufferUpdate(pair)
 	if err != nil {
-		b.flushAndCleanup(pair)
+		b.invalidateAndCleanupOrderbook(pair)
 	}
 
 	return false, err
@@ -742,26 +742,19 @@ func (b *Binance) processJob(p currency.Pair) error {
 	// new update to initiate this.
 	err = b.applyBufferUpdate(p)
 	if err != nil {
-		b.flushAndCleanup(p)
+		b.invalidateAndCleanupOrderbook(p)
 		return err
 	}
 	return nil
 }
 
-// flushAndCleanup flushes orderbook and clean local cache
-func (b *Binance) flushAndCleanup(p currency.Pair) {
-	errClean := b.Websocket.Orderbook.FlushOrderbook(p, asset.Spot)
-	if errClean != nil {
-		log.Errorf(log.WebsocketMgr,
-			"%s flushing websocket error: %v",
-			b.Name,
-			errClean)
+// invalidateAndCleanupOrderbook invalidaates orderbook and cleans local cache
+func (b *Binance) invalidateAndCleanupOrderbook(p currency.Pair) {
+	if err := b.Websocket.Orderbook.InvalidateOrderbook(p, asset.Spot); err != nil {
+		log.Errorf(log.WebsocketMgr, "%s invalidate orderbook websocket error: %v", b.Name, err)
 	}
-	errClean = b.obm.cleanup(p)
-	if errClean != nil {
-		log.Errorf(log.WebsocketMgr, "%s cleanup websocket error: %v",
-			b.Name,
-			errClean)
+	if err := b.obm.cleanup(p); err != nil {
+		log.Errorf(log.WebsocketMgr, "%s cleanup websocket error: %v", b.Name, err)
 	}
 }
 

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -1676,7 +1676,7 @@ func (b *Bitfinex) resubOrderbook(c *subscription.Subscription) error {
 	if len(c.Pairs) != 1 {
 		return subscription.ErrNotSinglePair
 	}
-	if err := b.Websocket.Orderbook.FlushOrderbook(c.Pairs[0], c.Asset); err != nil {
+	if err := b.Websocket.Orderbook.InvalidateOrderbook(c.Pairs[0], c.Asset); err != nil {
 		// Non-fatal error
 		log.Errorf(log.ExchangeSys, "%s error flushing orderbook: %v", b.Name, err)
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
-	"github.com/thrasher-corp/gocryptotrader/exchange/websocket/buffer"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -202,9 +201,6 @@ func (b *Bitfinex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.generateSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferConfig: buffer.Config{
-			UpdateEntriesByID: true,
-		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
-	"github.com/thrasher-corp/gocryptotrader/exchange/websocket/buffer"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -174,9 +173,6 @@ func (b *Bitmex) Setup(exch *config.Exchange) error {
 		Unsubscriber:          b.Unsubscribe,
 		GenerateSubscriptions: b.generateSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
-		OrderbookBufferConfig: buffer.Config{
-			UpdateEntriesByID: true,
-		},
 	})
 	if err != nil {
 		return err

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -867,26 +867,11 @@ func TestGetHistoricTrades(t *testing.T) {
 
 func TestChecksum(t *testing.T) {
 	b := &orderbook.Base{
-		Asks: []orderbook.Tranche{
-			{Price: 0.3965, Amount: 44149.815},
-			{Price: 0.3967, Amount: 16000.0},
-		},
-		Bids: []orderbook.Tranche{
-			{Price: 0.396, Amount: 51.0},
-			{Price: 0.396, Amount: 25.0},
-			{Price: 0.3958, Amount: 18570.0},
-		},
+		Asks: []orderbook.Tranche{{Price: 0.3965, Amount: 44149.815}, {Price: 0.3967, Amount: 16000.0}},
+		Bids: []orderbook.Tranche{{Price: 0.396, Amount: 51.0}, {Price: 0.396, Amount: 25.0}, {Price: 0.3958, Amount: 18570.0}},
 	}
 
-	expecting := uint32(3802968298)
-	err := checksum(b, expecting)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = checksum(b, uint32(1223123))
-	if !errors.Is(err, errChecksumFailure) {
-		t.Errorf("received '%v', expected '%v'", err, errChecksumFailure)
-	}
+	require.Equal(t, uint32(3802968298), generateChecksum(b))
 }
 
 func TestTrim(t *testing.T) {

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -164,9 +164,7 @@ func (b *BTCMarkets) Setup(exch *config.Exchange) error {
 		GenerateSubscriptions: b.generateSubscriptions,
 		Features:              &b.Features.Supports.WebsocketCapabilities,
 		OrderbookBufferConfig: buffer.Config{
-			SortBuffer:          true,
-			UpdateIDProgression: true,
-			Checksum:            checksum,
+			SortBuffer: true,
 		},
 	})
 	if err != nil {

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -204,7 +204,6 @@ func (ku *Kucoin) Setup(exch *config.Exchange) error {
 			OrderbookBufferConfig: buffer.Config{
 				SortBuffer:            true,
 				SortBufferByUpdateIDs: true,
-				UpdateIDProgression:   true,
 			},
 			TradeFeed: ku.Features.Enabled.TradeFeed,
 		})

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3908,14 +3908,12 @@ func TestGetHistoricCandlesExtended(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-func TestCalculateUpdateOrderbookChecksum(t *testing.T) {
+func TestGenerateOrderbookChecksum(t *testing.T) {
 	t.Parallel()
 	var orderbookBase orderbook.Base
 	err := json.Unmarshal([]byte(calculateOrderbookChecksumUpdateOrderbookJSON), &orderbookBase)
 	require.NoError(t, err)
-
-	err = ok.CalculateUpdateOrderbookChecksum(&orderbookBase, 2832680552)
-	assert.NoError(t, err)
+	require.Equal(t, uint32(2832680552), generateOrderbookChecksum(&orderbookBase))
 }
 
 func TestOrderPushData(t *testing.T) {

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
-	"github.com/thrasher-corp/gocryptotrader/exchange/websocket/buffer"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/account"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
@@ -218,10 +217,7 @@ func (ok *Okx) Setup(exch *config.Exchange) error {
 		GenerateSubscriptions:                  ok.generateSubscriptions,
 		Features:                               &ok.Features.Supports.WebsocketCapabilities,
 		MaxWebsocketSubscriptionsPerConnection: 240,
-		OrderbookBufferConfig: buffer.Config{
-			Checksum: ok.CalculateUpdateOrderbookChecksum,
-		},
-		RateLimitDefinitions: ok.Requester.GetRateLimiterDefinitions(),
+		RateLimitDefinitions:                   ok.Requester.GetRateLimiterDefinitions(),
 	}); err != nil {
 		return err
 	}

--- a/exchanges/orderbook/depth_test.go
+++ b/exchanges/orderbook/depth_test.go
@@ -30,7 +30,7 @@ func TestGetLength(t *testing.T) {
 	_, err = d.GetAskLength()
 	assert.ErrorIs(t, err, ErrOrderbookInvalid, "GetAskLength should error with invalid depth")
 
-	err = d.LoadSnapshot([]Tranche{{Price: 1337}}, nil, 0, time.Now(), time.Now(), true)
+	err = d.LoadSnapshot(&Base{Bids: []Tranche{{Price: 1337}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	askLen, err := d.GetAskLength()
@@ -50,7 +50,7 @@ func TestGetLength(t *testing.T) {
 	_, err = d.GetBidLength()
 	assert.ErrorIs(t, err, ErrOrderbookInvalid, "GetBidLength should error with invalid depth")
 
-	err = d.LoadSnapshot(nil, []Tranche{{Price: 1337}}, 0, time.Now(), time.Now(), true)
+	err = d.LoadSnapshot(&Base{Asks: []Tranche{{Price: 1337}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	bidLen, err := d.GetBidLength()
@@ -159,10 +159,10 @@ func TestTotalAmounts(t *testing.T) {
 func TestLoadSnapshot(t *testing.T) {
 	t.Parallel()
 	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1}}, Tranches{{Price: 1337, Amount: 10}}, 0, time.Time{}, time.Now(), false)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1}}, Asks: Tranches{{Price: 1337, Amount: 10}}, UpdatePushedAt: time.Now()})
 	assert.ErrorIs(t, err, errLastUpdatedNotSet, "LoadSnapshot should error correctly")
 
-	err = d.LoadSnapshot(Tranches{{Price: 1337, Amount: 2}}, Tranches{{Price: 1338, Amount: 10}}, 0, time.Now(), time.Now(), false)
+	err = d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 2}}, Asks: Tranches{{Price: 1338, Amount: 10}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	ob, err := d.Retrieve()
@@ -181,7 +181,7 @@ func TestInvalidate(t *testing.T) {
 	d.pair = currency.NewPair(currency.BTC, currency.WABI)
 	d.asset = asset.Spot
 
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1}}, Tranches{{Price: 1337, Amount: 10}}, 0, time.Now(), time.Now(), false)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1}}, Asks: Tranches{{Price: 1337, Amount: 10}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	ob, err := d.Retrieve()
@@ -204,232 +204,6 @@ func TestInvalidate(t *testing.T) {
 
 	assert.Empty(t, ob.Asks, "Orderbook Asks should be flushed")
 	assert.Empty(t, ob.Bids, "Orderbook Bids should be flushed")
-}
-
-func TestUpdateBidAskByPrice(t *testing.T) {
-	t.Parallel()
-	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1338, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	err = d.UpdateBidAskByPrice(&Update{})
-	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateBidAskByPrice should error correctly")
-
-	err = d.UpdateBidAskByPrice(&Update{UpdateTime: time.Now()})
-	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
-
-	updates := &Update{
-		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 1}},
-		Asks:       Tranches{{Price: 1338, Amount: 3, ID: 2}},
-		UpdateID:   1,
-		UpdateTime: time.Now(),
-	}
-	err = d.UpdateBidAskByPrice(updates)
-	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
-
-	ob, err := d.Retrieve()
-	assert.NoError(t, err, "Retrieve should not error")
-	assert.Equal(t, 3.0, ob.Asks[0].Amount, "Asks amount should be correct")
-	assert.Equal(t, 2.0, ob.Bids[0].Amount, "Bids amount should be correct")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1337, Amount: 0, ID: 1}},
-		Asks:       Tranches{{Price: 1338, Amount: 0, ID: 2}},
-		UpdateID:   2,
-		UpdateTime: time.Now(),
-	}
-	err = d.UpdateBidAskByPrice(updates)
-	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
-
-	askLen, err := d.GetAskLength()
-	assert.NoError(t, err, "GetAskLength should not error")
-	assert.Zero(t, askLen, "Ask Length should be correct")
-
-	bidLen, err := d.GetBidLength()
-	assert.NoError(t, err, "GetBidLength should not error")
-	assert.Zero(t, bidLen, "Bid Length should be correct")
-}
-
-func TestDeleteBidAskByID(t *testing.T) {
-	t.Parallel()
-	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates := &Update{
-		Bids: Tranches{{Price: 1337, Amount: 2, ID: 1}},
-		Asks: Tranches{{Price: 1337, Amount: 2, ID: 2}},
-	}
-
-	err = d.DeleteBidAskByID(updates, false)
-	assert.ErrorIs(t, err, errLastUpdatedNotSet, "DeleteBidAskByID should error correctly")
-
-	updates.UpdateTime = time.Now()
-	err = d.DeleteBidAskByID(updates, false)
-	assert.NoError(t, err, "DeleteBidAskByID should not error")
-
-	ob, err := d.Retrieve()
-	assert.NoError(t, err, "Retrieve should not error")
-	assert.Empty(t, ob.Asks, "Asks should be empty")
-	assert.Empty(t, ob.Bids, "Bids should be empty")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 1}},
-		UpdateTime: time.Now(),
-	}
-	err = d.DeleteBidAskByID(updates, false)
-	assert.ErrorIs(t, err, errIDCannotBeMatched, "DeleteBidAskByID should error correctly")
-
-	updates = &Update{
-		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 2}},
-		UpdateTime: time.Now(),
-	}
-	err = d.DeleteBidAskByID(updates, false)
-	assert.ErrorIs(t, err, errIDCannotBeMatched, "DeleteBidAskByID should error correctly")
-
-	updates = &Update{
-		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 2}},
-		UpdateTime: time.Now(),
-	}
-	err = d.DeleteBidAskByID(updates, true)
-	assert.NoError(t, err, "DeleteBidAskByID should not error")
-}
-
-func TestUpdateBidAskByID(t *testing.T) {
-	t.Parallel()
-	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates := &Update{
-		Bids: Tranches{{Price: 1337, Amount: 2, ID: 1}},
-		Asks: Tranches{{Price: 1337, Amount: 2, ID: 2}},
-	}
-
-	err = d.UpdateBidAskByID(updates)
-	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateBidAskByID should error correctly")
-
-	updates.UpdateTime = time.Now()
-	err = d.UpdateBidAskByID(updates)
-	assert.NoError(t, err, "UpdateBidAskByID should not error")
-
-	ob, err := d.Retrieve()
-	assert.NoError(t, err, "Retrieve should not error")
-	assert.Equal(t, 2.0, ob.Asks[0].Amount, "First ask amount should be correct")
-	assert.Equal(t, 2.0, ob.Bids[0].Amount, "First bid amount should be correct")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 666}},
-		UpdateTime: time.Now(),
-	}
-	// random unmatching IDs
-	err = d.UpdateBidAskByID(updates)
-	assert.ErrorIs(t, err, errIDCannotBeMatched, "UpdateBidAskByID should error correctly")
-
-	updates = &Update{
-		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 69}},
-		UpdateTime: time.Now(),
-	}
-	err = d.UpdateBidAskByID(updates)
-	assert.ErrorIs(t, err, errIDCannotBeMatched, "UpdateBidAskByID should error correctly")
-}
-
-func TestInsertBidAskByID(t *testing.T) {
-	t.Parallel()
-	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates := &Update{
-		Asks: Tranches{{Price: 1337, Amount: 2, ID: 3}},
-	}
-	err = d.InsertBidAskByID(updates)
-	assert.ErrorIs(t, err, errLastUpdatedNotSet, "InsertBidAskByID should error correctly")
-
-	updates.UpdateTime = time.Now()
-
-	err = d.InsertBidAskByID(updates)
-	assert.ErrorIs(t, err, errCollisionDetected, "InsertBidAskByID should error correctly on collision")
-
-	err = d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 3}},
-		UpdateTime: time.Now(),
-	}
-
-	err = d.InsertBidAskByID(updates)
-	assert.ErrorIs(t, err, errCollisionDetected, "InsertBidAskByID should error correctly on collision")
-
-	err = d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
-		Asks:       Tranches{{Price: 1336, Amount: 2, ID: 4}},
-		UpdateTime: time.Now(),
-	}
-	err = d.InsertBidAskByID(updates)
-	assert.NoError(t, err, "InsertBidAskByID should not error")
-
-	ob, err := d.Retrieve()
-	assert.NoError(t, err, "Retrieve should not error")
-	assert.Len(t, ob.Asks, 2, "Should have correct Asks")
-	assert.Len(t, ob.Bids, 2, "Should have correct Bids")
-}
-
-func TestUpdateInsertByID(t *testing.T) {
-	t.Parallel()
-	d := NewDepth(id)
-	err := d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates := &Update{
-		Bids: Tranches{{Price: 1338, Amount: 0, ID: 3}},
-		Asks: Tranches{{Price: 1336, Amount: 2, ID: 4}},
-	}
-	err = d.UpdateInsertByID(updates)
-	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateInsertByID should error correctly")
-
-	updates.UpdateTime = time.Now()
-	err = d.UpdateInsertByID(updates)
-	assert.ErrorIs(t, err, errAmountCannotBeLessOrEqualToZero, "UpdateInsertByID should error correctly")
-
-	// Above will invalidate the book
-	_, err = d.Retrieve()
-	assert.ErrorIs(t, err, ErrOrderbookInvalid, "Retrieve should error correctly")
-
-	err = d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
-		Asks:       Tranches{{Price: 1336, Amount: 0, ID: 4}},
-		UpdateTime: time.Now(),
-	}
-	err = d.UpdateInsertByID(updates)
-	assert.ErrorIs(t, err, errAmountCannotBeLessOrEqualToZero, "UpdateInsertByID should error correctly")
-
-	// Above will invalidate the book
-	_, err = d.Retrieve()
-	assert.ErrorIs(t, err, ErrOrderbookInvalid, "Retrieve should error correctly")
-
-	err = d.LoadSnapshot(Tranches{{Price: 1337, Amount: 1, ID: 1}}, Tranches{{Price: 1337, Amount: 10, ID: 2}}, 0, time.Now(), time.Now(), false)
-	assert.NoError(t, err, "LoadSnapshot should not error")
-
-	updates = &Update{
-		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
-		Asks:       Tranches{{Price: 1336, Amount: 2, ID: 4}},
-		UpdateTime: time.Now(),
-	}
-	err = d.UpdateInsertByID(updates)
-	assert.NoError(t, err, "UpdateInsertByID should not error")
-
-	ob, err := d.Retrieve()
-	assert.NoError(t, err, "Retrieve should not error")
-	assert.Len(t, ob.Asks, 2, "Should have correct Asks")
-	assert.Len(t, ob.Bids, 2, "Should have correct Bids")
 }
 
 func TestAssignOptions(t *testing.T) {
@@ -536,7 +310,7 @@ func TestGetMidPrice_Depth(t *testing.T) {
 	_, err = depth.GetMidPrice()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetMidPrice should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	mid, err := depth.GetMidPrice()
@@ -550,13 +324,13 @@ func TestGetMidPriceNoLock_Depth(t *testing.T) {
 	_, err := depth.getMidPriceNoLock()
 	assert.ErrorIs(t, err, errNoLiquidity, "getMidPriceNoLock should error correctly")
 
-	err = depth.LoadSnapshot(bid, nil, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	_, err = depth.getMidPriceNoLock()
 	assert.ErrorIs(t, err, errNoLiquidity, "getMidPriceNoLock should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	mid, err := depth.getMidPriceNoLock()
@@ -579,7 +353,7 @@ func TestGetBestBidASk_Depth(t *testing.T) {
 	_, err = depth.GetBestAsk()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetBestAsk should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	mid, err := depth.GetBestBid()
@@ -601,13 +375,13 @@ func TestGetSpreadAmount(t *testing.T) {
 	_, err = depth.GetSpreadAmount()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetSpreadAmount should error correctly")
 
-	err = depth.LoadSnapshot(nil, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	_, err = depth.GetSpreadAmount()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetSpreadAmount should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	spread, err := depth.GetSpreadAmount()
@@ -625,13 +399,13 @@ func TestGetSpreadPercentage(t *testing.T) {
 	_, err = depth.GetSpreadPercentage()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetSpreadPercentage should error correctly")
 
-	err = depth.LoadSnapshot(nil, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	_, err = depth.GetSpreadPercentage()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetSpreadPercentage should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	spread, err := depth.GetSpreadPercentage()
@@ -649,13 +423,13 @@ func TestGetImbalance_Depth(t *testing.T) {
 	_, err = depth.GetImbalance()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetImbalance should error correctly")
 
-	err = depth.LoadSnapshot(nil, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	_, err = depth.GetImbalance()
 	assert.ErrorIs(t, err, errNoLiquidity, "GetImbalance should error correctly")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	imbalance, err := depth.GetImbalance()
@@ -678,7 +452,7 @@ func TestGetTranches(t *testing.T) {
 	assert.Empty(t, askT, "Ask tranche should be empty")
 	assert.Empty(t, bidT, "Bid tranche should be empty")
 
-	err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	assert.NoError(t, err, "LoadSnapshot should not error")
 
 	askT, bidT, err = depth.GetTranches(0)
@@ -728,7 +502,7 @@ func TestMovementMethods(t *testing.T) {
 			_, err = callMethod(depth, methodName, tt.tests[0].inputs)
 			assert.ErrorIs(t, err, errNoLiquidity, "should error correctly with no liquidity")
 
-			err = depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+			err = depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			assert.NoError(t, err, "LoadSnapshot should not error")
 
 			for i, subT := range tt.tests {

--- a/exchanges/orderbook/incremental_updates.go
+++ b/exchanges/orderbook/incremental_updates.go
@@ -1,0 +1,228 @@
+package orderbook
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+)
+
+// Action defines a set of differing states required to implement an incoming orderbook update used in conjunction with
+// UpdateEntriesByID
+type Action uint8
+
+const (
+	Amend        Action = iota + 1 // Amend applies amount adjustment by ID
+	Delete                         // Delete removes price level from book by ID
+	Insert                         // Insert adds price level to book
+	UpdateInsert                   // UpdateInsert on conflict applies amount adjustment or appends new amount to book
+)
+
+// Public error vars
+var (
+	ErrDepthNotFound = errors.New("orderbook depth not found")
+	ErrEmptyUpdate   = errors.New("update contains no bids or asks")
+)
+
+var (
+	errInvalidAction          = errors.New("invalid action")
+	errAmendFailure           = errors.New("amend update failure")
+	errDeleteFailure          = errors.New("delete update failure")
+	errInsertFailure          = errors.New("insert update failure")
+	errUpdateInsertFailure    = errors.New("update/insert update failure")
+	errRESTSnapshot           = errors.New("cannot update REST protocol loaded snapshot")
+	errChecksumMismatch       = errors.New("checksum mismatch")
+	errChecksumGeneratorUnset = errors.New("checksum generator unset")
+)
+
+// Update holds changes that are to be applied to a stored orderbook
+type Update struct {
+	UpdateID       int64
+	UpdateTime     time.Time
+	UpdatePushedAt time.Time
+	Asset          asset.Item
+	Bids           []Tranche
+	Asks           []Tranche
+	Pair           currency.Pair
+
+	// ExpectedChecksum defines the expected value when the books have been verified
+	ExpectedChecksum uint32
+	// GenerateChecksum is a function that will be called to generate a checksum from the stored orderbook post update
+	GenerateChecksum func(snapshot *Base) uint32
+	// AllowEmpty, when true, permits loading an empty order book update to set an UpdateID without including actual data
+	AllowEmpty bool
+	// Action defines the action to be performed on the orderbook e.g. amend, delete, insert, update/insert
+	// Orderbook IDs are used to identify the orderbook level to be updated, deleted or inserted
+	Action Action
+
+	SkipOutOfOrderLastUpdateID bool
+}
+
+// ProcessUpdates applies updates to the orderbook depth, on error it will invalidate the orderbook and return the
+// error, this is to ensure the orderbook is always in a valid state.
+func (d *Depth) ProcessUpdate(u *Update) error {
+	if len(u.Bids) == 0 && len(u.Asks) == 0 && !u.AllowEmpty {
+		return d.Invalidate(ErrEmptyUpdate)
+	}
+
+	// TODO: Enforce UpdatePushedAt set to determine server latency
+
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	if d.validationError != nil {
+		return d.validationError
+	}
+
+	// This will process out of order updates but will not error on them.
+	// TODO: Error on out of order updates; this is intentionally kept as is from the buffer package.
+	if u.SkipOutOfOrderLastUpdateID && d.lastUpdateID >= u.UpdateID {
+		return nil
+	}
+
+	if d.options.restSnapshot {
+		return d.invalidate(errRESTSnapshot)
+	}
+
+	if u.Action != 0 {
+		if err := d.updateByIDAndAction(u); err != nil {
+			return d.invalidate(err)
+		}
+	} else {
+		if err := d.updateBidAskByPrice(u); err != nil {
+			return d.invalidate(err)
+		}
+	}
+
+	if u.ExpectedChecksum != 0 {
+		if u.GenerateChecksum == nil {
+			return d.invalidate(errChecksumGeneratorUnset)
+		}
+		if checksum := u.GenerateChecksum(d.snapshot()); checksum != u.ExpectedChecksum {
+			return d.invalidate(fmt.Errorf("%s %s %s %w: expected '%d', got '%d'", d.exchange, d.pair, d.asset, errChecksumMismatch, u.ExpectedChecksum, checksum))
+		}
+	} else if d.verifyOrderbook {
+		if err := verify(d.snapshot()); err != nil {
+			return d.invalidate(err)
+		}
+	}
+
+	return nil
+}
+
+// // TODO: Confirm no alloc as it shouldn't escape
+func (d *Depth) snapshot() *Base {
+	return &Base{
+		Bids:                   d.bidTranches.Tranches,
+		Asks:                   d.askTranches.Tranches,
+		Exchange:               d.options.exchange,
+		Pair:                   d.pair,
+		Asset:                  d.asset,
+		IsFundingRate:          d.options.isFundingRate,
+		PriceDuplication:       d.options.priceDuplication,
+		IDAlignment:            d.options.idAligned,
+		ChecksumStringRequired: d.options.checksumStringRequired,
+	}
+}
+
+// updateByIDAndAction will receive an action to execute against the orderbook it will then match by IDs instead of
+// price to perform the action
+func (d *Depth) updateByIDAndAction(u *Update) error {
+	switch u.Action {
+	case Amend:
+		if err := d.updateBidAskByID(u); err != nil {
+			return fmt.Errorf("%w %w", errAmendFailure, err)
+		}
+	case Delete:
+		// edge case for Bitfinex as their streaming endpoint duplicates deletes
+		bypassErr := d.options.exchange == "Bitfinex" && d.options.isFundingRate // TODO: Confirm this is still correct
+		if err := d.deleteBidAskByID(u, bypassErr); err != nil {
+			return fmt.Errorf("%w %w", errDeleteFailure, err)
+		}
+	case Insert:
+		if err := d.insertBidAskByID(u); err != nil {
+			return fmt.Errorf("%w %w", errInsertFailure, err)
+		}
+	case UpdateInsert:
+		if err := d.updateInsertByID(u); err != nil {
+			return fmt.Errorf("%w %w", errUpdateInsertFailure, err)
+		}
+	default:
+		return fmt.Errorf("%w [%d]", errInvalidAction, u.Action)
+	}
+	return nil
+}
+
+// updateBidAskByPrice updates the bid and ask spread by supplied updates, this will trim total length of depth level to
+// a specified supplied number
+func (d *Depth) updateBidAskByPrice(update *Update) error {
+	if update.UpdateTime.IsZero() {
+		return fmt.Errorf("%s %s %s %w", d.exchange, d.pair, d.asset, errLastUpdatedNotSet)
+	}
+	d.bidTranches.updateInsertByPrice(update.Bids, d.options.maxDepth)
+	d.askTranches.updateInsertByPrice(update.Asks, d.options.maxDepth)
+	d.updateAndAlert(update)
+	return nil
+}
+
+// updateBidAskByID amends details by ID
+func (d *Depth) updateBidAskByID(update *Update) error {
+	if update.UpdateTime.IsZero() {
+		return fmt.Errorf("%s %s %s %w", d.exchange, d.pair, d.asset, errLastUpdatedNotSet)
+	}
+	if err := d.bidTranches.updateByID(update.Bids); err != nil {
+		return err
+	}
+	if err := d.askTranches.updateByID(update.Asks); err != nil {
+		return err
+	}
+	d.updateAndAlert(update)
+	return nil
+}
+
+// deleteBidAskByID deletes a price level by ID
+func (d *Depth) deleteBidAskByID(update *Update, bypassErr bool) error {
+	if update.UpdateTime.IsZero() {
+		return fmt.Errorf("%s %s %s %w", d.exchange, d.pair, d.asset, errLastUpdatedNotSet)
+	}
+	if err := d.bidTranches.deleteByID(update.Bids, bypassErr); err != nil {
+		return err
+	}
+	if err := d.askTranches.deleteByID(update.Asks, bypassErr); err != nil {
+		return err
+	}
+	d.updateAndAlert(update)
+	return nil
+}
+
+// insertBidAskByID inserts new updates
+func (d *Depth) insertBidAskByID(update *Update) error {
+	if update.UpdateTime.IsZero() {
+		return fmt.Errorf("%s %s %s %w", d.exchange, d.pair, d.asset, errLastUpdatedNotSet)
+	}
+	if err := d.bidTranches.insertUpdates(update.Bids); err != nil {
+		return err
+	}
+	if err := d.askTranches.insertUpdates(update.Asks); err != nil {
+		return err
+	}
+	d.updateAndAlert(update)
+	return nil
+}
+
+// updateInsertByID updates or inserts by ID at current price level.
+func (d *Depth) updateInsertByID(update *Update) error {
+	if update.UpdateTime.IsZero() {
+		return fmt.Errorf("%s %s %s %w", d.exchange, d.pair, d.asset, errLastUpdatedNotSet)
+	}
+	if err := d.bidTranches.updateInsertByID(update.Bids); err != nil {
+		return err
+	}
+	if err := d.askTranches.updateInsertByID(update.Asks); err != nil {
+		return err
+	}
+	d.updateAndAlert(update)
+	return nil
+}

--- a/exchanges/orderbook/incremental_updates_test.go
+++ b/exchanges/orderbook/incremental_updates_test.go
@@ -1,0 +1,340 @@
+package orderbook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSnapshot(length int) *Base {
+	return &Base{
+		Bids:           newBids(length),
+		Asks:           newAsks(length, length),
+		LastUpdated:    time.Now(),
+		UpdatePushedAt: time.Now(),
+		LastUpdateID:   1,
+	}
+}
+
+func newBids(length int) Tranches {
+	bids := make(Tranches, length)
+	for i := range length {
+		bids[i] = Tranche{Price: 1337 - float64(i), Amount: 1, ID: int64(i + 1)}
+	}
+	return bids
+}
+
+func newAsks(idOffset, length int) Tranches {
+	asks := make(Tranches, length)
+	for i := range length {
+		asks[i] = Tranche{Price: 1338 + float64(i), Amount: 1, ID: int64(i + 1 + idOffset)}
+	}
+	return asks
+}
+
+func TestProcessUpdate(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	assert.ErrorIs(t, d.ProcessUpdate(&Update{}), ErrEmptyUpdate)
+	assert.ErrorIs(t, d.ProcessUpdate(&Update{AllowEmpty: true}), ErrEmptyUpdate, "excercise validation error return from last ProcessUpdate call which invalidates the orderbook")
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	assert.NoError(t, d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}, SkipOutOfOrderLastUpdateID: true}))
+	ob, err := d.Retrieve()
+	require.NoError(t, err)
+	assert.NotEqual(t, int64(69420), ob.Asks[0].ID, "Update above should skip insertion")
+	d.options.restSnapshot = true // Simulate the snapshot has been loaded from REST
+	err = d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}})
+	assert.ErrorIs(t, err, errRESTSnapshot)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.ProcessUpdate(&Update{Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}})
+	assert.ErrorIs(t, err, errLastUpdatedNotSet)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.ProcessUpdate(&Update{Action: Insert, Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}})
+	assert.ErrorIs(t, err, errLastUpdatedNotSet)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	d.verifyOrderbook = true
+	d.askTranches.Tranches[0].Amount = 0
+	err = d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}})
+	assert.ErrorIs(t, err, errAmountInvalid)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}, ExpectedChecksum: 1337})
+	require.ErrorIs(t, err, errChecksumGeneratorUnset)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}, ExpectedChecksum: 1337, GenerateChecksum: func(*Base) uint32 { return 1336 }})
+	require.ErrorIs(t, err, errChecksumMismatch)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.ProcessUpdate(&Update{UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 69420, ID: 69420}}, ExpectedChecksum: 1337, GenerateChecksum: func(*Base) uint32 { return 1337 }})
+	require.NoError(t, err)
+}
+
+func TestUpdateByIDAndAction(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err := d.updateByIDAndAction(&Update{})
+	assert.ErrorIs(t, err, errInvalidAction, "UpdateByIDAndAction should error correctly")
+
+	err = d.updateByIDAndAction(&Update{Action: Amend, UpdateTime: time.Now(), Asks: Tranches{{Price: 1338, Amount: 69420, ID: 69420}}})
+	assert.ErrorIs(t, err, errAmendFailure, "UpdateByIDAndAction should error correctly")
+	err = d.updateByIDAndAction(&Update{Action: Amend, UpdateTime: time.Now(), Asks: Tranches{{Price: 1338, Amount: 69420, ID: 21}}})
+	assert.NoError(t, err, "UpdateByIDAndAction should not error")
+	ob, err := d.Retrieve()
+	require.NoError(t, err)
+	assert.Equal(t, 69420.0, ob.Asks[0].Amount, "First ask amount should be correct")
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.updateByIDAndAction(&Update{Action: Delete, UpdateTime: time.Now(), Asks: Tranches{{Price: 1338, Amount: 1, ID: 69420}}})
+	assert.ErrorIs(t, err, errDeleteFailure, "UpdateByIDAndAction should error correctly")
+	err = d.updateByIDAndAction(&Update{Action: Delete, UpdateTime: time.Now(), Asks: Tranches{{ID: 21}}})
+	assert.NoError(t, err, "UpdateByIDAndAction should not error")
+	ob, err = d.Retrieve()
+	require.NoError(t, err)
+	assert.NotEqual(t, 21, ob.Asks[0].ID, "Ask element should be deleted")
+	assert.Len(t, ob.Asks, 19, "Asks length should be correct")
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.updateByIDAndAction(&Update{Action: Insert, UpdateTime: time.Now(), Asks: Tranches{{Price: 1338, Amount: 1, ID: 21}}})
+	assert.ErrorIs(t, err, errInsertFailure, "UpdateByIDAndAction should error correctly")
+	err = d.updateByIDAndAction(&Update{Action: Insert, UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 1, ID: 69420}}})
+	assert.NoError(t, err, "UpdateByIDAndAction should not error")
+	ob, err = d.Retrieve()
+	require.NoError(t, err)
+	assert.Equal(t, int64(69420), ob.Asks[0].ID, "First ask ID should be correct")
+
+	require.NoError(t, d.LoadSnapshot(newSnapshot(20)))
+	err = d.updateByIDAndAction(&Update{Action: UpdateInsert, UpdateTime: time.Now(), Asks: Tranches{{Price: 1338, Amount: 0, ID: 21}}})
+	assert.ErrorIs(t, err, errUpdateInsertFailure, "UpdateByIDAndAction should error correctly")
+	err = d.updateByIDAndAction(&Update{Action: UpdateInsert, UpdateTime: time.Now(), Asks: Tranches{{Price: 1337.5, Amount: 1, ID: 69420}}})
+	assert.NoError(t, err, "UpdateByIDAndAction should not error")
+	ob, err = d.Retrieve()
+	require.NoError(t, err)
+	assert.Equal(t, int64(69420), ob.Asks[0].ID, "First ask ID should be correct")
+}
+
+func TestUpdateBidAskByID(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates := &Update{
+		Bids: Tranches{{Price: 1337, Amount: 2, ID: 1}},
+		Asks: Tranches{{Price: 1337, Amount: 2, ID: 2}},
+	}
+
+	err = d.updateBidAskByID(updates)
+	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateBidAskByID should error correctly")
+
+	updates.UpdateTime = time.Now()
+	err = d.updateBidAskByID(updates)
+	assert.NoError(t, err, "UpdateBidAskByID should not error")
+
+	ob, err := d.Retrieve()
+	assert.NoError(t, err, "Retrieve should not error")
+	assert.Equal(t, 2.0, ob.Asks[0].Amount, "First ask amount should be correct")
+	assert.Equal(t, 2.0, ob.Bids[0].Amount, "First bid amount should be correct")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 666}},
+		UpdateTime: time.Now(),
+	}
+	// random unmatching IDs
+	err = d.updateBidAskByID(updates)
+	assert.ErrorIs(t, err, errIDCannotBeMatched, "UpdateBidAskByID should error correctly")
+
+	updates = &Update{
+		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 69}},
+		UpdateTime: time.Now(),
+	}
+	err = d.updateBidAskByID(updates)
+	assert.ErrorIs(t, err, errIDCannotBeMatched, "UpdateBidAskByID should error correctly")
+}
+
+func TestDeleteBidAskByID(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates := &Update{
+		Bids: Tranches{{Price: 1337, Amount: 2, ID: 1}},
+		Asks: Tranches{{Price: 1337, Amount: 2, ID: 2}},
+	}
+
+	err = d.deleteBidAskByID(updates, false)
+	assert.ErrorIs(t, err, errLastUpdatedNotSet, "DeleteBidAskByID should error correctly")
+
+	updates.UpdateTime = time.Now()
+	err = d.deleteBidAskByID(updates, false)
+	assert.NoError(t, err, "DeleteBidAskByID should not error")
+
+	ob, err := d.Retrieve()
+	assert.NoError(t, err, "Retrieve should not error")
+	assert.Empty(t, ob.Asks, "Asks should be empty")
+	assert.Empty(t, ob.Bids, "Bids should be empty")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 1}},
+		UpdateTime: time.Now(),
+	}
+	err = d.deleteBidAskByID(updates, false)
+	assert.ErrorIs(t, err, errIDCannotBeMatched, "DeleteBidAskByID should error correctly")
+
+	updates = &Update{
+		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 2}},
+		UpdateTime: time.Now(),
+	}
+	err = d.deleteBidAskByID(updates, false)
+	assert.ErrorIs(t, err, errIDCannotBeMatched, "DeleteBidAskByID should error correctly")
+
+	updates = &Update{
+		Asks:       Tranches{{Price: 1337, Amount: 2, ID: 2}},
+		UpdateTime: time.Now(),
+	}
+	err = d.deleteBidAskByID(updates, true)
+	assert.NoError(t, err, "DeleteBidAskByID should not error")
+}
+
+func TestInsertBidAskByID(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates := &Update{
+		Asks: Tranches{{Price: 1337, Amount: 2, ID: 3}},
+	}
+	err = d.insertBidAskByID(updates)
+	assert.ErrorIs(t, err, errLastUpdatedNotSet, "InsertBidAskByID should error correctly")
+
+	updates.UpdateTime = time.Now()
+
+	err = d.insertBidAskByID(updates)
+	assert.ErrorIs(t, err, errCollisionDetected, "InsertBidAskByID should error correctly on collision")
+
+	err = d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 3}},
+		UpdateTime: time.Now(),
+	}
+
+	err = d.insertBidAskByID(updates)
+	assert.ErrorIs(t, err, errCollisionDetected, "InsertBidAskByID should error correctly on collision")
+
+	err = d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
+		Asks:       Tranches{{Price: 1336, Amount: 2, ID: 4}},
+		UpdateTime: time.Now(),
+	}
+	err = d.insertBidAskByID(updates)
+	assert.NoError(t, err, "InsertBidAskByID should not error")
+
+	ob, err := d.Retrieve()
+	assert.NoError(t, err, "Retrieve should not error")
+	assert.Len(t, ob.Asks, 2, "Should have correct Asks")
+	assert.Len(t, ob.Bids, 2, "Should have correct Bids")
+}
+
+func TestUpdateInsertByID(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates := &Update{
+		Bids: Tranches{{Price: 1338, Amount: 0, ID: 3}},
+		Asks: Tranches{{Price: 1336, Amount: 2, ID: 4}},
+	}
+	err = d.updateInsertByID(updates)
+	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateInsertByID should error correctly")
+
+	updates.UpdateTime = time.Now()
+	err = d.updateInsertByID(updates)
+	assert.ErrorIs(t, err, errAmountCannotBeLessOrEqualToZero, "UpdateInsertByID should error correctly")
+
+	err = d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
+		Asks:       Tranches{{Price: 1336, Amount: 0, ID: 4}},
+		UpdateTime: time.Now(),
+	}
+	err = d.updateInsertByID(updates)
+	assert.ErrorIs(t, err, errAmountCannotBeLessOrEqualToZero, "UpdateInsertByID should error correctly")
+
+	err = d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1337, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1338, Amount: 2, ID: 3}},
+		Asks:       Tranches{{Price: 1336, Amount: 2, ID: 4}},
+		UpdateTime: time.Now(),
+	}
+	err = d.updateInsertByID(updates)
+	assert.NoError(t, err, "UpdateInsertByID should not error")
+
+	ob, err := d.Retrieve()
+	assert.NoError(t, err, "Retrieve should not error")
+	assert.Len(t, ob.Asks, 2, "Should have correct Asks")
+	assert.Len(t, ob.Bids, 2, "Should have correct Bids")
+}
+
+func TestUpdateBidAskByPrice(t *testing.T) {
+	t.Parallel()
+	d := NewDepth(id)
+	err := d.LoadSnapshot(&Base{Bids: Tranches{{Price: 1337, Amount: 1, ID: 1}}, Asks: Tranches{{Price: 1338, Amount: 10, ID: 2}}, LastUpdated: time.Now(), UpdatePushedAt: time.Now()})
+	assert.NoError(t, err, "LoadSnapshot should not error")
+
+	err = d.updateBidAskByPrice(&Update{})
+	assert.ErrorIs(t, err, errLastUpdatedNotSet, "UpdateBidAskByPrice should error correctly")
+
+	err = d.updateBidAskByPrice(&Update{UpdateTime: time.Now()})
+	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
+
+	updates := &Update{
+		Bids:       Tranches{{Price: 1337, Amount: 2, ID: 1}},
+		Asks:       Tranches{{Price: 1338, Amount: 3, ID: 2}},
+		UpdateID:   1,
+		UpdateTime: time.Now(),
+	}
+	err = d.updateBidAskByPrice(updates)
+	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
+
+	ob, err := d.Retrieve()
+	assert.NoError(t, err, "Retrieve should not error")
+	assert.Equal(t, 3.0, ob.Asks[0].Amount, "Asks amount should be correct")
+	assert.Equal(t, 2.0, ob.Bids[0].Amount, "Bids amount should be correct")
+
+	updates = &Update{
+		Bids:       Tranches{{Price: 1337, Amount: 0, ID: 1}},
+		Asks:       Tranches{{Price: 1338, Amount: 0, ID: 2}},
+		UpdateID:   2,
+		UpdateTime: time.Now(),
+	}
+	err = d.updateBidAskByPrice(updates)
+	assert.NoError(t, err, "UpdateBidAskByPrice should not error")
+
+	askLen, err := d.GetAskLength()
+	assert.NoError(t, err, "GetAskLength should not error")
+	assert.Zero(t, askLen, "Ask Length should be correct")
+
+	bidLen, err := d.GetBidLength()
+	assert.NoError(t, err, "GetBidLength should not error")
+	assert.Zero(t, bidLen, "Bid Length should be correct")
+}

--- a/exchanges/orderbook/orderbook_types.go
+++ b/exchanges/orderbook/orderbook_types.go
@@ -148,36 +148,6 @@ type options struct {
 	maxDepth               int
 }
 
-// Action defines a set of differing states required to implement an incoming
-// orderbook update used in conjunction with UpdateEntriesByID
-type Action uint8
-
-const (
-	// Amend applies amount adjustment by ID
-	Amend Action = iota + 1
-	// Delete removes price level from book by ID
-	Delete
-	// Insert adds price level to book
-	Insert
-	// UpdateInsert on conflict applies amount adjustment or appends new amount
-	// to book
-	UpdateInsert
-)
-
-// Update and things and stuff
-type Update struct {
-	UpdateID       int64 // Used when no time is provided
-	UpdateTime     time.Time
-	UpdatePushedAt time.Time
-	Asset          asset.Item
-	Action
-	Bids []Tranche
-	Asks []Tranche
-	Pair currency.Pair
-	// Checksum defines the expected value when the books have been verified
-	Checksum uint32
-}
-
 // Movement defines orderbook traversal details from either hitting the bids or
 // lifting the asks.
 type Movement struct {

--- a/exchanges/orderbook/tranches.go
+++ b/exchanges/orderbook/tranches.go
@@ -68,9 +68,7 @@ updates:
 			ts[y].StrAmount = updts[x].StrAmount
 			continue updates
 		}
-		return fmt.Errorf("update error: %w ID: %d not found",
-			errIDCannotBeMatched,
-			updts[x].ID)
+		return fmt.Errorf("update error: %w ID: %d not found", errIDCannotBeMatched, updts[x].ID)
 	}
 	return nil
 }

--- a/exchanges/orderbook/tranches_test.go
+++ b/exchanges/orderbook/tranches_test.go
@@ -1256,7 +1256,7 @@ func TestGetMovementByBaseAmount(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(tt.BidLiquidity, nil, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Bids: tt.BidLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1390,7 +1390,7 @@ func TestGetBaseAmountFromNominalSlippage(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(tt.BidLiquidity, nil, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Bids: tt.BidLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			assert.NoError(t, err, "LoadSnapshot should not error")
 
 			base, err := depth.bidTranches.hitBidsByNominalSlippage(tt.NominalSlippage, tt.ReferencePrice)
@@ -1497,7 +1497,7 @@ func TestGetBaseAmountFromImpact(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(tt.BidLiquidity, nil, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Bids: tt.BidLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1582,7 +1582,7 @@ func TestGetMovementByQuoteAmount(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(nil, tt.AskLiquidity, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Asks: tt.AskLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1714,7 +1714,7 @@ func TestGetQuoteAmountFromNominalSlippage(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(nil, tt.AskLiquidity, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Asks: tt.AskLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			assert.NoError(t, err, "LoadSnapshot should not error")
 
 			quote, err := depth.askTranches.liftAsksByNominalSlippage(tt.NominalSlippage, tt.ReferencePrice)
@@ -1802,7 +1802,7 @@ func TestGetQuoteAmountFromImpact(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			depth := NewDepth(id)
-			err := depth.LoadSnapshot(nil, tt.AskLiquidity, 0, time.Now(), time.Now(), true)
+			err := depth.LoadSnapshot(&Base{Asks: tt.AskLiquidity, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 			assert.NoError(t, err, "LoadSnapshot should not error")
 
 			quote, err := depth.askTranches.liftAsksByImpactSlippage(tt.ImpactSlippage, tt.ReferencePrice)
@@ -1824,7 +1824,7 @@ func TestGetHeadPrice(t *testing.T) {
 	if _, err := depth.askTranches.getHeadPriceNoLock(); !errors.Is(err, errNoLiquidity) {
 		t.Fatalf("received: '%v' but expected: '%v'", err, errNoLiquidity)
 	}
-	err := depth.LoadSnapshot(bid, ask, 0, time.Now(), time.Now(), true)
+	err := depth.LoadSnapshot(&Base{Bids: bid, Asks: ask, LastUpdated: time.Now(), UpdatePushedAt: time.Now(), RestSnapshot: true})
 	if err != nil {
 		t.Fatalf("failed to load snapshot: %s", err)
 	}


### PR DESCRIPTION
# PR Description

Buffer package:

* Shift orderbook logic to orderbook package
* Change Orderbook struct mutex to RWMutex to slightly relieve concurrent lookups between connections
* `Flushbuffer` method change to not purge entire map on reconnection
* Change name `FlushOrderbook` -> `InvalidateOrderbook` in line with orderbook call
* General clean

NOTE: Buffer package can be RM'd or renamed and repurposed just for looking up websocket orderbooks. It really doesn't serve any useful purpose. Getting out of order updates shouldn't be occurring anyway and we shouldn't be trying to sort them. But at least the main logic is pulled out for this future update. 

Orderbook package:

* LoadSnapshot method signature change to take in orderbook.Base pointer (clean)
* Change field name `UpdateIDProgression` -> `SkipOutOfOrderLastUpdateID` as it's a little bit more intuitive
* Change `Checksum` function signature to just return a generated checksum from stored orderbook for standardisation of error returns 
* removed redundant `updateEntriesByID` field and is now using Action field
* Most of Update processing and checking now occurs under one lock instead of retrieving that field under a read mutex context checking that then getting the next field. 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
