### PR TITLE
Deribit: add block trade and block RFQ APIs

### DIFF
--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -88,6 +88,17 @@ Refer to the [ADD_NEW_EXCHANGE.md](/docs/ADD_NEW_EXCHANGE.md) document for compr
     }
 ```
 
+- Prefer package-level sentinel errors for validation, parsing, and custom unmarshalling failures that produce deterministic, testable outcomes when callers or tests need stable `errors.Is` matching.
+- When returning additional context for a sentinel error, wrap the sentinel with `fmt.Errorf` and `%w` rather than replacing it with a new inline `errors.New(...)` value.
+
+```go
+    var errInvalidOrderSide = errors.New("invalid order side")
+
+    if side == "" {
+        return fmt.Errorf("%w: empty input", errInvalidOrderSide)
+    }
+```
+
 - Prefer meaningful and specific error messages that identify the operation being performed.
 - Always include enough context in errors to aid in debugging and traceability.
 - Do not use panic; always return and propagate errors cleanly.
@@ -131,6 +142,11 @@ Use `require` and `assert` appropriately:
     // Wrong — f variant used without format verbs:
     assert.ErrorIsf(t, err, errInvalidOrderSize, "validate should return expected error")
 ```
+
+#### Sentinel error coverage
+
+- When returning sentinel errors directly or wrapped, add direct `assert.ErrorIs` or `require.ErrorIs` coverage for that path.
+- For validation and custom unmarshalling helpers, prefer a focused test for the exact sentinel error path rather than relying only on indirect endpoint coverage.
 
 ### Test Coverage
 

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2588,7 +2588,7 @@ func validateBlockRFQTradeAllocations(tradeAllocations []BlockRFQTradeAllocation
 
 func validateBlockRFQHedge(hedge *BlockRFQHedgeLeg) (*BlockRFQHedgeLeg, error) {
 	if hedge == nil {
-		return nil, nil
+		return nil, common.ErrNilPointer
 	}
 	checkedHedge := *hedge
 	if checkedHedge.InstrumentName == "" {
@@ -2630,9 +2630,12 @@ func (e *Exchange) CreateBlockRFQ(ctx context.Context, req *CreateBlockRFQReques
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	params := url.Values{}
 	err = setJSONParam(params, "legs", checkedLegs)
@@ -2683,9 +2686,12 @@ func (e *Exchange) AddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuoteRe
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if req.Amount < 0 {
 		return nil, errInvalidAmount
@@ -2741,9 +2747,12 @@ func (e *Exchange) EditBlockRFQQuote(ctx context.Context, req *EditBlockRFQQuote
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if req.Amount < 0 {
 		return nil, errInvalidAmount
@@ -2859,9 +2868,12 @@ func (e *Exchange) AcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQReques
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	params := url.Values{}
 	params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -159,15 +159,6 @@ const (
 	getCombos       = "public/get_combos"
 	createCombos    = "private/create_combo"
 
-	// Block Trades Endpoints
-	executeBlockTrades             = "private/execute_block_trade"
-	getBlockTrades                 = "private/get_block_trade"
-	getLastBlockTradesByCurrency   = "private/get_last_block_trades_by_currency"
-	invalidateBlockTradesSignature = "private/invalidate_block_trade_signature"
-	movePositions                  = "private/move_positions"
-	simulateBlockPosition          = "private/simulate_block_trade"
-	verifyBlockTrades              = "private/verify_block_trade"
-
 	// roles
 
 	roleMaker = "maker"
@@ -2319,7 +2310,7 @@ func (e *Exchange) ExecuteBlockTrade(ctx context.Context, timestampMS time.Time,
 	params.Set("counterparty_signature", signature)
 	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
 	var resp []BlockTradeResponse
-	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, executeBlockTrades, params, &resp)
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/execute_block_trade", params, &resp)
 }
 
 // VerifyBlockTrade verifies and creates block trade signature
@@ -2366,7 +2357,7 @@ func (e *Exchange) VerifyBlockTrade(ctx context.Context, timestampMS time.Time, 
 	resp := &struct {
 		Signature string `json:"signature"`
 	}{}
-	return resp.Signature, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, verifyBlockTrades, params, resp)
+	return resp.Signature, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/verify_block_trade", params, resp)
 }
 
 // InvalidateBlockTradeSignature user at any time (before the private/execute_block_trade is called) can invalidate its own signature effectively cancelling block trade
@@ -2377,7 +2368,7 @@ func (e *Exchange) InvalidateBlockTradeSignature(ctx context.Context, signature 
 	params := url.Values{}
 	params.Set("signature", signature)
 	var resp string
-	err := e.SendHTTPAuthRequest(ctx, exchange.RestSpot, nonMatchingEPL, http.MethodGet, invalidateBlockTradesSignature, params, &resp)
+	err := e.SendHTTPAuthRequest(ctx, exchange.RestSpot, blockTradeWriteEPL, http.MethodGet, "private/invalidate_block_trade_signature", params, &resp)
 	if err != nil {
 		return err
 	}
@@ -2395,7 +2386,580 @@ func (e *Exchange) GetUserBlockTrade(ctx context.Context, id string) ([]BlockTra
 	params := url.Values{}
 	params.Set("id", id)
 	var resp []BlockTradeData
-	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, nonMatchingEPL, http.MethodGet, getBlockTrades, params, &resp)
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_block_trade", params, &resp)
+}
+
+// GetBlockTradeRequests provides a list of block trade requests including pending approvals, declined trades, and expired trades.
+func (e *Exchange) GetBlockTradeRequests(ctx context.Context, brokerCode string) ([]PendingBlockTradeData, error) {
+	params := url.Values{}
+	if brokerCode != "" {
+		params.Set("broker_code", brokerCode)
+	}
+	var resp []PendingBlockTradeData
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_block_trade_requests", params, &resp)
+}
+
+// ApproveBlockTrade approves a pending block trade.
+func (e *Exchange) ApproveBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string) error {
+	if tradeNonce == "" {
+		return errMissingNonce
+	}
+	if timestampMS.IsZero() {
+		return errZeroTimestamp
+	}
+	if role != roleMaker && role != roleTaker {
+		return errInvalidTradeRole
+	}
+	params := url.Values{}
+	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
+	params.Set("nonce", tradeNonce)
+	params.Set("role", role)
+	var resp string
+	err := e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeWriteEPL, http.MethodGet, "private/approve_block_trade", params, &resp)
+	if err != nil {
+		return err
+	}
+	if resp != "ok" {
+		return fmt.Errorf("server response: %s", resp)
+	}
+	return nil
+}
+
+// RejectBlockTrade rejects a pending block trade.
+func (e *Exchange) RejectBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string) error {
+	if tradeNonce == "" {
+		return errMissingNonce
+	}
+	if timestampMS.IsZero() {
+		return errZeroTimestamp
+	}
+	if role != roleMaker && role != roleTaker {
+		return errInvalidTradeRole
+	}
+	params := url.Values{}
+	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
+	params.Set("nonce", tradeNonce)
+	params.Set("role", role)
+	var resp string
+	err := e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeWriteEPL, http.MethodGet, "private/reject_block_trade", params, &resp)
+	if err != nil {
+		return err
+	}
+	if resp != "ok" {
+		return fmt.Errorf("server response: %s", resp)
+	}
+	return nil
+}
+
+// GetBlockTrades returns list of users block trades.
+func (e *Exchange) GetBlockTrades(ctx context.Context, req *GetBlockTradesRequest) ([]BlockTradeCollection, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	params := url.Values{}
+	if !req.Currency.IsEmpty() {
+		params.Set("currency", req.Currency.String())
+	}
+	if req.StartID != "" {
+		params.Set("start_id", req.StartID)
+	}
+	if req.EndID != "" {
+		params.Set("end_id", req.EndID)
+	}
+	if req.Count > 0 {
+		params.Set("count", strconv.FormatUint(req.Count, 10))
+	}
+	if req.BlockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))
+	}
+	if req.BrokerCode != "" {
+		params.Set("broker_code", req.BrokerCode)
+	}
+	var resp []BlockTradeCollection
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_block_trades", params, &resp)
+}
+
+// GetBrokerTradeRequests retrieves broker trade requests including pending, declined, and expired.
+func (e *Exchange) GetBrokerTradeRequests(ctx context.Context) ([]BrokerTradeRequestItem, error) {
+	var resp []BrokerTradeRequestItem
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_broker_trade_requests", url.Values{}, &resp)
+}
+
+// GetBrokerTrades retrieves broker trade history.
+func (e *Exchange) GetBrokerTrades(ctx context.Context, req *GetBrokerTradesRequest) (*BrokerTradeHistoryResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	params := url.Values{}
+	if !req.Currency.IsEmpty() {
+		params.Set("currency", req.Currency.String())
+	}
+	if req.Count > 0 {
+		params.Set("count", strconv.FormatUint(req.Count, 10))
+	}
+	if req.StartID != "" {
+		params.Set("start_id", req.StartID)
+	}
+	if req.EndID != "" {
+		params.Set("end_id", req.EndID)
+	}
+	var resp *BrokerTradeHistoryResponse
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_broker_trades", params, &resp)
+}
+
+func validateBlockRFQDirection(direction string) (string, error) {
+	if direction == "" {
+		return "", nil
+	}
+	normalisedDirection := strings.ToLower(direction)
+	if normalisedDirection != sideBUY && normalisedDirection != sideSELL {
+		return "", errInvalidOrderSideOrDirection
+	}
+	return normalisedDirection, nil
+}
+
+func validateBlockRFQLegs(legs []BlockRFQLeg, required bool) ([]BlockRFQLeg, error) {
+	if len(legs) == 0 {
+		if required {
+			return nil, errNoArgumentPassed
+		}
+		return nil, nil
+	}
+	checkedLegs := make([]BlockRFQLeg, len(legs))
+	copy(checkedLegs, legs)
+	for i := range checkedLegs {
+		if checkedLegs[i].InstrumentName == "" {
+			return nil, fmt.Errorf("%w, empty string", errInvalidInstrumentName)
+		}
+		if checkedLegs[i].Ratio <= 0 {
+			return nil, errInvalidAmount
+		}
+		normalisedDirection, err := validateBlockRFQDirection(checkedLegs[i].Direction)
+		if err != nil {
+			return nil, err
+		}
+		checkedLegs[i].Direction = normalisedDirection
+		if checkedLegs[i].Price < 0 {
+			return nil, fmt.Errorf("%w, leg price can't be negative", errInvalidPrice)
+		}
+	}
+	return checkedLegs, nil
+}
+
+func validateCreateBlockRFQLegs(legs []CreateBlockRFQLeg) ([]CreateBlockRFQLeg, error) {
+	if len(legs) == 0 {
+		return nil, errNoArgumentPassed
+	}
+	checkedLegs := make([]CreateBlockRFQLeg, len(legs))
+	copy(checkedLegs, legs)
+	for i := range checkedLegs {
+		if checkedLegs[i].InstrumentName == "" {
+			return nil, fmt.Errorf("%w, empty string", errInvalidInstrumentName)
+		}
+		if checkedLegs[i].Amount <= 0 {
+			return nil, errInvalidAmount
+		}
+		normalisedDirection, err := validateBlockRFQDirection(checkedLegs[i].Direction)
+		if err != nil {
+			return nil, err
+		}
+		checkedLegs[i].Direction = normalisedDirection
+	}
+	return checkedLegs, nil
+}
+
+func validateBlockRFQTradeAllocations(tradeAllocations []BlockRFQTradeAllocation) error {
+	for i := range tradeAllocations {
+		hasUserID := tradeAllocations[i].UserID != 0
+		hasClientInfo := tradeAllocations[i].ClientInfo != nil && (tradeAllocations[i].ClientInfo.ClientID != 0 || tradeAllocations[i].ClientInfo.ClientLinkID != 0)
+		if !hasUserID && !hasClientInfo {
+			return errUserIDOrClientInfoRequired
+		}
+		if tradeAllocations[i].Amount <= 0 {
+			return errInvalidAmount
+		}
+	}
+	return nil
+}
+
+func validateBlockRFQHedge(hedge *BlockRFQHedgeLeg) (*BlockRFQHedgeLeg, error) {
+	if hedge == nil {
+		return nil, nil
+	}
+	checkedHedge := *hedge
+	if checkedHedge.InstrumentName == "" {
+		return nil, fmt.Errorf("%w, empty string", errInvalidInstrumentName)
+	}
+	normalisedDirection, err := validateBlockRFQDirection(checkedHedge.Direction)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge.Direction = normalisedDirection
+	if checkedHedge.Amount <= 0 {
+		return nil, errInvalidAmount
+	}
+	if checkedHedge.Price < 0 {
+		return nil, fmt.Errorf("%w, hedge price can't be negative", errInvalidPrice)
+	}
+	return &checkedHedge, nil
+}
+
+func setJSONParam(params url.Values, key string, value any) error {
+	encodedValue, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	params.Set(key, string(encodedValue))
+	return nil
+}
+
+// CreateBlockRFQ creates a new block RFQ.
+func (e *Exchange) CreateBlockRFQ(ctx context.Context, req *CreateBlockRFQRequest) (*BlockRFQData, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	checkedLegs, err := validateCreateBlockRFQLegs(req.Legs)
+	if err != nil {
+		return nil, err
+	}
+	err = validateBlockRFQTradeAllocations(req.TradeAllocations)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	params := url.Values{}
+	err = setJSONParam(params, "legs", checkedLegs)
+	if err != nil {
+		return nil, err
+	}
+	if len(req.Makers) > 0 {
+		err = setJSONParam(params, "makers", req.Makers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(req.TradeAllocations) > 0 {
+		err = setJSONParam(params, "trade_allocations", req.TradeAllocations)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if checkedHedge != nil {
+		err = setJSONParam(params, "hedge", checkedHedge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if req.Label != "" {
+		params.Set("label", req.Label)
+	}
+	if req.Disclosed {
+		params.Set("disclosed", "true")
+	}
+	var resp *BlockRFQData
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQWriteEPL, http.MethodGet, "private/create_block_rfq", params, &resp)
+}
+
+// AddBlockRFQQuote adds a quote for an existing block RFQ.
+func (e *Exchange) AddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuoteRequest) (*BlockRFQQuote, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
+	if err != nil {
+		return nil, err
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	params := url.Values{}
+	params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))
+	if req.Amount > 0 {
+		params.Set("amount", strconv.FormatFloat(req.Amount, 'f', -1, 64))
+	}
+	if req.Price > 0 {
+		params.Set("price", strconv.FormatFloat(req.Price, 'f', -1, 64))
+	}
+	if normalisedDirection != "" {
+		params.Set("direction", normalisedDirection)
+	}
+	if req.ExecutionInstruction != "" {
+		params.Set("execution_instruction", req.ExecutionInstruction)
+	}
+	if !req.ExpiresAt.IsZero() {
+		params.Set("expires_at", strconv.FormatInt(req.ExpiresAt.UnixMilli(), 10))
+	}
+	if len(checkedLegs) > 0 {
+		err = setJSONParam(params, "legs", checkedLegs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if checkedHedge != nil {
+		err = setJSONParam(params, "hedge", checkedHedge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if req.Label != "" {
+		params.Set("label", req.Label)
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/add_block_rfq_quote", params, &resp)
+}
+
+// EditBlockRFQQuote edits an existing block RFQ quote.
+func (e *Exchange) EditBlockRFQQuote(ctx context.Context, req *EditBlockRFQQuoteRequest) (*BlockRFQQuote, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQQuoteID <= 0 && (req.BlockRFQID <= 0 || req.Label == "") {
+		return nil, errMissingBlockRFQQuoteIdentifier
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	params := url.Values{}
+	if req.BlockRFQQuoteID > 0 {
+		params.Set("block_rfq_quote_id", strconv.FormatUint(req.BlockRFQQuoteID, 10))
+	}
+	if req.BlockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))
+	}
+	if req.Amount > 0 {
+		params.Set("amount", strconv.FormatFloat(req.Amount, 'f', -1, 64))
+	}
+	if req.Price > 0 {
+		params.Set("price", strconv.FormatFloat(req.Price, 'f', -1, 64))
+	}
+	if len(checkedLegs) > 0 {
+		err = setJSONParam(params, "legs", checkedLegs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if checkedHedge != nil {
+		err = setJSONParam(params, "hedge", checkedHedge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if req.Label != "" {
+		params.Set("label", req.Label)
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/edit_block_rfq_quote", params, &resp)
+}
+
+// CancelBlockRFQQuote cancels an existing block RFQ quote.
+func (e *Exchange) CancelBlockRFQQuote(ctx context.Context, blockRFQQuoteID, blockRFQID uint64, label string) (*BlockRFQQuote, error) {
+	if blockRFQQuoteID <= 0 && (blockRFQID <= 0 || label == "") {
+		return nil, errMissingBlockRFQQuoteIdentifier
+	}
+	params := url.Values{}
+	if blockRFQQuoteID > 0 {
+		params.Set("block_rfq_quote_id", strconv.FormatUint(blockRFQQuoteID, 10))
+	}
+	if blockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(blockRFQID, 10))
+	}
+	if label != "" {
+		params.Set("label", label)
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/cancel_block_rfq_quote", params, &resp)
+}
+
+// CancelAllBlockRFQQuotes cancels all block RFQ quotes created by the current account.
+func (e *Exchange) CancelAllBlockRFQQuotes(ctx context.Context, blockRFQID uint64, detailed bool) (*BlockRFQQuoteCancelResponse, error) {
+	params := url.Values{}
+	if blockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(blockRFQID, 10))
+	}
+	if detailed {
+		params.Set("detailed", "true")
+	}
+	var resp *BlockRFQQuoteCancelResponse
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/cancel_all_block_rfq_quotes", params, &resp)
+}
+
+// CancelBlockRFQ cancels a block RFQ.
+func (e *Exchange) CancelBlockRFQ(ctx context.Context, blockRFQID uint64) (*BlockRFQData, error) {
+	if blockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	params := url.Values{}
+	params.Set("block_rfq_id", strconv.FormatUint(blockRFQID, 10))
+	var resp *BlockRFQData
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQWriteEPL, http.MethodGet, "private/cancel_block_rfq", params, &resp)
+}
+
+// CancelBlockRFQTrigger cancels a trigger attached to a block RFQ.
+func (e *Exchange) CancelBlockRFQTrigger(ctx context.Context, blockRFQID uint64) (*BlockRFQData, error) {
+	if blockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	params := url.Values{}
+	params.Set("block_rfq_id", strconv.FormatUint(blockRFQID, 10))
+	var resp *BlockRFQData
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQWriteEPL, http.MethodGet, "private/cancel_block_rfq_trigger", params, &resp)
+}
+
+// AcceptBlockRFQ accepts an existing block RFQ.
+func (e *Exchange) AcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQRequest) (*BlockRFQAcceptResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
+	if err != nil {
+		return nil, err
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	params := url.Values{}
+	params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))
+	if req.Price > 0 {
+		params.Set("price", strconv.FormatFloat(req.Price, 'f', -1, 64))
+	}
+	if req.Amount > 0 {
+		params.Set("amount", strconv.FormatFloat(req.Amount, 'f', -1, 64))
+	}
+	if normalisedDirection != "" {
+		params.Set("direction", normalisedDirection)
+	}
+	if checkedHedge != nil {
+		err = setJSONParam(params, "hedge", checkedHedge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(checkedLegs) > 0 {
+		err = setJSONParam(params, "legs", checkedLegs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if req.TimeInForce != "" {
+		params.Set("time_in_force", req.TimeInForce)
+	}
+	var resp *BlockRFQAcceptResponse
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQWriteEPL, http.MethodGet, "private/accept_block_rfq", params, &resp)
+}
+
+// GetBlockRFQs returns a list of Block RFQs that were either created by the user or assigned to them as a maker.
+func (e *Exchange) GetBlockRFQs(ctx context.Context, req *GetBlockRFQsRequest) (*BlockRFQListResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	params := url.Values{}
+	if !req.Currency.IsEmpty() {
+		params.Set("currency", req.Currency.String())
+	}
+	if req.Count > 0 {
+		params.Set("count", strconv.FormatUint(req.Count, 10))
+	}
+	if req.State != "" {
+		params.Set("state", req.State)
+	}
+	if req.Role != "" {
+		params.Set("role", req.Role)
+	}
+	if req.Continuation != "" {
+		params.Set("continuation", req.Continuation)
+	}
+	if req.BlockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(req.BlockRFQID, 10))
+	}
+	var resp *BlockRFQListResponse
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQReadEPL, http.MethodGet, "private/get_block_rfqs", params, &resp)
+}
+
+// GetBlockRFQQuotes retrieves open quotes for Block RFQs.
+func (e *Exchange) GetBlockRFQQuotes(ctx context.Context, blockRFQID, blockRFQQuoteID uint64, label string) ([]BlockRFQQuote, error) {
+	params := url.Values{}
+	if blockRFQID > 0 {
+		params.Set("block_rfq_id", strconv.FormatUint(blockRFQID, 10))
+	}
+	if blockRFQQuoteID > 0 {
+		params.Set("block_rfq_quote_id", strconv.FormatUint(blockRFQQuoteID, 10))
+	}
+	if label != "" {
+		params.Set("label", label)
+	}
+	var resp []BlockRFQQuote
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQReadEPL, http.MethodGet, "private/get_block_rfq_quotes", params, &resp)
+}
+
+// GetBlockRFQMakers returns a list of all available Block RFQ makers.
+func (e *Exchange) GetBlockRFQMakers(ctx context.Context) ([]string, error) {
+	var resp []string
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQReadEPL, http.MethodGet, "private/get_block_rfq_makers", url.Values{}, &resp)
+}
+
+// GetBlockRFQUserInfo returns identity and rating information for the requesting account and subaccounts.
+func (e *Exchange) GetBlockRFQUserInfo(ctx context.Context) (*BlockRFQUserInfoResponse, error) {
+	var resp *BlockRFQUserInfoResponse
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockRFQReadEPL, http.MethodGet, "private/get_block_rfq_user_info", url.Values{}, &resp)
+}
+
+// GetBlockRFQTrades returns a list of recent Block RFQ trades.
+func (e *Exchange) GetBlockRFQTrades(ctx context.Context, ccy currency.Code, continuation string, count uint64) (*BlockRFQTradeTapeResponse, error) {
+	if ccy.IsEmpty() {
+		return nil, currency.ErrCurrencyCodeEmpty
+	}
+	params := url.Values{}
+	params.Set("currency", ccy.String())
+	if continuation != "" {
+		params.Set("continuation", continuation)
+	}
+	if count > 0 {
+		params.Set("count", strconv.FormatUint(count, 10))
+	}
+	var resp *BlockRFQTradeTapeResponse
+	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, blockRFQReadEPL, common.EncodeURLValues("public/get_block_rfq_trades", params), &resp)
 }
 
 // GetTime retrieves the current time (in milliseconds). This API endpoint can be used to check the clock skew between your software and Deribit's systems.
@@ -2424,7 +2988,7 @@ func (e *Exchange) GetLastBlockTradesByCurrency(ctx context.Context, ccy currenc
 		params.Set("count", strconv.FormatInt(count, 10))
 	}
 	var resp []BlockTradeData
-	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, nonMatchingEPL, http.MethodGet, getLastBlockTradesByCurrency, params, &resp)
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_last_block_trades_by_currency", params, &resp)
 }
 
 // MovePositions moves positions from source subaccount to target subaccount
@@ -2459,7 +3023,7 @@ func (e *Exchange) MovePositions(ctx context.Context, ccy currency.Code, sourceS
 	params.Set("target_uid", strconv.FormatInt(targetSubAccountUID, 10))
 	params.Set("trades", string(values))
 	var resp []BlockTradeMoveResponse
-	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, nonMatchingEPL, http.MethodGet, movePositions, params, &resp)
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/move_positions", params, &resp)
 }
 
 // SimulateBlockTrade checks if a block trade can be executed
@@ -2493,7 +3057,7 @@ func (e *Exchange) SimulateBlockTrade(ctx context.Context, role string, trades [
 	params.Set("role", role)
 	params.Set("trades", string(values))
 	var resp bool
-	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, simulateBlockPosition, params, &resp)
+	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/simulate_block_trade", params, &resp)
 }
 
 // GetLockedStatus retrieves information about locked currencies

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2267,7 +2267,7 @@ func (e *Exchange) CreateCombo(ctx context.Context, args []ComboParam) (*ComboDe
 // ExecuteBlockTrade executes a block trade request
 // The whole request have to be exact the same as in private/verify_block_trade, only role field should be set appropriately - it basically means that both sides have to agree on the same timestamp, nonce, trades fields and server will assure that role field is different between sides (each party accepted own role).
 // Using the same timestamp and nonce by both sides in private/verify_block_trade assures that even if unintentionally both sides execute given block trade with valid counterparty_signature, the given block trade will be executed only once
-func (e *Exchange) ExecuteBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string, ccy currency.Code, trades []BlockTradeParam) ([]BlockTradeResponse, error) {
+func (e *Exchange) ExecuteBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string, ccy currency.Code, trades []BlockTradeParam) (*ExecutedBlockTradeCollection, error) {
 	if tradeNonce == "" {
 		return nil, errMissingNonce
 	}
@@ -2309,7 +2309,7 @@ func (e *Exchange) ExecuteBlockTrade(ctx context.Context, timestampMS time.Time,
 	params.Set("role", role)
 	params.Set("counterparty_signature", signature)
 	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
-	var resp []BlockTradeResponse
+	var resp *ExecutedBlockTradeCollection
 	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, matchingEPL, http.MethodGet, "private/execute_block_trade", params, &resp)
 }
 
@@ -2379,13 +2379,13 @@ func (e *Exchange) InvalidateBlockTradeSignature(ctx context.Context, signature 
 }
 
 // GetUserBlockTrade returns information about users block trade
-func (e *Exchange) GetUserBlockTrade(ctx context.Context, id string) ([]BlockTradeData, error) {
+func (e *Exchange) GetUserBlockTrade(ctx context.Context, id string) (*BlockTradeCollection, error) {
 	if id == "" {
 		return nil, errMissingBlockTradeID
 	}
 	params := url.Values{}
 	params.Set("id", id)
-	var resp []BlockTradeData
+	var resp *BlockTradeCollection
 	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_block_trade", params, &resp)
 }
 

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2399,8 +2399,7 @@ func (e *Exchange) GetBlockTradeRequests(ctx context.Context, brokerCode string)
 	return resp, e.SendHTTPAuthRequest(ctx, exchange.RestFutures, blockTradeReadEPL, http.MethodGet, "private/get_block_trade_requests", params, &resp)
 }
 
-// ApproveBlockTrade approves a pending block trade.
-func (e *Exchange) ApproveBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string) error {
+func validatePendingBlockTradeAction(timestampMS time.Time, tradeNonce, role string) error {
 	if tradeNonce == "" {
 		return errMissingNonce
 	}
@@ -2409,6 +2408,14 @@ func (e *Exchange) ApproveBlockTrade(ctx context.Context, timestampMS time.Time,
 	}
 	if role != roleMaker && role != roleTaker {
 		return errInvalidTradeRole
+	}
+	return nil
+}
+
+// ApproveBlockTrade approves a pending block trade.
+func (e *Exchange) ApproveBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string) error {
+	if err := validatePendingBlockTradeAction(timestampMS, tradeNonce, role); err != nil {
+		return err
 	}
 	params := url.Values{}
 	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
@@ -2427,14 +2434,8 @@ func (e *Exchange) ApproveBlockTrade(ctx context.Context, timestampMS time.Time,
 
 // RejectBlockTrade rejects a pending block trade.
 func (e *Exchange) RejectBlockTrade(ctx context.Context, timestampMS time.Time, tradeNonce, role string) error {
-	if tradeNonce == "" {
-		return errMissingNonce
-	}
-	if timestampMS.IsZero() {
-		return errZeroTimestamp
-	}
-	if role != roleMaker && role != roleTaker {
-		return errInvalidTradeRole
+	if err := validatePendingBlockTradeAction(timestampMS, tradeNonce, role); err != nil {
+		return err
 	}
 	params := url.Values{}
 	params.Set("timestamp", strconv.FormatInt(timestampMS.UnixMilli(), 10))
@@ -2558,6 +2559,9 @@ func validateCreateBlockRFQLegs(legs []CreateBlockRFQLeg) ([]CreateBlockRFQLeg, 
 		}
 		if checkedLegs[i].Amount <= 0 {
 			return nil, errInvalidAmount
+		}
+		if checkedLegs[i].Direction == "" {
+			return nil, errInvalidOrderSideOrDirection
 		}
 		normalisedDirection, err := validateBlockRFQDirection(checkedLegs[i].Direction)
 		if err != nil {

--- a/exchanges/deribit/deribit.go
+++ b/exchanges/deribit/deribit.go
@@ -2510,7 +2510,7 @@ func (e *Exchange) GetBrokerTrades(ctx context.Context, req *GetBrokerTradesRequ
 
 func validateBlockRFQDirection(direction string) (string, error) {
 	if direction == "" {
-		return "", nil
+		return "", errInvalidOrderSideOrDirection
 	}
 	normalisedDirection := strings.ToLower(direction)
 	if normalisedDirection != sideBUY && normalisedDirection != sideSELL {
@@ -2534,6 +2534,9 @@ func validateBlockRFQLegs(legs []BlockRFQLeg, required bool) ([]BlockRFQLeg, err
 		}
 		if checkedLegs[i].Ratio <= 0 {
 			return nil, errInvalidAmount
+		}
+		if checkedLegs[i].Direction == "" {
+			return nil, errInvalidOrderSideOrDirection
 		}
 		normalisedDirection, err := validateBlockRFQDirection(checkedLegs[i].Direction)
 		if err != nil {
@@ -2593,6 +2596,9 @@ func validateBlockRFQHedge(hedge *BlockRFQHedgeLeg) (*BlockRFQHedgeLeg, error) {
 	checkedHedge := *hedge
 	if checkedHedge.InstrumentName == "" {
 		return nil, fmt.Errorf("%w, empty string", errInvalidInstrumentName)
+	}
+	if checkedHedge.Direction == "" {
+		return nil, errInvalidOrderSideOrDirection
 	}
 	normalisedDirection, err := validateBlockRFQDirection(checkedHedge.Direction)
 	if err != nil {
@@ -2678,9 +2684,13 @@ func (e *Exchange) AddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuoteRe
 	if req.BlockRFQID <= 0 {
 		return nil, errMissingBlockRFQID
 	}
-	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
-	if err != nil {
-		return nil, err
+	var normalisedDirection string
+	if req.Direction != "" {
+		validatedDirection, err := validateBlockRFQDirection(req.Direction)
+		if err != nil {
+			return nil, err
+		}
+		normalisedDirection = validatedDirection
 	}
 	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
 	if err != nil {
@@ -2860,9 +2870,13 @@ func (e *Exchange) AcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQReques
 	if req.Price < 0 {
 		return nil, errInvalidPrice
 	}
-	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
-	if err != nil {
-		return nil, err
+	var normalisedDirection string
+	if req.Direction != "" {
+		validatedDirection, err := validateBlockRFQDirection(req.Direction)
+		if err != nil {
+			return nil, err
+		}
+		normalisedDirection = validatedDirection
 	}
 	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
 	if err != nil {

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3424,6 +3424,22 @@ func TestBlockRFQQuoteCancelResponseUnmarshalQuotes(t *testing.T) {
 	require.Equal(t, uint64(21), response.Quotes[0].BlockRFQID)
 }
 
+func TestBlockRFQQuoteCancelResponseUnmarshalEmpty(t *testing.T) {
+	t.Parallel()
+	var response BlockRFQQuoteCancelResponse
+	err := response.UnmarshalJSON([]byte(" \t\n"))
+	require.ErrorIs(t, err, errEmptyBlockRFQQuoteCancelResponse)
+	assert.ErrorContains(t, err, "\" \\t\\n\"")
+}
+
+func TestBrokerTradeUserIDUnmarshalError(t *testing.T) {
+	t.Parallel()
+	var userID BrokerTradeUserID
+	err := json.Unmarshal([]byte(`{}`), &userID)
+	require.ErrorIs(t, err, errInvalidBrokerTradeUserID)
+	assert.ErrorContains(t, err, "\"{}\"")
+}
+
 func TestCreateBlockRFQ(t *testing.T) {
 	t.Parallel()
 	_, err := e.CreateBlockRFQ(t.Context(), nil)
@@ -3500,9 +3516,8 @@ func TestEditBlockRFQQuote(t *testing.T) {
 	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
 	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1, Amount: 1, Price: -1})
 	require.ErrorIs(t, err, errInvalidPrice)
-	// Identify via block_rfq_id + label instead of quote ID
 	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQID: 1, Label: "test", Amount: -1})
-	require.ErrorIs(t, err, errInvalidAmount)
+	require.ErrorIs(t, err, errInvalidAmount, "request must support identification via block_rfq_id + label without quote ID")
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1 << 62, Amount: 1, Price: 10, Label: "gct-block-rfq-quote"})
@@ -3517,9 +3532,8 @@ func TestWSEditBlockRFQQuote(t *testing.T) {
 	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
 	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1, Amount: 1, Price: -1})
 	require.ErrorIs(t, err, errInvalidPrice)
-	// Identify via block_rfq_id + label instead of quote ID
 	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQID: 1, Label: "test", Amount: -1})
-	require.ErrorIs(t, err, errInvalidAmount)
+	require.ErrorIs(t, err, errInvalidAmount, "request must support identification via block_rfq_id + label without quote ID")
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1 << 62, Amount: 1, Price: 10, Label: "gct-block-rfq-quote"})

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3268,11 +3268,10 @@ func TestBlockRFQDataTakerRatingUnmarshal(t *testing.T) {
 func TestValidateBlockRFQDirection(t *testing.T) {
 	t.Parallel()
 
-	normalisedDirection, err := validateBlockRFQDirection("")
-	require.NoError(t, err)
-	assert.Empty(t, normalisedDirection)
+	_, err := validateBlockRFQDirection("")
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
 
-	normalisedDirection, err = validateBlockRFQDirection(strings.ToUpper(sideBUY))
+	normalisedDirection, err := validateBlockRFQDirection(strings.ToUpper(sideBUY))
 	require.NoError(t, err)
 	assert.Equal(t, sideBUY, normalisedDirection)
 
@@ -3303,6 +3302,9 @@ func TestValidateBlockRFQLegs(t *testing.T) {
 
 	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 0, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: 10}}, true)
 	require.ErrorIs(t, err, errInvalidAmount)
+
+	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Price: 10}}, true)
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
 
 	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: "sideways", Price: 10}}, true)
 	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
@@ -3376,6 +3378,9 @@ func TestValidateBlockRFQHedge(t *testing.T) {
 
 	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, Direction: sideBUY, Price: 10})
 	require.ErrorIs(t, err, errInvalidInstrumentName)
+
+	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Price: 10})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
 
 	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Direction: "sideways", Price: 10})
 	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
@@ -3489,6 +3494,8 @@ func TestAddBlockRFQQuote(t *testing.T) {
 	require.ErrorIs(t, err, errInvalidAmount)
 	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: 10, Direction: "sideways"})
 	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
 	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1, Direction: order.Buy.Lower()})
 	require.ErrorIs(t, err, errInvalidPrice)
 
@@ -3507,6 +3514,8 @@ func TestWSAddBlockRFQQuote(t *testing.T) {
 	require.ErrorIs(t, err, errInvalidAmount)
 	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: 10, Direction: "sideways"})
 	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
 	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1, Direction: order.Buy.Lower()})
 	require.ErrorIs(t, err, errInvalidPrice)
 

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3431,6 +3431,14 @@ func TestBlockRFQQuoteCancelResponseUnmarshalEmpty(t *testing.T) {
 	assert.ErrorContains(t, err, "\" \\t\\n\"")
 }
 
+func TestBlockRFQQuoteCancelResponseUnmarshalInvalid(t *testing.T) {
+	t.Parallel()
+	var response BlockRFQQuoteCancelResponse
+	err := json.Unmarshal([]byte(`{"unexpected":true}`), &response)
+	require.ErrorIs(t, err, errInvalidBlockRFQQuoteCancelResponse)
+	assert.ErrorContains(t, err, `"{\"unexpected\":true}"`)
+}
+
 func TestBrokerTradeUserIDUnmarshalError(t *testing.T) {
 	t.Parallel()
 	var userID BrokerTradeUserID

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3033,6 +3033,670 @@ func TestWSRetrieveUserBlockTrade(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+func TestGetBlockTradeRequests(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	result, err := e.GetBlockTradeRequests(t.Context(), "")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestWSRetrieveBlockTradeRequests(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	result, err := e.WSRetrieveBlockTradeRequests(t.Context(), "")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestApproveBlockTrade(t *testing.T) {
+	t.Parallel()
+	err := e.ApproveBlockTrade(t.Context(), time.Now(), "", roleMaker)
+	require.ErrorIs(t, err, errMissingNonce)
+	err = e.ApproveBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
+	require.ErrorIs(t, err, errZeroTimestamp)
+	err = e.ApproveBlockTrade(t.Context(), time.Now(), "nonce", "")
+	require.ErrorIs(t, err, errInvalidTradeRole)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	err = e.ApproveBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
+	assert.NoError(t, err)
+}
+
+func TestWSApproveBlockTrade(t *testing.T) {
+	t.Parallel()
+	err := e.WSApproveBlockTrade(t.Context(), time.Now(), "", roleMaker)
+	require.ErrorIs(t, err, errMissingNonce)
+	err = e.WSApproveBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
+	require.ErrorIs(t, err, errZeroTimestamp)
+	err = e.WSApproveBlockTrade(t.Context(), time.Now(), "nonce", "")
+	require.ErrorIs(t, err, errInvalidTradeRole)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	err = e.WSApproveBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
+	assert.NoError(t, err)
+}
+
+func TestRejectBlockTrade(t *testing.T) {
+	t.Parallel()
+	err := e.RejectBlockTrade(t.Context(), time.Now(), "", roleMaker)
+	require.ErrorIs(t, err, errMissingNonce)
+	err = e.RejectBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
+	require.ErrorIs(t, err, errZeroTimestamp)
+	err = e.RejectBlockTrade(t.Context(), time.Now(), "nonce", "")
+	require.ErrorIs(t, err, errInvalidTradeRole)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	err = e.RejectBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
+	assert.NoError(t, err)
+}
+
+func TestWSRejectBlockTrade(t *testing.T) {
+	t.Parallel()
+	err := e.WSRejectBlockTrade(t.Context(), time.Now(), "", roleMaker)
+	require.ErrorIs(t, err, errMissingNonce)
+	err = e.WSRejectBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
+	require.ErrorIs(t, err, errZeroTimestamp)
+	err = e.WSRejectBlockTrade(t.Context(), time.Now(), "nonce", "")
+	require.ErrorIs(t, err, errInvalidTradeRole)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	err = e.WSRejectBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
+	assert.NoError(t, err)
+}
+
+func TestGetBlockTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.GetBlockTrades(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	result, err := e.GetBlockTrades(t.Context(), &GetBlockTradesRequest{Count: 5})
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestWSRetrieveBlockTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSRetrieveBlockTrades(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	result, err := e.WSRetrieveBlockTrades(t.Context(), &GetBlockTradesRequest{Count: 5})
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestGetBrokerTradeRequests(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.GetBrokerTradeRequests(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBrokerTradeRequests(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.WSRetrieveBrokerTradeRequests(t.Context())
+	require.NoError(t, err)
+}
+
+func TestGetBrokerTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.GetBrokerTrades(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err = e.GetBrokerTrades(t.Context(), &GetBrokerTradesRequest{Count: 5})
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBrokerTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSRetrieveBrokerTrades(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err = e.WSRetrieveBrokerTrades(t.Context(), &GetBrokerTradesRequest{Count: 5})
+	require.NoError(t, err)
+}
+
+func TestBrokerTradeRequestItemUnmarshal(t *testing.T) {
+	t.Parallel()
+	const payload = `[
+		{
+			"timestamp": 1700000000000,
+			"state": "pending",
+			"trades": [{"amount": 10, "direction": "buy", "price": 50000, "instrument_name": "BTC-PERPETUAL"}],
+			"maker": {"state": "approved", "client_id": 1, "user_id": "***009", "client_name": "Alice", "client_link_name": "link1", "client_link_id": 11},
+			"taker": {"state": "pending", "client_id": 2, "user_id": 200, "client_name": "Bob", "client_link_name": "link2", "client_link_id": 22},
+			"nonce": "abc123"
+		}
+	]`
+	var resp []BrokerTradeRequestItem
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "abc123", resp[0].Nonce)
+	assert.Equal(t, "pending", resp[0].State)
+	assert.Equal(t, BrokerTradeUserID("***009"), resp[0].Maker.UserID)
+	assert.Equal(t, uint64(1), resp[0].Maker.ClientID)
+	assert.Equal(t, uint64(11), resp[0].Maker.ClientLinkID)
+	assert.Equal(t, "approved", resp[0].Maker.State)
+	assert.Equal(t, BrokerTradeUserID("200"), resp[0].Taker.UserID)
+	assert.Equal(t, uint64(2), resp[0].Taker.ClientID)
+	assert.Equal(t, uint64(22), resp[0].Taker.ClientLinkID)
+	require.Len(t, resp[0].Trades, 1)
+	assert.Equal(t, "BTC-PERPETUAL", resp[0].Trades[0].InstrumentName)
+}
+
+func TestBrokerTradeHistoryResponseUnmarshal(t *testing.T) {
+	t.Parallel()
+	const payload = `{
+		"history": [{
+			"id": "bt-1",
+			"timestamp": 1700000000000,
+			"trades": [{"trade_id": "t1", "instrument_name": "BTC-PERPETUAL", "amount": 5, "price": 50000, "direction": "buy"}],
+			"maker": {"user_id": "***100", "client_id": 1, "client_name": "Alice", "client_link_name": "link1", "client_link_id": 11},
+			"taker": {"user_id": 200, "client_id": 2, "client_name": "Bob", "client_link_name": "link2", "client_link_id": 22}
+		}],
+		"next_start_id": "ns-42"
+	}`
+	var resp BrokerTradeHistoryResponse
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "ns-42", resp.NextStartID)
+	require.Len(t, resp.History, 1)
+	assert.Equal(t, "bt-1", resp.History[0].ID)
+	assert.Equal(t, BrokerTradeUserID("***100"), resp.History[0].Maker.UserID)
+	assert.Equal(t, uint64(1), resp.History[0].Maker.ClientID)
+	assert.Equal(t, uint64(11), resp.History[0].Maker.ClientLinkID)
+	assert.Equal(t, BrokerTradeUserID("200"), resp.History[0].Taker.UserID)
+	assert.Equal(t, uint64(2), resp.History[0].Taker.ClientID)
+	assert.Equal(t, uint64(22), resp.History[0].Taker.ClientLinkID)
+	require.Len(t, resp.History[0].Trades, 1)
+	assert.Equal(t, "BTC-PERPETUAL", resp.History[0].Trades[0].InstrumentName)
+}
+
+func TestBlockRFQAcceptResponseUnmarshal(t *testing.T) {
+	t.Parallel()
+	const payload = `{
+		"trade_trigger": {"state": "triggered", "price": 50000, "direction": "buy"},
+		"block_trades": [{"id": "bt-1", "timestamp": 1700000000000, "trades": []}]
+	}`
+	var resp BlockRFQAcceptResponse
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "triggered", resp.TradeTrigger.State)
+	assert.Equal(t, float64(50000), resp.TradeTrigger.Price)
+	assert.Equal(t, "buy", resp.TradeTrigger.Direction)
+	require.Len(t, resp.BlockTrades, 1)
+	assert.Equal(t, "bt-1", resp.BlockTrades[0].ID)
+}
+
+func TestBlockRFQTradeAllocationResponseUnmarshal(t *testing.T) {
+	t.Parallel()
+	const payload = `[{"user_id":"***321","amount":1.5,"client_info":{"client_id":12,"client_link_id":34,"name":"desk-a"}}]`
+	var resp []BlockRFQTradeAllocationResponse
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, BrokerTradeUserID("***321"), resp[0].UserID)
+	assert.Equal(t, float64(1.5), resp[0].Amount)
+	require.NotNil(t, resp[0].ClientInfo)
+	assert.Equal(t, uint64(12), resp[0].ClientInfo.ClientID)
+	assert.Equal(t, uint64(34), resp[0].ClientInfo.ClientLinkID)
+	assert.Equal(t, "desk-a", resp[0].ClientInfo.Name)
+}
+
+func TestValidateBlockRFQDirection(t *testing.T) {
+	t.Parallel()
+
+	normalisedDirection, err := validateBlockRFQDirection("")
+	require.NoError(t, err)
+	assert.Empty(t, normalisedDirection)
+
+	normalisedDirection, err = validateBlockRFQDirection(strings.ToUpper(sideBUY))
+	require.NoError(t, err)
+	assert.Equal(t, sideBUY, normalisedDirection)
+
+	normalisedDirection, err = validateBlockRFQDirection(sideBUY)
+	require.NoError(t, err)
+	assert.Equal(t, sideBUY, normalisedDirection)
+
+	normalisedDirection, err = validateBlockRFQDirection(sideSELL)
+	require.NoError(t, err)
+	assert.Equal(t, sideSELL, normalisedDirection)
+
+	_, err = validateBlockRFQDirection("sideways")
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+}
+
+func TestValidateBlockRFQLegs(t *testing.T) {
+	t.Parallel()
+
+	legs, err := validateBlockRFQLegs(nil, false)
+	require.NoError(t, err)
+	assert.Nil(t, legs)
+
+	_, err = validateBlockRFQLegs(nil, true)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 1, Direction: sideBUY, Price: 10}}, true)
+	require.ErrorIs(t, err, errInvalidInstrumentName)
+
+	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 0, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: 10}}, true)
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: "sideways", Price: 10}}, true)
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+
+	_, err = validateBlockRFQLegs([]BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: -1}}, true)
+	require.ErrorIs(t, err, errInvalidPrice)
+
+	input := []BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: strings.ToUpper(sideBUY), Price: 10}}
+	got, err := validateBlockRFQLegs(input, true)
+	require.NoError(t, err)
+	assert.Equal(t, []BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: 10}}, got)
+	assert.Equal(t, strings.ToUpper(sideBUY), input[0].Direction, "validateBlockRFQLegs should not mutate the caller input")
+
+	got, err = validateBlockRFQLegs(input, false)
+	require.NoError(t, err)
+	assert.Equal(t, []BlockRFQLeg{{Ratio: 1, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: 10}}, got)
+}
+
+func TestValidateCreateBlockRFQLegs(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateCreateBlockRFQLegs(nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{Amount: 1, Direction: sideBUY}})
+	require.ErrorIs(t, err, errInvalidInstrumentName)
+
+	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 0, Direction: sideBUY}})
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 1, Direction: "sideways"}})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+
+	input := []CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 1, Direction: strings.ToUpper(sideBUY)}}
+	got, err := validateCreateBlockRFQLegs(input)
+	require.NoError(t, err)
+	assert.Equal(t, []CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 1, Direction: sideBUY}}, got)
+	assert.Equal(t, strings.ToUpper(sideBUY), input[0].Direction, "validateCreateBlockRFQLegs should not mutate the caller input")
+}
+
+func TestValidateBlockRFQTradeAllocations(t *testing.T) {
+	t.Parallel()
+
+	err := validateBlockRFQTradeAllocations(nil)
+	require.NoError(t, err)
+
+	err = validateBlockRFQTradeAllocations([]BlockRFQTradeAllocation{{Amount: 1}})
+	require.ErrorIs(t, err, errUserIDOrClientInfoRequired)
+
+	err = validateBlockRFQTradeAllocations([]BlockRFQTradeAllocation{{UserID: 1, Amount: 0}})
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	err = validateBlockRFQTradeAllocations([]BlockRFQTradeAllocation{{UserID: 1, Amount: 1}})
+	require.NoError(t, err)
+
+	err = validateBlockRFQTradeAllocations([]BlockRFQTradeAllocation{{ClientInfo: &BlockRFQTradeAllocationClientInfo{ClientID: 123}, Amount: 1}})
+	require.NoError(t, err)
+
+	err = validateBlockRFQTradeAllocations([]BlockRFQTradeAllocation{{ClientInfo: &BlockRFQTradeAllocationClientInfo{}, Amount: 1}})
+	require.ErrorIs(t, err, errUserIDOrClientInfoRequired)
+}
+
+func TestValidateBlockRFQHedge(t *testing.T) {
+	t.Parallel()
+
+	hedge, err := validateBlockRFQHedge(nil)
+	require.NoError(t, err)
+	assert.Nil(t, hedge)
+
+	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, Direction: sideBUY, Price: 10})
+	require.ErrorIs(t, err, errInvalidInstrumentName)
+
+	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Direction: "sideways", Price: 10})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+
+	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 0, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: 10})
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Direction: sideBUY, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
+
+	input := &BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Direction: strings.ToUpper(sideSELL), Price: 10}
+	got, err := validateBlockRFQHedge(input)
+	require.NoError(t, err)
+	assert.Equal(t, &BlockRFQHedgeLeg{Amount: 1, InstrumentName: btcPerpInstrument, Direction: sideSELL, Price: 10}, got)
+	assert.Equal(t, strings.ToUpper(sideSELL), input.Direction, "validateBlockRFQHedge should not mutate the caller input")
+}
+
+func createBlockRFQTestLegs() []CreateBlockRFQLeg {
+	return []CreateBlockRFQLeg{
+		{
+			InstrumentName: btcPerpInstrument,
+			Amount:         1,
+			Direction:      order.Buy.Lower(),
+		},
+	}
+}
+
+func TestBlockRFQQuoteCancelResponseUnmarshalCount(t *testing.T) {
+	t.Parallel()
+	var response BlockRFQQuoteCancelResponse
+	err := json.Unmarshal([]byte(`7`), &response)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), response.CancelCount)
+	require.Empty(t, response.Quotes)
+}
+
+func TestBlockRFQQuoteCancelResponseUnmarshalQuotes(t *testing.T) {
+	t.Parallel()
+	var response BlockRFQQuoteCancelResponse
+	err := json.Unmarshal([]byte(`[{"block_rfq_quote_id": 42, "block_rfq_id": 21}]`), &response)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), response.CancelCount)
+	require.Len(t, response.Quotes, 1)
+	require.Equal(t, uint64(42), response.Quotes[0].BlockRFQQuoteID)
+	require.Equal(t, uint64(21), response.Quotes[0].BlockRFQID)
+}
+
+func TestCreateBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.CreateBlockRFQ(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.CreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{})
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.CreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: []CreateBlockRFQLeg{{Amount: 1, Direction: order.Buy.Lower()}}})
+	require.ErrorIs(t, err, errInvalidInstrumentName)
+	_, err = e.CreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: createBlockRFQTestLegs(), TradeAllocations: []BlockRFQTradeAllocation{{Amount: 1}}})
+	require.ErrorIs(t, err, errUserIDOrClientInfoRequired)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.CreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: createBlockRFQTestLegs(), Label: "gct-block-rfq-test"})
+	require.NoError(t, err)
+}
+
+func TestWSCreateBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSCreateBlockRFQ(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.WSCreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{})
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.WSCreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: []CreateBlockRFQLeg{{Amount: 1, Direction: order.Buy.Lower()}}})
+	require.ErrorIs(t, err, errInvalidInstrumentName)
+	_, err = e.WSCreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: createBlockRFQTestLegs(), TradeAllocations: []BlockRFQTradeAllocation{{Amount: 1}}})
+	require.ErrorIs(t, err, errUserIDOrClientInfoRequired)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSCreateBlockRFQ(t.Context(), &CreateBlockRFQRequest{Legs: createBlockRFQTestLegs(), Label: "gct-block-rfq-test"})
+	require.NoError(t, err)
+}
+
+func TestAddBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.AddBlockRFQQuote(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 0, Amount: 1, Price: 10, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: -1, Price: 10, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errInvalidAmount)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: 10, Direction: "sideways"})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errInvalidPrice)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.AddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1 << 62, Amount: 1, Price: 10, Direction: order.Buy.Lower(), Label: "gct-block-rfq-quote"})
+	require.NoError(t, err)
+}
+
+func TestWSAddBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSAddBlockRFQQuote(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 0, Amount: 1, Price: 10, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: -1, Price: 10, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errInvalidAmount)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: 10, Direction: "sideways"})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1, Amount: 1, Price: -1, Direction: order.Buy.Lower()})
+	require.ErrorIs(t, err, errInvalidPrice)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSAddBlockRFQQuote(t.Context(), &AddBlockRFQQuoteRequest{BlockRFQID: 1 << 62, Amount: 1, Price: 10, Direction: order.Buy.Lower(), Label: "gct-block-rfq-quote"})
+	require.NoError(t, err)
+}
+
+func TestEditBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.EditBlockRFQQuote(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 0, Amount: 1, Price: 10})
+	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
+	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1, Amount: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
+	// Identify via block_rfq_id + label instead of quote ID
+	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQID: 1, Label: "test", Amount: -1})
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.EditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1 << 62, Amount: 1, Price: 10, Label: "gct-block-rfq-quote"})
+	require.NoError(t, err)
+}
+
+func TestWSEditBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSEditBlockRFQQuote(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 0, Amount: 1, Price: 10})
+	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
+	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1, Amount: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
+	// Identify via block_rfq_id + label instead of quote ID
+	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQID: 1, Label: "test", Amount: -1})
+	require.ErrorIs(t, err, errInvalidAmount)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSEditBlockRFQQuote(t.Context(), &EditBlockRFQQuoteRequest{BlockRFQQuoteID: 1 << 62, Amount: 1, Price: 10, Label: "gct-block-rfq-quote"})
+	require.NoError(t, err)
+}
+
+func TestCancelBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.CancelBlockRFQQuote(t.Context(), 0, 0, "")
+	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.CancelBlockRFQQuote(t.Context(), 1<<62, 0, "")
+	require.NoError(t, err)
+}
+
+func TestWSCancelBlockRFQQuote(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSCancelBlockRFQQuote(t.Context(), 0, 0, "")
+	require.ErrorIs(t, err, errMissingBlockRFQQuoteIdentifier)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSCancelBlockRFQQuote(t.Context(), 1<<62, 0, "")
+	require.NoError(t, err)
+}
+
+func TestCancelAllBlockRFQQuotes(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err := e.CancelAllBlockRFQQuotes(t.Context(), 0, false)
+	require.NoError(t, err)
+}
+
+func TestWSCancelAllBlockRFQQuotes(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err := e.WSCancelAllBlockRFQQuotes(t.Context(), 0, false)
+	require.NoError(t, err)
+}
+
+func TestCancelBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.CancelBlockRFQ(t.Context(), 0)
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.CancelBlockRFQ(t.Context(), 1<<62)
+	require.NoError(t, err)
+}
+
+func TestWSCancelBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSCancelBlockRFQ(t.Context(), 0)
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSCancelBlockRFQ(t.Context(), 1<<62)
+	require.NoError(t, err)
+}
+
+func TestCancelBlockRFQTrigger(t *testing.T) {
+	t.Parallel()
+	_, err := e.CancelBlockRFQTrigger(t.Context(), 0)
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.CancelBlockRFQTrigger(t.Context(), 1<<62)
+	require.NoError(t, err)
+}
+
+func TestWSCancelBlockRFQTrigger(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSCancelBlockRFQTrigger(t.Context(), 0)
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSCancelBlockRFQTrigger(t.Context(), 1<<62)
+	require.NoError(t, err)
+}
+
+func TestAcceptBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.AcceptBlockRFQ(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.AcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 0})
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+	_, err = e.AcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Amount: -1})
+	require.ErrorIs(t, err, errInvalidAmount)
+	_, err = e.AcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
+	_, err = e.AcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Direction: "sideways"})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.AcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1 << 62, Amount: 1, Price: 10, Direction: "buy"})
+	require.NoError(t, err)
+}
+
+func TestWSAcceptBlockRFQ(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSAcceptBlockRFQ(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+	_, err = e.WSAcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 0})
+	require.ErrorIs(t, err, errMissingBlockRFQID)
+	_, err = e.WSAcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Amount: -1})
+	require.ErrorIs(t, err, errInvalidAmount)
+	_, err = e.WSAcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Price: -1})
+	require.ErrorIs(t, err, errInvalidPrice)
+	_, err = e.WSAcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1, Direction: "sideways"})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	_, err = e.WSAcceptBlockRFQ(t.Context(), &AcceptBlockRFQRequest{BlockRFQID: 1 << 62, Amount: 1, Price: 10, Direction: "buy"})
+	require.NoError(t, err)
+}
+
+func TestGetBlockRFQs(t *testing.T) {
+	t.Parallel()
+	_, err := e.GetBlockRFQs(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err = e.GetBlockRFQs(t.Context(), &GetBlockRFQsRequest{Count: 10})
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBlockRFQs(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSRetrieveBlockRFQs(t.Context(), nil)
+	require.ErrorIs(t, err, errNoArgumentPassed)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err = e.WSRetrieveBlockRFQs(t.Context(), &GetBlockRFQsRequest{Count: 10})
+	require.NoError(t, err)
+}
+
+func TestGetBlockRFQQuotes(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.GetBlockRFQQuotes(t.Context(), 0, 0, "")
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBlockRFQQuotes(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.WSRetrieveBlockRFQQuotes(t.Context(), 0, 0, "")
+	require.NoError(t, err)
+}
+
+func TestGetBlockRFQMakers(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.GetBlockRFQMakers(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBlockRFQMakers(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.WSRetrieveBlockRFQMakers(t.Context())
+	require.NoError(t, err)
+}
+
+func TestGetBlockRFQUserInfo(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.GetBlockRFQUserInfo(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBlockRFQUserInfo(t *testing.T) {
+	t.Parallel()
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
+	_, err := e.WSRetrieveBlockRFQUserInfo(t.Context())
+	require.NoError(t, err)
+}
+
+func TestGetBlockRFQTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.GetBlockRFQTrades(t.Context(), currency.EMPTYCODE, "", 5)
+	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
+
+	_, err = e.GetBlockRFQTrades(t.Context(), currency.BTC, "", 10)
+	require.NoError(t, err)
+}
+
+func TestWSRetrieveBlockRFQTrades(t *testing.T) {
+	t.Parallel()
+	_, err := e.WSRetrieveBlockRFQTrades(t.Context(), currency.EMPTYCODE, "", 5)
+	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
+
+	_, err = e.WSRetrieveBlockRFQTrades(t.Context(), currency.BTC, "", 10)
+	require.NoError(t, err)
+}
+
 func TestGetLastBlockTradesbyCurrency(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetLastBlockTradesByCurrency(t.Context(), currency.EMPTYCODE, "", "", 5)

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -4527,7 +4527,7 @@ func TestWSRetrieveCombos(t *testing.T) {
 	_, err := e.WSRetrieveCombos(t.Context(), currency.EMPTYCODE)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
-	result, err := e.WSRetrieveCombos(t.Context(), futureComboTradablePair.Base)
+	result, err := e.WSRetrieveCombos(t.Context(), currency.BTC)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3006,13 +3006,15 @@ func TestWSExecuteBlockTrade(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-const getUserBlocTradeResponseJSON = `[ { "trade_seq": 37, "trade_id": "92437", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 0.0001, "order_type": "limit", "order_id": "343062", "matching_id": null, "liquidity": "T", "iv": 0, "instrument_name": "BTC-9AUG19-10250-C", "index_price": 11738, "fee_currency": "BTC", "fee": 0.00025, "direction": "sell", "block_trade_id": "61", "amount": 10 }, { "trade_seq": 25350, "trade_id": "92435", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 11590, "order_type": "limit", "order_id": "343058", "matching_id": null, "liquidity": "T", "instrument_name": "BTC-PERPETUAL", "index_price": 11737.98, "fee_currency": "BTC", "fee": 0.00000164, "direction": "buy", "block_trade_id": "61", "amount": 190 } ]`
+const getUserBlocTradeResponseJSON = `{ "id": "61", "timestamp": 1565089523720, "trades": [ { "trade_seq": 37, "trade_id": "92437", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 0.0001, "order_type": "limit", "order_id": "343062", "matching_id": null, "liquidity": "T", "iv": 0, "instrument_name": "BTC-9AUG19-10250-C", "index_price": 11738, "fee_currency": "BTC", "fee": 0.00025, "direction": "sell", "block_trade_id": "61", "amount": 10 }, { "trade_seq": 25350, "trade_id": "92435", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 11590, "order_type": "limit", "order_id": "343058", "matching_id": null, "liquidity": "T", "instrument_name": "BTC-PERPETUAL", "index_price": 11737.98, "fee_currency": "BTC", "fee": 0.00000164, "direction": "buy", "block_trade_id": "61", "amount": 190 } ] }`
 
 func TestGetUserBlocTrade(t *testing.T) {
 	t.Parallel()
-	var resp []BlockTradeData
+	var resp BlockTradeCollection
 	err := json.Unmarshal([]byte(getUserBlocTradeResponseJSON), &resp)
 	require.NoError(t, err)
+	assert.Equal(t, "61", resp.ID)
+	assert.Len(t, resp.Trades, 2)
 	_, err = e.GetUserBlockTrade(t.Context(), "")
 	require.ErrorIs(t, err, errMissingBlockTradeID)
 

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3006,12 +3006,12 @@ func TestWSExecuteBlockTrade(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-const getUserBlocTradeResponseJSON = `{ "id": "61", "timestamp": 1565089523720, "trades": [ { "trade_seq": 37, "trade_id": "92437", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 0.0001, "order_type": "limit", "order_id": "343062", "matching_id": null, "liquidity": "T", "iv": 0, "instrument_name": "BTC-9AUG19-10250-C", "index_price": 11738, "fee_currency": "BTC", "fee": 0.00025, "direction": "sell", "block_trade_id": "61", "amount": 10 }, { "trade_seq": 25350, "trade_id": "92435", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 11590, "order_type": "limit", "order_id": "343058", "matching_id": null, "liquidity": "T", "instrument_name": "BTC-PERPETUAL", "index_price": 11737.98, "fee_currency": "BTC", "fee": 0.00000164, "direction": "buy", "block_trade_id": "61", "amount": 190 } ] }`
+const getUserBlockTradeResponseJSON = `{ "id": "61", "timestamp": 1565089523720, "trades": [ { "trade_seq": 37, "trade_id": "92437", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 0.0001, "order_type": "limit", "order_id": "343062", "matching_id": null, "liquidity": "T", "iv": 0, "instrument_name": "BTC-9AUG19-10250-C", "index_price": 11738, "fee_currency": "BTC", "fee": 0.00025, "direction": "sell", "block_trade_id": "61", "amount": 10 }, { "trade_seq": 25350, "trade_id": "92435", "timestamp": 1565089523719, "tick_direction": 3, "state": "filled", "price": 11590, "order_type": "limit", "order_id": "343058", "matching_id": null, "liquidity": "T", "instrument_name": "BTC-PERPETUAL", "index_price": 11737.98, "fee_currency": "BTC", "fee": 0.00000164, "direction": "buy", "block_trade_id": "61", "amount": 190 } ] }`
 
-func TestGetUserBlocTrade(t *testing.T) {
+func TestGetUserBlockTrade(t *testing.T) {
 	t.Parallel()
 	var resp BlockTradeCollection
-	err := json.Unmarshal([]byte(getUserBlocTradeResponseJSON), &resp)
+	err := json.Unmarshal([]byte(getUserBlockTradeResponseJSON), &resp)
 	require.NoError(t, err)
 	assert.Equal(t, "61", resp.ID)
 	assert.Len(t, resp.Trades, 2)

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3371,9 +3371,8 @@ func TestValidateBlockRFQTradeAllocations(t *testing.T) {
 func TestValidateBlockRFQHedge(t *testing.T) {
 	t.Parallel()
 
-	hedge, err := validateBlockRFQHedge(nil)
-	require.NoError(t, err)
-	assert.Nil(t, hedge)
+	_, err := validateBlockRFQHedge(nil)
+	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	_, err = validateBlockRFQHedge(&BlockRFQHedgeLeg{Amount: 1, Direction: sideBUY, Price: 10})
 	require.ErrorIs(t, err, errInvalidInstrumentName)

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3049,60 +3049,53 @@ func TestWSRetrieveBlockTradeRequests(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-func TestApproveBlockTrade(t *testing.T) {
+func TestValidatePendingBlockTradeAction(t *testing.T) {
 	t.Parallel()
-	err := e.ApproveBlockTrade(t.Context(), time.Now(), "", roleMaker)
+
+	err := validatePendingBlockTradeAction(time.Now(), "", roleMaker)
 	require.ErrorIs(t, err, errMissingNonce)
-	err = e.ApproveBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
+
+	err = validatePendingBlockTradeAction(time.Time{}, "nonce", roleMaker)
 	require.ErrorIs(t, err, errZeroTimestamp)
-	err = e.ApproveBlockTrade(t.Context(), time.Now(), "nonce", "")
+
+	err = validatePendingBlockTradeAction(time.Now(), "nonce", "")
 	require.ErrorIs(t, err, errInvalidTradeRole)
 
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	err = e.ApproveBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
-	assert.NoError(t, err)
+	err = validatePendingBlockTradeAction(time.Now(), "nonce", roleMaker)
+	require.NoError(t, err)
 }
 
-func TestWSApproveBlockTrade(t *testing.T) {
+func TestBlockTradeActionMethods(t *testing.T) {
 	t.Parallel()
-	err := e.WSApproveBlockTrade(t.Context(), time.Now(), "", roleMaker)
-	require.ErrorIs(t, err, errMissingNonce)
-	err = e.WSApproveBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
-	require.ErrorIs(t, err, errZeroTimestamp)
-	err = e.WSApproveBlockTrade(t.Context(), time.Now(), "nonce", "")
-	require.ErrorIs(t, err, errInvalidTradeRole)
 
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	err = e.WSApproveBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
-	assert.NoError(t, err)
-}
+	tests := []struct {
+		name string
+		fn   func(context.Context, time.Time, string, string) error
+	}{
+		{name: "ApproveBlockTrade", fn: e.ApproveBlockTrade},
+		{name: "WSApproveBlockTrade", fn: e.WSApproveBlockTrade},
+		{name: "RejectBlockTrade", fn: e.RejectBlockTrade},
+		{name: "WSRejectBlockTrade", fn: e.WSRejectBlockTrade},
+	}
 
-func TestRejectBlockTrade(t *testing.T) {
-	t.Parallel()
-	err := e.RejectBlockTrade(t.Context(), time.Now(), "", roleMaker)
-	require.ErrorIs(t, err, errMissingNonce)
-	err = e.RejectBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
-	require.ErrorIs(t, err, errZeroTimestamp)
-	err = e.RejectBlockTrade(t.Context(), time.Now(), "nonce", "")
-	require.ErrorIs(t, err, errInvalidTradeRole)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	err = e.RejectBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
-	assert.NoError(t, err)
-}
+			err := tc.fn(t.Context(), time.Now(), "", roleMaker)
+			require.ErrorIs(t, err, errMissingNonce)
 
-func TestWSRejectBlockTrade(t *testing.T) {
-	t.Parallel()
-	err := e.WSRejectBlockTrade(t.Context(), time.Now(), "", roleMaker)
-	require.ErrorIs(t, err, errMissingNonce)
-	err = e.WSRejectBlockTrade(t.Context(), time.Time{}, "nonce", roleMaker)
-	require.ErrorIs(t, err, errZeroTimestamp)
-	err = e.WSRejectBlockTrade(t.Context(), time.Now(), "nonce", "")
-	require.ErrorIs(t, err, errInvalidTradeRole)
+			err = tc.fn(t.Context(), time.Time{}, "nonce", roleMaker)
+			require.ErrorIs(t, err, errZeroTimestamp)
 
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	err = e.WSRejectBlockTrade(t.Context(), time.Now(), "nonce", roleMaker)
-	assert.NoError(t, err)
+			err = tc.fn(t.Context(), time.Now(), "nonce", "")
+			require.ErrorIs(t, err, errInvalidTradeRole)
+
+			sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+			err = tc.fn(t.Context(), time.Now(), "nonce", roleMaker)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestGetBlockTrades(t *testing.T) {
@@ -3249,6 +3242,29 @@ func TestBlockRFQTradeAllocationResponseUnmarshal(t *testing.T) {
 	assert.Equal(t, "desk-a", resp[0].ClientInfo.Name)
 }
 
+func TestBlockRFQDataTakerRatingUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+		exp     float64
+	}{
+		{name: "string", payload: `{"taker_rating":"0.75"}`, exp: 0.75},
+		{name: "number", payload: `{"taker_rating":0.5}`, exp: 0.5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var resp BlockRFQData
+			err := json.Unmarshal([]byte(tc.payload), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tc.exp, resp.TakerRating.Float64())
+		})
+	}
+}
+
 func TestValidateBlockRFQDirection(t *testing.T) {
 	t.Parallel()
 
@@ -3316,6 +3332,9 @@ func TestValidateCreateBlockRFQLegs(t *testing.T) {
 
 	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 0, Direction: sideBUY}})
 	require.ErrorIs(t, err, errInvalidAmount)
+
+	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 1}})
+	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)
 
 	_, err = validateCreateBlockRFQLegs([]CreateBlockRFQLeg{{InstrumentName: btcPerpInstrument, Amount: 1, Direction: "sideways"}})
 	require.ErrorIs(t, err, errInvalidOrderSideOrDirection)

--- a/exchanges/deribit/deribit_test.go
+++ b/exchanges/deribit/deribit_test.go
@@ -3897,7 +3897,7 @@ func TestSimulateBlockTrade(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	assert.True(t, result)
 }
 
 func TestWsSimulateBlockTrade(t *testing.T) {
@@ -3956,7 +3956,7 @@ func TestWsSimulateBlockTrade(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	assert.True(t, result)
 }
 
 func setupWs() {

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -1056,7 +1056,7 @@ type BlockRFQData struct {
 	BlockRFQID            uint64               `json:"block_rfq_id"`
 	Role                  string               `json:"role"`
 	State                 string               `json:"state"`
-	TakerRating           string               `json:"taker_rating"`
+	TakerRating           types.Number         `json:"taker_rating"`
 	Makers                []string             `json:"makers"`
 	Amount                float64              `json:"amount"`
 	MinTradeAmount        float64              `json:"min_trade_amount"`
@@ -1149,10 +1149,10 @@ type BlockRFQAcceptResponse struct {
 
 // BlockRFQUserIdentity contains identity details for a single account.
 type BlockRFQUserIdentity struct {
-	UserID      uint64  `json:"user_id"`
-	TakerRating float64 `json:"taker_rating"`
-	Identity    string  `json:"identity"`
-	IsMaker     bool    `json:"is_maker"`
+	UserID      uint64       `json:"user_id"`
+	TakerRating types.Number `json:"taker_rating"`
+	Identity    string       `json:"identity"`
+	IsMaker     bool         `json:"is_maker"`
 }
 
 // BlockRFQParentIdentity describes group identity information.

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -993,6 +993,16 @@ type BlockTradeCollection struct {
 	BrokerName string           `json:"broker_name"`
 }
 
+// ExecutedBlockTradeCollection represents an executed block trade object containing grouped trades.
+type ExecutedBlockTradeCollection struct {
+	ID         string               `json:"id"`
+	Timestamp  types.Time           `json:"timestamp"`
+	Trades     []BlockTradeResponse `json:"trades"`
+	AppName    string               `json:"app_name"`
+	BrokerCode string               `json:"broker_code"`
+	BrokerName string               `json:"broker_name"`
+}
+
 // BlockRFQLeg describes one RFQ leg.
 type BlockRFQLeg struct {
 	Ratio          float64 `json:"ratio"`

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -64,6 +64,7 @@ var (
 	errMissingBlockRFQID                   = errors.New("missing block rfq id")
 	errMissingBlockRFQQuoteIdentifier      = errors.New("block_rfq_quote_id required, or both block_rfq_id and label")
 	errEmptyBlockRFQQuoteCancelResponse    = errors.New("empty block rfq quote cancel response")
+	errInvalidBlockRFQQuoteCancelResponse  = errors.New("invalid block rfq quote cancel response")
 	errInvalidBrokerTradeUserID            = errors.New("invalid broker trade user_id")
 	errMissingSubAccountID                 = errors.New("missing subaccount id")
 	errUnsupportedInstrumentFormat         = errors.New("unsupported instrument type format")
@@ -1121,7 +1122,7 @@ func (a *BlockRFQQuoteCancelResponse) UnmarshalJSON(data []byte) error {
 	if trimmed[0] == '[' {
 		var quotes []BlockRFQQuote
 		if err := json.Unmarshal(trimmed, &quotes); err != nil {
-			return err
+			return fmt.Errorf("%w: %q: %v", errInvalidBlockRFQQuoteCancelResponse, string(data), err)
 		}
 		a.Quotes = quotes
 		a.CancelCount = uint64(len(quotes))
@@ -1130,7 +1131,7 @@ func (a *BlockRFQQuoteCancelResponse) UnmarshalJSON(data []byte) error {
 
 	var cancelCount uint64
 	if err := json.Unmarshal(trimmed, &cancelCount); err != nil {
-		return err
+		return fmt.Errorf("%w: %q: %v", errInvalidBlockRFQQuoteCancelResponse, string(data), err)
 	}
 	a.CancelCount = cancelCount
 	a.Quotes = nil

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -1,8 +1,10 @@
 package deribit
 
 import (
+	"bytes"
 	"errors"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -53,10 +55,13 @@ var (
 	errMaxScopeIsRequired                  = errors.New("max scope is required")
 	errTradeModeIsRequired                 = errors.New("self trading mode is required")
 	errUserIDRequired                      = errors.New("userID is required")
+	errUserIDOrClientInfoRequired          = errors.New("user_id or client_info is required")
 	errInvalidOrderSideOrDirection         = errors.New("invalid direction, only 'buy' or 'sell' are supported")
 	errDifferentInstruments                = errors.New("given instruments should have the same currency")
 	errZeroTimestamp                       = errors.New("zero timestamps are not allowed")
 	errMissingBlockTradeID                 = errors.New("missing block trade id")
+	errMissingBlockRFQID                   = errors.New("missing block rfq id")
+	errMissingBlockRFQQuoteIdentifier      = errors.New("block_rfq_quote_id required, or both block_rfq_id and label")
 	errMissingSubAccountID                 = errors.New("missing subaccount id")
 	errUnsupportedInstrumentFormat         = errors.New("unsupported instrument type format")
 	errSessionNameRequired                 = errors.New("session_name is required")
@@ -950,6 +955,370 @@ type BlockTradeData struct {
 	Direction              string     `json:"direction"`
 	BlockTradeID           string     `json:"block_trade_id"`
 	Amount                 float64    `json:"amount"`
+}
+
+// BlockTradeState contains state and timestamp metadata for pending block trade requests.
+type BlockTradeState struct {
+	Value     string     `json:"value"`
+	Timestamp types.Time `json:"timestamp"`
+}
+
+// PendingBlockTradeData represents a pending block trade request object.
+type PendingBlockTradeData struct {
+	Nonce             string            `json:"nonce"`
+	Timestamp         types.Time        `json:"timestamp"`
+	Trades            []BlockTradeParam `json:"trades"`
+	AppName           string            `json:"app_name"`
+	Username          string            `json:"username"`
+	Role              string            `json:"role"`
+	UserID            int64             `json:"user_id"`
+	BrokerCode        string            `json:"broker_code"`
+	BrokerName        string            `json:"broker_name"`
+	State             BlockTradeState   `json:"state"`
+	CounterpartyState BlockTradeState   `json:"counterparty_state"`
+	ComboID           string            `json:"combo_id"`
+}
+
+// BlockTradeCollection represents a block trade object containing grouped trades.
+type BlockTradeCollection struct {
+	ID         string           `json:"id"`
+	Timestamp  types.Time       `json:"timestamp"`
+	Trades     []BlockTradeData `json:"trades"`
+	AppName    string           `json:"app_name"`
+	BrokerCode string           `json:"broker_code"`
+	BrokerName string           `json:"broker_name"`
+}
+
+// BlockRFQLeg describes one RFQ leg.
+type BlockRFQLeg struct {
+	Ratio          float64 `json:"ratio"`
+	InstrumentName string  `json:"instrument_name"`
+	Direction      string  `json:"direction"`
+	Price          float64 `json:"price"`
+}
+
+// BlockRFQHedgeLeg describes optional hedge details for a Block RFQ.
+type BlockRFQHedgeLeg struct {
+	Amount         float64 `json:"amount"`
+	InstrumentName string  `json:"instrument_name"`
+	Direction      string  `json:"direction"`
+	Price          float64 `json:"price"`
+}
+
+// BlockRFQQuoteLevel describes quote levels (bids/asks) in an RFQ.
+type BlockRFQQuoteLevel struct {
+	Makers               []string   `json:"makers"`
+	BlockRFQQuoteID      uint64     `json:"block_rfq_quote_id,omitempty"`
+	Direction            string     `json:"direction,omitempty"`
+	Price                float64    `json:"price"`
+	LastUpdateTimestamp  types.Time `json:"last_update_timestamp"`
+	ExecutionInstruction string     `json:"execution_instruction"`
+	Amount               float64    `json:"amount"`
+	ExpiresAt            types.Time `json:"expires_at"`
+}
+
+// BlockRFQTradeAllocationClientInfo describes broker/client allocation routing.
+type BlockRFQTradeAllocationClientInfo struct {
+	ClientID     uint64 `json:"client_id,omitempty"`
+	ClientLinkID uint64 `json:"client_link_id,omitempty"`
+	Name         string `json:"name,omitempty"`
+}
+
+// BlockRFQTradeAllocation describes request-side RFQ trade allocations.
+type BlockRFQTradeAllocation struct {
+	UserID     uint64                             `json:"user_id,omitempty"`
+	Amount     float64                            `json:"amount"`
+	ClientInfo *BlockRFQTradeAllocationClientInfo `json:"client_info,omitempty"`
+}
+
+// BlockRFQTradeAllocationResponse describes response-side RFQ trade allocations.
+type BlockRFQTradeAllocationResponse struct {
+	UserID     BrokerTradeUserID                  `json:"user_id"`
+	Amount     float64                            `json:"amount"`
+	ClientInfo *BlockRFQTradeAllocationClientInfo `json:"client_info,omitempty"`
+}
+
+// BlockRFQTrade describes a trade inside an RFQ payload.
+type BlockRFQTrade struct {
+	Direction        string                            `json:"direction"`
+	Price            float64                           `json:"price"`
+	Amount           float64                           `json:"amount"`
+	Maker            string                            `json:"maker"`
+	HedgeAmount      float64                           `json:"hedge_amount"`
+	TradeTrigger     map[string]any                    `json:"trade_trigger"`
+	TradeAllocations []BlockRFQTradeAllocationResponse `json:"trade_allocations"`
+}
+
+// BlockRFQData represents one Block RFQ entry.
+type BlockRFQData struct {
+	CreationTimestamp     types.Time           `json:"creation_timestamp"`
+	ExpirationTimestamp   types.Time           `json:"expiration_timestamp"`
+	BlockRFQID            uint64               `json:"block_rfq_id"`
+	Role                  string               `json:"role"`
+	State                 string               `json:"state"`
+	TakerRating           string               `json:"taker_rating"`
+	Makers                []string             `json:"makers"`
+	Amount                float64              `json:"amount"`
+	MinTradeAmount        float64              `json:"min_trade_amount"`
+	Asks                  []BlockRFQQuoteLevel `json:"asks"`
+	Bids                  []BlockRFQQuoteLevel `json:"bids"`
+	Legs                  []BlockRFQLeg        `json:"legs"`
+	Hedge                 *BlockRFQHedgeLeg    `json:"hedge"`
+	ComboID               string               `json:"combo_id"`
+	Label                 string               `json:"label"`
+	AppName               string               `json:"app_name"`
+	MarkPrice             float64              `json:"mark_price"`
+	Disclosed             bool                 `json:"disclosed"`
+	Taker                 string               `json:"taker"`
+	IndexPrices           map[string]float64   `json:"index_prices"`
+	IncludedInTakerRating bool                 `json:"included_in_taker_rating"`
+	Trades                []BlockRFQTrade      `json:"trades"`
+	TradeTrigger          map[string]any       `json:"trade_trigger"`
+}
+
+// BlockRFQListResponse wraps RFQ list + continuation token response.
+type BlockRFQListResponse struct {
+	BlockRFQs    []BlockRFQData `json:"block_rfqs"`
+	Continuation string         `json:"continuation"`
+}
+
+// BlockRFQQuote describes a maker quote entry.
+type BlockRFQQuote struct {
+	CreationTimestamp    types.Time        `json:"creation_timestamp"`
+	LastUpdateTimestamp  types.Time        `json:"last_update_timestamp"`
+	BlockRFQID           uint64            `json:"block_rfq_id"`
+	BlockRFQQuoteID      uint64            `json:"block_rfq_quote_id"`
+	QuoteState           string            `json:"quote_state"`
+	ExecutionInstruction string            `json:"execution_instruction"`
+	Price                float64           `json:"price"`
+	Amount               float64           `json:"amount"`
+	Direction            string            `json:"direction"`
+	FilledAmount         float64           `json:"filled_amount"`
+	Legs                 []BlockRFQLeg     `json:"legs"`
+	Hedge                *BlockRFQHedgeLeg `json:"hedge"`
+	Replaced             bool              `json:"replaced"`
+	Label                string            `json:"label"`
+	AppName              string            `json:"app_name"`
+	QuoteStateReason     string            `json:"quote_state_reason"`
+}
+
+// BlockRFQQuoteCancelResponse represents cancel-all block RFQ quotes response data.
+type BlockRFQQuoteCancelResponse struct {
+	CancelCount uint64          `json:"cancel_count"`
+	Quotes      []BlockRFQQuote `json:"quotes"`
+}
+
+// UnmarshalJSON deserialises block RFQ quote cancellation response into a BlockRFQQuoteCancelResponse instance.
+func (a *BlockRFQQuoteCancelResponse) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return errors.New("empty block rfq quote cancel response")
+	}
+
+	if trimmed[0] == '[' {
+		var quotes []BlockRFQQuote
+		if err := json.Unmarshal(trimmed, &quotes); err != nil {
+			return err
+		}
+		a.Quotes = quotes
+		a.CancelCount = uint64(len(quotes))
+		return nil
+	}
+
+	var cancelCount uint64
+	if err := json.Unmarshal(trimmed, &cancelCount); err != nil {
+		return err
+	}
+	a.CancelCount = cancelCount
+	a.Quotes = nil
+	return nil
+}
+
+// BlockRFQTradeTrigger describes a typed trade trigger returned in accept responses.
+type BlockRFQTradeTrigger struct {
+	State     string  `json:"state"`
+	Price     float64 `json:"price"`
+	Direction string  `json:"direction"`
+}
+
+// BlockRFQAcceptResponse represents the response payload from accepting a block RFQ.
+type BlockRFQAcceptResponse struct {
+	TradeTrigger BlockRFQTradeTrigger   `json:"trade_trigger"`
+	BlockTrades  []BlockTradeCollection `json:"block_trades"`
+}
+
+// BlockRFQUserIdentity contains identity details for a single account.
+type BlockRFQUserIdentity struct {
+	UserID      uint64  `json:"user_id"`
+	TakerRating float64 `json:"taker_rating"`
+	Identity    string  `json:"identity"`
+	IsMaker     bool    `json:"is_maker"`
+}
+
+// BlockRFQParentIdentity describes group identity information.
+type BlockRFQParentIdentity struct {
+	Identity string `json:"identity"`
+	IsMaker  bool   `json:"is_maker"`
+}
+
+// BlockRFQUserInfoResponse wraps user info response payload.
+type BlockRFQUserInfoResponse struct {
+	Parent BlockRFQParentIdentity `json:"parent"`
+	Users  []BlockRFQUserIdentity `json:"users"`
+}
+
+// BlockRFQTradeData is one public trade tape entry.
+type BlockRFQTradeData struct {
+	ID          uint64             `json:"id"`
+	Timestamp   types.Time         `json:"timestamp"`
+	Direction   string             `json:"direction"`
+	Amount      float64            `json:"amount"`
+	Price       float64            `json:"price,omitempty"`
+	MarkPrice   float64            `json:"mark_price"`
+	Legs        []BlockRFQLeg      `json:"legs"`
+	ComboID     string             `json:"combo_id"`
+	Hedge       *BlockRFQHedgeLeg  `json:"hedge"`
+	IndexPrices map[string]float64 `json:"index_prices"`
+	Trades      []BlockRFQTrade    `json:"trades"`
+}
+
+// BlockRFQTradeTapeResponse wraps public block RFQ trade tape response payload.
+type BlockRFQTradeTapeResponse struct {
+	BlockRFQs    []BlockRFQTradeData `json:"block_rfqs"`
+	Continuation string              `json:"continuation"`
+}
+
+// GetBlockTradesRequest contains request parameters for fetching block trades.
+type GetBlockTradesRequest struct {
+	Currency   currency.Code
+	StartID    string
+	EndID      string
+	Count      uint64
+	BlockRFQID uint64
+	BrokerCode string
+}
+
+// CreateBlockRFQLeg describes one request leg for creating a block RFQ.
+type CreateBlockRFQLeg struct {
+	InstrumentName string  `json:"instrument_name"`
+	Amount         float64 `json:"amount"`
+	Direction      string  `json:"direction"`
+}
+
+// CreateBlockRFQRequest contains parameters for creating a block RFQ.
+type CreateBlockRFQRequest struct {
+	Legs             []CreateBlockRFQLeg
+	Makers           []string
+	TradeAllocations []BlockRFQTradeAllocation
+	Hedge            *BlockRFQHedgeLeg
+	Label            string
+	Disclosed        bool
+}
+
+// AddBlockRFQQuoteRequest contains parameters for adding a block RFQ quote.
+type AddBlockRFQQuoteRequest struct {
+	BlockRFQID           uint64
+	Amount               float64
+	Price                float64
+	Direction            string
+	ExecutionInstruction string
+	ExpiresAt            time.Time
+	Legs                 []BlockRFQLeg
+	Hedge                *BlockRFQHedgeLeg
+	Label                string
+}
+
+// EditBlockRFQQuoteRequest contains parameters for editing a block RFQ quote.
+type EditBlockRFQQuoteRequest struct {
+	BlockRFQQuoteID uint64
+	BlockRFQID      uint64
+	Amount          float64
+	Price           float64
+	Legs            []BlockRFQLeg
+	Hedge           *BlockRFQHedgeLeg
+	Label           string
+}
+
+// GetBlockRFQsRequest contains filters for listing block RFQs.
+type GetBlockRFQsRequest struct {
+	Currency     currency.Code
+	Count        uint64
+	State        string
+	Role         string
+	Continuation string
+	BlockRFQID   uint64
+}
+
+// AcceptBlockRFQRequest contains parameters for accepting a block RFQ.
+type AcceptBlockRFQRequest struct {
+	BlockRFQID  uint64
+	Price       float64
+	Amount      float64
+	Direction   string
+	Hedge       *BlockRFQHedgeLeg
+	Legs        []BlockRFQLeg
+	TimeInForce string
+}
+
+// GetBrokerTradesRequest contains request parameters for fetching broker trades.
+type GetBrokerTradesRequest struct {
+	Currency currency.Code
+	Count    uint64
+	StartID  string
+	EndID    string
+}
+
+// BrokerTradeUserID supports Deribit broker user_id payloads that may be masked strings or numeric IDs.
+type BrokerTradeUserID string
+
+// UnmarshalJSON unmarshals a broker trade user ID from either string or integer payloads.
+func (b *BrokerTradeUserID) UnmarshalJSON(data []byte) error {
+	var stringValue string
+	if err := json.Unmarshal(data, &stringValue); err == nil {
+		*b = BrokerTradeUserID(stringValue)
+		return nil
+	}
+	var integerValue uint64
+	if err := json.Unmarshal(data, &integerValue); err == nil {
+		*b = BrokerTradeUserID(strconv.FormatUint(integerValue, 10))
+		return nil
+	}
+	return errors.New("invalid broker trade user_id")
+}
+
+// BrokerTradeParty describes a maker or taker party in a broker trade request or history entry.
+type BrokerTradeParty struct {
+	State          string            `json:"state,omitempty"`
+	ClientID       uint64            `json:"client_id"`
+	UserID         BrokerTradeUserID `json:"user_id"`
+	ClientName     string            `json:"client_name"`
+	ClientLinkName string            `json:"client_link_name"`
+	ClientLinkID   uint64            `json:"client_link_id"`
+}
+
+// BrokerTradeRequestItem represents one item in the get_broker_trade_requests response.
+type BrokerTradeRequestItem struct {
+	Timestamp types.Time        `json:"timestamp"`
+	State     string            `json:"state"`
+	Trades    []BlockTradeParam `json:"trades"`
+	Maker     BrokerTradeParty  `json:"maker"`
+	Taker     BrokerTradeParty  `json:"taker"`
+	Nonce     string            `json:"nonce"`
+}
+
+// BrokerTradeHistoryEntry represents one entry in the get_broker_trades history array.
+type BrokerTradeHistoryEntry struct {
+	ID        string           `json:"id"`
+	Timestamp types.Time       `json:"timestamp"`
+	Trades    []BlockTradeData `json:"trades"`
+	Maker     BrokerTradeParty `json:"maker"`
+	Taker     BrokerTradeParty `json:"taker"`
+}
+
+// BrokerTradeHistoryResponse wraps the get_broker_trades response payload.
+type BrokerTradeHistoryResponse struct {
+	History     []BrokerTradeHistoryEntry `json:"history"`
+	NextStartID string                    `json:"next_start_id"`
 }
 
 // Announcement represents public announcements.

--- a/exchanges/deribit/deribit_types.go
+++ b/exchanges/deribit/deribit_types.go
@@ -3,6 +3,7 @@ package deribit
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"time"
@@ -62,6 +63,8 @@ var (
 	errMissingBlockTradeID                 = errors.New("missing block trade id")
 	errMissingBlockRFQID                   = errors.New("missing block rfq id")
 	errMissingBlockRFQQuoteIdentifier      = errors.New("block_rfq_quote_id required, or both block_rfq_id and label")
+	errEmptyBlockRFQQuoteCancelResponse    = errors.New("empty block rfq quote cancel response")
+	errInvalidBrokerTradeUserID            = errors.New("invalid broker trade user_id")
 	errMissingSubAccountID                 = errors.New("missing subaccount id")
 	errUnsupportedInstrumentFormat         = errors.New("unsupported instrument type format")
 	errSessionNameRequired                 = errors.New("session_name is required")
@@ -1112,7 +1115,7 @@ type BlockRFQQuoteCancelResponse struct {
 func (a *BlockRFQQuoteCancelResponse) UnmarshalJSON(data []byte) error {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
-		return errors.New("empty block rfq quote cancel response")
+		return fmt.Errorf("%w: %q", errEmptyBlockRFQQuoteCancelResponse, string(data))
 	}
 
 	if trimmed[0] == '[' {
@@ -1173,7 +1176,7 @@ type BlockRFQTradeData struct {
 	Timestamp   types.Time         `json:"timestamp"`
 	Direction   string             `json:"direction"`
 	Amount      float64            `json:"amount"`
-	Price       float64            `json:"price,omitempty"`
+	Price       float64            `json:"price"`
 	MarkPrice   float64            `json:"mark_price"`
 	Legs        []BlockRFQLeg      `json:"legs"`
 	ComboID     string             `json:"combo_id"`
@@ -1283,7 +1286,7 @@ func (b *BrokerTradeUserID) UnmarshalJSON(data []byte) error {
 		*b = BrokerTradeUserID(strconv.FormatUint(integerValue, 10))
 		return nil
 	}
-	return errors.New("invalid broker trade user_id")
+	return fmt.Errorf("%w: %q", errInvalidBrokerTradeUserID, string(data))
 }
 
 // BrokerTradeParty describes a maker or taker party in a broker trade request or history entry.

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2070,7 +2070,7 @@ func (e *Exchange) WSExecuteBlockTrade(ctx context.Context, timestampMS time.Tim
 		Currency:              ccy.String(),
 	}
 	var resp []BlockTradeResponse
-	return resp, e.SendWSRequest(ctx, matchingEPL, executeBlockTrades, input, &resp, true)
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/execute_block_trade", input, &resp, true)
 }
 
 // WSVerifyBlockTrade verifies and creates block trade signature through the websocket connection.
@@ -2119,7 +2119,7 @@ func (e *Exchange) WSVerifyBlockTrade(ctx context.Context, timestampMS time.Time
 	resp := &struct {
 		Signature string `json:"signature"`
 	}{}
-	return resp.Signature, e.SendWSRequest(ctx, matchingEPL, verifyBlockTrades, input, &resp, true)
+	return resp.Signature, e.SendWSRequest(ctx, matchingEPL, "private/verify_block_trade", input, &resp, true)
 }
 
 // WsInvalidateBlockTradeSignature user at any time (before the private/execute_block_trade is called) can invalidate its own signature effectively cancelling block trade through the websocket connection.
@@ -2130,7 +2130,7 @@ func (e *Exchange) WsInvalidateBlockTradeSignature(ctx context.Context, signatur
 	params := url.Values{}
 	params.Set("signature", signature)
 	var resp string
-	err := e.SendWSRequest(ctx, nonMatchingEPL, invalidateBlockTradesSignature, params, &resp, true)
+	err := e.SendWSRequest(ctx, blockTradeWriteEPL, "private/invalidate_block_trade_signature", params, &resp, true)
 	if err != nil {
 		return err
 	}
@@ -2146,7 +2146,446 @@ func (e *Exchange) WSRetrieveUserBlockTrade(ctx context.Context, id string) ([]B
 		return nil, errMissingBlockTradeID
 	}
 	var resp []BlockTradeData
-	return resp, e.SendWSRequest(ctx, nonMatchingEPL, getBlockTrades, map[string]string{"id": id}, &resp, true)
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_block_trade", map[string]string{"id": id}, &resp, true)
+}
+
+// WSRetrieveBlockTradeRequests returns block trade requests through the websocket connection.
+func (e *Exchange) WSRetrieveBlockTradeRequests(ctx context.Context, brokerCode string) ([]PendingBlockTradeData, error) {
+	input := map[string]string{}
+	if brokerCode != "" {
+		input["broker_code"] = brokerCode
+	}
+	var resp []PendingBlockTradeData
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_block_trade_requests", input, &resp, true)
+}
+
+// WSApproveBlockTrade approves a pending block trade through the websocket connection.
+func (e *Exchange) WSApproveBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string) error {
+	if nonce == "" {
+		return errMissingNonce
+	}
+	if timestampMS.IsZero() {
+		return errZeroTimestamp
+	}
+	if role != roleMaker && role != roleTaker {
+		return errInvalidTradeRole
+	}
+	input := map[string]any{
+		"timestamp": timestampMS.UnixMilli(),
+		"nonce":     nonce,
+		"role":      role,
+	}
+	var resp string
+	err := e.SendWSRequest(ctx, blockTradeWriteEPL, "private/approve_block_trade", input, &resp, true)
+	if err != nil {
+		return err
+	}
+	if resp != "ok" {
+		return fmt.Errorf("server response: %s", resp)
+	}
+	return nil
+}
+
+// WSRejectBlockTrade rejects a pending block trade through the websocket connection.
+func (e *Exchange) WSRejectBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string) error {
+	if nonce == "" {
+		return errMissingNonce
+	}
+	if timestampMS.IsZero() {
+		return errZeroTimestamp
+	}
+	if role != roleMaker && role != roleTaker {
+		return errInvalidTradeRole
+	}
+	input := map[string]any{
+		"timestamp": timestampMS.UnixMilli(),
+		"nonce":     nonce,
+		"role":      role,
+	}
+	var resp string
+	err := e.SendWSRequest(ctx, blockTradeWriteEPL, "private/reject_block_trade", input, &resp, true)
+	if err != nil {
+		return err
+	}
+	if resp != "ok" {
+		return fmt.Errorf("server response: %s", resp)
+	}
+	return nil
+}
+
+// WSRetrieveBlockTrades returns a list of users block trades through the websocket connection.
+func (e *Exchange) WSRetrieveBlockTrades(ctx context.Context, req *GetBlockTradesRequest) ([]BlockTradeCollection, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	input := map[string]any{}
+	if !req.Currency.IsEmpty() {
+		input["currency"] = req.Currency.String()
+	}
+	if req.StartID != "" {
+		input["start_id"] = req.StartID
+	}
+	if req.EndID != "" {
+		input["end_id"] = req.EndID
+	}
+	if req.Count > 0 {
+		input["count"] = req.Count
+	}
+	if req.BlockRFQID > 0 {
+		input["block_rfq_id"] = req.BlockRFQID
+	}
+	if req.BrokerCode != "" {
+		input["broker_code"] = req.BrokerCode
+	}
+	var resp []BlockTradeCollection
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_block_trades", input, &resp, true)
+}
+
+// WSRetrieveBrokerTradeRequests retrieves broker trade requests through the websocket connection.
+func (e *Exchange) WSRetrieveBrokerTradeRequests(ctx context.Context) ([]BrokerTradeRequestItem, error) {
+	var resp []BrokerTradeRequestItem
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_broker_trade_requests", nil, &resp, true)
+}
+
+// WSRetrieveBrokerTrades retrieves broker trade history through the websocket connection.
+func (e *Exchange) WSRetrieveBrokerTrades(ctx context.Context, req *GetBrokerTradesRequest) (*BrokerTradeHistoryResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	input := map[string]any{}
+	if !req.Currency.IsEmpty() {
+		input["currency"] = req.Currency.String()
+	}
+	if req.Count > 0 {
+		input["count"] = req.Count
+	}
+	if req.StartID != "" {
+		input["start_id"] = req.StartID
+	}
+	if req.EndID != "" {
+		input["end_id"] = req.EndID
+	}
+	var resp *BrokerTradeHistoryResponse
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_broker_trades", input, &resp, true)
+}
+
+// WSCreateBlockRFQ creates a new block RFQ through the websocket connection.
+func (e *Exchange) WSCreateBlockRFQ(ctx context.Context, req *CreateBlockRFQRequest) (*BlockRFQData, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	checkedLegs, err := validateCreateBlockRFQLegs(req.Legs)
+	if err != nil {
+		return nil, err
+	}
+	err = validateBlockRFQTradeAllocations(req.TradeAllocations)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	input := map[string]any{
+		"legs": checkedLegs,
+	}
+	if len(req.Makers) > 0 {
+		input["makers"] = req.Makers
+	}
+	if len(req.TradeAllocations) > 0 {
+		input["trade_allocations"] = req.TradeAllocations
+	}
+	if checkedHedge != nil {
+		input["hedge"] = checkedHedge
+	}
+	if req.Label != "" {
+		input["label"] = req.Label
+	}
+	if req.Disclosed {
+		input["disclosed"] = true
+	}
+	var resp *BlockRFQData
+	return resp, e.SendWSRequest(ctx, blockRFQWriteEPL, "private/create_block_rfq", input, &resp, true)
+}
+
+// WSAddBlockRFQQuote adds a quote to an existing block RFQ through the websocket connection.
+func (e *Exchange) WSAddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuoteRequest) (*BlockRFQQuote, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
+	if err != nil {
+		return nil, err
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	input := map[string]any{
+		"block_rfq_id": req.BlockRFQID,
+	}
+	if req.Amount > 0 {
+		input["amount"] = req.Amount
+	}
+	if req.Price > 0 {
+		input["price"] = req.Price
+	}
+	if normalisedDirection != "" {
+		input["direction"] = normalisedDirection
+	}
+	if req.ExecutionInstruction != "" {
+		input["execution_instruction"] = req.ExecutionInstruction
+	}
+	if !req.ExpiresAt.IsZero() {
+		input["expires_at"] = req.ExpiresAt.UnixMilli()
+	}
+	if len(checkedLegs) > 0 {
+		input["legs"] = checkedLegs
+	}
+	if checkedHedge != nil {
+		input["hedge"] = checkedHedge
+	}
+	if req.Label != "" {
+		input["label"] = req.Label
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/add_block_rfq_quote", input, &resp, true)
+}
+
+// WSEditBlockRFQQuote edits an existing block RFQ quote through the websocket connection.
+func (e *Exchange) WSEditBlockRFQQuote(ctx context.Context, req *EditBlockRFQQuoteRequest) (*BlockRFQQuote, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQQuoteID <= 0 && (req.BlockRFQID <= 0 || req.Label == "") {
+		return nil, errMissingBlockRFQQuoteIdentifier
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	input := map[string]any{}
+	if req.BlockRFQQuoteID > 0 {
+		input["block_rfq_quote_id"] = req.BlockRFQQuoteID
+	}
+	if req.BlockRFQID > 0 {
+		input["block_rfq_id"] = req.BlockRFQID
+	}
+	if req.Amount > 0 {
+		input["amount"] = req.Amount
+	}
+	if req.Price > 0 {
+		input["price"] = req.Price
+	}
+	if len(checkedLegs) > 0 {
+		input["legs"] = checkedLegs
+	}
+	if checkedHedge != nil {
+		input["hedge"] = checkedHedge
+	}
+	if req.Label != "" {
+		input["label"] = req.Label
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/edit_block_rfq_quote", input, &resp, true)
+}
+
+// WSCancelBlockRFQQuote cancels a block RFQ quote through the websocket connection.
+func (e *Exchange) WSCancelBlockRFQQuote(ctx context.Context, blockRFQQuoteID, blockRFQID uint64, label string) (*BlockRFQQuote, error) {
+	if blockRFQQuoteID <= 0 && (blockRFQID <= 0 || label == "") {
+		return nil, errMissingBlockRFQQuoteIdentifier
+	}
+	input := map[string]any{}
+	if blockRFQQuoteID > 0 {
+		input["block_rfq_quote_id"] = blockRFQQuoteID
+	}
+	if blockRFQID > 0 {
+		input["block_rfq_id"] = blockRFQID
+	}
+	if label != "" {
+		input["label"] = label
+	}
+	var resp *BlockRFQQuote
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/cancel_block_rfq_quote", input, &resp, true)
+}
+
+// WSCancelAllBlockRFQQuotes cancels all block RFQ quotes through the websocket connection.
+func (e *Exchange) WSCancelAllBlockRFQQuotes(ctx context.Context, blockRFQID uint64, detailed bool) (*BlockRFQQuoteCancelResponse, error) {
+	input := map[string]any{}
+	if blockRFQID > 0 {
+		input["block_rfq_id"] = blockRFQID
+	}
+	if detailed {
+		input["detailed"] = true
+	}
+	var resp *BlockRFQQuoteCancelResponse
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/cancel_all_block_rfq_quotes", input, &resp, true)
+}
+
+// WSCancelBlockRFQ cancels a block RFQ through the websocket connection.
+func (e *Exchange) WSCancelBlockRFQ(ctx context.Context, blockRFQID uint64) (*BlockRFQData, error) {
+	if blockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	var resp *BlockRFQData
+	return resp, e.SendWSRequest(ctx, blockRFQWriteEPL, "private/cancel_block_rfq", map[string]uint64{"block_rfq_id": blockRFQID}, &resp, true)
+}
+
+// WSCancelBlockRFQTrigger cancels a block RFQ trigger through the websocket connection.
+func (e *Exchange) WSCancelBlockRFQTrigger(ctx context.Context, blockRFQID uint64) (*BlockRFQData, error) {
+	if blockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	var resp *BlockRFQData
+	return resp, e.SendWSRequest(ctx, blockRFQWriteEPL, "private/cancel_block_rfq_trigger", map[string]uint64{"block_rfq_id": blockRFQID}, &resp, true)
+}
+
+// WSAcceptBlockRFQ accepts an existing block RFQ through the websocket connection.
+func (e *Exchange) WSAcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQRequest) (*BlockRFQAcceptResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	if req.BlockRFQID <= 0 {
+		return nil, errMissingBlockRFQID
+	}
+	if req.Amount < 0 {
+		return nil, errInvalidAmount
+	}
+	if req.Price < 0 {
+		return nil, errInvalidPrice
+	}
+	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
+	if err != nil {
+		return nil, err
+	}
+	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
+	if err != nil {
+		return nil, err
+	}
+	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
+	if err != nil {
+		return nil, err
+	}
+	input := map[string]any{
+		"block_rfq_id": req.BlockRFQID,
+	}
+	if req.Price > 0 {
+		input["price"] = req.Price
+	}
+	if req.Amount > 0 {
+		input["amount"] = req.Amount
+	}
+	if normalisedDirection != "" {
+		input["direction"] = normalisedDirection
+	}
+	if checkedHedge != nil {
+		input["hedge"] = checkedHedge
+	}
+	if len(checkedLegs) > 0 {
+		input["legs"] = checkedLegs
+	}
+	if req.TimeInForce != "" {
+		input["time_in_force"] = req.TimeInForce
+	}
+	var resp *BlockRFQAcceptResponse
+	return resp, e.SendWSRequest(ctx, blockRFQWriteEPL, "private/accept_block_rfq", input, &resp, true)
+}
+
+// WSRetrieveBlockRFQs returns Block RFQs through the websocket connection.
+func (e *Exchange) WSRetrieveBlockRFQs(ctx context.Context, req *GetBlockRFQsRequest) (*BlockRFQListResponse, error) {
+	if req == nil {
+		return nil, errNoArgumentPassed
+	}
+	input := map[string]any{}
+	if !req.Currency.IsEmpty() {
+		input["currency"] = req.Currency.String()
+	}
+	if req.Count > 0 {
+		input["count"] = req.Count
+	}
+	if req.State != "" {
+		input["state"] = req.State
+	}
+	if req.Role != "" {
+		input["role"] = req.Role
+	}
+	if req.Continuation != "" {
+		input["continuation"] = req.Continuation
+	}
+	if req.BlockRFQID > 0 {
+		input["block_rfq_id"] = req.BlockRFQID
+	}
+	var resp *BlockRFQListResponse
+	return resp, e.SendWSRequest(ctx, blockRFQReadEPL, "private/get_block_rfqs", input, &resp, true)
+}
+
+// WSRetrieveBlockRFQQuotes retrieves open Block RFQ quotes through the websocket connection.
+func (e *Exchange) WSRetrieveBlockRFQQuotes(ctx context.Context, blockRFQID, blockRFQQuoteID uint64, label string) ([]BlockRFQQuote, error) {
+	input := map[string]any{}
+	if blockRFQID > 0 {
+		input["block_rfq_id"] = blockRFQID
+	}
+	if blockRFQQuoteID > 0 {
+		input["block_rfq_quote_id"] = blockRFQQuoteID
+	}
+	if label != "" {
+		input["label"] = label
+	}
+	var resp []BlockRFQQuote
+	return resp, e.SendWSRequest(ctx, blockRFQReadEPL, "private/get_block_rfq_quotes", input, &resp, true)
+}
+
+// WSRetrieveBlockRFQMakers retrieves available Block RFQ makers through the websocket connection.
+func (e *Exchange) WSRetrieveBlockRFQMakers(ctx context.Context) ([]string, error) {
+	var resp []string
+	return resp, e.SendWSRequest(ctx, blockRFQReadEPL, "private/get_block_rfq_makers", nil, &resp, true)
+}
+
+// WSRetrieveBlockRFQUserInfo retrieves block RFQ user identity info through the websocket connection.
+func (e *Exchange) WSRetrieveBlockRFQUserInfo(ctx context.Context) (*BlockRFQUserInfoResponse, error) {
+	var resp *BlockRFQUserInfoResponse
+	return resp, e.SendWSRequest(ctx, blockRFQReadEPL, "private/get_block_rfq_user_info", nil, &resp, true)
+}
+
+// WSRetrieveBlockRFQTrades retrieves recent public Block RFQ trades through the websocket connection.
+func (e *Exchange) WSRetrieveBlockRFQTrades(ctx context.Context, ccy currency.Code, continuation string, count uint64) (*BlockRFQTradeTapeResponse, error) {
+	if ccy.IsEmpty() {
+		return nil, currency.ErrCurrencyCodeEmpty
+	}
+	input := map[string]any{
+		"currency": ccy.String(),
+	}
+	if continuation != "" {
+		input["continuation"] = continuation
+	}
+	if count > 0 {
+		input["count"] = count
+	}
+	var resp *BlockRFQTradeTapeResponse
+	return resp, e.SendWSRequest(ctx, blockRFQReadEPL, "public/get_block_rfq_trades", input, &resp, false)
 }
 
 // WSRetrieveLastBlockTradesByCurrency returns list of last users block trades through the websocket connection.
@@ -2166,7 +2605,7 @@ func (e *Exchange) WSRetrieveLastBlockTradesByCurrency(ctx context.Context, ccy 
 		Count:    count,
 	}
 	var resp []BlockTradeData
-	return resp, e.SendWSRequest(ctx, nonMatchingEPL, getLastBlockTradesByCurrency, input, &resp, true)
+	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_last_block_trades_by_currency", input, &resp, true)
 }
 
 // WSMovePositions moves positions from source subaccount to target subaccount through the websocket connection.
@@ -2203,7 +2642,7 @@ func (e *Exchange) WSMovePositions(ctx context.Context, ccy currency.Code, sourc
 		SourceUID: sourceSubAccountUID,
 	}
 	var resp []BlockTradeMoveResponse
-	return resp, e.SendWSRequest(ctx, nonMatchingEPL, movePositions, input, &resp, true)
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/move_positions", input, &resp, true)
 }
 
 // WsSimulateBlockTrade checks if a block trade can be executed through the websocket
@@ -2237,7 +2676,7 @@ func (e *Exchange) WsSimulateBlockTrade(ctx context.Context, role string, trades
 		Trades: trades,
 	}
 	var resp bool
-	return resp, e.SendWSRequest(ctx, matchingEPL, simulateBlockPosition, input, resp, true)
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/simulate_block_trade", input, resp, true)
 }
 
 // SendWSRequest sends a request through the websocket connection.

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2307,9 +2307,13 @@ func (e *Exchange) WSAddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuote
 	if req.BlockRFQID <= 0 {
 		return nil, errMissingBlockRFQID
 	}
-	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
-	if err != nil {
-		return nil, err
+	var normalisedDirection string
+	if req.Direction != "" {
+		validatedDirection, err := validateBlockRFQDirection(req.Direction)
+		if err != nil {
+			return nil, err
+		}
+		normalisedDirection = validatedDirection
 	}
 	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
 	if err != nil {
@@ -2474,9 +2478,13 @@ func (e *Exchange) WSAcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQRequ
 	if req.Price < 0 {
 		return nil, errInvalidPrice
 	}
-	normalisedDirection, err := validateBlockRFQDirection(req.Direction)
-	if err != nil {
-		return nil, err
+	var normalisedDirection string
+	if req.Direction != "" {
+		validatedDirection, err := validateBlockRFQDirection(req.Direction)
+		if err != nil {
+			return nil, err
+		}
+		normalisedDirection = validatedDirection
 	}
 	checkedLegs, err := validateBlockRFQLegs(req.Legs, false)
 	if err != nil {

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2270,9 +2270,12 @@ func (e *Exchange) WSCreateBlockRFQ(ctx context.Context, req *CreateBlockRFQRequ
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	input := map[string]any{
 		"legs": checkedLegs,
@@ -2312,9 +2315,12 @@ func (e *Exchange) WSAddBlockRFQQuote(ctx context.Context, req *AddBlockRFQQuote
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if req.Amount < 0 {
 		return nil, errInvalidAmount
@@ -2365,9 +2371,12 @@ func (e *Exchange) WSEditBlockRFQQuote(ctx context.Context, req *EditBlockRFQQuo
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if req.Amount < 0 {
 		return nil, errInvalidAmount
@@ -2473,9 +2482,12 @@ func (e *Exchange) WSAcceptBlockRFQ(ctx context.Context, req *AcceptBlockRFQRequ
 	if err != nil {
 		return nil, err
 	}
-	checkedHedge, err := validateBlockRFQHedge(req.Hedge)
-	if err != nil {
-		return nil, err
+	var checkedHedge *BlockRFQHedgeLeg
+	if req.Hedge != nil {
+		checkedHedge, err = validateBlockRFQHedge(req.Hedge)
+		if err != nil {
+			return nil, err
+		}
 	}
 	input := map[string]any{
 		"block_rfq_id": req.BlockRFQID,

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -2127,10 +2126,8 @@ func (e *Exchange) WsInvalidateBlockTradeSignature(ctx context.Context, signatur
 	if signature == "" {
 		return errMissingSignature
 	}
-	params := url.Values{}
-	params.Set("signature", signature)
 	var resp string
-	err := e.SendWSRequest(ctx, blockTradeWriteEPL, "private/invalidate_block_trade_signature", params, &resp, true)
+	err := e.SendWSRequest(ctx, blockTradeWriteEPL, "private/invalidate_block_trade_signature", map[string]string{"signature": signature}, &resp, true)
 	if err != nil {
 		return err
 	}

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2664,7 +2664,7 @@ func (e *Exchange) WsSimulateBlockTrade(ctx context.Context, role string, trades
 		Trades: trades,
 	}
 	var resp bool
-	return resp, e.SendWSRequest(ctx, matchingEPL, "private/simulate_block_trade", input, resp, true)
+	return resp, e.SendWSRequest(ctx, matchingEPL, "private/simulate_block_trade", input, &resp, true)
 }
 
 // SendWSRequest sends a request through the websocket connection.

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2025,7 +2025,7 @@ func (e *Exchange) UnsubscribeAllPrivateChannels(ctx context.Context) (string, e
 // WSExecuteBlockTrade executes a block trade request
 // The whole request have to be exact the same as in private/verify_block_trade, only role field should be set appropriately - it basically means that both sides have to agree on the same timestamp, nonce, trades fields and server will assure that role field is different between sides (each party accepted own role).
 // Using the same timestamp and nonce by both sides in private/verify_block_trade assures that even if unintentionally both sides execute given block trade with valid counterparty_signature, the given block trade will be executed only once
-func (e *Exchange) WSExecuteBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string, ccy currency.Code, trades []BlockTradeParam) ([]BlockTradeResponse, error) {
+func (e *Exchange) WSExecuteBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string, ccy currency.Code, trades []BlockTradeParam) (*ExecutedBlockTradeCollection, error) {
 	if nonce == "" {
 		return nil, errMissingNonce
 	}
@@ -2069,7 +2069,7 @@ func (e *Exchange) WSExecuteBlockTrade(ctx context.Context, timestampMS time.Tim
 		Timestamp:             timestampMS.UnixMilli(),
 		Currency:              ccy.String(),
 	}
-	var resp []BlockTradeResponse
+	var resp *ExecutedBlockTradeCollection
 	return resp, e.SendWSRequest(ctx, matchingEPL, "private/execute_block_trade", input, &resp, true)
 }
 
@@ -2141,11 +2141,11 @@ func (e *Exchange) WsInvalidateBlockTradeSignature(ctx context.Context, signatur
 }
 
 // WSRetrieveUserBlockTrade returns information about users block trade through the websocket connection.
-func (e *Exchange) WSRetrieveUserBlockTrade(ctx context.Context, id string) ([]BlockTradeData, error) {
+func (e *Exchange) WSRetrieveUserBlockTrade(ctx context.Context, id string) (*BlockTradeCollection, error) {
 	if id == "" {
 		return nil, errMissingBlockTradeID
 	}
-	var resp []BlockTradeData
+	var resp *BlockTradeCollection
 	return resp, e.SendWSRequest(ctx, blockTradeReadEPL, "private/get_block_trade", map[string]string{"id": id}, &resp, true)
 }
 

--- a/exchanges/deribit/deribit_ws_endpoints.go
+++ b/exchanges/deribit/deribit_ws_endpoints.go
@@ -2161,14 +2161,8 @@ func (e *Exchange) WSRetrieveBlockTradeRequests(ctx context.Context, brokerCode 
 
 // WSApproveBlockTrade approves a pending block trade through the websocket connection.
 func (e *Exchange) WSApproveBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string) error {
-	if nonce == "" {
-		return errMissingNonce
-	}
-	if timestampMS.IsZero() {
-		return errZeroTimestamp
-	}
-	if role != roleMaker && role != roleTaker {
-		return errInvalidTradeRole
+	if err := validatePendingBlockTradeAction(timestampMS, nonce, role); err != nil {
+		return err
 	}
 	input := map[string]any{
 		"timestamp": timestampMS.UnixMilli(),
@@ -2188,14 +2182,8 @@ func (e *Exchange) WSApproveBlockTrade(ctx context.Context, timestampMS time.Tim
 
 // WSRejectBlockTrade rejects a pending block trade through the websocket connection.
 func (e *Exchange) WSRejectBlockTrade(ctx context.Context, timestampMS time.Time, nonce, role string) error {
-	if nonce == "" {
-		return errMissingNonce
-	}
-	if timestampMS.IsZero() {
-		return errZeroTimestamp
-	}
-	if role != roleMaker && role != roleTaker {
-		return errInvalidTradeRole
+	if err := validatePendingBlockTradeAction(timestampMS, nonce, role); err != nil {
+		return err
 	}
 	input := map[string]any{
 		"timestamp": timestampMS.UnixMilli(),

--- a/exchanges/deribit/ratelimit.go
+++ b/exchanges/deribit/ratelimit.go
@@ -19,6 +19,10 @@ const (
 	matchingEPL
 	portfolioMarginEPL
 	privatePortfolioMarginEPL
+	blockTradeReadEPL
+	blockTradeWriteEPL
+	blockRFQReadEPL
+	blockRFQWriteEPL
 )
 
 // GetRateLimits returns the rate limit for the exchange
@@ -28,5 +32,9 @@ func GetRateLimits() request.RateLimitDefinitions {
 		matchingEPL:               request.GetRateLimiterWithWeight(request.NewRateLimit(time.Second, minMatchingBurst), matchingWeight),
 		portfolioMarginEPL:        request.GetRateLimiterWithWeight(request.NewRateLimit(5*time.Second, portfoliMarginRate), standardWeight),
 		privatePortfolioMarginEPL: request.GetRateLimiterWithWeight(request.NewRateLimit(5*time.Second, portfoliMarginRate), standardWeight),
+		blockTradeReadEPL:         request.GetRateLimiterWithWeight(request.NewRateLimit(time.Second, nonMatchingRate), standardWeight),
+		blockTradeWriteEPL:        request.GetRateLimiterWithWeight(request.NewRateLimit(time.Second, nonMatchingRate), standardWeight),
+		blockRFQReadEPL:           request.GetRateLimiterWithWeight(request.NewRateLimit(time.Second, nonMatchingRate), standardWeight),
+		blockRFQWriteEPL:          request.GetRateLimiterWithWeight(request.NewRateLimit(time.Second, nonMatchingRate), standardWeight),
 	}
 }


### PR DESCRIPTION
Fixes #2081.

Adds the Deribit block trade and block RFQ API coverage requested in #2081, with REST + websocket parity, docs-aligned request/response types, and direct test coverage for the new validation paths.

Highlights
- add block trade endpoints for verify/execute/invalidate, pending request review, trade history, broker trade requests/history, and simulation
- add block RFQ endpoints for create/add/edit/cancel/accept flows plus RFQ/quote/maker/user/trade retrieval
- align request payloads with the current Deribit OpenAPI, including:
  - dedicated create_block_rfq leg request shape
  - accept_block_rfq parameter shape
  - add/edit_block_rfq_quote parameter shape
  - broker/client trade allocation validation
- tighten response typing for broker trade and block RFQ payloads where the docs/examples require different shapes from request models
- add direct validator coverage, offline parameter-validation tests, and focused unmarshal coverage for the new response types
- add rate-limit entries for the new Deribit endpoints

Validation
- `go test ./exchanges/deribit -count=1`
- `golangci-lint run ./exchanges/deribit`
- `codespell --dictionary=-,./contrib/spellcheck/codespell_custom_dictionary.txt exchanges/deribit/deribit.go exchanges/deribit/deribit_ws_endpoints.go exchanges/deribit/deribit_types.go exchanges/deribit/deribit_test.go exchanges/deribit/ratelimit.go`
- `git diff --check`
