### PR TITLE
Fix NTP: implement RFC 5905 offset calculation and verify time before warning

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -333,11 +333,28 @@ func (bot *Engine) Start() error {
 
 	if bot.Settings.EnableNTPClient {
 		if bot.Config.NTPClient.Level == 0 {
-			responseMessage, err := bot.Config.SetNTPCheck(os.Stdin)
+			// Check NTP config and ensure pools are configured
+			bot.Config.CheckNTPConfig()
+
+			// Perform actual NTP check before prompting user
+			offset, err := CheckNTPOffset(context.Background(), bot.Config.NTPClient.Pool)
 			if err != nil {
-				return fmt.Errorf("unable to set NTP check: %w", err)
+				gctlog.Warnf(gctlog.TimeMgr, "Unable to check NTP time: %v", err)
+			} else {
+				// Prompt user if time is actually out of sync
+				allowedDiff := *bot.Config.NTPClient.AllowedDifference
+				allowedNegDiff := -*bot.Config.NTPClient.AllowedNegativeDifference
+				if offset > allowedDiff || offset < allowedNegDiff {
+					gctlog.Warnf(gctlog.TimeMgr, "System time offset detected: %v (allowed: +%v / %v)", offset, allowedDiff, allowedNegDiff)
+					responseMessage, err := bot.Config.SetNTPCheck(os.Stdin)
+					if err != nil {
+						return fmt.Errorf("unable to set NTP check: %w", err)
+					}
+					gctlog.Infoln(gctlog.TimeMgr, responseMessage)
+				} else {
+					gctlog.Debugf(gctlog.TimeMgr, "System time is in sync (offset: %v)", offset)
+				}
 			}
-			gctlog.Infoln(gctlog.TimeMgr, responseMessage)
 		}
 		if n, err := setupNTPManager(&bot.Config.NTPClient, *bot.Config.Logging.Enabled); err != nil {
 			gctlog.Errorf(gctlog.Global, "NTP manager unable to start: %s", err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -57,6 +58,8 @@ type Engine struct {
 // Bot is a happy global engine to allow various areas of the application
 // to access its setup services and functions
 var Bot *Engine
+
+var startupNTPOffsetChecker = checkNTPOffset
 
 // New starts a new engine
 func New() (*Engine, error) {
@@ -332,29 +335,8 @@ func (bot *Engine) Start() error {
 	}
 
 	if bot.Settings.EnableNTPClient {
-		if bot.Config.NTPClient.Level == 0 {
-			// Check NTP config and ensure pools are configured
-			bot.Config.CheckNTPConfig()
-
-			// Perform actual NTP check before prompting user
-			offset, err := CheckNTPOffset(context.Background(), bot.Config.NTPClient.Pool)
-			if err != nil {
-				gctlog.Warnf(gctlog.TimeMgr, "Unable to check NTP time: %v", err)
-			} else {
-				// Prompt user if time is actually out of sync
-				allowedDiff := *bot.Config.NTPClient.AllowedDifference
-				allowedNegDiff := -*bot.Config.NTPClient.AllowedNegativeDifference
-				if offset > allowedDiff || offset < allowedNegDiff {
-					gctlog.Warnf(gctlog.TimeMgr, "System time offset detected: %v (allowed: +%v / %v)", offset, allowedDiff, allowedNegDiff)
-					responseMessage, err := bot.Config.SetNTPCheck(os.Stdin)
-					if err != nil {
-						return fmt.Errorf("unable to set NTP check: %w", err)
-					}
-					gctlog.Infoln(gctlog.TimeMgr, responseMessage)
-				} else {
-					gctlog.Debugf(gctlog.TimeMgr, "System time is in sync (offset: %v)", offset)
-				}
-			}
+		if err := bot.handleStartupNTPPolicy(os.Stdin); err != nil {
+			return err
 		}
 		if n, err := setupNTPManager(&bot.Config.NTPClient, *bot.Config.Logging.Enabled); err != nil {
 			gctlog.Errorf(gctlog.Global, "NTP manager unable to start: %s", err)
@@ -572,6 +554,37 @@ func (bot *Engine) Start() error {
 		}
 	}
 
+	return nil
+}
+
+// handleStartupNTPPolicy keeps startup NTP prompting policy separate from the
+// transport details used to measure the offset.
+func (bot *Engine) handleStartupNTPPolicy(input io.Reader) error {
+	if bot == nil || bot.Config == nil || !bot.Settings.EnableNTPClient || bot.Config.NTPClient.Level != 0 {
+		return nil
+	}
+
+	bot.Config.CheckNTPConfig()
+
+	offset, err := startupNTPOffsetChecker(context.Background(), bot.Config.NTPClient.Pool)
+	if err != nil {
+		gctlog.Warnf(gctlog.TimeMgr, "Unable to check NTP time during startup: %v", err)
+		return nil
+	}
+
+	allowedDiff := *bot.Config.NTPClient.AllowedDifference
+	allowedNegDiff := -*bot.Config.NTPClient.AllowedNegativeDifference
+	if offset <= allowedDiff && offset >= allowedNegDiff {
+		gctlog.Debugf(gctlog.TimeMgr, "System time is in sync (offset: %v)", offset)
+		return nil
+	}
+
+	gctlog.Warnf(gctlog.TimeMgr, "System time offset detected: %v (allowed: +%v / %v)", offset, allowedDiff, allowedNegDiff)
+	responseMessage, err := bot.Config.SetNTPCheck(input)
+	if err != nil {
+		return fmt.Errorf("unable to set NTP check: %w", err)
+	}
+	gctlog.Infoln(gctlog.TimeMgr, responseMessage)
 	return nil
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -59,8 +59,10 @@ type Engine struct {
 // to access its setup services and functions
 var Bot *Engine
 
-var startupNTPOffsetChecker = checkNTPOffset
-var startupNTPOffsetRetryLimit = defaultRetryLimit
+var (
+	startupNTPOffsetChecker    = checkNTPOffset
+	startupNTPOffsetRetryLimit = defaultRetryLimit
+)
 
 // New starts a new engine
 func New() (*Engine, error) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -60,6 +60,7 @@ type Engine struct {
 var Bot *Engine
 
 var startupNTPOffsetChecker = checkNTPOffset
+var startupNTPOffsetRetryLimit = defaultRetryLimit
 
 // New starts a new engine
 func New() (*Engine, error) {
@@ -566,7 +567,19 @@ func (bot *Engine) handleStartupNTPPolicy(input io.Reader) error {
 
 	bot.Config.CheckNTPConfig()
 
-	offset, err := startupNTPOffsetChecker(context.Background(), bot.Config.NTPClient.Pool)
+	var (
+		offset time.Duration
+		err    error
+	)
+	for i := range startupNTPOffsetRetryLimit {
+		offset, err = startupNTPOffsetChecker(context.Background(), bot.Config.NTPClient.Pool)
+		if err == nil {
+			break
+		}
+		if i == startupNTPOffsetRetryLimit-1 {
+			break
+		}
+	}
 	if err != nil {
 		gctlog.Warnf(gctlog.TimeMgr, "Unable to check NTP time during startup: %v", err)
 		return nil

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -26,6 +26,15 @@ func stubStartupNTPOffsetChecker(t *testing.T, fn func(context.Context, []string
 	})
 }
 
+func stubStartupNTPOffsetRetryLimit(t *testing.T, limit int) {
+	t.Helper()
+	original := startupNTPOffsetRetryLimit
+	startupNTPOffsetRetryLimit = limit
+	t.Cleanup(func() {
+		startupNTPOffsetRetryLimit = original
+	})
+}
+
 func testStartupNTPConfig(level int) *config.Config {
 	allowedDifference := time.Second
 	allowedNegativeDifference := time.Second
@@ -43,19 +52,46 @@ func testStartupNTPConfig(level int) *config.Config {
 
 func TestHandleStartupNTPPolicy(t *testing.T) {
 	t.Run("query failure should warn and continue", func(t *testing.T) {
+		stubStartupNTPOffsetRetryLimit(t, 3)
 		bot := &Engine{
 			Config: testStartupNTPConfig(0),
 			Settings: Settings{
 				CoreSettings: CoreSettings{EnableNTPClient: true},
 			},
 		}
+		calls := 0
 		stubStartupNTPOffsetChecker(t, func(context.Context, []string) (time.Duration, error) {
+			calls++
 			return 0, assert.AnError
 		})
 
 		err := bot.handleStartupNTPPolicy(strings.NewReader(""))
 		require.NoError(t, err, "handleStartupNTPPolicy must not error when startup NTP querying fails")
 		assert.Equal(t, 0, bot.Config.NTPClient.Level, "NTP level should remain unchanged when querying fails")
+		assert.Equal(t, 3, calls, "handleStartupNTPPolicy should retry transient startup NTP failures")
+	})
+
+	t.Run("transient query failure should recover on retry", func(t *testing.T) {
+		stubStartupNTPOffsetRetryLimit(t, 3)
+		bot := &Engine{
+			Config: testStartupNTPConfig(0),
+			Settings: Settings{
+				CoreSettings: CoreSettings{EnableNTPClient: true},
+			},
+		}
+		calls := 0
+		stubStartupNTPOffsetChecker(t, func(context.Context, []string) (time.Duration, error) {
+			calls++
+			if calls < 2 {
+				return 0, assert.AnError
+			}
+			return 2 * time.Second, nil
+		})
+
+		err := bot.handleStartupNTPPolicy(strings.NewReader("w\n"))
+		require.NoError(t, err, "handleStartupNTPPolicy must not error when a retry succeeds")
+		assert.Equal(t, 2, calls, "handleStartupNTPPolicy should stop retrying after a successful startup NTP query")
+		assert.Equal(t, 1, bot.Config.NTPClient.Level, "NTP level should update after a successful retry and prompt response")
 	})
 
 	t.Run("offset within threshold should not prompt", func(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"os"
 	"slices"
 	"strings"
@@ -13,7 +14,82 @@ import (
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitfinex"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitstamp"
+	gctlog "github.com/thrasher-corp/gocryptotrader/log"
 )
+
+func stubStartupNTPOffsetChecker(t *testing.T, fn func(context.Context, []string) (time.Duration, error)) {
+	t.Helper()
+	original := startupNTPOffsetChecker
+	startupNTPOffsetChecker = fn
+	t.Cleanup(func() {
+		startupNTPOffsetChecker = original
+	})
+}
+
+func testStartupNTPConfig(level int) *config.Config {
+	allowedDifference := time.Second
+	allowedNegativeDifference := time.Second
+	loggingEnabled := false
+	return &config.Config{
+		Logging: gctlog.Config{Enabled: &loggingEnabled},
+		NTPClient: config.NTPClientConfig{
+			Level:                     level,
+			Pool:                      []string{"ntp.invalid:123"},
+			AllowedDifference:         &allowedDifference,
+			AllowedNegativeDifference: &allowedNegativeDifference,
+		},
+	}
+}
+
+func TestHandleStartupNTPPolicy(t *testing.T) {
+	t.Run("query failure should warn and continue", func(t *testing.T) {
+		bot := &Engine{
+			Config: testStartupNTPConfig(0),
+			Settings: Settings{
+				CoreSettings: CoreSettings{EnableNTPClient: true},
+			},
+		}
+		stubStartupNTPOffsetChecker(t, func(context.Context, []string) (time.Duration, error) {
+			return 0, assert.AnError
+		})
+
+		err := bot.handleStartupNTPPolicy(strings.NewReader(""))
+		require.NoError(t, err, "handleStartupNTPPolicy must not error when startup NTP querying fails")
+		assert.Equal(t, 0, bot.Config.NTPClient.Level, "NTP level should remain unchanged when querying fails")
+	})
+
+	t.Run("offset within threshold should not prompt", func(t *testing.T) {
+		bot := &Engine{
+			Config: testStartupNTPConfig(0),
+			Settings: Settings{
+				CoreSettings: CoreSettings{EnableNTPClient: true},
+			},
+		}
+		stubStartupNTPOffsetChecker(t, func(context.Context, []string) (time.Duration, error) {
+			return 500 * time.Millisecond, nil
+		})
+
+		err := bot.handleStartupNTPPolicy(strings.NewReader(""))
+		require.NoError(t, err, "handleStartupNTPPolicy must not error when the offset is within threshold")
+		assert.Equal(t, 0, bot.Config.NTPClient.Level, "NTP level should remain unchanged when the offset is within threshold")
+	})
+
+	t.Run("offset outside threshold should prompt and update config", func(t *testing.T) {
+		bot := &Engine{
+			Config: testStartupNTPConfig(0),
+			Settings: Settings{
+				CoreSettings: CoreSettings{EnableNTPClient: true},
+			},
+		}
+		stubStartupNTPOffsetChecker(t, func(context.Context, []string) (time.Duration, error) {
+			return 2 * time.Second, nil
+		})
+
+		err := bot.handleStartupNTPPolicy(strings.NewReader("w\n"))
+		require.NoError(t, err, "handleStartupNTPPolicy must not error when prompting for out-of-threshold offsets")
+		assert.Equal(t, 1, bot.Config.NTPClient.Level, "NTP level should update after the startup prompt response")
+	})
+}
 
 // blockedCIExchanges are exchanges that are not able to be tested on CI
 var blockedCIExchanges = []string{

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -35,14 +35,14 @@ func stubStartupNTPOffsetRetryLimit(t *testing.T, limit int) {
 	})
 }
 
-func testStartupNTPConfig(level int) *config.Config {
+func testStartupNTPConfig() *config.Config {
 	allowedDifference := time.Second
 	allowedNegativeDifference := time.Second
 	loggingEnabled := false
 	return &config.Config{
 		Logging: gctlog.Config{Enabled: &loggingEnabled},
 		NTPClient: config.NTPClientConfig{
-			Level:                     level,
+			Level:                     0,
 			Pool:                      []string{"ntp.invalid:123"},
 			AllowedDifference:         &allowedDifference,
 			AllowedNegativeDifference: &allowedNegativeDifference,
@@ -54,7 +54,7 @@ func TestHandleStartupNTPPolicy(t *testing.T) {
 	t.Run("query failure should warn and continue", func(t *testing.T) {
 		stubStartupNTPOffsetRetryLimit(t, 3)
 		bot := &Engine{
-			Config: testStartupNTPConfig(0),
+			Config: testStartupNTPConfig(),
 			Settings: Settings{
 				CoreSettings: CoreSettings{EnableNTPClient: true},
 			},
@@ -74,7 +74,7 @@ func TestHandleStartupNTPPolicy(t *testing.T) {
 	t.Run("transient query failure should recover on retry", func(t *testing.T) {
 		stubStartupNTPOffsetRetryLimit(t, 3)
 		bot := &Engine{
-			Config: testStartupNTPConfig(0),
+			Config: testStartupNTPConfig(),
 			Settings: Settings{
 				CoreSettings: CoreSettings{EnableNTPClient: true},
 			},
@@ -96,7 +96,7 @@ func TestHandleStartupNTPPolicy(t *testing.T) {
 
 	t.Run("offset within threshold should not prompt", func(t *testing.T) {
 		bot := &Engine{
-			Config: testStartupNTPConfig(0),
+			Config: testStartupNTPConfig(),
 			Settings: Settings{
 				CoreSettings: CoreSettings{EnableNTPClient: true},
 			},
@@ -112,7 +112,7 @@ func TestHandleStartupNTPPolicy(t *testing.T) {
 
 	t.Run("offset outside threshold should prompt and update config", func(t *testing.T) {
 		bot := &Engine{
-			Config: testStartupNTPConfig(0),
+			Config: testStartupNTPConfig(),
 			Settings: Settings{
 				CoreSettings: CoreSettings{EnableNTPClient: true},
 			},

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -130,8 +130,13 @@ func timeToNTPTimestamp(t time.Time) (seconds, fractional uint32) {
 		return 0, 0
 	}
 
-	nanos := uint32(t.Nanosecond())
-	fractional = uint32((uint64(nanos) << 32) / uint64(time.Second))
+	nanos := int64(t.Nanosecond())
+	frac := (nanos << 32) / int64(time.Second)
+	if frac < 0 || frac > math.MaxUint32 {
+		return 0, 0
+	}
+
+	fractional = uint32(frac)
 	return uint32(unixSeconds), fractional
 }
 

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"sync/atomic"
 	"time"
@@ -31,8 +32,10 @@ var (
 	errInvalidNTPStratum   = errors.New("invalid NTP stratum")
 )
 
-var queryNTPOffsetFunc = queryNTPOffset
-var queryNTPOffsetFromPoolFunc = queryNTPOffsetFromPool
+var (
+	queryNTPOffsetFunc         = queryNTPOffset
+	queryNTPOffsetFromPoolFunc = queryNTPOffsetFromPool
+)
 
 // checkNTPOffset performs a one-time NTP check and returns the measured offset.
 // It is used during startup before the NTP manager loop begins.
@@ -121,11 +124,15 @@ func ntpTimestampToTime(seconds, fractional uint32) time.Time {
 
 // timeToNTPTimestamp converts a time.Time to its NTP seconds and fractional
 // components so requests can be correlated with responses.
-func timeToNTPTimestamp(t time.Time) (uint32, uint32) {
+func timeToNTPTimestamp(t time.Time) (seconds, fractional uint32) {
 	unixSeconds := t.Unix() + ntpEpochOffset
-	nanos := t.Nanosecond()
-	frac := (uint64(nanos) << 32) / 1.e9
-	return uint32(unixSeconds), uint32(frac)
+	if unixSeconds < 0 || unixSeconds > math.MaxUint32 {
+		return 0, 0
+	}
+
+	nanos := uint32(t.Nanosecond())
+	fractional = uint32((uint64(nanos) << 32) / uint64(time.Second))
+	return uint32(unixSeconds), fractional
 }
 
 // calculateNTPOffset applies the RFC 5905 clock offset formula using the four

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -25,12 +25,14 @@ var errNoValidNTPServer = errors.New("no valid NTP server could be reached")
 var (
 	errInvalidNTPResponse  = errors.New("invalid NTP response")
 	errInvalidNTPMode      = errors.New("invalid NTP mode")
+	errInvalidNTPOriginate = errors.New("invalid NTP originate timestamp")
 	errZeroNTPTransmitTime = errors.New("zero NTP transmit timestamp")
 	errZeroNTPReceiveTime  = errors.New("zero NTP receive timestamp")
 	errInvalidNTPStratum   = errors.New("invalid NTP stratum")
 )
 
 var queryNTPOffsetFunc = queryNTPOffset
+var queryNTPOffsetFromPoolFunc = queryNTPOffsetFromPool
 
 // checkNTPOffset performs a one-time NTP check and returns the measured offset.
 // It is used during startup before the NTP manager loop begins.
@@ -46,15 +48,17 @@ func queryNTPOffset(ctx context.Context, pools []string) (time.Duration, error) 
 	}
 
 	dialer := &net.Dialer{Timeout: ntpDialTimeout}
+	var lastErr error
 
 	for i := range pools {
-		offset, err := queryNTPOffsetFromPool(ctx, dialer, pools[i])
+		offset, err := queryNTPOffsetFromPoolFunc(ctx, dialer, pools[i])
 		if err == nil {
 			return offset, nil
 		}
+		lastErr = err
 		log.Warnf(log.TimeMgr, "Unable to query NTP host %v: %v. Attempting next", pools[i], err)
 	}
-	return 0, errNoValidNTPServer
+	return 0, fmt.Errorf("%w: %w", errNoValidNTPServer, lastErr)
 }
 
 // queryNTPOffsetFromPool performs a single NTP exchange against one pool and
@@ -75,8 +79,15 @@ func queryNTPOffsetFromPool(ctx context.Context, dialer *net.Dialer, pool string
 	}
 
 	originTimestamp := time.Now()
+	origSec, origFrac := timeToNTPTimestamp(originTimestamp)
 
-	req := &ntpPacket{Settings: 0x1B}
+	req := &ntpPacket{
+		Settings:     0x1B,
+		TxTimeSec:    origSec,
+		TxTimeFrac:   origFrac,
+		OrigTimeSec:  0,
+		OrigTimeFrac: 0,
+	}
 	if err := binary.Write(conn, binary.BigEndian, req); err != nil {
 		return 0, fmt.Errorf("unable to write request to %v: %w", pool, err)
 	}
@@ -89,6 +100,9 @@ func queryNTPOffsetFromPool(ctx context.Context, dialer *net.Dialer, pool string
 	destinationTimestamp := time.Now()
 
 	if err := validateNTPResponse(rsp); err != nil {
+		return 0, fmt.Errorf("invalid response from %v: %w", pool, err)
+	}
+	if err := validateNTPOriginateTimestamp(rsp, origSec, origFrac); err != nil {
 		return 0, fmt.Errorf("invalid response from %v: %w", pool, err)
 	}
 
@@ -105,6 +119,15 @@ func ntpTimestampToTime(seconds, fractional uint32) time.Time {
 	return time.Unix(unixSeconds, nanos)
 }
 
+// timeToNTPTimestamp converts a time.Time to its NTP seconds and fractional
+// components so requests can be correlated with responses.
+func timeToNTPTimestamp(t time.Time) (uint32, uint32) {
+	unixSeconds := t.Unix() + ntpEpochOffset
+	nanos := t.Nanosecond()
+	frac := (uint64(nanos) << 32) / 1.e9
+	return uint32(unixSeconds), uint32(frac)
+}
+
 // calculateNTPOffset applies the RFC 5905 clock offset formula using the four
 // timestamps involved in one NTP request/response exchange.
 func calculateNTPOffset(origin, receive, transmit, destination time.Time) time.Duration {
@@ -118,11 +141,15 @@ func validateNTPResponse(rsp *ntpPacket) error {
 		return errInvalidNTPResponse
 	}
 
+	if (rsp.Settings>>6)&0x03 == 3 {
+		return errInvalidNTPResponse
+	}
+
 	if rsp.Settings&0x07 != 4 {
 		return errInvalidNTPMode
 	}
 
-	if rsp.Stratum == 0 {
+	if rsp.Stratum == 0 || rsp.Stratum >= 16 {
 		return errInvalidNTPStratum
 	}
 
@@ -134,6 +161,19 @@ func validateNTPResponse(rsp *ntpPacket) error {
 		return errZeroNTPTransmitTime
 	}
 
+	return nil
+}
+
+// validateNTPOriginateTimestamp ensures the response matches the client's
+// transmit timestamp, preventing stale or mismatched UDP replies from being
+// trusted for offset calculation.
+func validateNTPOriginateTimestamp(rsp *ntpPacket, seconds, fractional uint32) error {
+	if rsp == nil {
+		return errInvalidNTPResponse
+	}
+	if rsp.OrigTimeSec != seconds || rsp.OrigTimeFrac != fractional {
+		return errInvalidNTPOriginate
+	}
 	return nil
 }
 

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -22,72 +22,80 @@ const (
 // errNoValidNTPServer is returned when no valid NTP server could be reached
 var errNoValidNTPServer = errors.New("no valid NTP server could be reached")
 
-// CheckNTPOffset performs a one-time NTP check and returns the time offset.
-// This can be called before the NTP manager is started to verify time sync.
-// It uses the RFC 5905 formula: offset = ((T2-T1) + (T3-T4)) / 2
-func CheckNTPOffset(ctx context.Context, pools []string) (time.Duration, error) {
+var (
+	errInvalidNTPResponse  = errors.New("invalid NTP response")
+	errInvalidNTPMode      = errors.New("invalid NTP mode")
+	errZeroNTPTransmitTime = errors.New("zero NTP transmit timestamp")
+	errZeroNTPReceiveTime  = errors.New("zero NTP receive timestamp")
+	errInvalidNTPStratum   = errors.New("invalid NTP stratum")
+)
+
+var queryNTPOffsetFunc = queryNTPOffset
+
+// checkNTPOffset performs a one-time NTP check and returns the measured offset.
+// It is used during startup before the NTP manager loop begins.
+func checkNTPOffset(ctx context.Context, pools []string) (time.Duration, error) {
+	return queryNTPOffsetFunc(ctx, pools)
+}
+
+// queryNTPOffset centralises NTP offset measurement so startup checks and the
+// long-running NTP manager use identical transport and calculation logic
+func queryNTPOffset(ctx context.Context, pools []string) (time.Duration, error) {
 	if len(pools) == 0 {
 		return 0, errors.New("no NTP pools configured")
 	}
 
-	dialer := &net.Dialer{
-		Timeout: ntpDialTimeout,
-	}
+	dialer := &net.Dialer{Timeout: ntpDialTimeout}
 
 	for i := range pools {
-		conn, err := dialer.DialContext(ctx, "udp", pools[i])
-		if err != nil {
-			log.Warnf(log.TimeMgr, "NTP check: Unable to connect to %v, attempting next", pools[i])
-			continue
+		offset, err := queryNTPOffsetFromPool(ctx, dialer, pools[i])
+		if err == nil {
+			return offset, nil
 		}
-
-		if err = conn.SetDeadline(time.Now().Add(ntpReadWriteTimeout)); err != nil {
-			log.Warnf(log.TimeMgr, "NTP check: Unable to set deadline on %v. Error %s. Attempting next\n", pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		// T1: Record time before sending request (origin timestamp)
-		t1 := time.Now()
-
-		req := &ntpPacket{Settings: 0x1B}
-		if err = binary.Write(conn, binary.BigEndian, req); err != nil {
-			log.Warnf(log.TimeMgr, "NTP check: Unable to write to %v. Error %s. Attempting next\n", pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		rsp := &ntpPacket{}
-		if err = binary.Read(conn, binary.BigEndian, rsp); err != nil {
-			log.Warnf(log.TimeMgr, "NTP check: Unable to read from %v. Error: %s. Attempting next\n", pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		// T4: Record time after receiving response (Destination timestamp)
-		t4 := time.Now()
-
-		if err = conn.Close(); err != nil {
-			log.Errorln(log.TimeMgr, err)
-		}
-
-		// T2: Server receive timestamp (when server received our request)
-		t2 := ntpTimestampToTime(rsp.RxTimeSec, rsp.RxTimeFrac)
-		// T3: Server transmit timestamp (when server sent our response)
-		t3 := ntpTimestampToTime(rsp.TxTimeSec, rsp.TxTimeFrac)
-
-		// RFC 5905 offset calculation: ((T2-T1) + (T3-T4)) / 2
-		// This formula cancels out the network round-trip time
-		offset := (t2.Sub(t1) + t3.Sub(t4)) / 2
-		return offset, nil
+		log.Warnf(log.TimeMgr, "Unable to query NTP host %v: %v. Attempting next", pools[i], err)
 	}
 	return 0, errNoValidNTPServer
+}
+
+// queryNTPOffsetFromPool performs a single NTP exchange against one pool and
+// returns the RFC 5905 offset derived from that response.
+func queryNTPOffsetFromPool(ctx context.Context, dialer *net.Dialer, pool string) (time.Duration, error) {
+	conn, err := dialer.DialContext(ctx, "udp", pool)
+	if err != nil {
+		return 0, fmt.Errorf("unable to connect to %v: %w", pool, err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Errorln(log.TimeMgr, err)
+		}
+	}()
+
+	if err := conn.SetDeadline(time.Now().Add(ntpReadWriteTimeout)); err != nil {
+		return 0, fmt.Errorf("unable to set deadline on %v: %w", pool, err)
+	}
+
+	originTimestamp := time.Now()
+
+	req := &ntpPacket{Settings: 0x1B}
+	if err := binary.Write(conn, binary.BigEndian, req); err != nil {
+		return 0, fmt.Errorf("unable to write request to %v: %w", pool, err)
+	}
+
+	rsp := &ntpPacket{}
+	if err := binary.Read(conn, binary.BigEndian, rsp); err != nil {
+		return 0, fmt.Errorf("unable to read response from %v: %w", pool, err)
+	}
+
+	destinationTimestamp := time.Now()
+
+	if err := validateNTPResponse(rsp); err != nil {
+		return 0, fmt.Errorf("invalid response from %v: %w", pool, err)
+	}
+
+	receiveTimestamp := ntpTimestampToTime(rsp.RxTimeSec, rsp.RxTimeFrac)
+	transmitTimestamp := ntpTimestampToTime(rsp.TxTimeSec, rsp.TxTimeFrac)
+
+	return calculateNTPOffset(originTimestamp, receiveTimestamp, transmitTimestamp, destinationTimestamp), nil
 }
 
 // ntpTimestampToTime converts timestamp (seconds and fractional) to time.Time
@@ -95,6 +103,38 @@ func ntpTimestampToTime(seconds, fractional uint32) time.Time {
 	unixSeconds := int64(seconds) - ntpEpochOffset
 	nanos := (int64(fractional) * 1.e9) >> 32
 	return time.Unix(unixSeconds, nanos)
+}
+
+// calculateNTPOffset applies the RFC 5905 clock offset formula using the four
+// timestamps involved in one NTP request/response exchange.
+func calculateNTPOffset(origin, receive, transmit, destination time.Time) time.Duration {
+	return (receive.Sub(origin) + transmit.Sub(destination)) / 2
+}
+
+// validateNTPResponse rejects obviously invalid server replies before their
+// timestamps are trusted for offset calculation.
+func validateNTPResponse(rsp *ntpPacket) error {
+	if rsp == nil {
+		return errInvalidNTPResponse
+	}
+
+	if rsp.Settings&0x07 != 4 {
+		return errInvalidNTPMode
+	}
+
+	if rsp.Stratum == 0 {
+		return errInvalidNTPStratum
+	}
+
+	if rsp.RxTimeSec == 0 && rsp.RxTimeFrac == 0 {
+		return errZeroNTPReceiveTime
+	}
+
+	if rsp.TxTimeSec == 0 && rsp.TxTimeFrac == 0 {
+		return errZeroNTPTransmitTime
+	}
+
+	return nil
 }
 
 // setupNTPManager creates a new NTP manager
@@ -229,72 +269,12 @@ func (m *ntpManager) processTime(ctx context.Context) error {
 	negDiff := m.allowedNegativeDifference
 	configNTPNegativeTime := -negDiff
 	if offset > configNTPTime || offset < configNTPNegativeTime {
-		log.Warnf(log.TimeMgr, "NTP manager: Time out of sync (Offset): %v | (Allowed) +%v / %v\n", offset, configNTPTime, configNTPNegativeTime)
+		log.Warnf(log.TimeMgr, "NTP manager: Time out of sync (Offset): %v | (Allowed) +%v / %v", offset, configNTPTime, configNTPNegativeTime)
 	}
 	return nil
 }
 
-// getTimeOffset queries NTP servers and returns the calculated time offset
-// using the RFC5905 formula: offset = ((T2-T1) + (T3-T4)) / 2
-// This properly accounts for network round-trip time
+// getTimeOffset returns the measured NTP offset for the manager's configured pools
 func (m *ntpManager) getTimeOffset(ctx context.Context) (time.Duration, error) {
-	dialer := &net.Dialer{
-		Timeout: ntpDialTimeout,
-	}
-
-	for i := range m.pools {
-		conn, err := dialer.DialContext(ctx, "udp", m.pools[i])
-		if err != nil {
-			log.Warnf(log.TimeMgr, "Unable to connect to hosts %v attempting to next", m.pools[i])
-			continue
-		}
-
-		if err = conn.SetDeadline(time.Now().Add(ntpReadWriteTimeout)); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to set deadline on hosts %v. Error %s. attempting to next\n", m.pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		// T1: Record time before sending request (origin timestamp)
-		t1 := time.Now()
-
-		req := &ntpPacket{Settings: 0x1B}
-		if err = binary.Write(conn, binary.BigEndian, req); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to write to hosts %v. Error %s. Attempting to next\n", m.pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		rsp := &ntpPacket{}
-		if err = binary.Read(conn, binary.BigEndian, rsp); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to read from hosts %v. Error: %s. Attempting to next\n", m.pools[i], err)
-			if err = conn.Close(); err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		// T4L Record time after receiving response (Destination timestamp)
-		t4 := time.Now()
-
-		if err = conn.Close(); err != nil {
-			log.Errorln(log.TimeMgr, err)
-		}
-
-		// T2: Server receive timestamp (when server received our request)
-		t2 := ntpTimestampToTime(rsp.RxTimeSec, rsp.RxTimeFrac)
-		// T3: Server transmit timestamp (when server sent our response)
-		t3 := ntpTimestampToTime(rsp.TxTimeSec, rsp.TxTimeFrac)
-
-		// RFC 5905 offset calculation: ((T2-T1) + (T3-T4)) / 2
-		// This formula cancels out the network round-trip time
-		offset := (t2.Sub(t1) + t3.Sub(t4)) / 2
-		return offset, nil
-	}
-	log.Warnln(log.TimeMgr, "No valid NTP servers found")
-	return 0, errNoValidNTPServer
+	return queryNTPOffsetFunc(ctx, m.pools)
 }

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -136,8 +136,19 @@ func timeToNTPTimestamp(t time.Time) (seconds, fractional uint32) {
 		return 0, 0
 	}
 
-	fractional = uint32(frac)
-	return uint32(unixSeconds), fractional
+	seconds = binary.BigEndian.Uint32([]byte{
+		byte(unixSeconds >> 24),
+		byte(unixSeconds >> 16),
+		byte(unixSeconds >> 8),
+		byte(unixSeconds),
+	})
+	fractional = binary.BigEndian.Uint32([]byte{
+		byte(frac >> 24),
+		byte(frac >> 16),
+		byte(frac >> 8),
+		byte(frac),
+	})
+	return seconds, fractional
 }
 
 // calculateNTPOffset applies the RFC 5905 clock offset formula using the four

--- a/engine/ntp_manager_test.go
+++ b/engine/ntp_manager_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -65,6 +66,7 @@ func TestNTPManagerStart(t *testing.T) {
 	cfg := &config.NTPClientConfig{
 		AllowedDifference:         &sec,
 		AllowedNegativeDifference: &sec,
+		Pool:                      []string{"0.pool.ntp.org:123"},
 	}
 	m, err = setupNTPManager(cfg, true)
 	assert.NoError(t, err)
@@ -114,6 +116,7 @@ func TestFetchNTPTime(t *testing.T) {
 		AllowedDifference:         &sec,
 		AllowedNegativeDifference: &sec,
 		Level:                     1,
+		Pool:                      []string{"0.pool.ntp.org:123"},
 	}
 	m, err = setupNTPManager(cfg, true)
 	assert.NoError(t, err)
@@ -125,14 +128,6 @@ func TestFetchNTPTime(t *testing.T) {
 	assert.NoError(t, err)
 
 	tt, err := m.FetchNTPTime()
-	assert.NoError(t, err)
-
-	if tt.IsZero() {
-		t.Error("expected time")
-	}
-
-	m.pools = []string{"0.pool.ntp.org:123"}
-	tt, err = m.FetchNTPTime()
 	assert.NoError(t, err)
 
 	if tt.IsZero() {
@@ -151,17 +146,17 @@ func TestProcessTime(t *testing.T) {
 	m, err := setupNTPManager(cfg, true)
 	assert.NoError(t, err)
 
-	err = m.processTime()
+	err = m.processTime(context.Background())
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
 	err = m.Start()
 	assert.NoError(t, err)
 
-	err = m.processTime()
+	err = m.processTime(context.Background())
 	assert.NoError(t, err)
 
 	m.allowedDifference = time.Duration(1)
 	m.allowedNegativeDifference = time.Duration(1)
-	err = m.processTime()
+	err = m.processTime(context.Background())
 	assert.NoError(t, err)
 }

--- a/engine/ntp_manager_test.go
+++ b/engine/ntp_manager_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -17,6 +18,15 @@ func stubQueryNTPOffset(t *testing.T, fn func(context.Context, []string) (time.D
 	queryNTPOffsetFunc = fn
 	t.Cleanup(func() {
 		queryNTPOffsetFunc = original
+	})
+}
+
+func stubQueryNTPOffsetFromPool(t *testing.T, fn func(context.Context, *net.Dialer, string) (time.Duration, error)) {
+	t.Helper()
+	original := queryNTPOffsetFromPoolFunc
+	queryNTPOffsetFromPoolFunc = fn
+	t.Cleanup(func() {
+		queryNTPOffsetFromPoolFunc = original
 	})
 }
 
@@ -191,10 +201,39 @@ func TestNTPTimestampToTime(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.True(t, ntpTimestampToTime(tc.seconds, tc.fractional).Equal(tc.expected), "ntpTimestampToTime should convert NTP timestamps to the expected time")
+		})
+	}
+}
+
+func TestTimeToNTPTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected time.Time
+	}{
+		{
+			name:     "unix epoch",
+			input:    time.Unix(0, 0),
+			expected: time.Unix(0, 0),
+		},
+		{
+			name:     "with nanoseconds",
+			input:    time.Unix(123, 456000000),
+			expected: time.Unix(123, 456000000),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sec, frac := timeToNTPTimestamp(tc.input)
+			converted := ntpTimestampToTime(sec, frac)
+			assert.WithinDuration(t, tc.expected, converted, time.Microsecond, "timeToNTPTimestamp should round trip with ntpTimestampToTime")
 		})
 	}
 }
@@ -207,6 +246,20 @@ func TestCheckNTPOffset(t *testing.T) {
 
 	_, err := checkNTPOffset(context.Background(), []string{"ntp.invalid:123"})
 	require.ErrorIs(t, err, wantErr, "checkNTPOffset must return the mocked query error")
+}
+
+func TestQueryNTPOffsetNoValidServer(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	stubQueryNTPOffsetFromPool(t, func(context.Context, *net.Dialer, string) (time.Duration, error) {
+		return 0, wantErr
+	})
+
+	_, err := queryNTPOffset(context.Background(), []string{"ntp.invalid:123"})
+	require.Error(t, err, "queryNTPOffset must error when no pool can be reached")
+	require.ErrorIs(t, err, errNoValidNTPServer, "queryNTPOffset must wrap errNoValidNTPServer when all pools fail")
+	require.ErrorIs(t, err, wantErr, "queryNTPOffset must retain the last underlying pool error for debugging")
 }
 
 func TestCalculateNTPOffset(t *testing.T) {
@@ -245,10 +298,30 @@ func TestValidateNTPResponse(t *testing.T) {
 			wantErr: errInvalidNTPMode,
 		},
 		{
+			name: "invalid leap indicator alarm",
+			packet: &ntpPacket{
+				Settings:  0xC4,
+				Stratum:   1,
+				RxTimeSec: 1,
+				TxTimeSec: 1,
+			},
+			wantErr: errInvalidNTPResponse,
+		},
+		{
 			name: "invalid stratum",
 			packet: &ntpPacket{
 				Settings:  0x04,
 				Stratum:   0,
+				RxTimeSec: 1,
+				TxTimeSec: 1,
+			},
+			wantErr: errInvalidNTPStratum,
+		},
+		{
+			name: "unsynchronised high stratum",
+			packet: &ntpPacket{
+				Settings:  0x04,
+				Stratum:   16,
 				RxTimeSec: 1,
 				TxTimeSec: 1,
 			},
@@ -285,7 +358,6 @@ func TestValidateNTPResponse(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateNTPResponse(tc.packet)
@@ -294,6 +366,56 @@ func TestValidateNTPResponse(t *testing.T) {
 				return
 			}
 			require.ErrorIs(t, err, tc.wantErr, "validateNTPResponse must return the expected validation error")
+		})
+	}
+}
+
+func TestValidateNTPOriginateTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		packet     *ntpPacket
+		seconds    uint32
+		fractional uint32
+		wantErr    error
+	}{
+		{
+			name:    "nil packet",
+			packet:  nil,
+			wantErr: errInvalidNTPResponse,
+		},
+		{
+			name: "mismatched originate timestamp",
+			packet: &ntpPacket{
+				OrigTimeSec:  2,
+				OrigTimeFrac: 3,
+			},
+			seconds:    1,
+			fractional: 2,
+			wantErr:    errInvalidNTPOriginate,
+		},
+		{
+			name: "matching originate timestamp",
+			packet: &ntpPacket{
+				OrigTimeSec:  1,
+				OrigTimeFrac: 2,
+			},
+			seconds:    1,
+			fractional: 2,
+			wantErr:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateNTPOriginateTimestamp(tc.packet, tc.seconds, tc.fractional)
+			if tc.wantErr == nil {
+				require.NoError(t, err, "validateNTPOriginateTimestamp must not error for matching originate timestamps")
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr, "validateNTPOriginateTimestamp must return the expected validation error")
 		})
 	}
 }

--- a/engine/ntp_manager_test.go
+++ b/engine/ntp_manager_test.go
@@ -2,19 +2,30 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/config"
 )
 
+func stubQueryNTPOffset(t *testing.T, fn func(context.Context, []string) (time.Duration, error)) {
+	t.Helper()
+	original := queryNTPOffsetFunc
+	queryNTPOffsetFunc = fn
+	t.Cleanup(func() {
+		queryNTPOffsetFunc = original
+	})
+}
+
 func TestSetupNTPManager(t *testing.T) {
 	_, err := setupNTPManager(nil, false)
-	assert.ErrorIs(t, err, errNilConfig)
+	require.ErrorIs(t, err, errNilConfig, "setupNTPManager must return errNilConfig for a nil config")
 
 	_, err = setupNTPManager(&config.NTPClientConfig{}, false)
-	assert.ErrorIs(t, err, errNilNTPConfigValues)
+	require.ErrorIs(t, err, errNilNTPConfigValues, "setupNTPManager must return errNilNTPConfigValues for incomplete config values")
 
 	sec := time.Second
 	cfg := &config.NTPClientConfig{
@@ -22,18 +33,14 @@ func TestSetupNTPManager(t *testing.T) {
 		AllowedNegativeDifference: &sec,
 	}
 	m, err := setupNTPManager(cfg, false)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
 
-	if m == nil {
-		t.Error("expected manager")
-	}
+	require.NotNil(t, m, "manager must not be nil for a valid config")
 }
 
 func TestNTPManagerIsRunning(t *testing.T) {
 	var m *ntpManager
-	if m.IsRunning() {
-		t.Error("expected false")
-	}
+	assert.False(t, m.IsRunning(), "IsRunning should return false for a nil manager")
 
 	sec := time.Second
 	cfg := &config.NTPClientConfig{
@@ -42,50 +49,47 @@ func TestNTPManagerIsRunning(t *testing.T) {
 		Level:                     1,
 	}
 	m, err := setupNTPManager(cfg, false)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
 
-	if m.IsRunning() {
-		t.Error("expected false")
-	}
+	assert.False(t, m.IsRunning(), "IsRunning should return false before the manager starts")
 
 	err = m.Start()
-	if err != nil {
-		t.Error(err)
-	}
-	if !m.IsRunning() {
-		t.Error("expected true")
-	}
+	require.NoError(t, err, "Start must not error for an enabled manager")
+	assert.True(t, m.IsRunning(), "IsRunning should return true after the manager starts")
 }
 
 func TestNTPManagerStart(t *testing.T) {
 	var m *ntpManager
 	err := m.Start()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
+	require.ErrorIs(t, err, ErrNilSubsystem, "Start must return ErrNilSubsystem for a nil manager")
 
 	sec := time.Second
 	cfg := &config.NTPClientConfig{
 		AllowedDifference:         &sec,
 		AllowedNegativeDifference: &sec,
-		Pool:                      []string{"0.pool.ntp.org:123"},
+		Pool:                      []string{"ntp.invalid:123"},
 	}
 	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
+	stubQueryNTPOffset(t, func(context.Context, []string) (time.Duration, error) {
+		return 0, nil
+	})
 
 	err = m.Start()
-	assert.ErrorIs(t, err, errNTPManagerDisabled)
+	require.ErrorIs(t, err, errNTPManagerDisabled, "Start must return errNTPManagerDisabled when the manager level is disabled")
 
 	m.level = 1
 	err = m.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err, "Start must not error once the manager level is enabled")
 
 	err = m.Start()
-	assert.ErrorIs(t, err, ErrSubSystemAlreadyStarted)
+	require.ErrorIs(t, err, ErrSubSystemAlreadyStarted, "Start must return ErrSubSystemAlreadyStarted when called twice")
 }
 
 func TestNTPManagerStop(t *testing.T) {
 	var m *ntpManager
 	err := m.Stop()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
+	require.ErrorIs(t, err, ErrNilSubsystem, "Stop must return ErrNilSubsystem for a nil manager")
 
 	sec := time.Second
 	cfg := &config.NTPClientConfig{
@@ -94,45 +98,47 @@ func TestNTPManagerStop(t *testing.T) {
 		Level:                     1,
 	}
 	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
 
 	err = m.Stop()
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
+	require.ErrorIs(t, err, ErrSubSystemNotStarted, "Stop must return ErrSubSystemNotStarted before the manager starts")
 
 	err = m.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err, "Start must not error for an enabled manager")
 
 	err = m.Stop()
-	assert.NoError(t, err)
+	require.NoError(t, err, "Stop must not error after the manager starts")
 }
 
 func TestFetchNTPTime(t *testing.T) {
 	var m *ntpManager
 	_, err := m.FetchNTPTime()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
+	require.ErrorIs(t, err, ErrNilSubsystem, "FetchNTPTime must return ErrNilSubsystem for a nil manager")
 
 	sec := time.Second
 	cfg := &config.NTPClientConfig{
 		AllowedDifference:         &sec,
 		AllowedNegativeDifference: &sec,
 		Level:                     1,
-		Pool:                      []string{"0.pool.ntp.org:123"},
+		Pool:                      []string{"ntp.invalid:123"},
 	}
 	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
+	stubQueryNTPOffset(t, func(context.Context, []string) (time.Duration, error) {
+		return 2 * time.Second, nil
+	})
 
 	_, err = m.FetchNTPTime()
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
+	require.ErrorIs(t, err, ErrSubSystemNotStarted, "FetchNTPTime must return ErrSubSystemNotStarted before the manager starts")
 
 	err = m.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err, "Start must not error for an enabled manager")
 
+	before := time.Now()
 	tt, err := m.FetchNTPTime()
-	assert.NoError(t, err)
+	require.NoError(t, err, "FetchNTPTime must not error after the manager starts")
 
-	if tt.IsZero() {
-		t.Error("expected time")
-	}
+	assert.WithinDuration(t, before.Add(2*time.Second), tt, 250*time.Millisecond, "FetchNTPTime should apply the mocked NTP offset")
 }
 
 func TestProcessTime(t *testing.T) {
@@ -141,22 +147,153 @@ func TestProcessTime(t *testing.T) {
 		AllowedDifference:         &sec,
 		AllowedNegativeDifference: &sec,
 		Level:                     1,
-		Pool:                      []string{"0.pool.ntp.org:123"},
+		Pool:                      []string{"ntp.invalid:123"},
 	}
 	m, err := setupNTPManager(cfg, true)
-	assert.NoError(t, err)
+	require.NoError(t, err, "setupNTPManager must not error for a valid config")
+	stubQueryNTPOffset(t, func(context.Context, []string) (time.Duration, error) {
+		return 0, nil
+	})
 
 	err = m.processTime(context.Background())
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
+	require.ErrorIs(t, err, ErrSubSystemNotStarted, "processTime must return ErrSubSystemNotStarted before the manager starts")
 
 	err = m.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err, "Start must not error for an enabled manager")
 
 	err = m.processTime(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err, "processTime must not error when the mocked offset is within threshold")
 
 	m.allowedDifference = time.Duration(1)
 	m.allowedNegativeDifference = time.Duration(1)
+	stubQueryNTPOffset(t, func(context.Context, []string) (time.Duration, error) {
+		return 2 * time.Second, nil
+	})
 	err = m.processTime(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err, "processTime must not error when the mocked offset is outside threshold")
+}
+
+func TestNTPTimestampToTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		seconds    uint32
+		fractional uint32
+		expected   time.Time
+	}{
+		{
+			name:       "unix epoch",
+			seconds:    ntpEpochOffset,
+			fractional: 0,
+			expected:   time.Unix(0, 0),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, ntpTimestampToTime(tc.seconds, tc.fractional).Equal(tc.expected), "ntpTimestampToTime should convert NTP timestamps to the expected time")
+		})
+	}
+}
+
+func TestCheckNTPOffset(t *testing.T) {
+	wantErr := errors.New("boom")
+	stubQueryNTPOffset(t, func(context.Context, []string) (time.Duration, error) {
+		return 0, wantErr
+	})
+
+	_, err := checkNTPOffset(context.Background(), []string{"ntp.invalid:123"})
+	require.ErrorIs(t, err, wantErr, "checkNTPOffset must return the mocked query error")
+}
+
+func TestCalculateNTPOffset(t *testing.T) {
+	t.Parallel()
+
+	origin := time.Unix(100, 0)
+	receive := time.Unix(101, 0)
+	transmit := time.Unix(101, 500000000)
+	destination := time.Unix(102, 0)
+
+	offset := calculateNTPOffset(origin, receive, transmit, destination)
+	assert.Equal(t, 250*time.Millisecond, offset, "calculateNTPOffset should apply the RFC 5905 offset formula")
+}
+
+func TestValidateNTPResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		packet  *ntpPacket
+		wantErr error
+	}{
+		{
+			name:    "nil packet",
+			packet:  nil,
+			wantErr: errInvalidNTPResponse,
+		},
+		{
+			name: "invalid mode",
+			packet: &ntpPacket{
+				Settings:  0x03,
+				Stratum:   1,
+				RxTimeSec: 1,
+				TxTimeSec: 1,
+			},
+			wantErr: errInvalidNTPMode,
+		},
+		{
+			name: "invalid stratum",
+			packet: &ntpPacket{
+				Settings:  0x04,
+				Stratum:   0,
+				RxTimeSec: 1,
+				TxTimeSec: 1,
+			},
+			wantErr: errInvalidNTPStratum,
+		},
+		{
+			name: "zero receive timestamp",
+			packet: &ntpPacket{
+				Settings:  0x04,
+				Stratum:   1,
+				TxTimeSec: 1,
+			},
+			wantErr: errZeroNTPReceiveTime,
+		},
+		{
+			name: "zero transmit timestamp",
+			packet: &ntpPacket{
+				Settings:  0x04,
+				Stratum:   1,
+				RxTimeSec: 1,
+			},
+			wantErr: errZeroNTPTransmitTime,
+		},
+		{
+			name: "valid packet",
+			packet: &ntpPacket{
+				Settings:  0x04,
+				Stratum:   1,
+				RxTimeSec: 1,
+				TxTimeSec: 1,
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateNTPResponse(tc.packet)
+			if tc.wantErr == nil {
+				require.NoError(t, err, "validateNTPResponse must not error for a valid packet")
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr, "validateNTPResponse must return the expected validation error")
+		})
+	}
 }


### PR DESCRIPTION
# PR implement RFC 5905 offset calculation and verify time before warning

Before I got 
```
[DEBUG] | DATABASE | 19/12/2025 22:06:26 | Database manager starting...
[DEBUG] | CONNECTION | 19/12/2025 22:06:26 | Connection manager starting...
[DEBUG] | LOG | 19/12/2025 22:06:26 | Internet connectivity found
[DEBUG] | CONNECTION | 19/12/2025 22:06:26 | Connection manager started.
Your system time is out of sync, this may cause issues with trading
How would you like to show future notifications? (a)lert at startup / (w)arn periodically / (d)isable
```

No, the issue is not my system/setup

```
❯ timedatectl timesync-status

       Server: 162.159.200.1 (time.cloudflare.com)
Poll interval: 34min 8s (min: 32s; max 34min 8s)
         Leap: normal
      Version: 4
      Stratum: 3
    Reference: AE20804
    Precision: 1us (-26)
Root distance: 2.852ms (max: 5s)
       Offset: -383us
        Delay: 10.140ms
       Jitter: 1.091ms
 Packet count: 15
    Frequency: -18.014ppm
```

```
My PC (perfectly synced)           NTP Server
        |                                       |
   T1 = 10:00:00.000 ─── You send request ───→  |
        |                                       | T2 = 10:00:00.050 (server receives)
        |                                       | T3 = 10:00:00.050 (server sends response)
        |  ←── Response packet arrives ─────────|
   T4 = 10:00:00.100 (you receive it)           |
```

The 4 timestamps
```
| Name | When | Which Clock | Where is it? |
|------|------|-------------|--------------|
| **T1** | Client sends request | Client | **Not recorded** in current code! |
| **T2** | Server receives request | Server | `RxTimeSec` / `RxTimeFrac` |
| **T3** | Server sends response | Server | `TxTimeSec` / `TxTimeFrac` |
| **T4** | Client receives response | Client | **Not recorded** in current code! |
```

Original code
```go
NTPTime := T3              // 10:00:00.050 (server's transmit time)
currentTime := time.Now()  // 10:00:00.100 (this is T4)
diff := NTPTime.Sub(currentTime)  // T3 - T4 = -50ms
```

The issue
`T3 - T4` gives us `-(network_delay) + offset`
If my clock is perfect (offset = 0), I still get `-50ms` due to network

The current code asks: "Bonjour, what time did the server say it was?"
But that's stale information (packet took time to travel)



By the time you read `T3 = 10:00:00.050`, it's already `10:00:00.100` on your clock. You can't just compare them directly.

RFC 5905 compensates for network delay/latency 
```
offset = ((T2 - T1) + (T3 - T4)) / 2
```

Where:
- **T1** = Origin Timestamp - when client sent the request
- **T2** = Receive Timestamp - when server received the request (`RxTimeSec`/`RxTimeFrac`)
- **T3** = Transmit Timestamp - when server sent the response (`TxTimeSec`/`TxTimeFrac`)
- **T4** = Destination Timestamp - when client received the response

This formula cancels out the network round-trip time, giving an accurate offset measurement.


```
Client                          Server
  |                               |
  |-------- Request ------------>| T1 (client records)
  |                               | T2 (server records in RxTime)
  |                               |
  |                               | T3 (server records in TxTime)
  |<------- Response ------------|
  | T4 (client records)           |
  |                               |

Network delay (one way) ≈ ((T4-T1) - (T3-T2)) / 2
Offset = ((T2-T1) + (T3-T4)) / 2
```

**Also worth to mention**
Even when the calculation was fixed, I noticed it didn't actually actually check if the time is out of sync. It seemed like it assumed and asked the user how they want to be notified in the future.

**Also**
Migrated from net.DialTimeout to net.Dialer.DialContext 

**Anyways** after these changes it all worked. Just gonna do the pull request now (can't wait to do 10 more fixes because the automated tests are gonna complain

**Sources to confirm:**
https://datatracker.ietf.org/doc/html/rfc5905

GuerrillaNtp https://github.com/robertvazan/guerrillantp
   - RFC4330-compliant SNTP client
   - Provides CorrectionOffset and RoundTripTime
   - Uses all four timestamps: OriginTimestamp, ReceiveTimestamp, TransmitTimestamp, DestinationTimestamp

GuerrillaNtp documentation:
```json
{
  "Response": {
    "OriginateTimestamp": "2023-10-27T10:30:00.0000000Z",  // T1
    "ReceiveTimestamp": "2023-10-27T10:30:00.0100000Z",    // T2
    "TransmitTimestamp": "2023-10-27T10:30:00.0150000Z"    // T3
  },
  "CorrectionOffset": "00:00:00.0051234",  // Calculated using RFC formula
  "RoundTripTime": "00:00:00.0258765"      // (T4-T1) - (T3-T2)
}
```


## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
