### PR TITLE
Binance/BinanceUS: Fix various live test failures

### DIFF
--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -368,18 +368,20 @@ func TestUTakerBuySellVol(t *testing.T) {
 
 func TestUCompositeIndexInfo(t *testing.T) {
 	t.Parallel()
-	cp, err := currency.NewPairFromString("DEFI-USDT")
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = e.UCompositeIndexInfo(t.Context(), cp)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = e.UCompositeIndexInfo(t.Context(), currency.EMPTYPAIR)
-	if err != nil {
-		t.Error(err)
-	}
+	r, err := e.UCompositeIndexInfo(t.Context(), currency.EMPTYPAIR)
+	require.NoError(t, err, "UCompositeIndexInfo with no pair must not error")
+	require.NotEmpty(t, r, "UCompositeIndexInfo must return composite index info")
+	cp, err := currency.NewPairFromString(r[0].Symbol)
+	require.NoErrorf(t, err, "NewPairFromString must not error for symbol %s", r[0].Symbol)
+	r, err = e.UCompositeIndexInfo(t.Context(), cp)
+	require.NoErrorf(t, err, "UCompositeIndexInfo for pair %s must not error", cp)
+	require.NotEmptyf(t, r, "UCompositeIndexInfo for pair %s must return composite index info", cp)
+	require.NotEmptyf(t, r[0].BaseAssetList, "UCompositeIndexInfo for pair %s must return a non empty base asset list", cp)
+	b := r[0].BaseAssetList[0]
+	assert.NotEmpty(t, b.BaseAsset, "BaseAsset should be set")
+	assert.NotEmpty(t, b.QuoteAsset, "QuoteAsset asset should be set")
+	assert.NotZero(t, b.WeightInQuantity, "WeightInQuantity should be set")
+	assert.NotZero(t, b.WeightInPercentage, "WeightInPercentage should be set")
 }
 
 func TestUFuturesNewOrder(t *testing.T) {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1565,6 +1565,7 @@ func TestGetAggregatedTradesBatched(t *testing.T) {
 				name: "custom limit with start time set, no end time",
 				args: &AggregatedTradeRequestParams{StartTime: start, Limit: 2042},
 				expFunc: func(t *testing.T, results []AggregatedTrade) {
+					t.Helper()
 					// 2000 records in was about 6 minutes in 2025; Adjust if Binance enters a phase of zero-fees or low-volume
 					require.Equal(t, 2042, len(results), "must return exactly the limit number of records")
 					assert.WithinDuration(t, results[len(results)-1].TimeStamp.Time(), start, 20*time.Minute, "last record should be within 20 minutes of start time")

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1484,7 +1484,7 @@ func TestGetHistoricTrades(t *testing.T) {
 	end := start.Add(15 * time.Minute)
 	result, err := e.GetHistoricTrades(t.Context(), p, asset.Spot, start, end)
 	require.NoError(t, err, "GetHistoricTrades must not error")
-	assert.Greater(t, len(result), 1001, "GetHistoricTrades should enough trades")
+	assert.Greater(t, len(result), 1001, "GetHistoricTrades should have enough trades")
 	for _, r := range result {
 		require.WithinRange(t, r.Timestamp, start, end, "All trades must be within time range")
 	}

--- a/exchanges/binance/testdata/http.json
+++ b/exchanges/binance/testdata/http.json
@@ -90752,86 +90752,162 @@
   "/fapi/v1/indexInfo": {
    "GET": [
     {
-     "data": {
-      "baseAssetList": [
-       {
-        "baseAsset": "AAVE",
-        "weightInPercentage": "0.07255900",
-        "weightInQuantity": "0.57321317"
-       },
-       {
-        "baseAsset": "ALPHA",
-        "weightInPercentage": "0.02039700",
-        "weightInQuantity": "60.33241822"
-       },
-       {
-        "baseAsset": "BAL",
-        "weightInPercentage": "0.02362800",
-        "weightInQuantity": "1.24967422"
-       },
-       {
-        "baseAsset": "BAND",
-        "weightInPercentage": "0.03501400",
-        "weightInQuantity": "3.29870857"
-       },
-       {
-        "baseAsset": "BEL",
-        "weightInPercentage": "0.01843900",
-        "weightInQuantity": "8.75756110"
-       },
-       {
-        "baseAsset": "BZRX",
-        "weightInPercentage": "0.02294900",
-        "weightInQuantity": "67.18425714"
-       }
-      ],
-      "symbol": "DEFIUSDT",
-      "time": 1608086821000
-     },
-     "queryString": "symbol=DEFIUSDT",
-     "bodyParams": "",
-     "headers": {}
-    },
-    {
      "data": [
       {
        "baseAssetList": [
         {
-         "baseAsset": "AAVE",
-         "weightInPercentage": "0.07255900",
-         "weightInQuantity": "0.57321317"
+         "baseAsset": "BTC",
+         "quoteAsset": "AAVE",
+         "weightInPercentage": "0.00376500",
+         "weightInQuantity": "0.03738265"
         },
         {
-         "baseAsset": "ALPHA",
-         "weightInPercentage": "0.02039700",
-         "weightInQuantity": "60.33241822"
+         "baseAsset": "BTC",
+         "quoteAsset": "ADA",
+         "weightInPercentage": "0.02638100",
+         "weightInQuantity": "0.00078048"
         },
         {
-         "baseAsset": "BAL",
-         "weightInPercentage": "0.02362800",
-         "weightInQuantity": "1.24967422"
+         "baseAsset": "BTC",
+         "quoteAsset": "AVAX",
+         "weightInPercentage": "0.01082800",
+         "weightInQuantity": "0.01147365"
         },
         {
-         "baseAsset": "BAND",
-         "weightInPercentage": "0.03501400",
-         "weightInQuantity": "3.29870857"
+         "baseAsset": "BTC",
+         "quoteAsset": "BCH",
+         "weightInPercentage": "0.00992300",
+         "weightInQuantity": "0.20359666"
         },
         {
-         "baseAsset": "BEL",
-         "weightInPercentage": "0.01843900",
-         "weightInQuantity": "8.75756110"
-        },
-        {
-         "baseAsset": "BZRX",
-         "weightInPercentage": "0.02294900",
-         "weightInQuantity": "67.18425714"
+         "baseAsset": "BTC",
+         "quoteAsset": "BNB",
+         "weightInPercentage": "0.11126600",
+         "weightInQuantity": "3.58068053"
         }
        ],
-       "symbol": "DEFIUSDT",
-       "time": 1608086822007
+       "component": "quoteAsset",
+       "symbol": "BTCDOMUSDT",
+       "time": 1758250144006
+      },
+      {
+       "baseAssetList": [
+        {
+         "baseAsset": "1000000BOB",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.00204918",
+         "weightInQuantity": "0.04619791"
+        },
+        {
+         "baseAsset": "1000000MOG",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.00204918",
+         "weightInQuantity": "0.00254617"
+        },
+        {
+         "baseAsset": "1000BONK",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.00204918",
+         "weightInQuantity": "0.10008223"
+        },
+        {
+         "baseAsset": "1000CAT",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.00204918",
+         "weightInQuantity": "0.29881191"
+        },
+        {
+         "baseAsset": "1000CHEEMS",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.00204918",
+         "weightInQuantity": "1.98279472"
+        }
+       ],
+       "component": "baseAsset",
+       "symbol": "ALLUSDT",
+       "time": 1758250144006
+      },
+      {
+       "baseAssetList": [
+        {
+         "baseAsset": "1000000BOB",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.01000000",
+         "weightInQuantity": "0.21446069"
+        },
+        {
+         "baseAsset": "1000WHY",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.01000000",
+         "weightInQuantity": "333.26983733"
+        },
+        {
+         "baseAsset": "1000X",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.01000000",
+         "weightInQuantity": "0.22663334"
+        },
+        {
+         "baseAsset": "AGT",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.01000000",
+         "weightInQuantity": "1.63266620"
+        },
+        {
+         "baseAsset": "AIN",
+         "quoteAsset": "USDT",
+         "weightInPercentage": "0.01000000",
+         "weightInQuantity": "0.08414804"
+        }
+       ],
+       "component": "baseAsset",
+       "symbol": "SMALLUSDT",
+       "time": 1758250144006
       }
      ],
      "queryString": "",
+     "bodyParams": "",
+     "headers": {}
+    },
+    {
+     "data": {
+      "baseAssetList": [
+       {
+        "baseAsset": "BTC",
+        "quoteAsset": "AAVE",
+        "weightInPercentage": "0.00376500",
+        "weightInQuantity": "0.03738265"
+       },
+       {
+        "baseAsset": "BTC",
+        "quoteAsset": "ADA",
+        "weightInPercentage": "0.02638100",
+        "weightInQuantity": "0.00078048"
+       },
+       {
+        "baseAsset": "BTC",
+        "quoteAsset": "AVAX",
+        "weightInPercentage": "0.01082800",
+        "weightInQuantity": "0.01147365"
+       },
+       {
+        "baseAsset": "BTC",
+        "quoteAsset": "BCH",
+        "weightInPercentage": "0.00992300",
+        "weightInQuantity": "0.20359666"
+       },
+       {
+        "baseAsset": "BTC",
+        "quoteAsset": "BNB",
+        "weightInPercentage": "0.11126600",
+        "weightInQuantity": "3.58068053"
+       }
+      ],
+      "component": "quoteAsset",
+      "symbol": "BTCDOMUSDT",
+      "time": 1758250145000
+     },
+     "queryString": "symbol=BTCDOMUSDT",
      "bodyParams": "",
      "headers": {}
     }

--- a/exchanges/binance/ufutures_types.go
+++ b/exchanges/binance/ufutures_types.go
@@ -185,9 +185,10 @@ type UCompositeIndexInfoData struct {
 	Symbol        string     `json:"symbol"`
 	Time          types.Time `json:"time"`
 	BaseAssetList []struct {
-		BaseAsset          string  `json:"baseAsset"`
-		WeightInQuantity   float64 `json:"weightInQuantity,string"`
-		WeightInPercentage float64 `json:"weightInPercentage,string"`
+		BaseAsset          currency.Code `json:"baseAsset"`
+		QuoteAsset         currency.Code `json:"quoteAsset"`
+		WeightInQuantity   float64       `json:"weightInQuantity,string"`
+		WeightInPercentage float64       `json:"weightInPercentage,string"`
 	} `json:"baseAssetList"`
 }
 

--- a/exchanges/binanceus/binanceus_types.go
+++ b/exchanges/binanceus/binanceus_types.go
@@ -129,8 +129,8 @@ type AggregatedTradeRequestParams struct {
 	// The first trade to retrieve
 	FromID int64
 	// The API seems to accept (start and end time) or FromID and no other combinations
-	StartTime int64
-	EndTime   int64
+	StartTime time.Time
+	EndTime   time.Time
 	// Default 500; max 1000.
 	Limit int
 }

--- a/exchanges/binanceus/binanceus_wrapper.go
+++ b/exchanges/binanceus/binanceus_wrapper.go
@@ -467,8 +467,8 @@ func (e *Exchange) GetHistoricTrades(ctx context.Context, p currency.Pair, asset
 	}
 	req := AggregatedTradeRequestParams{
 		Symbol:    p,
-		StartTime: timestampStart.UnixMilli(),
-		EndTime:   timestampEnd.UnixMilli(),
+		StartTime: timestampStart,
+		EndTime:   timestampEnd,
 	}
 	trades, err := e.GetAggregateTrades(ctx, &req)
 	if err != nil {


### PR DESCRIPTION
* Fixes failures on `TestGetAggregatedTradesBatched` and `TestGetHistoricTrades`
* Refactors and simplifies `GetAggregatedTradesBatched` (hopefully)

Note: These fixes are for testing with `--tags mock_test_off`

Fixes #2010

- [x] Test fix (non-breaking change which fixes an issue)