### PR TITLE
updated relayWebsocketEvent to check if err is not nil

### DIFF
--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -911,7 +911,7 @@ func relayWebsocketEvent(result any, event, assetType, exchangeName string) {
 		Exchange:  exchangeName,
 	}
 	err := BroadcastWebsocketMessage(evt)
-	if !errors.Is(err, ErrWebsocketServiceNotRunning) {
+	if err != nil && !errors.Is(err, ErrWebsocketServiceNotRunning) {
 		log.Errorf(log.APIServerMgr, "Failed to broadcast websocket event %v. Error: %s",
 			event, err)
 	}


### PR DESCRIPTION
# PR Description

The `relayWebsocketEvent` function checks the type of the error after broadcasting the WebSocket event to the WebSocket RPC. But interestingly it does not check if there is an error in the first place. This leads to a condition in which clients are getting the WebSocket events normally but the engine will constantly complain that there has been an error sending the event. But the log prints the error as `nil` since there hasn't been an error.
I have updated the function to check if there has indeed been an error before checking the type of the error.

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
