### PR TITLE
exchanges/GateIO: Fix wrong function names in comments

### DIFF
--- a/exchanges/gateio/gateio_websocket_request_spot_test.go
+++ b/exchanges/gateio/gateio_websocket_request_spot_test.go
@@ -192,7 +192,7 @@ func TestWebsocketSpotGetOrderStatus(t *testing.T) {
 	require.NotEmpty(t, got)
 }
 
-// getWebsocketInstance returns a websocket instance copy for testing.
+// newExchangeWithWebsocket returns a websocket instance copy for testing.
 // This restricts the pairs to a single pair per asset type to reduce test time.
 func newExchangeWithWebsocket(t *testing.T, a asset.Item) *Exchange {
 	t.Helper()

--- a/exchanges/subscription/subscription_test.go
+++ b/exchanges/subscription/subscription_test.go
@@ -69,7 +69,7 @@ func TestEnsureKeyed(t *testing.T) {
 	assert.Equal(t, s.Key, k2, "Key should be the key provided")
 }
 
-// TestSubscriptionMarshalling ensures json Marshalling is clean and concise
+// TestSubscriptionMarshaling ensures json Marshalling is clean and concise
 // Since there is no UnmarshalJSON, this just exercises the json field tags of Subscription, and regressions in conciseness
 func TestSubscriptionMarshaling(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# PR Description

fix wrong function name in comment

Fixes # (issue)

## Type of change


- [x] New feature (non-breaking change which adds functionality)


## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
