### PR TITLE
Bithumb: Filter zero quantity values in GetOrderBook

### DIFF
--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -132,6 +132,30 @@ func (b *Bithumb) GetOrderBook(ctx context.Context, symbol string) (*Orderbook, 
 		return nil, errors.New(response.Message)
 	}
 
+	filteredBids := make([]struct {
+		Quantity float64 `json:"quantity,string"`
+		Price    float64 `json:"price,string"`
+	}, 0, len(response.Data.Bids))
+
+	for _, bid := range response.Data.Bids {
+		if bid.Quantity > 0 {
+			filteredBids = append(filteredBids, bid)
+		}
+	}
+	response.Data.Bids = filteredBids
+
+	filteredAsks := make([]struct {
+		Quantity float64 `json:"quantity,string"`
+		Price    float64 `json:"price,string"`
+	}, 0, len(response.Data.Asks))
+
+	for _, ask := range response.Data.Asks {
+		if ask.Quantity > 0 {
+			filteredAsks = append(filteredAsks, ask)
+		}
+	}
+	response.Data.Asks = filteredAsks
+
 	return &response, nil
 }
 

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -132,31 +132,19 @@ func (b *Bithumb) GetOrderBook(ctx context.Context, symbol string) (*Orderbook, 
 		return nil, errors.New(response.Message)
 	}
 
-	filteredBids := make([]struct {
-		Quantity float64 `json:"quantity,string"`
-		Price    float64 `json:"price,string"`
-	}, 0, len(response.Data.Bids))
-
-	for _, bid := range response.Data.Bids {
-		if bid.Quantity > 0 {
-			filteredBids = append(filteredBids, bid)
-		}
-	}
-	response.Data.Bids = filteredBids
-
-	filteredAsks := make([]struct {
-		Quantity float64 `json:"quantity,string"`
-		Price    float64 `json:"price,string"`
-	}, 0, len(response.Data.Asks))
-
-	for _, ask := range response.Data.Asks {
-		if ask.Quantity > 0 {
-			filteredAsks = append(filteredAsks, ask)
-		}
-	}
-	response.Data.Asks = filteredAsks
+	response.Data.Bids = response.Data.Bids.FilterZeros()
+	response.Data.Asks = response.Data.Asks.FilterZeros()
 
 	return &response, nil
+}
+
+func (o OrderbookLevels) FilterZeros() (c OrderbookLevels) {
+	for _, l := range o {
+		if l.Quantity > 0 {
+			c = append(c, l)
+		}
+	}
+	return c
 }
 
 // GetAssetStatus returns the withdrawal and deposit status for the symbol

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -132,19 +132,21 @@ func (b *Bithumb) GetOrderBook(ctx context.Context, symbol string) (*Orderbook, 
 		return nil, errors.New(response.Message)
 	}
 
-	response.Data.Bids = response.Data.Bids.FilterZeros()
-	response.Data.Asks = response.Data.Asks.FilterZeros()
+	response.Data.Bids.FilterZeroQuantities()
+	response.Data.Asks.FilterZeroQuantities()
 
 	return &response, nil
 }
 
-func (o OrderbookLevels) FilterZeros() (c OrderbookLevels) {
-	for _, l := range o {
-		if l.Quantity > 0 {
-			c = append(c, l)
+// FilterZeroQuantities filters out orderbook levels with zero quantity
+func (o *OrderbookLevels) FilterZeroQuantities() {
+	b := (*o)[:0]
+	for _, x := range *o {
+		if x.Quantity > 0 {
+			b = append(b, x)
 		}
 	}
-	return c
+	*o = b
 }
 
 // GetAssetStatus returns the withdrawal and deposit status for the symbol

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -86,6 +86,19 @@ func TestGetOrderBook(t *testing.T) {
 	assert.NotEmpty(t, ob.Data.Timestamp, "Timestamp should not be empty")
 	assert.NotEmpty(t, ob.Data.OrderCurrency, "OrderCurrency should not be empty")
 	assert.NotEmpty(t, ob.Data.PaymentCurrency, "PaymentCurrency should not be empty")
+	if assert.NotEmpty(t, ob.Data.Asks, "Should have items in Asks") {
+		for i, ask := range ob.Data.Asks {
+			assert.Positivef(t, ask.Price, "Ask[%d] Price should be positive", i)
+			assert.Positivef(t, ask.Quantity, "Ask[%d] Quantity should be positive", i)
+		}
+	}
+
+	if assert.NotEmpty(t, ob.Data.Bids, "Should have items in Bids") {
+		for i, bid := range ob.Data.Bids {
+			assert.Positivef(t, bid.Price, "Bid[%d] Price should be positive", i)
+			assert.Positivef(t, bid.Quantity, "Bid[%d] Quantity should be positive", i)
+		}
+	}
 }
 
 func TestGetTransactionHistory(t *testing.T) {

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -86,19 +86,22 @@ func TestGetOrderBook(t *testing.T) {
 	assert.NotEmpty(t, ob.Data.Timestamp, "Timestamp should not be empty")
 	assert.NotEmpty(t, ob.Data.OrderCurrency, "OrderCurrency should not be empty")
 	assert.NotEmpty(t, ob.Data.PaymentCurrency, "PaymentCurrency should not be empty")
-	if assert.NotEmpty(t, ob.Data.Asks, "Should have items in Asks") {
-		for i, ask := range ob.Data.Asks {
-			assert.Positivef(t, ask.Price, "Ask[%d] Price should be positive", i)
-			assert.Positivef(t, ask.Quantity, "Ask[%d] Quantity should be positive", i)
-		}
-	}
+}
 
-	if assert.NotEmpty(t, ob.Data.Bids, "Should have items in Bids") {
-		for i, bid := range ob.Data.Bids {
-			assert.Positivef(t, bid.Price, "Bid[%d] Price should be positive", i)
-			assert.Positivef(t, bid.Quantity, "Bid[%d] Quantity should be positive", i)
-		}
+func TestOrderbookLevelsFilterZeroQuantities(t *testing.T) {
+	t.Parallel()
+	bids := OrderbookLevels{
+		{Price: 99, Quantity: 0},
+		{Price: 98, Quantity: 2},
 	}
+	asks := OrderbookLevels{
+		{Price: 100, Quantity: 0},
+		{Price: 101, Quantity: 1},
+	}
+	bids.FilterZeroQuantities()
+	asks.FilterZeroQuantities()
+	assert.Len(t, asks, 1, "Asks should have 1 item")
+	assert.Len(t, bids, 1, "Bids should have 1 item")
 }
 
 func TestGetTransactionHistory(t *testing.T) {

--- a/exchanges/bithumb/bithumb_types.go
+++ b/exchanges/bithumb/bithumb_types.go
@@ -40,17 +40,11 @@ type TickersResponse struct {
 type Orderbook struct {
 	Status string `json:"status"`
 	Data   struct {
-		Timestamp       types.Time `json:"timestamp"`
-		OrderCurrency   string     `json:"order_currency"`
-		PaymentCurrency string     `json:"payment_currency"`
-		Bids            []struct {
-			Quantity float64 `json:"quantity,string"`
-			Price    float64 `json:"price,string"`
-		} `json:"bids"`
-		Asks []struct {
-			Quantity float64 `json:"quantity,string"`
-			Price    float64 `json:"price,string"`
-		} `json:"asks"`
+		Timestamp       types.Time      `json:"timestamp"`
+		OrderCurrency   string          `json:"order_currency"`
+		PaymentCurrency string          `json:"payment_currency"`
+		Bids            OrderbookLevels `json:"bids"`
+		Asks            OrderbookLevels `json:"asks"`
 	} `json:"data"`
 	Message string `json:"message"`
 }
@@ -330,3 +324,10 @@ type StatusAll struct {
 	} `json:"data"`
 	Message string `json:"message"`
 }
+
+type OrderbookLevel struct {
+	Quantity float64 `json:"quantity,string"`
+	Price    float64 `json:"price,string"`
+}
+
+type OrderbookLevels []OrderbookLevel

--- a/exchanges/bithumb/bithumb_types.go
+++ b/exchanges/bithumb/bithumb_types.go
@@ -325,9 +325,11 @@ type StatusAll struct {
 	Message string `json:"message"`
 }
 
+// OrderbookLevel defines a single level in the orderbook
 type OrderbookLevel struct {
 	Quantity float64 `json:"quantity,string"`
 	Price    float64 `json:"price,string"`
 }
 
+// OrderbookLevels defines a slice of OrderbookLevel
 type OrderbookLevels []OrderbookLevel


### PR DESCRIPTION
bugfix: added a filter to eliminate zero quantity of bids and asks at bithumb::GetOrderBook

feature: added assertions in TestGetOrderBook

# PR Description

Added a filter to elimite zero values of quantity in both bids and asks in the response of GetOrderBook
Additionally, a check in test file to verify that the changes are working correctly. (also made the assertion.NotEmpty conditionally because wasnt sure if this should be empty or not)

Fixes # (issue)
#1947 

## Type of change



## How has this been tested

Tested with debugger and with the additions of the bithumb_test

## Checklist

