### PR TITLE
backtester/engine: Fix TestStart race

### DIFF
--- a/backtester/engine/live_test.go
+++ b/backtester/engine/live_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,20 +64,23 @@ func TestSetupLiveDataHandler(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	dc := &dataChecker{
+	dc1 := &dataChecker{
 		shutdown: make(chan bool),
 	}
-	err := dc.Start()
+	err := dc1.Start()
 	assert.NoError(t, err)
 
-	close(dc.shutdown)
-	dc.wg.Wait()
-	atomic.CompareAndSwapUint32(&dc.started, 0, 1)
-	err = dc.Start()
+	close(dc1.shutdown)
+	dc1.wg.Wait()
+
+	dc2 := &dataChecker{
+		started: 1,
+	}
+	err = dc2.Start()
 	assert.ErrorIs(t, err, engine.ErrSubSystemAlreadyStarted)
 
-	var dh *dataChecker
-	err = dh.Start()
+	var dc3 *dataChecker
+	err = dc3.Start()
 	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 }
 

--- a/backtester/engine/live_test.go
+++ b/backtester/engine/live_test.go
@@ -64,33 +64,25 @@ func TestSetupLiveDataHandler(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	t.Run("successful start", func(t *testing.T) {
-		t.Parallel()
-		dc := &dataChecker{
-			shutdown: make(chan bool),
-		}
-		err := dc.Start()
-		assert.NoError(t, err)
 
-		close(dc.shutdown)
-		dc.wg.Wait()
-	})
+	var dc *dataChecker
+	err := dc.Start()
+	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
-	t.Run("already started", func(t *testing.T) {
-		t.Parallel()
-		dc := &dataChecker{
-			started: 1,
-		}
-		err := dc.Start()
-		assert.ErrorIs(t, err, engine.ErrSubSystemAlreadyStarted)
-	})
+	dc = &dataChecker{
+		shutdown: make(chan bool),
+	}
+	err = dc.Start()
+	require.NoError(t, err)
 
-	t.Run("nil pointer", func(t *testing.T) {
-		t.Parallel()
-		var dc *dataChecker
-		err := dc.Start()
-		assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
-	})
+	close(dc.shutdown)
+	dc.wg.Wait()
+
+	dc = &dataChecker{
+		started: 1,
+	}
+	err = dc.Start()
+	assert.ErrorIs(t, err, engine.ErrSubSystemAlreadyStarted)
 }
 
 func TestDataCheckerIsRunning(t *testing.T) {

--- a/backtester/engine/live_test.go
+++ b/backtester/engine/live_test.go
@@ -64,24 +64,33 @@ func TestSetupLiveDataHandler(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Parallel()
-	dc1 := &dataChecker{
-		shutdown: make(chan bool),
-	}
-	err := dc1.Start()
-	assert.NoError(t, err)
+	t.Run("successful start", func(t *testing.T) {
+		t.Parallel()
+		dc := &dataChecker{
+			shutdown: make(chan bool),
+		}
+		err := dc.Start()
+		assert.NoError(t, err)
 
-	close(dc1.shutdown)
-	dc1.wg.Wait()
+		close(dc.shutdown)
+		dc.wg.Wait()
+	})
 
-	dc2 := &dataChecker{
-		started: 1,
-	}
-	err = dc2.Start()
-	assert.ErrorIs(t, err, engine.ErrSubSystemAlreadyStarted)
+	t.Run("already started", func(t *testing.T) {
+		t.Parallel()
+		dc := &dataChecker{
+			started: 1,
+		}
+		err := dc.Start()
+		assert.ErrorIs(t, err, engine.ErrSubSystemAlreadyStarted)
+	})
 
-	var dc3 *dataChecker
-	err = dc3.Start()
-	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	t.Run("nil pointer", func(t *testing.T) {
+		t.Parallel()
+		var dc *dataChecker
+		err := dc.Start()
+		assert.ErrorIs(t, err, gctcommon.ErrNilPointer)
+	})
 }
 
 func TestDataCheckerIsRunning(t *testing.T) {


### PR DESCRIPTION

# PR Description

TestStart does 3 tests
test1 = Start() with no error
test2 = Start() on an already started struct
test3 = Start() on nil

Previously, test1 and test2 were on the same struct. Depending on the go scheduler, we could have test2 fail because the field "started" could go from 1 to 0 just after the atomic compare and swap. So we would Start() a second time on the same struct but the field "started" would already be back to 0.

Fixes #1987 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
