### PR TITLE
workflows: Add check for common LLM targeted unicode characters

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -51,3 +51,9 @@ jobs:
         echo "::error::Replace !errors.Is(err, target) with testify equivalents"
         exit 1
 
+    - name: Check for zero width unicode characters
+      run: |
+        grep -r -I --color=always -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}]" . || exit 0
+        echo "::error::Remove zero width unicode characters"
+        exit 1
+

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Check for zero width unicode characters
       run: |
-        grep -r -I --color=always -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}]" . || exit 0
+        grep -r -n -I --color=always --exclude-dir=.git -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}]" . || exit 0
         echo "::error::Remove zero width unicode characters"
         exit 1
 

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Check for zero width unicode characters
       run: |
-        grep -r -n -I --color=always --exclude-dir=.git -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}]" . || exit 0
+        grep -r -n -I --color=always --exclude-dir=.git -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}\x{2060}]" . || exit 0
         echo "::error::Remove zero width unicode characters"
         exit 1
 

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -51,9 +51,15 @@ jobs:
         echo "::error::Replace !errors.Is(err, target) with testify equivalents"
         exit 1
 
-    - name: Check for zero width unicode characters
+    - name: Check for LLM targeted invisible Unicode
       run: |
-        grep -r -n -I --color=always --exclude-dir=.git -P "[\x{200B}\x{200C}\x{200D}\x{FEFF}\x{2060}]" . || exit 0
-        echo "::error::Remove zero width unicode characters"
+        WHITELIST=''
+        if [[ -z "$WHITELIST" ]]; then
+          PATTERN='(?!\x20)[\p{Cf}\p{Z}\p{M}]'
+        else
+          PATTERN="(?![\x20$WHITELIST])[\p{Cf}\p{Z}\p{M}]"
+        fi
+        grep -r -n -I --color=always --exclude-dir=.git -P "$PATTERN" . || exit 0
+        echo "::error::Remove zero-width/format, separator or combining-mark characters"
         exit 1
 

--- a/backtester/eventhandlers/portfolio/portfolio_test.go
+++ b/backtester/eventhandlers/portfolio/portfolio_test.go
@@ -786,7 +786,7 @@ func TestCalculatePNL(t *testing.T) {
 		t.Fatalf("expected one position, received '%v'", len(pos))
 	}
 	if len(pos[0].PNLHistory) == 0 {
-		t.Fatal("expected a pnl entry ( ͡° ͜ʖ ͡°)")
+		t.Fatal("expected a pnl entry 😎")
 	}
 	if !pos[0].UnrealisedPNL.Equal(decimal.NewFromInt(26700)) {
 		// 20 orders * $1 difference * 1x leverage

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -1003,7 +1003,7 @@ func (e *Exchange) AddOrReduceMargin(ctx context.Context, arg *AddOrReduceMargin
 }
 
 // GetExecution retrieves users' execution records, sorted by execTime in descending order. However, for Normal spot, they are sorted by execId in descending order.
-// Execution Type possible values: 'Trade', 'AdlTrade' Auto-Deleveraging, 'Funding' Funding fee, 'BustTrade' Liquidation, 'Delivery' USDC futures delivery, 'BlockTrade'
+// Execution Type possible values: 'Trade', 'AdlTrade' Auto-Deleveraging, 'Funding' Funding fee, 'BustTrade' Liquidation, 'Delivery' USDC futures delivery, 'BlockTrade'
 // UTA Spot: 'stopOrderType', "" for normal order, "tpslOrder" for TP/SL order, "Stop" for conditional order, "OcoOrder" for OCO order
 func (e *Exchange) GetExecution(ctx context.Context, category, symbol, orderID, orderLinkID, baseCoin, executionType, stopOrderType, cursor string, startTime, endTime time.Time, limit int64) (*ExecutionResponse, error) {
 	params, err := fillCategoryAndSymbol(category, symbol, true)
@@ -1694,8 +1694,8 @@ func (e *Exchange) GetAllowedDepositCoinInfo(ctx context.Context, coin, chain, c
 }
 
 // SetDepositAccount sets auto transfer account after deposit. The same function as the setting for Deposit on web GUI
-// account types: CONTRACT Derivatives Account
-// 'SPOT' Spot Account 'INVESTMENT' ByFi Account (The service has been offline) 'OPTION' USDC Account 'UNIFIED' UMA or UTA 'FUND' Funding Account
+// account types: CONTRACT Derivatives Account
+// 'SPOT' Spot Account 'INVESTMENT' ByFi Account (The service has been offline) 'OPTION' USDC Account 'UNIFIED' UMA or UTA 'FUND' Funding Account
 func (e *Exchange) SetDepositAccount(ctx context.Context, accountType string) (*StatusResponse, error) {
 	if accountType == "" {
 		return nil, errMissingAccountType


### PR DESCRIPTION
# PR Description

Adds bad bing (zero width encoded messages directed at LLMs) protection. Despite testing this on Copilot and Jules, they didn't execute on it but it's good to detect these things anyway.

Thanks to @cranktakular for sharing this article: https://www.promptfoo.dev/blog/invisible-unicode-threats/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Encoding a secret message in a .md file and getting LLMs to read from it

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
