### PR TITLE
Deribit: Remove deprecated public and private portfolio margin endpoints

### DIFF
--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -121,7 +121,6 @@ const (
 
 	// account management eps
 	getAnnouncements                  = "public/get_announcements"
-	getPublicPortfolioMargins         = "public/get_portfolio_margins"
 	changeAPIKeyName                  = "private/change_api_key_name"
 	changeMarginModel                 = "private/change_margin_model"
 	changeScopeInAPIKey               = "private/change_scope_in_api_key"
@@ -137,7 +136,6 @@ const (
 	getAffiliateProgramInfo           = "private/get_affiliate_program_info"
 	getEmailLanguage                  = "private/get_email_language"
 	getNewAnnouncements               = "private/get_new_announcements"
-	getPrivatePortfolioMargins        = "private/get_portfolio_margins"
 	getPosition                       = "private/get_position"
 	getPositions                      = "private/get_positions"
 	getSubAccounts                    = "private/get_subaccounts"
@@ -973,24 +971,6 @@ func (d *Deribit) GetAnnouncements(ctx context.Context, startTime time.Time, cou
 	return resp, d.SendHTTPRequest(ctx, exchange.RestFutures, nonMatchingEPL, common.EncodeURLValues(getAnnouncements, params), &resp)
 }
 
-// GetPublicPortfolioMargins public version of the method calculates portfolio margin info for simulated position. For concrete user position, the private version of the method must be used. The public version of the request has special restricted rate limit (not more than once per a second for the IP).
-func (d *Deribit) GetPublicPortfolioMargins(ctx context.Context, ccy currency.Code, simulatedPositions map[string]float64) (*PortfolioMargin, error) {
-	if ccy.IsEmpty() {
-		return nil, currency.ErrCurrencyCodeEmpty
-	}
-	params := url.Values{}
-	params.Set("currency", ccy.String())
-	if len(simulatedPositions) != 0 {
-		values, err := json.Marshal(simulatedPositions)
-		if err != nil {
-			return nil, err
-		}
-		params.Set("simulated_positions", string(values))
-	}
-	var resp *PortfolioMargin
-	return resp, d.SendHTTPRequest(ctx, exchange.RestFutures, portfolioMarginEPL, common.EncodeURLValues(getPublicPortfolioMargins, params), &resp)
-}
-
 // ChangeAPIKeyName changes the name of the api key requested
 func (d *Deribit) ChangeAPIKeyName(ctx context.Context, id int64, name string) (*APIKeyData, error) {
 	if id <= 0 {
@@ -1191,27 +1171,6 @@ func (d *Deribit) GetNewAnnouncements(ctx context.Context) ([]Announcement, erro
 	var resp []Announcement
 	return resp, d.SendHTTPAuthRequest(ctx, exchange.RestFutures, nonMatchingEPL, http.MethodGet,
 		getNewAnnouncements, nil, &resp)
-}
-
-// GetPrivatePortfolioMargins calculates portfolio margin info for simulated position or current position of the user. This request has special restricted rate limit (not more than once per a second).
-func (d *Deribit) GetPrivatePortfolioMargins(ctx context.Context, ccy currency.Code, accPositions bool, simulatedPositions map[string]float64) (*PortfolioMargin, error) {
-	if ccy.IsEmpty() {
-		return nil, currency.ErrCurrencyCodeEmpty
-	}
-	params := url.Values{}
-	params.Set("currency", ccy.String())
-	if accPositions {
-		params.Set("acc_positions", "true")
-	}
-	if len(simulatedPositions) != 0 {
-		values, err := json.Marshal(simulatedPositions)
-		if err != nil {
-			return nil, err
-		}
-		params.Set("simulated_positions", string(values))
-	}
-	var resp *PortfolioMargin
-	return resp, d.SendHTTPAuthRequest(ctx, exchange.RestFutures, nonMatchingEPL, http.MethodGet, getPrivatePortfolioMargins, params, &resp)
 }
 
 // GetPosition gets the data of all positions in the requested instrument name

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -1286,16 +1286,6 @@ func TestWSRetrieveAnnouncements(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-func TestGetPublicPortfolioMargins(t *testing.T) {
-	info, err := d.GetInstrument(t.Context(), "BTC-PERPETUAL")
-	require.NoError(t, err)
-	_, err = d.GetPublicPortfolioMargins(t.Context(), currency.EMPTYCODE, map[string]float64{"BTC-PERPETUAL": info.ContractSize * 2})
-	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-	result, err := d.GetPublicPortfolioMargins(t.Context(), currency.BTC, map[string]float64{"BTC-PERPETUAL": info.ContractSize * 2})
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-}
-
 func TestGetAccessLog(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
@@ -1558,28 +1548,6 @@ func TestWSRetrieveNewAnnouncements(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
 	result, err := d.WSRetrieveNewAnnouncements()
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-}
-
-func TestGetPrivatePortfolioMargins(t *testing.T) {
-	t.Parallel()
-	_, err := d.GetPrivatePortfolioMargins(t.Context(), currency.EMPTYCODE, false, nil)
-	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
-	result, err := d.GetPrivatePortfolioMargins(t.Context(), currency.BTC, false, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-}
-
-func TestWsRetrievePrivatePortfolioMargins(t *testing.T) {
-	t.Parallel()
-	_, err := d.WSRetrievePrivatePortfolioMargins(currency.EMPTYCODE, false, nil)
-	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
-
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, d)
-	result, err := d.WSRetrievePrivatePortfolioMargins(currency.BTC, false, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3470,16 +3438,6 @@ func TestGetRecentTrades(t *testing.T) {
 		require.NoErrorf(t, err, "expected nil, got %v for asset type %s pair %s", err, assetType, cp)
 		require.NotNilf(t, result, "expected result not to be nil for asset type %s pair %s", assetType, cp)
 	}
-}
-
-func TestWSRetrievePublicPortfolioMargins(t *testing.T) {
-	t.Parallel()
-	info, err := d.GetInstrument(t.Context(), btcPerpInstrument)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	result, err := d.WSRetrievePublicPortfolioMargins(currency.BTC, map[string]float64{btcPerpInstrument: info.ContractSize * 2})
-	require.NoError(t, err)
-	assert.NotNil(t, result)
 }
 
 func TestCancelAllOrders(t *testing.T) {

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -967,51 +967,6 @@ type Announcement struct {
 	Action string `json:"action"`
 }
 
-// PortfolioMargin represents public portfolio margins.
-type PortfolioMargin struct {
-	VolumeRange         []float64          `json:"vol_range"`
-	VegaPow2            float64            `json:"vega_pow2"`
-	VegaPow1            float64            `json:"vega_pow1"`
-	Skew                float64            `json:"skew"`
-	PriceRange          float64            `json:"price_range"`
-	OptSumContinguency  float64            `json:"opt_sum_continguency"`
-	OptContinguency     float64            `json:"opt_continguency"`
-	Kurtosis            float64            `json:"kurtosis"`
-	IntRate             float64            `json:"int_rate"`
-	InitialMarginFactor float64            `json:"initial_margin_factor"`
-	FtuContinguency     float64            `json:"ftu_continguency"`
-	AtmRange            float64            `json:"atm_range"`
-	ProjectedMarginPos  float64            `json:"projected_margin_pos"`
-	ProjectedMargin     float64            `json:"projected_margin"`
-	PositionSizes       map[string]float64 `json:"position_sizes"`
-	Pls                 []float64          `json:"pls"`
-	PcoOpt              float64            `json:"pco_opt"`
-	PcoFtu              float64            `json:"pco_ftu"`
-	OptSummary          []any              `json:"opt_summary"`
-	OptPls              []float64          `json:"opt_pls"`
-	OptEntries          []any              `json:"opt_entries"`
-	MarginPos           float64            `json:"margin_pos"`
-	Margin              float64            `json:"margin"`
-	FtuSummary          []struct {
-		ShortTotalCost  float64    `json:"short_total_cost"`
-		PlVec           []float64  `json:"pl_vec"`
-		LongTotalCost   float64    `json:"long_total_cost"`
-		ExpiryTimestamp types.Time `json:"exp_tstamp"`
-	} `json:"ftu_summary"`
-	FtuPls     []float64 `json:"ftu_pls"`
-	FtuEntries []struct {
-		TotalCost       float64    `json:"total_cost"`
-		Size            float64    `json:"size"`
-		PlVec           []float64  `json:"pl_vec"`
-		MarkPrice       float64    `json:"mark_price"`
-		InstrumentName  string     `json:"instrument_name"`
-		ExpiryTimestamp types.Time `json:"exp_tstamp"`
-	} `json:"ftu_entries"`
-	CoOpt                float64    `json:"co_opt"`
-	CoFtu                float64    `json:"co_ftu"`
-	CalculationTimestamp types.Time `json:"calculation_timestamp"`
-}
-
 // AccessLog represents access log information.
 type AccessLog struct {
 	RecordsTotal int64             `json:"records_total"`

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -838,24 +838,6 @@ func (d *Deribit) WSRetrieveAnnouncements(startTime time.Time, count int64) ([]A
 	return resp, d.SendWSRequest(nonMatchingEPL, getAnnouncements, input, &resp, false)
 }
 
-// WSRetrievePublicPortfolioMargins public version of the method calculates portfolio margin info for simulated position. For concrete user position, the private version of the method must be used. The public version of the request has special restricted rate limit (not more than once per a second for the IP).
-func (d *Deribit) WSRetrievePublicPortfolioMargins(ccy currency.Code, simulatedPositions map[string]float64) (*PortfolioMargin, error) {
-	if ccy.IsEmpty() {
-		return nil, currency.ErrCurrencyCodeEmpty
-	}
-	input := &struct {
-		Currency           currency.Code      `json:"currency"`
-		SimulatedPositions map[string]float64 `json:"simulated_positions"`
-	}{
-		Currency: ccy,
-	}
-	if len(simulatedPositions) != 0 {
-		input.SimulatedPositions = simulatedPositions
-	}
-	var resp *PortfolioMargin
-	return resp, d.SendWSRequest(nonMatchingEPL, getPublicPortfolioMargins, input, &resp, false)
-}
-
 // WSChangeAPIKeyName changes the name of the api key requested through the websocket connection.
 func (d *Deribit) WSChangeAPIKeyName(id int64, name string) (*APIKeyData, error) {
 	if id <= 0 {
@@ -1056,26 +1038,6 @@ func (d *Deribit) WSRetrieveEmailLanguage() (string, error) {
 func (d *Deribit) WSRetrieveNewAnnouncements() ([]Announcement, error) {
 	var resp []Announcement
 	return resp, d.SendWSRequest(nonMatchingEPL, getNewAnnouncements, nil, &resp, true)
-}
-
-// WSRetrievePrivatePortfolioMargins alculates portfolio margin info for simulated position or current position of the user through the websocket connection. This request has special restricted rate limit (not more than once per a second).
-func (d *Deribit) WSRetrievePrivatePortfolioMargins(ccy currency.Code, accPositions bool, simulatedPositions map[string]float64) (*PortfolioMargin, error) {
-	if ccy.IsEmpty() {
-		return nil, currency.ErrCurrencyCodeEmpty
-	}
-	input := &struct {
-		Currency           currency.Code      `json:"currency"`
-		AccountPositions   bool               `json:"acc_positions,omitempty"`
-		SimulatedPositions map[string]float64 `json:"simulated_positions,omitempty"`
-	}{
-		Currency:         ccy,
-		AccountPositions: accPositions,
-	}
-	if len(simulatedPositions) != 0 {
-		input.SimulatedPositions = simulatedPositions
-	}
-	var resp *PortfolioMargin
-	return resp, d.SendWSRequest(portfolioMarginEPL, getPrivatePortfolioMargins, input, &resp, true)
 }
 
 // WSRetrievePosition retrieves the data of all positions in the requested instrument name through the websocket connection.


### PR DESCRIPTION
# PR Description

Removes the deprecated public and private portfolio margin endpoints as they are no longer supported

## Type of change

- [x] Test fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
