### PR TITLE
Bitmex: Use mock server for leaderboard and historical stats tests

### DIFF
--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -206,6 +206,7 @@ func TestGetLeaderboard(t *testing.T) {
 	require.NoError(t, err, "Setup must not error")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Request method should match expected")
 		assert.Equal(t, "/api/v1/leaderboard", r.URL.Path, "Request path should match expected")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(`[
@@ -389,6 +390,7 @@ func TestGetStatsHistorical(t *testing.T) {
 	require.NoError(t, err, "Setup must not error")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Request method should match expected")
 		assert.Equal(t, "/api/v1/stats/history", r.URL.Path, "Request path should match expected")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(`[

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -206,8 +206,8 @@ func TestGetLeaderboard(t *testing.T) {
 	require.NoError(t, err, "Setup must not error")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method, "Request method should match expected")
-		assert.Equal(t, "/api/v1/leaderboard", r.URL.Path, "Request path should match expected")
+		assert.Equal(t, http.MethodGet, r.Method, "Request method should be correct")
+		assert.Equal(t, "/api/v1/leaderboard", r.URL.Path, "Request path should be correct")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(`[
 			{
@@ -225,8 +225,8 @@ func TestGetLeaderboard(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err = b.API.Endpoints.SetRunning(exchange.RestSpot.String(), server.URL+"/api/v1")
-	require.NoError(t, err, "SetRunning must not error")
+	err = b.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api/v1")
+	require.NoError(t, err, "SetRunningURL must not error")
 
 	expectedLeaderboard := []Leaderboard{
 		{IsRealName: true, Name: "Trader Joe", Profit: 12345.67},
@@ -235,7 +235,7 @@ func TestGetLeaderboard(t *testing.T) {
 
 	result, err := b.GetLeaderboard(t.Context(), LeaderboardGetParams{})
 	require.NoError(t, err, "GetLeaderboard must not error")
-	assert.Equal(t, expectedLeaderboard, result, "GetLeaderboard result should match expected")
+	assert.Equal(t, expectedLeaderboard, result, "GetLeaderboard result should be correct")
 }
 
 func TestGetAliasOnLeaderboard(t *testing.T) {
@@ -390,8 +390,8 @@ func TestGetStatsHistorical(t *testing.T) {
 	require.NoError(t, err, "Setup must not error")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method, "Request method should match expected")
-		assert.Equal(t, "/api/v1/stats/history", r.URL.Path, "Request path should match expected")
+		assert.Equal(t, http.MethodGet, r.Method, "Request method should be correct")
+		assert.Equal(t, "/api/v1/stats/history", r.URL.Path, "Request path should be correct")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(`[
 			{
@@ -408,13 +408,13 @@ func TestGetStatsHistorical(t *testing.T) {
 				"turnover": 4500000000,
 				"volume": 90000
 			}
-		]`))
+		]`)) // Bitmex sends XBt as the currency for BTC, so we mimic it exactly
 		assert.NoError(t, err, "Writing response to handler should not error")
 	}))
 	defer server.Close()
 
-	err = b.API.Endpoints.SetRunning(exchange.RestSpot.String(), server.URL+"/api/v1")
-	require.NoError(t, err, "SetRunning must not error")
+	err = b.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api/v1")
+	require.NoError(t, err, "SetRunningURL must not error")
 
 	expectedStats := []StatsHistory{
 		{Currency: "XBt", Date: time.Date(2023, 10, 26, 0, 0, 0, 0, time.UTC), RootSymbol: "XBT", Turnover: 5000000000, Volume: 100000},
@@ -423,7 +423,7 @@ func TestGetStatsHistorical(t *testing.T) {
 
 	result, err := b.GetStatsHistorical(t.Context())
 	require.NoError(t, err, "GetStatsHistorical must not error")
-	assert.Equal(t, expectedStats, result, "GetStatsHistorical result should match expected")
+	assert.Equal(t, expectedStats, result, "GetStatsHistorical result should be correct")
 }
 
 func TestGetStatSummary(t *testing.T) {

--- a/exchanges/bitmex/bitmex_types.go
+++ b/exchanges/bitmex/bitmex_types.go
@@ -460,11 +460,11 @@ type Stats struct {
 
 // StatsHistory stats history
 type StatsHistory struct {
-	Currency   string `json:"currency"`
-	Date       string `json:"date"`
-	RootSymbol string `json:"rootSymbol"`
-	Turnover   int64  `json:"turnover"`
-	Volume     int64  `json:"volume"`
+	Currency   string    `json:"currency"`
+	Date       time.Time `json:"date"`
+	RootSymbol string    `json:"rootSymbol"`
+	Turnover   int64     `json:"turnover"`
+	Volume     int64     `json:"volume"`
 }
 
 // StatsUSD contains summary of exchange stats


### PR DESCRIPTION
# PR Description

Bitmex's leaderboard and historical stat endpoints have been flaky recently. I've communicated with their support about it but the issue keeps on occurring, so this PR makes the two tests offline. Full mock functionality hasn't been implemented, just these two endpoints for now.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
