### PR TITLE
config: Fix TestPromptForConfigEncryption race

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1487,7 +1487,7 @@ func (c *Config) readConfig(d io.Reader) error {
 // If they agree, c.EncryptConfig is set to Enabled, the config is encrypted and saved
 // Otherwise, c.EncryptConfig is set to Disabled and the file is resaved
 func (c *Config) saveWithEncryptPrompt(path string) error {
-	if confirm, err := promptForConfigEncryption(); err != nil {
+	if confirm, err := PromptForConfigEncryption(); err != nil {
 		return nil //nolint:nilerr // Ignore encryption prompt failures; The user will be prompted again
 	} else if confirm {
 		c.EncryptConfig = fileEncryptionEnabled

--- a/config/config.go
+++ b/config/config.go
@@ -1487,7 +1487,7 @@ func (c *Config) readConfig(d io.Reader) error {
 // If they agree, c.EncryptConfig is set to Enabled, the config is encrypted and saved
 // Otherwise, c.EncryptConfig is set to Disabled and the file is resaved
 func (c *Config) saveWithEncryptPrompt(path string) error {
-	if confirm, err := PromptForConfigEncryption(); err != nil {
+	if confirm, err := promptForConfigEncryption(os.Stdin); err != nil {
 		return nil //nolint:nilerr // Ignore encryption prompt failures; The user will be prompted again
 	} else if confirm {
 		c.EncryptConfig = fileEncryptionEnabled

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -43,15 +43,20 @@ var (
 
 // promptForConfigEncryption asks for encryption confirmation
 // returns true if encryption was desired, false otherwise
-func promptForConfigEncryption() (bool, error) {
+func promptForConfigEncryption(r io.Reader) (bool, error) {
 	fmt.Println("Would you like to encrypt your config file (y/n)?")
 
 	input := ""
-	if _, err := fmt.Scanln(&input); err != nil {
+	if _, err := fmt.Fscanln(r, &input); err != nil {
 		return false, err
 	}
 
 	return common.YesOrNo(input), nil
+}
+
+// PromptForConfigEncryption asks for encryption confirmation using stdin
+func PromptForConfigEncryption() (bool, error) {
+	return promptForConfigEncryption(os.Stdin)
 }
 
 // PromptForConfigKey asks for configuration key

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -54,11 +54,6 @@ func promptForConfigEncryption(r io.Reader) (bool, error) {
 	return common.YesOrNo(input), nil
 }
 
-// PromptForConfigEncryption asks for encryption confirmation using stdin
-func PromptForConfigEncryption() (bool, error) {
-	return promptForConfigEncryption(os.Stdin)
-}
-
 // PromptForConfigKey asks for configuration key
 func PromptForConfigKey(confirmKey bool) ([]byte, error) {
 	for range 3 {

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -19,9 +19,65 @@ import (
 func TestPromptForConfigEncryption(t *testing.T) {
 	t.Parallel()
 
-	confirm, err := promptForConfigEncryption()
-	require.ErrorIs(t, err, io.EOF)
-	require.False(t, confirm)
+	testCases := []struct {
+		name          string
+		input         string
+		expectedBool  bool
+		expectedError error
+	}{
+		{
+			name:          "input_y",
+			input:         "y\n",
+			expectedBool:  true,
+			expectedError: nil,
+		},
+		{
+			name:          "input_n",
+			input:         "n\n",
+			expectedBool:  false,
+			expectedError: nil,
+		},
+		{
+			name:          "input_yes",
+			input:         "yes\n",
+			expectedBool:  true,
+			expectedError: nil,
+		},
+		{
+			name:          "input_no",
+			input:         "no\n",
+			expectedBool:  false,
+			expectedError: nil,
+		},
+		{
+			name:          "input_invalid",
+			input:         "invalid\n",
+			expectedBool:  false,
+			expectedError: nil,
+		},
+		{
+			name:          "input_empty_eof",
+			input:         "",
+			expectedBool:  false,
+			expectedError: io.EOF,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reader := strings.NewReader(tc.input)
+			confirm, err := promptForConfigEncryption(reader)
+
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedBool, confirm)
+		})
+	}
 }
 
 func TestPromptForConfigKey(t *testing.T) {

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -64,7 +64,6 @@ func TestPromptForConfigEncryption(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			reader := strings.NewReader(tc.input)

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -26,26 +26,26 @@ func TestPromptForConfigEncryption(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:          "input_y",
-			input:         "y\n",
-			expectedBool:  true,
+			name:         "input_y",
+			input:        "y\n",
+			expectedBool: true,
 		},
 		{
-			name:          "input_n",
-			input:         "n\n",
+			name:  "input_n",
+			input: "n\n",
 		},
 		{
-			name:          "input_yes",
-			input:         "yes\n",
-			expectedBool:  true,
+			name:         "input_yes",
+			input:        "yes\n",
+			expectedBool: true,
 		},
 		{
-			name:          "input_no",
-			input:         "no\n",
+			name:  "input_no",
+			input: "no\n",
 		},
 		{
-			name:          "input_invalid",
-			input:         "invalid\n",
+			name:  "input_invalid",
+			input: "invalid\n",
 		},
 		{
 			name:          "input_empty_eof",

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -58,12 +58,7 @@ func TestPromptForConfigEncryption(t *testing.T) {
 			t.Parallel()
 			reader := strings.NewReader(tc.input)
 			confirm, err := promptForConfigEncryption(reader)
-
-			if tc.expectedError != nil {
-				require.ErrorIs(t, err, tc.expectedError)
-			} else {
-				require.NoError(t, err)
-			}
+			require.ErrorIs(t, err, tc.expectedError)
 			require.Equal(t, tc.expectedBool, confirm)
 		})
 	}

--- a/config/config_encryption_test.go
+++ b/config/config_encryption_test.go
@@ -29,36 +29,26 @@ func TestPromptForConfigEncryption(t *testing.T) {
 			name:          "input_y",
 			input:         "y\n",
 			expectedBool:  true,
-			expectedError: nil,
 		},
 		{
 			name:          "input_n",
 			input:         "n\n",
-			expectedBool:  false,
-			expectedError: nil,
 		},
 		{
 			name:          "input_yes",
 			input:         "yes\n",
 			expectedBool:  true,
-			expectedError: nil,
 		},
 		{
 			name:          "input_no",
 			input:         "no\n",
-			expectedBool:  false,
-			expectedError: nil,
 		},
 		{
 			name:          "input_invalid",
 			input:         "invalid\n",
-			expectedBool:  false,
-			expectedError: nil,
 		},
 		{
 			name:          "input_empty_eof",
-			input:         "",
-			expectedBool:  false,
 			expectedError: io.EOF,
 		},
 	}


### PR DESCRIPTION
# PR Description

From jules:

Here's how I resolved a race condition in the encryption prompt tests:
I've refactored `promptForConfigEncryption` to accept an `io.Reader`. This allows tests to use `strings.NewReader` instead of relying on the global `os.Stdin`. This change isolates the input source for `TestPromptForConfigEncryption`, preventing concurrent access conflicts with `TestPromptForConfigKey` which uses `withInteractiveResponse` to manipulate `os.Stdin`.

The original issue manifested as a data race detected by `go test -race` between these two test functions due to their parallel execution (`t.Parallel()`) and their interaction with the shared `os.Stdin` resource.

Here are the changes I made:
- `config/config_encryption.go`:
    - Modified `promptForConfigEncryption` to `promptForConfigEncryption(r io.Reader) (bool, error)`.
    - Introduced `PromptForConfigEncryption()` as a public wrapper that calls the refactored function with `os.Stdin` for application use.
- `config/config.go`:
    - Updated the call site for prompting config encryption to use the new `PromptForConfigEncryption()` wrapper.
- `config/config_encryption_test.go`:
    - Updated `TestPromptForConfigEncryption` to call the (now unexported) `promptForConfigEncryption` with `strings.NewReader` for various input scenarios.
    - `t.Parallel()` was maintained for `TestPromptForConfigEncryption`.

To verify, I confirmed that running `go test -race ./config/...` shows the previously reported race condition is no longer present. All tests in the `config` package now pass with the race detector enabled.

Fixes #1928

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
