### PR TITLE
backtester: fix report template generation when using exchange level funding

### DIFF
--- a/backtester/report/tpl.gohtml
+++ b/backtester/report/tpl.gohtml
@@ -292,11 +292,11 @@
 					</tr>
 					</thead>
 					<tbody>
-					{{ range $mapKey, $stats := .Statistics.ExchangeAssetPairStatistics }}
+					{{ range $key, $stats := .Statistics.ExchangeAssetPairStatistics }}
 						<tr>
-							<td>{{ $mapKey.Exchange }}</td>
-							<td>{{ $mapKey.Asset }}</td>
-							<td>{{ $mapKey.Base }}-{{ $mapKey.Quote }}</td>
+							<td>{{ $key.Exchange }}</td>
+							<td>{{ $key.Asset }}</td>
+							<td>{{ $key.Base }}-{{ $key.Quote }}</td>
 							<td>{{ $.Prettify.Decimal8 $stats.MarketMovement }}%</td>
 						</tr>
 					{{ end }}
@@ -323,11 +323,11 @@
 					</tr>
 					</thead>
 					<tbody>
-					{{ range $mapKey, $stats := .Statistics.ExchangeAssetPairStatistics}}
+					{{ range $key, $stats := .Statistics.ExchangeAssetPairStatistics}}
 						<tr>
-							<td>{{ $mapKey.Exchange}}</td>
-							<td>{{ $mapKey.Asset}}</td>
-							<td>{{ $mapKey.Base.Currency}}-{{$mapKey.Quote.Currency}}</td>
+							<td>{{ $key.Exchange}}</td>
+							<td>{{ $key.Asset}}</td>
+							<td>{{ $key.Base.Currency}}-{{$key.Quote.Currency}}</td>
 							<td>{{ $.Prettify.Decimal8 $stats.InitialHoldings.BaseInitialFunds }} {{$stats.FinalHoldings.Pair.Base}}</td>
 							<td>{{ $.Prettify.Decimal8 $stats.InitialHoldings.QuoteInitialFunds }} {{$stats.FinalHoldings.Pair.Quote}}</td>
 							<td>{{ $.Prettify.Decimal8 $stats.InitialHoldings.TotalInitialValue }} {{$stats.FinalHoldings.Pair.Quote}}</td>
@@ -1217,11 +1217,11 @@
 				</table>
 			</div>
 		</div>
-		{{ range $mapKey, $stats := .Statistics.ExchangeAssetPairStatistics}}
+		{{ range $key, $stats := .Statistics.ExchangeAssetPairStatistics}}
 
 		<div class="card card-cascade narrower">
 			<div class="view view-cascade bg-primary">
-				<h2 id="currency-statistics" class="px-4 card-header-title text-light">Pair Statistics for {{$mapKey.Exchange}} {{ $mapKey.Asset}} {{ $mapKey.Base.Currency}}-{{$mapKey.Quote.Currency}}</h2>
+				<h2 id="currency-statistics" class="px-4 card-header-title text-light">Pair Statistics for {{$key.Exchange}} {{ $key.Asset}} {{ $key.Base.Currency}}-{{$key.Quote.Currency}}</h2>
 			</div>
 			<div class="card-body card-body-cascade ">
 				<table class="table table-hover table-bordered table-striped">
@@ -1652,9 +1652,9 @@
 				<h2 id="orders" class="px-4 card-header-title text-light">Orders</h2>
 			</div>
 			<div class="card-body card-body-cascade ">
-				{{ range $mapKey, $val :=  .Statistics.ExchangeAssetPairStatistics}}
+				{{ range $key, $val :=  .Statistics.ExchangeAssetPairStatistics}}
 					<div  >
-						<h3>{{$mapKey.Exchange}} {{$mapKey.Asset}} {{ $mapKey.Base }}-{{$mapKey.Quote}}</h3>
+						<h3>{{$key.Exchange}} {{$key.Asset}} {{ $key.Base }}-{{$key.Quote}}</h3>
 					</div>
 					<div >
 						<table class="table table-hover table-bordered table-striped">
@@ -1672,11 +1672,11 @@
 							{{range $val.FinalOrders.Orders}}
 								<tr>
 									<td>{{ .Order.Date }}</td>
-									<td>{{  $.Prettify.Decimal8 .ClosePrice}} {{$mapKey.Quote}}</td>
+									<td>{{  $.Prettify.Decimal8 .ClosePrice}} {{$key.Quote}}</td>
 									<td>{{ .Order.Side }}</td>
-									<td>{{$.Prettify.Float8  .Order.Price }} {{$mapKey.Quote}}</td>
-									<td>{{$.Prettify.Float8  .Order.Amount }} {{$mapKey.Base}}</td>
-									<td>{{$.Prettify.Float8 .Order.Fee }} {{$mapKey.Quote}}</td>
+									<td>{{$.Prettify.Float8  .Order.Price }} {{$key.Quote}}</td>
+									<td>{{$.Prettify.Float8  .Order.Amount }} {{$key.Base}}</td>
+									<td>{{$.Prettify.Float8 .Order.Fee }} {{$key.Quote}}</td>
 									<td>{{ $.Prettify.Decimal8 .CostBasis }} {{.Order.FeeAsset}}</td>
 									<td>{{ $.Prettify.Decimal8 .SlippageRate }}%</td>
 								</tr>
@@ -1693,9 +1693,9 @@
 				<h2 id="events"  class="px-4 card-header-title text-light">Events</h2>
 			</div>
 			<div class="card-body card-body-cascade ">
-				{{ range $mapKey, $val :=  .Statistics.ExchangeAssetPairStatistics}}
+				{{ range $key, $val :=  .Statistics.ExchangeAssetPairStatistics}}
 					<div>
-						<h3>{{$mapKey.Exchange}} {{$mapKey.Asset}} {{ $mapKey.Base }}-{{$mapKey.Quote}}</h3>
+						<h3>{{$key.Exchange}} {{$key.Asset}} {{ $key.Base }}-{{$key.Quote}}</h3>
 					</div>
 					<div >
 						<table class="table table-hover table-bordered table-striped">
@@ -1704,16 +1704,16 @@
 								<th>Price</th>
 								<th>Action</th>
 								<th>Event Details</th>
-								{{if $mapKey.Asset.IsFutures}}
+								{{if $key.Asset.IsFutures}}
 									<th>Holdings</th>
 									<th>Position Direction</th>
 									<th>Unrealised PNL</th>
 									<th>Realised PNL</th>
 								{{ else }}
-									<th>{{$mapKey.Base}} Funds</th>
-									<th>{{$mapKey.Quote}} Funds</th>
-									<th>Total value in {{$mapKey.Quote}}</th>
-									<th>Committed funds in {{$mapKey.Quote}}</th>
+									<th>{{$key.Base}} Funds</th>
+									<th>{{$key.Quote}} Funds</th>
+									<th>Total value in {{$key.Quote}}</th>
+									<th>Committed funds in {{$key.Quote}}</th>
 								{{ end }}
 
 							</tr>
@@ -1722,7 +1722,7 @@
 								<tr>
 									{{ if ne $ev.FillEvent nil }}
 										<td><b>{{$ev.FillEvent.GetTime}}</b></td>
-										<td>{{ $.Prettify.Decimal8 $ev.FillEvent.GetClosePrice}} {{if $mapKey.Asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$mapKey.Quote}}{{end}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.FillEvent.GetClosePrice}} {{if $key.Asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$key.Quote}}{{end}}</td>
 										<td>{{$ev.FillEvent.GetDirection}}</td>
 										<td>
 											<ul>
@@ -1733,7 +1733,7 @@
 										</td>
 									{{ else if ne $ev.SignalEvent nil}}
 										<td>{{$ev.SignalEvent.GetTime}}</td>
-										<td>{{ $.Prettify.Decimal8 $ev.SignalEvent.GetClosePrice}} {{if $mapKey.Asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$mapKey.Quote}}{{end}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.SignalEvent.GetClosePrice}} {{if $key.Asset.IsFutures}}{{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}{{else}}{{$key.Quote}}{{end}}</td>
 										<td>{{$ev.SignalEvent.GetDirection}}</td>
 										<td>
 											<ul>
@@ -1743,23 +1743,23 @@
 											</ul>
 										</td>
 									{{ end }}
-									{{if $mapKey.Asset.IsFutures}}
+									{{if $key.Asset.IsFutures}}
 										{{if ne $ev.PNL nil }}
-											<td>{{ $.Prettify.Decimal8 $ev.PNL.GetExposure}} {{$mapKey.Base}}-{{$mapKey.Quote}}</td>
+											<td>{{ $.Prettify.Decimal8 $ev.PNL.GetExposure}} {{$key.Base}}-{{$key.Quote}}</td>
 											<td>{{$ev.PNL.GetDirection}}</td>
 											<td>{{$.Prettify.Decimal8 $ev.PNL.GetUnrealisedPNL.PNL}} {{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}</td>
 											<td>{{$.Prettify.Decimal8 $ev.PNL.GetRealisedPNL.PNL}} {{if ne $ev.PNL nil }}{{$ev.PNL.GetCollateralCurrency}}{{end}}</td>
 										{{else}}
-											<td>0 {{$mapKey.Base}}-{{$mapKey.Quote}}</td>
+											<td>0 {{$key.Base}}-{{$key.Quote}}</td>
 											<td>N/A</td>
 											<td>0</td>
 											<td>0</td>
 										{{end}}
 									{{else }}
-										<td>{{ $.Prettify.Decimal8 $ev.Holdings.BaseSize}} {{$mapKey.Base}}</td>
-										<td>{{ $.Prettify.Decimal8 $ev.Holdings.QuoteSize}} {{$mapKey.Quote}}</td>
-										<td>{{ $.Prettify.Decimal8 $ev.Holdings.TotalValue}} {{$mapKey.Quote}}</td>
-										<td>{{ $.Prettify.Decimal8 $ev.Holdings.CommittedFunds}} {{$mapKey.Quote}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.Holdings.BaseSize}} {{$key.Base}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.Holdings.QuoteSize}} {{$key.Quote}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.Holdings.TotalValue}} {{$key.Quote}}</td>
+										<td>{{ $.Prettify.Decimal8 $ev.Holdings.CommittedFunds}} {{$key.Quote}}</td>
 									{{end}}
 								</tr>
 							{{end}}


### PR DESCRIPTION
# PR Description

Fixes report generation failure (due to buggy iteration of `ExchangeAssetPairStatistics` in *tpl.gohtml*) when exchange level funding is enabled.

```
Could not stop task 52a3aefb-3f43-4914-9099-89073e2ca8cd top2bottom2. Error: template: tpl.gohtml:296:34: executing "tpl.gohtml" at <.>: range can't iterate over {binance spot BTCUSDT  false false true 1 0 1 {2022-08-01 00:00:00 +0000 UTC 23268.01 false} {2022-11-30 00:00:00 +0000 UTC 17163.64 false} {2022-11-21 00:00:00 +0000 UTC 15781.29 true} {2022-08-13 00:00:00 +0000 UTC 24441.38 true} {0001-01-01 00:00:00 +0000 UTC 0 false} {0001-01-01 00:00:00 ...
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Since the only change is within a `UseExchangeLevelFunding` conditional, only strategies that have it enabled are affected.
Each of these strategies were tested and now generate reports successfully.

- [x] go test ./... -race
- [x] golangci-lint run
- [x] go run ./backtester -singlerunstrategypath backtester/config/strategyexamples/dca-api-candles-exchange-level-funding.strat
- [x] go run ./backtester -singlerunstrategypath backtester/config/strategyexamples/t2b2-api-candles-exchange-funding.strat

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
