### PR TITLE
backtester: Refactor sortByMFI to use slices.SortFunc

### DIFF
--- a/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
+++ b/backtester/eventhandlers/strategies/top2bottom2/top2bottom2.go
@@ -165,8 +165,7 @@ func (s *Strategy) selectTopAndBottomPerformers(mfiFundEvents []mfiFundEvent, re
 	if len(mfiFundEvents) == 0 {
 		return resp, nil
 	}
-	slices.SortFunc(mfiFundEvents, func(a, b mfiFundEvent) int { return a.mfi.Compare(b.mfi) })
-	slices.Reverse(mfiFundEvents)
+	slices.SortFunc(mfiFundEvents, func(a, b mfiFundEvent) int { return b.mfi.Compare(a.mfi) })
 	buyingOrSelling := false
 	for i := range mfiFundEvents {
 		if i < 2 && mfiFundEvents[i].mfi.GreaterThanOrEqual(s.mfiHigh) {


### PR DESCRIPTION
# PR Description


The comment for the `sortByMFI` function was incorrectly referencing a non-existent function name `sortOrdersByPrice` and inaccurately describing its purpose. 

This change updates the comment to correctly identify the function and accurately describe its behavior of sorting `mfiFundEvent` slices by their MFI values.



## Type of change



- [X] Docs update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
