### PR TITLE
devcontainer: Update Dockerfile and settings for VSCode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,30 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/go/.devcontainer/base.Dockerfile
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+## Dev Container base image
+# See: https://github.com/devcontainers/images/tree/main/src/go
+# Use the published "dev-" tagged image for the latest Go version.
+# See MCR tags: dev-1.25, dev-1.25-bookworm
+ARG VARIANT=dev-1.25-bookworm
+FROM mcr.microsoft.com/devcontainers/go:${VARIANT}
 
-# [Choice] Node.js version: lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c ". /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+USER root
+RUN apt-get update \
+	&& export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get install -y --no-install-recommends \
+		git \
+		make \
+		build-essential \
+		bash-completion \
+		ca-certificates \
+		curl \
+		unzip \
+		libssl-dev \
+		protobuf-compiler \
+		jq \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
-# RUN mv -vn config_example.json config.json
 WORKDIR /workspace
 
-# RUN cp . /workspace/
-# RUN CWD
-# RUN GO111MODULE=on go mod vendor
-# RUN go build .
-# RUN go build ./cmd/gctcli
+RUN mkdir -p /home/vscode/.cache/go-build /go \
+	&& chown -R vscode:vscode /home/vscode/.cache /go
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// For dev container configuration options, see https://aka.ms/devcontainer.json.
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
 	"name": "GoCryptoTrader Dev Container",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/docker-existing-docker-compose
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-	"name": "Existing Docker Compose (Extend)",
+	"name": "GoCryptoTrader Dev Container",
 
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
@@ -28,14 +27,16 @@
 	// "shutdownAction": "none",
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	"postCreateCommand": "go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && go install mvdan.cc/gofumpt@latest && go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest",
 
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// Uncomment to connect as a non-root user if you've added one. See https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user.
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"golang.go"
+				"golang.go",
+				"eamodio.gitlens",
+				"github.vscode-pull-request-github"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	// "shutdownAction": "none",
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	"postCreateCommand": "go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && go install mvdan.cc/gofumpt@latest && go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest",
+	"postCreateCommand": "bash .devcontainer/post_create.sh",
 
 	// Uncomment to connect as a non-root user if you've added one. See https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user.
 	"remoteUser": "vscode",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
   daemon:
@@ -7,7 +6,7 @@ services:
     # debugging) to execute as the user. Uncomment the next line if you want the entire 
     # container to run as this user instead. Note that, on Linux, you may need to 
     # ensure the UID and GID of the container user you create matches your local user. 
-    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    # See https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user for details.
     #
     user: vscode
 
@@ -23,17 +22,23 @@ services:
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
       - ..:/workspace:cached
-
-
+      # Persist Go module cache and build cache for faster builds
+      - gopath:/go
+      - gocache:/home/vscode/.cache/go-build
+      
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 
 
-    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
-    #cap_add:
-    #  - SYS_PTRACE
-    #security_opt:
-    #  - seccomp:unconfined
+    # Enable ptrace for dlv/go debugging
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
 
-    # Overrides default command so things don't shut down after the process ends.
+    # Keep the container alive with a long-running process
     command: /bin/sh -c "while sleep 1000; do :; done"
- 
+
+volumes:
+  gopath:
+  gocache:
+

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -24,8 +24,8 @@ install_go_tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 # Formatting
 install_go_tool mvdan.cc/gofumpt@latest
 
-# Go modernize analyzer
-install_go_tool  golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
+# Go modernise enforcer
+install_go_tool golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
 
 log "Installed tools:"
 

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v go >/dev/null 2>&1 || { echo "Go is not installed" >&2; exit 1; }
+
+log() { echo "[post-create] $*"; }
+
+install_go_tool() {
+  local pkg="$1"
+  log "Installing: $pkg"
+  go install "$pkg"
+}
+
+# Protobuf + gRPC codegen
+install_go_tool google.golang.org/protobuf/cmd/protoc-gen-go@latest
+install_go_tool google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+install_go_tool github.com/bufbuild/buf/cmd/buf@latest
+install_go_tool github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
+install_go_tool github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
+
+# Linting
+install_go_tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+
+# Formatting
+install_go_tool mvdan.cc/gofumpt@latest
+
+# Go modernize analyzer
+install_go_tool  golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
+
+log "Installed tools:"
+
+for t in protoc-gen-go protoc-gen-go-grpc buf protoc-gen-grpc-gateway protoc-gen-openapiv2 golangci-lint gofumpt modernize; do
+  command -v "$t" || true
+done
+
+log "Setup is complete :)"


### PR DESCRIPTION
# PR Description

Updates the VSCode devcontainer settings since it's a bit outdated. Uses Debian 12 (Bookworm) and the dev version since bullseye is based off Debian 11. Also adds our common go deps for linting/formatting.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] Running the devcontainer

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
