### PR TITLE
cmd/documentation: Add GitHub token support for contributor list retrieval

### DIFF
--- a/cmd/documentation/README.md
+++ b/cmd/documentation/README.md
@@ -29,7 +29,7 @@ Be aware, this tool will:
 - Works off a configuration JSON file located at ``gocryptotrader/cmd/documentation/`` for future use with multiple repositories.
 - Automatically find the directory and file tree for the GoCryptoTrader source code and alert you of undocumented file systems which **need** to be updated.
 - Automatically find the template folder tree.
-- Fetch an updated contributor list and rank on pull request commit amount
+- Fetch an updated contributor list and rank on pull request commit amount. Set the `GITHUB_TOKEN` env or use the `ghtoken` command line flag for optional authentication.
 - Sets up core folder docs for the root directory tree including **LICENSE** and **CONTRIBUTORS**
 
 ### config.json example

--- a/cmd/documentation/cmd_templates/documentation.tmpl
+++ b/cmd/documentation/cmd_templates/documentation.tmpl
@@ -11,7 +11,7 @@ Be aware, this tool will:
 - Works off a configuration JSON file located at ``gocryptotrader/cmd/documentation/`` for future use with multiple repositories.
 - Automatically find the directory and file tree for the GoCryptoTrader source code and alert you of undocumented file systems which **need** to be updated.
 - Automatically find the template folder tree.
-- Fetch an updated contributor list and rank on pull request commit amount
+- Fetch an updated contributor list and rank on pull request commit amount. Set the `GITHUB_TOKEN` env or use the `ghtoken` command line flag for optional authentication.
 - Sets up core folder docs for the root directory tree including **LICENSE** and **CONTRIBUTORS**
 
 ### config.json example

--- a/cmd/documentation/documentation.go
+++ b/cmd/documentation/documentation.go
@@ -75,6 +75,7 @@ var (
 	// checking
 	ref          = []string{"gocryptotrader", "cmd", "documentation"}
 	engineFolder = "engine"
+	githubToken  = os.Getenv("GITHUB_TOKEN")
 )
 
 // Contributor defines an account associated with this code base by doing
@@ -123,6 +124,7 @@ type Attributes struct {
 func main() {
 	flag.BoolVar(&verbose, "v", false, "Verbose output")
 	flag.StringVar(&toolDir, "tooldir", "", "Pass in the documentation tool directory if outside tool folder")
+	flag.StringVar(&githubToken, "ghtoken", githubToken, "Github authentication token to use when fetching the contributors list")
 	flag.Parse()
 
 	wd, err := os.Getwd()
@@ -354,10 +356,16 @@ func GetContributorList(ctx context.Context, repo string, verbose bool) ([]Contr
 	vals := url.Values{}
 	vals.Set("per_page", strconv.Itoa(defaultGithubAPIPerPageLimit))
 
+	headers := make(map[string]string)
+	if githubToken != "" {
+		headers["Authorization"] = "Bearer " + githubToken
+		fmt.Println("Using GitHub token for authentication")
+	}
+
 	for page := 1; ; page++ {
 		vals.Set("page", strconv.Itoa(page))
 
-		contents, err := common.SendHTTPRequest(ctx, http.MethodGet, common.EncodeURLValues(repo+GithubAPIEndpoint, vals), nil, nil, verbose)
+		contents, err := common.SendHTTPRequest(ctx, http.MethodGet, common.EncodeURLValues(repo+GithubAPIEndpoint, vals), headers, nil, verbose)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# PR Description

Adds optional GitHub authentication support to the documentation tool

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Running the documentation tool

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
