### PR TITLE
exchanges/refactor: Use strings.builder for string construction

### DIFF
--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -425,11 +425,11 @@ func orderbookChecksum(ob *orderbook.Book) uint32 {
 
 // concatOrderbookLiquidity concatenates price and amounts together for checksum processing
 func concatOrderbookLiquidity(liquidity orderbook.Levels) string {
-	var c string
+	var c strings.Builder
 	for x := range min(10, len(liquidity)) {
-		c += trim(liquidity[x].Price) + trim(liquidity[x].Amount)
+		c.WriteString(trim(liquidity[x].Price) + trim(liquidity[x].Amount))
 	}
-	return c
+	return c.String()
 }
 
 // trim turns value into string, removes the decimal point and all the leading zeros

--- a/exchanges/btcmarkets/btcmarkets_websocket.go
+++ b/exchanges/btcmarkets/btcmarkets_websocket.go
@@ -427,7 +427,8 @@ func orderbookChecksum(ob *orderbook.Book) uint32 {
 func concatOrderbookLiquidity(liquidity orderbook.Levels) string {
 	var c strings.Builder
 	for x := range min(10, len(liquidity)) {
-		c.WriteString(trim(liquidity[x].Price) + trim(liquidity[x].Amount))
+		c.WriteString(trim(liquidity[x].Price))
+		c.WriteString(trim(liquidity[x].Amount))
 	}
 	return c.String()
 }

--- a/exchanges/bybit/bybit.go
+++ b/exchanges/bybit/bybit.go
@@ -2593,16 +2593,16 @@ func (e *Exchange) SendAuthHTTPRequestV5(ctx context.Context, ePath exchange.URL
 		return fmt.Errorf("%w code: %d message: %s", request.ErrAuthRequestFailed, response.RetCode, response.RetMsg)
 	}
 	if len(response.RetExtInfo.List) > 0 && response.RetCode != 0 {
-		var errMessage string
+		var errMessage strings.Builder
 		var failed bool
 		for i := range response.RetExtInfo.List {
 			if response.RetExtInfo.List[i].Code != 0 {
 				failed = true
-				errMessage += fmt.Sprintf("code: %d message: %s ", response.RetExtInfo.List[i].Code, response.RetExtInfo.List[i].Message)
+				errMessage.WriteString(fmt.Sprintf("code: %d message: %s ", response.RetExtInfo.List[i].Code, response.RetExtInfo.List[i].Message))
 			}
 		}
 		if failed {
-			return fmt.Errorf("%w %s", request.ErrAuthRequestFailed, errMessage)
+			return fmt.Errorf("%w %s", request.ErrAuthRequestFailed, errMessage.String())
 		}
 	}
 	return err


### PR DESCRIPTION
# PR Description

The modernize has added an analyzer for using strings.Builder for string construction. strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

Fixes # (issue)

## Type of change


- [x] New feature (non-breaking change which adds functionality)


## How has this been tested

No need.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
