### PR TITLE
Currecy/Asset: Environment variable to Ignore enabled currency/asset check/error

### DIFF
--- a/currency/manager_test.go
+++ b/currency/manager_test.go
@@ -71,8 +71,9 @@ func TestGetAssetTypes(t *testing.T) {
 }
 
 func TestIgnoreEnabledCheckBypassPaths(t *testing.T) {
-	// test cannot be parallel due to t.Setenv
+	// test cannot be parallel due to package var
 	p := initTest(t)
+	ignoreEnabledCurrencyAssetCheck = false
 	futuresPair := NewPairWithDelimiter("BTC", "USD", "-")
 	spotPair := NewPairWithDelimiter("LTC", "USD", "-")
 	p.Pairs[asset.Futures].Enabled = nil
@@ -108,7 +109,7 @@ func TestIgnoreEnabledCheckBypassPaths(t *testing.T) {
 	assert.Equal(t, EMPTYPAIR, pair)
 	assert.Equal(t, asset.Empty, a)
 
-	t.Setenv("IGNORE_ENABLED_CHECK", "true")
+	ignoreEnabledCurrencyAssetCheck = true
 
 	assets = p.GetAssetTypes(true)
 	assert.True(t, assets.Contains(asset.Futures))


### PR DESCRIPTION
# PR Description
PRs like #2159 with messages like
> note: It's imperative we remove wrapper impediments for REST calls e.g. if an asset is not enabled but supported. A client should be able to call these functions outside of enabled pairs/assets trading scope for hedging and pricing. This also includes returned websocket stream data.

Make me feel FEELINGS! I think it is totally the wrong direction to take. So rather than change every single wrapper function and every single websocket implementation, I thought this opt-in check would be a better way to address the issue.

Just add environment var `IGNORE_ENABLED_CHECK=true`. It allows processing of non-enabled currencies and assets through wrapper and websocket functions

Fixes # (issue)
- Shazbert

- [x] New feature (non-breaking change which adds functionality)


## How has this been tested
- TestIgnoreEnabledCheckBypassPaths

# Feature on:
Config:
<img width="299" height="132" alt="image" src="https://github.com/user-attachments/assets/d0bffac1-6fea-40cf-b1e7-3c6a557e0d86" />

```
go run . submitorder --exchange="gateio" --asset="margin" --pair="btc-usdt" --side="sell" --type="MARKET" --amount="1"
2026/02/13 09:29:36 rpc error: code = Unknown desc = GateIO unsuccessful HTTP status code: 403 raw response: {"message":"Request API key does not have spot write permission","label":"FORBIDDEN"}
, authenticated request failed
```


```
go run . getticker --exchange="gateio" --asset="margin" --pair="eth-usdt"
{
 "pair": {
  "delimiter": "-",
  "base": "eth",
  "quote": "usdt"
 },
 "last_updated": 1770935492,
 "last": 1928.25,
 "high": 2001.62,
 "low": 1896.71,
 "bid": 1928.25,
 "ask": 1928.26,
 "volume": 105785.5351
}%   
```

# Feature off:

```
go run . submitorder --exchange="gateio" --asset="margin" --pair="btc-usdt" --side="sell" --type="MARKET" --amount="1"
2026/02/13 09:41:23 rpc error: code = Unknown desc = margin asset type not enabled
```

```
go run . getticker --exchange="gateio" --asset="margin" --pair="eth-usdt"
2026/02/13 09:35:56 rpc error: code = Unknown desc = margin asset type not enabled
exit status 1
```

