### PR TITLE
NilGuard: return on first nil

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -84,7 +84,7 @@ var (
 )
 
 // NilGuard returns an ErrNilPointer with the type of the first nil argument
-func NilGuard(ptrs ...any) (errs error) {
+func NilGuard(ptrs ...any) error {
 	for _, p := range ptrs {
 		/* 	Internally interfaces contain a type and a value address
 		Obviously can't compare to nil, since the types won't match, so we look into the interface
@@ -93,10 +93,10 @@ func NilGuard(ptrs ...any) (errs error) {
 		We optimize here by converting to [2]uintptr and just checking the address, instead of casting to a local eface type
 		*/
 		if (*[2]uintptr)(unsafe.Pointer(&p))[1] == 0 {
-			errs = AppendError(errs, fmt.Errorf("%w: %T", ErrNilPointer, p))
+			return fmt.Errorf("%w: %T", ErrNilPointer, p)
 		}
 	}
-	return errs
+	return nil
 }
 
 // MatchesEmailPattern ensures that the string is an email address by regexp check

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -670,11 +670,6 @@ func TestNilGuard(t *testing.T) {
 
 	err = NilGuard(&s, nil, (*int)(nil))
 	assert.ErrorIs(t, err, ErrNilPointer)
-	assert.ErrorContains(t, err, "*int")
-	var mErr *multiError
-	require.ErrorAs(t, err, &mErr, "err must be a multiError")
-	assert.Len(t, mErr.Unwrap(), 2, "Should get 2 errors back")
-
 	assert.ErrorIs(t, NilGuard(nil), ErrNilPointer, "Unusual input of an untyped nil should still error correctly")
 
 	err = NilGuard()


### PR DESCRIPTION
# PR Description
I think an improvement to `common.NilGuard` is to return on the first nil, rather than to append all nils. This allows for (lack of a better term) compounding nil checks, eg calling `common.NilGuard(e, e.Websocket, e.Websocket.Match)`. Calling that snippet now would lead to a panic if `e` was nil. [See this](https://github.com/thrasher-corp/gocryptotrader/pull/2051#discussion_r2409345028)for a real world example

I think it still achieves its goal of guarding against nils. Since the error returned is always a slice of `common.ErrNilPointer`, there isn't much loss in the slice return as you cannot really do too much extra with each err returned to inspect which param is nil. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
- [x] go test ./... -race
- [x] golangci-lint run
