### PR TITLE
exchange: Update logging for pair updates and add verbose check

### DIFF
--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -778,9 +778,10 @@ func (b *Base) UpdatePairs(incoming currency.Pairs, a asset.Item, enabled bool) 
 	}
 
 	if len(diff.Remove) > 0 {
-		log.Debugf(log.ExchangeSys, "%s Checked and updated enabled pairs [%v] - Removed: %d.", b.Name, strings.ToUpper(a.String()), len(diff.Remove))
 		if b.IsVerbose() {
 			log.Debugf(log.ExchangeSys, "%s Checked and updated enabled pairs [%v] - removed: %s.", b.Name, strings.ToUpper(a.String()), diff.Remove)
+		} else {
+			log.Debugf(log.ExchangeSys, "%s Checked and updated enabled pairs [%v] - Removed: %d.", b.Name, strings.ToUpper(a.String()), len(diff.Remove))
 		}
 	}
 	if err := b.Config.CurrencyPairs.StorePairs(a, enabledPairs, true); err != nil {


### PR DESCRIPTION
# PR Description

Defaults to showing a added/removed count for updated pairs for each asset and allows a user to print all pairs if they set verbose to true, reducing test output spam but still allows us to see when there's exchange startup issues.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Running GCT

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
