### PR TITLE
kraken: handle authenticated websocket subscriptions without pairs

### DIFF
--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,7 +1,6 @@
 package kraken
 
 import (
-	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -18,7 +17,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
-	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/fundingrate"
@@ -26,7 +24,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
-	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
@@ -1130,64 +1127,6 @@ func TestWsOwnTradesSub(t *testing.T) {
 	err = e.Unsubscribe(subs)
 	assert.NoError(t, err, "Unsubscribing an auth channel should not error")
 	assert.Empty(t, e.Websocket.GetSubscriptions(), "Should have successfully removed channel")
-}
-
-type mockAuthSubConnection struct {
-	websocket.Connection
-	responses [][]byte
-	expected  int
-}
-
-func (m *mockAuthSubConnection) SendMessageReturnResponses(_ context.Context, _ request.EndpointLimit, _, _ any, expected int) ([][]byte, error) {
-	m.expected = expected
-	return m.responses, nil
-}
-
-func TestManageSubsAuthenticatedNoPairs(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name, channel, qualifiedChannel string
-		response                        []byte
-	}{
-		{name: "own trades", channel: subscription.MyTradesChannel, qualifiedChannel: krakenWsOwnTrades, response: []byte(`{"channelName":"ownTrades","event":"subscriptionStatus","reqid":3,"status":"subscribed","subscription":{"name":"ownTrades"}}`)},
-		{name: "open orders", channel: subscription.MyOrdersChannel, qualifiedChannel: krakenWsOpenOrders, response: []byte(`{"channelName":"openOrders","event":"subscriptionStatus","reqid":3,"status":"subscribed","subscription":{"name":"openOrders"}}`)},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ex := new(Exchange)
-			require.NoError(t, testexch.Setup(ex), "Setup Instance must not error")
-			conn := &mockAuthSubConnection{responses: [][]byte{tc.response}}
-			ex.Websocket.AuthConn = conn
-
-			err := ex.manageSubs(t.Context(), krakenWsSubscribe, subscription.List{{
-				Channel:          tc.channel,
-				QualifiedChannel: tc.qualifiedChannel,
-				Authenticated:    true,
-			}})
-			require.NoError(t, err, "auth subscription without pairs must not error")
-			assert.Equal(t, 1, conn.expected, "auth subscription without pairs should wait for one response")
-		})
-	}
-}
-
-func TestManageSubsAuthenticatedNoPairsRequiresSingleResponse(t *testing.T) {
-	t.Parallel()
-
-	ex := new(Exchange)
-	require.NoError(t, testexch.Setup(ex), "Setup Instance must not error")
-	conn := &mockAuthSubConnection{}
-	ex.Websocket.AuthConn = conn
-
-	err := ex.manageSubs(t.Context(), krakenWsSubscribe, subscription.List{{
-		Channel:          subscription.MyTradesChannel,
-		QualifiedChannel: krakenWsOwnTrades,
-		Authenticated:    true,
-	}})
-	require.ErrorIs(t, err, errExpectedOneSubResponse)
-	require.ErrorContains(t, err, "got 0; Channel: myTrades")
-	assert.Equal(t, 1, conn.expected, "auth subscription without pairs should still wait for one response")
 }
 
 func TestWsProcessSubStatusAuthenticated(t *testing.T) {

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -913,10 +913,10 @@ func (e *Exchange) wsProcessSubStatus(resp []byte) {
 
 	keySub := &subscription.Subscription{Channel: c}
 	lookupKey := any(subscription.ChannelKey{Subscription: keySub})
-	pName, err := jsonparser.GetUnsafeString(resp, "pair")
-	if err == nil {
-		pair, err := currency.NewPairFromString(pName)
-		if err != nil {
+	if pName, pErr := jsonparser.GetUnsafeString(resp, "pair"); pErr == nil {
+		pair, pErr := currency.NewPairFromString(pName)
+		if pErr != nil {
+			log.Errorf(log.ExchangeSys, "%s error parsing websocket subscription pair %q: %s from message: %s", e.Name, pName, pErr, resp)
 			return
 		}
 		keySub.Pairs = currency.Pairs{pair}

--- a/exchanges/kraken/kraken_websocket_test.go
+++ b/exchanges/kraken/kraken_websocket_test.go
@@ -1,0 +1,84 @@
+package kraken
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
+	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
+)
+
+type mockAuthSubConnection struct {
+	websocket.Connection
+	responses [][]byte
+	expected  int
+}
+
+func (m *mockAuthSubConnection) SendMessageReturnResponses(_ context.Context, _ request.EndpointLimit, _, _ any, expected int) ([][]byte, error) {
+	m.expected = expected
+	return m.responses, nil
+}
+
+func TestManageSubs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name             string
+		channel          string
+		qualifiedChannel string
+		response         []byte
+		responseCount    int
+		errIs            error
+		errContains      string
+	}{
+		{name: "own trades", channel: subscription.MyTradesChannel, qualifiedChannel: krakenWsOwnTrades, response: []byte(`{"channelName":"ownTrades","event":"subscriptionStatus","reqid":3,"status":"subscribed","subscription":{"name":"ownTrades"}}`), responseCount: 1},
+		{name: "open orders", channel: subscription.MyOrdersChannel, qualifiedChannel: krakenWsOpenOrders, response: []byte(`{"channelName":"openOrders","event":"subscriptionStatus","reqid":3,"status":"subscribed","subscription":{"name":"openOrders"}}`), responseCount: 1},
+		{name: "requires single response", channel: subscription.MyTradesChannel, qualifiedChannel: krakenWsOwnTrades, responseCount: 0, errIs: errExpectedOneSubResponse, errContains: "got 0; Channel: myTrades"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ex := new(Exchange)
+			require.NoError(t, testexch.Setup(ex), "Setup Instance must not error")
+
+			conn := &mockAuthSubConnection{expected: -1}
+			if tc.responseCount > 0 {
+				conn.responses = [][]byte{tc.response}
+			}
+			ex.Websocket.AuthConn = conn
+
+			err := ex.manageSubs(t.Context(), krakenWsSubscribe, subscription.List{{
+				Channel:          tc.channel,
+				QualifiedChannel: tc.qualifiedChannel,
+				Authenticated:    true,
+			}})
+			if tc.errIs != nil {
+				require.ErrorIs(t, err, tc.errIs)
+				require.ErrorContains(t, err, tc.errContains)
+			} else {
+				require.NoError(t, err, "auth subscription without pairs must not error")
+			}
+			assert.Equal(t, 1, conn.expected, "auth subscription without pairs waits for one response")
+		})
+	}
+}
+
+func TestWsProcessSubStatusInvalidPair(t *testing.T) {
+	t.Parallel()
+
+	ex := new(Exchange)
+	require.NoError(t, testexch.Setup(ex), "Setup Instance must not error")
+	s := &subscription.Subscription{
+		Channel: subscription.TickerChannel,
+		Pairs:   currency.Pairs{currency.NewBTCUSD()},
+	}
+	require.NoError(t, ex.Websocket.AddSubscriptions(nil, s), "subscription must be added in subscribing state")
+
+	ex.wsProcessSubStatus([]byte(`{"channelName":"ticker","event":"subscriptionStatus","pair":"not-a-pair","status":"subscribed","subscription":{"name":"ticker"}}`))
+	assert.Equal(t, subscription.SubscribingState, s.State(), "invalid websocket subscription pair should leave the subscription state unchanged")
+}


### PR DESCRIPTION
Fixes #1930.

Kraken authenticated websocket channels such as `myTrades` / `myOrders` (`ownTrades` / `openOrders`) do not include pairs, but the current subscribe path still waits for `len(s.Pairs)` responses and later assumes subscription status payloads always contain a `pair`, which can fail with `buffer size must be positive`.

This change:
- waits for one response when subscribing to authenticated no-pair channels
- validates no-pair subscription responses without trying to parse a pair
- falls back to channel-only matching in `wsProcessSubStatus` when Kraken omits `pair`

Validation:
- `go test ./exchanges/kraken -count=1`
- `golangci-lint run --verbose ./exchanges/kraken/...`
- `codespell` on touched files
