### PR TITLE
gateio: use contract stats for perpetual open interest

### DIFF
--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -2891,7 +2891,21 @@ func TestGetOpenInterest(t *testing.T) {
 		key.PairAsset{Base: usdtPair.Base.Item, Quote: usdtPair.Quote.Item, Asset: asset.USDTMarginedFutures},
 	)
 	assert.NoError(t, err, "GetOpenInterest should not error for multiple explicit perpetual pairs")
-	require.Len(t, resp, 2, "GetOpenInterest returns the requested perpetual pairs")
+	require.Len(t, resp, 2, "GetOpenInterest returns exactly the requested perpetual pairs")
+
+	expected := map[asset.Item]currency.Pair{
+		asset.CoinMarginedFutures: coinPair,
+		asset.USDTMarginedFutures: usdtPair,
+	}
+	found := make(map[asset.Item]bool, len(expected))
+	for _, oi := range resp {
+		expPair, ok := expected[oi.Key.Asset]
+		require.Truef(t, ok, "unexpected asset in OpenInterest response: %v", oi.Key.Asset)
+		assert.Truef(t, expPair.Equal(oi.Key.Pair()), "OpenInterest pair mismatch for asset %v", oi.Key.Asset)
+		assert.Positivef(t, oi.OpenInterest, "OpenInterest should return positive open interest for asset %v", oi.Key.Asset)
+		found[oi.Key.Asset] = true
+	}
+	require.Len(t, found, len(expected), "OpenInterest response missing expected assets")
 
 	resp, err = e.GetOpenInterest(t.Context())
 	assert.NoError(t, err, "GetOpenInterest should not error")

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -2196,11 +2196,9 @@ func (e *Exchange) GetOpenInterest(ctx context.Context, keys ...key.PairAsset) (
 	}
 	for _, a := range assets {
 		useStats := useOpenInterestStats(keys, a)
-		var requestedPair currency.Pair
-		if useStats {
-			if requestedPair, errs = e.MatchSymbolWithAvailablePairs(keys[0].Pair().String(), a, false); errs != nil {
-				return nil, errs
-			}
+		requestedPair, err := getRequestedOpenInterestPair(e, keys, a)
+		if err != nil {
+			return nil, err
 		}
 		contracts, err := e.getOpenInterestContracts(ctx, a, requestedPair)
 		if err != nil {
@@ -2293,6 +2291,13 @@ func openInterestFromStats(stats []ContractStat) (float64, error) {
 
 func useOpenInterestStats(keys []key.PairAsset, a asset.Item) bool {
 	return a != asset.DeliveryFutures && len(keys) == 1 && keys[0].Asset == a
+}
+
+func getRequestedOpenInterestPair(e *Exchange, keys []key.PairAsset, a asset.Item) (currency.Pair, error) {
+	if len(keys) != 1 || keys[0].Asset != a {
+		return currency.EMPTYPAIR, nil
+	}
+	return e.MatchSymbolWithAvailablePairs(keys[0].Pair().String(), a, false)
 }
 
 func (e *Exchange) getOpenInterestFromStats(ctx context.Context, a asset.Item, p currency.Pair) (float64, error) {

--- a/exchanges/gateio/gateio_wrapper_test.go
+++ b/exchanges/gateio/gateio_wrapper_test.go
@@ -104,6 +104,31 @@ func TestUseOpenInterestStats(t *testing.T) {
 	assert.True(t, useOpenInterestStats([]key.PairAsset{{Asset: asset.USDTMarginedFutures}}, asset.USDTMarginedFutures))
 }
 
+func TestGetRequestedOpenInterestPair(t *testing.T) {
+	t.Parallel()
+
+	pair := getPair(t, asset.DeliveryFutures)
+	requested, err := getRequestedOpenInterestPair(e, []key.PairAsset{{
+		Base:  pair.Base.Item,
+		Quote: pair.Quote.Item,
+		Asset: asset.DeliveryFutures,
+	}}, asset.DeliveryFutures)
+	require.NoError(t, err)
+	assert.Equal(t, pair, requested)
+
+	requested, err = getRequestedOpenInterestPair(e, []key.PairAsset{{
+		Base:  pair.Base.Item,
+		Quote: pair.Quote.Item,
+		Asset: asset.DeliveryFutures,
+	}}, asset.CoinMarginedFutures)
+	require.NoError(t, err)
+	assert.Equal(t, currency.EMPTYPAIR, requested)
+
+	requested, err = getRequestedOpenInterestPair(e, []key.PairAsset{{Asset: asset.DeliveryFutures}, {Asset: asset.DeliveryFutures}}, asset.DeliveryFutures)
+	require.NoError(t, err)
+	assert.Equal(t, currency.EMPTYPAIR, requested)
+}
+
 func TestMessageID(t *testing.T) {
 	t.Parallel()
 	id := e.MessageID()


### PR DESCRIPTION
Addresses #1803.

`GetOpenInterest` was deriving a notional-style value from contract metadata instead of using GateIO's reported `open_interest`. This switches `asset.CoinMarginedFutures` and `asset.USDTMarginedFutures` to `GetFutureStats`, which exposes the actual contract `open_interest` field.

Delivery futures are left on the existing fallback path for now because GateIO's public API docs do not appear to expose a delivery-futures stats/open-interest endpoint analogous to `/futures/{settle}/contract_stats`.

Tests:
- `TestOpenInterestFromStats`
- `TestGetOpenInterest`

Validation:
- focused GateIO open-interest tests passed
- `codespell` on touched files
- `golangci-lint run --verbose ./exchanges/gateio/...`

Note:
- a broader `go test ./exchanges/gateio -count=1` still hits the pre-existing `TestFetchOrderbook` failure, which also reproduces on `upstream/master`
