### PR TITLE
request/rate limit: add context value check and fix bug 

### DIFF
--- a/exchange/websocket/connection.go
+++ b/exchange/websocket/connection.go
@@ -214,7 +214,7 @@ func (c *connection) writeToConn(ctx context.Context, epl request.EndpointLimit,
 	}
 
 	if rl != nil {
-		if err := request.RateLimit(ctx, rl); err != nil {
+		if err := rl.RateLimit(ctx); err != nil {
 			return fmt.Errorf("%s websocket connection: rate limit error: %w", c.ExchangeName, err)
 		}
 	}

--- a/exchanges/request/limit_test.go
+++ b/exchanges/request/limit_test.go
@@ -1,0 +1,164 @@
+package request
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/common"
+	"golang.org/x/time/rate"
+)
+
+func TestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	err := (*RateLimiterWithWeight)(nil).RateLimit(t.Context())
+	assert.ErrorIs(t, err, common.ErrNilPointer)
+
+	r := &RateLimiterWithWeight{limiter: rate.NewLimiter(rate.Limit(10), 1)}
+	err = r.RateLimit(t.Context())
+	assert.ErrorIs(t, err, errInvalidWeightCount, "should return errInvalidWeightCount for zero weight")
+
+	r = NewRateLimitWithWeight(time.Second, 10, 1)
+	start := time.Now()
+	err = r.RateLimit(t.Context())
+	elapsed := time.Since(start)
+	require.NoError(t, err, "rate limit must not error")
+	assert.Less(t, elapsed, time.Millisecond*50, "should complete quickly for first request")
+
+	r = NewRateLimitWithWeight(time.Second, 10, 5)
+	start = time.Now()
+	err = r.RateLimit(t.Context())
+	elapsed = time.Since(start)
+	require.NoError(t, err, "rate limit must not error")
+	assert.Less(t, elapsed, time.Millisecond*600, "should complete within reasonable time for weight 5")
+
+	r = NewRateLimitWithWeight(100*time.Millisecond, 1, 1)
+	start = time.Now()
+	err = r.RateLimit(WithNoDelayPermitted(t.Context()))
+	require.NoError(t, err, "first rate limit call must not error and must be immediate")
+	firstElapsed := time.Since(start)
+	assert.Less(t, firstElapsed, 50*time.Millisecond, "first call should be immediate")
+
+	start = time.Now()
+	err = r.RateLimit(t.Context())
+	require.NoError(t, err, "second rate limit call must not error")
+	secondElapsed := time.Since(start)
+	assert.GreaterOrEqual(t, secondElapsed, 90*time.Millisecond, "second call should be delayed by approximately 100ms")
+	assert.Less(t, secondElapsed, 150*time.Millisecond, "delay should not be excessive")
+
+	err = r.RateLimit(WithNoDelayPermitted(t.Context()))
+	assert.ErrorIs(t, err, errNoDelayPermitted, "should return correct error")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err = r.RateLimit(ctx)
+	assert.ErrorIs(t, err, context.Canceled, "should return correct error")
+
+	ctx, cancel = context.WithDeadline(t.Context(), time.Now())
+	defer cancel()
+
+	err = r.RateLimit(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "should return correct error")
+}
+
+func TestReservationsCancelAll(t *testing.T) {
+	t.Parallel()
+
+	var reservations Reservations
+	require.NotPanics(t, func() { reservations.CancelAll(time.Now()) }, "cancelling empty reservations must not panic")
+
+	r := NewRateLimitWithWeight(time.Millisecond*50, 1, 1)
+
+	err := r.RateLimit(t.Context())
+	require.NoError(t, err, "must not error and must be immediate when reservations are set")
+
+	err = r.RateLimit(WithNoDelayPermitted(t.Context()))
+	require.ErrorIs(t, err, errNoDelayPermitted, "must error when no delay permitted this will reset reservations")
+
+	tn := time.Now()
+	err = r.RateLimit(t.Context())
+	elapsed := time.Since(tn)
+	require.NoError(t, err, "RateLimit must not error")
+	assert.LessOrEqual(t, elapsed, 60*time.Millisecond, "should be delayed by approximately 50ms when reservations are reset on error")
+}
+
+func TestNewRateLimit(t *testing.T) {
+	t.Parallel()
+
+	r := NewRateLimit(time.Second, 10)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, rate.Limit(10), r.Limit(), "limit should be 10 per second")
+
+	r = NewRateLimit(time.Second, 0)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, rate.Inf, r.Limit(), "limit should be infinite on zero actions")
+
+	r = NewRateLimit(time.Second, -1)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, rate.Inf, r.Limit(), "limit should be infinite on negative actions")
+
+	r = NewRateLimit(0, 10)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, rate.Inf, r.Limit(), "limit should be infinite on zero interval")
+
+	r = NewRateLimit(-time.Second, 10)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, rate.Inf, r.Limit(), "limit should be infinite on negative interval")
+}
+
+func TestNewRateLimitWithWeight(t *testing.T) {
+	t.Parallel()
+
+	r := NewRateLimitWithWeight(time.Second, 10, 5)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, Weight(5), r.weight, "weight should be 5")
+	assert.Equal(t, rate.Limit(10), r.limiter.Limit(), "limit should be 10 per second")
+}
+
+func TestNewWeightedRateLimitByDuration(t *testing.T) {
+	t.Parallel()
+
+	r := NewWeightedRateLimitByDuration(time.Second)
+	require.NotNil(t, r, "limiter must not be nil")
+	assert.Equal(t, Weight(1), r.weight, "weight should be 1")
+	assert.Equal(t, rate.Limit(1), r.limiter.Limit(), "limit should be 1 per second")
+}
+
+func TestGetRateLimiterWithWeight(t *testing.T) {
+	t.Parallel()
+
+	r := rate.NewLimiter(rate.Limit(10), 1)
+	weighted := GetRateLimiterWithWeight(r, 5)
+	require.NotNil(t, weighted, "weighted limiter must not be nil")
+	assert.Equal(t, Weight(5), weighted.weight, "weight should be 5")
+	assert.Equal(t, r, weighted.limiter, "should reference same limiter")
+}
+
+func TestNewBasicRateLimit(t *testing.T) {
+	t.Parallel()
+
+	defs := NewBasicRateLimit(time.Second, 10, 5)
+	require.NotNil(t, defs, "definitions must not be nil")
+	require.Len(t, defs, 3, "should have 3 definitions")
+
+	for _, key := range []EndpointLimit{Unset, Auth, UnAuth} {
+		r, ok := defs[key]
+		require.True(t, ok, "should have definition for %v", key)
+		assert.Equal(t, Weight(5), r.weight, "weight should be 5 for %v", key)
+		assert.Equal(t, rate.Limit(10), r.limiter.Limit(), "limit should be 10 per second for %v", key)
+	}
+
+	assert.Same(t, defs[Unset], defs[Auth], "Unset and Auth should be same instance")
+	assert.Same(t, defs[Auth], defs[UnAuth], "Auth and UnAuth should be same instance")
+}
+
+func TestWithNoDelayPermitted(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, hasNoDelayPermitted(WithNoDelayPermitted(t.Context())))
+	assert.False(t, hasNoDelayPermitted(t.Context()))
+	assert.False(t, hasNoDelayPermitted(WithVerbose(t.Context())))
+}


### PR DESCRIPTION
# PR Description

* Change `RateLimit` function to be method of `RateLimiterWithWeight`
* Have single time value on all delay calls so that reservations can be cancelled correctly
* Add function `WithNoDelayPermitted` so that any delay will error for e.g. outbound orders that are time critical

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
