### PR TITLE
Deribit: Replace bespoke message IDs with uuid v7

### DIFF
--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -64,6 +64,7 @@ var (
 	errSubjectIDRequired                   = errors.New("subject id is required")
 	errMissingSignature                    = errors.New("missing signature")
 	errStartingHeartbeat                   = errors.New("error starting heartbeat")
+	errSendingHeartbeat                    = errors.New("error sending heartbeat")
 
 	websocketRequestTimeout = time.Second * 30
 

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -844,7 +844,7 @@ type TransactionsData struct {
 // response
 type wsInput struct {
 	JSONRPCVersion string         `json:"jsonrpc,omitempty"`
-	ID             int64          `json:"id,omitempty"`
+	ID             string         `json:"id,omitempty"`
 	Method         string         `json:"method"`
 	Params         map[string]any `json:"params,omitempty"`
 }
@@ -853,7 +853,7 @@ type wsInput struct {
 // response
 type WsRequest struct {
 	JSONRPCVersion string `json:"jsonrpc,omitempty"`
-	ID             int64  `json:"id,omitempty"`
+	ID             string `json:"id,omitempty"`
 	Method         string `json:"method"`
 	Params         any    `json:"params,omitempty"`
 }
@@ -862,14 +862,14 @@ type WsRequest struct {
 // response
 type WsSubscriptionInput struct {
 	JSONRPCVersion string              `json:"jsonrpc,omitempty"`
-	ID             int64               `json:"id,omitempty"`
+	ID             string              `json:"id,omitempty"`
 	Method         string              `json:"method"`
 	Params         map[string][]string `json:"params,omitempty"`
 }
 
 type wsResponse struct {
 	JSONRPCVersion string `json:"jsonrpc,omitempty"`
-	ID             int64  `json:"id,omitempty"`
+	ID             string `json:"id,omitempty"`
 	Result         any    `json:"result,omitempty"`
 	Error          struct {
 		Message string `json:"message,omitempty"`
@@ -880,7 +880,7 @@ type wsResponse struct {
 
 type wsLoginResponse struct {
 	JSONRPCVersion string          `json:"jsonrpc"`
-	ID             int64           `json:"id"`
+	ID             string          `json:"id"`
 	Method         string          `json:"method"`
 	Result         map[string]any  `json:"result"`
 	Error          *UnmarshalError `json:"error"`
@@ -888,7 +888,7 @@ type wsLoginResponse struct {
 
 type wsSubscriptionResponse struct {
 	JSONRPCVersion string   `json:"jsonrpc"`
-	ID             int64    `json:"id"`
+	ID             string   `json:"id"`
 	Method         string   `json:"method"`
 	Result         []string `json:"result"`
 }
@@ -1065,7 +1065,7 @@ type BlockTradeMoveResponse struct {
 
 // WsResponse represents generalized websocket subscription push data and immediate websocket call responses.
 type WsResponse struct {
-	ID     int64 `json:"id,omitempty"`
+	ID     string `json:"id,omitempty"`
 	Params struct {
 		Data    any    `json:"data"`
 		Channel string `json:"channel"`

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -63,6 +63,7 @@ var (
 	errRefreshTokenRequired                = errors.New("refresh token is required")
 	errSubjectIDRequired                   = errors.New("subject id is required")
 	errMissingSignature                    = errors.New("missing signature")
+	errStartingHeartbeat                   = errors.New("error starting heartbeat")
 
 	websocketRequestTimeout = time.Second * 30
 

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -870,8 +870,14 @@ type WsSubscriptionInput struct {
 type wsResponse struct {
 	JSONRPCVersion string `json:"jsonrpc,omitempty"`
 	ID             string `json:"id,omitempty"`
-	Result         any    `json:"result,omitempty"`
-	Error          struct {
+	Method         string `json:"method"`
+	Params         struct {
+		Data    any    `json:"data"`
+		Channel string `json:"channel"`
+		Type    string `json:"type"` // Used in heartbeat and test_request messages
+	} `json:"params"`
+	Result any `json:"result,omitempty"`
+	Error  struct {
 		Message string `json:"message,omitempty"`
 		Code    int64  `json:"code,omitempty"`
 		Data    any    `json:"data"`
@@ -1061,23 +1067,6 @@ type BlockTradeMoveResponse struct {
 	InstrumentName      string  `json:"instrument_name"`
 	Direction           string  `json:"direction"`
 	Amount              float64 `json:"amount"`
-}
-
-// WsResponse represents generalized websocket subscription push data and immediate websocket call responses.
-type WsResponse struct {
-	ID     string `json:"id,omitempty"`
-	Params struct {
-		Data    any    `json:"data"`
-		Channel string `json:"channel"`
-
-		// Used in heartbead and test_request messages.
-		Type string `json:"type"`
-	} `json:"params"`
-	Method         string `json:"method"`
-	JSONRPCVersion string `json:"jsonrpc"`
-
-	// for status "ok" and "version" push data messages
-	Result any `json:"result"`
 }
 
 // VersionInformation represents websocket version information

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gofrs/uuid"
 	gws "github.com/gorilla/websocket"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/crypto"
@@ -165,7 +166,7 @@ func (e *Exchange) wsLogin(ctx context.Context) error {
 	req := wsInput{
 		JSONRPCVersion: rpcVersion,
 		Method:         "public/auth",
-		ID:             e.Websocket.Conn.GenerateMessageID(false),
+		ID:             uuid.Must(uuid.NewV7()).String(),
 		Params: map[string]any{
 			"grant_type": "client_signature",
 			"client_id":  creds.Key,
@@ -817,7 +818,7 @@ func (e *Exchange) handleSubscription(ctx context.Context, method string, subs s
 
 	r := WsSubscriptionInput{
 		JSONRPCVersion: rpcVersion,
-		ID:             e.Websocket.Conn.GenerateMessageID(false),
+		ID:             uuid.Must(uuid.NewV7()).String(),
 		Method:         method,
 		Params:         map[string][]string{"channels": subs.QualifiedChannels()},
 	}

--- a/exchanges/deribit/deribit_websocket.go
+++ b/exchanges/deribit/deribit_websocket.go
@@ -106,22 +106,12 @@ var defaultSubscriptions = subscription.List{
 	{Enabled: true, Asset: asset.All, Channel: subscription.MyTradesChannel, Interval: kline.HundredMilliseconds, Authenticated: true},
 }
 
-var (
-	pingMessage = WsSubscriptionInput{
-		ID:             2,
-		JSONRPCVersion: rpcVersion,
-		Method:         "public/test",
-		Params:         map[string][]string{},
-	}
-	setHeartBeatMessage = wsInput{
-		ID:             1,
-		JSONRPCVersion: rpcVersion,
-		Method:         "public/set_heartbeat",
-		Params: map[string]any{
-			"interval": 15,
-		},
-	}
-)
+var pingMessage = WsSubscriptionInput{
+	ID:             2,
+	JSONRPCVersion: rpcVersion,
+	Method:         "public/test",
+	Params:         map[string][]string{},
+}
 
 // WsConnect starts a new connection with the websocket API
 func (e *Exchange) WsConnect() error {
@@ -130,20 +120,42 @@ func (e *Exchange) WsConnect() error {
 		return websocket.ErrWebsocketNotEnabled
 	}
 	var dialer gws.Dialer
-	err := e.Websocket.Conn.Dial(ctx, &dialer, http.Header{})
-	if err != nil {
+	if err := e.Websocket.Conn.Dial(ctx, &dialer, http.Header{}); err != nil {
 		return err
 	}
 	e.Websocket.Wg.Add(1)
 	go e.wsReadData(ctx)
+	go e.wsStartHeartbeat(ctx)
 	if e.Websocket.CanUseAuthenticatedEndpoints() {
-		err = e.wsLogin(ctx)
-		if err != nil {
+		if err := e.wsLogin(ctx); err != nil {
 			log.Errorf(log.ExchangeSys, "%v - authentication failed: %v\n", e.Name, err)
 			e.Websocket.SetCanUseAuthenticatedEndpoints(false)
+			return err
 		}
 	}
-	return e.Websocket.Conn.SendJSONMessage(ctx, request.Unset, setHeartBeatMessage)
+	return nil
+}
+
+func (e *Exchange) wsStartHeartbeat(ctx context.Context) {
+	msg := wsInput{
+		ID:             uuid.Must(uuid.NewV7()).String(),
+		JSONRPCVersion: rpcVersion,
+		Method:         "public/set_heartbeat",
+		Params: map[string]any{
+			"interval": 15,
+		},
+	}
+	respRaw, err := e.Websocket.Conn.SendMessageReturnResponse(ctx, request.Unset, msg.ID, msg)
+	if err == nil {
+		var resp wsResponse
+		err = json.Unmarshal(respRaw, &resp)
+		if resp.Error.Code != 0 || resp.Error.Message != "" {
+			err = fmt.Errorf("code: %d message: %s", resp.Error.Code, resp.Error.Message)
+		}
+	}
+	if err != nil {
+		log.Errorf(log.ExchangeSys, "%v %s: %s\n", e.Name, errStartingHeartbeat, err)
+	}
 }
 
 func (e *Exchange) wsLogin(ctx context.Context) error {

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -2304,7 +2305,7 @@ func (e *Exchange) SendWSRequest(ctx context.Context, epl request.EndpointLimit,
 	}
 	input := &WsRequest{
 		JSONRPCVersion: rpcVersion,
-		ID:             e.Websocket.Conn.GenerateMessageID(true),
+		ID:             uuid.Must(uuid.NewV7()).String(),
 		Method:         method,
 		Params:         params,
 	}


### PR DESCRIPTION
This PR is a prototype for changes that can be made to most of the exchanges.

UUID V7 is a time ordered unique identifier. I'd generally been clinging to V4 until recently)

By using standard IDs directly in our exchange implementations we reduce inter-linking, testing plane, and overall code.
The aim is that by the end of this websocket itself won't need an message ID generator func or field, and most exchanges will use the V7 uuid. Where not possible, they'll have whatever they need, but called directly.

I'm opting to use `Must()`, which will panic on error, because random number generator failing should be nearly impossible, and we'd nearly definitely panic soon anyway on crypto. I've never seen a `Must(V4)` panic in many years.

Out-Of-Scope:
* First 3 attempts at this I started to refactor and deduplicate the various types in deribit (request types, response types, error types). That turned out to be many yaks hiding behind one-another, so I've avoided touching it too much.
* This is just one exchange first, to keep the review fast and easy. Once merged, I'll tackle the rest in one or maybe two PRs, depending on any outliers that are easier to deal with first.

Motivation:
* When refactoring inside multi-connection websockets I started to hack wildly at the message generator, got frustrated, and now we're here. Welcome 👋 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
