### PR TITLE
exchanges: Refactor time handling and other minor improvements

### DIFF
--- a/backtester/report/chart.go
+++ b/backtester/report/chart.go
@@ -26,7 +26,7 @@ func createUSDTotalsChart(items []statistics.ValueAtTime, stats []statistics.Fun
 	for i := range items {
 		usdTotalChartPlot[i] = LinePlot{
 			Value:     items[i].Value.InexactFloat64(),
-			UnixMilli: items[i].Time.UTC().UnixMilli(),
+			UnixMilli: items[i].Time.UnixMilli(),
 		}
 	}
 	response.Data = append(response.Data, ChartLine{
@@ -45,7 +45,7 @@ func createUSDTotalsChart(items []statistics.ValueAtTime, stats []statistics.Fun
 			}
 			plots = append(plots, LinePlot{
 				Value:     stats[i].ReportItem.Snapshots[j].USDValue.InexactFloat64(),
-				UnixMilli: stats[i].ReportItem.Snapshots[j].Time.UTC().UnixMilli(),
+				UnixMilli: stats[i].ReportItem.Snapshots[j].Time.UnixMilli(),
 			})
 		}
 		response.Data = append(response.Data, ChartLine{
@@ -76,7 +76,7 @@ func createHoldingsOverTimeChart(stats []statistics.FundingItemStatistics) (*Cha
 				response.ShowZeroDisclaimer = true
 			}
 			plots = append(plots, LinePlot{
-				UnixMilli: stats[i].ReportItem.Snapshots[j].Time.UTC().UnixMilli(),
+				UnixMilli: stats[i].ReportItem.Snapshots[j].Time.UnixMilli(),
 				Value:     stats[i].ReportItem.Snapshots[j].Available.InexactFloat64(),
 			})
 		}

--- a/backtester/report/report.go
+++ b/backtester/report/report.go
@@ -167,7 +167,7 @@ func (d *Data) enhanceCandles() error {
 			_, offset := time.Now().Zone()
 			tt := d.OriginalCandles[intVal].Candles[j].Time.Add(time.Duration(offset) * time.Second)
 			enhancedCandle := DetailedCandle{
-				UnixMilli:    tt.UTC().UnixMilli(),
+				UnixMilli:    tt.UnixMilli(),
 				Open:         d.OriginalCandles[intVal].Candles[j].Open,
 				High:         d.OriginalCandles[intVal].Candles[j].High,
 				Low:          d.OriginalCandles[intVal].Candles[j].Low,

--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -47,21 +46,6 @@ func Int64FromString(raw any) (int64, error) {
 		return 0, fmt.Errorf("unable to parse as int64: %T", raw)
 	}
 	return n, nil
-}
-
-// TimeFromUnixTimestampFloat format
-func TimeFromUnixTimestampFloat(raw any) (time.Time, error) {
-	ts, ok := raw.(float64)
-	if !ok {
-		return time.Time{}, fmt.Errorf("unable to parse, value not float64: %T", raw)
-	}
-	return time.UnixMilli(int64(ts)), nil
-}
-
-// TimeFromUnixTimestampDecimal converts a unix timestamp in decimal form to a time.Time in UTC
-func TimeFromUnixTimestampDecimal(input float64) time.Time {
-	i, f := math.Modf(input)
-	return time.Unix(int64(i), int64(f*(1e9))).UTC()
 }
 
 // BoolPtr takes in boolean condition and returns pointer version of it

--- a/common/convert/convert_test.go
+++ b/common/convert/convert_test.go
@@ -2,7 +2,6 @@ package convert
 
 import (
 	"testing"
-	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -75,39 +74,6 @@ func TestInt64FromString(t *testing.T) {
 	_, err = Int64FromString(testString)
 	if err == nil {
 		t.Error("Common Int64FromString. Converted invalid syntax.")
-	}
-}
-
-func TestTimeFromUnixTimestampFloat(t *testing.T) {
-	t.Parallel()
-	testTimestamp := float64(1414456320000)
-	expectedOutput := time.Date(2014, time.October, 28, 0, 32, 0, 0, time.UTC)
-
-	actualOutput, err := TimeFromUnixTimestampFloat(testTimestamp)
-	if actualOutput.UTC().String() != expectedOutput.UTC().String() || err != nil {
-		t.Errorf("Common TimeFromUnixTimestampFloat. Expected '%v'. Actual '%v'. Error: %s",
-			expectedOutput, actualOutput, err)
-	}
-
-	testString := "Time"
-	_, err = TimeFromUnixTimestampFloat(testString)
-	if err == nil {
-		t.Error("Common TimeFromUnixTimestampFloat. Converted invalid syntax.")
-	}
-}
-
-func TestTimeFromUnixTimestampDecimal(t *testing.T) {
-	for in, exp := range map[float64]time.Time{
-		1590633982.5714:   time.Date(2020, 5, 28, 2, 46, 22, 571400000, time.UTC),
-		1560516023.070651: time.Date(2019, 6, 14, 12, 40, 23, 70651000, time.UTC),
-		// Examples from Kraken
-		1373750306.9819:   time.Date(2013, 7, 13, 21, 18, 26, 981900000, time.UTC),
-		1534614098.345543: time.Date(2018, 8, 18, 17, 41, 38, 345543000, time.UTC),
-	} {
-		got := TimeFromUnixTimestampDecimal(in)
-		z, _ := got.Zone()
-		assert.Equal(t, "UTC", z, "TimeFromUnixTimestampDecimal should return a UTC time")
-		assert.WithinRangef(t, got, exp.Add(-time.Microsecond), exp.Add(time.Microsecond), "TimeFromUnixTimestampDecimal(%f) should parse a unix timestamp correctly", in)
 	}
 }
 

--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -94,32 +94,6 @@ func (a *Alphapoint) GetTrades(ctx context.Context, currencyPair string, startIn
 	return response, nil
 }
 
-// GetTradesByDate gets trades by date
-// CurrencyPair - instrument code (ex: “BTCUSD”)
-// StartDate - specifies the starting time in epoch time, type is long
-// EndDate - specifies the end time in epoch time, type is long
-func (a *Alphapoint) GetTradesByDate(ctx context.Context, currencyPair string, startDate, endDate int64) (Trades, error) {
-	req := make(map[string]any)
-	req["ins"] = currencyPair
-	req["startDate"] = startDate
-	req["endDate"] = endDate
-	response := Trades{}
-
-	err := a.SendHTTPRequest(ctx,
-		exchange.RestSpot,
-		http.MethodPost,
-		alphapointTradesByDate,
-		req,
-		&response)
-	if err != nil {
-		return response, err
-	}
-	if !response.IsAccepted {
-		return response, errors.New(response.RejectReason)
-	}
-	return response, nil
-}
-
 // GetOrderbook fetches the current orderbook for a given currency pair
 // CurrencyPair - trade pair (ex: “BTCUSD”)
 func (a *Alphapoint) GetOrderbook(ctx context.Context, currencyPair string) (Orderbook, error) {

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -108,52 +108,6 @@ func TestGetTrades(t *testing.T) {
 	}
 }
 
-func TestGetTradesByDate(t *testing.T) {
-	t.Parallel()
-	var trades Trades
-	var err error
-	if onlineTest {
-		trades, err = a.GetTradesByDate(t.Context(),
-			"BTCUSD", 1414799400, 1414800000)
-		if err != nil {
-			t.Errorf("Init error: %s", err)
-		}
-		_, err = a.GetTradesByDate(t.Context(),
-			"wigwham", 1414799400, 1414800000)
-		if err == nil {
-			t.Error("GetTradesByDate Expected error")
-		}
-	} else {
-		mockResp := []byte(
-			string(`{"isAccepted":true,"dateTimeUtc":635504540880633671,"ins":"BTCUSD","startDate":1414799400,"endDate":1414800000,"trades":[{"tid":11505,"px":334.669,"qty":0.1211,"unixtime":1414799403,"utcticks":635503962032459843,"incomingOrderSide":1,"incomingServerOrderId":5185651,"bookServerOrderId":5162440},{"tid":11506,"px":334.669,"qty":0.1211,"unixtime":1414799405,"utcticks":635503962058446171,"incomingOrderSide":1,"incomingServerOrderId":5186245,"bookServerOrderId":5162440},{"tid":11507,"px":336.498,"qty":0.011,"unixtime":1414799407,"utcticks":635503962072967656,"incomingOrderSide":0,"incomingServerOrderId":5186530,"bookServerOrderId":5178944},{"tid":11508,"px":335.948,"qty":0.011,"unixtime":1414799410,"utcticks":635503962108055546,"incomingOrderSide":0,"incomingServerOrderId":5187260,"bookServerOrderId":5186531}]}`),
-		)
-
-		err = json.Unmarshal(mockResp, &trades)
-		if err != nil {
-			t.Fatal("GetTradesByDate unmarshalling error: ", err)
-		}
-	}
-
-	if trades.DateTimeUTC < 0 {
-		t.Error("Alphapoint trades.Count value is negative")
-	}
-	if trades.EndDate < 0 {
-		t.Error("Alphapoint trades.DateTimeUTC value is negative")
-	}
-	if trades.Instrument != "BTCUSD" {
-		t.Error("Alphapoint trades.Instrument value is incorrect")
-	}
-	if !trades.IsAccepted {
-		t.Error("Alphapoint trades.IsAccepted value is true")
-	}
-	if trades.RejectReason != "" {
-		t.Error("Alphapoint trades.IsAccepted value has been returned")
-	}
-	if trades.StartDate < 0 {
-		t.Error("Alphapoint trades.StartIndex value is negative")
-	}
-}
-
 func TestGetOrderbook(t *testing.T) {
 	t.Parallel()
 	var orderBook Orderbook

--- a/exchanges/alphapoint/alphapoint_types.go
+++ b/exchanges/alphapoint/alphapoint_types.go
@@ -2,18 +2,19 @@ package alphapoint
 
 import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Response contains general responses from the exchange
 type Response struct {
-	IsAccepted    bool    `json:"isAccepted"`
-	RejectReason  string  `json:"rejectReason"`
-	Fee           float64 `json:"fee"`
-	FeeProduct    string  `json:"feeProduct"`
-	CancelOrderID int64   `json:"cancelOrderId"`
-	ServerOrderID int64   `json:"serverOrderId"`
-	DateTimeUTC   float64 `json:"dateTimeUtc"`
-	ModifyOrderID int64   `json:"modifyOrderId"`
+	IsAccepted    bool       `json:"isAccepted"`
+	RejectReason  string     `json:"rejectReason"`
+	Fee           float64    `json:"fee"`
+	FeeProduct    string     `json:"feeProduct"`
+	CancelOrderID int64      `json:"cancelOrderId"`
+	ServerOrderID int64      `json:"serverOrderId"`
+	DateTimeUTC   types.Time `json:"dateTimeUtc"`
+	ModifyOrderID int64      `json:"modifyOrderId"`
 	Addresses     []DepositAddresses
 }
 
@@ -36,15 +37,15 @@ type Ticker struct {
 
 // Trades holds trade information
 type Trades struct {
-	IsAccepted   bool    `json:"isAccepted"`
-	RejectReason string  `json:"rejectReason"`
-	DateTimeUTC  int64   `json:"dateTimeUtc"`
-	Instrument   string  `json:"ins"`
-	StartIndex   int     `json:"startIndex"`
-	Count        int     `json:"count"`
-	StartDate    int64   `json:"startDate"`
-	EndDate      int64   `json:"endDate"`
-	Trades       []Trade `json:"trades"`
+	IsAccepted   bool       `json:"isAccepted"`
+	RejectReason string     `json:"rejectReason"`
+	DateTimeUTC  types.Time `json:"dateTimeUtc"`
+	Instrument   string     `json:"ins"`
+	StartIndex   int        `json:"startIndex"`
+	Count        int        `json:"count"`
+	StartDate    int64      `json:"startDate"`
+	EndDate      int64      `json:"endDate"`
+	Trades       []Trade    `json:"trades"`
 }
 
 // Trade is a sub-type which holds the singular trade that occurred in the past
@@ -148,15 +149,15 @@ type AccountInfo struct {
 
 // Order is a generalised order type
 type Order struct {
-	ServerOrderID int     `json:"ServerOrderId"`
-	AccountID     int     `json:"AccountId"`
-	Price         float64 `json:"Price"`
-	QtyTotal      float64 `json:"QtyTotal"`
-	QtyRemaining  float64 `json:"QtyRemaining"`
-	ReceiveTime   int64   `json:"ReceiveTime"`
-	Side          int64   `json:"Side"`
-	State         int     `json:"orderState"`
-	OrderType     int     `json:"orderType"`
+	ServerOrderID int        `json:"ServerOrderId"`
+	AccountID     int        `json:"AccountId"`
+	Price         float64    `json:"Price"`
+	QtyTotal      float64    `json:"QtyTotal"`
+	QtyRemaining  float64    `json:"QtyRemaining"`
+	ReceiveTime   types.Time `json:"ReceiveTime"`
+	Side          int64      `json:"Side"`
+	State         int        `json:"orderState"`
+	OrderType     int        `json:"orderType"`
 }
 
 // OpenOrders holds the full range of orders by instrument
@@ -169,7 +170,7 @@ type OpenOrders struct {
 type OrderInfo struct {
 	OpenOrders   []OpenOrders `json:"openOrdersInfo"`
 	IsAccepted   bool         `json:"isAccepted"`
-	DateTimeUTC  int64        `json:"dateTimeUtc"`
+	DateTimeUTC  types.Time   `json:"dateTimeUtc"`
 	RejectReason string       `json:"rejectReason"`
 }
 

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -357,8 +357,7 @@ func (a *Alphapoint) GetActiveOrders(ctx context.Context, req *order.MultiOrderR
 			if resp[x].OpenOrders[y].State != 1 {
 				continue
 			}
-
-			orderDetail := order.Detail{
+			orders = append(orders, order.Detail{
 				Amount:          resp[x].OpenOrders[y].QtyTotal,
 				Exchange:        a.Name,
 				ExecutedAmount:  resp[x].OpenOrders[y].QtyTotal - resp[x].OpenOrders[y].QtyRemaining,
@@ -366,12 +365,10 @@ func (a *Alphapoint) GetActiveOrders(ctx context.Context, req *order.MultiOrderR
 				OrderID:         strconv.FormatInt(int64(resp[x].OpenOrders[y].ServerOrderID), 10),
 				Price:           resp[x].OpenOrders[y].Price,
 				RemainingAmount: resp[x].OpenOrders[y].QtyRemaining,
-			}
-
-			orderDetail.Side = orderSideMap[resp[x].OpenOrders[y].Side]
-			orderDetail.Date = time.Unix(resp[x].OpenOrders[y].ReceiveTime, 0)
-			orderDetail.Type = orderTypeMap[resp[x].OpenOrders[y].OrderType]
-			orders = append(orders, orderDetail)
+				Side:            orderSideMap[resp[x].OpenOrders[y].Side],
+				Date:            resp[x].OpenOrders[y].ReceiveTime.Time(),
+				Type:            orderTypeMap[resp[x].OpenOrders[y].OrderType],
+			})
 		}
 	}
 	return req.Filter(a.Name, orders), nil
@@ -398,7 +395,7 @@ func (a *Alphapoint) GetOrderHistory(ctx context.Context, req *order.MultiOrderR
 				continue
 			}
 
-			orderDetail := order.Detail{
+			orders = append(orders, order.Detail{
 				Amount:          resp[x].OpenOrders[y].QtyTotal,
 				AccountID:       strconv.FormatInt(int64(resp[x].OpenOrders[y].AccountID), 10),
 				Exchange:        a.Name,
@@ -406,12 +403,10 @@ func (a *Alphapoint) GetOrderHistory(ctx context.Context, req *order.MultiOrderR
 				OrderID:         strconv.FormatInt(int64(resp[x].OpenOrders[y].ServerOrderID), 10),
 				Price:           resp[x].OpenOrders[y].Price,
 				RemainingAmount: resp[x].OpenOrders[y].QtyRemaining,
-			}
-
-			orderDetail.Side = orderSideMap[resp[x].OpenOrders[y].Side]
-			orderDetail.Date = time.Unix(resp[x].OpenOrders[y].ReceiveTime, 0)
-			orderDetail.Type = orderTypeMap[resp[x].OpenOrders[y].OrderType]
-			orders = append(orders, orderDetail)
+				Side:            orderSideMap[resp[x].OpenOrders[y].Side],
+				Date:            resp[x].OpenOrders[y].ReceiveTime.Time(),
+				Type:            orderTypeMap[resp[x].OpenOrders[y].OrderType],
+			})
 		}
 	}
 	return req.Filter(a.Name, orders), nil

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -373,69 +372,8 @@ func (b *Binance) GetSpotKline(ctx context.Context, arg *KlinesRequestParams) ([
 	if !arg.EndTime.IsZero() {
 		params.Set("endTime", strconv.FormatInt(arg.EndTime.UnixMilli(), 10))
 	}
-
-	path := candleStick + "?" + params.Encode()
-	var resp any
-
-	err = b.SendHTTPRequest(ctx,
-		exchange.RestSpotSupplementary,
-		path,
-		spotDefaultRate,
-		&resp)
-	if err != nil {
-		return nil, err
-	}
-	responseData, ok := resp.([]any)
-	if !ok {
-		return nil, common.GetTypeAssertError("[]any", resp)
-	}
-
-	klineData := make([]CandleStick, len(responseData))
-	for x := range responseData {
-		individualData, ok := responseData[x].([]any)
-		if !ok {
-			return nil, common.GetTypeAssertError("[]any", responseData[x])
-		}
-		if len(individualData) != 12 {
-			return nil, errors.New("unexpected kline data length")
-		}
-		var candle CandleStick
-		if candle.OpenTime, err = convert.TimeFromUnixTimestampFloat(individualData[0]); err != nil {
-			return nil, err
-		}
-		if candle.Open, err = convert.FloatFromString(individualData[1]); err != nil {
-			return nil, err
-		}
-		if candle.High, err = convert.FloatFromString(individualData[2]); err != nil {
-			return nil, err
-		}
-		if candle.Low, err = convert.FloatFromString(individualData[3]); err != nil {
-			return nil, err
-		}
-		if candle.Close, err = convert.FloatFromString(individualData[4]); err != nil {
-			return nil, err
-		}
-		if candle.Volume, err = convert.FloatFromString(individualData[5]); err != nil {
-			return nil, err
-		}
-		if candle.CloseTime, err = convert.TimeFromUnixTimestampFloat(individualData[6]); err != nil {
-			return nil, err
-		}
-		if candle.QuoteAssetVolume, err = convert.FloatFromString(individualData[7]); err != nil {
-			return nil, err
-		}
-		if candle.TradeCount, ok = individualData[8].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", individualData[8])
-		}
-		if candle.TakerBuyAssetVolume, err = convert.FloatFromString(individualData[9]); err != nil {
-			return nil, err
-		}
-		if candle.TakerBuyQuoteAssetVolume, err = convert.FloatFromString(individualData[10]); err != nil {
-			return nil, err
-		}
-		klineData[x] = candle
-	}
-	return klineData, nil
+	var resp []CandleStick
+	return resp, b.SendHTTPRequest(ctx, exchange.RestSpotSupplementary, common.EncodeURLValues(candleStick, params), spotDefaultRate, &resp)
 }
 
 // GetAveragePrice returns current average price for a symbol.
@@ -1013,11 +951,11 @@ func (b *Binance) DepositHistory(ctx context.Context, c currency.Code, status st
 	}
 
 	if !startTime.IsZero() {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().UnixMilli(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
 	}
 
 	if !endTime.IsZero() {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	if offset != 0 {
@@ -1065,11 +1003,11 @@ func (b *Binance) WithdrawHistory(ctx context.Context, c currency.Code, status s
 	}
 
 	if !startTime.IsZero() {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().UnixMilli(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.UnixMilli(), 10))
 	}
 
 	if !endTime.IsZero() {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().UnixMilli(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 
 	if offset != 0 {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1173,9 +1173,8 @@ func TestGetSpotKline(t *testing.T) {
 		EndTime:   end,
 	})
 	require.NoError(t, err, "GetSpotKline must not error")
-	assert.NotEmpty(t, r, "GetSpotKline should return data")
 	if mockTests {
-		require.Len(t, r, 24, "GetSpotKline must return 24 items in mock test")
+		require.Equal(t, 24, len(r), "GetSpotKline must return 24 items in mock test")
 		exp := CandleStick{
 			OpenTime:                 types.Time(time.UnixMilli(1577836800000)),
 			Open:                     7195.24,
@@ -1190,6 +1189,8 @@ func TestGetSpotKline(t *testing.T) {
 			TakerBuyQuoteAssetVolume: 235537.29504531,
 		}
 		assert.Equal(t, exp, r[0])
+	} else {
+		assert.NotEmpty(t, r, "GetSpotKline should return data")
 	}
 }
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1165,16 +1165,31 @@ func TestGetAggregatedTrades(t *testing.T) {
 func TestGetSpotKline(t *testing.T) {
 	t.Parallel()
 	start, end := getTime()
-	_, err := b.GetSpotKline(t.Context(),
-		&KlinesRequestParams{
-			Symbol:    currency.NewBTCUSDT(),
-			Interval:  kline.FiveMin.Short(),
-			Limit:     24,
-			StartTime: start,
-			EndTime:   end,
-		})
-	if err != nil {
-		t.Error("Binance GetSpotKline() error", err)
+	r, err := b.GetSpotKline(t.Context(), &KlinesRequestParams{
+		Symbol:    currency.NewBTCUSDT(),
+		Interval:  kline.FiveMin.Short(),
+		Limit:     24,
+		StartTime: start,
+		EndTime:   end,
+	})
+	require.NoError(t, err, "GetSpotKline must not error")
+	assert.NotEmpty(t, r, "GetSpotKline should return data")
+	if mockTests {
+		require.Len(t, r, 24, "GetSpotKline must return 24 items in mock test")
+		exp := CandleStick{
+			OpenTime:                 types.Time(time.UnixMilli(1577836800000)),
+			Open:                     7195.24,
+			High:                     7196.25,
+			Low:                      7178.64,
+			Close:                    7179.78,
+			Volume:                   95.509133,
+			CloseTime:                types.Time(time.UnixMilli(1577837099999)),
+			QuoteAssetVolume:         686317.13625177,
+			TradeCount:               1127,
+			TakerBuyAssetVolume:      32.773245,
+			TakerBuyQuoteAssetVolume: 235537.29504531,
+		}
+		assert.Equal(t, exp, r[0])
 	}
 }
 
@@ -1484,14 +1499,9 @@ func TestGetAggregatedTradesBatched(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	start, err := time.Parse(time.RFC3339, "2020-01-02T15:04:05Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectTime, err := time.Parse(time.RFC3339Nano, "2020-01-02T16:19:04.831Z")
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	start := time.Date(2020, 1, 2, 15, 4, 5, 0, time.UTC)
+	expectTime := time.Date(2020, 1, 2, 16, 19, 4, 831_000_000, time.UTC)
 	tests := []struct {
 		name string
 		// mock test or live test
@@ -1576,10 +1586,7 @@ func TestGetAggregatedTradesBatched(t *testing.T) {
 
 func TestGetAggregatedTradesErrors(t *testing.T) {
 	t.Parallel()
-	start, err := time.Parse(time.RFC3339, "2020-01-02T15:04:05Z")
-	if err != nil {
-		t.Fatal(err)
-	}
+	start := time.Date(2020, 1, 2, 15, 4, 5, 0, time.UTC)
 	tests := []struct {
 		name string
 		args *AggregatedTradeRequestParams

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/types"
 )
@@ -306,17 +307,34 @@ type IndexMarkPrice struct {
 
 // CandleStick holds kline data
 type CandleStick struct {
-	OpenTime                 time.Time
-	Open                     float64
-	High                     float64
-	Low                      float64
-	Close                    float64
-	Volume                   float64
-	CloseTime                time.Time
-	QuoteAssetVolume         float64
-	TradeCount               float64
-	TakerBuyAssetVolume      float64
-	TakerBuyQuoteAssetVolume float64
+	OpenTime                 types.Time
+	Open                     types.Number
+	High                     types.Number
+	Low                      types.Number
+	Close                    types.Number
+	Volume                   types.Number
+	CloseTime                types.Time
+	QuoteAssetVolume         types.Number
+	TradeCount               int64
+	TakerBuyAssetVolume      types.Number
+	TakerBuyQuoteAssetVolume types.Number
+}
+
+// UnmarshalJSON unmarshals JSON data into a CandleStick struct
+func (c *CandleStick) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[]any{
+		&c.OpenTime,
+		&c.Open,
+		&c.High,
+		&c.Low,
+		&c.Close,
+		&c.Volume,
+		&c.CloseTime,
+		&c.QuoteAssetVolume,
+		&c.TradeCount,
+		&c.TakerBuyAssetVolume,
+		&c.TakerBuyQuoteAssetVolume,
+	})
 }
 
 // AveragePrice holds current average symbol price
@@ -692,16 +710,16 @@ var WithdrawalFees = map[currency.Code]float64{
 
 // DepositHistory stores deposit history info
 type DepositHistory struct {
-	Amount        float64 `json:"amount,string"`
-	Coin          string  `json:"coin"`
-	Network       string  `json:"network"`
-	Status        uint8   `json:"status"`
-	Address       string  `json:"address"`
-	AddressTag    string  `json:"adressTag"`
-	TransactionID string  `json:"txId"`
-	InsertTime    float64 `json:"insertTime"`
-	TransferType  uint8   `json:"transferType"`
-	ConfirmTimes  string  `json:"confirmTimes"`
+	Amount        float64    `json:"amount,string"`
+	Coin          string     `json:"coin"`
+	Network       string     `json:"network"`
+	Status        uint8      `json:"status"`
+	Address       string     `json:"address"`
+	AddressTag    string     `json:"adressTag"`
+	TransactionID string     `json:"txId"`
+	InsertTime    types.Time `json:"insertTime"`
+	TransferType  uint8      `json:"transferType"`
+	ConfirmTimes  string     `json:"confirmTimes"`
 }
 
 // WithdrawResponse contains status of withdrawal request

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -322,7 +322,7 @@ type CandleStick struct {
 
 // UnmarshalJSON unmarshals JSON data into a CandleStick struct
 func (c *CandleStick) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[]any{
+	return json.Unmarshal(data, &[11]any{
 		&c.OpenTime,
 		&c.Open,
 		&c.High,

--- a/exchanges/binance/binance_ufutures.go
+++ b/exchanges/binance/binance_ufutures.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -70,13 +71,13 @@ const (
 // UServerTime gets the server time
 func (b *Binance) UServerTime(ctx context.Context) (time.Time, error) {
 	var data struct {
-		ServerTime int64 `json:"serverTime"`
+		ServerTime types.Time `json:"serverTime"`
 	}
 	err := b.SendHTTPRequest(ctx, exchange.RestUSDTMargined, ufuturesServerTime, uFuturesDefaultRate, &data)
 	if err != nil {
 		return time.Time{}, err
 	}
-	return time.UnixMilli(data.ServerTime), nil
+	return data.ServerTime.Time(), nil
 }
 
 // UExchangeInfo stores usdt margined futures data

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -1653,12 +1653,12 @@ func (b *Binance) GetHistoricCandles(ctx context.Context, pair currency.Pair, a 
 		}
 		for i := range candles {
 			timeSeries = append(timeSeries, kline.Candle{
-				Time:   candles[i].OpenTime,
-				Open:   candles[i].Open,
-				High:   candles[i].High,
-				Low:    candles[i].Low,
-				Close:  candles[i].Close,
-				Volume: candles[i].Volume,
+				Time:   candles[i].OpenTime.Time(),
+				Open:   candles[i].Open.Float64(),
+				High:   candles[i].High.Float64(),
+				Low:    candles[i].Low.Float64(),
+				Close:  candles[i].Close.Float64(),
+				Volume: candles[i].Volume.Float64(),
 			})
 		}
 	case asset.USDTMarginedFutures:
@@ -1734,12 +1734,12 @@ func (b *Binance) GetHistoricCandlesExtended(ctx context.Context, pair currency.
 			}
 			for i := range candles {
 				timeSeries = append(timeSeries, kline.Candle{
-					Time:   candles[i].OpenTime,
-					Open:   candles[i].Open,
-					High:   candles[i].High,
-					Low:    candles[i].Low,
-					Close:  candles[i].Close,
-					Volume: candles[i].Volume,
+					Time:   candles[i].OpenTime.Time(),
+					Open:   candles[i].Open.Float64(),
+					High:   candles[i].High.Float64(),
+					Low:    candles[i].Low.Float64(),
+					Close:  candles[i].Close.Float64(),
+					Volume: candles[i].Volume.Float64(),
 				})
 			}
 		case asset.USDTMarginedFutures:
@@ -1933,7 +1933,7 @@ func (b *Binance) GetServerTime(ctx context.Context, ai asset.Item) (time.Time, 
 		if err != nil {
 			return time.Time{}, err
 		}
-		return time.UnixMilli(info.ServerTime), nil
+		return info.ServerTime.Time(), nil
 	}
 	return time.Time{}, fmt.Errorf("%s %w", ai, asset.ErrNotSupported)
 }
@@ -2128,14 +2128,14 @@ func (b *Binance) GetHistoricalFundingRates(ctx context.Context, r *fundingrate.
 			}
 			for j := range frh {
 				pairRate.FundingRates = append(pairRate.FundingRates, fundingrate.Rate{
-					Time: time.UnixMilli(frh[j].FundingTime),
+					Time: frh[j].FundingTime.Time(),
 					Rate: decimal.NewFromFloat(frh[j].FundingRate),
 				})
 			}
 			if len(frh) < requestLimit {
 				break
 			}
-			sd = time.UnixMilli(frh[len(frh)-1].FundingTime)
+			sd = frh[len(frh)-1].FundingTime.Time()
 		}
 		var mp []UMarkPrice
 		mp, err = b.UGetMarkPrice(ctx, fPair)
@@ -2155,8 +2155,7 @@ func (b *Binance) GetHistoricalFundingRates(ctx context.Context, r *fundingrate.
 			}
 			for j := range income {
 				for x := range pairRate.FundingRates {
-					tt := time.UnixMilli(income[j].Time)
-					tt = tt.Truncate(time.Duration(fundingRateFrequency) * time.Hour)
+					tt := income[j].Time.Time().Truncate(time.Duration(fundingRateFrequency) * time.Hour)
 					if !tt.Equal(pairRate.FundingRates[x].Time) {
 						continue
 					}
@@ -2194,14 +2193,14 @@ func (b *Binance) GetHistoricalFundingRates(ctx context.Context, r *fundingrate.
 			}
 			for j := range frh {
 				pairRate.FundingRates = append(pairRate.FundingRates, fundingrate.Rate{
-					Time: time.UnixMilli(frh[j].FundingTime),
+					Time: frh[j].FundingTime.Time(),
 					Rate: decimal.NewFromFloat(frh[j].FundingRate),
 				})
 			}
 			if len(frh) < requestLimit {
 				break
 			}
-			sd = time.UnixMilli(frh[len(frh)-1].FundingTime)
+			sd = frh[len(frh)-1].FundingTime.Time()
 		}
 		var mp []IndexMarkPrice
 		mp, err = b.GetIndexAndMarkPrice(ctx, fPair.String(), "")
@@ -2221,8 +2220,7 @@ func (b *Binance) GetHistoricalFundingRates(ctx context.Context, r *fundingrate.
 			}
 			for j := range income {
 				for x := range pairRate.FundingRates {
-					tt := time.UnixMilli(income[j].Timestamp)
-					tt = tt.Truncate(8 * time.Hour)
+					tt := income[j].Timestamp.Time().Truncate(8 * time.Hour)
 					if !tt.Equal(pairRate.FundingRates[x].Time) {
 						continue
 					}

--- a/exchanges/binance/cfutures_types.go
+++ b/exchanges/binance/cfutures_types.go
@@ -39,25 +39,25 @@ type MarkPriceData struct {
 	Symbol          string     `json:"symbol"`
 	MarkPrice       float64    `json:"markPrice"`
 	LastFundingRate float64    `json:"lastFundingRate"`
-	NextFundingTime int64      `json:"nextFundingTime"`
+	NextFundingTime types.Time `json:"nextFundingTime"`
 	Time            types.Time `json:"time"`
 }
 
 // SymbolPriceTicker stores ticker price stats
 type SymbolPriceTicker struct {
-	Symbol string  `json:"symbol"`
-	Price  float64 `json:"price,string"`
-	Time   int64   `json:"time"`
+	Symbol string     `json:"symbol"`
+	Price  float64    `json:"price,string"`
+	Time   types.Time `json:"time"`
 }
 
 // SymbolOrderBookTicker stores orderbook ticker data
 type SymbolOrderBookTicker struct {
-	Symbol   string  `json:"symbol"`
-	BidPrice float64 `json:"bidPrice,string"`
-	AskPrice float64 `json:"askPrice,string"`
-	BidQty   float64 `json:"bidQty,string"`
-	AskQty   float64 `json:"askQty,string"`
-	Time     int64   `json:"time"`
+	Symbol   string     `json:"symbol"`
+	BidPrice float64    `json:"bidPrice,string"`
+	AskPrice float64    `json:"askPrice,string"`
+	BidQty   float64    `json:"bidQty,string"`
+	AskQty   float64    `json:"askQty,string"`
+	Time     types.Time `json:"time"`
 }
 
 // FuturesCandleStick holds kline data
@@ -82,83 +82,83 @@ func (f *FuturesCandleStick) UnmarshalJSON(data []byte) error {
 
 // AllLiquidationOrders gets all liquidation orders
 type AllLiquidationOrders struct {
-	Symbol       string  `json:"symbol"`
-	Price        float64 `json:"price,string"`
-	OrigQty      float64 `json:"origQty,string"`
-	ExecutedQty  float64 `json:"executedQty,string"`
-	AveragePrice float64 `json:"averagePrice,string"`
-	Status       string  `json:"status"`
-	TimeInForce  string  `json:"timeInForce"`
-	OrderType    string  `json:"type"`
-	Side         string  `json:"side"`
-	Time         int64   `json:"time"`
+	Symbol       string     `json:"symbol"`
+	Price        float64    `json:"price,string"`
+	OrigQty      float64    `json:"origQty,string"`
+	ExecutedQty  float64    `json:"executedQty,string"`
+	AveragePrice float64    `json:"averagePrice,string"`
+	Status       string     `json:"status"`
+	TimeInForce  string     `json:"timeInForce"`
+	OrderType    string     `json:"type"`
+	Side         string     `json:"side"`
+	Time         types.Time `json:"time"`
 }
 
 // OpenInterestData stores open interest data
 type OpenInterestData struct {
-	Symbol       string  `json:"symbol"`
-	Pair         string  `json:"pair"`
-	OpenInterest float64 `json:"openInterest,string"`
-	ContractType string  `json:"contractType"`
-	Time         int64   `json:"time"`
+	Symbol       string     `json:"symbol"`
+	Pair         string     `json:"pair"`
+	OpenInterest float64    `json:"openInterest,string"`
+	ContractType string     `json:"contractType"`
+	Time         types.Time `json:"time"`
 }
 
 // OpenInterestStats stores stats for open interest data
 type OpenInterestStats struct {
-	Pair                 string  `json:"pair"`
-	ContractType         string  `json:"contractType"`
-	SumOpenInterest      float64 `json:"sumOpenInterest,string"`
-	SumOpenInterestValue float64 `json:"sumOpenInterestValue,string"`
-	Timestamp            int64   `json:"timestamp"`
+	Pair                 string     `json:"pair"`
+	ContractType         string     `json:"contractType"`
+	SumOpenInterest      float64    `json:"sumOpenInterest,string"`
+	SumOpenInterestValue float64    `json:"sumOpenInterestValue,string"`
+	Timestamp            types.Time `json:"timestamp"`
 }
 
 // TopTraderAccountRatio stores account ratio data for top traders
 type TopTraderAccountRatio struct {
-	Pair           string  `json:"pair"`
-	LongShortRatio float64 `json:"longShortRatio,string"`
-	LongAccount    float64 `json:"longAccount,string"`
-	ShortAccount   float64 `json:"shortAccount,string"`
-	Timestamp      int64   `json:"timestamp"`
+	Pair           string     `json:"pair"`
+	LongShortRatio float64    `json:"longShortRatio,string"`
+	LongAccount    float64    `json:"longAccount,string"`
+	ShortAccount   float64    `json:"shortAccount,string"`
+	Timestamp      types.Time `json:"timestamp"`
 }
 
 // TopTraderPositionRatio stores position ratio for top trader accounts
 type TopTraderPositionRatio struct {
-	Pair           string  `json:"pair"`
-	LongShortRatio float64 `json:"longShortRatio,string"`
-	LongPosition   float64 `json:"longPosition,string"`
-	ShortPosition  float64 `json:"shortPosition,string"`
-	Timestamp      int64   `json:"timestamp"`
+	Pair           string     `json:"pair"`
+	LongShortRatio float64    `json:"longShortRatio,string"`
+	LongPosition   float64    `json:"longPosition,string"`
+	ShortPosition  float64    `json:"shortPosition,string"`
+	Timestamp      types.Time `json:"timestamp"`
 }
 
 // GlobalLongShortRatio stores ratio data of all longs vs shorts
 type GlobalLongShortRatio struct {
-	Symbol         string  `json:"symbol"`
-	LongShortRatio float64 `json:"longShortRatio"`
-	LongAccount    float64 `json:"longAccount"`
-	ShortAccount   float64 `json:"shortAccount"`
-	Timestamp      string  `json:"timestamp"`
+	Symbol         string     `json:"symbol"`
+	LongShortRatio float64    `json:"longShortRatio"`
+	LongAccount    float64    `json:"longAccount"`
+	ShortAccount   float64    `json:"shortAccount"`
+	Timestamp      types.Time `json:"timestamp"`
 }
 
 // TakerBuySellVolume stores taker buy sell volume
 type TakerBuySellVolume struct {
-	Pair           string  `json:"pair"`
-	ContractType   string  `json:"contractType"`
-	TakerBuyVolume float64 `json:"takerBuyVol,string"`
-	BuySellRatio   float64 `json:"takerSellVol,string"`
-	BuyVol         float64 `json:"takerBuyVolValue,string"`
-	SellVol        float64 `json:"takerSellVolValue,string"`
-	Timestamp      int64   `json:"timestamp"`
+	Pair           string     `json:"pair"`
+	ContractType   string     `json:"contractType"`
+	TakerBuyVolume float64    `json:"takerBuyVol,string"`
+	BuySellRatio   float64    `json:"takerSellVol,string"`
+	BuyVol         float64    `json:"takerBuyVolValue,string"`
+	SellVol        float64    `json:"takerSellVolValue,string"`
+	Timestamp      types.Time `json:"timestamp"`
 }
 
 // FuturesBasisData gets futures basis data
 type FuturesBasisData struct {
-	Pair         string  `json:"pair"`
-	ContractType string  `json:"contractType"`
-	FuturesPrice float64 `json:"futuresPrice,string"`
-	IndexPrice   float64 `json:"indexPrice,string"`
-	Basis        float64 `json:"basis,string"`
-	BasisRate    float64 `json:"basisRate,string"`
-	Timestamp    int64   `json:"timestamp"`
+	Pair         string     `json:"pair"`
+	ContractType string     `json:"contractType"`
+	FuturesPrice float64    `json:"futuresPrice,string"`
+	IndexPrice   float64    `json:"indexPrice,string"`
+	Basis        float64    `json:"basis,string"`
+	BasisRate    float64    `json:"basisRate,string"`
+	Timestamp    types.Time `json:"timestamp"`
 }
 
 // PlaceBatchOrderData stores batch order data for placing
@@ -182,32 +182,32 @@ type PlaceBatchOrderData struct {
 
 // BatchCancelOrderData stores batch cancel order data
 type BatchCancelOrderData struct {
-	ClientOrderID string  `json:"clientOrderID"`
-	CumQty        float64 `json:"cumQty,string"`
-	CumBase       float64 `json:"cumBase,string"`
-	ExecuteQty    float64 `json:"executeQty,string"`
-	OrderID       int64   `json:"orderID,string"`
-	AvgPrice      float64 `json:"avgPrice,string"`
-	OrigQty       float64 `json:"origQty,string"`
-	Price         float64 `json:"price,string"`
-	ReduceOnly    bool    `json:"reduceOnly"`
-	Side          string  `json:"side"`
-	PositionSide  string  `json:"positionSide"`
-	Status        string  `json:"status"`
-	StopPrice     int64   `json:"stopPrice"`
-	ClosePosition bool    `json:"closePosition"`
-	Symbol        string  `json:"symbol"`
-	Pair          string  `json:"pair"`
-	TimeInForce   string  `json:"TimeInForce"`
-	OrderType     string  `json:"type"`
-	OrigType      string  `json:"origType"`
-	ActivatePrice float64 `json:"activatePrice,string"`
-	PriceRate     float64 `json:"priceRate,string"`
-	UpdateTime    int64   `json:"updateTime"`
-	WorkingType   string  `json:"workingType"`
-	PriceProtect  bool    `json:"priceProtect"`
-	Code          int64   `json:"code"`
-	Msg           string  `json:"msg"`
+	ClientOrderID string     `json:"clientOrderID"`
+	CumQty        float64    `json:"cumQty,string"`
+	CumBase       float64    `json:"cumBase,string"`
+	ExecuteQty    float64    `json:"executeQty,string"`
+	OrderID       int64      `json:"orderID,string"`
+	AvgPrice      float64    `json:"avgPrice,string"`
+	OrigQty       float64    `json:"origQty,string"`
+	Price         float64    `json:"price,string"`
+	ReduceOnly    bool       `json:"reduceOnly"`
+	Side          string     `json:"side"`
+	PositionSide  string     `json:"positionSide"`
+	Status        string     `json:"status"`
+	StopPrice     int64      `json:"stopPrice"`
+	ClosePosition bool       `json:"closePosition"`
+	Symbol        string     `json:"symbol"`
+	Pair          string     `json:"pair"`
+	TimeInForce   string     `json:"TimeInForce"`
+	OrderType     string     `json:"type"`
+	OrigType      string     `json:"origType"`
+	ActivatePrice float64    `json:"activatePrice,string"`
+	PriceRate     float64    `json:"priceRate,string"`
+	UpdateTime    types.Time `json:"updateTime"`
+	WorkingType   string     `json:"workingType"`
+	PriceProtect  bool       `json:"priceProtect"`
+	Code          int64      `json:"code"`
+	Msg           string     `json:"msg"`
 }
 
 // FuturesNewOrderRequest stores all the data needed to submit a
@@ -233,30 +233,30 @@ type FuturesNewOrderRequest struct {
 
 // FuturesOrderPlaceData stores futures order data
 type FuturesOrderPlaceData struct {
-	ClientOrderID string  `json:"clientOrderId"`
-	CumQty        float64 `json:"cumQty,string"`
-	CumBase       float64 `json:"cumBase,string"`
-	ExecuteQty    float64 `json:"executedQty,string"`
-	OrderID       int64   `json:"orderId"`
-	AvgPrice      float64 `json:"avgPrice,string"`
-	OrigQty       float64 `json:"origQty,string"`
-	Price         float64 `json:"price,string"`
-	ReduceOnly    bool    `json:"reduceOnly"`
-	Side          string  `json:"side"`
-	PositionSide  string  `json:"positionSide"`
-	Status        string  `json:"status"`
-	StopPrice     float64 `json:"stopPrice,string"`
-	ClosePosition bool    `json:"closePosition"`
-	Symbol        string  `json:"symbol"`
-	Pair          string  `json:"pair"`
-	TimeInForce   string  `json:"TimeInForce"`
-	OrderType     string  `json:"type"`
-	OrigType      string  `json:"origType"`
-	ActivatePrice float64 `json:"activatePrice,string"`
-	PriceRate     float64 `json:"priceRate,string"`
-	UpdateTime    int64   `json:"updateTime"`
-	WorkingType   string  `json:"workingType"`
-	PriceProtect  bool    `json:"priceProtect"`
+	ClientOrderID string     `json:"clientOrderId"`
+	CumQty        float64    `json:"cumQty,string"`
+	CumBase       float64    `json:"cumBase,string"`
+	ExecuteQty    float64    `json:"executedQty,string"`
+	OrderID       int64      `json:"orderId"`
+	AvgPrice      float64    `json:"avgPrice,string"`
+	OrigQty       float64    `json:"origQty,string"`
+	Price         float64    `json:"price,string"`
+	ReduceOnly    bool       `json:"reduceOnly"`
+	Side          string     `json:"side"`
+	PositionSide  string     `json:"positionSide"`
+	Status        string     `json:"status"`
+	StopPrice     float64    `json:"stopPrice,string"`
+	ClosePosition bool       `json:"closePosition"`
+	Symbol        string     `json:"symbol"`
+	Pair          string     `json:"pair"`
+	TimeInForce   string     `json:"TimeInForce"`
+	OrderType     string     `json:"type"`
+	OrigType      string     `json:"origType"`
+	ActivatePrice float64    `json:"activatePrice,string"`
+	PriceRate     float64    `json:"priceRate,string"`
+	UpdateTime    types.Time `json:"updateTime"`
+	WorkingType   string     `json:"workingType"`
+	PriceProtect  bool       `json:"priceProtect"`
 }
 
 // FuturesOrderGetData stores futures order data for get requests
@@ -354,14 +354,14 @@ type MarginInfoData struct {
 
 // FuturesAccountBalanceData stores account balance data for futures
 type FuturesAccountBalanceData struct {
-	AccountAlias       string  `json:"accountAlias"`
-	Asset              string  `json:"asset"`
-	Balance            float64 `json:"balance,string"`
-	WithdrawAvailable  float64 `json:"withdrawAvailable,string"`
-	CrossWalletBalance float64 `json:"crossWalletBalance,string"`
-	CrossUnPNL         float64 `json:"crossUnPNL,string"`
-	AvailableBalance   float64 `json:"availableBalance,string"`
-	UpdateTime         int64   `json:"updateTime"`
+	AccountAlias       string     `json:"accountAlias"`
+	Asset              string     `json:"asset"`
+	Balance            float64    `json:"balance,string"`
+	WithdrawAvailable  float64    `json:"withdrawAvailable,string"`
+	CrossWalletBalance float64    `json:"crossWalletBalance,string"`
+	CrossUnPNL         float64    `json:"crossUnPNL,string"`
+	AvailableBalance   float64    `json:"availableBalance,string"`
+	UpdateTime         types.Time `json:"updateTime"`
 }
 
 // FuturesAccountInformationPosition  holds account position data
@@ -440,12 +440,12 @@ type ModifyIsolatedMarginData struct {
 
 // GetPositionMarginChangeHistoryData gets margin change history for positions
 type GetPositionMarginChangeHistoryData struct {
-	Amount           float64 `json:"amount"`
-	Asset            string  `json:"asset"`
-	Symbol           string  `json:"symbol"`
-	Timestamp        int64   `json:"time"`
-	MarginChangeType int64   `json:"type"`
-	PositionSide     string  `json:"positionSide"`
+	Amount           float64    `json:"amount"`
+	Asset            string     `json:"asset"`
+	Symbol           string     `json:"symbol"`
+	Timestamp        types.Time `json:"time"`
+	MarginChangeType int64      `json:"type"`
+	PositionSide     string     `json:"positionSide"`
 }
 
 // FuturesPositionInformation stores futures position info
@@ -469,32 +469,32 @@ type FuturesPositionInformation struct {
 
 // FuturesAccountTradeList stores account trade list data
 type FuturesAccountTradeList struct {
-	Symbol          string  `json:"symbol"`
-	ID              int64   `json:"id"`
-	OrderID         int64   `json:"orderID"`
-	Pair            string  `json:"pair"`
-	Side            string  `json:"side"`
-	Price           string  `json:"price"`
-	Qty             float64 `json:"qty"`
-	RealizedPNL     float64 `json:"realizedPNL"`
-	MarginAsset     string  `json:"marginAsset"`
-	BaseQty         float64 `json:"baseQty"`
-	Commission      float64 `json:"commission"`
-	CommissionAsset string  `json:"commissionAsset"`
-	Timestamp       int64   `json:"timestamp"`
-	PositionSide    string  `json:"positionSide"`
-	Buyer           bool    `json:"buyer"`
-	Maker           bool    `json:"maker"`
+	Symbol          string     `json:"symbol"`
+	ID              int64      `json:"id"`
+	OrderID         int64      `json:"orderID"`
+	Pair            string     `json:"pair"`
+	Side            string     `json:"side"`
+	Price           string     `json:"price"`
+	Qty             float64    `json:"qty"`
+	RealizedPNL     float64    `json:"realizedPNL"`
+	MarginAsset     string     `json:"marginAsset"`
+	BaseQty         float64    `json:"baseQty"`
+	Commission      float64    `json:"commission"`
+	CommissionAsset string     `json:"commissionAsset"`
+	Timestamp       types.Time `json:"timestamp"`
+	PositionSide    string     `json:"positionSide"`
+	Buyer           bool       `json:"buyer"`
+	Maker           bool       `json:"maker"`
 }
 
 // FuturesIncomeHistoryData stores futures income history data
 type FuturesIncomeHistoryData struct {
-	Symbol     string  `json:"symbol"`
-	IncomeType string  `json:"incomeType"`
-	Income     float64 `json:"income,string"`
-	Asset      string  `json:"asset"`
-	Info       string  `json:"info"`
-	Timestamp  int64   `json:"time"`
+	Symbol     string     `json:"symbol"`
+	IncomeType string     `json:"incomeType"`
+	Income     float64    `json:"income,string"`
+	Asset      string     `json:"asset"`
+	Info       string     `json:"info"`
+	Timestamp  types.Time `json:"time"`
 }
 
 // NotionalBracketData stores notional bracket data
@@ -511,27 +511,27 @@ type NotionalBracketData struct {
 
 // ForcedOrdersData stores forced orders data
 type ForcedOrdersData struct {
-	OrderID       int64   `json:"orderId"`
-	Symbol        string  `json:"symbol"`
-	Status        string  `json:"status"`
-	ClientOrderID string  `json:"clientOrderId"`
-	Price         float64 `json:"price,string"`
-	AvgPrice      float64 `json:"avgPrice,string"`
-	OrigQty       float64 `json:"origQty,string"`
-	ExecutedQty   float64 `json:"executedQty,string"`
-	CumQuote      float64 `json:"cumQuote,string"`
-	TimeInForce   string  `json:"timeInForce"`
-	OrderType     string  `json:"orderType"`
-	ReduceOnly    bool    `json:"reduceOnly"`
-	ClosePosition bool    `json:"closePosition"`
-	Side          string  `json:"side"`
-	PositionSide  string  `json:"positionSide"`
-	StopPrice     float64 `json:"stopPrice,string"`
-	WorkingType   string  `json:"workingType"`
-	PriceProtect  float64 `json:"priceProtect,string"`
-	OrigType      string  `json:"origType"`
-	Time          int64   `json:"time"`
-	UpdateTime    int64   `json:"updateTime"`
+	OrderID       int64      `json:"orderId"`
+	Symbol        string     `json:"symbol"`
+	Status        string     `json:"status"`
+	ClientOrderID string     `json:"clientOrderId"`
+	Price         float64    `json:"price,string"`
+	AvgPrice      float64    `json:"avgPrice,string"`
+	OrigQty       float64    `json:"origQty,string"`
+	ExecutedQty   float64    `json:"executedQty,string"`
+	CumQuote      float64    `json:"cumQuote,string"`
+	TimeInForce   string     `json:"timeInForce"`
+	OrderType     string     `json:"orderType"`
+	ReduceOnly    bool       `json:"reduceOnly"`
+	ClosePosition bool       `json:"closePosition"`
+	Side          string     `json:"side"`
+	PositionSide  string     `json:"positionSide"`
+	StopPrice     float64    `json:"stopPrice,string"`
+	WorkingType   string     `json:"workingType"`
+	PriceProtect  float64    `json:"priceProtect,string"`
+	OrigType      string     `json:"origType"`
+	Time          types.Time `json:"time"`
+	UpdateTime    types.Time `json:"updateTime"`
 }
 
 // ADLEstimateData stores data for ADL estimates
@@ -546,18 +546,18 @@ type ADLEstimateData struct {
 
 // InterestHistoryData gets interest history data
 type InterestHistoryData struct {
-	Asset       string  `json:"asset"`
-	Interest    float64 `json:"interest"`
-	LendingType string  `json:"lendingType"`
-	ProductName string  `json:"productName"`
-	Time        string  `json:"time"`
+	Asset       string     `json:"asset"`
+	Interest    float64    `json:"interest"`
+	LendingType string     `json:"lendingType"`
+	ProductName string     `json:"productName"`
+	Time        types.Time `json:"time"`
 }
 
 // FundingRateData stores funding rates data
 type FundingRateData struct {
-	Symbol      string  `json:"symbol"`
-	FundingRate float64 `json:"fundingRate,string"`
-	FundingTime int64   `json:"fundingTime"`
+	Symbol      string     `json:"symbol"`
+	FundingRate float64    `json:"fundingRate,string"`
+	FundingTime types.Time `json:"fundingTime"`
 }
 
 // SymbolsData stores perp futures' symbols
@@ -578,7 +578,7 @@ type UFuturesExchangeInfo struct {
 		Limit         int64  `json:"limit"`
 		RateLimitType string `json:"rateLimitType"`
 	} `json:"rateLimits"`
-	ServerTime int64                `json:"serverTime"`
+	ServerTime types.Time           `json:"serverTime"`
 	Symbols    []UFuturesSymbolInfo `json:"symbols"`
 	Timezone   string               `json:"timezone"`
 }
@@ -634,7 +634,7 @@ type CExchangeInfo struct {
 		Limit         int64  `json:"limit"`
 		RateLimitType string `json:"rateLimitType"`
 	} `json:"rateLimits"`
-	ServerTime int64 `json:"serverTime"`
+	ServerTime types.Time `json:"serverTime"`
 	Symbols    []struct {
 		Filters []struct {
 			FilterType        string  `json:"filterType"`

--- a/exchanges/binance/cfutures_types_test.go
+++ b/exchanges/binance/cfutures_types_test.go
@@ -2,8 +2,12 @@ package binance
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 func TestFuturesNewOrderRequest_Unmarshal(t *testing.T) {
@@ -37,34 +41,32 @@ func TestFuturesNewOrderRequest_Unmarshal(t *testing.T) {
 `
 
 	var x FuturesOrderPlaceData
-
-	if err := json.Unmarshal([]byte(inp), &x); err != nil {
-		t.Error(err)
+	require.NoError(t, json.Unmarshal([]byte(inp), &x))
+	exp := FuturesOrderPlaceData{
+		OrderID:       18662274680,
+		Symbol:        "ETHUSD_PERP",
+		Pair:          "ETHUSD",
+		Status:        "NEW",
+		ClientOrderID: "customID",
+		Price:         4096.0,
+		AvgPrice:      2.0,
+		OrigQty:       8.0,
+		ExecuteQty:    4.0,
+		CumQty:        32.0,
+		CumBase:       16.0,
+		TimeInForce:   "GTC",
+		OrderType:     cfuturesLimit,
+		ReduceOnly:    true,
+		ClosePosition: true,
+		StopPrice:     2048.0,
+		Side:          "BUY",
+		PositionSide:  "BOTH",
+		WorkingType:   "CONTRACT_PRICE",
+		PriceProtect:  true,
+		OrigType:      cfuturesMarket,
+		UpdateTime:    types.Time(time.UnixMilli(1635931801320)),
+		ActivatePrice: 64.0,
+		PriceRate:     32.0,
 	}
-
-	if x.OrderID != 18662274680 ||
-		x.Symbol != "ETHUSD_PERP" ||
-		x.Pair != "ETHUSD" ||
-		x.Status != "NEW" ||
-		x.ClientOrderID != "customID" ||
-		x.Price != 4096 ||
-		x.AvgPrice != 2 ||
-		x.OrigQty != 8 ||
-		x.ExecuteQty != 4 ||
-		x.CumQty != 32 ||
-		x.CumBase != 16 ||
-		x.TimeInForce != "GTC" ||
-		x.OrderType != cfuturesLimit ||
-		!x.ReduceOnly ||
-		!x.ClosePosition ||
-		x.StopPrice != 2048 ||
-		x.WorkingType != "CONTRACT_PRICE" ||
-		!x.PriceProtect ||
-		x.OrigType != cfuturesMarket ||
-		x.UpdateTime != 1635931801320 ||
-		x.ActivatePrice != 64 ||
-		x.PriceRate != 32 {
-		// If any of these values isn't set as expected, mark test as failed.
-		t.Errorf("unmarshaling failed: %v", x)
-	}
+	assert.Equal(t, exp, x)
 }

--- a/exchanges/binance/ufutures_types.go
+++ b/exchanges/binance/ufutures_types.go
@@ -43,7 +43,7 @@ var (
 // OrderbookData stores ob data for umargined and cmargined futures
 type OrderbookData struct {
 	LastUpdateID int64             `json:"lastUpdateID"`
-	Timestamp    int64             `json:"T"`
+	Timestamp    types.Time        `json:"T"`
 	Bids         [][2]types.Number `json:"bids"`
 	Asks         [][2]types.Number `json:"asks"`
 }
@@ -60,13 +60,13 @@ type UPublicTradesData struct {
 
 // UCompressedTradeData stores compressed trade data
 type UCompressedTradeData struct {
-	AggregateTradeID int64   `json:"a"`
-	Price            float64 `json:"p,string"`
-	Quantity         float64 `json:"q,string"`
-	FirstTradeID     int64   `json:"f"`
-	LastTradeID      int64   `json:"l"`
-	Timestamp        int64   `json:"t"`
-	IsBuyerMaker     bool    `json:"m"`
+	AggregateTradeID int64      `json:"a"`
+	Price            float64    `json:"p,string"`
+	Quantity         float64    `json:"q,string"`
+	FirstTradeID     int64      `json:"f"`
+	LastTradeID      int64      `json:"l"`
+	Timestamp        types.Time `json:"t"`
+	IsBuyerMaker     bool       `json:"m"`
 }
 
 // UMarkPrice stores mark price data
@@ -91,99 +91,99 @@ type FundingRateInfoResponse struct {
 
 // FundingRateHistory stores funding rate history
 type FundingRateHistory struct {
-	Symbol      string  `json:"symbol"`
-	FundingRate float64 `json:"fundingRate,string"`
-	FundingTime int64   `json:"fundingTime"`
+	Symbol      string     `json:"symbol"`
+	FundingRate float64    `json:"fundingRate,string"`
+	FundingTime types.Time `json:"fundingTime"`
 }
 
 // U24HrPriceChangeStats stores price change stats data
 type U24HrPriceChangeStats struct {
-	Symbol             string  `json:"symbol"`
-	PriceChange        float64 `json:"priceChange,string"`
-	PriceChangePercent float64 `json:"priceChangePercent,string"`
-	WeightedAvgPrice   float64 `json:"weightedAvgPrice,string"`
-	PrevClosePrice     float64 `json:"prevClosePrice,string"`
-	LastPrice          float64 `json:"lastPrice,string"`
-	LastQty            float64 `json:"lastQty,string"`
-	OpenPrice          float64 `json:"openPrice,string"`
-	HighPrice          float64 `json:"highPrice,string"`
-	LowPrice           float64 `json:"lowPrice,string"`
-	Volume             float64 `json:"volume,string"`
-	QuoteVolume        float64 `json:"quoteVolume,string"`
-	OpenTime           int64   `json:"openTime"`
-	CloseTime          int64   `json:"closeTime"`
-	FirstID            int64   `json:"firstId"`
-	LastID             int64   `json:"lastId"`
-	Count              int64   `json:"count"`
+	Symbol             string     `json:"symbol"`
+	PriceChange        float64    `json:"priceChange,string"`
+	PriceChangePercent float64    `json:"priceChangePercent,string"`
+	WeightedAvgPrice   float64    `json:"weightedAvgPrice,string"`
+	PrevClosePrice     float64    `json:"prevClosePrice,string"`
+	LastPrice          float64    `json:"lastPrice,string"`
+	LastQty            float64    `json:"lastQty,string"`
+	OpenPrice          float64    `json:"openPrice,string"`
+	HighPrice          float64    `json:"highPrice,string"`
+	LowPrice           float64    `json:"lowPrice,string"`
+	Volume             float64    `json:"volume,string"`
+	QuoteVolume        float64    `json:"quoteVolume,string"`
+	OpenTime           types.Time `json:"openTime"`
+	CloseTime          types.Time `json:"closeTime"`
+	FirstID            int64      `json:"firstId"`
+	LastID             int64      `json:"lastId"`
+	Count              int64      `json:"count"`
 }
 
 // USymbolPriceTicker stores symbol price ticker data
 type USymbolPriceTicker struct {
-	Symbol string  `json:"symbol"`
-	Price  float64 `json:"price,string"`
-	Time   int64   `json:"time"`
+	Symbol string     `json:"symbol"`
+	Price  float64    `json:"price,string"`
+	Time   types.Time `json:"time"`
 }
 
 // USymbolOrderbookTicker stores symbol orderbook ticker data
 type USymbolOrderbookTicker struct {
-	Symbol   string  `json:"symbol"`
-	BidPrice float64 `json:"bidPrice,string"`
-	BidQty   float64 `json:"bidQty,string"`
-	AskPrice float64 `json:"askPrice,string"`
-	AskQty   float64 `json:"askQty,string"`
-	Time     int64   `json:"time"`
+	Symbol   string     `json:"symbol"`
+	BidPrice float64    `json:"bidPrice,string"`
+	BidQty   float64    `json:"bidQty,string"`
+	AskPrice float64    `json:"askPrice,string"`
+	AskQty   float64    `json:"askQty,string"`
+	Time     types.Time `json:"time"`
 }
 
 // ULiquidationOrdersData stores liquidation orders data
 type ULiquidationOrdersData struct {
-	Symbol       string  `json:"symbol"`
-	Price        float64 `json:"price,string"`
-	OrigQty      float64 `json:"origQty,string"`
-	ExecutedQty  float64 `json:"executedQty,string"`
-	AveragePrice float64 `json:"averagePrice,string"`
-	Status       string  `json:"status"`
-	TimeInForce  string  `json:"timeInForce"`
-	OrderType    string  `json:"type"`
-	Side         string  `json:"side"`
-	Time         int64   `json:"time"`
+	Symbol       string     `json:"symbol"`
+	Price        float64    `json:"price,string"`
+	OrigQty      float64    `json:"origQty,string"`
+	ExecutedQty  float64    `json:"executedQty,string"`
+	AveragePrice float64    `json:"averagePrice,string"`
+	Status       string     `json:"status"`
+	TimeInForce  string     `json:"timeInForce"`
+	OrderType    string     `json:"type"`
+	Side         string     `json:"side"`
+	Time         types.Time `json:"time"`
 }
 
 // UOpenInterestData stores open interest data
 type UOpenInterestData struct {
-	OpenInterest float64 `json:"openInterest,string"`
-	Symbol       string  `json:"symbol"`
-	Time         int64   `json:"time"`
+	OpenInterest float64    `json:"openInterest,string"`
+	Symbol       string     `json:"symbol"`
+	Time         types.Time `json:"time"`
 }
 
 // UOpenInterestStats stores open interest stats data
 type UOpenInterestStats struct {
-	Symbol               string  `json:"symbol"`
-	SumOpenInterest      float64 `json:"sumOpenInterest,string"`
-	SumOpenInterestValue float64 `json:"sumOpenInterestValue,string"`
-	Timestamp            int64   `json:"timestamp"`
+	Symbol               string     `json:"symbol"`
+	SumOpenInterest      float64    `json:"sumOpenInterest,string"`
+	SumOpenInterestValue float64    `json:"sumOpenInterestValue,string"`
+	Timestamp            types.Time `json:"timestamp"`
 }
 
 // ULongShortRatio stores top trader accounts' or positions' or global long/short ratio data
 type ULongShortRatio struct {
-	Symbol         string  `json:"symbol"`
-	LongShortRatio float64 `json:"longShortRatio,string"`
-	LongAccount    float64 `json:"longAccount,string"`
-	ShortAccount   float64 `json:"shortAccount,string"`
-	Timestamp      int64   `json:"timestamp"`
+	Symbol         string     `json:"symbol"`
+	LongShortRatio float64    `json:"longShortRatio,string"`
+	LongAccount    float64    `json:"longAccount,string"`
+	ShortAccount   float64    `json:"shortAccount,string"`
+	Timestamp      types.Time `json:"timestamp"`
 }
 
 // UTakerVolumeData stores volume data on buy/sell side from takers
 type UTakerVolumeData struct {
-	BuySellRatio float64 `json:"buySellRatio,string"`
-	BuyVol       float64 `json:"buyVol,string"`
-	SellVol      float64 `json:"sellVol,string"`
-	Timestamp    int64   `json:"timestamp"`
+	BuySellRatio float64    `json:"buySellRatio,string"`
+	BuyVol       float64    `json:"buyVol,string"`
+	SellVol      float64    `json:"sellVol,string"`
+	Timestamp    types.Time `json:"timestamp"`
 }
 
 // UCompositeIndexInfoData stores composite index data for usdt margined futures
 type UCompositeIndexInfoData struct {
-	Symbol        string `json:"symbol"`
-	Time          int64  `json:"time"`
+	Symbol        string     `json:"symbol"`
+	Time          types.Time `json:"time"`
 	BaseAssetList []struct {
 		BaseAsset          string  `json:"baseAsset"`
 		WeightInQuantity   float64 `json:"weightInQuantity,string"`
@@ -263,7 +263,7 @@ type UAccountInformationV2Data struct {
 	CanTrade                    bool        `json:"canTrade"`
 	CanDeposit                  bool        `json:"canDeposit"`
 	CanWithdraw                 bool        `json:"canWithdraw"`
-	UpdateTime                  int64       `json:"updateTime"`
+	UpdateTime                  types.Time  `json:"updateTime"`
 	MultiAssetsMargin           bool        `json:"multiAssetsMargin"`
 	TotalInitialMargin          float64     `json:"totalInitialMargin,string"`
 	TotalMaintenanceMargin      float64     `json:"totalMaintMargin,string"`
@@ -331,12 +331,12 @@ type UModifyIsolatedPosMargin struct {
 
 // UPositionMarginChangeHistoryData gets position margin change history data
 type UPositionMarginChangeHistoryData struct {
-	Amount       float64 `json:"amount,string"`
-	Asset        string  `json:"asset"`
-	Symbol       string  `json:"symbol"`
-	Time         int64   `json:"time"`
-	MarginType   int64   `json:"type"`
-	PositionSide string  `json:"positionSide"`
+	Amount       float64    `json:"amount,string"`
+	Asset        string     `json:"asset"`
+	Symbol       string     `json:"symbol"`
+	Time         types.Time `json:"time"`
+	MarginType   int64      `json:"type"`
+	PositionSide string     `json:"positionSide"`
 }
 
 // UPositionInformationV2 stores positions data
@@ -360,32 +360,32 @@ type UPositionInformationV2 struct {
 
 // UAccountTradeHistory stores trade data for the users account
 type UAccountTradeHistory struct {
-	Buyer           bool    `json:"buyer"`
-	Commission      float64 `json:"commission,string"`
-	CommissionAsset string  `json:"commissionAsset"`
-	ID              int64   `json:"id"`
-	Maker           bool    `json:"maker"`
-	OrderID         int64   `json:"orderId"`
-	Price           float64 `json:"price,string"`
-	Qty             float64 `json:"qty,string"`
-	QuoteQty        float64 `json:"quoteQty"`
-	RealizedPNL     float64 `json:"realizedPnl,string"`
-	Side            string  `json:"side"`
-	PositionSide    string  `json:"positionSide"`
-	Symbol          string  `json:"symbol"`
-	Time            int64   `json:"time"`
+	Buyer           bool       `json:"buyer"`
+	Commission      float64    `json:"commission,string"`
+	CommissionAsset string     `json:"commissionAsset"`
+	ID              int64      `json:"id"`
+	Maker           bool       `json:"maker"`
+	OrderID         int64      `json:"orderId"`
+	Price           float64    `json:"price,string"`
+	Qty             float64    `json:"qty,string"`
+	QuoteQty        float64    `json:"quoteQty"`
+	RealizedPNL     float64    `json:"realizedPnl,string"`
+	Side            string     `json:"side"`
+	PositionSide    string     `json:"positionSide"`
+	Symbol          string     `json:"symbol"`
+	Time            types.Time `json:"time"`
 }
 
 // UAccountIncomeHistory stores income history data
 type UAccountIncomeHistory struct {
-	Symbol     string  `json:"symbol"`
-	IncomeType string  `json:"incomeType"`
-	Income     float64 `json:"income,string"`
-	Asset      string  `json:"asset"`
-	Info       string  `json:"info"`
-	Time       int64   `json:"time"`
-	TranID     int64   `json:"tranId"`
-	TradeID    string  `json:"tradeId"`
+	Symbol     string     `json:"symbol"`
+	IncomeType string     `json:"incomeType"`
+	Income     float64    `json:"income,string"`
+	Asset      string     `json:"asset"`
+	Info       string     `json:"info"`
+	Time       types.Time `json:"time"`
+	TranID     int64      `json:"tranId"`
+	TradeID    string     `json:"tradeId"`
 }
 
 // UNotionalLeverageAndBrakcetsData stores notional and leverage brackets data for the account
@@ -413,27 +413,27 @@ type UPositionADLEstimationData struct {
 
 // UForceOrdersData stores liquidation orders data for the account
 type UForceOrdersData struct {
-	OrderID       int64   `json:"orderId"`
-	Symbol        string  `json:"symbol"`
-	Status        string  `json:"status"`
-	ClientOrderID string  `json:"clientOrderId"`
-	Price         float64 `json:"price,string"`
-	AvgPrice      float64 `json:"avgPrice,string"`
-	OrigQty       float64 `json:"origQty,string"`
-	ExecutedQty   float64 `json:"executedQty,string"`
-	CumQuote      float64 `json:"cumQuote,string"`
-	TimeInForce   string  `json:"timeInForce"`
-	OrderType     string  `json:"type"`
-	ReduceOnly    bool    `json:"reduceOnly"`
-	ClosePosition bool    `json:"closePosition"`
-	Side          string  `json:"side"`
-	PositionSide  string  `json:"positionSide"`
-	StopPrice     float64 `json:"stopPrice,string"`
-	WorkingType   string  `json:"workingType"`
-	PriceProtect  bool    `json:"priceProtect,string"`
-	OrigType      string  `json:"origType"`
-	Time          int64   `json:"time"`
-	UpdateTime    int64   `json:"updateTime"`
+	OrderID       int64      `json:"orderId"`
+	Symbol        string     `json:"symbol"`
+	Status        string     `json:"status"`
+	ClientOrderID string     `json:"clientOrderId"`
+	Price         float64    `json:"price,string"`
+	AvgPrice      float64    `json:"avgPrice,string"`
+	OrigQty       float64    `json:"origQty,string"`
+	ExecutedQty   float64    `json:"executedQty,string"`
+	CumQuote      float64    `json:"cumQuote,string"`
+	TimeInForce   string     `json:"timeInForce"`
+	OrderType     string     `json:"type"`
+	ReduceOnly    bool       `json:"reduceOnly"`
+	ClosePosition bool       `json:"closePosition"`
+	Side          string     `json:"side"`
+	PositionSide  string     `json:"positionSide"`
+	StopPrice     float64    `json:"stopPrice,string"`
+	WorkingType   string     `json:"workingType"`
+	PriceProtect  bool       `json:"priceProtect,string"`
+	OrigType      string     `json:"origType"`
+	Time          types.Time `json:"time"`
+	UpdateTime    types.Time `json:"updateTime"`
 }
 
 // UFuturesNewOrderRequest stores order data for placing

--- a/exchanges/binanceus/binanceus.go
+++ b/exchanges/binanceus/binanceus.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -125,12 +124,10 @@ var (
 	errInvalidAssetAmount                     = errors.New("invalid asset amount")
 	errIncompleteArguments                    = errors.New("missing required argument")
 	errStartTimeOrFromIDNotSet                = errors.New("please set StartTime or FromId, but not both")
-	errUnexpectedKlineDataLength              = errors.New("unexpected kline data length")
 	errMissingRequiredArgumentCoin            = errors.New("missing required argument,coin")
 	errMissingRequiredArgumentNetwork         = errors.New("missing required argument,network")
 	errAmountValueMustBeGreaterThan0          = errors.New("amount must be greater than 0")
 	errMissingPaymentAccountInfo              = errors.New("error: missing payment account")
-	errUnixMilliSecTypeAssertion              = errors.New("error while asserting unix time integer")
 	errMissingRequiredParameterAddress        = errors.New("missing required parameter \"address\"")
 	errMissingCurrencySymbol                  = errors.New("missing currency symbol")
 	errEitherOrderIDOrClientOrderIDIsRequired = errors.New("either order id or client order id is required")
@@ -415,70 +412,8 @@ func (bi *Binanceus) GetSpotKline(ctx context.Context, arg *KlinesRequestParams)
 		params.Set("endTime", strconv.FormatInt((arg.EndTime).UnixMilli(), 10))
 	}
 	path := common.EncodeURLValues(candleStick, params)
-	var resp any
-	err = bi.SendHTTPRequest(ctx,
-		exchange.RestSpotSupplementary,
-		path,
-		spotDefaultRate,
-		&resp)
-	if err != nil {
-		return nil, err
-	}
-	responseData, ok := resp.([]any)
-	if !ok {
-		return nil, common.GetTypeAssertError("[]any", resp, "responseData")
-	}
-
-	klineData := make([]CandleStick, len(responseData))
-	for x := range responseData {
-		individualData, ok := responseData[x].([]any)
-		if !ok {
-			return nil, common.GetTypeAssertError("[]any", responseData[x], "individualData")
-		}
-		if len(individualData) != 12 {
-			return nil, errUnexpectedKlineDataLength
-		}
-		var candle CandleStick
-		val, ok := individualData[0].(float64)
-		if !ok {
-			return nil, errUnixMilliSecTypeAssertion
-		}
-		candle.OpenTime = time.UnixMilli(int64(val))
-		if candle.Open, err = convert.FloatFromString(individualData[1]); err != nil {
-			return nil, err
-		}
-		if candle.High, err = convert.FloatFromString(individualData[2]); err != nil {
-			return nil, err
-		}
-		if candle.Low, err = convert.FloatFromString(individualData[3]); err != nil {
-			return nil, err
-		}
-		if candle.Close, err = convert.FloatFromString(individualData[4]); err != nil {
-			return nil, err
-		}
-		if candle.Volume, err = convert.FloatFromString(individualData[5]); err != nil {
-			return nil, err
-		}
-		val, ok = individualData[6].(float64)
-		if !ok {
-			return nil, errUnixMilliSecTypeAssertion
-		}
-		candle.CloseTime = time.UnixMilli(int64(val))
-		if candle.QuoteAssetVolume, err = convert.FloatFromString(individualData[7]); err != nil {
-			return nil, err
-		}
-		if candle.TradeCount, ok = individualData[8].(float64); !ok {
-			return nil, common.GetTypeAssertError("float64", individualData[8], "trade count")
-		}
-		if candle.TakerBuyAssetVolume, err = convert.FloatFromString(individualData[9]); err != nil {
-			return nil, err
-		}
-		if candle.TakerBuyQuoteAssetVolume, err = convert.FloatFromString(individualData[10]); err != nil {
-			return nil, err
-		}
-		klineData[x] = candle
-	}
-	return klineData, nil
+	var resp []CandleStick
+	return resp, bi.SendHTTPRequest(ctx, exchange.RestSpotSupplementary, path, spotDefaultRate, &resp)
 }
 
 // GetSinglePriceData to get the latest price for a token symbol or symbols.
@@ -1469,10 +1404,10 @@ func (bi *Binanceus) WithdrawalHistory(ctx context.Context, c currency.Code, sta
 		params.Set("status", status)
 	}
 	if !startTime.IsZero() && startTime.Unix() != 0 {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
 	}
 	if !endTime.IsZero() && endTime.Unix() != 0 {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 	if offset != 0 {
 		params.Set("offset", strconv.Itoa(offset))
@@ -1596,11 +1531,11 @@ func (bi *Binanceus) DepositHistory(ctx context.Context, c currency.Code, status
 		}
 	}
 	if !startTime.IsZero() && startTime.Unix() != 0 {
-		params.Set("startTime", strconv.FormatInt(startTime.UTC().Unix(), 10))
+		params.Set("startTime", strconv.FormatInt(startTime.Unix(), 10))
 	}
 
 	if !endTime.IsZero() && endTime.Unix() != 0 {
-		params.Set("endTime", strconv.FormatInt(endTime.UTC().Unix(), 10))
+		params.Set("endTime", strconv.FormatInt(endTime.Unix(), 10))
 	}
 
 	if offset != 0 {

--- a/exchanges/binanceus/binanceus_types.go
+++ b/exchanges/binanceus/binanceus_types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
@@ -200,17 +201,22 @@ type KlinesRequestParams struct {
 
 // CandleStick holds kline data
 type CandleStick struct {
-	OpenTime                 time.Time
-	Open                     float64
-	High                     float64
-	Low                      float64
-	Close                    float64
-	Volume                   float64
-	CloseTime                time.Time
-	QuoteAssetVolume         float64
-	TradeCount               float64
-	TakerBuyAssetVolume      float64
-	TakerBuyQuoteAssetVolume float64
+	OpenTime                 types.Time
+	Open                     types.Number
+	High                     types.Number
+	Low                      types.Number
+	Close                    types.Number
+	Volume                   types.Number
+	CloseTime                types.Time
+	QuoteAssetVolume         types.Number
+	TradeCount               types.Number
+	TakerBuyAssetVolume      types.Number
+	TakerBuyQuoteAssetVolume types.Number
+}
+
+// UnmarshalJSON unmarshals JSON data into a CandleStick struct
+func (c *CandleStick) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[11]any{&c.OpenTime, &c.Open, &c.High, &c.Low, &c.Close, &c.Volume, &c.CloseTime, &c.QuoteAssetVolume, &c.TradeCount, &c.TakerBuyAssetVolume, &c.TakerBuyQuoteAssetVolume})
 }
 
 // SymbolPrice represents a symbol and it's price.
@@ -718,15 +724,15 @@ type WithdrawalResponse struct {
 
 // WithdrawStatusResponse defines a withdrawal status response
 type WithdrawStatusResponse struct {
-	ID             string  `json:"id"`
-	Amount         float64 `json:"amount,string"`
-	TransactionFee float64 `json:"transactionFee,string"`
-	Coin           string  `json:"coin"`
-	Status         int64   `json:"status"`
-	Address        string  `json:"address"`
-	ApplyTime      string  `json:"applyTime"`
-	Network        string  `json:"network"`
-	TransferType   int64   `json:"transferType"`
+	ID             string         `json:"id"`
+	Amount         float64        `json:"amount,string"`
+	TransactionFee float64        `json:"transactionFee,string"`
+	Coin           string         `json:"coin"`
+	Status         int64          `json:"status"`
+	Address        string         `json:"address"`
+	ApplyTime      types.DateTime `json:"applyTime"`
+	Network        string         `json:"network"`
+	TransferType   int64          `json:"transferType"`
 }
 
 // FiatAssetRecord asset information for fiat.
@@ -777,16 +783,16 @@ type DepositAddress struct {
 
 // DepositHistory stores deposit history info.
 type DepositHistory struct {
-	Amount       string `json:"amount"`
-	Coin         string `json:"coin"`
-	Network      string `json:"network"`
-	Status       int64  `json:"status"`
-	Address      string `json:"address"`
-	AddressTag   string `json:"addressTag"`
-	TxID         string `json:"txId"`
-	InsertTime   int64  `json:"insertTime"`
-	TransferType int64  `json:"transferType"`
-	ConfirmTimes string `json:"confirmTimes"`
+	Amount       string     `json:"amount"`
+	Coin         string     `json:"coin"`
+	Network      string     `json:"network"`
+	Status       int64      `json:"status"`
+	Address      string     `json:"address"`
+	AddressTag   string     `json:"addressTag"`
+	TxID         string     `json:"txId"`
+	InsertTime   types.Time `json:"insertTime"`
+	TransferType int64      `json:"transferType"`
+	ConfirmTimes string     `json:"confirmTimes"`
 }
 
 // UserAccountStream represents the response for getting the listen key for the websocket

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -406,10 +406,6 @@ func (bi *Binanceus) GetWithdrawalsHistory(ctx context.Context, c currency.Code,
 	}
 	resp := make([]exchange.WithdrawalHistory, len(withdrawals))
 	for i := range withdrawals {
-		tm, err := time.Parse(time.DateTime, withdrawals[i].ApplyTime)
-		if err != nil {
-			return nil, err
-		}
 		resp[i] = exchange.WithdrawalHistory{
 			Status:          strconv.FormatInt(withdrawals[i].Status, 10),
 			TransferID:      withdrawals[i].ID,
@@ -419,7 +415,7 @@ func (bi *Binanceus) GetWithdrawalsHistory(ctx context.Context, c currency.Code,
 			CryptoToAddress: withdrawals[i].Address,
 			CryptoTxID:      withdrawals[i].ID,
 			CryptoChain:     withdrawals[i].Network,
-			Timestamp:       tm,
+			Timestamp:       withdrawals[i].ApplyTime.Time(),
 		}
 	}
 	return resp, nil
@@ -825,12 +821,12 @@ func (bi *Binanceus) GetHistoricCandles(ctx context.Context, pair currency.Pair,
 	timeSeries := make([]kline.Candle, len(candles))
 	for x := range candles {
 		timeSeries[x] = kline.Candle{
-			Time:   candles[x].OpenTime,
-			Open:   candles[x].Open,
-			High:   candles[x].High,
-			Low:    candles[x].Low,
-			Close:  candles[x].Close,
-			Volume: candles[x].Volume,
+			Time:   candles[x].OpenTime.Time(),
+			Open:   candles[x].Open.Float64(),
+			High:   candles[x].High.Float64(),
+			Low:    candles[x].Low.Float64(),
+			Close:  candles[x].Close.Float64(),
+			Volume: candles[x].Volume.Float64(),
 		}
 	}
 	return req.ProcessResponse(timeSeries)
@@ -859,12 +855,12 @@ func (bi *Binanceus) GetHistoricCandlesExtended(ctx context.Context, pair curren
 
 		for i := range candles {
 			timeSeries = append(timeSeries, kline.Candle{
-				Time:   candles[i].OpenTime,
-				Open:   candles[i].Open,
-				High:   candles[i].High,
-				Low:    candles[i].Low,
-				Close:  candles[i].Close,
-				Volume: candles[i].Volume,
+				Time:   candles[i].OpenTime.Time(),
+				Open:   candles[i].Open.Float64(),
+				High:   candles[i].High.Float64(),
+				Low:    candles[i].Low.Float64(),
+				Close:  candles[i].Close.Float64(),
+				Volume: candles[i].Volume.Float64(),
 			})
 		}
 	}

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -750,18 +750,16 @@ func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 // timestampStart is a millisecond timestamp
 // timestampEnd is a millisecond timestamp
 // reOrderResp reorders the returned data.
-func (b *Bitfinex) GetTrades(ctx context.Context, currencyPair string, limit, timestampStart, timestampEnd int64, reOrderResp bool) ([]Trade, error) {
+func (b *Bitfinex) GetTrades(ctx context.Context, currencyPair string, limit uint64, start, end time.Time, reOrderResp bool) ([]Trade, error) {
 	v := url.Values{}
 	if limit > 0 {
-		v.Set("limit", strconv.FormatInt(limit, 10))
+		v.Set("limit", strconv.FormatUint(limit, 10))
 	}
-
-	if timestampStart > 0 {
-		v.Set("start", strconv.FormatInt(timestampStart, 10))
+	if !start.IsZero() {
+		v.Set("start", strconv.FormatInt(start.UnixMilli(), 10))
 	}
-
-	if timestampEnd > 0 {
-		v.Set("end", strconv.FormatInt(timestampEnd, 10))
+	if !end.IsZero() {
+		v.Set("end", strconv.FormatInt(end.UnixMilli(), 10))
 	}
 	sortVal := "0"
 	if reOrderResp {
@@ -769,72 +767,9 @@ func (b *Bitfinex) GetTrades(ctx context.Context, currencyPair string, limit, ti
 	}
 	v.Set("sort", sortVal)
 
-	path := bitfinexAPIVersion2 + bitfinexTrades + currencyPair + "/hist" + "?" + v.Encode()
-
-	var resp [][]any
-	err := b.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp, tradeRateLimit)
-	if err != nil {
-		return nil, err
-	}
-
-	history := make([]Trade, len(resp))
-	for i := range resp {
-		amount, ok := resp[i][2].(float64)
-		if !ok {
-			return nil, errors.New("unable to type assert amount")
-		}
-		side := order.Buy.String()
-		if amount < 0 {
-			side = order.Sell.String()
-			amount *= -1
-		}
-
-		tid, ok := resp[i][0].(float64)
-		if !ok {
-			return nil, errors.New("unable to type assert trade ID")
-		}
-		timestamp, ok := resp[i][1].(float64)
-		if !ok {
-			return nil, errors.New("unable to type assert timestamp")
-		}
-
-		if len(resp[i]) > 4 {
-			var rate float64
-			rate, ok = resp[i][3].(float64)
-			if !ok {
-				return nil, errors.New("unable to type assert rate")
-			}
-			var period float64
-			period, ok = resp[i][4].(float64)
-			if !ok {
-				return nil, errors.New("unable to type assert period")
-			}
-
-			history[i] = Trade{
-				TID:       int64(tid),
-				Timestamp: int64(timestamp),
-				Amount:    amount,
-				Rate:      rate,
-				Period:    int64(period),
-				Type:      side,
-			}
-			continue
-		}
-		price, ok := resp[i][3].(float64)
-		if !ok {
-			return nil, errors.New("unable to type assert price")
-		}
-
-		history[i] = Trade{
-			TID:       int64(tid),
-			Timestamp: int64(timestamp),
-			Amount:    amount,
-			Price:     price,
-			Type:      side,
-		}
-	}
-
-	return history, nil
+	path := common.EncodeURLValues(bitfinexAPIVersion2+bitfinexTrades+currencyPair+"/hist", v)
+	var resp []Trade
+	return resp, b.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp, tradeRateLimit)
 }
 
 // GetOrderbook retrieves the orderbook bid and ask price points for a currency
@@ -997,108 +932,39 @@ func (b *Bitfinex) GetLends(ctx context.Context, symbol string, values url.Value
 // GetCandles returns candle chart data
 // timeFrame values: '1m', '5m', '15m', '30m', '1h', '3h', '6h', '12h', '1D', '1W', '14D', '1M'
 // section values: last or hist
-func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, start, end int64, limit uint64, historic bool) ([]Candle, error) {
+func (b *Bitfinex) GetCandles(ctx context.Context, symbol, timeFrame string, start, end time.Time, limit uint64, historic bool) ([]Candle, error) {
 	var fundingPeriod string
 	if symbol[0] == 'f' {
 		fundingPeriod = ":p30"
 	}
 
-	path := bitfinexAPIVersion2 +
-		bitfinexCandles +
-		":" +
-		timeFrame +
-		":" +
-		symbol +
-		fundingPeriod
+	path := bitfinexAPIVersion2 + bitfinexCandles + ":" + timeFrame + ":" + symbol + fundingPeriod
 
 	if historic {
 		v := url.Values{}
-		if start > 0 {
-			v.Set("start", strconv.FormatInt(start, 10))
+		if !start.IsZero() {
+			v.Set("start", strconv.FormatInt(start.UnixMilli(), 10))
 		}
 
-		if end > 0 {
-			v.Set("end", strconv.FormatInt(end, 10))
+		if !end.IsZero() {
+			v.Set("end", strconv.FormatInt(end.UnixMilli(), 10))
 		}
 
 		if limit > 0 {
 			v.Set("limit", strconv.FormatUint(limit, 10))
 		}
 
-		path += "/hist"
-		if len(v) > 0 {
-			path += "?" + v.Encode()
-		}
-
-		var response [][]any
-		err := b.SendHTTPRequest(ctx, exchange.RestSpot, path, &response, candle)
-		if err != nil {
-			return nil, err
-		}
-
-		candles := make([]Candle, len(response))
-		for i := range response {
-			var c Candle
-			timestamp, ok := response[i][0].(float64)
-			if !ok {
-				return nil, errors.New("unable to type assert timestamp")
-			}
-			c.Timestamp = time.UnixMilli(int64(timestamp))
-			if c.Open, ok = response[i][1].(float64); !ok {
-				return nil, errors.New("unable to type assert open")
-			}
-			if c.Close, ok = response[i][2].(float64); !ok {
-				return nil, errors.New("unable to type assert close")
-			}
-			if c.High, ok = response[i][3].(float64); !ok {
-				return nil, errors.New("unable to type assert high")
-			}
-			if c.Low, ok = response[i][4].(float64); !ok {
-				return nil, errors.New("unable to type assert low")
-			}
-			if c.Volume, ok = response[i][5].(float64); !ok {
-				return nil, errors.New("unable to type assert volume")
-			}
-			candles[i] = c
-		}
-
-		return candles, nil
+		var response []Candle
+		return response, b.SendHTTPRequest(ctx, exchange.RestSpot, common.EncodeURLValues(path+"/hist", v), &response, candle)
 	}
 
 	path += "/last"
 
-	var response []any
-	err := b.SendHTTPRequest(ctx, exchange.RestSpot, path, &response, candle)
+	var c Candle
+	err := b.SendHTTPRequest(ctx, exchange.RestSpot, path, &c, candle)
 	if err != nil {
 		return nil, err
 	}
-
-	if len(response) == 0 {
-		return nil, errors.New("no data returned")
-	}
-
-	var c Candle
-	timestamp, ok := response[0].(float64)
-	if !ok {
-		return nil, errors.New("unable to type assert timestamp")
-	}
-	c.Timestamp = time.UnixMilli(int64(timestamp))
-	if c.Open, ok = response[1].(float64); !ok {
-		return nil, errors.New("unable to type assert open")
-	}
-	if c.Close, ok = response[2].(float64); !ok {
-		return nil, errors.New("unable to type assert close")
-	}
-	if c.High, ok = response[3].(float64); !ok {
-		return nil, errors.New("unable to type assert high")
-	}
-	if c.Low, ok = response[4].(float64); !ok {
-		return nil, errors.New("unable to type assert low")
-	}
-	if c.Volume, ok = response[5].(float64); !ok {
-		return nil, errors.New("unable to type assert volume")
-	}
-
 	return []Candle{c}, nil
 }
 
@@ -1831,7 +1697,6 @@ func (b *Bitfinex) GetBalanceHistory(ctx context.Context, symbol string, timeSin
 
 // GetMovementHistory returns an array of past deposits and withdrawals
 func (b *Bitfinex) GetMovementHistory(ctx context.Context, symbol, method string, timeSince, timeUntil time.Time, limit int) ([]MovementHistory, error) {
-	var response [][]any
 	req := make(map[string]any)
 	req["currency"] = symbol
 
@@ -1839,89 +1704,18 @@ func (b *Bitfinex) GetMovementHistory(ctx context.Context, symbol, method string
 		req["method"] = method
 	}
 	if !timeSince.IsZero() {
-		req["since"] = timeSince
+		req["since"] = timeSince.UnixMilli()
 	}
 	if !timeUntil.IsZero() {
-		req["until"] = timeUntil
+		req["until"] = timeUntil.UnixMilli()
 	}
 	if limit > 0 {
 		req["limit"] = limit
 	}
 
-	err := b.SendAuthenticatedHTTPRequestV2(ctx, exchange.RestSpot, http.MethodPost,
-		"auth/r/"+bitfinexHistoryMovements+"/"+symbol+"/"+bitfinexHistoryShort,
-		req,
-		&response,
-		orderMulti)
-	if err != nil {
-		return nil, err
-	}
-	var resp []MovementHistory //nolint:prealloc // its an array in an array
-	var ok bool
-	for i := range response {
-		var move MovementHistory
-		for j := range response[i] {
-			if response[i][j] == nil {
-				continue
-			}
-			switch j {
-			case 0:
-				var id float64
-				id, ok = response[i][j].(float64)
-				if !ok {
-					return nil, common.GetTypeAssertError("float64", response[i][j], "Movements.Id")
-				}
-				move.ID = int64(id)
-			case 1:
-				move.Currency, ok = response[i][j].(string)
-				if !ok {
-					return nil, common.GetTypeAssertError("string", response[i][j], "Movements.Currency")
-				}
-			case 5:
-				move.TimestampCreated, ok = response[i][j].(float64)
-				if !ok {
-					return nil, common.GetTypeAssertError("float64", response[i][j], "Movements.MovementStartedAt")
-				}
-			case 6:
-				move.Timestamp, ok = response[i][j].(float64)
-				if !ok {
-					return nil, common.GetTypeAssertError("float64", response[i][j], "Movements.MovementLastUpdated")
-				}
-			case 9:
-				move.Status, ok = response[i][j].(string)
-				if !ok {
-					return nil, common.GetTypeAssertError("string", response[i][j], "Movements.CurrentStatus")
-				}
-			case 12:
-				move.Amount, ok = response[i][j].(float64)
-				if !ok {
-					return nil, common.GetTypeAssertError("float64", response[i][j], "Movements.AmountOfFundsMoved")
-				}
-			case 13:
-				move.Fee, ok = response[i][j].(float64)
-				if !ok {
-					return nil, common.GetTypeAssertError("float64", response[i][j], "Movements.FeesApplied")
-				}
-			case 16:
-				move.Address, ok = response[i][j].(string)
-				if !ok {
-					return nil, common.GetTypeAssertError("string", response[i][j], "Movements.DestinationAddress")
-				}
-			case 20:
-				move.TxID, ok = response[i][j].(string)
-				if !ok {
-					return nil, common.GetTypeAssertError("string", response[i][j], "Movements.TransactionId")
-				}
-			case 21:
-				move.Description, ok = response[i][j].(string)
-				if !ok {
-					return nil, common.GetTypeAssertError("string", response[i][j], "Movements.WithdrawTransactionNote")
-				}
-			}
-		}
-		resp = append(resp, move)
-	}
-	return resp, nil
+	var resp []MovementHistory
+	path := bitfinexV2Auth + "r/" + bitfinexHistoryMovements + "/" + symbol + "/" + bitfinexHistoryShort
+	return resp, b.SendAuthenticatedHTTPRequestV2(ctx, exchange.RestSpot, http.MethodPost, path, req, &resp, orderMulti)
 }
 
 // GetTradeHistory returns past executed trades
@@ -2232,18 +2026,12 @@ func getOfflineTradeFee(price, amount float64) float64 {
 }
 
 // GetCryptocurrencyWithdrawalFee returns an estimate of fee based on type of transaction
-func (b *Bitfinex) GetCryptocurrencyWithdrawalFee(c currency.Code, accountFees AccountFees) (fee float64, err error) {
-	switch result := accountFees.Withdraw[c.String()].(type) {
-	case string:
-		fee, err = strconv.ParseFloat(result, 64)
-		if err != nil {
-			return 0, err
-		}
-	case float64:
-		fee = result
+func (b *Bitfinex) GetCryptocurrencyWithdrawalFee(c currency.Code, accountFees AccountFees) (float64, error) {
+	fee, ok := accountFees.Withdraw[c.String()]
+	if !ok {
+		return 0, fmt.Errorf("withdrawal fee for %s not found", c.String())
 	}
-
-	return fee, nil
+	return fee.Float64(), nil
 }
 
 func getInternationalBankDepositFee(amount float64) float64 {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -27,6 +27,7 @@ import (
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 	testsubs "github.com/thrasher-corp/gocryptotrader/internal/testing/subscriptions"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Please supply API keys here or in config/testdata.json to test authenticated endpoints
@@ -666,14 +667,45 @@ func TestGetMovementHistory(t *testing.T) {
 	}
 }
 
-func TestGetTradeHistory(t *testing.T) {
+func TestMovementHistoryUnmarshalJSON(t *testing.T) {
 	t.Parallel()
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, b)
-	_, err := b.GetTradeHistory(t.Context(),
-		"BTCUSD", time.Time{}, time.Time{}, 1, 0)
-	if err != nil {
-		t.Error(err)
+	deposit := []byte(`[13105603,"ETH","ETHEREUM",null,null,1569348774000,1569348774000,null,null,"COMPLETED",null,null,0.26300954,-0.00135,null,null,"DESTINATION_ADDRESS",null,null,null,"TRANSACTION_ID",null]`)
+	var result MovementHistory
+	require.NoError(t, json.Unmarshal(deposit, &result))
+	stringPtr := func(s string) *string {
+		return &s
 	}
+	exp := MovementHistory{
+		ID:                 13105603,
+		Currency:           "ETH",
+		CurrencyName:       "ETHEREUM",
+		MTSStarted:         types.Time(time.Unix(1569348774, 0)),
+		MTSUpdated:         types.Time(time.Unix(1569348774, 0)),
+		Status:             "COMPLETED",
+		Amount:             0.26300954,
+		Fees:               -0.00135,
+		DestinationAddress: "DESTINATION_ADDRESS",
+		TransactionID:      stringPtr("TRANSACTION_ID"),
+		TransactionType:    "deposit",
+	}
+	assert.Equal(t, exp, result, "MovementHistory should unmarshal correctly")
+	withdrawal := []byte(`[13293039,"ETH","ETHEREUM",null,null,1574175052000,1574181326000,null,null,"CANCELED",null,null,-0.24,-0.00135,null,null,"DESTINATION_ADDRESS",null,null,null,"TRANSACTION_ID","Purchase of 100 pizzas"]`)
+	require.NoError(t, json.Unmarshal(withdrawal, &result))
+	exp = MovementHistory{
+		ID:                 13293039,
+		Currency:           "ETH",
+		CurrencyName:       "ETHEREUM",
+		MTSStarted:         types.Time(time.Unix(1574175052, 0)),
+		MTSUpdated:         types.Time(time.Unix(1574181326, 0)),
+		Status:             "CANCELED",
+		Amount:             -0.24,
+		Fees:               -0.00135,
+		DestinationAddress: "DESTINATION_ADDRESS",
+		TransactionID:      stringPtr("TRANSACTION_ID"),
+		TransactionNote:    stringPtr("Purchase of 100 pizzas"),
+		TransactionType:    "withdrawal",
+	}
+	assert.Equal(t, exp, result, "MovementHistory should unmarshal correctly")
 }
 
 func TestNewOffer(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -308,10 +308,9 @@ func checkFundingTick(tb testing.TB, tick *Ticker) {
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 
-	_, err := b.GetTrades(t.Context(), "tBTCUSD", 5, 0, 0, false)
-	if err != nil {
-		t.Error(err)
-	}
+	r, err := b.GetTrades(t.Context(), "tBTCUSD", 5, time.Time{}, time.Time{}, false)
+	require.NoError(t, err, "GetTrades must not error")
+	assert.NotEmpty(t, r, "GetTrades should return some trades")
 }
 
 func TestGetOrderbook(t *testing.T) {
@@ -368,12 +367,9 @@ func TestGetLends(t *testing.T) {
 
 func TestGetCandles(t *testing.T) {
 	t.Parallel()
-	e := time.Now().Add(-time.Hour * 2).Truncate(time.Hour)
-	s := e.Add(-time.Hour * 4)
-	_, err := b.GetCandles(t.Context(), "fUST", "1D", s.UnixMilli(), e.UnixMilli(), 10000, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c, err := b.GetCandles(t.Context(), "fUST", "1D", time.Now().AddDate(0, 0, -1), time.Now(), 10000, true)
+	require.NoError(t, err, "GetCandles must not error")
+	assert.NotEmpty(t, c, "GetCandles should return some candles")
 }
 
 func TestGetLeaderboard(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -2,7 +2,6 @@ package bitfinex
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -450,34 +449,32 @@ type MovementHistory struct {
 
 // UnmarshalJSON unmarshals JSON data into a MovementHistory struct
 func (m *MovementHistory) UnmarshalJSON(data []byte) error {
-	var rawDogs []json.RawMessage
-	if err := json.Unmarshal(data, &rawDogs); err != nil {
-		return fmt.Errorf("error unmarshalling MovementHistory data: %w", err)
-	}
-	if len(rawDogs) < 22 {
-		return fmt.Errorf("expected 22 elements, got %d", len(rawDogs))
-	}
-
-	for _, toUnmarshal := range []struct {
-		idx   int
-		field any
-	}{
-		{0, &m.ID},
-		{1, &m.Currency},
-		{2, &m.CurrencyName},
-		{5, &m.MTSStarted},
-		{6, &m.MTSUpdated},
-		{9, &m.Status},
-		{12, &m.Amount},
-		{13, &m.Fees},
-		{16, &m.DestinationAddress},
-		{17, &m.PaymentID},
-		{20, &m.TransactionID},
-		{21, &m.TransactionNote},
-	} {
-		if err := json.Unmarshal(rawDogs[toUnmarshal.idx], toUnmarshal.field); err != nil {
-			return fmt.Errorf("error unmarshalling field %d: %w", toUnmarshal.idx, err)
-		}
+	var unusedField any
+	if err := json.Unmarshal(data, &[22]any{
+		&m.ID,
+		&m.Currency,
+		&m.CurrencyName,
+		&unusedField,
+		&unusedField,
+		&m.MTSStarted,
+		&m.MTSUpdated,
+		&unusedField,
+		&unusedField,
+		&m.Status,
+		&unusedField,
+		&unusedField,
+		&m.Amount,
+		&m.Fees,
+		&unusedField,
+		&unusedField,
+		&m.DestinationAddress,
+		&m.PaymentID,
+		&unusedField,
+		&unusedField,
+		&m.TransactionID,
+		&m.TransactionNote,
+	}); err != nil {
+		return err
 	}
 
 	if m.Amount < 0 {

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -2,6 +2,8 @@ package bitfinex
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -197,15 +199,40 @@ type Orderbook struct {
 
 // Trade holds resp information
 type Trade struct {
-	Timestamp int64
 	TID       int64
-	Price     float64
+	Timestamp types.Time
 	Amount    float64
-	Exchange  string
+	Price     float64
 	Rate      float64
-	Period    int64
-	Type      string
+	Period    int64 // Funding offer period in days
 	Side      order.Side
+}
+
+// UnmarshalJSON unmarshals JSON data into a Trade struct
+func (t *Trade) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch len(raw) {
+	case 4:
+		if err := json.Unmarshal(data, &[4]any{&t.TID, &t.Timestamp, &t.Amount, &t.Price}); err != nil {
+			return err
+		}
+	case 5:
+		if err := json.Unmarshal(data, &[5]any{&t.TID, &t.Timestamp, &t.Amount, &t.Rate, &t.Period}); err != nil {
+			return err
+		}
+	default:
+		return errors.New("invalid trade data length")
+	}
+	t.Side = order.Buy
+	if t.Amount < 0 {
+		t.Amount = math.Abs(t.Amount)
+		t.Side = order.Sell
+	}
+	return nil
 }
 
 // Lendbook holds most recent funding data for a relevant currency
@@ -216,19 +243,19 @@ type Lendbook struct {
 
 // FundingBookItem is a generalised sub-type to hold book information
 type FundingBookItem struct {
-	Rate            float64 `json:"rate,string"`
-	Amount          float64 `json:"amount,string"`
-	Period          int     `json:"period"`
-	Timestamp       string  `json:"timestamp"`
-	FlashReturnRate string  `json:"frr"`
+	Rate            float64    `json:"rate,string"`
+	Amount          float64    `json:"amount,string"`
+	Period          int        `json:"period"`
+	Timestamp       types.Time `json:"timestamp"`
+	FlashReturnRate string     `json:"frr"`
 }
 
 // Lends holds the lent information by currency
 type Lends struct {
-	Rate       float64 `json:"rate,string"`
-	AmountLent float64 `json:"amount_lent,string"`
-	AmountUsed float64 `json:"amount_used,string"`
-	Timestamp  int64   `json:"timestamp"`
+	Rate       float64    `json:"rate,string"`
+	AmountLent float64    `json:"amount_lent,string"`
+	AmountUsed float64    `json:"amount_used,string"`
+	Timestamp  types.Time `json:"timestamp"`
 }
 
 // AccountInfoFull adds the error message to Account info
@@ -254,7 +281,7 @@ type AccountInfoFees struct {
 
 // AccountFees stores withdrawal account fee data from Bitfinex
 type AccountFees struct {
-	Withdraw map[string]any `json:"withdraw"`
+	Withdraw map[string]types.Number `json:"withdraw"`
 }
 
 // AccountSummary holds account summary data
@@ -395,80 +422,121 @@ type GenericResponse struct {
 
 // Position holds position information
 type Position struct {
-	ID        int64   `json:"id"`
-	Symbol    string  `json:"string"`
-	Status    string  `json:"active"`
-	Base      float64 `json:"base,string"`
-	Amount    float64 `json:"amount,string"`
-	Timestamp string  `json:"timestamp"`
-	Swap      float64 `json:"swap,string"`
-	PL        float64 `json:"pl,string"`
+	ID        int64      `json:"id"`
+	Symbol    string     `json:"string"`
+	Status    string     `json:"active"`
+	Base      float64    `json:"base,string"`
+	Amount    float64    `json:"amount,string"`
+	Timestamp types.Time `json:"timestamp"`
+	Swap      float64    `json:"swap,string"`
+	PL        float64    `json:"pl,string"`
 }
 
 // BalanceHistory holds balance history information
 type BalanceHistory struct {
-	Currency    string  `json:"currency"`
-	Amount      float64 `json:"amount,string"`
-	Balance     float64 `json:"balance,string"`
-	Description string  `json:"description"`
-	Timestamp   string  `json:"timestamp"`
+	Currency    string     `json:"currency"`
+	Amount      float64    `json:"amount,string"`
+	Balance     float64    `json:"balance,string"`
+	Description string     `json:"description"`
+	Timestamp   types.Time `json:"timestamp"`
 }
 
 // MovementHistory holds deposit and withdrawal history data
 type MovementHistory struct {
-	ID               int64   `json:"id"`
-	TxID             string  `json:"txid"`
-	Currency         string  `json:"currency"`
-	Method           string  `json:"method"`
-	Type             string  `json:"withdrawal"`
-	Amount           float64 `json:"amount,string"`
-	Description      string  `json:"description"`
-	Address          string  `json:"address"`
-	Status           string  `json:"status"`
-	Timestamp        float64 `json:"timestamp"`
-	TimestampCreated float64 `json:"timestamp_created"`
-	Fee              float64 `json:"fee"`
+	ID                 int64
+	Currency           string
+	CurrencyName       string // AKA Method
+	TXID               string
+	MTSStarted         types.Time
+	MTSUpdated         types.Time
+	Status             string
+	Amount             types.Number // Positive for deposits, negative for withdrawals
+	Fees               types.Number
+	DestinationAddress string
+	PaymentID          *string
+	TransactionID      *string
+	TransactionNote    *string
+	TransactionType    string // "deposit" or "withdrawal"
+}
+
+// UnmarshalJSON unmarshals JSON data into a MovementHistory struct
+func (m *MovementHistory) UnmarshalJSON(data []byte) error {
+	tmp := [22]any{
+		&m.ID,                 // [0]
+		&m.Currency,           // [1]
+		&m.CurrencyName,       // [2]
+		new(any),              // [3] null placeholder
+		new(any),              // [4] null placeholder
+		&m.MTSStarted,         // [5]
+		&m.MTSUpdated,         // [6]
+		new(any),              // [7] null placeholder
+		new(any),              // [8] null placeholder
+		&m.Status,             // [9]
+		new(any),              // [10] null placeholder
+		new(any),              // [11] null placeholder
+		&m.Amount,             // [12]
+		&m.Fees,               // [13]
+		new(any),              // [14] null placeholder
+		new(any),              // [15] null placeholder
+		&m.DestinationAddress, // [16]
+		new(any),              // [17] null placeholder
+		new(any),              // [18] null placeholder
+		new(any),              // [19] null placeholder
+		&m.TransactionID,      // [20]
+		&m.TransactionNote,    // [21] (nil if JSON “null”)
+	}
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return fmt.Errorf("error unmarshalling MovementHistory data: %w", err)
+	}
+
+	if m.Amount < 0 {
+		m.TransactionType = "withdrawal"
+	} else {
+		m.TransactionType = "deposit"
+	}
+	return nil
 }
 
 // TradeHistory holds trade history data
 type TradeHistory struct {
-	Price       float64 `json:"price,string"`
-	Amount      float64 `json:"amount,string"`
-	Timestamp   int64   `json:"timestamp"`
-	Exchange    string  `json:"exchange"`
-	Type        string  `json:"type"`
-	FeeCurrency string  `json:"fee_currency"`
-	FeeAmount   float64 `json:"fee_amount,string"`
-	TID         int64   `json:"tid"`
-	OrderID     int64   `json:"order_id"`
+	Price       float64    `json:"price,string"`
+	Amount      float64    `json:"amount,string"`
+	Timestamp   types.Time `json:"timestamp"`
+	Exchange    string     `json:"exchange"`
+	Type        string     `json:"type"`
+	FeeCurrency string     `json:"fee_currency"`
+	FeeAmount   float64    `json:"fee_amount,string"`
+	TID         int64      `json:"tid"`
+	OrderID     int64      `json:"order_id"`
 }
 
 // Offer holds offer information
 type Offer struct {
-	ID              int64   `json:"id"`
-	Currency        string  `json:"currency"`
-	Rate            float64 `json:"rate,string"`
-	Period          int64   `json:"period"`
-	Direction       string  `json:"direction"`
-	Timestamp       string  `json:"timestamp"`
-	Type            string  `json:"type"`
-	IsLive          bool    `json:"is_live"`
-	IsCancelled     bool    `json:"is_cancelled"`
-	OriginalAmount  float64 `json:"original_amount,string"`
-	RemainingAmount float64 `json:"remaining_amount,string"`
-	ExecutedAmount  float64 `json:"executed_amount,string"`
+	ID              int64      `json:"id"`
+	Currency        string     `json:"currency"`
+	Rate            float64    `json:"rate,string"`
+	Period          int64      `json:"period"`
+	Direction       string     `json:"direction"`
+	Timestamp       types.Time `json:"timestamp"`
+	Type            string     `json:"type"`
+	IsLive          bool       `json:"is_live"`
+	IsCancelled     bool       `json:"is_cancelled"`
+	OriginalAmount  float64    `json:"original_amount,string"`
+	RemainingAmount float64    `json:"remaining_amount,string"`
+	ExecutedAmount  float64    `json:"executed_amount,string"`
 }
 
 // MarginFunds holds active funding information used in a margin position
 type MarginFunds struct {
-	ID         int64   `json:"id"`
-	PositionID int64   `json:"position_id"`
-	Currency   string  `json:"currency"`
-	Rate       float64 `json:"rate,string"`
-	Period     int     `json:"period"`
-	Amount     float64 `json:"amount,string"`
-	Timestamp  string  `json:"timestamp"`
-	AutoClose  bool    `json:"auto_close"`
+	ID         int64      `json:"id"`
+	PositionID int64      `json:"position_id"`
+	Currency   string     `json:"currency"`
+	Rate       float64    `json:"rate,string"`
+	Period     int        `json:"period"`
+	Amount     float64    `json:"amount,string"`
+	Timestamp  types.Time `json:"timestamp"`
+	AutoClose  bool       `json:"auto_close"`
 }
 
 // MarginTotalTakenFunds holds position funding including sum of active backing
@@ -493,28 +561,19 @@ type WebsocketBook struct {
 	Period int64
 }
 
-// wsTrade holds trade information
-type wsTrade struct {
-	ID        int64
-	Timestamp types.Time
-	Amount    float64
-	Price     float64
-	Period    int64 // Funding offer period in days
-}
-
-// UnmarshalJSON unmarshals json bytes into a wsTrade
-func (t *wsTrade) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[5]any{&t.ID, &t.Timestamp, &t.Amount, &t.Price, &t.Period})
-}
-
-// Candle holds OHLC data
+// Candle holds OHLCV data
 type Candle struct {
-	Timestamp time.Time
-	Open      float64
-	Close     float64
-	High      float64
-	Low       float64
-	Volume    float64
+	Timestamp types.Time
+	Open      types.Number
+	Close     types.Number
+	High      types.Number
+	Low       types.Number
+	Volume    types.Number
+}
+
+// UnmarshalJSON unmarshals JSON data into a Candle struct
+func (c *Candle) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[6]any{&c.Timestamp, &c.Open, &c.Close, &c.High, &c.Low, &c.Volume})
 }
 
 // Leaderboard keys
@@ -578,7 +637,7 @@ type WebsocketOrder struct {
 	Status     string
 	Price      float64
 	PriceAvg   float64
-	Timestamp  int64
+	Timestamp  types.Time
 	Notify     int
 }
 
@@ -586,7 +645,7 @@ type WebsocketOrder struct {
 type WebsocketTradeExecuted struct {
 	TradeID        int64
 	Pair           string
-	Timestamp      int64
+	Timestamp      types.Time
 	OrderID        int64
 	AmountExecuted float64
 	PriceExecuted  float64
@@ -596,7 +655,7 @@ type WebsocketTradeExecuted struct {
 type WebsocketTradeData struct {
 	TradeID        int64
 	Pair           string
-	Timestamp      int64
+	Timestamp      types.Time
 	OrderID        int64
 	AmountExecuted float64
 	PriceExecuted  float64

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -804,8 +804,9 @@ func (b *Bitfinex) handleWSAllCandleUpdates(c *subscription.Subscription, respRa
 		wsCandles = []Candle{wsCandle}
 	}
 
+	klines := make([]websocket.KlineData, len(wsCandles))
 	for i := range wsCandles {
-		b.Websocket.DataHandler <- websocket.KlineData{
+		klines[i] = websocket.KlineData{
 			Exchange:   b.Name,
 			AssetType:  c.Asset,
 			Pair:       c.Pairs[0],
@@ -817,6 +818,7 @@ func (b *Bitfinex) handleWSAllCandleUpdates(c *subscription.Subscription, respRa
 			Volume:     wsCandles[i].Volume.Float64(),
 		}
 	}
+	b.Websocket.DataHandler <- klines
 	return nil
 }
 

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -1,12 +1,12 @@
 package bitfinex
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -19,7 +19,6 @@ import (
 	"github.com/buger/jsonparser"
 	gws "github.com/gorilla/websocket"
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -33,6 +32,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -628,7 +628,7 @@ func (b *Bitfinex) handleWSChannelUpdate(s *subscription.Subscription, respRaw [
 	case subscription.OrderbookChannel:
 		return b.handleWSBookUpdate(s, d)
 	case subscription.CandlesChannel:
-		return b.handleWSCandleUpdate(s, d)
+		return b.handleWSAllCandleUpdates(s, respRaw)
 	case subscription.TickerChannel:
 		return b.handleWSTickerUpdate(s, d)
 	case subscription.AllTradesChannel:
@@ -777,82 +777,45 @@ func (b *Bitfinex) handleWSBookUpdate(c *subscription.Subscription, d []any) err
 	return nil
 }
 
-func (b *Bitfinex) handleWSCandleUpdate(c *subscription.Subscription, d []any) error {
+func (b *Bitfinex) handleWSAllCandleUpdates(c *subscription.Subscription, respRaw []byte) error {
 	if c == nil {
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
 	}
 	if len(c.Pairs) != 1 {
 		return subscription.ErrNotSinglePair
 	}
-	candleBundle, ok := d[1].([]any)
-	if !ok || len(candleBundle) == 0 {
-		return nil
+	v, valueType, _, err := jsonparser.Get(respRaw, "[1]")
+	if err != nil {
+		return fmt.Errorf("%w `candlesUpdate[1]`: %w", common.ErrParsingWSField, err)
+	}
+	if valueType != jsonparser.Array {
+		return fmt.Errorf("%w `candlesUpdate[1]`: %w %q", common.ErrParsingWSField, jsonparser.UnknownValueTypeError, valueType)
+	}
+	var wsCandles []Candle
+	if bytes.HasPrefix(v, []byte("[[")) {
+		if err := json.Unmarshal(v, &wsCandles); err != nil {
+			return fmt.Errorf("error unmarshalling candle snapshot: %w", err)
+		}
+	} else {
+		var wsCandle Candle
+		if err := json.Unmarshal(v, &wsCandle); err != nil {
+			return fmt.Errorf("error unmarshalling candle update: %w", err)
+		}
+		wsCandles = []Candle{wsCandle}
 	}
 
-	switch candleData := candleBundle[0].(type) {
-	case []any:
-		for i := range candleBundle {
-			var element []any
-			element, ok = candleBundle[i].([]any)
-			if !ok {
-				return errors.New("candle type assertion for element data")
-			}
-			if len(element) < 6 {
-				return errors.New("invalid candleBundle length")
-			}
-			var err error
-			var klineData websocket.KlineData
-			if klineData.Timestamp, err = convert.TimeFromUnixTimestampFloat(element[0]); err != nil {
-				return fmt.Errorf("unable to convert candle timestamp: %w", err)
-			}
-			if klineData.OpenPrice, ok = element[1].(float64); !ok {
-				return errors.New("unable to type assert candle open price")
-			}
-			if klineData.ClosePrice, ok = element[2].(float64); !ok {
-				return errors.New("unable to type assert candle close price")
-			}
-			if klineData.HighPrice, ok = element[3].(float64); !ok {
-				return errors.New("unable to type assert candle high price")
-			}
-			if klineData.LowPrice, ok = element[4].(float64); !ok {
-				return errors.New("unable to type assert candle low price")
-			}
-			if klineData.Volume, ok = element[5].(float64); !ok {
-				return errors.New("unable to type assert candle volume")
-			}
-			klineData.Exchange = b.Name
-			klineData.AssetType = c.Asset
-			klineData.Pair = c.Pairs[0]
-			b.Websocket.DataHandler <- klineData
+	for i := range wsCandles {
+		b.Websocket.DataHandler <- websocket.KlineData{
+			Exchange:   b.Name,
+			AssetType:  c.Asset,
+			Pair:       c.Pairs[0],
+			Timestamp:  wsCandles[i].Timestamp.Time(),
+			OpenPrice:  wsCandles[i].Open.Float64(),
+			ClosePrice: wsCandles[i].Close.Float64(),
+			HighPrice:  wsCandles[i].High.Float64(),
+			LowPrice:   wsCandles[i].Low.Float64(),
+			Volume:     wsCandles[i].Volume.Float64(),
 		}
-	case float64:
-		if len(candleBundle) < 6 {
-			return errors.New("invalid candleBundle length")
-		}
-		var err error
-		var klineData websocket.KlineData
-		if klineData.Timestamp, err = convert.TimeFromUnixTimestampFloat(candleData); err != nil {
-			return fmt.Errorf("unable to convert candle timestamp: %w", err)
-		}
-		if klineData.OpenPrice, ok = candleBundle[1].(float64); !ok {
-			return errors.New("unable to type assert candle open price")
-		}
-		if klineData.ClosePrice, ok = candleBundle[2].(float64); !ok {
-			return errors.New("unable to type assert candle close price")
-		}
-		if klineData.HighPrice, ok = candleBundle[3].(float64); !ok {
-			return errors.New("unable to type assert candle high price")
-		}
-		if klineData.LowPrice, ok = candleBundle[4].(float64); !ok {
-			return errors.New("unable to type assert candle low price")
-		}
-		if klineData.Volume, ok = candleBundle[5].(float64); !ok {
-			return errors.New("unable to type assert candle volume")
-		}
-		klineData.Exchange = b.Name
-		klineData.AssetType = c.Asset
-		klineData.Pair = c.Pairs[0]
-		b.Websocket.DataHandler <- klineData
 	}
 	return nil
 }
@@ -951,14 +914,14 @@ func (b *Bitfinex) handleWSAllTrades(s *subscription.Subscription, respRaw []byt
 	if err != nil {
 		return fmt.Errorf("%w `tradesUpdate[1]`: %w", common.ErrParsingWSField, err)
 	}
-	var wsTrades []*wsTrade
+	var wsTrades []*Trade
 	switch valueType {
 	case jsonparser.String:
 		t, err := b.handleWSPublicTradeUpdate(respRaw)
 		if err != nil {
 			return fmt.Errorf("%w `tradesUpdate[2]`: %w", common.ErrParsingWSField, err)
 		}
-		wsTrades = []*wsTrade{t}
+		wsTrades = []*Trade{t}
 	case jsonparser.Array:
 		if wsTrades, err = b.handleWSPublicTradesSnapshot(v); err != nil {
 			return fmt.Errorf("%w `tradesSnapshot`: %w", common.ErrParsingWSField, err)
@@ -972,18 +935,15 @@ func (b *Bitfinex) handleWSAllTrades(s *subscription.Subscription, respRaw []byt
 			Exchange:     b.Name,
 			AssetType:    s.Asset,
 			CurrencyPair: s.Pairs[0],
-			TID:          strconv.FormatInt(w.ID, 10),
+			TID:          strconv.FormatInt(w.TID, 10),
 			Timestamp:    w.Timestamp.Time().UTC(),
-			Side:         order.Buy,
+			Side:         w.Side,
 			Amount:       w.Amount,
 			Price:        w.Price,
 		}
 		if w.Period != 0 {
 			t.AssetType = asset.MarginFunding
-		}
-		if t.Amount < 0 {
-			t.Side = order.Sell
-			t.Amount = math.Abs(t.Amount)
+			t.Price = w.Rate
 		}
 		if feedEnabled {
 			b.Websocket.DataHandler <- t
@@ -995,17 +955,17 @@ func (b *Bitfinex) handleWSAllTrades(s *subscription.Subscription, respRaw []byt
 	return err
 }
 
-func (b *Bitfinex) handleWSPublicTradesSnapshot(v []byte) ([]*wsTrade, error) {
-	var trades []*wsTrade
+func (b *Bitfinex) handleWSPublicTradesSnapshot(v []byte) ([]*Trade, error) {
+	var trades []*Trade
 	return trades, json.Unmarshal(v, &trades)
 }
 
-func (b *Bitfinex) handleWSPublicTradeUpdate(respRaw []byte) (*wsTrade, error) {
+func (b *Bitfinex) handleWSPublicTradeUpdate(respRaw []byte) (*Trade, error) {
 	v, _, _, err := jsonparser.Get(respRaw, "[2]")
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTrade{}
+	t := &Trade{}
 	return t, json.Unmarshal(v, t)
 }
 
@@ -1199,7 +1159,7 @@ func (b *Bitfinex) handleWSMyTradeUpdate(d []any, eventType string) error {
 	if timestamp, ok = tradeData[2].(float64); !ok {
 		return errors.New("unable to type assert trade timestamp")
 	}
-	tData.Timestamp = int64(timestamp)
+	tData.Timestamp = types.Time(time.UnixMilli(int64(timestamp)))
 	var orderID float64
 	if orderID, ok = tradeData[3].(float64); !ok {
 		return errors.New("unable to type assert trade order ID")

--- a/exchanges/bitflyer/bitflyer_types.go
+++ b/exchanges/bitflyer/bitflyer_types.go
@@ -1,35 +1,41 @@
 package bitflyer
 
-import "errors"
+import (
+	"errors"
+	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+	"github.com/thrasher-corp/gocryptotrader/types"
+)
 
 var errUnhandledCurrency = errors.New("unhandled currency")
 
 // ChainAnalysisBlock holds block information from the bitcoin network
 type ChainAnalysisBlock struct {
-	BlockHash     string   `json:"block_hash"`
-	Height        int64    `json:"height"`
-	IsMain        bool     `json:"is_main"`
-	Version       float64  `json:"version"`
-	PreviousBlock string   `json:"prev_block"`
-	MerkleRoot    string   `json:"merkle_root"`
-	Timestamp     string   `json:"timestamp"`
-	Bits          int64    `json:"bits"`
-	Nonce         int64    `json:"nonce"`
-	TxNum         int64    `json:"txnum"`
-	TotalFees     float64  `json:"total_fees"`
-	TxHashes      []string `json:"tx_hashes"`
+	BlockHash     string    `json:"block_hash"`
+	Height        int64     `json:"height"`
+	IsMain        bool      `json:"is_main"`
+	Version       float64   `json:"version"`
+	PreviousBlock string    `json:"prev_block"`
+	MerkleRoot    string    `json:"merkle_root"`
+	Timestamp     time.Time `json:"timestamp"`
+	Bits          int64     `json:"bits"`
+	Nonce         int64     `json:"nonce"`
+	TxNum         int64     `json:"txnum"`
+	TotalFees     float64   `json:"total_fees"`
+	TxHashes      []string  `json:"tx_hashes"`
 }
 
 // ChainAnalysisTransaction holds transaction data from the bitcoin network
 type ChainAnalysisTransaction struct {
-	TxHash        string  `json:"tx_hash"`
-	BlockHeight   int64   `json:"block_height"`
-	Confirmations int64   `json:"confirmed"`
-	Fees          float64 `json:"fees"`
-	Size          int64   `json:"size"`
-	ReceivedDate  string  `json:"received_date"`
-	Version       float64 `json:"version"`
-	LockTime      int64   `json:"lock_time"`
+	TxHash        string     `json:"tx_hash"`
+	BlockHeight   int64      `json:"block_height"`
+	Confirmations int64      `json:"confirmed"`
+	Fees          float64    `json:"fees"`
+	Size          int64      `json:"size"`
+	ReceivedDate  string     `json:"received_date"`
+	Version       float64    `json:"version"`
+	LockTime      types.Time `json:"lock_time"`
 	Inputs        []struct {
 		PrevHash  string `json:"prev_hash"`
 		PrevIndex int    `json:"prev_index"`
@@ -75,7 +81,7 @@ type Orderbook struct {
 // Ticker holds ticker information
 type Ticker struct {
 	ProductCode     string  `json:"product_code"`
-	TimeStamp       string  `json:"timestamp"`
+	TimeStamp       Time    `json:"timestamp"`
 	TickID          int64   `json:"tick_id"`
 	BestBid         float64 `json:"best_bid"`
 	BestAsk         float64 `json:"best_ask"`
@@ -94,7 +100,7 @@ type ExecutedTrade struct {
 	Side           string  `json:"side"`
 	Price          float64 `json:"price"`
 	Size           float64 `json:"size"`
-	ExecDate       string  `json:"exec_date"`
+	ExecDate       Time    `json:"exec_date"`
 	BuyAcceptedID  string  `json:"buy_child_order_acceptance_id"`
 	SellAcceptedID string  `json:"sell_child_order_acceptance_id"`
 }
@@ -294,3 +300,23 @@ type NewOrder struct {
 	MinuteToExpire float64 `json:"minute_to_expire"`
 	TimeInForce    string  `json:"time_in_force"`
 }
+
+// Time is a custom type that wraps time.Time to implement json.Unmarshaller
+type Time time.Time
+
+// UnmarshalJSON implements the json.Unmarshaller interface for Time
+func (t *Time) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	parsedTime, err := time.Parse("2006-01-02T15:04:05.999999999", str)
+	if err != nil {
+		return err
+	}
+	*t = Time(parsedTime)
+	return nil
+}
+
+// Time returns the time.Time representation of the DateTime type
+func (t *Time) Time() time.Time { return time.Time(*t) }

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -271,11 +271,6 @@ func (b *Bitflyer) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 	}
 	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		var timestamp time.Time
-		timestamp, err = time.Parse("2006-01-02T15:04:05.999999999", tradeData[i].ExecDate)
-		if err != nil {
-			return nil, err
-		}
 		var side order.Side
 		side, err = order.StringToOrderSide(tradeData[i].Side)
 		if err != nil {
@@ -289,7 +284,7 @@ func (b *Bitflyer) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 			Side:         side,
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Size,
-			Timestamp:    timestamp,
+			Timestamp:    tradeData[i].ExecDate.Time(),
 		}
 	}
 

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -237,39 +236,21 @@ func (b *Bithumb) GetAccountBalance(ctx context.Context, c string) (FullBalance,
 		}
 
 		c := splitTag[len(splitTag)-1]
-
-		var val float64
-		switch v := datum.(type) {
-		case float64:
-			val = v
-		case string:
-			val, err = strconv.ParseFloat(v, 64)
-			if err != nil {
-				return fullBalance, err
-			}
-		default:
-			return fullBalance, common.GetTypeAssertError("float64|string", datum)
-		}
+		val := datum.Float64()
 
 		switch splitTag[0] {
 		case "available":
 			fullBalance.Available[c] = val
-
 		case "in":
 			fullBalance.InUse[c] = val
-
 		case "total":
 			fullBalance.Total[c] = val
-
 		case "misu":
 			fullBalance.Misu[c] = val
-
 		case "xcoin":
 			fullBalance.Xcoin[c] = val
-
 		default:
-			return fullBalance, fmt.Errorf("getaccountbalance error tag name %s unhandled",
-				splitTag)
+			return fullBalance, fmt.Errorf("getaccountbalance error tag name %s unhandled", splitTag)
 		}
 	}
 
@@ -695,7 +676,7 @@ var errCode = map[string]string{
 }
 
 // GetCandleStick returns candle stick data for requested pair
-func (b *Bithumb) GetCandleStick(ctx context.Context, symbol, interval string) (resp OHLCVResponse, err error) {
+func (b *Bithumb) GetCandleStick(ctx context.Context, symbol, interval string) (resp *OHLCVResponse, err error) {
 	path := publicCandleStick + symbol + "/" + interval
 	err = b.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 	return

--- a/exchanges/bithumb/bithumb_types.go
+++ b/exchanges/bithumb/bithumb_types.go
@@ -40,9 +40,9 @@ type TickersResponse struct {
 type Orderbook struct {
 	Status string `json:"status"`
 	Data   struct {
-		Timestamp       int64  `json:"timestamp,string"`
-		OrderCurrency   string `json:"order_currency"`
-		PaymentCurrency string `json:"payment_currency"`
+		Timestamp       types.Time `json:"timestamp"`
+		OrderCurrency   string     `json:"order_currency"`
+		PaymentCurrency string     `json:"payment_currency"`
 		Bids            []struct {
 			Quantity float64 `json:"quantity,string"`
 			Price    float64 `json:"price,string"`
@@ -59,12 +59,12 @@ type Orderbook struct {
 type TransactionHistory struct {
 	Status string `json:"status"`
 	Data   []struct {
-		ContNumber      int64   `json:"cont_no,string"`
-		TransactionDate string  `json:"transaction_date"`
-		Type            string  `json:"type"`
-		UnitsTraded     float64 `json:"units_traded,string"`
-		Price           float64 `json:"price,string"`
-		Total           float64 `json:"total,string"`
+		ContNumber      int64          `json:"cont_no,string"`
+		TransactionDate types.DateTime `json:"transaction_date"`
+		Type            string         `json:"type"`
+		UnitsTraded     float64        `json:"units_traded,string"`
+		Price           float64        `json:"price,string"`
+		Total           float64        `json:"total,string"`
 	} `json:"data"`
 	Message string `json:"message"`
 }
@@ -83,9 +83,9 @@ type Account struct {
 
 // Balance holds balance details
 type Balance struct {
-	Status  string         `json:"status"`
-	Data    map[string]any `json:"data"`
-	Message string         `json:"message"`
+	Status  string                  `json:"status"`
+	Data    map[string]types.Number `json:"data"`
+	Message string                  `json:"message"`
 }
 
 // WalletAddressRes contains wallet address information
@@ -145,7 +145,7 @@ type UserTransactions struct {
 	Status string `json:"status"`
 	Data   []struct {
 		Search          int64         `json:"search,string"`
-		TransferDate    int64         `json:"transfer_date"`
+		TransferDate    types.Time    `json:"transfer_date"`
 		OrderCurrency   currency.Code `json:"order_currency"`
 		PaymentCurrency currency.Code `json:"payment_currency"`
 		Units           float64       `json:"units,string"`
@@ -290,8 +290,23 @@ type FullBalance struct {
 
 // OHLCVResponse holds returned kline data
 type OHLCVResponse struct {
-	Status string   `json:"status"`
-	Data   [][6]any `json:"data"`
+	Status string      `json:"status"`
+	Data   []OHLCVItem `json:"data"`
+}
+
+// OHLCVItem holds a single kline item
+type OHLCVItem struct {
+	Timestamp types.Time
+	Open      types.Number
+	High      types.Number
+	Low       types.Number
+	Close     types.Number
+	Volume    types.Number
+}
+
+// UnmarshalJSON unmarshals OHLCV
+func (o *OHLCVItem) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[6]any{&o.Timestamp, &o.Open, &o.High, &o.Low, &o.Close, &o.Volume})
 }
 
 // Status defines the current exchange allowance to deposit or withdraw a

--- a/exchanges/bithumb/bithumb_ws_orderbook.go
+++ b/exchanges/bithumb/bithumb_ws_orderbook.go
@@ -408,28 +408,24 @@ func (b *Bithumb) SeedLocalCache(ctx context.Context, p currency.Pair) error {
 
 // SeedLocalCacheWithBook seeds the local orderbook cache
 func (b *Bithumb) SeedLocalCacheWithBook(p currency.Pair, o *Orderbook) error {
-	var newOrderBook orderbook.Book
-	newOrderBook.Bids = make(orderbook.Levels, len(o.Data.Bids))
+	ob := &orderbook.Book{
+		Pair:              p,
+		Asset:             asset.Spot,
+		Exchange:          b.Name,
+		LastUpdated:       o.Data.Timestamp.Time(),
+		ValidateOrderbook: b.ValidateOrderbook,
+		Bids:              make(orderbook.Levels, len(o.Data.Bids)),
+		Asks:              make(orderbook.Levels, len(o.Data.Asks)),
+	}
 	for i := range o.Data.Bids {
-		newOrderBook.Bids[i] = orderbook.Level{
-			Amount: o.Data.Bids[i].Quantity,
-			Price:  o.Data.Bids[i].Price,
-		}
+		ob.Bids[i].Price = o.Data.Bids[i].Price
+		ob.Bids[i].Amount = o.Data.Bids[i].Quantity
 	}
-	newOrderBook.Asks = make(orderbook.Levels, len(o.Data.Asks))
 	for i := range o.Data.Asks {
-		newOrderBook.Asks[i] = orderbook.Level{
-			Amount: o.Data.Asks[i].Quantity,
-			Price:  o.Data.Asks[i].Price,
-		}
+		ob.Asks[i].Price = o.Data.Asks[i].Price
+		ob.Asks[i].Amount = o.Data.Asks[i].Quantity
 	}
-
-	newOrderBook.Pair = p
-	newOrderBook.Asset = asset.Spot
-	newOrderBook.Exchange = b.Name
-	newOrderBook.LastUpdated = time.UnixMilli(o.Data.Timestamp)
-	newOrderBook.ValidateOrderbook = b.ValidateOrderbook
-	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook)
+	return b.Websocket.Orderbook.LoadSnapshot(ob)
 }
 
 // setNeedsFetchingBook completes the book fetching initiation.

--- a/exchanges/bitmex/bitmex_types.go
+++ b/exchanges/bitmex/bitmex_types.go
@@ -103,7 +103,7 @@ type Execution struct {
 	TimeInForce           string    `json:"timeInForce"`
 	Timestamp             time.Time `json:"timestamp"`
 	TradePublishIndicator string    `json:"tradePublishIndicator"`
-	TransactTime          string    `json:"transactTime"`
+	TransactTime          time.Time `json:"transactTime"`
 	TrdMatchID            string    `json:"trdMatchID"`
 	Triggered             string    `json:"triggered"`
 	UnderlyingLastPx      float64   `json:"underlyingLastPx"`
@@ -187,7 +187,7 @@ type Instrument struct {
 	PrevTotalTurnover              float64   `json:"prevTotalTurnover"`
 	PrevTotalVolume                float64   `json:"prevTotalVolume"`
 	PublishInterval                string    `json:"publishInterval"`
-	PublishTime                    string    `json:"publishTime"`
+	PublishTime                    time.Time `json:"publishTime"`
 	QuoteCurrency                  string    `json:"quoteCurrency"`
 	QuoteToSettleMultiplier        int64     `json:"quoteToSettleMultiplier"`
 	RebalanceInterval              string    `json:"rebalanceInterval"`
@@ -573,7 +573,7 @@ type TransactionInfo struct {
 	TransactID     string    `json:"transactID"`
 	Network        string    `json:"network"`
 	TransactStatus string    `json:"transactStatus"`
-	TransactTime   string    `json:"transactTime"`
+	TransactTime   time.Time `json:"transactTime"`
 	TransactType   string    `json:"transactType"`
 	Tx             string    `json:"tx"`
 }

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -58,7 +58,6 @@ const (
 
 	bitstampRateInterval = time.Minute * 10
 	bitstampRequestRate  = 8000
-	bitstampTimeLayout   = "2006-1-2 15:04:05"
 )
 
 // Bitstamp is the overarching type across the bitstamp package
@@ -260,53 +259,14 @@ func (b *Bitstamp) GetBalance(ctx context.Context) (Balances, error) {
 
 // GetUserTransactions returns an array of transactions
 func (b *Bitstamp) GetUserTransactions(ctx context.Context, currencyPair string) ([]UserTransactions, error) {
-	type Response struct {
-		Date          string       `json:"datetime"`
-		TransactionID int64        `json:"id"`
-		Type          int64        `json:"type,string"`
-		USD           types.Number `json:"usd"`
-		EUR           types.Number `json:"eur"`
-		XRP           types.Number `json:"xrp"`
-		BTC           types.Number `json:"btc"`
-		BTCUSD        types.Number `json:"btc_usd"`
-		Fee           float64      `json:"fee,string"`
-		OrderID       int64        `json:"order_id"`
-	}
-
-	var response []Response
+	var resp []UserTransactions
+	var err error
 	if currencyPair == "" {
-		if err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, bitstampAPIUserTransactions,
-			true,
-			url.Values{},
-			&response); err != nil {
-			return nil, err
-		}
+		err = b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, bitstampAPIUserTransactions, true, url.Values{}, &resp)
 	} else {
-		if err := b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, bitstampAPIUserTransactions+"/"+currencyPair,
-			true,
-			url.Values{},
-			&response); err != nil {
-			return nil, err
-		}
+		err = b.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, bitstampAPIUserTransactions+"/"+currencyPair, true, url.Values{}, &resp)
 	}
-
-	transactions := make([]UserTransactions, len(response))
-	for x := range response {
-		transactions[x] = UserTransactions{
-			Date:          response[x].Date,
-			TransactionID: response[x].TransactionID,
-			Type:          response[x].Type,
-			EUR:           response[x].EUR.Float64(),
-			XRP:           response[x].XRP.Float64(),
-			USD:           response[x].USD.Float64(),
-			BTC:           response[x].BTC.Float64(),
-			BTCUSD:        response[x].BTCUSD.Float64(),
-			Fee:           response[x].Fee,
-			OrderID:       response[x].OrderID,
-		}
-	}
-
-	return transactions, nil
+	return resp, err
 }
 
 // GetOpenOrders returns all open orders on the exchange
@@ -633,10 +593,6 @@ func (b *Bitstamp) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange
 		}
 	}
 	return json.Unmarshal(interim, result)
-}
-
-func parseTime(dateTime string) (time.Time, error) {
-	return time.Parse(bitstampTimeLayout, dateTime)
 }
 
 func filterOrderbookZeroBidPrice(ob *orderbook.Book) {

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -364,11 +364,11 @@ func TestGetOpenOrders(t *testing.T) {
 	if mockTests {
 		assert.NotEmpty(t, o, "Orders should not be empty")
 		for _, res := range o {
-			assert.Equal(t, "2022-01-31 14:43:15", res.DateTime, "DateTime should match")
+			assert.Equal(t, time.Date(2022, 1, 31, 14, 43, 15, 0, time.UTC), res.DateTime.Time(), "DateTime should match")
 			assert.Equal(t, int64(1234123412341234), res.ID, "ID should match")
 			assert.Equal(t, 0.50000000, res.Amount, "Amount should match")
 			assert.Equal(t, 100.00, res.Price, "Price should match")
-			assert.Equal(t, 0, res.Type, "Type should match")
+			assert.Equal(t, int64(0), res.Type, "Type should match")
 			assert.Equal(t, 0.50000000, res.AmountAtCreate, "AmountAtCreate should match")
 			assert.Equal(t, 110.00, res.LimitPrice, "LimitPrice should match")
 			assert.Equal(t, "1234123412341234", res.ClientOrderID, "ClientOrderID should match")
@@ -388,14 +388,14 @@ func TestGetOrderStatus(t *testing.T) {
 		assert.ErrorContains(t, err, "Order not found")
 	} else {
 		require.NoError(t, err, "GetOrderStatus must not error")
-		assert.Equal(t, "2022-01-31 14:43:15", o.DateTime, "DateTime should match")
+		assert.Equal(t, time.Date(2022, 1, 31, 14, 43, 15, 0, time.UTC), o.DateTime.Time(), "DateTime should match")
 		assert.Equal(t, "1458532827766784", o.ID, "OrderID should match")
 		assert.Equal(t, 200.00, o.AmountRemaining, "AmountRemaining should match")
 		assert.Equal(t, int64(0), o.Type, "Type should match")
 		assert.Equal(t, "0.50000000", o.ClientOrderID, "ClientOrderID should match")
 		assert.Equal(t, "BTC/USD", o.Market, "Market should match")
 		for _, tr := range o.Transactions {
-			assert.Equal(t, "2022-01-31 14:43:15", tr.DateTime, "DateTime should match")
+			assert.Equal(t, time.Date(2022, 1, 31, 14, 43, 15, 0, time.UTC), tr.DateTime.Time(), "DateTime should match")
 			assert.Equal(t, 50.00, tr.Price, "Price should match")
 			assert.Equal(t, 101.00, tr.FromCurrency, "FromCurrency should match")
 			assert.Equal(t, 1.0, tr.ToCurrency, "ToCurrency should match")
@@ -417,7 +417,7 @@ func TestGetWithdrawalRequests(t *testing.T) {
 		for _, req := range r {
 			assert.Equal(t, int64(1), req.OrderID, "OrderId should match")
 			assert.Equal(t, "aMDHooGmAkyrsaQiKhAORhSNTmoRzxqWIO", req.Address, "Address should match")
-			assert.Equal(t, "2022-01-31 16:07:32", req.Date, "Date should match")
+			assert.Equal(t, time.Date(2022, 1, 31, 16, 7, 32, 0, time.UTC), req.Date.Time(), "Date should match")
 			assert.Equal(t, currency.BTC, req.Currency, "Currency should match")
 			assert.Equal(t, 0.00006000, req.Amount, "Amount should match")
 			assert.Equal(t, "NsOeFbQhRnpGzNIThWGBTkQwRJqTNOGPVhYavrVyMfkAyMUmIlUpFIwGTzSvpeOP", req.TransactionID, "TransactionID should match")
@@ -711,24 +711,6 @@ func TestGetDepositAddress(t *testing.T) {
 	require.NoError(t, err, "GetDepositAddress must not error")
 	assert.NotEmpty(t, a.Address, "Address should not be empty")
 	assert.NotEmpty(t, a.Tag, "Tag should not be empty")
-}
-
-func TestParseTime(t *testing.T) {
-	t.Parallel()
-
-	tm, err := parseTime("2019-10-18 01:55:14")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if tm.Year() != 2019 ||
-		tm.Month() != 10 ||
-		tm.Day() != 18 ||
-		tm.Hour() != 1 ||
-		tm.Minute() != 55 ||
-		tm.Second() != 14 {
-		t.Error("invalid time values")
-	}
 }
 
 func TestWsSubscription(t *testing.T) {

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -23,18 +23,18 @@ const (
 
 // Ticker holds ticker information
 type Ticker struct {
-	Last            float64   `json:"last,string"`
-	High            float64   `json:"high,string"`
-	Low             float64   `json:"low,string"`
-	Vwap            float64   `json:"vwap,string"`
-	Volume          float64   `json:"volume,string"`
-	Bid             float64   `json:"bid,string"`
-	Ask             float64   `json:"ask,string"`
-	Timestamp       int64     `json:"timestamp,string"`
-	Open            float64   `json:"open,string"`
-	Open24          float64   `json:"open_24,string"`
-	Side            orderSide `json:"side,string"`
-	PercentChange24 float64   `json:"percent_change_24,string"`
+	Last            float64    `json:"last,string"`
+	High            float64    `json:"high,string"`
+	Low             float64    `json:"low,string"`
+	Vwap            float64    `json:"vwap,string"`
+	Volume          float64    `json:"volume,string"`
+	Bid             float64    `json:"bid,string"`
+	Ask             float64    `json:"ask,string"`
+	Timestamp       types.Time `json:"timestamp"`
+	Open            float64    `json:"open,string"`
+	Open24          float64    `json:"open_24,string"`
+	Side            orderSide  `json:"side,string"`
+	PercentChange24 float64    `json:"percent_change_24,string"`
 }
 
 // OrderbookBase holds singular price information
@@ -63,11 +63,11 @@ type TradingPair struct {
 
 // Transactions holds transaction data
 type Transactions struct {
-	Date    int64   `json:"date,string"`
-	TradeID int64   `json:"tid,string"`
-	Price   float64 `json:"price,string"`
-	Type    int     `json:"type,string"`
-	Amount  float64 `json:"amount,string"`
+	Date    types.Time `json:"date"`
+	TradeID int64      `json:"tid,string"`
+	Price   float64    `json:"price,string"`
+	Type    int        `json:"type,string"`
+	Amount  float64    `json:"amount,string"`
 }
 
 // EURUSDConversionRate holds buy sell conversion rate information
@@ -101,49 +101,49 @@ type Balances map[string]Balance
 
 // UserTransactions holds user transaction information
 type UserTransactions struct {
-	Date          string  `json:"datetime"`
-	TransactionID int64   `json:"id"`
-	Type          int64   `json:"type,string"`
-	USD           float64 `json:"usd"`
-	EUR           float64 `json:"eur"`
-	BTC           float64 `json:"btc"`
-	XRP           float64 `json:"xrp"`
-	BTCUSD        float64 `json:"btc_usd"`
-	Fee           float64 `json:"fee,string"`
-	OrderID       int64   `json:"order_id"`
+	Date          types.DateTime `json:"datetime"`
+	TransactionID int64          `json:"id"`
+	Type          int64          `json:"type,string"`
+	USD           types.Number   `json:"usd"`
+	EUR           types.Number   `json:"eur"`
+	BTC           types.Number   `json:"btc"`
+	XRP           types.Number   `json:"xrp"`
+	BTCUSD        types.Number   `json:"btc_usd"`
+	Fee           types.Number   `json:"fee"`
+	OrderID       int64          `json:"order_id"`
 }
 
 // Order holds current open order data
 type Order struct {
-	ID             int64   `json:"id,string"`
-	DateTime       string  `json:"datetime"`
-	Type           int     `json:"type,string"`
-	Price          float64 `json:"price,string"`
-	Amount         float64 `json:"amount,string"`
-	AmountAtCreate float64 `json:"amount_at_create,string"`
-	Currency       string  `json:"currency_pair"`
-	LimitPrice     float64 `json:"limit_price,string"`
-	ClientOrderID  string  `json:"client_order_id"`
-	Market         string  `json:"market"`
+	ID             int64          `json:"id,string"`
+	DateTime       types.DateTime `json:"datetime"`
+	Type           int64          `json:"type,string"`
+	Price          float64        `json:"price,string"`
+	Amount         float64        `json:"amount,string"`
+	AmountAtCreate float64        `json:"amount_at_create,string"`
+	Currency       string         `json:"currency_pair"`
+	LimitPrice     float64        `json:"limit_price,string"`
+	ClientOrderID  string         `json:"client_order_id"`
+	Market         string         `json:"market"`
 }
 
 // OrderStatus holds order status information
 type OrderStatus struct {
-	AmountRemaining float64 `json:"amount_remaining,string"`
-	Type            int64   `json:"type"`
-	ID              string  `json:"id"`
-	DateTime        string  `json:"datetime"`
-	Status          string  `json:"status"`
-	ClientOrderID   string  `json:"client_order_id"`
-	Market          string  `json:"market"`
+	AmountRemaining float64        `json:"amount_remaining,string"`
+	Type            int64          `json:"type"`
+	ID              string         `json:"id"`
+	DateTime        types.DateTime `json:"datetime"`
+	Status          string         `json:"status"`
+	ClientOrderID   string         `json:"client_order_id"`
+	Market          string         `json:"market"`
 	Transactions    []struct {
-		TradeID      int64   `json:"tid"`
-		FromCurrency float64 `json:"{from_currency},string"`
-		ToCurrency   float64 `json:"{to_currency},string"`
-		Price        float64 `json:"price,string"`
-		Fee          float64 `json:"fee,string"`
-		DateTime     string  `json:"datetime"`
-		Type         int     `json:"type"`
+		TradeID      int64          `json:"tid"`
+		FromCurrency float64        `json:"{from_currency},string"`
+		ToCurrency   float64        `json:"{to_currency},string"`
+		Price        float64        `json:"price,string"`
+		Fee          float64        `json:"fee,string"`
+		DateTime     types.DateTime `json:"datetime"`
+		Type         int64          `json:"type"`
 	}
 }
 
@@ -163,16 +163,16 @@ type DepositAddress struct {
 
 // WithdrawalRequests holds request information on withdrawals
 type WithdrawalRequests struct {
-	OrderID       int64         `json:"id"`
-	Date          string        `json:"datetime"`
-	Type          int64         `json:"type"`
-	Amount        float64       `json:"amount,string"`
-	Status        int64         `json:"status"`
-	Currency      currency.Code `json:"currency"`
-	Address       string        `json:"address"`
-	TransactionID string        `json:"transaction_id"`
-	Network       string        `json:"network"`
-	TxID          int64         `json:"txid"`
+	OrderID       int64          `json:"id"`
+	Date          types.DateTime `json:"datetime"`
+	Type          int64          `json:"type"`
+	Amount        float64        `json:"amount,string"`
+	Status        int64          `json:"status"`
+	Currency      currency.Code  `json:"currency"`
+	Address       string         `json:"address"`
+	TransactionID string         `json:"transaction_id"`
+	Network       string         `json:"network"`
+	TxID          int64          `json:"txid"`
 }
 
 // CryptoWithdrawalResponse response from a crypto withdrawal request
@@ -228,16 +228,16 @@ type websocketTradeResponse struct {
 }
 
 type websocketTradeData struct {
-	Microtimestamp string  `json:"microtimestamp"`
-	Amount         float64 `json:"amount"`
-	BuyOrderID     int64   `json:"buy_order_id"`
-	SellOrderID    int64   `json:"sell_order_id"`
-	AmountStr      string  `json:"amount_str"`
-	PriceStr       string  `json:"price_str"`
-	Timestamp      int64   `json:"timestamp,string"`
-	Price          float64 `json:"price"`
-	Type           int     `json:"type"`
-	ID             int64   `json:"id"`
+	Microtimestamp string     `json:"microtimestamp"`
+	Amount         float64    `json:"amount"`
+	BuyOrderID     int64      `json:"buy_order_id"`
+	SellOrderID    int64      `json:"sell_order_id"`
+	AmountStr      string     `json:"amount_str"`
+	PriceStr       string     `json:"price_str"`
+	Timestamp      types.Time `json:"timestamp"`
+	Price          float64    `json:"price"`
+	Type           int        `json:"type"`
+	ID             int64      `json:"id"`
 }
 
 // WebsocketAuthResponse holds the auth token for subscribing to auth channels

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -158,7 +158,7 @@ func (b *Bitstamp) handleWSTrade(msg []byte) error {
 		side = order.Sell
 	}
 	return trade.AddTradesToBuffer(trade.Data{
-		Timestamp:    time.Unix(wsTradeTemp.Data.Timestamp, 0),
+		Timestamp:    wsTradeTemp.Data.Timestamp.Time(),
 		CurrencyPair: p,
 		AssetType:    asset.Spot,
 		Exchange:     b.Name,

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -264,7 +264,7 @@ func (b *Bitstamp) UpdateTicker(ctx context.Context, p currency.Pair, a asset.It
 		Volume:       tick.Volume,
 		Open:         tick.Open,
 		Pair:         fPair,
-		LastUpdated:  time.Unix(tick.Timestamp, 0),
+		LastUpdated:  tick.Timestamp.Time(),
 		ExchangeName: b.Name,
 		AssetType:    a,
 	})
@@ -386,15 +386,10 @@ func (b *Bitstamp) GetWithdrawalsHistory(ctx context.Context, c currency.Code, _
 	}
 	resp := make([]exchange.WithdrawalHistory, 0, len(withdrawals))
 	for i := range withdrawals {
-		var tm time.Time
-		tm, err = parseTime(withdrawals[i].Date)
-		if err != nil {
-			return nil, fmt.Errorf("getWithdrawalsHistory unable to parse Date field: %w", err)
-		}
 		if c.IsEmpty() || c.Equal(withdrawals[i].Currency) {
 			resp = append(resp, exchange.WithdrawalHistory{
 				Status:          strconv.FormatInt(withdrawals[i].Status, 10),
-				Timestamp:       tm,
+				Timestamp:       withdrawals[i].Date.Time(),
 				Currency:        withdrawals[i].Currency.String(),
 				Amount:          withdrawals[i].Amount,
 				TransferType:    strconv.FormatInt(withdrawals[i].Type, 10),
@@ -432,7 +427,7 @@ func (b *Bitstamp) GetRecentTrades(ctx context.Context, p currency.Pair, assetTy
 			Side:         s,
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
-			Timestamp:    time.Unix(tradeData[i].Date, 0),
+			Timestamp:    tradeData[i].Date.Time(),
 		}
 	}
 
@@ -531,10 +526,6 @@ func (b *Bitstamp) GetOrderInfo(ctx context.Context, orderID string, _ currency.
 			Amount: o.Transactions[i].ToCurrency,
 		}
 	}
-	orderDate, err := time.Parse(time.DateTime, o.DateTime)
-	if err != nil {
-		return nil, err
-	}
 	status, err := order.StringToOrderStatus(o.Status)
 	if err != nil {
 		return nil, err
@@ -542,7 +533,7 @@ func (b *Bitstamp) GetOrderInfo(ctx context.Context, orderID string, _ currency.
 	return &order.Detail{
 		RemainingAmount: o.AmountRemaining,
 		OrderID:         o.ID,
-		Date:            orderDate,
+		Date:            o.DateTime.Time(),
 		Trades:          th,
 		Status:          status,
 	}, nil
@@ -677,13 +668,6 @@ func (b *Bitstamp) GetActiveOrders(ctx context.Context, req *order.MultiOrderReq
 			orderSide = order.Sell
 		}
 
-		var tm time.Time
-		tm, err = parseTime(resp[i].DateTime)
-		if err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s GetActiveOrders unable to parse time: %s\n", b.Name, err)
-		}
-
 		var p currency.Pair
 		if currPair == "all" {
 			// Currency pairs are returned as format "currency_pair": "BTC/USD"
@@ -702,7 +686,7 @@ func (b *Bitstamp) GetActiveOrders(ctx context.Context, req *order.MultiOrderReq
 			Price:    resp[i].Price,
 			Type:     order.Limit,
 			Side:     orderSide,
-			Date:     tm,
+			Date:     resp[i].DateTime.Time(),
 			Pair:     p,
 			Exchange: b.Name,
 		}
@@ -776,16 +760,9 @@ func (b *Bitstamp) GetOrderHistory(ctx context.Context, req *order.MultiOrderReq
 				format.Delimiter)
 		}
 
-		var tm time.Time
-		tm, err = parseTime(resp[i].Date)
-		if err != nil {
-			log.Errorf(log.ExchangeSys,
-				"%s GetOrderHistory unable to parse time: %s\n", b.Name, err)
-		}
-
 		orders = append(orders, order.Detail{
 			OrderID:  strconv.FormatInt(resp[i].OrderID, 10),
-			Date:     tm,
+			Date:     resp[i].Date.Time(),
 			Exchange: b.Name,
 			Pair:     currPair,
 		})

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -617,10 +617,6 @@ func (b *BTSE) calculateTradingFee(ctx context.Context, feeBuilder *exchange.Fee
 	return feeTiers[0].TakerFee
 }
 
-func parseOrderTime(timeStr string) (time.Time, error) {
-	return time.Parse(time.DateTime, timeStr)
-}
-
 // HasLiquidity returns if a market pair has a bid or ask != 0
 func (m *MarketPair) HasLiquidity() bool {
 	return m.LowestAsk != 0 || m.HighestBid != 0

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -387,12 +387,6 @@ func TestGetFee(t *testing.T) {
 	assert.NoError(t, err, "fee builuder should not error for a fraction of a squillion")
 }
 
-func TestParseOrderTime(t *testing.T) {
-	actual, err := parseOrderTime("2018-08-20 19:20:46")
-	assert.NoError(t, err, "parseOrderTime should not error")
-	assert.EqualValues(t, 1534792846, actual.Unix(), "parseOrderTime should provide correct value")
-}
-
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, b, canManipulateRealOrders)

--- a/exchanges/btse/btse_types.go
+++ b/exchanges/btse/btse_types.go
@@ -17,9 +17,9 @@ const (
 
 // FundingHistoryData stores funding history data
 type FundingHistoryData struct {
-	Time   int64   `json:"time"`
-	Rate   float64 `json:"rate"`
-	Symbol string  `json:"symbol"`
+	Time   types.Time `json:"time"`
+	Rate   float64    `json:"rate"`
+	Symbol string     `json:"symbol"`
 }
 
 // MarketSummary response data
@@ -27,41 +27,41 @@ type MarketSummary []*MarketPair
 
 // MarketPair is a single pair in Market Summary
 type MarketPair struct {
-	Symbol              string   `json:"symbol"`
-	Last                float64  `json:"last"`
-	LowestAsk           float64  `json:"lowestAsk"`
-	HighestBid          float64  `json:"highestBid"`
-	PercentageChange    float64  `json:"percentageChange"`
-	Volume              float64  `json:"volume"`
-	High24Hr            float64  `json:"high24Hr"`
-	Low24Hr             float64  `json:"low24Hr"`
-	Base                string   `json:"base"`
-	Quote               string   `json:"quote"`
-	Active              bool     `json:"active"`
-	Size                float64  `json:"size"`
-	MinValidPrice       float64  `json:"minValidPrice"`
-	MinPriceIncrement   float64  `json:"minPriceIncrement"`
-	MinOrderSize        float64  `json:"minOrderSize"`
-	MaxOrderSize        float64  `json:"maxOrderSize"`
-	MinSizeIncrement    float64  `json:"minSizeIncrement"`
-	OpenInterest        float64  `json:"openInterest"`
-	OpenInterestUSD     float64  `json:"openInterestUSD"`
-	ContractStart       int64    `json:"contractStart"`
-	ContractEnd         int64    `json:"contractEnd"`
-	TimeBasedContract   bool     `json:"timeBasedContract"`
-	OpenTime            int64    `json:"openTime"`
-	CloseTime           int64    `json:"closeTime"`
-	StartMatching       int64    `json:"startMatching"`
-	InactiveTime        int64    `json:"inactiveTime"`
-	FundingRate         float64  `json:"fundingRate"`
-	ContractSize        float64  `json:"contractSize"`
-	MaxPosition         int64    `json:"maxPosition"`
-	MinRiskLimit        int      `json:"minRiskLimit"`
-	MaxRiskLimit        int      `json:"maxRiskLimit"`
-	AvailableSettlement []string `json:"availableSettlement"`
-	Futures             bool     `json:"futures"`
-	IsMarketOpenToSpot  bool     `json:"isMarketOpenToSpot"`
-	IsMarketOpenToOTC   bool     `json:"isMarketOpenToOtc"`
+	Symbol              string     `json:"symbol"`
+	Last                float64    `json:"last"`
+	LowestAsk           float64    `json:"lowestAsk"`
+	HighestBid          float64    `json:"highestBid"`
+	PercentageChange    float64    `json:"percentageChange"`
+	Volume              float64    `json:"volume"`
+	High24Hr            float64    `json:"high24Hr"`
+	Low24Hr             float64    `json:"low24Hr"`
+	Base                string     `json:"base"`
+	Quote               string     `json:"quote"`
+	Active              bool       `json:"active"`
+	Size                float64    `json:"size"`
+	MinValidPrice       float64    `json:"minValidPrice"`
+	MinPriceIncrement   float64    `json:"minPriceIncrement"`
+	MinOrderSize        float64    `json:"minOrderSize"`
+	MaxOrderSize        float64    `json:"maxOrderSize"`
+	MinSizeIncrement    float64    `json:"minSizeIncrement"`
+	OpenInterest        float64    `json:"openInterest"`
+	OpenInterestUSD     float64    `json:"openInterestUSD"`
+	ContractStart       int64      `json:"contractStart"`
+	ContractEnd         int64      `json:"contractEnd"`
+	TimeBasedContract   bool       `json:"timeBasedContract"`
+	OpenTime            types.Time `json:"openTime"`
+	CloseTime           types.Time `json:"closeTime"`
+	StartMatching       int64      `json:"startMatching"`
+	InactiveTime        types.Time `json:"inactiveTime"`
+	FundingRate         float64    `json:"fundingRate"`
+	ContractSize        float64    `json:"contractSize"`
+	MaxPosition         int64      `json:"maxPosition"`
+	MinRiskLimit        int        `json:"minRiskLimit"`
+	MaxRiskLimit        int        `json:"maxRiskLimit"`
+	AvailableSettlement []string   `json:"availableSettlement"`
+	Futures             bool       `json:"futures"`
+	IsMarketOpenToSpot  bool       `json:"isMarketOpenToSpot"`
+	IsMarketOpenToOTC   bool       `json:"isMarketOpenToOtc"`
 }
 
 // OHLCV holds Open, High Low, Close, Volume data for set symbol
@@ -91,48 +91,48 @@ type SpotMarket struct {
 
 // FuturesMarket stores market data
 type FuturesMarket struct {
-	Symbol              string   `json:"symbol"`
-	Last                float64  `json:"last"`
-	LowestAsk           float64  `json:"lowestAsk"`
-	HighestBid          float64  `json:"highestBid"`
-	OpenInterest        float64  `json:"openInterest"`
-	OpenInterestUSD     float64  `json:"openInterestUSD"`
-	PercentageChange    float64  `json:"percentageChange"`
-	Volume              float64  `json:"volume"`
-	High24Hr            float64  `json:"high24Hr"`
-	Low24Hr             float64  `json:"low24Hr"`
-	Base                string   `json:"base"`
-	Quote               string   `json:"quote"`
-	ContractStart       int64    `json:"contractStart"`
-	ContractEnd         int64    `json:"contractEnd"`
-	Active              bool     `json:"active"`
-	TimeBasedContract   bool     `json:"timeBasedContract"`
-	OpenTime            int64    `json:"openTime"`
-	CloseTime           int64    `json:"closeTime"`
-	StartMatching       int64    `json:"startMatching"`
-	InactiveTime        int64    `json:"inactiveTime"`
-	FundingRate         float64  `json:"fundingRate"`
-	ContractSize        float64  `json:"contractSize"`
-	MaxPosition         int64    `json:"maxPosition"`
-	MinValidPrice       float64  `json:"minValidPrice"`
-	MinPriceIncrement   float64  `json:"minPriceIncrement"`
-	MinOrderSize        int32    `json:"minOrderSize"`
-	MaxOrderSize        int32    `json:"maxOrderSize"`
-	MinRiskLimit        int32    `json:"minRiskLimit"`
-	MaxRiskLimit        int32    `json:"maxRiskLimit"`
-	MinSizeIncrement    float64  `json:"minSizeIncrement"`
-	AvailableSettlement []string `json:"availableSettlement"`
+	Symbol              string     `json:"symbol"`
+	Last                float64    `json:"last"`
+	LowestAsk           float64    `json:"lowestAsk"`
+	HighestBid          float64    `json:"highestBid"`
+	OpenInterest        float64    `json:"openInterest"`
+	OpenInterestUSD     float64    `json:"openInterestUSD"`
+	PercentageChange    float64    `json:"percentageChange"`
+	Volume              float64    `json:"volume"`
+	High24Hr            float64    `json:"high24Hr"`
+	Low24Hr             float64    `json:"low24Hr"`
+	Base                string     `json:"base"`
+	Quote               string     `json:"quote"`
+	ContractStart       int64      `json:"contractStart"`
+	ContractEnd         int64      `json:"contractEnd"`
+	Active              bool       `json:"active"`
+	TimeBasedContract   bool       `json:"timeBasedContract"`
+	OpenTime            types.Time `json:"openTime"`
+	CloseTime           types.Time `json:"closeTime"`
+	StartMatching       types.Time `json:"startMatching"`
+	InactiveTime        types.Time `json:"inactiveTime"`
+	FundingRate         float64    `json:"fundingRate"`
+	ContractSize        float64    `json:"contractSize"`
+	MaxPosition         int64      `json:"maxPosition"`
+	MinValidPrice       float64    `json:"minValidPrice"`
+	MinPriceIncrement   float64    `json:"minPriceIncrement"`
+	MinOrderSize        int32      `json:"minOrderSize"`
+	MaxOrderSize        int32      `json:"maxOrderSize"`
+	MinRiskLimit        int32      `json:"minRiskLimit"`
+	MaxRiskLimit        int32      `json:"maxRiskLimit"`
+	MinSizeIncrement    float64    `json:"minSizeIncrement"`
+	AvailableSettlement []string   `json:"availableSettlement"`
 }
 
 // Trade stores trade data
 type Trade struct {
-	SerialID int64   `json:"serialId"`
-	Symbol   string  `json:"symbol"`
-	Price    float64 `json:"price"`
-	Amount   float64 `json:"size"`
-	Time     int64   `json:"timestamp"`
-	Side     string  `json:"side"`
-	Type     string  `json:"type"`
+	SerialID int64      `json:"serialId"`
+	Symbol   string     `json:"symbol"`
+	Price    float64    `json:"price"`
+	Amount   float64    `json:"size"`
+	Time     types.Time `json:"timestamp"`
+	Side     string     `json:"side"`
+	Type     string     `json:"type"`
 }
 
 // QuoteData stores quote data
@@ -146,17 +146,17 @@ type Orderbook struct {
 	BuyQuote  []QuoteData `json:"buyQuote"`
 	SellQuote []QuoteData `json:"sellQuote"`
 	Symbol    string      `json:"symbol"`
-	Timestamp int64       `json:"timestamp"`
+	Timestamp types.Time  `json:"timestamp"`
 }
 
 // Ticker stores the ticker data
 type Ticker struct {
-	Price  float64 `json:"price,string"`
-	Size   float64 `json:"size,string"`
-	Bid    float64 `json:"bid,string"`
-	Ask    float64 `json:"ask,string"`
-	Volume float64 `json:"volume,string"`
-	Time   string  `json:"time"`
+	Price  float64    `json:"price,string"`
+	Size   float64    `json:"size,string"`
+	Bid    float64    `json:"bid,string"`
+	Ask    float64    `json:"ask,string"`
+	Volume float64    `json:"volume,string"`
+	Time   types.Time `json:"time"`
 }
 
 // MarketStatistics stores market statistics for a particular product
@@ -191,42 +191,42 @@ type AccountFees struct {
 
 // TradeHistory stores user trades for exchange
 type TradeHistory []struct {
-	Base         string  `json:"base"`
-	ClOrderID    string  `json:"clOrderID"`
-	FeeAmount    float64 `json:"feeAmount"`
-	FeeCurrency  string  `json:"feeCurrency"`
-	FilledPrice  float64 `json:"filledPrice"`
-	FilledSize   float64 `json:"filledSize"`
-	OrderID      string  `json:"orderId"`
-	OrderType    int     `json:"orderType"`
-	Price        float64 `json:"price"`
-	Quote        string  `json:"quote"`
-	RealizedPnl  float64 `json:"realizedPnl"`
-	SerialID     int64   `json:"serialId"`
-	Side         string  `json:"side"`
-	Size         float64 `json:"size"`
-	Symbol       string  `json:"symbol"`
-	Timestamp    string  `json:"timestamp"`
-	Total        float64 `json:"total"`
-	TradeID      string  `json:"tradeId"`
-	TriggerPrice float64 `json:"triggerPrice"`
-	TriggerType  int     `json:"triggerType"`
-	Username     string  `json:"username"`
-	Wallet       string  `json:"wallet"`
+	Base         string     `json:"base"`
+	ClOrderID    string     `json:"clOrderID"`
+	FeeAmount    float64    `json:"feeAmount"`
+	FeeCurrency  string     `json:"feeCurrency"`
+	FilledPrice  float64    `json:"filledPrice"`
+	FilledSize   float64    `json:"filledSize"`
+	OrderID      string     `json:"orderId"`
+	OrderType    int        `json:"orderType"`
+	Price        float64    `json:"price"`
+	Quote        string     `json:"quote"`
+	RealizedPnl  float64    `json:"realizedPnl"`
+	SerialID     int64      `json:"serialId"`
+	Side         string     `json:"side"`
+	Size         float64    `json:"size"`
+	Symbol       string     `json:"symbol"`
+	Timestamp    types.Time `json:"timestamp"`
+	Total        float64    `json:"total"`
+	TradeID      string     `json:"tradeId"`
+	TriggerPrice float64    `json:"triggerPrice"`
+	TriggerType  int        `json:"triggerType"`
+	Username     string     `json:"username"`
+	Wallet       string     `json:"wallet"`
 }
 
 // WalletHistory stores account funding history
 type WalletHistory []struct {
-	Amount      float64 `json:"amount"`
-	Currency    string  `json:"currency"`
-	Description string  `json:"description"`
-	Fees        float64 `json:"fees"`
-	OrderID     string  `json:"orderId"`
-	Status      string  `json:"status"`
-	Timestamp   int64   `json:"timestamp"`
-	Type        string  `json:"type"`
-	Username    string  `json:"username"`
-	Wallet      string  `json:"wallet"`
+	Amount      float64    `json:"amount"`
+	Currency    string     `json:"currency"`
+	Description string     `json:"description"`
+	Fees        float64    `json:"fees"`
+	OrderID     string     `json:"orderId"`
+	Status      string     `json:"status"`
+	Timestamp   types.Time `json:"timestamp"`
+	Type        string     `json:"type"`
+	Username    string     `json:"username"`
+	Wallet      string     `json:"wallet"`
 }
 
 // WalletAddress stores address for crypto deposit's
@@ -242,31 +242,31 @@ type WithdrawalResponse struct {
 
 // OpenOrder stores an open order info
 type OpenOrder struct {
-	AverageFillPrice             float64 `json:"averageFillPrice"`
-	CancelDuration               int64   `json:"cancelDuration"`
-	ClOrderID                    string  `json:"clOrderID"`
-	FillSize                     float64 `json:"fillSize"`
-	FilledSize                   float64 `json:"filledSize"`
-	OrderID                      string  `json:"orderID"`
-	OrderState                   string  `json:"orderState"`
-	OrderType                    int     `json:"orderType"`
-	OrderValue                   float64 `json:"orderValue"`
-	PegPriceDeviation            float64 `json:"pegPriceDeviation"`
-	PegPriceMax                  float64 `json:"pegPriceMax"`
-	PegPriceMin                  float64 `json:"pegPriceMin"`
-	Price                        float64 `json:"price"`
-	Side                         string  `json:"side"`
-	Size                         float64 `json:"size"`
-	Symbol                       string  `json:"symbol"`
-	Timestamp                    int64   `json:"timestamp"`
-	TrailValue                   float64 `json:"trailValue"`
-	TriggerOrder                 bool    `json:"triggerOrder"`
-	TriggerOrderType             int     `json:"triggerOrderType"`
-	TriggerOriginalPrice         float64 `json:"triggerOriginalPrice"`
-	TriggerPrice                 float64 `json:"triggerPrice"`
-	TriggerStopPrice             float64 `json:"triggerStopPrice"`
-	TriggerTrailingStopDeviation float64 `json:"triggerTrailingStopDeviation"`
-	Triggered                    bool    `json:"triggered"`
+	AverageFillPrice             float64    `json:"averageFillPrice"`
+	CancelDuration               int64      `json:"cancelDuration"`
+	ClOrderID                    string     `json:"clOrderID"`
+	FillSize                     float64    `json:"fillSize"`
+	FilledSize                   float64    `json:"filledSize"`
+	OrderID                      string     `json:"orderID"`
+	OrderState                   string     `json:"orderState"`
+	OrderType                    int        `json:"orderType"`
+	OrderValue                   float64    `json:"orderValue"`
+	PegPriceDeviation            float64    `json:"pegPriceDeviation"`
+	PegPriceMax                  float64    `json:"pegPriceMax"`
+	PegPriceMin                  float64    `json:"pegPriceMin"`
+	Price                        float64    `json:"price"`
+	Side                         string     `json:"side"`
+	Size                         float64    `json:"size"`
+	Symbol                       string     `json:"symbol"`
+	Timestamp                    types.Time `json:"timestamp"`
+	TrailValue                   float64    `json:"trailValue"`
+	TriggerOrder                 bool       `json:"triggerOrder"`
+	TriggerOrderType             int        `json:"triggerOrderType"`
+	TriggerOriginalPrice         float64    `json:"triggerOriginalPrice"`
+	TriggerPrice                 float64    `json:"triggerPrice"`
+	TriggerStopPrice             float64    `json:"triggerStopPrice"`
+	TriggerTrailingStopDeviation float64    `json:"triggerTrailingStopDeviation"`
+	Triggered                    bool       `json:"triggered"`
 }
 
 // CancelOrder stores slice of orders
@@ -274,23 +274,23 @@ type CancelOrder []Order
 
 // Order stores information for a single order
 type Order struct {
-	AverageFillPrice float64 `json:"averageFillPrice"`
-	ClOrderID        string  `json:"clOrderID"`
-	Deviation        float64 `json:"deviation"`
-	FillSize         float64 `json:"fillSize"`
-	Message          string  `json:"message"`
-	OrderID          string  `json:"orderID"`
-	OrderType        int     `json:"orderType"`
-	Price            float64 `json:"price"`
-	Side             string  `json:"side"`
-	Size             float64 `json:"size"`
-	Status           int     `json:"status"`
-	Stealth          float64 `json:"stealth"`
-	StopPrice        float64 `json:"stopPrice"`
-	Symbol           string  `json:"symbol"`
-	Timestamp        int64   `json:"timestamp"`
-	Trigger          bool    `json:"trigger"`
-	TriggerPrice     float64 `json:"triggerPrice"`
+	AverageFillPrice float64    `json:"averageFillPrice"`
+	ClOrderID        string     `json:"clOrderID"`
+	Deviation        float64    `json:"deviation"`
+	FillSize         float64    `json:"fillSize"`
+	Message          string     `json:"message"`
+	OrderID          string     `json:"orderID"`
+	OrderType        int        `json:"orderType"`
+	Price            float64    `json:"price"`
+	Side             string     `json:"side"`
+	Size             float64    `json:"size"`
+	Status           int        `json:"status"`
+	Stealth          float64    `json:"stealth"`
+	StopPrice        float64    `json:"stopPrice"`
+	Symbol           string     `json:"symbol"`
+	Timestamp        types.Time `json:"timestamp"`
+	Trigger          bool       `json:"trigger"`
+	TriggerPrice     float64    `json:"triggerPrice"`
 }
 
 type wsSub struct {
@@ -335,18 +335,18 @@ type wsNotification struct {
 }
 
 type wsOrderUpdate struct {
-	OrderID           string  `json:"orderID"`
-	OrderMode         string  `json:"orderMode"`
-	OrderType         string  `json:"orderType"`
-	PegPriceDeviation string  `json:"pegPriceDeviation"`
-	Price             float64 `json:"price,string"`
-	Size              float64 `json:"size,string"`
-	Status            string  `json:"status"`
-	Stealth           string  `json:"stealth"`
-	Symbol            string  `json:"symbol"`
-	Timestamp         int64   `json:"timestamp,string"`
-	TriggerPrice      float64 `json:"triggerPrice,string"`
-	Type              string  `json:"type"`
+	OrderID           string     `json:"orderID"`
+	OrderMode         string     `json:"orderMode"`
+	OrderType         string     `json:"orderType"`
+	PegPriceDeviation string     `json:"pegPriceDeviation"`
+	Price             float64    `json:"price,string"`
+	Size              float64    `json:"size,string"`
+	Status            string     `json:"status"`
+	Stealth           string     `json:"stealth"`
+	Symbol            string     `json:"symbol"`
+	Timestamp         types.Time `json:"timestamp"`
+	TriggerPrice      float64    `json:"triggerPrice,string"`
+	Type              string     `json:"type"`
 }
 
 // ErrorResponse contains errors received from API

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -234,7 +234,7 @@ func (b *BTSE) wsHandleData(_ context.Context, respRaw []byte) error {
 				Side:         oSide,
 				Status:       oStatus,
 				AssetType:    a,
-				Date:         time.UnixMilli(notification.Data[i].Timestamp),
+				Date:         notification.Data[i].Timestamp.Time(),
 				Pair:         p,
 			}
 		}

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -420,9 +420,7 @@ func (b *BTSE) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 
 	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		tradeTimestamp := time.UnixMilli(tradeData[i].Time)
-		var side order.Side
-		side, err = order.StringToOrderSide(tradeData[i].Side)
+		side, err := order.StringToOrderSide(tradeData[i].Side)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +432,7 @@ func (b *BTSE) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 			Side:         side,
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
-			Timestamp:    tradeTimestamp,
+			Timestamp:    tradeData[i].Time.Time(),
 		}
 	}
 	err = b.AddTradesToBuffer(resp...)
@@ -594,7 +592,7 @@ func (b *BTSE) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pair
 		od.Exchange = b.Name
 		od.Amount = o[i].Size
 		od.OrderID = o[i].OrderID
-		od.Date = time.Unix(o[i].Timestamp, 0)
+		od.Date = o[i].Timestamp.Time()
 		od.Side = side
 
 		od.Type = orderIntToType(o[i].OrderType)
@@ -615,18 +613,13 @@ func (b *BTSE) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pair
 		}
 
 		for i := range th {
-			createdAt, err := parseOrderTime(th[i].TradeID)
-			if err != nil {
-				log.Errorf(log.ExchangeSys,
-					"%s GetOrderInfo unable to parse time: %s\n", b.Name, err)
-			}
 			var orderSide order.Side
 			orderSide, err = order.StringToOrderSide(th[i].Side)
 			if err != nil {
 				return nil, err
 			}
 			od.Trades = append(od.Trades, order.TradeHistory{
-				Timestamp: createdAt,
+				Timestamp: th[i].Timestamp.Time(),
 				TID:       th[i].TradeID,
 				Price:     th[i].Price,
 				Amount:    th[i].Size,
@@ -762,7 +755,7 @@ func (b *BTSE) GetActiveOrders(ctx context.Context, req *order.MultiOrderRequest
 				ExecutedAmount:  resp[i].FilledSize,
 				RemainingAmount: resp[i].Size - resp[i].FilledSize,
 				OrderID:         resp[i].OrderID,
-				Date:            time.Unix(resp[i].Timestamp, 0),
+				Date:            resp[i].Timestamp.Time(),
 				Side:            side,
 				Price:           resp[i].Price,
 				Status:          status,
@@ -784,20 +777,13 @@ func (b *BTSE) GetActiveOrders(ctx context.Context, req *order.MultiOrderRequest
 			}
 
 			for i := range fills {
-				createdAt, err := parseOrderTime(fills[i].Timestamp)
-				if err != nil {
-					log.Errorf(log.ExchangeSys,
-						"%s GetActiveOrders unable to parse time: %s\n",
-						b.Name,
-						err)
-				}
 				var orderSide order.Side
 				orderSide, err = order.StringToOrderSide(fills[i].Side)
 				if err != nil {
 					return nil, err
 				}
 				openOrder.Trades = append(openOrder.Trades, order.TradeHistory{
-					Timestamp: createdAt,
+					Timestamp: fills[i].Timestamp.Time(),
 					TID:       fills[i].TradeID,
 					Price:     fills[i].Price,
 					Amount:    fills[i].Size,
@@ -858,7 +844,6 @@ func (b *BTSE) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mult
 			if err != nil {
 				return nil, err
 			}
-			orderTime := time.UnixMilli(currentOrder[y].Timestamp)
 			tempOrder := order.Detail{
 				OrderID:              currentOrder[y].OrderID,
 				ClientID:             currentOrder[y].ClOrderID,
@@ -868,7 +853,7 @@ func (b *BTSE) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mult
 				Amount:               currentOrder[y].Size,
 				ExecutedAmount:       currentOrder[y].FilledSize,
 				RemainingAmount:      currentOrder[y].Size - currentOrder[y].FilledSize,
-				Date:                 orderTime,
+				Date:                 currentOrder[y].Timestamp.Time(),
 				Side:                 orderSide,
 				Status:               orderStatus,
 				Pair:                 orderDeref.Pairs[x],
@@ -1113,11 +1098,11 @@ func (b *BTSE) GetFuturesContractDetails(ctx context.Context, item asset.Item) (
 		settlementCurrencies := make(currency.Currencies, len(marketSummary[i].AvailableSettlement))
 		var s, e time.Time
 		var ct futures.ContractType
-		if marketSummary[i].OpenTime > 0 {
-			s = time.UnixMilli(marketSummary[i].OpenTime)
+		if !marketSummary[i].OpenTime.Time().IsZero() {
+			s = marketSummary[i].OpenTime.Time()
 		}
-		if marketSummary[i].CloseTime > 0 {
-			e = time.UnixMilli(marketSummary[i].CloseTime)
+		if !marketSummary[i].CloseTime.Time().IsZero() {
+			e = marketSummary[i].CloseTime.Time()
 		}
 		if marketSummary[i].TimeBasedContract {
 			if e.Sub(s) > kline.OneMonth.Duration() {

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -153,48 +153,7 @@ func (by *Bybit) GetKlines(ctx context.Context, category, symbol string, interva
 	if err != nil {
 		return nil, err
 	}
-	return processKlineResponse(resp.List)
-}
-
-func processKlineResponse(in [][]string) ([]KlineItem, error) {
-	klines := make([]KlineItem, len(in))
-	for x := range in {
-		if len(in[x]) < 5 {
-			return nil, errors.New("invalid kline data")
-		}
-		startTimestamp, err := strconv.ParseInt(in[x][0], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		klines[x] = KlineItem{StartTime: time.UnixMilli(startTimestamp)}
-		klines[x].Open, err = strconv.ParseFloat(in[x][1], 64)
-		if err != nil {
-			return nil, err
-		}
-		klines[x].High, err = strconv.ParseFloat(in[x][2], 64)
-		if err != nil {
-			return nil, err
-		}
-		klines[x].Low, err = strconv.ParseFloat(in[x][3], 64)
-		if err != nil {
-			return nil, err
-		}
-		klines[x].Close, err = strconv.ParseFloat(in[x][4], 64)
-		if err != nil {
-			return nil, err
-		}
-		if len(in[x]) == 7 {
-			klines[x].TradeVolume, err = strconv.ParseFloat(in[x][5], 64)
-			if err != nil {
-				return nil, err
-			}
-			klines[x].Turnover, err = strconv.ParseFloat(in[x][6], 64)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return klines, nil
+	return resp.List, nil
 }
 
 // GetInstrumentInfo retrieves the list of instrument details given the category and symbol.
@@ -244,7 +203,7 @@ func (by *Bybit) GetMarkPriceKline(ctx context.Context, category, symbol string,
 	if err != nil {
 		return nil, err
 	}
-	return processKlineResponse(resp.List)
+	return resp.List, nil
 }
 
 // GetIndexPriceKline query for historical index price klines. Charts are returned in groups based on the requested interval.
@@ -272,7 +231,7 @@ func (by *Bybit) GetIndexPriceKline(ctx context.Context, category, symbol string
 	if err != nil {
 		return nil, err
 	}
-	return processKlineResponse(resp.List)
+	return resp.List, nil
 }
 
 // GetOrderBook retrieves for orderbook depth data.

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -75,25 +75,46 @@ func TestGetKlines(t *testing.T) {
 		s = time.Unix(1691897100, 0).Round(kline.FiveMin.Duration())
 		e = time.Unix(1691907100, 0).Round(kline.FiveMin.Duration())
 	}
-	_, err := b.GetKlines(t.Context(), "spot", spotTradablePair.String(), kline.FiveMin, s, e, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = b.GetKlines(t.Context(), "linear", usdtMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = b.GetKlines(t.Context(), "linear", usdcMarginedTradablePair.String(), kline.FiveMin, s, e, 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = b.GetKlines(t.Context(), "inverse", inverseTradablePair.String(), kline.FiveMin, s, e, 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = b.GetKlines(t.Context(), "option", optionsTradablePair.String(), kline.FiveMin, s, e, 5)
-	if err == nil {
-		t.Fatalf("expected 'params error: Category is invalid', but found nil")
+	for _, tc := range []struct {
+		category   string
+		pair       currency.Pair
+		reqLimit   uint64
+		expRespLen int
+		expError   error
+	}{
+		{"spot", spotTradablePair, 100, 34, nil}, // TODO: Update expected limit when mock data is updated
+		{"linear", usdtMarginedTradablePair, 5, 5, nil},
+		{"linear", usdcMarginedTradablePair, 5, 5, nil},
+		{"inverse", inverseTradablePair, 5, 5, nil},
+		{"option", optionsTradablePair, 5, 5, errInvalidCategory},
+	} {
+		t.Run(fmt.Sprintf("%s-%s", tc.category, tc.pair), func(t *testing.T) {
+			t.Parallel()
+			r, err := b.GetKlines(t.Context(), tc.category, tc.pair.String(), kline.FiveMin, s, e, tc.reqLimit)
+			if tc.expError != nil {
+				require.ErrorIs(t, err, tc.expError)
+				return
+			}
+			require.NoErrorf(t, err, "GetKlines for category %s and pair %s must not error", tc.category, tc.pair)
+			if mockTests {
+				require.Equalf(t, tc.expRespLen, len(r), "GetKlines for category %s and pair %s should return %d items", tc.category, tc.pair, tc.expRespLen)
+
+				switch tc.category {
+				case "spot":
+					assert.Equal(t, KlineItem{StartTime: types.Time(e), Open: 29393.99, High: 29399.76, Low: 29393.98, Close: 29399.76, TradeVolume: 1.168988, Turnover: 34363.5346739}, r[0])
+				case "linear":
+					if tc.pair == usdtMarginedTradablePair {
+						assert.Equal(t, KlineItem{StartTime: types.Time(e), Open: 0.0003, High: 0.0003, Low: 0.0002995, Close: 0.0003, TradeVolume: 55102100, Turnover: 16506.2427}, r[0])
+						return
+					}
+					assert.Equal(t, KlineItem{StartTime: types.Time(e), Open: 239.7, High: 239.7, Low: 239.7, Close: 239.7}, r[0])
+				case "inverse":
+					assert.Equal(t, KlineItem{StartTime: types.Time(e), Open: 0.2908, High: 0.2912, Low: 0.2908, Close: 0.2912, TradeVolume: 5131, Turnover: 17626.40000346}, r[0])
+				}
+			} else {
+				assert.NotEmptyf(t, r, "GetKlines for category %s and pair %s should return a non-empty list", tc.category, tc.pair)
+			}
+		})
 	}
 }
 

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -95,9 +95,9 @@ func TestGetKlines(t *testing.T) {
 				require.ErrorIs(t, err, tc.expError)
 				return
 			}
-			require.NoErrorf(t, err, "GetKlines for category %s and pair %s must not error", tc.category, tc.pair)
+			require.NoError(t, err)
 			if mockTests {
-				require.Equalf(t, tc.expRespLen, len(r), "GetKlines for category %s and pair %s must return %d items", tc.category, tc.pair, tc.expRespLen)
+				require.Equal(t, tc.expRespLen, len(r))
 
 				switch tc.category {
 				case "spot":
@@ -112,7 +112,7 @@ func TestGetKlines(t *testing.T) {
 					assert.Equal(t, KlineItem{StartTime: types.Time(e), Open: 0.2908, High: 0.2912, Low: 0.2908, Close: 0.2912, TradeVolume: 5131, Turnover: 17626.40000346}, r[0])
 				}
 			} else {
-				assert.NotEmptyf(t, r, "GetKlines for category %s and pair %s should return a non-empty list", tc.category, tc.pair)
+				assert.NotEmpty(t, r)
 			}
 		})
 	}

--- a/exchanges/bybit/bybit_test.go
+++ b/exchanges/bybit/bybit_test.go
@@ -97,7 +97,7 @@ func TestGetKlines(t *testing.T) {
 			}
 			require.NoErrorf(t, err, "GetKlines for category %s and pair %s must not error", tc.category, tc.pair)
 			if mockTests {
-				require.Equalf(t, tc.expRespLen, len(r), "GetKlines for category %s and pair %s should return %d items", tc.category, tc.pair, tc.expRespLen)
+				require.Equalf(t, tc.expRespLen, len(r), "GetKlines for category %s and pair %s must return %d items", tc.category, tc.pair, tc.expRespLen)
 
 				switch tc.category {
 				case "spot":

--- a/exchanges/bybit/bybit_types.go
+++ b/exchanges/bybit/bybit_types.go
@@ -1,7 +1,6 @@
 package bybit
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -137,19 +136,7 @@ type KlineItem struct {
 
 // UnmarshalJSON implements the json.Unmarshaler interface for KlineItem
 func (k *KlineItem) UnmarshalJSON(data []byte) error {
-	var rawData []json.RawMessage
-	if err := json.Unmarshal(data, &rawData); err != nil {
-		return err
-	}
-
-	switch len(rawData) {
-	case 5:
-		return json.Unmarshal(data, &[5]any{&k.StartTime, &k.Open, &k.High, &k.Low, &k.Close})
-	case 7:
-		return json.Unmarshal(data, &[7]any{&k.StartTime, &k.Open, &k.High, &k.Low, &k.Close, &k.TradeVolume, &k.Turnover})
-	default:
-		return fmt.Errorf("unexpected kline data length: %d", len(rawData))
-	}
+	return json.Unmarshal(data, &[7]any{&k.StartTime, &k.Open, &k.High, &k.Low, &k.Close, &k.TradeVolume, &k.Turnover})
 }
 
 // MarkPriceKlineResponse represents a kline data item.

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -1420,12 +1420,12 @@ func (by *Bybit) GetHistoricCandles(ctx context.Context, pair currency.Pair, a a
 		timeSeries = make([]kline.Candle, len(candles))
 		for x := range candles {
 			timeSeries[x] = kline.Candle{
-				Time:   candles[x].StartTime,
-				Open:   candles[x].Open,
-				High:   candles[x].High,
-				Low:    candles[x].Low,
-				Close:  candles[x].Close,
-				Volume: candles[x].TradeVolume,
+				Time:   candles[x].StartTime.Time(),
+				Open:   candles[x].Open.Float64(),
+				High:   candles[x].High.Float64(),
+				Low:    candles[x].Low.Float64(),
+				Close:  candles[x].Close.Float64(),
+				Volume: candles[x].TradeVolume.Float64(),
 			}
 		}
 		return req.ProcessResponse(timeSeries)
@@ -1461,12 +1461,12 @@ func (by *Bybit) GetHistoricCandlesExtended(ctx context.Context, pair currency.P
 
 			for i := range klineItems {
 				timeSeries = append(timeSeries, kline.Candle{
-					Time:   klineItems[i].StartTime,
-					Open:   klineItems[i].Open,
-					High:   klineItems[i].High,
-					Low:    klineItems[i].Low,
-					Close:  klineItems[i].Close,
-					Volume: klineItems[i].TradeVolume,
+					Time:   klineItems[i].StartTime.Time(),
+					Open:   klineItems[i].Open.Float64(),
+					High:   klineItems[i].High.Float64(),
+					Low:    klineItems[i].Low.Float64(),
+					Close:  klineItems[i].Close.Float64(),
+					Volume: klineItems[i].TradeVolume.Float64(),
 				})
 			}
 		}

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -1001,20 +1000,6 @@ func TestStatusToStandardStatus(t *testing.T) {
 		if result != testCases[i].Result {
 			t.Errorf("Expected: %v, received: %v", testCases[i].Result, result)
 		}
-	}
-}
-
-func TestParseTime(t *testing.T) {
-	// Rest examples use 2014-11-07T22:19:28.578544Z" and can be safely
-	// unmarhsalled into time.Time
-
-	// All events except for activate use the above, in the below test
-	// we'll use their API docs example
-	r := convert.TimeFromUnixTimestampDecimal(1483736448.299000).UTC()
-	if r.Year() != 2017 ||
-		r.Month().String() != "January" ||
-		r.Day() != 6 {
-		t.Error("unexpected result")
 	}
 }
 

--- a/exchanges/coinbasepro/coinbasepro_types.go
+++ b/exchanges/coinbasepro/coinbasepro_types.go
@@ -386,41 +386,41 @@ type WsChannel struct {
 
 // wsOrderReceived holds websocket received values
 type wsOrderReceived struct {
-	Type          string    `json:"type"`
-	OrderID       string    `json:"order_id"`
-	OrderType     string    `json:"order_type"`
-	Size          float64   `json:"size,string"`
-	Price         float64   `json:"price,omitempty,string"`
-	Funds         float64   `json:"funds,omitempty,string"`
-	Side          string    `json:"side"`
-	ClientOID     string    `json:"client_oid"`
-	ProductID     string    `json:"product_id"`
-	Sequence      int64     `json:"sequence"`
-	Time          time.Time `json:"time"`
-	RemainingSize float64   `json:"remaining_size,string"`
-	NewSize       float64   `json:"new_size,string"`
-	OldSize       float64   `json:"old_size,string"`
-	Reason        string    `json:"reason"`
-	Timestamp     float64   `json:"timestamp,string"`
-	UserID        string    `json:"user_id"`
-	ProfileID     string    `json:"profile_id"`
-	StopType      string    `json:"stop_type"`
-	StopPrice     float64   `json:"stop_price,string"`
-	TakerFeeRate  float64   `json:"taker_fee_rate,string"`
-	Private       bool      `json:"private"`
-	TradeID       int64     `json:"trade_id"`
-	MakerOrderID  string    `json:"maker_order_id"`
-	TakerOrderID  string    `json:"taker_order_id"`
-	TakerUserID   string    `json:"taker_user_id"`
+	Type          string     `json:"type"`
+	OrderID       string     `json:"order_id"`
+	OrderType     string     `json:"order_type"`
+	Size          float64    `json:"size,string"`
+	Price         float64    `json:"price,omitempty,string"`
+	Funds         float64    `json:"funds,omitempty,string"`
+	Side          string     `json:"side"`
+	ClientOID     string     `json:"client_oid"`
+	ProductID     string     `json:"product_id"`
+	Sequence      int64      `json:"sequence"`
+	Time          time.Time  `json:"time"`
+	RemainingSize float64    `json:"remaining_size,string"`
+	NewSize       float64    `json:"new_size,string"`
+	OldSize       float64    `json:"old_size,string"`
+	Reason        string     `json:"reason"`
+	Timestamp     types.Time `json:"timestamp"`
+	UserID        string     `json:"user_id"`
+	ProfileID     string     `json:"profile_id"`
+	StopType      string     `json:"stop_type"`
+	StopPrice     float64    `json:"stop_price,string"`
+	TakerFeeRate  float64    `json:"taker_fee_rate,string"`
+	Private       bool       `json:"private"`
+	TradeID       int64      `json:"trade_id"`
+	MakerOrderID  string     `json:"maker_order_id"`
+	TakerOrderID  string     `json:"taker_order_id"`
+	TakerUserID   string     `json:"taker_user_id"`
 }
 
 // WebsocketHeartBeat defines JSON response for a heart beat message
 type WebsocketHeartBeat struct {
-	Type        string `json:"type"`
-	Sequence    int64  `json:"sequence"`
-	LastTradeID int64  `json:"last_trade_id"`
-	ProductID   string `json:"product_id"`
-	Time        string `json:"time"`
+	Type        string    `json:"type"`
+	Sequence    int64     `json:"sequence"`
+	LastTradeID int64     `json:"last_trade_id"`
+	ProductID   string    `json:"product_id"`
+	Time        time.Time `json:"time"`
 }
 
 // WebsocketTicker defines ticker websocket response

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	gws "github.com/gorilla/websocket"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -163,7 +162,7 @@ func (c *CoinbasePro) wsHandleData(ctx context.Context, respRaw []byte) error {
 		}
 		ts := wsOrder.Time
 		if wsOrder.Type == "activate" {
-			ts = convert.TimeFromUnixTimestampDecimal(wsOrder.Timestamp)
+			ts = wsOrder.Timestamp.Time()
 		}
 
 		creds, err := c.GetCredentials(ctx)

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -170,7 +170,6 @@ func (c *CoinbasePro) Setup(exch *config.Exchange) error {
 		},
 	})
 	if err != nil {
-		fmt.Println("COINBASE ISSUE")
 		return err
 	}
 

--- a/exchanges/coinut/coinut_types.go
+++ b/exchanges/coinut/coinut_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // GenericResponse is the generic response you will get from coinut
@@ -30,22 +31,22 @@ type Instruments struct {
 
 // Ticker holds ticker information
 type Ticker struct {
-	High24                float64 `json:"high24,string"`
-	HighestBuy            float64 `json:"highest_buy,string"`
-	InstrumentID          int     `json:"inst_id"`
-	Last                  float64 `json:"last,string"`
-	Low24                 float64 `json:"low24,string"`
-	LowestSell            float64 `json:"lowest_sell,string"`
-	PreviousTransactionID int64   `json:"prev_trans_id"`
-	PriceChange24         float64 `json:"price_change_24,string"`
-	Reply                 string  `json:"reply"`
-	OpenInterest          float64 `json:"open_interest,string"`
-	Timestamp             int64   `json:"timestamp"`
-	TransactionID         int64   `json:"trans_id"`
-	Volume                float64 `json:"volume,string"`
-	Volume24              float64 `json:"volume24,string"`
-	Volume24Quote         float64 `json:"volume24_quote,string"`
-	VolumeQuote           float64 `json:"volume_quote,string"`
+	High24                float64    `json:"high24,string"`
+	HighestBuy            float64    `json:"highest_buy,string"`
+	InstrumentID          int        `json:"inst_id"`
+	Last                  float64    `json:"last,string"`
+	Low24                 float64    `json:"low24,string"`
+	LowestSell            float64    `json:"lowest_sell,string"`
+	PreviousTransactionID int64      `json:"prev_trans_id"`
+	PriceChange24         float64    `json:"price_change_24,string"`
+	Reply                 string     `json:"reply"`
+	OpenInterest          float64    `json:"open_interest,string"`
+	Timestamp             types.Time `json:"timestamp"`
+	TransactionID         int64      `json:"trans_id"`
+	Volume                float64    `json:"volume,string"`
+	Volume24              float64    `json:"volume24,string"`
+	Volume24Quote         float64    `json:"volume24_quote,string"`
+	VolumeQuote           float64    `json:"volume_quote,string"`
 }
 
 // OrderbookBase is a sub-type holding price and quantity
@@ -67,11 +68,11 @@ type Orderbook struct {
 
 // TradeBase is a sub-type holding information on trades
 type TradeBase struct {
-	Price         float64 `json:"price,string"`
-	Quantity      float64 `json:"qty,string"`
-	Side          string  `json:"side"`
-	Timestamp     int64   `json:"timestamp"`
-	TransactionID int64   `json:"trans_id"`
+	Price         float64    `json:"price,string"`
+	Quantity      float64    `json:"qty,string"`
+	Side          string     `json:"side"`
+	Timestamp     types.Time `json:"timestamp"`
+	TransactionID int64      `json:"trans_id"`
 }
 
 // Trades holds the full amount of trades associated with API keys
@@ -112,15 +113,15 @@ type Order struct {
 
 // OrderResponse is a response for orders
 type OrderResponse struct {
-	OrderID       int64   `json:"order_id"`
-	OpenQuantity  float64 `json:"open_qty,string"`
-	Price         float64 `json:"price,string"`
-	Quantity      float64 `json:"qty,string"`
-	InstrumentID  int64   `json:"inst_id"`
-	ClientOrderID int64   `json:"client_ord_id"`
-	Timestamp     int64   `json:"timestamp"`
-	OrderPrice    float64 `json:"order_price,string"`
-	Side          string  `json:"side"`
+	OrderID       int64      `json:"order_id"`
+	OpenQuantity  float64    `json:"open_qty,string"`
+	Price         float64    `json:"price,string"`
+	Quantity      float64    `json:"qty,string"`
+	InstrumentID  int64      `json:"inst_id"`
+	ClientOrderID int64      `json:"client_ord_id"`
+	Timestamp     types.Time `json:"timestamp"`
+	OrderPrice    float64    `json:"order_price,string"`
+	Side          string     `json:"side"`
 }
 
 // Commission holds trade commission structure
@@ -203,9 +204,9 @@ type Option struct {
 
 // OptionChainResponse is the response type for options
 type OptionChainResponse struct {
-	ExpiryTime   int64  `json:"expiry_time"`
-	SecurityType string `json:"sec_type"`
-	Asset        string `json:"asset"`
+	ExpiryTime   types.Time `json:"expiry_time"`
+	SecurityType string     `json:"sec_type"`
+	Asset        string     `json:"asset"`
 	Entries      []struct {
 		Call   Option  `json:"call"`
 		Put    Option  `json:"put"`
@@ -217,10 +218,10 @@ type OptionChainResponse struct {
 type OptionChainUpdate struct {
 	Option
 	GenericResponse
-	Asset        string  `json:"asset"`
-	ExpiryTime   int64   `json:"expiry_time"`
-	SecurityType string  `json:"sec_type"`
-	Volume       float64 `json:"volume,string"`
+	Asset        string     `json:"asset"`
+	ExpiryTime   types.Time `json:"expiry_time"`
+	SecurityType string     `json:"sec_type"`
+	Volume       float64    `json:"volume,string"`
 }
 
 // PositionHistory holds the complete position history
@@ -234,7 +235,7 @@ type PositionHistory struct {
 			FillQuantity  float64    `json:"fill_qty,omitempty"`
 			Position      struct {
 				Commission Commission `json:"commission"`
-				Timestamp  int64      `json:"timestamp"`
+				Timestamp  types.Time `json:"timestamp"`
 				OpenPrice  float64    `json:"open_price,string"`
 				RealizedPL float64    `json:"realized_pl,string"`
 				Quantity   float64    `json:"qty,string"`
@@ -242,16 +243,16 @@ type PositionHistory struct {
 			AssetAtExpiry float64 `json:"asset_at_expiry,string,omitempty"`
 		} `json:"records"`
 		Instrument struct {
-			ExpiryTime     int64   `json:"expiry_time"`
-			ContractSize   float64 `json:"contract_size,string"`
-			ConversionRate float64 `json:"conversion_rate,string"`
-			OptionType     string  `json:"option_type"`
-			InstrumentID   int     `json:"inst_id"`
-			SecType        string  `json:"sec_type"`
-			Asset          string  `json:"asset"`
-			Strike         float64 `json:"strike,string"`
+			ExpiryTime     types.Time `json:"expiry_time"`
+			ContractSize   float64    `json:"contract_size,string"`
+			ConversionRate float64    `json:"conversion_rate,string"`
+			OptionType     string     `json:"option_type"`
+			InstrumentID   int        `json:"inst_id"`
+			SecType        string     `json:"sec_type"`
+			Asset          string     `json:"asset"`
+			Strike         float64    `json:"strike,string"`
 		} `json:"inst"`
-		OpenTimestamp int64 `json:"open_timestamp"`
+		OpenTimestamp types.Time `json:"open_timestamp"`
 	} `json:"positions"`
 	TotalNumber int `json:"total_number"`
 }
@@ -263,7 +264,7 @@ type OpenPosition struct {
 	OpenPrice     float64    `json:"open_price,string"`
 	RealizedPL    float64    `json:"realized_pl,string"`
 	Quantity      float64    `json:"qty,string"`
-	OpenTimestamp int64      `json:"open_timestamp"`
+	OpenTimestamp types.Time `json:"open_timestamp"`
 	InstrumentID  int        `json:"inst_id"`
 }
 
@@ -283,23 +284,23 @@ type wsResponse struct {
 
 // WsTicker defines the resp for ticker updates from the websocket connection
 type WsTicker struct {
-	High24        float64  `json:"high24,string"`
-	HighestBuy    float64  `json:"highest_buy,string"`
-	InstID        int64    `json:"inst_id"`
-	Last          float64  `json:"last,string"`
-	Low24         float64  `json:"low24,string"`
-	LowestSell    float64  `json:"lowest_sell,string"`
-	Nonce         int64    `json:"nonce"`
-	PrevTransID   int64    `json:"prev_trans_id"`
-	PriceChange24 float64  `json:"price_change_24,string"`
-	Reply         string   `json:"reply"`
-	Status        []string `json:"status"`
-	Timestamp     int64    `json:"timestamp"`
-	TransID       int64    `json:"trans_id"`
-	Volume        float64  `json:"volume,string"`
-	Volume24      float64  `json:"volume24,string"`
-	Volume24Quote float64  `json:"volume24_quote,string"`
-	VolumeQuote   float64  `json:"volume_quote,string"`
+	High24        float64    `json:"high24,string"`
+	HighestBuy    float64    `json:"highest_buy,string"`
+	InstID        int64      `json:"inst_id"`
+	Last          float64    `json:"last,string"`
+	Low24         float64    `json:"low24,string"`
+	LowestSell    float64    `json:"lowest_sell,string"`
+	Nonce         int64      `json:"nonce"`
+	PrevTransID   int64      `json:"prev_trans_id"`
+	PriceChange24 float64    `json:"price_change_24,string"`
+	Reply         string     `json:"reply"`
+	Status        []string   `json:"status"`
+	Timestamp     types.Time `json:"timestamp"`
+	TransID       int64      `json:"trans_id"`
+	Volume        float64    `json:"volume,string"`
+	Volume24      float64    `json:"volume24,string"`
+	Volume24Quote float64    `json:"volume24_quote,string"`
+	VolumeQuote   float64    `json:"volume_quote,string"`
 }
 
 // WsOrderbookSnapshot defines the resp for orderbook snapshot updates from
@@ -347,23 +348,23 @@ type WsTradeSnapshot struct {
 
 // WsTradeData defines market trade data
 type WsTradeData struct {
-	InstID    int64   `json:"inst_id"`
-	TransID   int64   `json:"trans_id"`
-	Price     float64 `json:"price,string"`
-	Quantity  float64 `json:"qty,string"`
-	Side      string  `json:"side"`
-	Timestamp int64   `json:"timestamp"`
+	InstID    int64      `json:"inst_id"`
+	TransID   int64      `json:"trans_id"`
+	Price     float64    `json:"price,string"`
+	Quantity  float64    `json:"qty,string"`
+	Side      string     `json:"side"`
+	Timestamp types.Time `json:"timestamp"`
 }
 
 // WsTradeUpdate defines trade update response from the websocket connection
 type WsTradeUpdate struct {
-	InstID    int64   `json:"inst_id"`
-	TransID   int64   `json:"trans_id"`
-	Price     float64 `json:"price,string"`
-	Quantity  float64 `json:"qty,string"`
-	Side      string  `json:"side"`
-	Timestamp int64   `json:"timestamp"`
-	Reply     string  `json:"reply"`
+	InstID    int64      `json:"inst_id"`
+	TransID   int64      `json:"trans_id"`
+	Price     float64    `json:"price,string"`
+	Quantity  float64    `json:"qty,string"`
+	Side      string     `json:"side"`
+	Timestamp types.Time `json:"timestamp"`
+	Reply     string     `json:"reply"`
 }
 
 // WsInstrumentList defines instrument list
@@ -526,21 +527,21 @@ type WsOrderFilledResponse struct {
 	Order         WsOrderData                 `json:"order"`
 	Reply         string                      `json:"reply"`
 	Status        []string                    `json:"status"`
-	Timestamp     int64                       `json:"timestamp"`
+	Timestamp     types.Time                  `json:"timestamp"`
 	TransactionID int64                       `json:"trans_id"`
 }
 
 // WsOrderData ws response data
 type WsOrderData struct {
-	ClientOrderID int64    `json:"client_ord_id"`
-	InstrumentID  int64    `json:"inst_id"`
-	OpenQuantity  float64  `json:"open_qty,string"`
-	OrderID       int64    `json:"order_id"`
-	Price         float64  `json:"price,string"`
-	Quantity      float64  `json:"qty,string"`
-	Side          string   `json:"side"`
-	Timestamp     int64    `json:"timestamp"`
-	Status        []string `json:"status"`
+	ClientOrderID int64      `json:"client_ord_id"`
+	InstrumentID  int64      `json:"inst_id"`
+	OpenQuantity  float64    `json:"open_qty,string"`
+	OrderID       int64      `json:"order_id"`
+	Price         float64    `json:"price,string"`
+	Quantity      float64    `json:"qty,string"`
+	Side          string     `json:"side"`
+	Timestamp     types.Time `json:"timestamp"`
+	Status        []string   `json:"status"`
 }
 
 // WsOrderFilledCommissionData ws response data
@@ -551,19 +552,19 @@ type WsOrderFilledCommissionData struct {
 
 // WsOrderRejectedResponse ws response
 type WsOrderRejectedResponse struct {
-	Nonce         int64    `json:"nonce"`
-	Status        []string `json:"status"`
-	OrderID       int64    `json:"order_id"`
-	OpenQuantity  float64  `json:"open_qty,string"`
-	Price         float64  `json:"price,string"`
-	InstrumentID  int64    `json:"inst_id"`
-	Reasons       []string `json:"reasons"`
-	ClientOrderID int64    `json:"client_ord_id"`
-	Timestamp     int64    `json:"timestamp"`
-	Reply         string   `json:"reply"`
-	Quantity      float64  `json:"qty,string"`
-	Side          string   `json:"side"`
-	TransactionID int64    `json:"trans_id"`
+	Nonce         int64      `json:"nonce"`
+	Status        []string   `json:"status"`
+	OrderID       int64      `json:"order_id"`
+	OpenQuantity  float64    `json:"open_qty,string"`
+	Price         float64    `json:"price,string"`
+	InstrumentID  int64      `json:"inst_id"`
+	Reasons       []string   `json:"reasons"`
+	ClientOrderID int64      `json:"client_ord_id"`
+	Timestamp     types.Time `json:"timestamp"`
+	Reply         string     `json:"reply"`
+	Quantity      float64    `json:"qty,string"`
+	Side          string     `json:"side"`
+	TransactionID int64      `json:"trans_id"`
 }
 
 type wsInstList struct {
@@ -604,7 +605,7 @@ type WsTradeHistoryTradeData struct {
 	Order         WsOrderData                  `json:"order"`
 	FillPrice     float64                      `json:"fill_price,string"`
 	FillQuantity  float64                      `json:"fill_qty,string"`
-	Timestamp     int64                        `json:"timestamp"`
+	Timestamp     types.Time                   `json:"timestamp"`
 	TransactionID int64                        `json:"trans_id"`
 }
 
@@ -619,27 +620,27 @@ type WsLoginReq struct {
 
 // WsLoginResponse ws response data
 type WsLoginResponse struct {
-	APIKey          string   `json:"api_key"`
-	Country         string   `json:"country"`
-	DepositEnabled  bool     `json:"deposit_enabled"`
-	Deposited       bool     `json:"deposited"`
-	Email           string   `json:"email"`
-	FailedTimes     int64    `json:"failed_times"`
-	KycPassed       bool     `json:"kyc_passed"`
-	Language        string   `json:"lang"`
-	Nonce           int64    `json:"nonce"`
-	OTPEnabled      bool     `json:"otp_enabled"`
-	PhoneNumber     string   `json:"phone_number"`
-	ProductsEnabled []string `json:"products_enabled"`
-	Referred        bool     `json:"referred"`
-	Reply           string   `json:"reply"`
-	SessionID       string   `json:"session_id"`
-	Status          []string `json:"status"`
-	Timezone        string   `json:"timezone"`
-	Traded          bool     `json:"traded"`
-	UnverifiedEmail string   `json:"unverified_email"`
-	Username        string   `json:"username"`
-	WithdrawEnabled bool     `json:"withdraw_enabled"`
+	APIKey          string     `json:"api_key"`
+	Country         string     `json:"country"`
+	DepositEnabled  bool       `json:"deposit_enabled"`
+	Deposited       bool       `json:"deposited"`
+	Email           string     `json:"email"`
+	FailedTimes     types.Time `json:"failed_times"`
+	KycPassed       bool       `json:"kyc_passed"`
+	Language        string     `json:"lang"`
+	Nonce           int64      `json:"nonce"`
+	OTPEnabled      bool       `json:"otp_enabled"`
+	PhoneNumber     string     `json:"phone_number"`
+	ProductsEnabled []string   `json:"products_enabled"`
+	Referred        bool       `json:"referred"`
+	Reply           string     `json:"reply"`
+	SessionID       string     `json:"session_id"`
+	Status          []string   `json:"status"`
+	Timezone        string     `json:"timezone"`
+	Traded          bool       `json:"traded"`
+	UnverifiedEmail string     `json:"unverified_email"`
+	Username        string     `json:"username"`
+	WithdrawEnabled bool       `json:"withdraw_enabled"`
 }
 
 // WsNewOrderResponse returns if new_order response fails
@@ -679,31 +680,31 @@ type instrumentMap struct {
 }
 
 type wsOrderContainer struct {
-	OrderID       int64    `json:"order_id"`
-	ClientOrderID int64    `json:"client_ord_id"`
-	InstrumentID  int64    `json:"inst_id"`
-	Nonce         int64    `json:"nonce"`
-	Timestamp     int64    `json:"timestamp"`
-	TransactionID int64    `json:"trans_id"`
-	OpenQuantity  float64  `json:"open_qty,string"`
-	OrderPrice    float64  `json:"order_price,string"`
-	Quantity      float64  `json:"qty,string"`
-	FillPrice     float64  `json:"fill_price,string"`
-	FillQuantity  float64  `json:"fill_qty,string"`
-	Price         float64  `json:"price,string"`
-	Reply         string   `json:"reply"`
-	Side          string   `json:"side"`
-	Status        []string `json:"status"`
-	Reasons       []string `json:"reasons"`
+	OrderID       int64      `json:"order_id"`
+	ClientOrderID int64      `json:"client_ord_id"`
+	InstrumentID  int64      `json:"inst_id"`
+	Nonce         int64      `json:"nonce"`
+	Timestamp     types.Time `json:"timestamp"`
+	TransactionID int64      `json:"trans_id"`
+	OpenQuantity  float64    `json:"open_qty,string"`
+	OrderPrice    float64    `json:"order_price,string"`
+	Quantity      float64    `json:"qty,string"`
+	FillPrice     float64    `json:"fill_price,string"`
+	FillQuantity  float64    `json:"fill_qty,string"`
+	Price         float64    `json:"price,string"`
+	Reply         string     `json:"reply"`
+	Side          string     `json:"side"`
+	Status        []string   `json:"status"`
+	Reasons       []string   `json:"reasons"`
 	Order         struct {
-		ClientOrderID int64   `json:"client_ord_id"`
-		InstrumentID  int64   `json:"inst_id"`
-		OrderID       int64   `json:"order_id"`
-		Timestamp     int64   `json:"timestamp"`
-		Price         float64 `json:"price,string"`
-		Quantity      float64 `json:"qty,string"`
-		OpenQuantity  float64 `json:"open_qty,string"`
-		Side          string  `json:"side"`
+		ClientOrderID int64      `json:"client_ord_id"`
+		InstrumentID  int64      `json:"inst_id"`
+		OrderID       int64      `json:"order_id"`
+		Timestamp     types.Time `json:"timestamp"`
+		Price         float64    `json:"price,string"`
+		Quantity      float64    `json:"qty,string"`
+		OpenQuantity  float64    `json:"open_qty,string"`
+		Side          string     `json:"side"`
 	} `json:"order"`
 	Commission struct {
 		Amount   float64 `json:"amount,string"`

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -242,7 +242,7 @@ func (c *COINUT) wsHandleData(_ context.Context, respRaw []byte) error {
 			High:         wsTicker.High24,
 			Low:          wsTicker.Low24,
 			Last:         wsTicker.Last,
-			LastUpdated:  time.Unix(0, wsTicker.Timestamp),
+			LastUpdated:  wsTicker.Timestamp.Time(),
 			AssetType:    asset.Spot,
 			Pair:         p,
 		}
@@ -298,7 +298,7 @@ func (c *COINUT) wsHandleData(_ context.Context, respRaw []byte) error {
 			}
 
 			trades = append(trades, trade.Data{
-				Timestamp:    time.Unix(0, tradeSnap.Trades[i].Timestamp*1000),
+				Timestamp:    tradeSnap.Trades[i].Timestamp.Time(),
 				CurrencyPair: p,
 				AssetType:    asset.Spot,
 				Exchange:     c.Name,
@@ -340,7 +340,7 @@ func (c *COINUT) wsHandleData(_ context.Context, respRaw []byte) error {
 		}
 
 		return trade.AddTradesToBuffer(trade.Data{
-			Timestamp:    time.Unix(0, tradeUpdate.Timestamp*1000),
+			Timestamp:    tradeUpdate.Timestamp.Time(),
 			CurrencyPair: p,
 			AssetType:    asset.Spot,
 			Exchange:     c.Name,
@@ -432,7 +432,7 @@ func (c *COINUT) parseOrderContainer(oContainer *wsOrderContainer) (*order.Detai
 		OrderID:         orderID,
 		Side:            oSide,
 		Status:          oStatus,
-		Date:            time.Unix(0, oContainer.Timestamp),
+		Date:            oContainer.Timestamp.Time(),
 		Trades:          nil,
 	}
 	if oContainer.Reply == "order_filled" {
@@ -447,7 +447,7 @@ func (c *COINUT) parseOrderContainer(oContainer *wsOrderContainer) (*order.Detai
 		o.RemainingAmount = oContainer.Order.OpenQuantity
 		o.Amount = oContainer.Order.Quantity
 		o.OrderID = strconv.FormatInt(oContainer.Order.OrderID, 10)
-		o.LastUpdated = time.Unix(0, oContainer.Timestamp)
+		o.LastUpdated = oContainer.Timestamp.Time()
 		o.Pair, o.AssetType, err = c.GetRequestFormattedPairAndAssetType(c.instrumentMap.LookupInstrument(oContainer.Order.InstrumentID))
 		if err != nil {
 			return nil, err
@@ -459,7 +459,7 @@ func (c *COINUT) parseOrderContainer(oContainer *wsOrderContainer) (*order.Detai
 				Exchange:  c.Name,
 				TID:       strconv.FormatInt(oContainer.TransactionID, 10),
 				Side:      oSide,
-				Timestamp: time.Unix(0, oContainer.Timestamp),
+				Timestamp: oContainer.Timestamp.Time(),
 			},
 		}
 	} else {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -335,7 +335,7 @@ func (c *COINUT) UpdateTicker(ctx context.Context, p currency.Pair, a asset.Item
 		Ask:          tick.LowestSell,
 		Volume:       tick.Volume24,
 		Pair:         p,
-		LastUpdated:  time.Unix(0, tick.Timestamp),
+		LastUpdated:  tick.Timestamp.Time(),
 		ExchangeName: c.Name,
 		AssetType:    a,
 	})
@@ -444,7 +444,7 @@ func (c *COINUT) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 			Side:         side,
 			Price:        tradeData.Trades[i].Price,
 			Amount:       tradeData.Trades[i].Quantity,
-			Timestamp:    time.Unix(0, tradeData.Trades[i].Timestamp*int64(time.Microsecond)),
+			Timestamp:    tradeData.Trades[i].Timestamp.Time(),
 		}
 	}
 
@@ -824,7 +824,7 @@ func (c *COINUT) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 					OrderID:         strconv.FormatInt(openOrders.Orders[i].OrderID, 10),
 					Pair:            fPair,
 					Side:            side,
-					Date:            time.Unix(0, openOrders.Orders[i].Timestamp),
+					Date:            openOrders.Orders[i].Timestamp.Time(),
 					Status:          order.Active,
 					Price:           openOrders.Orders[i].Price,
 					Amount:          openOrders.Orders[i].Quantity,
@@ -886,7 +886,7 @@ func (c *COINUT) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 					Price:    openOrders.Orders[y].Price,
 					Exchange: c.Name,
 					Side:     side,
-					Date:     time.Unix(openOrders.Orders[y].Timestamp, 0),
+					Date:     openOrders.Orders[y].Timestamp.Time(),
 					Pair:     p,
 				})
 			}
@@ -935,7 +935,7 @@ func (c *COINUT) GetOrderHistory(ctx context.Context, req *order.MultiOrderReque
 						OrderID:         strconv.FormatInt(trades.Trades[x].OrderID, 10),
 						Pair:            p,
 						Side:            side,
-						Date:            time.Unix(0, trades.Trades[x].Timestamp),
+						Date:            trades.Trades[x].Timestamp.Time(),
 						Status:          order.Filled,
 						Price:           trades.Trades[x].Price,
 						Amount:          trades.Trades[x].Quantity,
@@ -1006,7 +1006,7 @@ func (c *COINUT) GetOrderHistory(ctx context.Context, req *order.MultiOrderReque
 					Price:    orders.Trades[y].Order.Price,
 					Exchange: c.Name,
 					Side:     side,
-					Date:     time.Unix(orders.Trades[y].Order.Timestamp, 0),
+					Date:     orders.Trades[y].Order.Timestamp.Time(),
 					Pair:     p,
 				})
 			}

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -21,6 +21,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/nonce"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Deribit is the overarching type across this package
@@ -2449,12 +2450,11 @@ func (d *Deribit) GetUserBlockTrade(ctx context.Context, id string) ([]BlockTrad
 
 // GetTime retrieves the current time (in milliseconds). This API endpoint can be used to check the clock skew between your software and Deribit's systems.
 func (d *Deribit) GetTime(ctx context.Context) (time.Time, error) {
-	var result int64
-	err := d.SendHTTPRequest(ctx, exchange.RestSpot, nonMatchingEPL, "public/get_time", &result)
-	if err != nil {
+	var timestamp types.Time
+	if err := d.SendHTTPRequest(ctx, exchange.RestSpot, nonMatchingEPL, "public/get_time", &timestamp); err != nil {
 		return time.Time{}, err
 	}
-	return time.UnixMilli(result), nil
+	return timestamp.Time(), nil
 }
 
 // GetLastBlockTradesByCurrency returns list of last users block trades

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -620,10 +620,10 @@ type MarginsData struct {
 
 // MMPConfigData gets the current configuration data for MMP
 type MMPConfigData struct {
-	Currency      string  `json:"currency"`
-	Interval      int64   `json:"interval"`
-	FrozenTime    int64   `json:"frozen_time"`
-	QuantityLimit float64 `json:"quantity_limit"`
+	Currency      string     `json:"currency"`
+	Interval      int64      `json:"interval"`
+	FrozenTime    types.Time `json:"frozen_time"`
+	QuantityLimit float64    `json:"quantity_limit"`
 }
 
 // UserTradesData stores data of user trades
@@ -1097,13 +1097,13 @@ type wsOrderbook struct {
 
 // wsCandlestickData represents publicly available market data used to generate a TradingView candle chart.
 type wsCandlestickData struct {
-	Volume float64 `json:"volume"`
-	Tick   int64   `json:"tick"`
-	Open   float64 `json:"open"`
-	Low    float64 `json:"low"`
-	High   float64 `json:"high"`
-	Cost   float64 `json:"cost"`
-	Close  float64 `json:"close"`
+	Volume float64    `json:"volume"`
+	Tick   types.Time `json:"tick"`
+	Open   float64    `json:"open"`
+	Low    float64    `json:"low"`
+	High   float64    `json:"high"`
+	Cost   float64    `json:"cost"`
+	Close  float64    `json:"close"`
 }
 
 // wsIndexPrice represents information about current value (price) for Deribit Index

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -627,7 +627,7 @@ func (d *Deribit) processCandleChart(respRaw []byte, channels []string) error {
 		return err
 	}
 	d.Websocket.DataHandler <- websocket.KlineData{
-		Timestamp:  time.UnixMilli(candleData.Tick),
+		Timestamp:  candleData.Tick.Time(),
 		Pair:       cp,
 		AssetType:  a,
 		Exchange:   d.Name,

--- a/exchanges/exmo/exmo_types.go
+++ b/exchanges/exmo/exmo_types.go
@@ -7,13 +7,13 @@ import (
 
 // Trades holds trade data
 type Trades struct {
-	TradeID  int64   `json:"trade_id"`
-	Type     string  `json:"type"`
-	Quantity float64 `json:"quantity,string"`
-	Price    float64 `json:"price,string"`
-	Amount   float64 `json:"amount,string"`
-	Date     int64   `json:"date"`
-	Pair     string  `json:"pair"`
+	TradeID  int64      `json:"trade_id"`
+	Type     string     `json:"type"`
+	Quantity float64    `json:"quantity,string"`
+	Price    float64    `json:"price,string"`
+	Amount   float64    `json:"amount,string"`
+	Date     types.Time `json:"date"`
+	Pair     string     `json:"pair"`
 }
 
 // Orderbook holds the orderbook data
@@ -29,15 +29,15 @@ type Orderbook struct {
 
 // Ticker holds the ticker data
 type Ticker struct {
-	Buy           float64 `json:"buy_price,string"`
-	Sell          float64 `json:"sell_price,string"`
-	Last          float64 `json:"last_trade,string"`
-	High          float64 `json:"high,string"`
-	Low           float64 `json:"low,string"`
-	Average       float64 `json:"average,string"`
-	Volume        float64 `json:"vol,string"`
-	VolumeCurrent float64 `json:"vol_curr,string"`
-	Updated       int64   `json:"updated"`
+	Buy           float64    `json:"buy_price,string"`
+	Sell          float64    `json:"sell_price,string"`
+	Last          float64    `json:"last_trade,string"`
+	High          float64    `json:"high,string"`
+	Low           float64    `json:"low,string"`
+	Average       float64    `json:"average,string"`
+	Volume        float64    `json:"vol,string"`
+	VolumeCurrent float64    `json:"vol_curr,string"`
+	Updated       types.Time `json:"updated"`
 }
 
 // PairSettings holds the pair settings
@@ -59,33 +59,33 @@ type AuthResponse struct {
 // UserInfo stores the user info
 type UserInfo struct {
 	AuthResponse
-	UID        int               `json:"uid"`
-	ServerDate int               `json:"server_date"`
-	Balances   map[string]string `json:"balances"`
-	Reserved   map[string]string `json:"reserved"`
+	UID        int                     `json:"uid"`
+	ServerDate int                     `json:"server_date"`
+	Balances   map[string]types.Number `json:"balances"`
+	Reserved   map[string]types.Number `json:"reserved"`
 }
 
 // OpenOrders stores the order info
 type OpenOrders struct {
-	OrderID  int64   `json:"order_id,string"`
-	Created  int64   `json:"created,string"`
-	Type     string  `json:"type"`
-	Pair     string  `json:"pair"`
-	Price    float64 `json:"price,string"`
-	Quantity float64 `json:"quantity,string"`
-	Amount   float64 `json:"amount,string"`
+	OrderID  int64      `json:"order_id,string"`
+	Created  types.Time `json:"created"`
+	Type     string     `json:"type"`
+	Pair     string     `json:"pair"`
+	Price    float64    `json:"price,string"`
+	Quantity float64    `json:"quantity,string"`
+	Amount   float64    `json:"amount,string"`
 }
 
 // UserTrades stores the users trade info
 type UserTrades struct {
-	TradeID  int64   `json:"trade_id"`
-	Date     int64   `json:"date"`
-	Type     string  `json:"type"`
-	Pair     string  `json:"pair"`
-	OrderID  int64   `json:"order_id"`
-	Quantity float64 `json:"quantity"`
-	Price    float64 `json:"price"`
-	Amount   float64 `json:"amount"`
+	TradeID  int64      `json:"trade_id"`
+	Date     types.Time `json:"date"`
+	Type     string     `json:"type"`
+	Pair     string     `json:"pair"`
+	OrderID  int64      `json:"order_id"`
+	Quantity float64    `json:"quantity"`
+	Price    float64    `json:"price"`
+	Amount   float64    `json:"amount"`
 }
 
 // CancelledOrder stores cancelled order data
@@ -139,14 +139,14 @@ type WalletHistory struct {
 	Begin   int64 `json:"begin,string"`
 	End     int64 `json:"end,string"`
 	History []struct {
-		Timestamp int64   `json:"dt"`
-		Type      string  `json:"type"`
-		Currency  string  `json:"curr"`
-		Status    string  `json:"status"`
-		Provider  string  `json:"provider"`
-		Amount    float64 `json:"amount,string"`
-		Account   string  `json:"account"`
-		TXID      string  `json:"txid"`
+		Timestamp types.Time `json:"dt"`
+		Type      string     `json:"type"`
+		Currency  string     `json:"curr"`
+		Status    string     `json:"status"`
+		Provider  string     `json:"provider"`
+		Amount    float64    `json:"amount,string"`
+		Account   string     `json:"account"`
+		TXID      string     `json:"txid"`
 	}
 }
 

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -182,7 +182,7 @@ func (e *EXMO) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Bid:          tick.Buy,
 			Low:          tick.Low,
 			Volume:       tick.Volume,
-			LastUpdated:  time.Unix(tick.Updated, 0),
+			LastUpdated:  tick.Updated.Time(),
 			ExchangeName: e.Name,
 			AssetType:    a,
 		})
@@ -272,11 +272,13 @@ func (e *EXMO) UpdateOrderbook(ctx context.Context, p currency.Pair, assetType a
 // UpdateAccountInfo retrieves balances for all enabled currencies for the
 // Exmo exchange
 func (e *EXMO) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (account.Holdings, error) {
-	var response account.Holdings
-	response.Exchange = e.Name
 	result, err := e.GetUserInfo(ctx)
 	if err != nil {
-		return response, err
+		return account.Holdings{}, err
+	}
+
+	response := account.Holdings{
+		Exchange: e.Name,
 	}
 
 	currencies := make([]account.Balance, 0, len(result.Balances))
@@ -287,15 +289,7 @@ func (e *EXMO) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (acc
 			if z != x {
 				continue
 			}
-			var avail, reserved float64
-			avail, err = strconv.ParseFloat(y, 64)
-			if err != nil {
-				return response, err
-			}
-			reserved, err = strconv.ParseFloat(w, 64)
-			if err != nil {
-				return response, err
-			}
+			avail, reserved := y.Float64(), w.Float64()
 			exchangeCurrency.Total = avail + reserved
 			exchangeCurrency.Hold = reserved
 			exchangeCurrency.Free = avail
@@ -335,7 +329,7 @@ func (e *EXMO) GetAccountFundingHistory(ctx context.Context) ([]exchange.Funding
 		resp = append(resp, exchange.FundingHistory{
 			Status:     hist.History[i].Status,
 			TransferID: hist.History[i].TXID,
-			Timestamp:  time.Unix(hist.History[i].Timestamp, 0),
+			Timestamp:  hist.History[i].Timestamp.Time(),
 			Currency:   hist.History[i].Currency,
 			Amount:     hist.History[i].Amount,
 			BankFrom:   hist.History[i].Provider,
@@ -358,7 +352,7 @@ func (e *EXMO) GetWithdrawalsHistory(ctx context.Context, _ currency.Code, _ ass
 		resp = append(resp, exchange.WithdrawalHistory{
 			Status:     hist.History[i].Status,
 			TransferID: hist.History[i].TXID,
-			Timestamp:  time.Unix(hist.History[i].Timestamp, 0),
+			Timestamp:  hist.History[i].Timestamp.Time(),
 			Currency:   hist.History[i].Currency,
 			Amount:     hist.History[i].Amount,
 			CryptoTxID: hist.History[i].TXID,
@@ -396,7 +390,7 @@ func (e *EXMO) GetRecentTrades(ctx context.Context, p currency.Pair, assetType a
 			Side:         side,
 			Price:        mapData[i].Price,
 			Amount:       mapData[i].Quantity,
-			Timestamp:    time.Unix(mapData[i].Date, 0),
+			Timestamp:    mapData[i].Date.Time(),
 		}
 	}
 
@@ -596,21 +590,18 @@ func (e *EXMO) GetActiveOrders(ctx context.Context, req *order.MultiOrderRequest
 
 	orders := make([]order.Detail, 0, len(resp))
 	for i := range resp {
-		var symbol currency.Pair
-		symbol, err = currency.NewPairDelimiter(resp[i].Pair, "_")
+		symbol, err := currency.NewPairDelimiter(resp[i].Pair, "_")
 		if err != nil {
 			return nil, err
 		}
-		orderDate := time.Unix(resp[i].Created, 0)
-		var side order.Side
-		side, err = order.StringToOrderSide(resp[i].Type)
+		side, err := order.StringToOrderSide(resp[i].Type)
 		if err != nil {
 			return nil, err
 		}
 		orders = append(orders, order.Detail{
 			OrderID:  strconv.FormatInt(resp[i].OrderID, 10),
 			Amount:   resp[i].Quantity,
-			Date:     orderDate,
+			Date:     resp[i].Created.Time(),
 			Price:    resp[i].Price,
 			Side:     side,
 			Exchange: e.Name,
@@ -654,9 +645,7 @@ func (e *EXMO) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequest
 		if err != nil {
 			return nil, err
 		}
-		orderDate := time.Unix(allTrades[i].Date, 0)
-		var side order.Side
-		side, err = order.StringToOrderSide(allTrades[i].Type)
+		side, err := order.StringToOrderSide(allTrades[i].Type)
 		if err != nil {
 			return nil, err
 		}
@@ -666,7 +655,7 @@ func (e *EXMO) GetOrderHistory(ctx context.Context, req *order.MultiOrderRequest
 			ExecutedAmount: allTrades[i].Quantity,
 			Cost:           allTrades[i].Amount,
 			CostAsset:      pair.Quote,
-			Date:           orderDate,
+			Date:           allTrades[i].Date.Time(),
 			Price:          allTrades[i].Price,
 			Side:           side,
 			Exchange:       e.Name,

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -3117,6 +3117,9 @@ func (g *Gateio) GetAllOptionsUnderlyings(ctx context.Context) ([]OptionUnderlyi
 
 // GetExpirationTime return the expiration time for the provided underlying.
 func (g *Gateio) GetExpirationTime(ctx context.Context, underlying string) (time.Time, error) {
+	if underlying == "" {
+		return time.Time{}, errInvalidUnderlying
+	}
 	var timestamps []types.Time
 	err := g.SendHTTPRequest(ctx, exchange.RestSpot, publicExpirationOptionsEPL, gateioOptionExpiration+"?underlying="+underlying, &timestamps)
 	if err != nil {

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -21,6 +21,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -752,14 +753,13 @@ func (g *Gateio) GetMySpotTradingHistory(ctx context.Context, p currency.Pair, o
 
 // GetServerTime retrieves current server time
 func (g *Gateio) GetServerTime(ctx context.Context, _ asset.Item) (time.Time, error) {
-	resp := struct {
-		ServerTime int64 `json:"server_time"`
-	}{}
-	err := g.SendHTTPRequest(ctx, exchange.RestSpot, publicGetServerTimeEPL, gateioSpotServerTime, &resp)
-	if err != nil {
+	var resp struct {
+		ServerTime types.Time `json:"server_time"`
+	}
+	if err := g.SendHTTPRequest(ctx, exchange.RestSpot, publicGetServerTimeEPL, gateioSpotServerTime, &resp); err != nil {
 		return time.Time{}, err
 	}
-	return time.Unix(resp.ServerTime, 0), nil
+	return resp.ServerTime.Time(), nil
 }
 
 // CountdownCancelorders Countdown cancel orders
@@ -876,6 +876,11 @@ func (g *Gateio) CancelPriceTriggeredOrder(ctx context.Context, orderID string) 
 
 // GenerateSignature returns hash for authenticated requests
 func (g *Gateio) GenerateSignature(secret, method, path, query string, body any, dtime time.Time) (string, error) {
+	rawQuery, err := url.QueryUnescape(query)
+	if err != nil {
+		return "", err
+	}
+
 	h := sha512.New()
 	if body != nil {
 		val, err := json.Marshal(body)
@@ -886,12 +891,8 @@ func (g *Gateio) GenerateSignature(secret, method, path, query string, body any,
 	}
 	h.Write(nil)
 	hashedPayload := hex.EncodeToString(h.Sum(nil))
-	t := strconv.FormatInt(dtime.Unix(), 10)
-	rawQuery, err := url.QueryUnescape(query)
-	if err != nil {
-		return "", err
-	}
-	msg := method + "\n" + path + "\n" + rawQuery + "\n" + hashedPayload + "\n" + t
+
+	msg := method + "\n" + path + "\n" + rawQuery + "\n" + hashedPayload + "\n" + strconv.FormatInt(dtime.Unix(), 10)
 	mac := hmac.New(sha512.New, []byte(secret))
 	mac.Write([]byte(msg))
 	return hex.EncodeToString(mac.Sum(nil)), nil
@@ -3116,15 +3117,15 @@ func (g *Gateio) GetAllOptionsUnderlyings(ctx context.Context) ([]OptionUnderlyi
 
 // GetExpirationTime return the expiration time for the provided underlying.
 func (g *Gateio) GetExpirationTime(ctx context.Context, underlying string) (time.Time, error) {
-	var timestamp []float64
-	err := g.SendHTTPRequest(ctx, exchange.RestSpot, publicExpirationOptionsEPL, gateioOptionExpiration+"?underlying="+underlying, &timestamp)
+	var timestamps []types.Time
+	err := g.SendHTTPRequest(ctx, exchange.RestSpot, publicExpirationOptionsEPL, gateioOptionExpiration+"?underlying="+underlying, &timestamps)
 	if err != nil {
 		return time.Time{}, err
 	}
-	if len(timestamp) == 0 {
+	if len(timestamps) == 0 {
 		return time.Time{}, errNoValidResponseFromServer
 	}
-	return time.Unix(int64(timestamp[0]), 0), nil
+	return timestamps[0].Time(), nil
 }
 
 // GetAllContractOfUnderlyingWithinExpiryDate retrieves list of contracts of the specified underlying and expiry time.

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -1473,9 +1473,10 @@ func TestGetAllOptionsUnderlyings(t *testing.T) {
 
 func TestGetExpirationTime(t *testing.T) {
 	t.Parallel()
-	if _, err := g.GetExpirationTime(t.Context(), "BTC_USDT"); err != nil {
-		t.Errorf("%s GetExpirationTime() error %v", g.Name, err)
-	}
+	_, err := g.GetExpirationTime(t.Context(), "")
+	assert.ErrorIs(t, err, errInvalidUnderlying)
+	_, err = g.GetExpirationTime(t.Context(), "BTC_USDT")
+	assert.NoError(t, err, "GetExpirationTime should not error")
 }
 
 func TestGetAllContractOfUnderlyingWithinExpiryDate(t *testing.T) {

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -32,6 +32,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -433,7 +434,7 @@ func (g *Gateio) processOrderbookSnapshot(incoming []byte, lastPushed time.Time)
 
 func (g *Gateio) processSpotOrders(data []byte) error {
 	resp := struct {
-		Time    int64         `json:"time"`
+		Time    types.Time    `json:"time"`
 		Channel string        `json:"channel"`
 		Event   string        `json:"event"`
 		Result  []WsSpotOrder `json:"result"`
@@ -481,7 +482,7 @@ func (g *Gateio) processUserPersonalTrades(data []byte) error {
 	}
 
 	resp := struct {
-		Time    int64                 `json:"time"`
+		Time    types.Time            `json:"time"`
 		Channel string                `json:"channel"`
 		Event   string                `json:"event"`
 		Result  []WsUserPersonalTrade `json:"result"`
@@ -512,7 +513,7 @@ func (g *Gateio) processUserPersonalTrades(data []byte) error {
 
 func (g *Gateio) processSpotBalances(ctx context.Context, data []byte) error {
 	resp := struct {
-		Time    int64           `json:"time"`
+		Time    types.Time      `json:"time"`
 		Channel string          `json:"channel"`
 		Event   string          `json:"event"`
 		Result  []WsSpotBalance `json:"result"`
@@ -545,7 +546,7 @@ func (g *Gateio) processSpotBalances(ctx context.Context, data []byte) error {
 
 func (g *Gateio) processMarginBalances(ctx context.Context, data []byte) error {
 	resp := struct {
-		Time    int64             `json:"time"`
+		Time    types.Time        `json:"time"`
 		Channel string            `json:"channel"`
 		Event   string            `json:"event"`
 		Result  []WsMarginBalance `json:"result"`
@@ -577,7 +578,7 @@ func (g *Gateio) processMarginBalances(ctx context.Context, data []byte) error {
 
 func (g *Gateio) processFundingBalances(data []byte) error {
 	resp := struct {
-		Time    int64              `json:"time"`
+		Time    types.Time         `json:"time"`
 		Channel string             `json:"channel"`
 		Event   string             `json:"event"`
 		Result  []WsFundingBalance `json:"result"`
@@ -592,7 +593,7 @@ func (g *Gateio) processFundingBalances(data []byte) error {
 
 func (g *Gateio) processCrossMarginBalance(ctx context.Context, data []byte) error {
 	resp := struct {
-		Time    int64                  `json:"time"`
+		Time    types.Time             `json:"time"`
 		Channel string                 `json:"channel"`
 		Event   string                 `json:"event"`
 		Result  []WsCrossMarginBalance `json:"result"`
@@ -624,7 +625,7 @@ func (g *Gateio) processCrossMarginBalance(ctx context.Context, data []byte) err
 
 func (g *Gateio) processCrossMarginLoans(data []byte) error {
 	resp := struct {
-		Time    int64             `json:"time"`
+		Time    types.Time        `json:"time"`
 		Channel string            `json:"channel"`
 		Event   string            `json:"event"`
 		Result  WsCrossMarginLoan `json:"result"`

--- a/exchanges/gateio/gateio_websocket_futures.go
+++ b/exchanges/gateio/gateio_websocket_futures.go
@@ -21,6 +21,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -299,7 +300,7 @@ func (g *Gateio) generateFuturesPayload(ctx context.Context, conn websocket.Conn
 
 func (g *Gateio) processFuturesTickers(data []byte, assetType asset.Item) error {
 	resp := struct {
-		Time    int64            `json:"time"`
+		Time    types.Time       `json:"time"`
 		Channel string           `json:"channel"`
 		Event   string           `json:"event"`
 		Result  []WsFutureTicker `json:"result"`
@@ -319,7 +320,7 @@ func (g *Gateio) processFuturesTickers(data []byte, assetType asset.Item) error 
 			Last:         resp.Result[x].Last.Float64(),
 			AssetType:    assetType,
 			Pair:         resp.Result[x].Contract,
-			LastUpdated:  time.Unix(resp.Time, 0),
+			LastUpdated:  resp.Time.Time(),
 		}
 	}
 	g.Websocket.DataHandler <- tickerPriceDatas
@@ -333,7 +334,7 @@ func (g *Gateio) processFuturesTrades(data []byte, assetType asset.Item) error {
 	}
 
 	resp := struct {
-		Time    int64             `json:"time"`
+		Time    types.Time        `json:"time"`
 		Channel string            `json:"channel"`
 		Event   string            `json:"event"`
 		Result  []WsFuturesTrades `json:"result"`
@@ -360,7 +361,7 @@ func (g *Gateio) processFuturesTrades(data []byte, assetType asset.Item) error {
 
 func (g *Gateio) processFuturesCandlesticks(data []byte, assetType asset.Item) error {
 	resp := struct {
-		Time    int64                `json:"time"`
+		Time    types.Time           `json:"time"`
 		Channel string               `json:"channel"`
 		Event   string               `json:"event"`
 		Result  []FuturesCandlestick `json:"result"`
@@ -514,7 +515,7 @@ func (g *Gateio) processFuturesOrderbookSnapshot(event string, incoming []byte, 
 
 func (g *Gateio) processFuturesOrdersPushData(data []byte, assetType asset.Item) ([]order.Detail, error) {
 	resp := struct {
-		Time    int64            `json:"time"`
+		Time    types.Time       `json:"time"`
 		Channel string           `json:"channel"`
 		Event   string           `json:"event"`
 		Result  []WsFuturesOrder `json:"result"`
@@ -567,7 +568,7 @@ func (g *Gateio) procesFuturesUserTrades(data []byte, assetType asset.Item) erro
 	}
 
 	resp := struct {
-		Time    int64                `json:"time"`
+		Time    types.Time           `json:"time"`
 		Channel string               `json:"channel"`
 		Event   string               `json:"event"`
 		Result  []WsFuturesUserTrade `json:"result"`
@@ -594,7 +595,7 @@ func (g *Gateio) procesFuturesUserTrades(data []byte, assetType asset.Item) erro
 
 func (g *Gateio) processFuturesLiquidatesNotification(data []byte) error {
 	resp := struct {
-		Time    int64                              `json:"time"`
+		Time    types.Time                         `json:"time"`
 		Channel string                             `json:"channel"`
 		Event   string                             `json:"event"`
 		Result  []WsFuturesLiquidationNotification `json:"result"`
@@ -609,7 +610,7 @@ func (g *Gateio) processFuturesLiquidatesNotification(data []byte) error {
 
 func (g *Gateio) processFuturesAutoDeleveragesNotification(data []byte) error {
 	resp := struct {
-		Time    int64                                  `json:"time"`
+		Time    types.Time                             `json:"time"`
 		Channel string                                 `json:"channel"`
 		Event   string                                 `json:"event"`
 		Result  []WsFuturesAutoDeleveragesNotification `json:"result"`
@@ -624,7 +625,7 @@ func (g *Gateio) processFuturesAutoDeleveragesNotification(data []byte) error {
 
 func (g *Gateio) processPositionCloseData(data []byte) error {
 	resp := struct {
-		Time    int64             `json:"time"`
+		Time    types.Time        `json:"time"`
 		Channel string            `json:"channel"`
 		Event   string            `json:"event"`
 		Result  []WsPositionClose `json:"result"`
@@ -639,7 +640,7 @@ func (g *Gateio) processPositionCloseData(data []byte) error {
 
 func (g *Gateio) processBalancePushData(ctx context.Context, data []byte, assetType asset.Item) error {
 	resp := struct {
-		Time    int64       `json:"time"`
+		Time    types.Time  `json:"time"`
 		Channel string      `json:"channel"`
 		Event   string      `json:"event"`
 		Result  []WsBalance `json:"result"`
@@ -675,7 +676,7 @@ func (g *Gateio) processBalancePushData(ctx context.Context, data []byte, assetT
 
 func (g *Gateio) processFuturesReduceRiskLimitNotification(data []byte) error {
 	resp := struct {
-		Time    int64                                  `json:"time"`
+		Time    types.Time                             `json:"time"`
 		Channel string                                 `json:"channel"`
 		Event   string                                 `json:"event"`
 		Result  []WsFuturesReduceRiskLimitNotification `json:"result"`
@@ -690,7 +691,7 @@ func (g *Gateio) processFuturesReduceRiskLimitNotification(data []byte) error {
 
 func (g *Gateio) processFuturesPositionsNotification(data []byte) error {
 	resp := struct {
-		Time    int64               `json:"time"`
+		Time    types.Time          `json:"time"`
 		Channel string              `json:"channel"`
 		Event   string              `json:"event"`
 		Result  []WsFuturesPosition `json:"result"`
@@ -705,7 +706,7 @@ func (g *Gateio) processFuturesPositionsNotification(data []byte) error {
 
 func (g *Gateio) processFuturesAutoOrderPushData(data []byte) error {
 	resp := struct {
-		Time    int64                `json:"time"`
+		Time    types.Time           `json:"time"`
 		Channel string               `json:"channel"`
 		Event   string               `json:"event"`
 		Result  []WsFuturesAutoOrder `json:"result"`

--- a/exchanges/gateio/gateio_websocket_option.go
+++ b/exchanges/gateio/gateio_websocket_option.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -387,7 +388,7 @@ func (g *Gateio) processOptionsTradesPushData(data []byte) error {
 		return nil
 	}
 	resp := struct {
-		Time    int64             `json:"time"`
+		Time    types.Time        `json:"time"`
 		Channel string            `json:"channel"`
 		Event   string            `json:"event"`
 		Result  []WsOptionsTrades `json:"result"`
@@ -453,7 +454,7 @@ func (g *Gateio) processOptionsContractPushData(incoming []byte) error {
 
 func (g *Gateio) processOptionsCandlestickPushData(data []byte) error {
 	resp := struct {
-		Time    int64                          `json:"time"`
+		Time    types.Time                     `json:"time"`
 		Channel string                         `json:"channel"`
 		Event   string                         `json:"event"`
 		Result  []WsOptionsContractCandlestick `json:"result"`
@@ -604,7 +605,7 @@ func (g *Gateio) processOptionsOrderbookSnapshotPushData(event string, incoming 
 
 func (g *Gateio) processOptionsOrderPushData(data []byte) error {
 	resp := struct {
-		Time    int64            `json:"time"`
+		Time    types.Time       `json:"time"`
 		Channel string           `json:"channel"`
 		Event   string           `json:"event"`
 		Result  []WsOptionsOrder `json:"result"`
@@ -646,7 +647,7 @@ func (g *Gateio) processOptionsUserTradesPushData(data []byte) error {
 		return nil
 	}
 	resp := struct {
-		Time    int64                `json:"time"`
+		Time    types.Time           `json:"time"`
 		Channel string               `json:"channel"`
 		Event   string               `json:"event"`
 		Result  []WsOptionsUserTrade `json:"result"`
@@ -672,7 +673,7 @@ func (g *Gateio) processOptionsUserTradesPushData(data []byte) error {
 
 func (g *Gateio) processOptionsLiquidatesPushData(data []byte) error {
 	resp := struct {
-		Time    int64                 `json:"time"`
+		Time    types.Time            `json:"time"`
 		Channel string                `json:"channel"`
 		Event   string                `json:"event"`
 		Result  []WsOptionsLiquidates `json:"result"`
@@ -687,7 +688,7 @@ func (g *Gateio) processOptionsLiquidatesPushData(data []byte) error {
 
 func (g *Gateio) processOptionsUsersPersonalSettlementsPushData(data []byte) error {
 	resp := struct {
-		Time    int64                     `json:"time"`
+		Time    types.Time                `json:"time"`
 		Channel string                    `json:"channel"`
 		Event   string                    `json:"event"`
 		Result  []WsOptionsUserSettlement `json:"result"`
@@ -702,7 +703,7 @@ func (g *Gateio) processOptionsUsersPersonalSettlementsPushData(data []byte) err
 
 func (g *Gateio) processOptionsPositionPushData(data []byte) error {
 	resp := struct {
-		Time    int64               `json:"time"`
+		Time    types.Time          `json:"time"`
 		Channel string              `json:"channel"`
 		Event   string              `json:"event"`
 		Result  []WsOptionsPosition `json:"result"`

--- a/exchanges/gemini/gemini_types.go
+++ b/exchanges/gemini/gemini_types.go
@@ -15,7 +15,7 @@ type Ticker struct {
 		USD       float64
 		BTC       float64
 		ETH       float64
-		Timestamp int64
+		Timestamp types.Time
 	}
 }
 
@@ -63,13 +63,13 @@ type OrderbookEntry struct {
 
 // Trade holds trade history for a specific currency pair
 type Trade struct {
-	Timestamp   int64   `json:"timestamp"`
-	Timestampms int64   `json:"timestampms"`
-	TID         int64   `json:"tid"`
-	Price       float64 `json:"price,string"`
-	Amount      float64 `json:"amount,string"`
-	Exchange    string  `json:"exchange"`
-	Type        string  `json:"type"`
+	Timestamp   types.Time `json:"timestamp"`
+	TimestampMS types.Time `json:"timestampms"`
+	TID         int64      `json:"tid"`
+	Price       float64    `json:"price,string"`
+	Amount      float64    `json:"amount,string"`
+	Exchange    string     `json:"exchange"`
+	Type        string     `json:"type"`
 }
 
 // Auction is generalized response type
@@ -90,16 +90,16 @@ type Auction struct {
 
 // AuctionHistory holds auction history information
 type AuctionHistory struct {
-	AuctionID       int64   `json:"auction_id"`
-	AuctionPrice    float64 `json:"auction_price,string"`
-	AuctionQuantity float64 `json:"auction_quantity,string"`
-	EID             int64   `json:"eid"`
-	HighestBidPrice float64 `json:"highest_bid_price,string"`
-	LowestAskPrice  float64 `json:"lowest_ask_price,string"`
-	AuctionResult   string  `json:"auction_result"`
-	Timestamp       int64   `json:"timestamp"`
-	TimestampMS     int64   `json:"timestampms"`
-	EventType       string  `json:"event_type"`
+	AuctionID       int64      `json:"auction_id"`
+	AuctionPrice    float64    `json:"auction_price,string"`
+	AuctionQuantity float64    `json:"auction_quantity,string"`
+	EID             int64      `json:"eid"`
+	HighestBidPrice float64    `json:"highest_bid_price,string"`
+	LowestAskPrice  float64    `json:"lowest_ask_price,string"`
+	AuctionResult   string     `json:"auction_result"`
+	Timestamp       types.Time `json:"timestamp"`
+	TimestampMS     types.Time `json:"timestampms"`
+	EventType       string     `json:"event_type"`
 }
 
 // OrderResult holds cancelled order information
@@ -116,7 +116,7 @@ type OrderResult struct {
 type TransferResponse struct {
 	Type                  string        `json:"type"`
 	Status                string        `json:"status"`
-	Timestamp             int64         `json:"timestampms"`
+	Timestamp             types.Time    `json:"timestampms"`
 	EventID               int64         `json:"eid"`
 	DepositAdvanceEventID int64         `json:"advanceEid"`
 	Currency              currency.Code `json:"currency"`
@@ -133,42 +133,42 @@ type TransferResponse struct {
 
 // Order contains order information
 type Order struct {
-	OrderID           int64    `json:"order_id,string"`
-	ID                int64    `json:"id,string"`
-	ClientOrderID     string   `json:"client_order_id"`
-	Symbol            string   `json:"symbol"`
-	Exchange          string   `json:"exchange"`
-	Price             float64  `json:"price,string"`
-	AvgExecutionPrice float64  `json:"avg_execution_price,string"`
-	Side              string   `json:"side"`
-	Type              string   `json:"type"`
-	Timestamp         int64    `json:"timestamp,string"`
-	TimestampMS       int64    `json:"timestampms"`
-	IsLive            bool     `json:"is_live"`
-	IsCancelled       bool     `json:"is_cancelled"`
-	IsHidden          bool     `json:"is_hidden"`
-	Options           []string `json:"options"`
-	WasForced         bool     `json:"was_forced"`
-	ExecutedAmount    float64  `json:"executed_amount,string"`
-	RemainingAmount   float64  `json:"remaining_amount,string"`
-	OriginalAmount    float64  `json:"original_amount,string"`
-	Message           string   `json:"message"`
+	OrderID           int64      `json:"order_id,string"`
+	ID                int64      `json:"id,string"`
+	ClientOrderID     string     `json:"client_order_id"`
+	Symbol            string     `json:"symbol"`
+	Exchange          string     `json:"exchange"`
+	Price             float64    `json:"price,string"`
+	AvgExecutionPrice float64    `json:"avg_execution_price,string"`
+	Side              string     `json:"side"`
+	Type              string     `json:"type"`
+	Timestamp         types.Time `json:"timestamp"`
+	TimestampMS       types.Time `json:"timestampms"`
+	IsLive            bool       `json:"is_live"`
+	IsCancelled       bool       `json:"is_cancelled"`
+	IsHidden          bool       `json:"is_hidden"`
+	Options           []string   `json:"options"`
+	WasForced         bool       `json:"was_forced"`
+	ExecutedAmount    float64    `json:"executed_amount,string"`
+	RemainingAmount   float64    `json:"remaining_amount,string"`
+	OriginalAmount    float64    `json:"original_amount,string"`
+	Message           string     `json:"message"`
 }
 
 // TradeHistory holds trade history information
 type TradeHistory struct {
-	Price           float64 `json:"price,string"`
-	Amount          float64 `json:"amount,string"`
-	Timestamp       int64   `json:"timestamp"`
-	TimestampMS     int64   `json:"timestampms"`
-	Type            string  `json:"type"`
-	FeeCurrency     string  `json:"fee_currency"`
-	FeeAmount       float64 `json:"fee_amount,string"`
-	TID             int64   `json:"tid"`
-	OrderID         int64   `json:"order_id,string"`
-	Exchange        string  `json:"exchange"`
-	IsAuctionFilled bool    `json:"is_auction_fill"`
-	ClientOrderID   string  `json:"client_order_id"`
+	Price           float64    `json:"price,string"`
+	Amount          float64    `json:"amount,string"`
+	Timestamp       types.Time `json:"timestamp"`
+	TimestampMS     types.Time `json:"timestampms"`
+	Type            string     `json:"type"`
+	FeeCurrency     string     `json:"fee_currency"`
+	FeeAmount       float64    `json:"fee_amount,string"`
+	TID             int64      `json:"tid"`
+	OrderID         int64      `json:"order_id,string"`
+	Exchange        string     `json:"exchange"`
+	IsAuctionFilled bool       `json:"is_auction_fill"`
+	ClientOrderID   string     `json:"client_order_id"`
 	// Used to store values
 	BaseCurrency  string
 	QuoteCurrency string
@@ -272,11 +272,11 @@ type WsSubscriptionAcknowledgementResponse struct {
 
 // WsHeartbeatResponse Gemini will send a heartbeat every five seconds so you'll know your WebSocket connection is active.
 type WsHeartbeatResponse struct {
-	Type           string `json:"type"`
-	Timestampms    int64  `json:"timestampms"`
-	Sequence       int64  `json:"sequence"`
-	TraceID        string `json:"trace_id"`
-	SocketSequence int64  `json:"socket_sequence"`
+	Type           string     `json:"type"`
+	TimestampMS    types.Time `json:"timestampms"`
+	Sequence       int64      `json:"sequence"`
+	TraceID        string     `json:"trace_id"`
+	SocketSequence int64      `json:"socket_sequence"`
 }
 
 // WsOrderResponse contains active orders
@@ -285,7 +285,7 @@ type WsOrderResponse struct {
 	IsCancelled       bool              `json:"is_cancelled"`
 	IsHidden          bool              `json:"is_hidden"`
 	SocketSequence    int64             `json:"socket_sequence"`
-	Timestampms       int64             `json:"timestampms"`
+	TimestampMS       types.Time        `json:"timestampms"`
 	AvgExecutionPrice float64           `json:"avg_execution_price,string"`
 	ExecutedAmount    float64           `json:"executed_amount,string"`
 	RemainingAmount   float64           `json:"remaining_amount,string"`
@@ -300,7 +300,7 @@ type WsOrderResponse struct {
 	Symbol            string            `json:"symbol"`
 	Side              string            `json:"side"`
 	OrderType         string            `json:"order_type"`
-	Timestamp         string            `json:"timestamp"`
+	Timestamp         types.Time        `json:"timestamp"`
 	Fill              WsOrderFilledData `json:"fill"`
 }
 
@@ -338,25 +338,25 @@ type wsSubscribeRequest struct {
 }
 
 type wsTrade struct {
-	Type      string  `json:"type"`
-	Symbol    string  `json:"symbol"`
-	EventID   int64   `json:"event_id"`
-	Timestamp int64   `json:"timestamp"`
-	Price     float64 `json:"price,string"`
-	Quantity  float64 `json:"quantity,string"`
-	Side      string  `json:"side"`
+	Type      string     `json:"type"`
+	Symbol    string     `json:"symbol"`
+	EventID   int64      `json:"event_id"`
+	Timestamp types.Time `json:"timestamp"`
+	Price     float64    `json:"price,string"`
+	Quantity  float64    `json:"quantity,string"`
+	Side      string     `json:"side"`
 }
 
 type wsAuctionResult struct {
-	Type             string  `json:"type"`
-	Symbol           string  `json:"symbol"`
-	Result           string  `json:"result"`
-	TimeMilliseconds int64   `json:"time_ms"`
-	HighestBidPrice  float64 `json:"highest_bid_price,string"`
-	LowestBidPrice   float64 `json:"lowest_ask_price,string"`
-	CollarPrice      float64 `json:"collar_price,string"`
-	AuctionPrice     float64 `json:"auction_price,string"`
-	AuctionQuantity  float64 `json:"auction_quantity,string"`
+	Type             string     `json:"type"`
+	Symbol           string     `json:"symbol"`
+	Result           string     `json:"result"`
+	TimeMilliseconds types.Time `json:"time_ms"`
+	HighestBidPrice  float64    `json:"highest_bid_price,string"`
+	LowestBidPrice   float64    `json:"lowest_ask_price,string"`
+	CollarPrice      float64    `json:"collar_price,string"`
+	AuctionPrice     float64    `json:"auction_price,string"`
+	AuctionQuantity  float64    `json:"auction_quantity,string"`
 }
 
 type wsL2MarketData struct {

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -284,7 +284,7 @@ func (g *Gemini) wsHandleData(respRaw []byte) error {
 				Side:            oSide,
 				Status:          oStatus,
 				AssetType:       asset.Spot,
-				Date:            time.UnixMilli(result[i].Timestampms),
+				Date:            result[i].TimestampMS.Time(),
 				Pair:            pair,
 			}
 		}
@@ -339,7 +339,7 @@ func (g *Gemini) wsHandleData(respRaw []byte) error {
 			}
 
 			tradeEvent := trade.Data{
-				Timestamp:    time.UnixMilli(result.Timestamp),
+				Timestamp:    result.Timestamp.Time(),
 				CurrencyPair: pair,
 				AssetType:    asset.Spot,
 				Exchange:     g.Name,
@@ -555,7 +555,7 @@ func (g *Gemini) wsProcessUpdate(result *wsL2MarketData) error {
 			}
 		}
 		trades[x] = trade.Data{
-			Timestamp:    time.UnixMilli(result.Trades[x].Timestamp),
+			Timestamp:    result.Trades[x].Timestamp.Time(),
 			CurrencyPair: pair,
 			AssetType:    asset.Spot,
 			Exchange:     g.Name,

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -344,7 +344,7 @@ func (g *Gemini) GetAccountFundingHistory(ctx context.Context) ([]exchange.Fundi
 		resp[i] = exchange.FundingHistory{
 			Status:          transfers[i].Status,
 			TransferID:      transfers[i].WithdrawalID,
-			Timestamp:       time.UnixMilli(transfers[i].Timestamp),
+			Timestamp:       transfers[i].Timestamp.Time(),
 			Currency:        transfers[i].Currency.String(),
 			Amount:          transfers[i].Amount,
 			Fee:             transfers[i].FeeAmount,
@@ -373,7 +373,7 @@ func (g *Gemini) GetWithdrawalsHistory(ctx context.Context, c currency.Code, a a
 		resp = append(resp, exchange.WithdrawalHistory{
 			Status:          transfers[i].Status,
 			TransferID:      transfers[i].WithdrawalID,
-			Timestamp:       time.UnixMilli(transfers[i].Timestamp),
+			Timestamp:       transfers[i].Timestamp.Time(),
 			Currency:        transfers[i].Currency.String(),
 			Amount:          transfers[i].Amount,
 			Fee:             transfers[i].FeeAmount,
@@ -406,16 +406,12 @@ func (g *Gemini) GetHistoricTrades(ctx context.Context, p currency.Pair, assetTy
 allTrades:
 	for {
 		var tradeData []Trade
-		tradeData, err = g.GetTrades(ctx,
-			p.String(),
-			ts.Unix(),
-			int64(limit),
-			false)
+		tradeData, err = g.GetTrades(ctx, p.String(), ts.Unix(), int64(limit), false)
 		if err != nil {
 			return nil, err
 		}
 		for i := range tradeData {
-			tradeTS := time.Unix(tradeData[i].Timestamp, 0)
+			tradeTS := tradeData[i].Timestamp.Time()
 			if tradeTS.After(timestampEnd) && !timestampEnd.IsZero() {
 				break allTrades
 			}
@@ -569,7 +565,7 @@ func (g *Gemini) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pa
 		Amount:          resp.OriginalAmount,
 		RemainingAmount: resp.RemainingAmount,
 		Pair:            cp,
-		Date:            time.UnixMilli(resp.TimestampMS),
+		Date:            resp.TimestampMS.Time(),
 		Price:           resp.Price,
 		HiddenOrder:     resp.IsHidden,
 		ClientOrderID:   resp.ClientOrderID,
@@ -678,7 +674,6 @@ func (g *Gemini) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 		if err != nil {
 			return nil, err
 		}
-		orderDate := time.Unix(resp[i].Timestamp, 0)
 
 		orders[i] = order.Detail{
 			Amount:          resp[i].OriginalAmount,
@@ -690,7 +685,7 @@ func (g *Gemini) GetActiveOrders(ctx context.Context, req *order.MultiOrderReque
 			Side:            side,
 			Price:           resp[i].Price,
 			Pair:            symbol,
-			Date:            orderDate,
+			Date:            resp[i].Timestamp.Time(),
 		}
 	}
 	return req.Filter(g.Name, orders), nil
@@ -741,14 +736,12 @@ func (g *Gemini) GetOrderHistory(ctx context.Context, req *order.MultiOrderReque
 		if err != nil {
 			return nil, err
 		}
-		orderDate := time.Unix(trades[i].Timestamp, 0)
-
 		detail := order.Detail{
 			OrderID:              strconv.FormatInt(trades[i].OrderID, 10),
 			Amount:               trades[i].Amount,
 			ExecutedAmount:       trades[i].Amount,
 			Exchange:             g.Name,
-			Date:                 orderDate,
+			Date:                 trades[i].Timestamp.Time(),
 			Side:                 side,
 			Fee:                  trades[i].FeeAmount,
 			Price:                trades[i].Price,

--- a/exchanges/huobi/cfutures_types.go
+++ b/exchanges/huobi/cfutures_types.go
@@ -269,13 +269,13 @@ type SwapWsSubFundingData struct {
 	Topic       string     `json:"topic"`
 	Timestamp   types.Time `json:"ts"`
 	FundingData []struct {
-		Symbol         string  `json:"symbol"`
-		ContractCode   string  `json:"contract_code"`
-		FeeAsset       string  `json:"fee_asset"`
-		FundingTime    int64   `json:"funding_time,string"`
-		FundingRate    float64 `json:"funding_rate,string"`
-		EstimatedRate  float64 `json:"estimated_rate,string"`
-		SettlementTime int64   `json:"settlement_time,string"`
+		Symbol         string     `json:"symbol"`
+		ContractCode   string     `json:"contract_code"`
+		FeeAsset       string     `json:"fee_asset"`
+		FundingTime    types.Time `json:"funding_time"`
+		FundingRate    float64    `json:"funding_rate,string"`
+		EstimatedRate  float64    `json:"estimated_rate,string"`
+		SettlementTime types.Time `json:"settlement_time"`
 	} `json:"data"`
 }
 
@@ -435,7 +435,7 @@ type CoinMarginedFuturesTrade struct {
 
 // InsuranceAndClawbackData stores insurance fund's and clawback rate's data
 type InsuranceAndClawbackData struct {
-	Timestamp string `json:"timestamp"`
+	Timestamp types.Time `json:"timestamp"`
 	Data      []struct {
 		ContractCode      string  `json:"contract_code"`
 		InsuranceFund     float64 `json:"insurance_fund"`
@@ -553,13 +553,13 @@ type SwapFundingRatesResponse struct {
 
 // FundingRatesData stores funding rates data
 type FundingRatesData struct {
-	EstimatedRate   float64 `json:"estimated_rate,string"`
-	FundingRate     float64 `json:"funding_rate,string"`
-	ContractCode    string  `json:"contractCode"`
-	Symbol          string  `json:"symbol"`
-	FeeAsset        string  `json:"fee_asset"`
-	FundingTime     int64   `json:"fundingTime,string"`
-	NextFundingTime int64   `json:"next_funding_time,string"`
+	EstimatedRate   float64    `json:"estimated_rate,string"`
+	FundingRate     float64    `json:"funding_rate,string"`
+	ContractCode    string     `json:"contractCode"`
+	Symbol          string     `json:"symbol"`
+	FeeAsset        string     `json:"fee_asset"`
+	FundingTime     types.Time `json:"fundingTime"`
+	NextFundingTime types.Time `json:"next_funding_time"`
 }
 
 // HistoricalFundingRateData stores historical funding rates for perpetuals
@@ -574,13 +574,13 @@ type HistoricalFundingRateData struct {
 
 // HistoricalRateData stores historical rates data
 type HistoricalRateData struct {
-	FundingRate     float64 `json:"funding_rate,string"`
-	RealizedRate    float64 `json:"realized_rate,string"`
-	FundingTime     int64   `json:"fundingTime,string"`
-	ContractCode    string  `json:"contract_code"`
-	Symbol          string  `json:"symbol"`
-	FeeAsset        string  `json:"fee_asset"`
-	AvgPremiumIndex float64 `json:"avg_premium_index,string"`
+	FundingRate     float64    `json:"funding_rate,string"`
+	RealizedRate    float64    `json:"realized_rate,string"`
+	FundingTime     types.Time `json:"fundingTime"`
+	ContractCode    string     `json:"contract_code"`
+	Symbol          string     `json:"symbol"`
+	FeeAsset        string     `json:"fee_asset"`
+	AvgPremiumIndex float64    `json:"avg_premium_index,string"`
 }
 
 // PremiumIndexKlineData stores kline data for premium

--- a/exchanges/huobi/cfutures_types.go
+++ b/exchanges/huobi/cfutures_types.go
@@ -253,13 +253,13 @@ type SwapWsSubLiquidationOrders struct {
 	Topic      string     `json:"topic"`
 	Timestamp  types.Time `json:"ts"`
 	OrdersData []struct {
-		Symbol       string  `json:"symbol"`
-		ContractCode string  `json:"contract_code"`
-		Direction    string  `json:"direction"`
-		Offset       string  `json:"offset"`
-		Volume       float64 `json:"volume"`
-		Price        float64 `json:"price"`
-		CreatedAt    int64   `json:"created_at"`
+		Symbol       string     `json:"symbol"`
+		ContractCode string     `json:"contract_code"`
+		Direction    string     `json:"direction"`
+		Offset       string     `json:"offset"`
+		Volume       float64    `json:"volume"`
+		Price        float64    `json:"price"`
+		CreatedAt    types.Time `json:"created_at"`
 	} `json:"data"`
 }
 
@@ -533,15 +533,15 @@ type TraderSentimentIndexPositionData struct {
 // LiquidationOrdersData stores data of liquidation orders
 type LiquidationOrdersData struct {
 	Data []struct {
-		QueryID      int64   `json:"query_id"`
-		ContractCode string  `json:"contract_code"`
-		Symbol       string  `json:"symbol"`
-		Direction    string  `json:"direction"`
-		Offset       string  `json:"offset"`
-		Volume       float64 `json:"volume"`
-		Price        float64 `json:"price"`
-		CreatedAt    int64   `json:"created_at"`
-		Amount       float64 `json:"amount"`
+		QueryID      int64      `json:"query_id"`
+		ContractCode string     `json:"contract_code"`
+		Symbol       string     `json:"symbol"`
+		Direction    string     `json:"direction"`
+		Offset       string     `json:"offset"`
+		Volume       float64    `json:"volume"`
+		Price        float64    `json:"price"`
+		CreatedAt    types.Time `json:"created_at"`
+		Amount       float64    `json:"amount"`
 	} `json:"data"`
 }
 

--- a/exchanges/huobi/futures_types.go
+++ b/exchanges/huobi/futures_types.go
@@ -427,16 +427,16 @@ type FFinancialRecords struct {
 type FSettlementRecords struct {
 	Data struct {
 		SettlementRecords []struct {
-			Symbol               string  `json:"symbol"`
-			MarginBalanceInit    float64 `json:"margin_balance_init"`
-			MarginBalance        int64   `json:"margin_balance"`
-			SettlementProfitReal float64 `json:"settlement_profit_real"`
-			SettlementTime       int64   `json:"settlement_time"`
-			Clawback             float64 `json:"clawback"`
-			DeliveryFee          float64 `json:"delivery_fee"`
-			OffsetProfitLoss     float64 `json:"offset_profitloss"`
-			Fee                  float64 `json:"fee"`
-			FeeAsset             string  `json:"fee_asset"`
+			Symbol               string     `json:"symbol"`
+			MarginBalanceInit    float64    `json:"margin_balance_init"`
+			MarginBalance        int64      `json:"margin_balance"`
+			SettlementProfitReal float64    `json:"settlement_profit_real"`
+			SettlementTime       types.Time `json:"settlement_time"`
+			Clawback             float64    `json:"clawback"`
+			DeliveryFee          float64    `json:"delivery_fee"`
+			OffsetProfitLoss     float64    `json:"offset_profitloss"`
+			Fee                  float64    `json:"fee"`
+			FeeAsset             string     `json:"fee_asset"`
 			Positions            []struct {
 				Symbol                 string  `json:"symbol"`
 				ContractCode           string  `json:"contract_code"`
@@ -725,29 +725,29 @@ type FOpenOrdersData struct {
 type FOrderHistoryData struct {
 	Data struct {
 		Orders []struct {
-			Symbol          string  `json:"symbol"`
-			ContractType    string  `json:"contract_type"`
-			ContractCode    string  `json:"contract_code"`
-			Volume          float64 `json:"volume"`
-			Price           float64 `json:"price"`
-			OrderPriceType  string  `json:"order_price_type"`
-			Direction       string  `json:"direction"`
-			Offset          string  `json:"offset"`
-			LeverageRate    float64 `json:"lever_rate"`
-			OrderID         int64   `json:"order_id"`
-			OrderIDString   string  `json:"order_id_str"`
-			OrderSource     string  `json:"order_source"`
-			CreateDate      int64   `json:"create_date"`
-			TradeVolume     float64 `json:"trade_volume"`
-			TradeTurnover   float64 `json:"trade_turnover"`
-			Fee             float64 `json:"fee"`
-			TradeAvgPrice   float64 `json:"trade_avg_price"`
-			MarginFrozen    float64 `json:"margin_frozen"`
-			Profit          float64 `json:"profit"`
-			Status          int64   `json:"status"`
-			OrderType       int64   `json:"order_type"`
-			FeeAsset        string  `json:"fee_asset"`
-			LiquidationType int64   `json:"liquidation_type"`
+			Symbol          string     `json:"symbol"`
+			ContractType    string     `json:"contract_type"`
+			ContractCode    string     `json:"contract_code"`
+			Volume          float64    `json:"volume"`
+			Price           float64    `json:"price"`
+			OrderPriceType  string     `json:"order_price_type"`
+			Direction       string     `json:"direction"`
+			Offset          string     `json:"offset"`
+			LeverageRate    float64    `json:"lever_rate"`
+			OrderID         int64      `json:"order_id"`
+			OrderIDString   string     `json:"order_id_str"`
+			OrderSource     string     `json:"order_source"`
+			CreateDate      types.Time `json:"create_date"`
+			TradeVolume     float64    `json:"trade_volume"`
+			TradeTurnover   float64    `json:"trade_turnover"`
+			Fee             float64    `json:"fee"`
+			TradeAvgPrice   float64    `json:"trade_avg_price"`
+			MarginFrozen    float64    `json:"margin_frozen"`
+			Profit          float64    `json:"profit"`
+			Status          int64      `json:"status"`
+			OrderType       int64      `json:"order_type"`
+			FeeAsset        string     `json:"fee_asset"`
+			LiquidationType int64      `json:"liquidation_type"`
 		} `json:"orders"`
 		TotalPage   int64 `json:"total_page"`
 		CurrentPage int64 `json:"current_page"`

--- a/exchanges/huobi/futures_types.go
+++ b/exchanges/huobi/futures_types.go
@@ -264,13 +264,13 @@ type FTopPositionsLongShortRatio struct {
 type FLiquidationOrdersInfo struct {
 	Data struct {
 		Orders []struct {
-			Symbol       string  `json:"symbol"`
-			ContractCode string  `json:"contract_code"`
-			Direction    string  `json:"direction"`
-			Offset       string  `json:"offset"`
-			Volume       float64 `json:"volume"`
-			Price        float64 `json:"price"`
-			CreatedAt    int64   `json:"created_at"`
+			Symbol       string     `json:"symbol"`
+			ContractCode string     `json:"contract_code"`
+			Direction    string     `json:"direction"`
+			Offset       string     `json:"offset"`
+			Volume       float64    `json:"volume"`
+			Price        float64    `json:"price"`
+			CreatedAt    types.Time `json:"created_at"`
 		} `json:"orders"`
 		TotalPage   int64 `json:"total_page"`
 		CurrentPage int64 `json:"current_page"`

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -20,6 +20,7 @@ import (
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -366,13 +367,13 @@ func (h *HUOBI) GetCurrenciesIncludingChains(ctx context.Context, curr currency.
 func (h *HUOBI) GetCurrentServerTime(ctx context.Context) (time.Time, error) {
 	var result struct {
 		Response
-		Timestamp int64 `json:"data"`
+		Timestamp types.Time `json:"data"`
 	}
 	err := h.SendHTTPRequest(ctx, exchange.RestSpot, "/v"+huobiAPIVersion+"/"+huobiTimestamp, &result)
 	if result.ErrorMessage != "" {
 		return time.Time{}, errors.New(result.ErrorMessage)
 	}
-	return time.UnixMilli(result.Timestamp), err
+	return result.Timestamp.Time(), err
 }
 
 // GetAccounts returns the Huobi user accounts

--- a/exchanges/huobi/huobi_cfutures.go
+++ b/exchanges/huobi/huobi_cfutures.go
@@ -282,7 +282,7 @@ func (h *HUOBI) GetTraderSentimentIndexPosition(ctx context.Context, code curren
 }
 
 // GetLiquidationOrders gets liquidation orders for a given perp
-func (h *HUOBI) GetLiquidationOrders(ctx context.Context, contract currency.Pair, tradeType string, startTime, endTime int64, direction string, fromID int64) (LiquidationOrdersData, error) {
+func (h *HUOBI) GetLiquidationOrders(ctx context.Context, contract currency.Pair, tradeType string, startTime, endTime time.Time, direction string, fromID int64) (LiquidationOrdersData, error) {
 	var resp LiquidationOrdersData
 	formattedContract, err := h.FormatSymbol(contract, asset.CoinMarginedFutures)
 	if err != nil {
@@ -296,11 +296,11 @@ func (h *HUOBI) GetLiquidationOrders(ctx context.Context, contract currency.Pair
 	params.Set("contract", formattedContract)
 	params.Set("trade_type", strconv.FormatInt(tType, 10))
 
-	if startTime != 0 {
-		params.Set("start_time", strconv.FormatInt(startTime, 10))
+	if !startTime.IsZero() {
+		params.Set("start_time", strconv.FormatInt(startTime.UnixMilli(), 10))
 	}
-	if endTime != 0 {
-		params.Set("end_time", strconv.FormatInt(startTime, 10))
+	if !endTime.IsZero() {
+		params.Set("end_time", strconv.FormatInt(endTime.UnixMilli(), 10))
 	}
 	if direction != "" {
 		params.Set("direct", direction)
@@ -512,8 +512,8 @@ func (h *HUOBI) GetSwapSettlementRecords(ctx context.Context, code currency.Pair
 		if startTime.After(endTime) {
 			return resp, errors.New("startTime cannot be after endTime")
 		}
-		req["start_time"] = strconv.FormatInt(startTime.Unix(), 10)
-		req["end_time"] = strconv.FormatInt(endTime.Unix(), 10)
+		req["start_time"] = strconv.FormatInt(startTime.UnixMilli(), 10)
+		req["end_time"] = strconv.FormatInt(endTime.UnixMilli(), 10)
 	}
 	if pageIndex != 0 {
 		req["page_index"] = pageIndex

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -521,8 +521,9 @@ func TestGetSwapMarketDepth(t *testing.T) {
 
 func TestGetSwapKlineData(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetSwapKlineData(t.Context(), btcusdPair, "5min", 5, time.Now().Add(-time.Hour), time.Now())
+	r, err := h.GetSwapKlineData(t.Context(), btcusdPair, "5min", 5, time.Now().Add(-time.Hour), time.Now())
 	require.NoError(t, err)
+	assert.NotEmpty(t, r.Data, "GetSwapKlineData should return some data")
 }
 
 func TestGetSwapMarketOverview(t *testing.T) {
@@ -570,8 +571,9 @@ func TestGetTraderSentimentIndexPosition(t *testing.T) {
 
 func TestGetLiquidationOrders(t *testing.T) {
 	t.Parallel()
-	_, err := h.GetLiquidationOrders(t.Context(), btcusdPair, "closed", 0, 0, "", 0)
+	r, err := h.GetLiquidationOrders(t.Context(), btcusdPair, "closed", time.Now().AddDate(0, 0, -1), time.Now(), "", 0)
 	require.NoError(t, err)
+	assert.NotEmpty(t, r.Data, "GetLiquidationOrders should return some data")
 }
 
 func TestGetHistoricalFundingRates(t *testing.T) {
@@ -662,8 +664,9 @@ func TestGetAccountFinancialRecords(t *testing.T) {
 func TestGetSwapSettlementRecords(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, h)
-	_, err := h.GetSwapSettlementRecords(t.Context(), ethusdPair, time.Time{}, time.Time{}, 0, 0)
+	r, err := h.GetSwapSettlementRecords(t.Context(), ethusdPair, time.Now().AddDate(0, -1, 0), time.Now(), 0, 0)
 	require.NoError(t, err)
+	assert.NotEmpty(t, r.Data, "GetSwapSettlementRecords should return some data")
 }
 
 func TestGetAvailableLeverage(t *testing.T) {

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -571,9 +571,8 @@ func TestGetTraderSentimentIndexPosition(t *testing.T) {
 
 func TestGetLiquidationOrders(t *testing.T) {
 	t.Parallel()
-	r, err := h.GetLiquidationOrders(t.Context(), btcusdPair, "closed", time.Now().AddDate(0, 0, -1), time.Now(), "", 0)
-	require.NoError(t, err)
-	assert.NotEmpty(t, r.Data, "GetLiquidationOrders should return some data")
+	_, err := h.GetLiquidationOrders(t.Context(), btcusdPair, "closed", time.Now().AddDate(0, 0, -2), time.Now(), "", 0)
+	assert.NoError(t, err, "GetLiquidationOrders should not error")
 }
 
 func TestGetHistoricalFundingRates(t *testing.T) {

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -379,13 +379,13 @@ type FWsSubLiquidationOrders struct {
 	Topic      string     `json:"topic"`
 	Timestamp  types.Time `json:"ts"`
 	OrdersData []struct {
-		Symbol       string  `json:"symbol"`
-		ContractCode string  `json:"contract_code"`
-		Direction    string  `json:"direction"`
-		Offset       string  `json:"offset"`
-		Volume       float64 `json:"volume"`
-		Price        float64 `json:"price"`
-		CreatedAt    int64   `json:"created_at"`
+		Symbol       string     `json:"symbol"`
+		ContractCode string     `json:"contract_code"`
+		Direction    string     `json:"direction"`
+		Offset       string     `json:"offset"`
+		Volume       float64    `json:"volume"`
+		Price        float64    `json:"price"`
+		CreatedAt    types.Time `json:"created_at"`
 	} `json:"data"`
 }
 
@@ -701,16 +701,16 @@ type OrderInfo struct {
 
 // OrderMatchInfo stores the order match info
 type OrderMatchInfo struct {
-	ID           int    `json:"id"`
-	OrderID      int    `json:"order-id"`
-	MatchID      int    `json:"match-id"`
-	Symbol       string `json:"symbol"`
-	Type         string `json:"type"`
-	Source       string `json:"source"`
-	Price        string `json:"price"`
-	FilledAmount string `json:"filled-amount"`
-	FilledFees   string `json:"filled-fees"`
-	CreatedAt    int64  `json:"created-at"`
+	ID           int        `json:"id"`
+	OrderID      int        `json:"order-id"`
+	MatchID      int        `json:"match-id"`
+	Symbol       string     `json:"symbol"`
+	Type         string     `json:"type"`
+	Source       string     `json:"source"`
+	Price        string     `json:"price"`
+	FilledAmount string     `json:"filled-amount"`
+	FilledFees   string     `json:"filled-fees"`
+	CreatedAt    types.Time `json:"created-at"`
 }
 
 // MarginOrder stores the margin order info

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -475,14 +475,14 @@ type ResponseV2 struct {
 
 // SwapMarketsData stores market data for swaps
 type SwapMarketsData struct {
-	Symbol         string  `json:"symbol"`
-	ContractCode   string  `json:"contract_code"`
-	ContractSize   float64 `json:"contract_size"`
-	PriceTick      float64 `json:"price_tick"`
-	SettlementDate string  `json:"settlement_date"`
-	CreateDate     string  `json:"create_date"`
-	DeliveryTime   string  `json:"delivery_time"`
-	ContractStatus int64   `json:"contract_status"`
+	Symbol         string     `json:"symbol"`
+	ContractCode   string     `json:"contract_code"`
+	ContractSize   float64    `json:"contract_size"`
+	PriceTick      float64    `json:"price_tick"`
+	SettlementDate types.Time `json:"settlement_date"`
+	CreateDate     string     `json:"create_date"`
+	DeliveryTime   types.Time `json:"delivery_time"`
+	ContractStatus int64      `json:"contract_status"`
 }
 
 // KlineItem stores a kline item
@@ -580,7 +580,7 @@ type OrderBookDataRequestParams struct {
 // Orderbook stores the orderbook data
 type Orderbook struct {
 	ID         int64        `json:"id"`
-	Timetstamp int64        `json:"ts"`
+	Timetstamp types.Time   `json:"ts"`
 	Bids       [][2]float64 `json:"bids"`
 	Asks       [][2]float64 `json:"asks"`
 }
@@ -678,25 +678,25 @@ type CancelOrderBatch struct {
 
 // OrderInfo stores the order info
 type OrderInfo struct {
-	ID               int64   `json:"id"`
-	Symbol           string  `json:"symbol"`
-	AccountID        int64   `json:"account-id"`
-	Amount           float64 `json:"amount,string"`
-	Price            float64 `json:"price,string"`
-	CreatedAt        int64   `json:"created-at"`
-	Type             string  `json:"type"`
-	FieldAmount      float64 `json:"field-amount,string"`
-	FieldCashAmount  float64 `json:"field-cash-amount,string"`
-	FilledAmount     float64 `json:"filled-amount,string"`
-	FilledCashAmount float64 `json:"filled-cash-amount,string"`
-	FilledFees       float64 `json:"filled-fees,string"`
-	FinishedAt       int64   `json:"finished-at"`
-	UserID           int64   `json:"user-id"`
-	Source           string  `json:"source"`
-	State            string  `json:"state"`
-	CanceledAt       int64   `json:"canceled-at"`
-	Exchange         string  `json:"exchange"`
-	Batch            string  `json:"batch"`
+	ID               int64      `json:"id"`
+	Symbol           string     `json:"symbol"`
+	AccountID        int64      `json:"account-id"`
+	Amount           float64    `json:"amount,string"`
+	Price            float64    `json:"price,string"`
+	CreatedAt        types.Time `json:"created-at"`
+	Type             string     `json:"type"`
+	FieldAmount      float64    `json:"field-amount,string"`
+	FieldCashAmount  float64    `json:"field-cash-amount,string"`
+	FilledAmount     float64    `json:"filled-amount,string"`
+	FilledCashAmount float64    `json:"filled-cash-amount,string"`
+	FilledFees       float64    `json:"filled-fees,string"`
+	FinishedAt       types.Time `json:"finished-at"`
+	UserID           int64      `json:"user-id"`
+	Source           string     `json:"source"`
+	State            string     `json:"state"`
+	CanceledAt       int64      `json:"canceled-at"`
+	Exchange         string     `json:"exchange"`
+	Batch            string     `json:"batch"`
 }
 
 // OrderMatchInfo stores the order match info

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -1341,7 +1341,7 @@ func (h *HUOBI) GetOrderInfo(ctx context.Context, orderID string, pair currency.
 			Pair:           p,
 			Type:           orderType,
 			Side:           orderSide,
-			Date:           time.UnixMilli(respData.CreatedAt),
+			Date:           respData.CreatedAt.Time(),
 			Status:         orderStatus,
 			Price:          respData.Price,
 			Amount:         respData.Amount,
@@ -1514,7 +1514,7 @@ func (h *HUOBI) GetActiveOrders(ctx context.Context, req *order.MultiOrderReques
 					RemainingAmount: resp[x].Amount - resp[x].FilledAmount,
 					Pair:            req.Pairs[i],
 					Exchange:        h.Name,
-					Date:            time.UnixMilli(resp[x].CreatedAt),
+					Date:            resp[x].CreatedAt.Time(),
 					AccountID:       strconv.FormatInt(resp[x].AccountID, 10),
 					Fee:             resp[x].FilledFees,
 				}
@@ -1648,8 +1648,8 @@ func (h *HUOBI) GetOrderHistory(ctx context.Context, req *order.MultiOrderReques
 					CostAsset:       req.Pairs[i].Quote,
 					Pair:            req.Pairs[i],
 					Exchange:        h.Name,
-					Date:            time.UnixMilli(resp[x].CreatedAt),
-					CloseTime:       time.UnixMilli(resp[x].FinishedAt),
+					Date:            resp[x].CreatedAt.Time(),
+					CloseTime:       resp[x].FinishedAt.Time(),
 					AccountID:       strconv.FormatInt(resp[x].AccountID, 10),
 					Fee:             resp[x].FilledFees,
 				}
@@ -1738,8 +1738,6 @@ func (h *HUOBI) GetOrderHistory(ctx context.Context, req *order.MultiOrderReques
 					if req.Type != orderVars.OrderType {
 						continue
 					}
-					orderCreateTime := time.Unix(openOrders.Data.Orders[x].CreateDate, 0)
-
 					p, err := currency.NewPairFromString(openOrders.Data.Orders[x].ContractCode)
 					if err != nil {
 						return orders, err
@@ -1759,7 +1757,7 @@ func (h *HUOBI) GetOrderHistory(ctx context.Context, req *order.MultiOrderReques
 						Type:            orderVars.OrderType,
 						Status:          orderVars.Status,
 						Pair:            p,
-						Date:            orderCreateTime,
+						Date:            openOrders.Data.Orders[x].CreateDate.Time(),
 					})
 				}
 				currentPage++
@@ -2191,9 +2189,7 @@ func (h *HUOBI) GetLatestFundingRates(ctx context.Context, r *fundingrate.Latest
 		if !isPerp {
 			continue
 		}
-		var ft, nft time.Time
-		nft = time.UnixMilli(rates[i].NextFundingTime)
-		ft = time.UnixMilli(rates[i].FundingTime)
+		ft, nft := rates[i].FundingTime.Time(), rates[i].NextFundingTime.Time()
 		var fri time.Duration
 		if len(h.Features.Supports.FuturesCapabilities.SupportedFundingRateFrequencies) == 1 {
 			// can infer funding rate interval from the only funding rate frequency defined
@@ -2201,7 +2197,7 @@ func (h *HUOBI) GetLatestFundingRates(ctx context.Context, r *fundingrate.Latest
 				fri = k.Duration()
 			}
 		}
-		if rates[i].FundingTime == 0 {
+		if rates[i].FundingTime.Time().IsZero() {
 			ft = nft.Add(-fri)
 		}
 		if ft.After(time.Now()) {

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1,7 +1,6 @@
 package kline
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -371,10 +370,7 @@ func setupTest(t *testing.T) {
 	t.Helper()
 	if verbose {
 		err := testhelpers.EnableVerboseTestOutput()
-		if err != nil {
-			fmt.Printf("failed to enable verbose test output: %v", err)
-			os.Exit(1)
-		}
+		require.NoError(t, err, "EnableVerboseTestOutput must not error")
 	}
 
 	testhelpers.MigrationDir = filepath.Join("..", "..", "database", "migrations")

--- a/exchanges/kraken/futures_types.go
+++ b/exchanges/kraken/futures_types.go
@@ -479,17 +479,17 @@ type CancelOrdersAfterData struct {
 
 // RecentOrderData stores order data of a recent order
 type RecentOrderData struct {
-	UID        string  `json:"uid"`
-	AccountID  string  `json:"accountId"`
-	Tradeable  string  `json:"tradeable"`
-	Direction  string  `json:"direction"`
-	Quantity   float64 `json:"quantity,string"`
-	Filled     float64 `json:"filled,string"`
-	Timestamp  string  `json:"timestamp"`
-	LimitPrice float64 `json:"limitPrice,string"`
-	OrderType  string  `json:"orderType"`
-	ClientID   string  `json:"clientId"`
-	StopPrice  float64 `json:"stopPrice,string"`
+	UID        string    `json:"uid"`
+	AccountID  string    `json:"accountId"`
+	Tradeable  string    `json:"tradeable"`
+	Direction  string    `json:"direction"`
+	Quantity   float64   `json:"quantity,string"`
+	Filled     float64   `json:"filled,string"`
+	Timestamp  time.Time `json:"timestamp"`
+	LimitPrice float64   `json:"limitPrice,string"`
+	OrderType  string    `json:"orderType"`
+	ClientID   string    `json:"clientId"`
+	StopPrice  float64   `json:"stopPrice,string"`
 }
 
 // FOpenOrdersData stores open orders data for futures

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -292,136 +292,39 @@ func (k *Kraken) GetDepth(ctx context.Context, symbol currency.Pair) (*Orderbook
 }
 
 // GetTrades returns current trades on Kraken
-func (k *Kraken) GetTrades(ctx context.Context, symbol currency.Pair) ([]RecentTrades, error) {
-	values := url.Values{}
+func (k *Kraken) GetTrades(ctx context.Context, symbol currency.Pair, since time.Time, count uint64) (*RecentTradesResponse, error) {
 	symbolValue, err := k.FormatSymbol(symbol, asset.Spot)
 	if err != nil {
 		return nil, err
 	}
-	translatedAsset := assetTranslator.LookupCurrency(symbolValue)
-	values.Set("pair", translatedAsset)
-
-	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenTrades, values.Encode())
-
-	data := make(map[string]any)
-	err = k.SendHTTPRequest(ctx, exchange.RestSpot, path, &data)
-	if err != nil {
-		return nil, err
+	values := url.Values{}
+	values.Set("pair", assetTranslator.LookupCurrency(symbolValue))
+	if !since.IsZero() {
+		values.Set("since", strconv.FormatInt(since.Unix(), 10))
+	}
+	if count > 0 {
+		values.Set("count", strconv.FormatUint(count, 10))
 	}
 
-	trades, ok := data[translatedAsset].([]any)
-	if !ok {
-		return nil, fmt.Errorf("no data returned for symbol %v", symbol)
-	}
-
-	var individualTrade []any
-	recentTrades := make([]RecentTrades, len(trades))
-	for x := range trades {
-		individualTrade, ok = trades[x].([]any)
-		if !ok {
-			return nil, errors.New("unable to parse individual trade data")
-		}
-		if len(individualTrade) != 7 {
-			return nil, errors.New("unrecognised trade data received")
-		}
-		var r RecentTrades
-
-		price, ok := individualTrade[0].(string)
-		if !ok {
-			return nil, common.GetTypeAssertError("string", individualTrade[0], "price")
-		}
-		r.Price, err = strconv.ParseFloat(price, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		volume, ok := individualTrade[1].(string)
-		if !ok {
-			return nil, common.GetTypeAssertError("string", individualTrade[1], "volume")
-		}
-		r.Volume, err = strconv.ParseFloat(volume, 64)
-		if err != nil {
-			return nil, err
-		}
-		r.Time, ok = individualTrade[2].(float64)
-		if !ok {
-			return nil, common.GetTypeAssertError("float64", individualTrade[2], "time")
-		}
-		r.BuyOrSell, ok = individualTrade[3].(string)
-		if !ok {
-			return nil, common.GetTypeAssertError("string", individualTrade[3], "buyOrSell")
-		}
-		r.MarketOrLimit, ok = individualTrade[4].(string)
-		if !ok {
-			return nil, common.GetTypeAssertError("string", individualTrade[4], "marketOrLimit")
-		}
-		r.Miscellaneous, ok = individualTrade[5].(string)
-		if !ok {
-			return nil, common.GetTypeAssertError("string", individualTrade[5], "miscellaneous")
-		}
-		tradeID, ok := individualTrade[6].(float64)
-		if !ok {
-			return nil, common.GetTypeAssertError("float64", individualTrade[6], "tradeID")
-		}
-		r.TradeID = int64(tradeID)
-		recentTrades[x] = r
-	}
-	return recentTrades, nil
+	path := common.EncodeURLValues("/"+krakenAPIVersion+"/public/"+krakenTrades, values)
+	var resp *RecentTradesResponse
+	return resp, k.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
 // GetSpread returns the full spread on Kraken
-func (k *Kraken) GetSpread(ctx context.Context, symbol currency.Pair) ([]Spread, error) {
-	values := url.Values{}
+func (k *Kraken) GetSpread(ctx context.Context, symbol currency.Pair, since time.Time) (*SpreadResponse, error) {
 	symbolValue, err := k.FormatSymbol(symbol, asset.Spot)
 	if err != nil {
 		return nil, err
 	}
+	values := url.Values{}
 	values.Set("pair", symbolValue)
-
-	result := make(map[string]any)
-	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenSpread, values.Encode())
-	err = k.SendHTTPRequest(ctx, exchange.RestSpot, path, &result)
-	if err != nil {
-		return nil, err
+	if !since.IsZero() {
+		values.Set("since", strconv.FormatInt(since.Unix(), 10))
 	}
-
-	data, ok := result[symbolValue]
-	if !ok {
-		return nil, fmt.Errorf("unable to find %s in spread data", symbolValue)
-	}
-
-	spreadData, ok := data.([]any)
-	if !ok {
-		return nil, errors.New("unable to type assert spreadData")
-	}
-
-	peanutButter := make([]Spread, len(spreadData))
-	for x := range spreadData {
-		subData, ok := spreadData[x].([]any)
-		if !ok {
-			return nil, errors.New("unable to type assert subData")
-		}
-
-		if len(subData) < 3 {
-			return nil, errors.New("unexpected data length")
-		}
-
-		var s Spread
-		timeData, ok := subData[0].(float64)
-		if !ok {
-			return nil, common.GetTypeAssertError("float64", subData[0], "timeData")
-		}
-		s.Time = time.Unix(int64(timeData), 0)
-
-		if s.Bid, err = convert.FloatFromString(subData[1]); err != nil {
-			return nil, err
-		}
-		if s.Ask, err = convert.FloatFromString(subData[2]); err != nil {
-			return nil, err
-		}
-		peanutButter[x] = s
-	}
-	return peanutButter, nil
+	var peanutButter *SpreadResponse
+	path := common.EncodeURLValues("/"+krakenAPIVersion+"/public/"+krakenSpread, values)
+	return peanutButter, k.SendHTTPRequest(ctx, exchange.RestSpot, path, &peanutButter)
 }
 
 // GetBalance returns your balance associated with your keys

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -381,22 +381,24 @@ func TestGetDepth(t *testing.T) {
 	assert.NoError(t, err, "GetDepth should not error")
 }
 
-// TestGetTrades API endpoint test
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 	testexch.UpdatePairsOnce(t, k)
-	_, err := k.GetTrades(t.Context(), spotTestPair)
-	assert.NoError(t, err, "GetTrades should not error")
-
-	_, err = k.GetTrades(t.Context(), currency.NewPairWithDelimiter("XXX", "XXX", ""))
-	assert.ErrorContains(t, err, "Unknown asset pair", "GetDepth should error correctly")
+	r, err := k.GetTrades(t.Context(), spotTestPair, time.Now().Add(-time.Hour*4), 1000)
+	require.NoError(t, err, "GetTrades must not error")
+	require.NotNil(t, r, "GetTrades must return a valid response")
 }
 
-// TestGetSpread API endpoint test
 func TestGetSpread(t *testing.T) {
 	t.Parallel()
-	_, err := k.GetSpread(t.Context(), currency.NewPair(currency.BCH, currency.EUR)) // XBTUSD not in spread data
-	assert.NoError(t, err, "GetSpread should not error")
+	p := currency.NewPair(currency.BCH, currency.EUR) // XBTUSD not in spread data
+	r, err := k.GetSpread(t.Context(), p, time.Now().Add(-time.Hour*4))
+	require.NoError(t, err, "GetSpread must not error")
+	require.NotNil(t, r, "GetSpread must return a valid response")
+	require.NotZero(t, r.Last.Time(), "GetSpread must return a valid last updated time")
+	v, ok := r.Spreads[p.String()]
+	require.True(t, ok, "GetSpread must return valid spread data for the given pair")
+	assert.NotEmpty(t, v, "GetSpread should return some spread data for the given pair")
 }
 
 // TestGetBalance API endpoint test
@@ -1233,13 +1235,16 @@ func TestWSProcessTrades(t *testing.T) {
 	close(k.Websocket.DataHandler)
 
 	invalid := []any{"trades", []any{[]any{"95873.80000", "0.00051182", "1708731380.3791859"}}}
+	rawBytes, err := json.Marshal(invalid)
+	require.NoError(t, err, "Marshal must not error marshalling invalid trade data")
+
 	pair := currency.NewPair(currency.XBT, currency.USD)
-	err = k.wsProcessTrades(invalid, pair)
-	require.ErrorContains(t, err, "unexpected trade data length")
+	err = k.wsProcessTrades(json.RawMessage(rawBytes), pair)
+	require.ErrorContains(t, err, "error unmarshalling trade data")
 
 	expJSON := []string{
-		`{"AssetType":"spot","CurrencyPair":"XBT/USD","Side":"BUY","Price":95873.80000,"Amount":0.00051182,"Timestamp":"2025-02-23T23:29:40.379185914Z"}`,
-		`{"AssetType":"spot","CurrencyPair":"XBT/USD","Side":"SELL","Price":95940.90000,"Amount":0.00011069,"Timestamp":"2025-02-24T02:01:12.853682041Z"}`,
+		`{"AssetType":"spot","CurrencyPair":"XBT/USD","Side":"BUY","Price":95873.80000,"Amount":0.00051182,"Timestamp":"2025-02-23T23:29:40.379186Z"}`,
+		`{"AssetType":"spot","CurrencyPair":"XBT/USD","Side":"SELL","Price":95940.90000,"Amount":0.00011069,"Timestamp":"2025-02-24T02:01:12.853682Z"}`,
 	}
 	require.Len(t, k.Websocket.DataHandler, len(expJSON), "Must see correct number of trades")
 	for resp := range k.Websocket.DataHandler {

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -803,6 +803,59 @@ func (e errorResponse) Warnings() string {
 	return strings.Join(e.warnings, ", ")
 }
 
+type wsTicker struct {
+	Ask                        [3]types.Number `json:"a"`
+	Bid                        [3]types.Number `json:"b"`
+	Last                       [2]types.Number `json:"c"`
+	Volume                     [2]types.Number `json:"v"`
+	VolumeWeightedAveragePrice [2]types.Number `json:"p"`
+	Trades                     [2]int64        `json:"t"`
+	Low                        [2]types.Number `json:"l"`
+	High                       [2]types.Number `json:"h"`
+	Open                       [2]types.Number `json:"o"`
+}
+
+type wsSpread struct {
+	Bid       types.Number
+	Ask       types.Number
+	Time      types.Time
+	BidVolume types.Number
+	AskVolume types.Number
+}
+
+func (w *wsSpread) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[5]any{&w.Bid, &w.Ask, &w.Time, &w.BidVolume, &w.AskVolume})
+}
+
+type wsTrades struct {
+	Price     types.Number
+	Volume    types.Number
+	Time      types.Time
+	Side      string
+	OrderType string
+	Misc      string
+}
+
+func (w *wsTrades) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[6]any{&w.Price, &w.Volume, &w.Time, &w.Side, &w.OrderType, &w.Misc})
+}
+
+type wsCandle struct {
+	LastUpdateTime types.Time
+	EndTime        types.Time
+	Open           types.Number
+	High           types.Number
+	Low            types.Number
+	Close          types.Number
+	VWAP           types.Number
+	Volume         types.Number
+	Count          int64
+}
+
+func (w *wsCandle) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[9]any{&w.LastUpdateTime, &w.EndTime, &w.Open, &w.High, &w.Low, &w.Close, &w.VWAP, &w.Volume, &w.Count})
+}
+
 type wsSnapshot struct {
 	Asks []wsOrderbookItem `json:"as"`
 	Bids []wsOrderbookItem `json:"bs"`

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -213,7 +213,7 @@ type RecentTradeResponseItem struct {
 
 // UnmarshalJSON unmarshals the recent trade response item
 func (r *RecentTradeResponseItem) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[]any{&r.Price, &r.Volume, &r.Time, &r.BuyOrSell, &r.MarketOrLimit, &r.Miscellaneous, &r.TradeID})
+	return json.Unmarshal(data, &[7]any{&r.Price, &r.Volume, &r.Time, &r.BuyOrSell, &r.MarketOrLimit, &r.Miscellaneous, &r.TradeID})
 }
 
 // OrderbookBase stores the orderbook price and amount data
@@ -238,7 +238,7 @@ type SpreadItem struct {
 
 // UnmarshalJSON unmarshals the spread item
 func (s *SpreadItem) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[]any{&s.Time, &s.Bid, &s.Ask})
+	return json.Unmarshal(data, &[3]any{&s.Time, &s.Bid, &s.Ask})
 }
 
 // SpreadResponse holds the spread response data

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -187,8 +187,7 @@ func (k *Kraken) wsHandleData(_ context.Context, respRaw []byte) error {
 
 		// For all types of channel second to last field is the channel Name
 		var chanName string
-		chanIndex := len(msg) - 2
-		if err := json.Unmarshal(msg[chanIndex], &chanName); err != nil {
+		if err := json.Unmarshal(msg[len(msg)-2], &chanName); err != nil {
 			return fmt.Errorf("error unmarshalling channel name: %w", err)
 		}
 
@@ -418,7 +417,7 @@ func (k *Kraken) wsProcessOpenOrders(ownOrdersResp json.RawMessage) error {
 			}
 
 			if val.Volume > 0 {
-				// Note: Only set if status is open
+				// Note: Volume and ExecutedVolume are only populated when status is open
 				d.RemainingAmount = val.Volume - val.ExecutedVolume
 			}
 			k.Websocket.DataHandler <- d

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buger/jsonparser"
 	gws "github.com/gorilla/websocket"
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
@@ -28,6 +27,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // List of all websocket channels to subscribe to
@@ -177,7 +177,7 @@ func (k *Kraken) wsReadData(ctx context.Context, comms chan websocket.Response) 
 
 func (k *Kraken) wsHandleData(_ context.Context, respRaw []byte) error {
 	if strings.HasPrefix(string(respRaw), "[") {
-		var msg []any
+		var msg []json.RawMessage
 		if err := json.Unmarshal(respRaw, &msg); err != nil {
 			return err
 		}
@@ -186,19 +186,23 @@ func (k *Kraken) wsHandleData(_ context.Context, respRaw []byte) error {
 		}
 
 		// For all types of channel second to last field is the channel Name
-		c, ok := msg[len(msg)-2].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", msg[len(msg)-2], "channelName")
+		var chanName string
+		chanIndex := len(msg) - 2
+		if err := json.Unmarshal(msg[chanIndex], &chanName); err != nil {
+			return fmt.Errorf("error unmarshalling channel name: %w", err)
 		}
 
 		pair := currency.EMPTYPAIR
-		if maybePair, ok2 := msg[len(msg)-1].(string); ok2 {
-			var err error
-			if pair, err = currency.NewPairFromString(maybePair); err != nil {
+		var maybePair string
+		if err := json.Unmarshal(msg[len(msg)-1], &maybePair); err == nil {
+			p, err := currency.NewPairFromString(maybePair)
+			if err != nil {
 				return err
 			}
+			pair = p
 		}
-		return k.wsReadDataResponse(c, pair, msg)
+
+		return k.wsReadDataResponse(chanName, pair, msg)
 	}
 
 	event, err := jsonparser.GetString(respRaw, "event")
@@ -246,14 +250,14 @@ func (k *Kraken) startWsPingHandler(conn websocket.Connection) {
 }
 
 // wsReadDataResponse classifies the WS response and sends to appropriate handler
-func (k *Kraken) wsReadDataResponse(c string, pair currency.Pair, response []any) error {
+func (k *Kraken) wsReadDataResponse(c string, pair currency.Pair, response []json.RawMessage) error {
 	switch c {
 	case krakenWsTicker:
-		return k.wsProcessTickers(response, pair)
+		return k.wsProcessTickers(response[1], pair)
 	case krakenWsSpread:
-		return k.wsProcessSpread(response, pair)
+		return k.wsProcessSpread(response[1], pair)
 	case krakenWsTrade:
-		return k.wsProcessTrades(response, pair)
+		return k.wsProcessTrades(response[1], pair)
 	case krakenWsOwnTrades:
 		return k.wsProcessOwnTrades(response[0])
 	case krakenWsOpenOrders:
@@ -263,7 +267,7 @@ func (k *Kraken) wsReadDataResponse(c string, pair currency.Pair, response []any
 	channelType := strings.TrimRight(c, "-0123456789")
 	switch channelType {
 	case krakenWsOHLC:
-		return k.wsProcessCandle(c, response, pair)
+		return k.wsProcessCandle(c, response[1], pair)
 	case krakenWsOrderbook:
 		return k.wsProcessOrderBook(c, response, pair)
 	default:
@@ -273,8 +277,7 @@ func (k *Kraken) wsReadDataResponse(c string, pair currency.Pair, response []any
 
 func (k *Kraken) wsProcessSystemStatus(respRaw []byte) error {
 	var systemStatus wsSystemStatus
-	err := json.Unmarshal(respRaw, &systemStatus)
-	if err != nil {
+	if err := json.Unmarshal(respRaw, &systemStatus); err != nil {
 		return fmt.Errorf("%s parsing system status: %s", err, respRaw)
 	}
 	if systemStatus.Status != "online" {
@@ -286,303 +289,249 @@ func (k *Kraken) wsProcessSystemStatus(respRaw []byte) error {
 	return nil
 }
 
-func (k *Kraken) wsProcessOwnTrades(ownOrders any) error {
-	if data, ok := ownOrders.([]any); ok {
-		for i := range data {
-			trades, err := json.Marshal(data[i])
-			if err != nil {
-				return err
-			}
-			var result map[string]*WsOwnTrade
-			err = json.Unmarshal(trades, &result)
-			if err != nil {
-				return err
-			}
-			for key, val := range result {
-				oSide, err := order.StringToOrderSide(val.Type)
-				if err != nil {
-					k.Websocket.DataHandler <- order.ClassificationError{
-						Exchange: k.Name,
-						OrderID:  key,
-						Err:      err,
-					}
-				}
-				oType, err := order.StringToOrderType(val.OrderType)
-				if err != nil {
-					k.Websocket.DataHandler <- order.ClassificationError{
-						Exchange: k.Name,
-						OrderID:  key,
-						Err:      err,
-					}
-				}
-				trade := order.TradeHistory{
-					Price:     val.Price,
-					Amount:    val.Vol,
-					Fee:       val.Fee,
-					Exchange:  k.Name,
-					TID:       key,
-					Type:      oType,
-					Side:      oSide,
-					Timestamp: val.Time.Time(),
-				}
-				k.Websocket.DataHandler <- &order.Detail{
-					Exchange: k.Name,
-					OrderID:  val.OrderTransactionID,
-					Trades:   []order.TradeHistory{trade},
-				}
-			}
-		}
+func (k *Kraken) wsProcessOwnTrades(ownOrdersRaw json.RawMessage) error {
+	var result []map[string]*WsOwnTrade
+	if err := json.Unmarshal(ownOrdersRaw, &result); err != nil {
+		return err
+	}
+
+	if len(result) == 0 {
 		return nil
 	}
-	return errors.New(k.Name + " - Invalid own trades data")
+
+	for key, val := range result[0] {
+		oSide, err := order.StringToOrderSide(val.Type)
+		if err != nil {
+			k.Websocket.DataHandler <- order.ClassificationError{
+				Exchange: k.Name,
+				OrderID:  key,
+				Err:      err,
+			}
+		}
+		oType, err := order.StringToOrderType(val.OrderType)
+		if err != nil {
+			k.Websocket.DataHandler <- order.ClassificationError{
+				Exchange: k.Name,
+				OrderID:  key,
+				Err:      err,
+			}
+		}
+		trade := order.TradeHistory{
+			Price:     val.Price,
+			Amount:    val.Vol,
+			Fee:       val.Fee,
+			Exchange:  k.Name,
+			TID:       key,
+			Type:      oType,
+			Side:      oSide,
+			Timestamp: val.Time.Time(),
+		}
+		k.Websocket.DataHandler <- &order.Detail{
+			Exchange: k.Name,
+			OrderID:  val.OrderTransactionID,
+			Trades:   []order.TradeHistory{trade},
+		}
+	}
+
+	return nil
 }
 
-func (k *Kraken) wsProcessOpenOrders(ownOrders any) error {
-	if data, ok := ownOrders.([]any); ok {
-		for i := range data {
-			orders, err := json.Marshal(data[i])
-			if err != nil {
-				return err
-			}
-			var result map[string]*WsOpenOrder
-			err = json.Unmarshal(orders, &result)
-			if err != nil {
-				return err
-			}
-			for key, val := range result {
-				d := &order.Detail{
-					Exchange:             k.Name,
-					OrderID:              key,
-					AverageExecutedPrice: val.AveragePrice,
-					Amount:               val.Volume,
-					LimitPriceUpper:      val.LimitPrice,
-					ExecutedAmount:       val.ExecutedVolume,
-					Fee:                  val.Fee,
-					Date:                 val.OpenTime.Time(),
-					LastUpdated:          val.LastUpdated.Time(),
-				}
-
-				if val.Status != "" {
-					if s, err := order.StringToOrderStatus(val.Status); err != nil {
-						k.Websocket.DataHandler <- order.ClassificationError{
-							Exchange: k.Name,
-							OrderID:  key,
-							Err:      err,
-						}
-					} else {
-						d.Status = s
-					}
-				}
-
-				if val.Description.Pair != "" {
-					if strings.Contains(val.Description.Order, "sell") {
-						d.Side = order.Sell
-					} else {
-						if oSide, err := order.StringToOrderSide(val.Description.Type); err != nil {
-							k.Websocket.DataHandler <- order.ClassificationError{
-								Exchange: k.Name,
-								OrderID:  key,
-								Err:      err,
-							}
-						} else {
-							d.Side = oSide
-						}
-					}
-
-					if oType, err := order.StringToOrderType(val.Description.OrderType); err != nil {
-						k.Websocket.DataHandler <- order.ClassificationError{
-							Exchange: k.Name,
-							OrderID:  key,
-							Err:      err,
-						}
-					} else {
-						d.Type = oType
-					}
-
-					if p, err := currency.NewPairFromString(val.Description.Pair); err != nil {
-						k.Websocket.DataHandler <- order.ClassificationError{
-							Exchange: k.Name,
-							OrderID:  key,
-							Err:      err,
-						}
-					} else {
-						d.Pair = p
-						if d.AssetType, err = k.GetPairAssetType(p); err != nil {
-							k.Websocket.DataHandler <- order.ClassificationError{
-								Exchange: k.Name,
-								OrderID:  key,
-								Err:      err,
-							}
-						}
-					}
-				}
-
-				if val.Description.Price > 0 {
-					d.Leverage = val.Description.Leverage
-					d.Price = val.Description.Price
-				}
-
-				if val.Volume > 0 {
-					// Note: We don't seem to ever get both there values
-					d.RemainingAmount = val.Volume - val.ExecutedVolume
-				}
-				k.Websocket.DataHandler <- d
-			}
-		}
-		return nil
+// wsProcessOpenOrders processes open orders from the websocket response
+func (k *Kraken) wsProcessOpenOrders(ownOrdersResp json.RawMessage) error {
+	var result []map[string]*WsOpenOrder
+	if err := json.Unmarshal(ownOrdersResp, &result); err != nil {
+		return err
 	}
-	return errors.New("invalid own trades data")
+
+	for r := range result {
+		for key, val := range result[r] {
+			d := &order.Detail{
+				Exchange:             k.Name,
+				OrderID:              key,
+				AverageExecutedPrice: val.AveragePrice,
+				Amount:               val.Volume,
+				LimitPriceUpper:      val.LimitPrice,
+				ExecutedAmount:       val.ExecutedVolume,
+				Fee:                  val.Fee,
+				Date:                 val.OpenTime.Time(),
+				LastUpdated:          val.LastUpdated.Time(),
+			}
+
+			if val.Status != "" {
+				if s, err := order.StringToOrderStatus(val.Status); err != nil {
+					k.Websocket.DataHandler <- order.ClassificationError{
+						Exchange: k.Name,
+						OrderID:  key,
+						Err:      err,
+					}
+				} else {
+					d.Status = s
+				}
+			}
+
+			if val.Description.Pair != "" {
+				if strings.Contains(val.Description.Order, "sell") {
+					d.Side = order.Sell
+				} else {
+					if oSide, err := order.StringToOrderSide(val.Description.Type); err != nil {
+						k.Websocket.DataHandler <- order.ClassificationError{
+							Exchange: k.Name,
+							OrderID:  key,
+							Err:      err,
+						}
+					} else {
+						d.Side = oSide
+					}
+				}
+
+				if oType, err := order.StringToOrderType(val.Description.OrderType); err != nil {
+					k.Websocket.DataHandler <- order.ClassificationError{
+						Exchange: k.Name,
+						OrderID:  key,
+						Err:      err,
+					}
+				} else {
+					d.Type = oType
+				}
+
+				if p, err := currency.NewPairFromString(val.Description.Pair); err != nil {
+					k.Websocket.DataHandler <- order.ClassificationError{
+						Exchange: k.Name,
+						OrderID:  key,
+						Err:      err,
+					}
+				} else {
+					d.Pair = p
+					if d.AssetType, err = k.GetPairAssetType(p); err != nil {
+						k.Websocket.DataHandler <- order.ClassificationError{
+							Exchange: k.Name,
+							OrderID:  key,
+							Err:      err,
+						}
+					}
+				}
+			}
+
+			if val.Description.Price > 0 {
+				d.Leverage = val.Description.Leverage
+				d.Price = val.Description.Price
+			}
+
+			if val.Volume > 0 {
+				// Note: We don't seem to ever get both there values
+				d.RemainingAmount = val.Volume - val.ExecutedVolume
+			}
+			k.Websocket.DataHandler <- d
+		}
+	}
+	return nil
+}
+
+type wsTicker struct {
+	Ask                        [3]types.Number `json:"a"`
+	Bid                        [3]types.Number `json:"b"`
+	Last                       [2]types.Number `json:"c"`
+	Volume                     [2]types.Number `json:"v"`
+	VolumeWeightedAveragePrice [2]types.Number `json:"p"`
+	Trades                     [2]int64        `json:"t"`
+	Low                        [2]types.Number `json:"l"`
+	High                       [2]types.Number `json:"h"`
+	Open                       [2]types.Number `json:"o"`
 }
 
 // wsProcessTickers converts ticker data and sends it to the datahandler
-func (k *Kraken) wsProcessTickers(response []any, pair currency.Pair) error {
-	t, ok := response[1].(map[string]any)
-	if !ok {
-		return errors.New("received invalid ticker data")
-	}
-	data := map[string]float64{}
-	for _, b := range []byte("abcvlho") { // p and t skipped
-		key := string(b)
-		a, ok := t[key].([]any)
-		if !ok {
-			return fmt.Errorf("received invalid ticker data: %w", common.GetTypeAssertError("[]any", t[key], "ticker."+key))
-		}
-		var s string
-		if s, ok = a[0].(string); !ok {
-			return fmt.Errorf("received invalid ticker data: %w", common.GetTypeAssertError("string", a[0], "ticker."+key+"[0]"))
-		}
-
-		f, err := strconv.ParseFloat(s, 64)
-		if err != nil {
-			return fmt.Errorf("received invalid ticker data: %w", err)
-		}
-		data[key] = f
+func (k *Kraken) wsProcessTickers(dataRaw json.RawMessage, pair currency.Pair) error {
+	var t wsTicker
+	if err := json.Unmarshal(dataRaw, &t); err != nil {
+		return fmt.Errorf("error unmarshalling ticker data: %w", err)
 	}
 
 	k.Websocket.DataHandler <- &ticker.Price{
 		ExchangeName: k.Name,
-		Ask:          data["a"],
-		Bid:          data["b"],
-		Close:        data["c"],
-		Volume:       data["v"],
-		Low:          data["l"],
-		High:         data["h"],
-		Open:         data["o"],
+		Ask:          t.Ask[0].Float64(),
+		Bid:          t.Bid[0].Float64(),
+		Close:        t.Last[0].Float64(),
+		Volume:       t.Volume[0].Float64(),
+		Low:          t.Low[0].Float64(),
+		High:         t.High[0].Float64(),
+		Open:         t.Open[0].Float64(),
 		AssetType:    asset.Spot,
 		Pair:         pair,
 	}
 	return nil
 }
 
-// wsProcessSpread converts spread/orderbook data and sends it to the datahandler
-func (k *Kraken) wsProcessSpread(response []any, pair currency.Pair) error {
-	data, ok := response[1].([]any)
-	if !ok {
-		return errors.New("received invalid spread data")
-	}
-	if len(data) < 5 {
-		return errors.New("unexpected wsProcessSpread data length")
-	}
-	bestBid, ok := data[0].(string)
-	if !ok {
-		return common.GetTypeAssertError("string", data[0], "bestBid")
-	}
-	bestAsk, ok := data[1].(string)
-	if !ok {
-		return common.GetTypeAssertError("string", data[1], "bestAsk")
-	}
-	timeData, ok := data[2].(string)
-	if !ok {
-		return common.GetTypeAssertError("string", data[2], "timeData")
-	}
-	timestamp, err := strconv.ParseFloat(timeData, 64)
-	if err != nil {
-		return err
-	}
-	bidVolume, ok := data[3].(string)
-	if !ok {
-		return common.GetTypeAssertError("string", data[3], "bidVolume")
-	}
-	askVolume, ok := data[4].(string)
-	if !ok {
-		return common.GetTypeAssertError("string", data[4], "askVolume")
-	}
+type wsSpread struct {
+	Bid       types.Number
+	Ask       types.Number
+	Time      types.Time
+	BidVolume types.Number
+	AskVolume types.Number
+}
 
+func (w *wsSpread) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[5]any{&w.Bid, &w.Ask, &w.Time, &w.BidVolume, &w.AskVolume})
+}
+
+// wsProcessSpread converts spread/orderbook data and sends it to the datahandler
+func (k *Kraken) wsProcessSpread(rawData json.RawMessage, pair currency.Pair) error {
+	var data wsSpread
+	if err := json.Unmarshal(rawData, &data); err != nil {
+		return fmt.Errorf("error unmarshalling spread data: %w", err)
+	}
 	if k.Verbose {
-		log.Debugf(log.ExchangeSys,
-			"%v Spread data for '%v' received. Best bid: '%v' Best ask: '%v' Time: '%v', Bid volume '%v', Ask volume '%v'",
+		log.Debugf(log.ExchangeSys, "%s Spread data for '%v' received. Best bid: '%v' Best ask: '%v' Time: '%v', Bid volume '%v', Ask volume '%v'",
 			k.Name,
 			pair,
-			bestBid,
-			bestAsk,
-			convert.TimeFromUnixTimestampDecimal(timestamp),
-			bidVolume,
-			askVolume)
+			data.Bid.Float64(),
+			data.Ask.Float64(),
+			data.Time.Time(),
+			data.BidVolume.Float64(),
+			data.AskVolume.Float64())
 	}
 	return nil
 }
 
+type wsTrades struct {
+	Price     types.Number
+	Volume    types.Number
+	Time      types.Time
+	Side      string
+	OrderType string
+	Misc      string
+}
+
+func (w *wsTrades) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[6]any{&w.Price, &w.Volume, &w.Time, &w.Side, &w.OrderType, &w.Misc})
+}
+
 // wsProcessTrades converts trade data and sends it to the datahandler
-func (k *Kraken) wsProcessTrades(response []any, pair currency.Pair) error {
-	data, ok := response[1].([]any)
-	if !ok {
-		return errors.New("received invalid trade data")
-	}
+func (k *Kraken) wsProcessTrades(respRaw json.RawMessage, pair currency.Pair) error {
 	saveTradeData := k.IsSaveTradeDataEnabled()
 	tradeFeed := k.IsTradeFeedEnabled()
 	if !saveTradeData && !tradeFeed {
 		return nil
 	}
-	trades := make([]trade.Data, len(data))
-	for i := range data {
-		t, ok := data[i].([]any)
-		if !ok {
-			return errors.New("unidentified trade data received")
-		}
-		if len(t) < 4 {
-			return fmt.Errorf("%w; unexpected trade data length: %d", common.ErrParsingWSField, len(t))
-		}
-		ts, ok := t[2].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", t[2], "trade.time")
-		}
-		timeData, err := strconv.ParseFloat(ts, 64)
-		if err != nil {
-			return err
-		}
-		p, ok := t[0].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", t[0], "trade.price")
-		}
-		price, err := strconv.ParseFloat(p, 64)
-		if err != nil {
-			return err
-		}
-		v, ok := t[1].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", t[1], "trade.volume")
-		}
-		amount, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return err
-		}
-		tSide := order.Buy
-		s, ok := t[3].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", t[3], "trade.side")
-		}
-		if s == "s" {
-			tSide = order.Sell
-		}
 
+	var t []wsTrades
+	if err := json.Unmarshal(respRaw, &t); err != nil {
+		return fmt.Errorf("error unmarshalling trade data: %w", err)
+	}
+
+	trades := make([]trade.Data, len(t))
+	for i := range trades {
+		side := order.Buy
+		if t[i].Side == "s" {
+			side = order.Sell
+		}
 		trades[i] = trade.Data{
 			AssetType:    asset.Spot,
 			CurrencyPair: pair,
 			Exchange:     k.Name,
-			Price:        price,
-			Amount:       amount,
-			Timestamp:    convert.TimeFromUnixTimestampDecimal(timeData),
-			Side:         tSide,
+			Price:        t[i].Price.Float64(),
+			Amount:       t[i].Volume.Float64(),
+			Timestamp:    t[i].Time.Time().UTC(),
+			Side:         side,
 		}
 	}
 	if tradeFeed {
@@ -596,8 +545,16 @@ func (k *Kraken) wsProcessTrades(response []any, pair currency.Pair) error {
 	return nil
 }
 
+func hasKey(raw json.RawMessage, key string) bool {
+	_, dataType, _, err := jsonparser.Get(raw, key)
+	if err != nil || dataType == jsonparser.NotExist {
+		return false
+	}
+	return true
+}
+
 // wsProcessOrderBook handles both partial and full orderbook updates
-func (k *Kraken) wsProcessOrderBook(c string, response []any, pair currency.Pair) error {
+func (k *Kraken) wsProcessOrderBook(c string, response []json.RawMessage, pair currency.Pair) error {
 	key := &subscription.Subscription{
 		Channel: c,
 		Asset:   asset.Spot,
@@ -615,36 +572,21 @@ func (k *Kraken) wsProcessOrderBook(c string, response []any, pair currency.Pair
 		return nil
 	}
 
-	ob, ok := response[1].(map[string]any)
-	if !ok {
-		return errors.New("received invalid orderbook data")
-	}
-
-	if len(response) == 5 {
-		ob2, ok2 := response[2].(map[string]any)
-		if !ok2 {
-			return errors.New("received invalid orderbook data")
+	if isSnapshot := hasKey(response[1], "as") && hasKey(response[1], "bs"); !isSnapshot {
+		var update wsUpdate
+		if err := json.Unmarshal(response[1], &update); err != nil {
+			return fmt.Errorf("error unmarshalling orderbook update: %w", err)
 		}
-
-		// Squish both maps together to process
-		for k, v := range ob2 {
-			if _, ok := ob[k]; ok {
-				return errors.New("cannot merge maps, conflict is present")
+		if len(response) == 5 {
+			var update2 wsUpdate
+			if err := json.Unmarshal(response[2], &update2); err != nil {
+				return fmt.Errorf("error unmarshalling orderbook update: %w", err)
 			}
-			ob[k] = v
+			update.Bids = make([]wsOrderbookItem, len(update2.Bids))
+			copy(update.Bids, update2.Bids)
+			update.Checksum = update2.Checksum
 		}
-	}
-	// NOTE: Updates are a priority so check if it's an update first as we don't
-	// need multiple map lookups to check for snapshot.
-	askData, asksExist := ob["a"].([]any)
-	bidData, bidsExist := ob["b"].([]any)
-	if asksExist || bidsExist {
-		checksum, ok := ob["c"].(string)
-		if !ok {
-			return errors.New("could not process orderbook update checksum not found")
-		}
-
-		err := k.wsProcessOrderBookUpdate(pair, askData, bidData, checksum)
+		err := k.wsProcessOrderBookUpdate(pair, &update)
 		if errors.Is(err, errInvalidChecksum) {
 			log.Debugf(log.Global, "%s Resubscribing to invalid %s orderbook", k.Name, pair)
 			go func() {
@@ -656,23 +598,21 @@ func (k *Kraken) wsProcessOrderBook(c string, response []any, pair currency.Pair
 		return err
 	}
 
-	askSnapshot, askSnapshotExists := ob["as"].([]any)
-	bidSnapshot, bidSnapshotExists := ob["bs"].([]any)
-	if !askSnapshotExists && !bidSnapshotExists {
-		return fmt.Errorf("%w for %v %v", errNoWebsocketOrderbookData, pair, asset.Spot)
+	var snapshot wsSnapshot
+	if err := json.Unmarshal(response[1], &snapshot); err != nil {
+		return fmt.Errorf("error unmarshalling orderbook snapshot: %w", err)
 	}
-
-	return k.wsProcessOrderBookPartial(pair, askSnapshot, bidSnapshot, key.Levels)
+	return k.wsProcessOrderBookPartial(pair, &snapshot, key.Levels)
 }
 
 // wsProcessOrderBookPartial creates a new orderbook entry for a given currency pair
-func (k *Kraken) wsProcessOrderBookPartial(pair currency.Pair, askData, bidData []any, levels int) error {
+func (k *Kraken) wsProcessOrderBookPartial(pair currency.Pair, obSnapshot *wsSnapshot, levels int) error {
 	base := orderbook.Book{
 		Pair:                   pair,
 		Asset:                  asset.Spot,
 		ValidateOrderbook:      k.ValidateOrderbook,
-		Bids:                   make(orderbook.Levels, len(bidData)),
-		Asks:                   make(orderbook.Levels, len(askData)),
+		Bids:                   make(orderbook.Levels, len(obSnapshot.Bids)),
+		Asks:                   make(orderbook.Levels, len(obSnapshot.Asks)),
 		MaxDepth:               levels,
 		ChecksumStringRequired: true,
 	}
@@ -680,91 +620,25 @@ func (k *Kraken) wsProcessOrderBookPartial(pair currency.Pair, askData, bidData 
 	// timestamped per entry using the highest last update time, we can attempt
 	// to respect both within a reasonable degree
 	var highestLastUpdate time.Time
-	for i := range askData {
-		asks, ok := askData[i].([]any)
-		if !ok {
-			return common.GetTypeAssertError("[]any", askData[i], "asks")
-		}
-		if len(asks) < 3 {
-			return errors.New("unexpected asks length")
-		}
-		priceStr, ok := asks[0].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", asks[0], "price")
-		}
-		price, err := strconv.ParseFloat(priceStr, 64)
-		if err != nil {
-			return err
-		}
-		amountStr, ok := asks[1].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", asks[1], "amount")
-		}
-		amount, err := strconv.ParseFloat(amountStr, 64)
-		if err != nil {
-			return err
-		}
-		tdStr, ok := asks[2].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", asks[2], "time")
-		}
-		timeData, err := strconv.ParseFloat(tdStr, 64)
-		if err != nil {
-			return err
-		}
-		base.Asks[i] = orderbook.Level{
-			Amount:    amount,
-			StrAmount: amountStr,
-			Price:     price,
-			StrPrice:  priceStr,
-		}
-		askUpdatedTime := convert.TimeFromUnixTimestampDecimal(timeData)
+	for i := range obSnapshot.Asks {
+		base.Asks[i].Price = obSnapshot.Asks[i].Price
+		base.Asks[i].StrPrice = obSnapshot.Asks[i].PriceRaw
+		base.Asks[i].Amount = obSnapshot.Asks[i].Amount
+		base.Asks[i].StrAmount = obSnapshot.Asks[i].AmountRaw
+
+		askUpdatedTime := obSnapshot.Asks[i].Time.Time()
 		if highestLastUpdate.Before(askUpdatedTime) {
 			highestLastUpdate = askUpdatedTime
 		}
 	}
 
-	for i := range bidData {
-		bids, ok := bidData[i].([]any)
-		if !ok {
-			return common.GetTypeAssertError("[]any", bidData[i], "bids")
-		}
-		if len(bids) < 3 {
-			return errors.New("unexpected bids length")
-		}
-		priceStr, ok := bids[0].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", bids[0], "price")
-		}
-		price, err := strconv.ParseFloat(priceStr, 64)
-		if err != nil {
-			return err
-		}
-		amountStr, ok := bids[1].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", bids[1], "amount")
-		}
-		amount, err := strconv.ParseFloat(amountStr, 64)
-		if err != nil {
-			return err
-		}
-		tdStr, ok := bids[2].(string)
-		if !ok {
-			return common.GetTypeAssertError("string", bids[2], "time")
-		}
-		timeData, err := strconv.ParseFloat(tdStr, 64)
-		if err != nil {
-			return err
-		}
+	for i := range obSnapshot.Bids {
+		base.Bids[i].Price = obSnapshot.Bids[i].Price
+		base.Bids[i].StrPrice = obSnapshot.Bids[i].PriceRaw
+		base.Bids[i].Amount = obSnapshot.Bids[i].Amount
+		base.Bids[i].StrAmount = obSnapshot.Bids[i].AmountRaw
 
-		base.Bids[i] = orderbook.Level{
-			Amount:    amount,
-			StrAmount: amountStr,
-			Price:     price,
-			StrPrice:  priceStr,
-		}
-
-		bidUpdateTime := convert.TimeFromUnixTimestampDecimal(timeData)
+		bidUpdateTime := obSnapshot.Bids[i].Time.Time()
 		if highestLastUpdate.Before(bidUpdateTime) {
 			highestLastUpdate = bidUpdateTime
 		}
@@ -775,12 +649,12 @@ func (k *Kraken) wsProcessOrderBookPartial(pair currency.Pair, askData, bidData 
 }
 
 // wsProcessOrderBookUpdate updates an orderbook entry for a given currency pair
-func (k *Kraken) wsProcessOrderBookUpdate(pair currency.Pair, askData, bidData []any, checksum string) error {
-	update := orderbook.Update{
+func (k *Kraken) wsProcessOrderBookUpdate(pair currency.Pair, wsUpdt *wsUpdate) error {
+	obUpdate := orderbook.Update{
 		Asset: asset.Spot,
 		Pair:  pair,
-		Bids:  make([]orderbook.Level, len(bidData)),
-		Asks:  make([]orderbook.Level, len(askData)),
+		Bids:  make(orderbook.Levels, len(wsUpdt.Bids)),
+		Asks:  make(orderbook.Levels, len(wsUpdt.Asks)),
 	}
 
 	// Calculating checksum requires incoming decimal place checks for both
@@ -789,107 +663,33 @@ func (k *Kraken) wsProcessOrderBookUpdate(pair currency.Pair, askData, bidData [
 	// decimal amounts could occur at any time.
 	var highestLastUpdate time.Time
 	// Ask data is not always sent
-	for i := range askData {
-		asks, ok := askData[i].([]any)
-		if !ok {
-			return errors.New("asks type assertion failure")
-		}
+	for i := range wsUpdt.Asks {
+		obUpdate.Asks[i].Price = wsUpdt.Asks[i].Price
+		obUpdate.Asks[i].StrPrice = wsUpdt.Asks[i].PriceRaw
+		obUpdate.Asks[i].Amount = wsUpdt.Asks[i].Amount
+		obUpdate.Asks[i].StrAmount = wsUpdt.Asks[i].AmountRaw
 
-		priceStr, ok := asks[0].(string)
-		if !ok {
-			return errors.New("price type assertion failure")
-		}
-
-		price, err := strconv.ParseFloat(priceStr, 64)
-		if err != nil {
-			return err
-		}
-
-		amountStr, ok := asks[1].(string)
-		if !ok {
-			return errors.New("amount type assertion failure")
-		}
-
-		amount, err := strconv.ParseFloat(amountStr, 64)
-		if err != nil {
-			return err
-		}
-
-		timeStr, ok := asks[2].(string)
-		if !ok {
-			return errors.New("time type assertion failure")
-		}
-
-		timeData, err := strconv.ParseFloat(timeStr, 64)
-		if err != nil {
-			return err
-		}
-
-		update.Asks[i] = orderbook.Level{
-			Amount:    amount,
-			StrAmount: amountStr,
-			Price:     price,
-			StrPrice:  priceStr,
-		}
-
-		askUpdatedTime := convert.TimeFromUnixTimestampDecimal(timeData)
+		askUpdatedTime := wsUpdt.Asks[i].Time.Time()
 		if highestLastUpdate.Before(askUpdatedTime) {
 			highestLastUpdate = askUpdatedTime
 		}
 	}
 
 	// Bid data is not always sent
-	for i := range bidData {
-		bids, ok := bidData[i].([]any)
-		if !ok {
-			return common.GetTypeAssertError("[]any", bidData[i], "bids")
-		}
+	for i := range wsUpdt.Bids {
+		obUpdate.Bids[i].Price = wsUpdt.Bids[i].Price
+		obUpdate.Bids[i].StrPrice = wsUpdt.Bids[i].PriceRaw
+		obUpdate.Bids[i].Amount = wsUpdt.Bids[i].Amount
+		obUpdate.Bids[i].StrAmount = wsUpdt.Bids[i].AmountRaw
 
-		priceStr, ok := bids[0].(string)
-		if !ok {
-			return errors.New("price type assertion failure")
-		}
-
-		price, err := strconv.ParseFloat(priceStr, 64)
-		if err != nil {
-			return err
-		}
-
-		amountStr, ok := bids[1].(string)
-		if !ok {
-			return errors.New("amount type assertion failure")
-		}
-
-		amount, err := strconv.ParseFloat(amountStr, 64)
-		if err != nil {
-			return err
-		}
-
-		timeStr, ok := bids[2].(string)
-		if !ok {
-			return errors.New("time type assertion failure")
-		}
-
-		timeData, err := strconv.ParseFloat(timeStr, 64)
-		if err != nil {
-			return err
-		}
-
-		update.Bids[i] = orderbook.Level{
-			Amount:    amount,
-			StrAmount: amountStr,
-			Price:     price,
-			StrPrice:  priceStr,
-		}
-
-		bidUpdatedTime := convert.TimeFromUnixTimestampDecimal(timeData)
+		bidUpdatedTime := wsUpdt.Bids[i].Time.Time()
 		if highestLastUpdate.Before(bidUpdatedTime) {
 			highestLastUpdate = bidUpdatedTime
 		}
 	}
-	update.UpdateTime = highestLastUpdate
+	obUpdate.UpdateTime = highestLastUpdate
 
-	err := k.Websocket.Orderbook.Update(&update)
+	err := k.Websocket.Orderbook.Update(&obUpdate)
 	if err != nil {
 		return err
 	}
@@ -899,12 +699,7 @@ func (k *Kraken) wsProcessOrderBookUpdate(pair currency.Pair, askData, bidData [
 		return fmt.Errorf("cannot calculate websocket checksum: book not found for %s %s %w", pair, asset.Spot, err)
 	}
 
-	token, err := strconv.ParseUint(checksum, 10, 32)
-	if err != nil {
-		return err
-	}
-
-	return validateCRC32(book, uint32(token))
+	return validateCRC32(book, wsUpdt.Checksum)
 }
 
 func validateCRC32(b *orderbook.Book, token uint32) error {
@@ -939,25 +734,27 @@ func trim(s string) string {
 	return s
 }
 
-// wsProcessCandle converts candle data and sends it to the data handler
-func (k *Kraken) wsProcessCandle(c string, resp []any, pair currency.Pair) error {
-	// 8 string quoted floats followed by 1 integer for trade count
-	dataRaw, ok := resp[1].([]any)
-	if !ok || len(dataRaw) != 9 {
-		return errors.New("received invalid candle data")
-	}
-	data := make([]float64, 8)
-	for i := range 8 {
-		s, ok := dataRaw[i].(string)
-		if !ok {
-			return fmt.Errorf("received invalid candle data: %w", common.GetTypeAssertError("string", dataRaw[i], "candle-data"))
-		}
+type wsCandle struct {
+	LastUpdateTime types.Time
+	EndTime        types.Time
+	Open           types.Number
+	High           types.Number
+	Low            types.Number
+	Close          types.Number
+	VWAP           types.Number
+	Volume         types.Number
+	Count          int64
+}
 
-		f, err := strconv.ParseFloat(s, 64)
-		if err != nil {
-			return fmt.Errorf("received invalid candle data: %w", err)
-		}
-		data[i] = f
+func (w *wsCandle) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[9]any{&w.LastUpdateTime, &w.EndTime, &w.Open, &w.High, &w.Low, &w.Close, &w.VWAP, &w.Volume, &w.Count})
+}
+
+// wsProcessCandle converts candle data and sends it to the data handler
+func (k *Kraken) wsProcessCandle(c string, resp json.RawMessage, pair currency.Pair) error {
+	var data wsCandle
+	if err := json.Unmarshal(resp, &data); err != nil {
+		return fmt.Errorf("error unmarshalling candle data: %w", err)
 	}
 
 	// Faster than getting it through the subscription
@@ -972,13 +769,13 @@ func (k *Kraken) wsProcessCandle(c string, resp []any, pair currency.Pair) error
 		Pair:       pair,
 		Timestamp:  time.Now(),
 		Exchange:   k.Name,
-		StartTime:  convert.TimeFromUnixTimestampDecimal(data[0]),
-		CloseTime:  convert.TimeFromUnixTimestampDecimal(data[1]),
-		OpenPrice:  data[2],
-		HighPrice:  data[3],
-		LowPrice:   data[4],
-		ClosePrice: data[5],
-		Volume:     data[7],
+		StartTime:  data.LastUpdateTime.Time(),
+		CloseTime:  data.LastUpdateTime.Time(),
+		OpenPrice:  data.Open.Float64(),
+		HighPrice:  data.High.Float64(),
+		LowPrice:   data.Low.Float64(),
+		ClosePrice: data.Close.Float64(),
+		Volume:     data.Volume.Float64(),
 		Interval:   interval,
 	}
 	return nil

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -27,7 +27,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/trade"
 	"github.com/thrasher-corp/gocryptotrader/log"
-	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // List of all websocket channels to subscribe to
@@ -426,18 +425,6 @@ func (k *Kraken) wsProcessOpenOrders(ownOrdersResp json.RawMessage) error {
 	return nil
 }
 
-type wsTicker struct {
-	Ask                        [3]types.Number `json:"a"`
-	Bid                        [3]types.Number `json:"b"`
-	Last                       [2]types.Number `json:"c"`
-	Volume                     [2]types.Number `json:"v"`
-	VolumeWeightedAveragePrice [2]types.Number `json:"p"`
-	Trades                     [2]int64        `json:"t"`
-	Low                        [2]types.Number `json:"l"`
-	High                       [2]types.Number `json:"h"`
-	Open                       [2]types.Number `json:"o"`
-}
-
 // wsProcessTickers converts ticker data and sends it to the datahandler
 func (k *Kraken) wsProcessTickers(dataRaw json.RawMessage, pair currency.Pair) error {
 	var t wsTicker
@@ -460,18 +447,6 @@ func (k *Kraken) wsProcessTickers(dataRaw json.RawMessage, pair currency.Pair) e
 	return nil
 }
 
-type wsSpread struct {
-	Bid       types.Number
-	Ask       types.Number
-	Time      types.Time
-	BidVolume types.Number
-	AskVolume types.Number
-}
-
-func (w *wsSpread) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[5]any{&w.Bid, &w.Ask, &w.Time, &w.BidVolume, &w.AskVolume})
-}
-
 // wsProcessSpread converts spread/orderbook data and sends it to the datahandler
 func (k *Kraken) wsProcessSpread(rawData json.RawMessage, pair currency.Pair) error {
 	var data wsSpread
@@ -489,19 +464,6 @@ func (k *Kraken) wsProcessSpread(rawData json.RawMessage, pair currency.Pair) er
 			data.AskVolume.Float64())
 	}
 	return nil
-}
-
-type wsTrades struct {
-	Price     types.Number
-	Volume    types.Number
-	Time      types.Time
-	Side      string
-	OrderType string
-	Misc      string
-}
-
-func (w *wsTrades) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[6]any{&w.Price, &w.Volume, &w.Time, &w.Side, &w.OrderType, &w.Misc})
 }
 
 // wsProcessTrades converts trade data and sends it to the datahandler
@@ -731,22 +693,6 @@ func trim(s string) string {
 	s = strings.Replace(s, ".", "", 1)
 	s = strings.TrimLeft(s, "0")
 	return s
-}
-
-type wsCandle struct {
-	LastUpdateTime types.Time
-	EndTime        types.Time
-	Open           types.Number
-	High           types.Number
-	Low            types.Number
-	Close          types.Number
-	VWAP           types.Number
-	Volume         types.Number
-	Count          int64
-}
-
-func (w *wsCandle) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &[9]any{&w.LastUpdateTime, &w.EndTime, &w.Open, &w.High, &w.Low, &w.Close, &w.VWAP, &w.Volume, &w.Count})
 }
 
 // wsProcessCandle converts candle data and sends it to the data handler

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -418,7 +418,7 @@ func (k *Kraken) wsProcessOpenOrders(ownOrdersResp json.RawMessage) error {
 			}
 
 			if val.Volume > 0 {
-				// Note: We don't seem to ever get both there values
+				// Note: Only set if status is open
 				d.RemainingAmount = val.Volume - val.ExecutedVolume
 			}
 			k.Websocket.DataHandler <- d
@@ -480,7 +480,7 @@ func (k *Kraken) wsProcessSpread(rawData json.RawMessage, pair currency.Pair) er
 		return fmt.Errorf("error unmarshalling spread data: %w", err)
 	}
 	if k.Verbose {
-		log.Debugf(log.ExchangeSys, "%s Spread data for '%v' received. Best bid: '%v' Best ask: '%v' Time: '%v', Bid volume '%v', Ask volume '%v'",
+		log.Debugf(log.ExchangeSys, "%s Spread data for %q received. Best bid: '%v' Best ask: '%v' Time: %q, Bid volume: '%v', Ask volume: '%v'",
 			k.Name,
 			pair,
 			data.Bid.Float64(),

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/thrasher-corp/gocryptotrader/common"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/key"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -617,25 +616,28 @@ func (k *Kraken) GetRecentTrades(ctx context.Context, p currency.Pair, assetType
 	var resp []trade.Data
 	switch assetType {
 	case asset.Spot:
-		var tradeData []RecentTrades
-		tradeData, err = k.GetTrades(ctx, p)
+		tradeData, err := k.GetTrades(ctx, p, time.Time{}, 1000)
 		if err != nil {
 			return nil, err
 		}
-		for i := range tradeData {
+		trades, ok := tradeData.Trades[assetTranslator.LookupCurrency(p.String())]
+		if !ok {
+			return nil, fmt.Errorf("unable to find symbol %s in trade data", p.String())
+		}
+		for i := range trades {
 			side := order.Buy
-			if tradeData[i].BuyOrSell == "s" {
+			if trades[i].BuyOrSell == "s" {
 				side = order.Sell
 			}
 			resp = append(resp, trade.Data{
-				TID:          strconv.FormatInt(tradeData[i].TradeID, 10),
+				TID:          strconv.FormatInt(trades[i].TradeID.Int64(), 10),
 				Exchange:     k.Name,
 				CurrencyPair: p,
 				AssetType:    assetType,
 				Side:         side,
-				Price:        tradeData[i].Price,
-				Amount:       tradeData[i].Volume,
-				Timestamp:    convert.TimeFromUnixTimestampDecimal(tradeData[i].Time),
+				Price:        trades[i].Price.Float64(),
+				Amount:       trades[i].Volume.Float64(),
+				Timestamp:    trades[i].Time.Time(),
 			})
 		}
 	case asset.Futures:
@@ -1291,11 +1293,6 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 			for o := range orderHistory.OrderEvents {
 				switch {
 				case orderHistory.OrderEvents[o].Event.ExecutionEvent.Execution.UID != "":
-					timeVar, err := time.Parse(krakenFormat,
-						orderHistory.OrderEvents[o].Event.ExecutionEvent.Execution.TakerOrder.Timestamp)
-					if err != nil {
-						return orders, err
-					}
 					oDirection, err := compatibleOrderSide(orderHistory.OrderEvents[o].Event.ExecutionEvent.Execution.TakerOrder.Direction)
 					if err != nil {
 						return orders, err
@@ -1314,17 +1311,12 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 						ClientID:  orderHistory.OrderEvents[o].Event.ExecutionEvent.Execution.TakerOrder.ClientID,
 						AssetType: asset.Futures,
 						Type:      oType,
-						Date:      timeVar,
+						Date:      orderHistory.OrderEvents[o].Event.ExecutionEvent.Execution.TakerOrder.Timestamp,
 						Side:      oDirection,
 						Exchange:  k.Name,
 						Pair:      pairs[p],
 					})
 				case orderHistory.OrderEvents[o].Event.OrderRejected.RecentOrder.UID != "":
-					timeVar, err := time.Parse(krakenFormat,
-						orderHistory.OrderEvents[o].Event.OrderRejected.RecentOrder.Timestamp)
-					if err != nil {
-						return orders, err
-					}
 					oDirection, err := compatibleOrderSide(orderHistory.OrderEvents[o].Event.OrderRejected.RecentOrder.Direction)
 					if err != nil {
 						return orders, err
@@ -1343,18 +1335,13 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 						ClientID:  orderHistory.OrderEvents[o].Event.OrderRejected.RecentOrder.AccountID,
 						AssetType: asset.Futures,
 						Type:      oType,
-						Date:      timeVar,
+						Date:      orderHistory.OrderEvents[o].Event.OrderRejected.RecentOrder.Timestamp,
 						Side:      oDirection,
 						Exchange:  k.Name,
 						Pair:      pairs[p],
 						Status:    order.Rejected,
 					})
 				case orderHistory.OrderEvents[o].Event.OrderCancelled.RecentOrder.UID != "":
-					timeVar, err := time.Parse(krakenFormat,
-						orderHistory.OrderEvents[o].Event.OrderCancelled.RecentOrder.Timestamp)
-					if err != nil {
-						return orders, err
-					}
 					oDirection, err := compatibleOrderSide(orderHistory.OrderEvents[o].Event.OrderCancelled.RecentOrder.Direction)
 					if err != nil {
 						return orders, err
@@ -1373,18 +1360,13 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 						ClientID:  orderHistory.OrderEvents[o].Event.OrderCancelled.RecentOrder.AccountID,
 						AssetType: asset.Futures,
 						Type:      oType,
-						Date:      timeVar,
+						Date:      orderHistory.OrderEvents[o].Event.OrderCancelled.RecentOrder.Timestamp,
 						Side:      oDirection,
 						Exchange:  k.Name,
 						Pair:      pairs[p],
 						Status:    order.Cancelled,
 					})
 				case orderHistory.OrderEvents[o].Event.OrderPlaced.RecentOrder.UID != "":
-					timeVar, err := time.Parse(krakenFormat,
-						orderHistory.OrderEvents[o].Event.OrderPlaced.RecentOrder.Timestamp)
-					if err != nil {
-						return orders, err
-					}
 					oDirection, err := compatibleOrderSide(orderHistory.OrderEvents[o].Event.OrderPlaced.RecentOrder.Direction)
 					if err != nil {
 						return orders, err
@@ -1403,7 +1385,7 @@ func (k *Kraken) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mu
 						ClientID:  orderHistory.OrderEvents[o].Event.OrderPlaced.RecentOrder.AccountID,
 						AssetType: asset.Futures,
 						Type:      oType,
-						Date:      timeVar,
+						Date:      orderHistory.OrderEvents[o].Event.OrderPlaced.RecentOrder.Timestamp,
 						Side:      oDirection,
 						Exchange:  k.Name,
 						Pair:      pairs[p],

--- a/exchanges/kucoin/kucoin_types.go
+++ b/exchanges/kucoin/kucoin_types.go
@@ -1342,63 +1342,26 @@ type OrderbookChanges struct {
 	Bids [][]types.Number `json:"bids"`
 }
 
-// WsCandlestickData represents candlestick information push data for a symbol
-type WsCandlestickData struct {
-	Symbol  string     `json:"symbol"`
-	Candles [7]string  `json:"candles"`
-	Time    types.Time `json:"time"`
-}
-
 // WsCandlestick represents candlestick information push data for a symbol
 type WsCandlestick struct {
-	Symbol  string `json:"symbol"`
-	Candles struct {
-		StartTime         time.Time
-		OpenPrice         float64
-		ClosePrice        float64
-		HighPrice         float64
-		LowPrice          float64
-		TransactionVolume float64
-		TransactionAmount float64
-	} `json:"candles"`
-	Time time.Time `json:"time"`
+	Symbol  string       `json:"symbol"`
+	Candles wsCandleItem `json:"candles"`
+	Time    types.Time   `json:"time"`
 }
 
-func (a *WsCandlestickData) getCandlestickData() (*WsCandlestick, error) {
-	cand := &WsCandlestick{
-		Symbol: a.Symbol,
-		Time:   a.Time.Time(),
-	}
-	timeStamp, err := strconv.ParseInt(a.Candles[0], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.StartTime = time.UnixMilli(timeStamp)
-	cand.Candles.OpenPrice, err = strconv.ParseFloat(a.Candles[1], 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.ClosePrice, err = strconv.ParseFloat(a.Candles[2], 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.HighPrice, err = strconv.ParseFloat(a.Candles[3], 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.LowPrice, err = strconv.ParseFloat(a.Candles[4], 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.TransactionVolume, err = strconv.ParseFloat(a.Candles[5], 64)
-	if err != nil {
-		return nil, err
-	}
-	cand.Candles.TransactionAmount, err = strconv.ParseFloat(a.Candles[6], 64)
-	if err != nil {
-		return nil, err
-	}
-	return cand, nil
+type wsCandleItem struct {
+	StartTime         types.Time
+	OpenPrice         types.Number
+	ClosePrice        types.Number
+	HighPrice         types.Number
+	LowPrice          types.Number
+	TransactionVolume types.Number
+	TransactionAmount types.Number
+}
+
+// UnmarshalJSON unmarshals data into a wsCandleItem
+func (a *wsCandleItem) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &[7]any{&a.StartTime, &a.OpenPrice, &a.ClosePrice, &a.HighPrice, &a.LowPrice, &a.TransactionVolume, &a.TransactionAmount})
 }
 
 // WsTrade represents a trade push data
@@ -2351,7 +2314,7 @@ type MarginActiveSymbolDetail struct {
 
 // MarginInterestRecords represents a cross/isolated margin interest records
 type MarginInterestRecords struct {
-	Timestamp   int64                `json:"timestamp"`
+	Timestamp   types.Time           `json:"timestamp"`
 	CurrentPage int64                `json:"currentPage"`
 	PageSize    int64                `json:"pageSize"`
 	TotalNum    int64                `json:"totalNum"`

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -846,13 +846,8 @@ func (ku *Kucoin) processCandlesticks(respData []byte, instrument, intervalStrin
 	if err != nil {
 		return err
 	}
-	response := WsCandlestickData{}
-	err = json.Unmarshal(respData, &response)
-	if err != nil {
-		return err
-	}
-	resp, err := response.getCandlestickData()
-	if err != nil {
+	var resp WsCandlestick
+	if err := json.Unmarshal(respData, &resp); err != nil {
 		return err
 	}
 	assets, err := ku.CalculateAssets(topic, pair)
@@ -864,17 +859,17 @@ func (ku *Kucoin) processCandlesticks(respData []byte, instrument, intervalStrin
 			continue
 		}
 		ku.Websocket.DataHandler <- &websocket.KlineData{
-			Timestamp:  response.Time.Time(),
+			Timestamp:  resp.Time.Time(),
 			Pair:       pair,
 			AssetType:  assets[x],
 			Exchange:   ku.Name,
-			StartTime:  resp.Candles.StartTime,
+			StartTime:  resp.Candles.StartTime.Time(),
 			Interval:   intervalString,
-			OpenPrice:  resp.Candles.OpenPrice,
-			ClosePrice: resp.Candles.ClosePrice,
-			HighPrice:  resp.Candles.HighPrice,
-			LowPrice:   resp.Candles.LowPrice,
-			Volume:     resp.Candles.TransactionVolume,
+			OpenPrice:  resp.Candles.OpenPrice.Float64(),
+			ClosePrice: resp.Candles.ClosePrice.Float64(),
+			HighPrice:  resp.Candles.HighPrice.Float64(),
+			LowPrice:   resp.Candles.LowPrice.Float64(),
+			Volume:     resp.Candles.TransactionVolume.Float64(),
 		}
 	}
 	return nil

--- a/exchanges/lbank/lbank_types.go
+++ b/exchanges/lbank/lbank_types.go
@@ -37,11 +37,11 @@ type MarketDepthResponse struct {
 
 // TradeResponse stores date_ms, amount, price, type, tid for a currency pair
 type TradeResponse struct {
-	DateMS int64   `json:"date_ms"`
-	Amount float64 `json:"amount"`
-	Price  float64 `json:"price"`
-	Type   string  `json:"type"`
-	TID    string  `json:"tid"`
+	DateMS types.Time `json:"date_ms"`
+	Amount float64    `json:"amount"`
+	Price  float64    `json:"price"`
+	Type   string     `json:"type"`
+	TID    string     `json:"tid"`
 }
 
 // KlineResponse stores kline info for given currency exchange
@@ -56,9 +56,9 @@ type KlineResponse struct {
 
 // InfoResponse stores info
 type InfoResponse struct {
-	Freeze map[string]string `json:"freeze"`
-	Asset  map[string]string `json:"asset"`
-	Free   map[string]string `json:"Free"`
+	Freeze map[string]types.Number `json:"freeze"`
+	Asset  map[string]types.Number `json:"asset"`
+	Free   map[string]types.Number `json:"Free"`
 }
 
 // InfoFinalResponse stores info
@@ -83,15 +83,15 @@ type RemoveOrderResponse struct {
 
 // OrderResponse stores the data related to the given OrderIDs
 type OrderResponse struct {
-	Symbol     string  `json:"symbol"`
-	Amount     float64 `json:"amount"`
-	CreateTime int64   `json:"created_time"`
-	Price      float64 `json:"price"`
-	AvgPrice   float64 `json:"avg_price"`
-	Type       string  `json:"type"`
-	OrderID    string  `json:"order_id"`
-	DealAmount float64 `json:"deal_amount"`
-	Status     int64   `json:"status"`
+	Symbol     string     `json:"symbol"`
+	Amount     float64    `json:"amount"`
+	CreateTime types.Time `json:"created_time"`
+	Price      float64    `json:"price"`
+	AvgPrice   float64    `json:"avg_price"`
+	Type       string     `json:"type"`
+	OrderID    string     `json:"order_id"`
+	DealAmount float64    `json:"deal_amount"`
+	Status     int64      `json:"status"`
 }
 
 // QueryOrderResponse stores the data from queries
@@ -142,15 +142,15 @@ type PairInfoResponse struct {
 
 // TransactionTemp stores details about transactions
 type TransactionTemp struct {
-	TxUUID       string  `json:"txUuid"`
-	OrderUUID    string  `json:"orderUuid"`
-	TradeType    string  `json:"tradeType"`
-	DealTime     int64   `json:"dealTime"`
-	DealPrice    float64 `json:"dealPrice"`
-	DealQuantity float64 `json:"dealQuantity"`
-	DealVolPrice float64 `json:"dealVolumePrice"`
-	TradeFee     float64 `json:"tradeFee"`
-	TradeFeeRate float64 `json:"tradeFeeRate"`
+	TxUUID       string     `json:"txUuid"`
+	OrderUUID    string     `json:"orderUuid"`
+	TradeType    string     `json:"tradeType"`
+	DealTime     types.Time `json:"dealTime"`
+	DealPrice    float64    `json:"dealPrice"`
+	DealQuantity float64    `json:"dealQuantity"`
+	DealVolPrice float64    `json:"dealVolumePrice"`
+	TradeFee     float64    `json:"tradeFee"`
+	TradeFeeRate float64    `json:"tradeFeeRate"`
 }
 
 // TransactionHistoryResp stores details about past transactions
@@ -211,14 +211,14 @@ type RevokeWithdrawResponse struct {
 // ListDataResponse contains some of withdrawal data
 type ListDataResponse struct {
 	ErrCapture
-	Amount    float64 `json:"amount"`
-	AssetCode string  `json:"assetCode"`
-	Address   string  `json:"address"`
-	Fee       float64 `json:"fee"`
-	ID        int64   `json:"id"`
-	Time      int64   `json:"time"`
-	TXHash    string  `json:"txhash"`
-	Status    string  `json:"status"`
+	Amount    float64    `json:"amount"`
+	AssetCode string     `json:"assetCode"`
+	Address   string     `json:"address"`
+	Fee       float64    `json:"fee"`
+	ID        int64      `json:"id"`
+	Time      types.Time `json:"time"`
+	TXHash    string     `json:"txhash"`
+	Status    string     `json:"status"`
 }
 
 // WithdrawalResponse stores data for withdrawals

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -246,21 +246,14 @@ func (l *Lbank) UpdateAccountInfo(ctx context.Context, assetType asset.Item) (ac
 	}
 	acc := account.SubAccount{AssetType: assetType}
 	for key, val := range data.Info.Asset {
-		c := currency.NewCode(key)
 		hold, ok := data.Info.Freeze[key]
 		if !ok {
 			return info, fmt.Errorf("hold data not found with %s", key)
 		}
-		totalVal, parseErr := strconv.ParseFloat(val, 64)
-		if parseErr != nil {
-			return info, parseErr
-		}
-		totalHold, parseErr := strconv.ParseFloat(hold, 64)
-		if parseErr != nil {
-			return info, parseErr
-		}
+		totalVal := val.Float64()
+		totalHold := hold.Float64()
 		acc.Currencies = append(acc.Currencies, account.Balance{
-			Currency: c,
+			Currency: currency.NewCode(key),
 			Total:    totalVal,
 			Hold:     totalHold,
 			Free:     totalVal - totalHold,
@@ -302,7 +295,7 @@ func (l *Lbank) GetWithdrawalsHistory(ctx context.Context, c currency.Code, a as
 		resp[i] = exchange.WithdrawalHistory{
 			Status:          withdrawalRecords.List[i].Status,
 			TransferID:      id,
-			Timestamp:       time.Unix(withdrawalRecords.List[i].Time, 0),
+			Timestamp:       withdrawalRecords.List[i].Time.Time(),
 			Currency:        withdrawalRecords.List[i].AssetCode,
 			Amount:          withdrawalRecords.List[i].Amount,
 			Fee:             withdrawalRecords.List[i].Fee,
@@ -340,7 +333,7 @@ allTrades:
 			return nil, err
 		}
 		for i := range tradeData {
-			tradeTime := time.UnixMilli(tradeData[i].DateMS)
+			tradeTime := tradeData[i].DateMS.Time()
 			if tradeTime.Before(timestampStart) || tradeTime.After(timestampEnd) {
 				break allTrades
 			}
@@ -617,7 +610,7 @@ func (l *Lbank) GetActiveOrders(ctx context.Context, getOrdersRequest *order.Mul
 			resp.Status = l.GetStatus(tempResp.Orders[0].Status)
 			resp.Price = tempResp.Orders[0].Price
 			resp.Amount = tempResp.Orders[0].Amount
-			resp.Date = time.Unix(tempResp.Orders[0].CreateTime, 0)
+			resp.Date = tempResp.Orders[0].CreateTime.Time()
 			resp.ExecutedAmount = tempResp.Orders[0].DealAmount
 			resp.RemainingAmount = tempResp.Orders[0].Amount - tempResp.Orders[0].DealAmount
 			resp.Fee, err = l.GetFeeByType(ctx,
@@ -701,7 +694,7 @@ func (l *Lbank) GetOrderHistory(ctx context.Context, getOrdersRequest *order.Mul
 				resp.Price = tempResp.Orders[x].Price
 				resp.AverageExecutedPrice = tempResp.Orders[x].AvgPrice
 				resp.Amount = tempResp.Orders[x].Amount
-				resp.Date = time.Unix(tempResp.Orders[x].CreateTime, 0)
+				resp.Date = tempResp.Orders[x].CreateTime.Time()
 				resp.ExecutedAmount = tempResp.Orders[x].DealAmount
 				resp.RemainingAmount = tempResp.Orders[x].Amount - tempResp.Orders[x].DealAmount
 				resp.Fee, err = l.GetFeeByType(ctx,

--- a/exchanges/okx/okx_types.go
+++ b/exchanges/okx/okx_types.go
@@ -177,9 +177,9 @@ const (
 
 // PremiumInfo represents data on premiums for the past 6 months.
 type PremiumInfo struct {
-	InstrumentID string `json:"instId"`
-	Premium      string `json:"premium"`
-	Timestamp    string `json:"ts"`
+	InstrumentID string     `json:"instId"`
+	Premium      string     `json:"premium"`
+	Timestamp    types.Time `json:"ts"`
 }
 
 // TickerResponse represents the detailed data from the market ticker endpoint.
@@ -823,13 +823,13 @@ func (arg *PlaceOrderRequestParam) Validate() error {
 
 // OrderData response message for place, cancel, and amend an order requests.
 type OrderData struct {
-	OrderID       string `json:"ordId"`
-	RequestID     string `json:"reqId"`
-	ClientOrderID string `json:"clOrdId"`
-	Tag           string `json:"tag"`
-	StatusCode    int64  `json:"sCode,string"` // Anything above 0 is an error with an attached message
-	StatusMessage string `json:"sMsg"`
-	Timestamp     string `json:"ts"`
+	OrderID       string     `json:"ordId"`
+	RequestID     string     `json:"reqId"`
+	ClientOrderID string     `json:"clOrdId"`
+	Tag           string     `json:"tag"`
+	StatusCode    int64      `json:"sCode,string"` // Anything above 0 is an error with an attached message
+	StatusMessage string     `json:"sMsg"`
+	Timestamp     types.Time `json:"ts"`
 }
 
 func (o *OrderData) Error() error {
@@ -3050,7 +3050,7 @@ type SpreadTrade struct {
 	State         string       `json:"state"`
 	Side          string       `json:"side"`
 	ExecType      string       `json:"execType"`
-	Timestamp     string       `json:"ts"`
+	Timestamp     types.Time   `json:"ts"`
 	Legs          []struct {
 		InstrumentID string       `json:"instId"`
 		Price        types.Number `json:"px"`

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -239,7 +239,7 @@ func (p *Poloniex) GetTimestamp(ctx context.Context) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return time.UnixMilli(resp.ServerTime), nil
+	return resp.ServerTime.Time(), nil
 }
 
 // GetLoanOrders returns the list of loan offers and demands for a given

--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -169,24 +169,24 @@ type DepositAddresses struct {
 // DepositsWithdrawals holds withdrawal information
 type DepositsWithdrawals struct {
 	Deposits []struct {
-		Currency      string  `json:"currency"`
-		Address       string  `json:"address"`
-		Amount        float64 `json:"amount,string"`
-		Confirmations int64   `json:"confirmations"`
-		TransactionID string  `json:"txid"`
-		Timestamp     int64   `json:"timestamp"`
-		Status        string  `json:"status"`
+		Currency      string     `json:"currency"`
+		Address       string     `json:"address"`
+		Amount        float64    `json:"amount,string"`
+		Confirmations int64      `json:"confirmations"`
+		TransactionID string     `json:"txid"`
+		Timestamp     types.Time `json:"timestamp"`
+		Status        string     `json:"status"`
 	} `json:"deposits"`
 	Withdrawals []struct {
-		WithdrawalNumber int64   `json:"withdrawalNumber"`
-		Currency         string  `json:"currency"`
-		Address          string  `json:"address"`
-		Amount           float64 `json:"amount,string"`
-		Confirmations    int64   `json:"confirmations"`
-		TransactionID    string  `json:"txid"`
-		Timestamp        int64   `json:"timestamp"`
-		Status           string  `json:"status"`
-		IPAddress        string  `json:"ipAddress"`
+		WithdrawalNumber int64      `json:"withdrawalNumber"`
+		Currency         string     `json:"currency"`
+		Address          string     `json:"address"`
+		Amount           float64    `json:"amount,string"`
+		Confirmations    int64      `json:"confirmations"`
+		TransactionID    string     `json:"txid"`
+		Timestamp        types.Time `json:"timestamp"`
+		Status           string     `json:"status"`
+		IPAddress        string     `json:"ipAddress"`
 	} `json:"withdrawals"`
 }
 
@@ -388,7 +388,7 @@ type WsTrade struct {
 	Side      string
 	Volume    float64
 	Price     float64
-	Timestamp int64
+	Timestamp types.Time
 }
 
 // WithdrawalFees the large list of predefined withdrawal fees
@@ -506,7 +506,7 @@ type WalletDeposits struct {
 	Amount        float64       `json:"amount,string"`
 	Confirmations int64         `json:"confirmations"`
 	TransactionID string        `json:"txid"`
-	Timestamp     int64         `json:"timestamp"`
+	Timestamp     types.Time    `json:"timestamp"`
 	Status        string        `json:"status"`
 }
 
@@ -517,7 +517,7 @@ type WalletWithdrawals struct {
 	Address              string        `json:"address"`
 	Amount               float64       `json:"amount,string"`
 	Fee                  float64       `json:"fee,string"`
-	Timestamp            int64         `json:"timestamp"`
+	Timestamp            types.Time    `json:"timestamp"`
 	Status               string        `json:"status"`
 	TransactionID        string        `json:"txid"`
 	IPAddress            string        `json:"ipAddress"`
@@ -526,5 +526,5 @@ type WalletWithdrawals struct {
 
 // TimeStampResponse returns the time
 type TimeStampResponse struct {
-	ServerTime int64 `json:"serverTime"`
+	ServerTime types.Time `json:"serverTime"`
 }

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -388,7 +388,7 @@ func (p *Poloniex) GetAccountFundingHistory(ctx context.Context) ([]exchange.Fun
 		resp[i] = exchange.FundingHistory{
 			ExchangeName:    p.Name,
 			Status:          walletActivity.Deposits[i].Status,
-			Timestamp:       time.Unix(walletActivity.Deposits[i].Timestamp, 0),
+			Timestamp:       walletActivity.Deposits[i].Timestamp.Time(),
 			Currency:        walletActivity.Deposits[i].Currency.String(),
 			Amount:          walletActivity.Deposits[i].Amount,
 			CryptoToAddress: walletActivity.Deposits[i].Address,
@@ -399,7 +399,7 @@ func (p *Poloniex) GetAccountFundingHistory(ctx context.Context) ([]exchange.Fun
 		resp[i] = exchange.FundingHistory{
 			ExchangeName:    p.Name,
 			Status:          walletActivity.Withdrawals[i].Status,
-			Timestamp:       time.Unix(walletActivity.Withdrawals[i].Timestamp, 0),
+			Timestamp:       walletActivity.Withdrawals[i].Timestamp.Time(),
 			Currency:        walletActivity.Withdrawals[i].Currency.String(),
 			Amount:          walletActivity.Withdrawals[i].Amount,
 			Fee:             walletActivity.Withdrawals[i].Fee,
@@ -424,7 +424,7 @@ func (p *Poloniex) GetWithdrawalsHistory(ctx context.Context, c currency.Code, _
 		}
 		resp[i] = exchange.WithdrawalHistory{
 			Status:          withdrawals.Withdrawals[i].Status,
-			Timestamp:       time.Unix(withdrawals.Withdrawals[i].Timestamp, 0),
+			Timestamp:       withdrawals.Withdrawals[i].Timestamp.Time(),
 			Currency:        withdrawals.Withdrawals[i].Currency.String(),
 			Amount:          withdrawals.Withdrawals[i].Amount,
 			Fee:             withdrawals.Withdrawals[i].Fee,

--- a/exchanges/trade/trade.go
+++ b/exchanges/trade/trade.go
@@ -259,7 +259,7 @@ func groupTradesToInterval(interval kline.Interval, times ...Data) map[int64][]D
 }
 
 func getNearestInterval(t time.Time, interval kline.Interval) int64 {
-	return t.Truncate(interval.Duration()).UTC().Unix()
+	return t.Truncate(interval.Duration()).Unix()
 }
 
 func classifyOHLCV(t time.Time, datas ...Data) (c kline.Candle) {

--- a/exchanges/yobit/yobit_types.go
+++ b/exchanges/yobit/yobit_types.go
@@ -1,6 +1,9 @@
 package yobit
 
-import "github.com/thrasher-corp/gocryptotrader/currency"
+import (
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/types"
+)
 
 // Response is a generic struct used for exchange API request result
 type Response struct {
@@ -11,7 +14,7 @@ type Response struct {
 
 // Info holds server time and pair information
 type Info struct {
-	ServerTime int64           `json:"server_time"`
+	ServerTime types.Time      `json:"server_time"`
 	Pairs      map[string]Pair `json:"pairs"`
 }
 
@@ -36,21 +39,21 @@ type Orderbook struct {
 
 // Trade stores trade information
 type Trade struct {
-	Type      string  `json:"type"`
-	Price     float64 `json:"price"`
-	Amount    float64 `json:"amount"`
-	TID       int64   `json:"tid"`
-	Timestamp int64   `json:"timestamp"`
+	Type      string     `json:"type"`
+	Price     float64    `json:"price"`
+	Amount    float64    `json:"amount"`
+	TID       int64      `json:"tid"`
+	Timestamp types.Time `json:"timestamp"`
 }
 
 // ActiveOrders stores active order information
 type ActiveOrders struct {
-	Pair             string  `json:"pair"`
-	Type             string  `json:"type"`
-	Amount           float64 `json:"amount"`
-	Rate             float64 `json:"rate"`
-	TimestampCreated float64 `json:"timestamp_created"`
-	Status           int     `json:"status"`
+	Pair             string     `json:"pair"`
+	Type             string     `json:"type"`
+	Amount           float64    `json:"amount"`
+	Rate             float64    `json:"rate"`
+	TimestampCreated types.Time `json:"timestamp_created"`
+	Status           int        `json:"status"`
 }
 
 // Pair holds pair information
@@ -72,21 +75,21 @@ type AccountInfo struct {
 		Trade    int `json:"trade"`
 		Withdraw int `json:"withdraw"`
 	} `json:"rights"`
-	TransactionCount int     `json:"transaction_count"`
-	OpenOrders       int     `json:"open_orders"`
-	ServerTime       float64 `json:"server_time"`
-	Error            string  `json:"error"`
+	TransactionCount int        `json:"transaction_count"`
+	OpenOrders       int        `json:"open_orders"`
+	ServerTime       types.Time `json:"server_time"`
+	Error            string     `json:"error"`
 }
 
 // OrderInfo stores order information
 type OrderInfo struct {
-	Pair             string  `json:"pair"`
-	Type             string  `json:"type"`
-	StartAmount      float64 `json:"start_amount"`
-	Amount           float64 `json:"amount"`
-	Rate             float64 `json:"rate"`
-	TimestampCreated float64 `json:"timestamp_created"`
-	Status           int     `json:"status"`
+	Pair             string     `json:"pair"`
+	Type             string     `json:"type"`
+	StartAmount      float64    `json:"start_amount"`
+	Amount           float64    `json:"amount"`
+	Rate             float64    `json:"rate"`
+	TimestampCreated types.Time `json:"timestamp_created"`
+	Status           int        `json:"status"`
 }
 
 // CancelOrder is used for the CancelOrder API request response
@@ -114,30 +117,30 @@ type TradeHistoryResponse struct {
 
 // TradeHistory stores trade history
 type TradeHistory struct {
-	Pair      string  `json:"pair"`
-	Type      string  `json:"type"`
-	Amount    float64 `json:"amount"`
-	Rate      float64 `json:"rate"`
-	OrderID   float64 `json:"order_id"`
-	MyOrder   int     `json:"is_your_order"`
-	Timestamp float64 `json:"timestamp"`
+	Pair      string     `json:"pair"`
+	Type      string     `json:"type"`
+	Amount    float64    `json:"amount"`
+	Rate      float64    `json:"rate"`
+	OrderID   float64    `json:"order_id"`
+	MyOrder   int        `json:"is_your_order"`
+	Timestamp types.Time `json:"timestamp"`
 }
 
 // DepositAddress stores a currency deposit address
 type DepositAddress struct {
 	Success int `json:"success"`
 	Return  struct {
-		Address         string  `json:"address"`
-		ProcessedAmount float64 `json:"processed_amount"`
-		ServerTime      int64   `json:"server_time"`
+		Address         string     `json:"address"`
+		ProcessedAmount float64    `json:"processed_amount"`
+		ServerTime      types.Time `json:"server_time"`
 	} `json:"return"`
 	Error string `json:"error"`
 }
 
 // WithdrawCoinsToAddress stores information for a withdrawcoins request
 type WithdrawCoinsToAddress struct {
-	ServerTime int64  `json:"server_time"`
-	Error      string `json:"error"`
+	ServerTime types.Time `json:"server_time"`
+	Error      string     `json:"error"`
 }
 
 // CreateCoupon stores information coupon information

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -305,7 +305,6 @@ func (y *Yobit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 
 	resp := make([]trade.Data, len(tradeData))
 	for i := range tradeData {
-		tradeTS := time.Unix(tradeData[i].Timestamp, 0)
 		side := order.Buy
 		if tradeData[i].Type == "ask" {
 			side = order.Sell
@@ -318,7 +317,7 @@ func (y *Yobit) GetRecentTrades(ctx context.Context, p currency.Pair, assetType 
 			Side:         side,
 			Price:        tradeData[i].Price,
 			Amount:       tradeData[i].Amount,
-			Timestamp:    tradeTS,
+			Timestamp:    tradeData[i].Timestamp.Time(),
 		}
 	}
 
@@ -465,7 +464,7 @@ func (y *Yobit) GetOrderInfo(ctx context.Context, orderID string, _ currency.Pai
 			Amount:   orderInfo.Amount,
 			Price:    orderInfo.Rate,
 			Side:     side,
-			Date:     time.Unix(int64(orderInfo.TimestampCreated), 0),
+			Date:     orderInfo.TimestampCreated.Time(),
 			Pair:     symbol,
 			Exchange: y.Name,
 		}, nil
@@ -572,7 +571,7 @@ func (y *Yobit) GetActiveOrders(ctx context.Context, req *order.MultiOrderReques
 				Amount:   resp[id].Amount,
 				Price:    resp[id].Rate,
 				Side:     side,
-				Date:     time.Unix(int64(resp[id].TimestampCreated), 0),
+				Date:     resp[id].TimestampCreated.Time(),
 				Pair:     symbol,
 				Exchange: y.Name,
 			})
@@ -626,7 +625,6 @@ func (y *Yobit) GetOrderHistory(ctx context.Context, req *order.MultiOrderReques
 		if err != nil {
 			return nil, err
 		}
-		orderDate := time.Unix(int64(allOrders[i].Timestamp), 0)
 		var side order.Side
 		side, err = order.StringToOrderSide(allOrders[i].Type)
 		if err != nil {
@@ -640,7 +638,7 @@ func (y *Yobit) GetOrderHistory(ctx context.Context, req *order.MultiOrderReques
 			AverageExecutedPrice: allOrders[i].Rate,
 			Side:                 side,
 			Status:               order.Filled,
-			Date:                 orderDate,
+			Date:                 allOrders[i].Timestamp.Time(),
 			Pair:                 pair,
 			Exchange:             y.Name,
 		}
@@ -673,7 +671,7 @@ func (y *Yobit) GetServerTime(ctx context.Context, _ asset.Item) (time.Time, err
 	if err != nil {
 		return time.Time{}, err
 	}
-	return time.Unix(info.ServerTime, 0), nil
+	return info.ServerTime.Time(), nil
 }
 
 // GetFuturesContractDetails returns all contracts from the exchange by asset type

--- a/types/time.go
+++ b/types/time.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 )
 
 // Time represents a time.Time object that can be unmarshalled from a float64 or string.
@@ -75,4 +77,28 @@ func (t Time) String() string {
 // MarshalJSON serializes the time to json.
 func (t Time) MarshalJSON() ([]byte, error) {
 	return t.Time().MarshalJSON()
+}
+
+// DateTime represents a time.Time object that can be unmarshalled from a string in the format "2006-01-02 15:04:05".
+type DateTime time.Time
+
+// UnmarshalJSON unmarshals json data into a DateTime type.
+func (d *DateTime) UnmarshalJSON(data []byte) error {
+	var ts string
+	if err := json.Unmarshal(data, &ts); err != nil {
+		return fmt.Errorf("error unmarshalling %q into string: %w", data, err)
+	}
+
+	tm, err := time.Parse(time.DateTime, ts)
+	if err != nil {
+		return fmt.Errorf("error parsing %q into DateTime: %w", ts, err)
+	}
+
+	*d = DateTime(tm)
+	return nil
+}
+
+// Time converts DateTime to time.Time
+func (d DateTime) Time() time.Time {
+	return time.Time(d)
 }

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -76,3 +76,16 @@ func TestTime_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `"0001-01-01T00:00:00Z"`, string(data))
 }
+
+func TestDateTimeUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	var (
+		testTime   DateTime
+		jsonError  *json.UnmarshalTypeError
+		parseError *time.ParseError
+	)
+	require.ErrorAs(t, json.Unmarshal([]byte(`69`), &testTime), &jsonError)
+	require.ErrorAs(t, json.Unmarshal([]byte(`"2025"`), &testTime), &parseError)
+	require.NoError(t, json.Unmarshal([]byte(`"2018-08-20 19:20:46"`), &testTime))
+	assert.Equal(t, time.Date(2018, 8, 20, 19, 20, 46, 0, time.UTC), testTime.Time())
+}


### PR DESCRIPTION
![21abde1f4077f78ee7fee13b08777236](https://github.com/user-attachments/assets/c85ccd3a-07ba-4faa-8e97-bec28026f9d8)

# PR Description

Unifies timestamp usage across the codebase and also removes the convert.Timestamp funcs. This was a bit involved for Bitfinex/Kraken. Also improves things along the way.

When looking at Alphapoint, the `GetTradesByDate` endpoint that we have is no longer in their docs so I removed it. 

## Type of change

- [x] Cleanup (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
