### PR TITLE
chore: drop legacy // +build comment

### DIFF
--- a/config/versions/continuity_test.go
+++ b/config/versions/continuity_test.go
@@ -1,5 +1,4 @@
 //go:build config_versions
-// +build config_versions
 
 // This test is run independently from CI for developer convenience when developing out-of-sequence versions
 // Called from a separate github workflow to prevent a PR from being merged without failing the main unit tests


### PR DESCRIPTION
# PR Description

From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild



Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
