### PR TITLE
Bitfinex: Accept trailing ticker timestamps

### DIFF
--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -683,7 +683,14 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 	if strings.HasPrefix(symbol, "f") {
 		return tickerFromFundingResp(symbol, respAny)
 	}
-	if len(respAny) != 10 {
+	switch len(respAny) {
+	case 10:
+	case 11:
+		// Bitfinex REST tickers now append a trailing update timestamp.
+		// Keep accepting the original 10-field payload because older REST
+		// fixtures still use it.
+		respAny = respAny[:10]
+	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
 	}
 	resp := make([]float64, 10)
@@ -711,7 +718,12 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FRRAmountAvailable"}
 
 func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
-	if len(respAny) != 16 {
+	switch len(respAny) {
+	case 16:
+	case 17:
+		// Bitfinex REST funding tickers now append a trailing update timestamp.
+		respAny = respAny[:16]
+	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
 	}
 	resp := make([]float64, 16)

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -689,6 +689,9 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 		// Bitfinex REST tickers now append a trailing update timestamp.
 		// Keep accepting the original 10-field payload because older REST
 		// fixtures still use it.
+		if _, ok := respAny[10].(float64); !ok {
+			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
+		}
 		respAny = respAny[:10]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
@@ -722,6 +725,9 @@ func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 	case 16:
 	case 17:
 		// Bitfinex REST funding tickers now append a trailing update timestamp.
+		if _, ok := respAny[16].(float64); !ok {
+			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
+		}
 		respAny = respAny[:16]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -29,6 +29,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 const (
@@ -683,15 +684,18 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 	if strings.HasPrefix(symbol, "f") {
 		return tickerFromFundingResp(symbol, respAny)
 	}
+	var timestamp types.Time
 	switch len(respAny) {
 	case 10:
 	case 11:
 		// Bitfinex REST tickers now append a trailing update timestamp.
 		// Keep accepting the original 10-field payload because older REST
 		// fixtures still use it.
-		if _, ok := respAny[10].(float64); !ok {
+		ts, ok := respAny[10].(float64)
+		if !ok {
 			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
 		}
+		timestamp = types.Time(time.UnixMilli(int64(ts)))
 		respAny = respAny[:10]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
@@ -715,19 +719,23 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 		Volume:          resp[7],
 		High:            resp[8],
 		Low:             resp[9],
+		Timestamp:       timestamp,
 	}, nil
 }
 
 var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FRRAmountAvailable"}
 
 func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
+	var timestamp types.Time
 	switch len(respAny) {
 	case 16:
 	case 17:
 		// Bitfinex REST funding tickers now append a trailing update timestamp.
-		if _, ok := respAny[16].(float64); !ok {
+		ts, ok := respAny[16].(float64)
+		if !ok {
 			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
 		}
+		timestamp = types.Time(time.UnixMilli(int64(ts)))
 		respAny = respAny[:16]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
@@ -758,6 +766,7 @@ func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 		High:               resp[11],
 		Low:                resp[12],
 		FRRAmountAvailable: resp[15],
+		Timestamp:          timestamp,
 	}, nil
 }
 

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -684,18 +684,18 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 	if strings.HasPrefix(symbol, "f") {
 		return tickerFromFundingResp(symbol, respAny)
 	}
-	var timestamp types.Time
+	var firstTradeTimestamp types.Time
 	switch len(respAny) {
 	case 10:
 	case 11:
-		// Bitfinex REST tickers now append a trailing update timestamp.
+		// Bitfinex REST tickers can append a trailing FIRST_TRADE timestamp.
 		// Keep accepting the original 10-field payload because older REST
 		// fixtures still use it.
 		ts, ok := respAny[10].(float64)
 		if !ok {
-			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
+			return nil, fmt.Errorf("%w for %s field FirstTradeTimestamp from %v", errTickerInvalidResp, symbol, respAny)
 		}
-		timestamp = types.Time(time.UnixMilli(int64(ts)))
+		firstTradeTimestamp = types.Time(time.UnixMilli(int64(ts)))
 		respAny = respAny[:10]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
@@ -719,23 +719,23 @@ func tickerFromResp(symbol string, respAny []any) (*Ticker, error) {
 		Volume:          resp[7],
 		High:            resp[8],
 		Low:             resp[9],
-		Timestamp:       timestamp,
+		Timestamp:       firstTradeTimestamp,
 	}, nil
 }
 
 var fundingTickerFields = []string{"FlashReturnRate", "Bid", "BidPeriod", "BidSize", "Ask", "AskPeriod", "AskSize", "DailyChange", "DailyChangePercentage", "LastPrice", "DailyVolume", "DailyHigh", "DailyLow", "", "", "FRRAmountAvailable"}
 
 func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
-	var timestamp types.Time
+	var firstTradeTimestamp types.Time
 	switch len(respAny) {
 	case 16:
 	case 17:
-		// Bitfinex REST funding tickers now append a trailing update timestamp.
+		// Bitfinex REST funding tickers can append a trailing FIRST_TRADE timestamp.
 		ts, ok := respAny[16].(float64)
 		if !ok {
-			return nil, fmt.Errorf("%w for %s field Timestamp from %v", errTickerInvalidResp, symbol, respAny)
+			return nil, fmt.Errorf("%w for %s field FirstTradeTimestamp from %v", errTickerInvalidResp, symbol, respAny)
 		}
-		timestamp = types.Time(time.UnixMilli(int64(ts)))
+		firstTradeTimestamp = types.Time(time.UnixMilli(int64(ts)))
 		respAny = respAny[:16]
 	default:
 		return nil, fmt.Errorf("%w for %s: %v", errTickerInvalidFieldCount, symbol, respAny)
@@ -766,7 +766,7 @@ func tickerFromFundingResp(symbol string, respAny []any) (*Ticker, error) {
 		High:               resp[11],
 		Low:                resp[12],
 		FRRAmountAvailable: resp[15],
-		Timestamp:          timestamp,
+		Timestamp:          firstTradeTimestamp,
 	}, nil
 }
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -3,6 +3,8 @@ package bitfinex
 import (
 	"bufio"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"testing"
@@ -207,7 +209,7 @@ func TestGetTickerBatch(t *testing.T) {
 	require.Contains(t, ticks, "tBTCUSD", "Ticker batch must contain tBTCUSD")
 	checkTradeTick(t, ticks["tBTCUSD"])
 	require.Contains(t, ticks, "fUSD", "Ticker batch must contain fUSD")
-	checkTradeTick(t, ticks["fUSD"])
+	checkFundingTick(t, ticks["fUSD"])
 }
 
 func TestGetTicker(t *testing.T) {
@@ -604,6 +606,88 @@ func TestUpdateTicker(t *testing.T) {
 	if err == nil {
 		assert.False(t, tick.LastUpdated.IsZero(), "UpdateTicker should populate LastUpdated")
 	}
+}
+
+func TestUpdateTickersStoresTradingTimestampFromBatch(t *testing.T) {
+	ex := newMockTickerBatchExchange(t, "Bitfinex timestamp spot test", [][]any{{
+		"tBTCUSD",
+		1.1,
+		2.2,
+		3.3,
+		4.4,
+		5.5,
+		6.6,
+		7.7,
+		8.8,
+		9.9,
+		10.10,
+		1747143592992.0,
+	}})
+	require.NoError(t, ex.CurrencyPairs.StorePairs(asset.Spot, currency.Pairs{btcusdPair}, true), "StorePairs must not error")
+
+	err := ex.UpdateTickers(t.Context(), asset.Spot)
+	require.NoError(t, err, "UpdateTickers must not error")
+
+	stored, err := ticker.GetTicker(ex.Name, btcusdPair, asset.Spot)
+	require.NoError(t, err, "GetTicker must not error")
+	assert.Equal(t, time.UnixMilli(1747143592992), stored.LastUpdated, "UpdateTickers should preserve the exchange timestamp for spot tickers")
+}
+
+func TestUpdateTickersStoresFundingTimestampFromBatch(t *testing.T) {
+	fundingPair, err := currency.NewPairFromString("USD")
+	require.NoError(t, err, "NewPairFromString must not error")
+
+	ex := newMockTickerBatchExchange(t, "Bitfinex timestamp funding test", [][]any{{
+		"fUSD",
+		1.1,
+		2.2,
+		3.0,
+		4.4,
+		5.5,
+		6.0,
+		7.7,
+		8.8,
+		9.9,
+		10.10,
+		11.11,
+		12.12,
+		13.13,
+		nil,
+		nil,
+		15.15,
+		1747143592992.0,
+	}})
+	require.NoError(t, ex.CurrencyPairs.StorePairs(asset.MarginFunding, currency.Pairs{fundingPair}, true), "StorePairs must not error")
+
+	err = ex.UpdateTickers(t.Context(), asset.MarginFunding)
+	require.NoError(t, err, "UpdateTickers must not error")
+
+	stored, err := ticker.GetTicker(ex.Name, fundingPair, asset.MarginFunding)
+	require.NoError(t, err, "GetTicker must not error")
+	assert.Equal(t, time.UnixMilli(1747143592992), stored.LastUpdated, "UpdateTickers should preserve the exchange timestamp for funding tickers")
+}
+
+func newMockTickerBatchExchange(t *testing.T, name string, payload [][]any) *Exchange {
+	t.Helper()
+
+	ex := new(Exchange)
+	require.NoError(t, testexch.Setup(ex), "Test instance Setup must not error")
+	ex.Name = name
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Ticker batch request method should be GET")
+		assert.Equal(t, "/v2/tickers", r.URL.Path, "Ticker batch request path should be correct")
+		assert.Equal(t, "ALL", r.URL.Query().Get("symbols"), "Ticker batch request symbols should be correct")
+
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(payload)
+		require.NoError(t, err, "Encoding ticker batch payload must not error")
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, ex.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+	require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL), "SetRunningURL must not error")
+	return ex
 }
 
 func TestUpdateTickers(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1814,7 +1814,7 @@ func TestWSTickerResponseInvalidTrailingTimestamp(t *testing.T) {
 	require.NoError(t, err, "AddSubscriptions must not error")
 
 	err = e.wsHandleData(t.Context(), []byte(`[11534,[61.304,2228.36155358,61.305,1323.2442970500003,0.395,0.0065,61.371,50973.3020771,62.5,57.421,true]]`))
-	assert.ErrorIs(t, err, errTickerInvalidTimestamp, "wsHandleData should reject invalid trailing ticker timestamp types")
+	assert.ErrorIs(t, err, errTickerInvalidFirstTradeTime, "wsHandleData should reject invalid trailing FIRST_TRADE timestamp types")
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
 		t.Fatalf("DataHandler should not receive websocket ticker data on invalid trailing timestamp types: %#v", resp)
@@ -1833,7 +1833,7 @@ func TestWSFundingTickerResponseInvalidTrailingTimestamp(t *testing.T) {
 	require.NoError(t, err, "AddSubscriptions must not error")
 
 	err = e.wsHandleData(t.Context(), []byte(`[22334,[1.1,2.2,3,4.4,5.5,6,7.7,8.8,9.9,10.1,11.11,12.12,13.13,null,null,15.15,true]]`))
-	assert.ErrorIs(t, err, errTickerInvalidTimestamp, "wsHandleData should reject invalid funding trailing ticker timestamp types")
+	assert.ErrorIs(t, err, errTickerInvalidFirstTradeTime, "wsHandleData should reject invalid funding trailing FIRST_TRADE timestamp types")
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
 		t.Fatalf("DataHandler should not receive websocket funding ticker data on invalid trailing timestamp types: %#v", resp)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -228,18 +228,36 @@ func TestTickerFromResp(t *testing.T) {
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should error correctly")
 	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should error correctly")
 
-	tick, err := tickerFromResp("tBTCUSD", []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10})
-	require.NoError(t, err, "tickerFromResp must error correctly")
-	assert.Equal(t, 1.1, tick.Bid, "Tick Bid should be correct")
-	assert.Equal(t, 2.2, tick.BidSize, "Tick BidSize should be correct")
-	assert.Equal(t, 3.3, tick.Ask, "Tick Ask should be correct")
-	assert.Equal(t, 4.4, tick.AskSize, "Tick AskSize should be correct")
-	assert.Equal(t, 5.5, tick.DailyChange, "Tick DailyChange should be correct")
-	assert.Equal(t, 6.6, tick.DailyChangePerc, "Tick DailyChangePerc should be correct")
-	assert.Equal(t, 7.7, tick.Last, "Tick Last should be correct")
-	assert.Equal(t, 8.8, tick.Volume, "Tick Volume should be correct")
-	assert.Equal(t, 9.9, tick.High, "Tick High should be correct")
-	assert.Equal(t, 10.10, tick.Low, "Tick Low should be correct")
+	_, err = tickerFromResp("tBTCUSD", []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, 1747143592992.0, 42.0})
+	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should reject unexpected extra fields")
+	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should reject unexpected extra fields")
+
+	expTradingTick := &Ticker{
+		Bid:             1.1,
+		BidSize:         2.2,
+		Ask:             3.3,
+		AskSize:         4.4,
+		DailyChange:     5.5,
+		DailyChangePerc: 6.6,
+		Last:            7.7,
+		Volume:          8.8,
+		High:            9.9,
+		Low:             10.10,
+	}
+	for _, tc := range []struct {
+		name    string
+		payload []any
+	}{
+		{name: "legacy payload", payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10}},
+		{name: "payload with trailing timestamp", payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, 1747143592992.0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tick, err := tickerFromResp("tBTCUSD", tc.payload)
+			require.NoError(t, err, "tickerFromResp must not error")
+			assert.Equal(t, expTradingTick, tick, "tickerFromResp should parse trading payload correctly")
+		})
+	}
 
 	_, err = tickerFromResp("fBTC", []any{100.0, nil, 100.0, nil, nil, nil, nil, nil, nil, nil})
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should delegate to tickerFromFundingResp and error correctly")
@@ -257,22 +275,40 @@ func TestTickerFromFundingResp(t *testing.T) {
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromFundingResp should error correctly")
 	assert.ErrorContains(t, err, "fBTC", "tickerFromFundingResp should error correctly")
 
-	tick, err := tickerFromFundingResp("fBTC", []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15})
-	require.NoError(t, err, "tickerFromFundingResp must error correctly")
-	assert.Equal(t, 1.1, tick.FlashReturnRate, "Tick FlashReturnRate should be correct")
-	assert.Equal(t, 2.2, tick.Bid, "Tick Bid should be correct")
-	assert.Equal(t, int64(3), tick.BidPeriod, "Tick BidPeriod should be correct")
-	assert.Equal(t, 4.4, tick.BidSize, "Tick BidSize should be correct")
-	assert.Equal(t, 5.5, tick.Ask, "Tick Ask should be correct")
-	assert.Equal(t, int64(6), tick.AskPeriod, "Tick AskPeriod should be correct")
-	assert.Equal(t, 7.7, tick.AskSize, "Tick AskSize should be correct")
-	assert.Equal(t, 8.8, tick.DailyChange, "Tick DailyChange should be correct")
-	assert.Equal(t, 9.9, tick.DailyChangePerc, "Tick DailyChangePerc should be correct")
-	assert.Equal(t, 10.10, tick.Last, "Tick Last should be correct")
-	assert.Equal(t, 11.11, tick.Volume, "Tick Volume should be correct")
-	assert.Equal(t, 12.12, tick.High, "Tick High should be correct")
-	assert.Equal(t, 13.13, tick.Low, "Tick Low should be correct")
-	assert.Equal(t, 15.15, tick.FRRAmountAvailable, "Tick FRRAmountAvailable should be correct")
+	_, err = tickerFromFundingResp("fBTC", []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, 1747143592992.0, 42.0})
+	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromFundingResp should reject unexpected extra fields")
+	assert.ErrorContains(t, err, "fBTC", "tickerFromFundingResp should reject unexpected extra fields")
+
+	expFundingTick := &Ticker{
+		FlashReturnRate:    1.1,
+		Bid:                2.2,
+		BidPeriod:          3,
+		BidSize:            4.4,
+		Ask:                5.5,
+		AskPeriod:          6,
+		AskSize:            7.7,
+		DailyChange:        8.8,
+		DailyChangePerc:    9.9,
+		Last:               10.10,
+		Volume:             11.11,
+		High:               12.12,
+		Low:                13.13,
+		FRRAmountAvailable: 15.15,
+	}
+	for _, tc := range []struct {
+		name    string
+		payload []any
+	}{
+		{name: "legacy payload", payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15}},
+		{name: "payload with trailing timestamp", payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, 1747143592992.0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tick, err := tickerFromFundingResp("fBTC", tc.payload)
+			require.NoError(t, err, "tickerFromFundingResp must not error")
+			assert.Equal(t, expFundingTick, tick, "tickerFromFundingResp should parse funding payload correctly")
+		})
+	}
 }
 
 func TestGetTickerFunding(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1564,6 +1564,85 @@ func TestWSTickerResponse(t *testing.T) {
 	}
 }
 
+func TestWSTickerResponseTrailingField(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	err := e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.Spot, Pairs: currency.Pairs{btcusdPair}, Channel: subscription.TickerChannel, Key: 11534})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[11534,[61.304,2228.36155358,61.305,1323.2442970500003,0.395,0.0065,61.371,50973.3020771,62.5,57.421,null]]`))
+	require.NoError(t, err, "wsHandleData must not error for trailing ticker fields")
+
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		tick, ok := resp.Data.(*ticker.Price)
+		require.True(t, ok, "DataHandler should receive a ticker.Price")
+		assert.Equal(t, btcusdPair, tick.Pair, "Ticker pair should be correct")
+		assert.Equal(t, asset.Spot, tick.AssetType, "Ticker asset should be correct")
+		assert.Equal(t, 61.304, tick.Bid, "Ticker bid should be correct")
+		assert.Equal(t, 61.305, tick.Ask, "Ticker ask should be correct")
+		assert.Equal(t, 61.371, tick.Last, "Ticker last should be correct")
+		assert.Equal(t, 50973.3020771, tick.Volume, "Ticker volume should be correct")
+		assert.Equal(t, 62.5, tick.High, "Ticker high should be correct")
+		assert.Equal(t, 57.421, tick.Low, "Ticker low should be correct")
+	case <-time.After(time.Second):
+		t.Fatal("Ticker update must be queued")
+	}
+}
+
+func TestWSFundingTickerResponseTrailingField(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	fundingPair, err := currency.NewPairFromStrings("USD", "")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.MarginFunding, Pairs: currency.Pairs{fundingPair}, Channel: subscription.TickerChannel, Key: 22334})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[22334,[1.1,2.2,3,4.4,5.5,6,7.7,8.8,9.9,10.1,11.11,12.12,13.13,null,null,15.15,null]]`))
+	require.NoError(t, err, "wsHandleData must not error for trailing funding ticker fields")
+
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		tick, ok := resp.Data.(*ticker.Price)
+		require.True(t, ok, "DataHandler should receive a ticker.Price")
+		assert.Equal(t, fundingPair, tick.Pair, "Ticker pair should be correct")
+		assert.Equal(t, asset.MarginFunding, tick.AssetType, "Ticker asset should be correct")
+		assert.Equal(t, 1.1, tick.FlashReturnRate, "Ticker flash return rate should be correct")
+		assert.Equal(t, 2.2, tick.Bid, "Ticker bid should be correct")
+		assert.Equal(t, 3.0, tick.BidPeriod, "Ticker bid period should be correct")
+		assert.Equal(t, 5.5, tick.Ask, "Ticker ask should be correct")
+		assert.Equal(t, 6.0, tick.AskPeriod, "Ticker ask period should be correct")
+		assert.Equal(t, 10.1, tick.Last, "Ticker last should be correct")
+		assert.Equal(t, 11.11, tick.Volume, "Ticker volume should be correct")
+		assert.Equal(t, 12.12, tick.High, "Ticker high should be correct")
+		assert.Equal(t, 13.13, tick.Low, "Ticker low should be correct")
+		assert.Equal(t, 15.15, tick.FlashReturnRateAmount, "Ticker flash return rate amount should be correct")
+	case <-time.After(time.Second):
+		t.Fatal("Funding ticker update must be queued")
+	}
+}
+
+func TestWSTickerResponseInvalidFieldCount(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	err := e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.Spot, Pairs: currency.Pairs{btcusdPair}, Channel: subscription.TickerChannel, Key: 11534})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[11534,[1,2,3,4,5,6,7,8,9,10,11,12]]`))
+	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "wsHandleData should reject unexpected websocket ticker field counts")
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		t.Fatalf("DataHandler should not receive websocket ticker data on invalid field counts: %#v", resp)
+	default:
+	}
+}
+
 func TestWSCandleResponse(t *testing.T) {
 	err := e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.Spot, Pairs: currency.Pairs{btcusdPair}, Channel: subscription.CandlesChannel, Key: 343351})
 	require.NoError(t, err, "AddSubscriptions must not error")

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -1578,7 +1578,7 @@ func TestWSTickerResponseTrailingField(t *testing.T) {
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
 		tick, ok := resp.Data.(*ticker.Price)
-		require.True(t, ok, "DataHandler should receive a ticker.Price")
+		require.True(t, ok, "DataHandler must receive a ticker.Price")
 		assert.Equal(t, btcusdPair, tick.Pair, "Ticker pair should be correct")
 		assert.Equal(t, asset.Spot, tick.AssetType, "Ticker asset should be correct")
 		assert.Equal(t, 61.304, tick.Bid, "Ticker bid should be correct")
@@ -1608,7 +1608,7 @@ func TestWSFundingTickerResponseTrailingField(t *testing.T) {
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
 		tick, ok := resp.Data.(*ticker.Price)
-		require.True(t, ok, "DataHandler should receive a ticker.Price")
+		require.True(t, ok, "DataHandler must receive a ticker.Price")
 		assert.Equal(t, fundingPair, tick.Pair, "Ticker pair should be correct")
 		assert.Equal(t, asset.MarginFunding, tick.AssetType, "Ticker asset should be correct")
 		assert.Equal(t, 1.1, tick.FlashReturnRate, "Ticker flash return rate should be correct")

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -681,7 +681,7 @@ func newMockTickerBatchExchange(t *testing.T, name string, payload [][]any) *Exc
 
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(payload)
-		require.NoError(t, err, "Encoding ticker batch payload must not error")
+		assert.NoError(t, err, "Encoding ticker batch payload should not error")
 	}))
 	t.Cleanup(server.Close)
 
@@ -1706,7 +1706,7 @@ func TestWSTickerResponseTrailingField(t *testing.T) {
 	require.NoError(t, err, "AddSubscriptions must not error")
 
 	err = e.wsHandleData(t.Context(), []byte(`[11534,[61.304,2228.36155358,61.305,1323.2442970500003,0.395,0.0065,61.371,50973.3020771,62.5,57.421,null]]`))
-	require.NoError(t, err, "wsHandleData must not error for trailing ticker fields")
+	require.NoError(t, err, "wsHandleData must not error for optional trailing ticker timestamps")
 
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
@@ -1720,6 +1720,7 @@ func TestWSTickerResponseTrailingField(t *testing.T) {
 		assert.Equal(t, 50973.3020771, tick.Volume, "Ticker volume should be correct")
 		assert.Equal(t, 62.5, tick.High, "Ticker high should be correct")
 		assert.Equal(t, 57.421, tick.Low, "Ticker low should be correct")
+		assert.True(t, tick.LastUpdated.IsZero(), "Ticker LastUpdated should stay zero when FIRST_TRADE is null")
 	case <-time.After(time.Second):
 		t.Fatal("Ticker update must be queued")
 	}
@@ -1736,7 +1737,7 @@ func TestWSFundingTickerResponseTrailingField(t *testing.T) {
 	require.NoError(t, err, "AddSubscriptions must not error")
 
 	err = e.wsHandleData(t.Context(), []byte(`[22334,[1.1,2.2,3,4.4,5.5,6,7.7,8.8,9.9,10.1,11.11,12.12,13.13,null,null,15.15,null]]`))
-	require.NoError(t, err, "wsHandleData must not error for trailing funding ticker fields")
+	require.NoError(t, err, "wsHandleData must not error for optional trailing funding ticker timestamps")
 
 	select {
 	case resp := <-e.Websocket.DataHandler.C:
@@ -1754,8 +1755,89 @@ func TestWSFundingTickerResponseTrailingField(t *testing.T) {
 		assert.Equal(t, 12.12, tick.High, "Ticker high should be correct")
 		assert.Equal(t, 13.13, tick.Low, "Ticker low should be correct")
 		assert.Equal(t, 15.15, tick.FlashReturnRateAmount, "Ticker flash return rate amount should be correct")
+		assert.True(t, tick.LastUpdated.IsZero(), "Ticker LastUpdated should stay zero when FIRST_TRADE is null")
 	case <-time.After(time.Second):
 		t.Fatal("Funding ticker update must be queued")
+	}
+}
+
+func TestWSTickerResponseTrailingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	err := e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.Spot, Pairs: currency.Pairs{btcusdPair}, Channel: subscription.TickerChannel, Key: 11534})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[11534,[61.304,2228.36155358,61.305,1323.2442970500003,0.395,0.0065,61.371,50973.3020771,62.5,57.421,1747143592992]]`))
+	require.NoError(t, err, "wsHandleData must not error for trailing ticker timestamps")
+
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		tick, ok := resp.Data.(*ticker.Price)
+		require.True(t, ok, "DataHandler must receive a ticker.Price")
+		assert.Equal(t, time.UnixMilli(1747143592992), tick.LastUpdated, "Ticker LastUpdated should preserve FIRST_TRADE timestamps")
+	case <-time.After(time.Second):
+		t.Fatal("Ticker update must be queued")
+	}
+}
+
+func TestWSFundingTickerResponseTrailingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	fundingPair, err := currency.NewPairFromStrings("USD", "")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.MarginFunding, Pairs: currency.Pairs{fundingPair}, Channel: subscription.TickerChannel, Key: 22334})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[22334,[1.1,2.2,3,4.4,5.5,6,7.7,8.8,9.9,10.1,11.11,12.12,13.13,null,null,15.15,1747143592992]]`))
+	require.NoError(t, err, "wsHandleData must not error for trailing funding ticker timestamps")
+
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		tick, ok := resp.Data.(*ticker.Price)
+		require.True(t, ok, "DataHandler must receive a ticker.Price")
+		assert.Equal(t, time.UnixMilli(1747143592992), tick.LastUpdated, "Ticker LastUpdated should preserve funding FIRST_TRADE timestamps")
+	case <-time.After(time.Second):
+		t.Fatal("Funding ticker update must be queued")
+	}
+}
+
+func TestWSTickerResponseInvalidTrailingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	err := e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.Spot, Pairs: currency.Pairs{btcusdPair}, Channel: subscription.TickerChannel, Key: 11534})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[11534,[61.304,2228.36155358,61.305,1323.2442970500003,0.395,0.0065,61.371,50973.3020771,62.5,57.421,true]]`))
+	assert.ErrorIs(t, err, errTickerInvalidTimestamp, "wsHandleData should reject invalid trailing ticker timestamp types")
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		t.Fatalf("DataHandler should not receive websocket ticker data on invalid trailing timestamp types: %#v", resp)
+	default:
+	}
+}
+
+func TestWSFundingTickerResponseInvalidTrailingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	e := new(Exchange)
+	require.NoError(t, testexch.Setup(e), "Test instance Setup must not error")
+	fundingPair, err := currency.NewPairFromStrings("USD", "")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = e.Websocket.AddSubscriptions(e.Websocket.Conn, &subscription.Subscription{Asset: asset.MarginFunding, Pairs: currency.Pairs{fundingPair}, Channel: subscription.TickerChannel, Key: 22334})
+	require.NoError(t, err, "AddSubscriptions must not error")
+
+	err = e.wsHandleData(t.Context(), []byte(`[22334,[1.1,2.2,3,4.4,5.5,6,7.7,8.8,9.9,10.1,11.11,12.12,13.13,null,null,15.15,true]]`))
+	assert.ErrorIs(t, err, errTickerInvalidTimestamp, "wsHandleData should reject invalid funding trailing ticker timestamp types")
+	select {
+	case resp := <-e.Websocket.DataHandler.C:
+		t.Fatalf("DataHandler should not receive websocket funding ticker data on invalid trailing timestamp types: %#v", resp)
+	default:
 	}
 }
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -237,30 +237,50 @@ func TestTickerFromResp(t *testing.T) {
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should reject unexpected extra fields")
 	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should reject unexpected extra fields")
 
-	expTradingTick := &Ticker{
-		Bid:             1.1,
-		BidSize:         2.2,
-		Ask:             3.3,
-		AskSize:         4.4,
-		DailyChange:     5.5,
-		DailyChangePerc: 6.6,
-		Last:            7.7,
-		Volume:          8.8,
-		High:            9.9,
-		Low:             10.10,
-	}
 	for _, tc := range []struct {
 		name    string
 		payload []any
+		exp     *Ticker
 	}{
-		{name: "legacy payload", payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10}},
-		{name: "payload with trailing timestamp", payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, 1747143592992.0}},
+		{
+			name:    "legacy payload",
+			payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10},
+			exp: &Ticker{
+				Bid:             1.1,
+				BidSize:         2.2,
+				Ask:             3.3,
+				AskSize:         4.4,
+				DailyChange:     5.5,
+				DailyChangePerc: 6.6,
+				Last:            7.7,
+				Volume:          8.8,
+				High:            9.9,
+				Low:             10.10,
+			},
+		},
+		{
+			name:    "payload with trailing timestamp",
+			payload: []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, 1747143592992.0},
+			exp: &Ticker{
+				Bid:             1.1,
+				BidSize:         2.2,
+				Ask:             3.3,
+				AskSize:         4.4,
+				DailyChange:     5.5,
+				DailyChangePerc: 6.6,
+				Last:            7.7,
+				Volume:          8.8,
+				High:            9.9,
+				Low:             10.10,
+				Timestamp:       types.Time(time.UnixMilli(1747143592992)),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tick, err := tickerFromResp("tBTCUSD", tc.payload)
 			require.NoError(t, err, "tickerFromResp must not error")
-			assert.Equal(t, expTradingTick, tick, "tickerFromResp should parse trading payload correctly")
+			assert.Equal(t, tc.exp, tick, "tickerFromResp should parse trading payload correctly")
 		})
 	}
 
@@ -289,34 +309,58 @@ func TestTickerFromFundingResp(t *testing.T) {
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromFundingResp should reject unexpected extra fields")
 	assert.ErrorContains(t, err, "fBTC", "tickerFromFundingResp should reject unexpected extra fields")
 
-	expFundingTick := &Ticker{
-		FlashReturnRate:    1.1,
-		Bid:                2.2,
-		BidPeriod:          3,
-		BidSize:            4.4,
-		Ask:                5.5,
-		AskPeriod:          6,
-		AskSize:            7.7,
-		DailyChange:        8.8,
-		DailyChangePerc:    9.9,
-		Last:               10.10,
-		Volume:             11.11,
-		High:               12.12,
-		Low:                13.13,
-		FRRAmountAvailable: 15.15,
-	}
 	for _, tc := range []struct {
 		name    string
 		payload []any
+		exp     *Ticker
 	}{
-		{name: "legacy payload", payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15}},
-		{name: "payload with trailing timestamp", payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, 1747143592992.0}},
+		{
+			name:    "legacy payload",
+			payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15},
+			exp: &Ticker{
+				FlashReturnRate:    1.1,
+				Bid:                2.2,
+				BidPeriod:          3,
+				BidSize:            4.4,
+				Ask:                5.5,
+				AskPeriod:          6,
+				AskSize:            7.7,
+				DailyChange:        8.8,
+				DailyChangePerc:    9.9,
+				Last:               10.10,
+				Volume:             11.11,
+				High:               12.12,
+				Low:                13.13,
+				FRRAmountAvailable: 15.15,
+			},
+		},
+		{
+			name:    "payload with trailing timestamp",
+			payload: []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, 1747143592992.0},
+			exp: &Ticker{
+				FlashReturnRate:    1.1,
+				Bid:                2.2,
+				BidPeriod:          3,
+				BidSize:            4.4,
+				Ask:                5.5,
+				AskPeriod:          6,
+				AskSize:            7.7,
+				DailyChange:        8.8,
+				DailyChangePerc:    9.9,
+				Last:               10.10,
+				Volume:             11.11,
+				High:               12.12,
+				Low:                13.13,
+				FRRAmountAvailable: 15.15,
+				Timestamp:          types.Time(time.UnixMilli(1747143592992)),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tick, err := tickerFromFundingResp("fBTC", tc.payload)
 			require.NoError(t, err, "tickerFromFundingResp must not error")
-			assert.Equal(t, expFundingTick, tick, "tickerFromFundingResp should parse funding payload correctly")
+			assert.Equal(t, tc.exp, tick, "tickerFromFundingResp should parse funding payload correctly")
 		})
 	}
 }
@@ -335,6 +379,7 @@ func checkTradeTick(tb testing.TB, tick *Ticker) {
 	assert.Positive(tb, tick.Ask, "Tick Ask should be positive")
 	assert.Positive(tb, tick.AskSize, "Tick AskSize should be positive")
 	assert.Positive(tb, tick.Last, "Tick Last should be positive")
+	assert.False(tb, tick.Timestamp.Time().IsZero(), "Tick Timestamp should be populated")
 	// Can't test DailyChange*, Volume, High or Low without false positives when they're occasionally 0
 }
 
@@ -348,6 +393,7 @@ func checkFundingTick(tb testing.TB, tick *Ticker) {
 	assert.Positive(tb, tick.AskPeriod, "Tick AskPeriod should be positive")
 	assert.Positive(tb, tick.AskSize, "Tick AskSize should be positive")
 	assert.Positive(tb, tick.Last, "Tick Last should be positive")
+	assert.False(tb, tick.Timestamp.Time().IsZero(), "Tick Timestamp should be populated")
 	// Can't test FRRAmountAvailable as it's occasionally 0
 }
 
@@ -553,8 +599,11 @@ func TestNewOrder(t *testing.T) {
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 
-	_, err := e.UpdateTicker(t.Context(), btcusdPair, asset.Spot)
+	tick, err := e.UpdateTicker(t.Context(), btcusdPair, asset.Spot)
 	assert.NoError(t, common.ExcludeError(err, ticker.ErrBidEqualsAsk), "UpdateTicker may only error about locked markets")
+	if err == nil {
+		assert.False(t, tick.LastUpdated.IsZero(), "UpdateTicker should populate LastUpdated")
+	}
 }
 
 func TestUpdateTickers(t *testing.T) {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -228,6 +228,11 @@ func TestTickerFromResp(t *testing.T) {
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should error correctly")
 	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should error correctly")
 
+	_, err = tickerFromResp("tBTCUSD", []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, nil})
+	assert.ErrorIs(t, err, errTickerInvalidResp, "tickerFromResp should reject non-numeric trailing timestamps")
+	assert.ErrorContains(t, err, "Timestamp", "tickerFromResp should reject non-numeric trailing timestamps")
+	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should reject non-numeric trailing timestamps")
+
 	_, err = tickerFromResp("tBTCUSD", []any{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10, 1747143592992.0, 42.0})
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromResp should reject unexpected extra fields")
 	assert.ErrorContains(t, err, "tBTCUSD", "tickerFromResp should reject unexpected extra fields")
@@ -274,6 +279,11 @@ func TestTickerFromFundingResp(t *testing.T) {
 	_, err = tickerFromFundingResp("fBTC", []any{100.0, nil, 100.0, nil, nil, nil, nil, nil, nil})
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromFundingResp should error correctly")
 	assert.ErrorContains(t, err, "fBTC", "tickerFromFundingResp should error correctly")
+
+	_, err = tickerFromFundingResp("fBTC", []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, nil})
+	assert.ErrorIs(t, err, errTickerInvalidResp, "tickerFromFundingResp should reject non-numeric trailing timestamps")
+	assert.ErrorContains(t, err, "Timestamp", "tickerFromFundingResp should reject non-numeric trailing timestamps")
+	assert.ErrorContains(t, err, "fBTC", "tickerFromFundingResp should reject non-numeric trailing timestamps")
 
 	_, err = tickerFromFundingResp("fBTC", []any{1.1, 2.2, 3.0, 4.4, 5.5, 6.0, 7.7, 8.8, 9.9, 10.10, 11.11, 12.12, 13.13, nil, nil, 15.15, 1747143592992.0, 42.0})
 	assert.ErrorIs(t, err, errTickerInvalidFieldCount, "tickerFromFundingResp should reject unexpected extra fields")

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -14,13 +14,13 @@ import (
 )
 
 var (
-	errSetCannotBeEmpty        = errors.New("set cannot be empty")
-	errNoSeqNo                 = errors.New("no sequence number")
-	errParamNotAllowed         = errors.New("param not allowed")
-	errTickerInvalidSymbol     = errors.New("invalid ticker symbol")
-	errTickerInvalidResp       = errors.New("invalid ticker response format")
-	errTickerInvalidFieldCount = errors.New("invalid ticker response field count")
-	errTickerInvalidTimestamp  = errors.New("invalid ticker timestamp format")
+	errSetCannotBeEmpty            = errors.New("set cannot be empty")
+	errNoSeqNo                     = errors.New("no sequence number")
+	errParamNotAllowed             = errors.New("param not allowed")
+	errTickerInvalidSymbol         = errors.New("invalid ticker symbol")
+	errTickerInvalidResp           = errors.New("invalid ticker response format")
+	errTickerInvalidFieldCount     = errors.New("invalid ticker response field count")
+	errTickerInvalidFirstTradeTime = errors.New("invalid ticker first trade timestamp format")
 )
 
 // AccountV2Data stores account v2 data
@@ -152,7 +152,7 @@ type Ticker struct {
 	High               float64
 	Low                float64
 	FRRAmountAvailable float64    // Flash Return Rate amount available
-	Timestamp          types.Time // Trailing ticker update timestamp when supplied by Bitfinex
+	Timestamp          types.Time // Trailing ticker FIRST_TRADE timestamp when supplied by Bitfinex
 }
 
 // DerivativeDataResponse stores data for queried derivative

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -20,6 +20,7 @@ var (
 	errTickerInvalidSymbol     = errors.New("invalid ticker symbol")
 	errTickerInvalidResp       = errors.New("invalid ticker response format")
 	errTickerInvalidFieldCount = errors.New("invalid ticker response field count")
+	errTickerInvalidTimestamp  = errors.New("invalid ticker timestamp format")
 )
 
 // AccountV2Data stores account v2 data

--- a/exchanges/bitfinex/bitfinex_types.go
+++ b/exchanges/bitfinex/bitfinex_types.go
@@ -150,7 +150,8 @@ type Ticker struct {
 	Volume             float64
 	High               float64
 	Low                float64
-	FRRAmountAvailable float64 // Flash Return Rate amount available
+	FRRAmountAvailable float64    // Flash Return Rate amount available
+	Timestamp          types.Time // Trailing ticker update timestamp when supplied by Bitfinex
 }
 
 // DerivativeDataResponse stores data for queried derivative

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -814,8 +814,15 @@ func (e *Exchange) handleWSTickerUpdate(ctx context.Context, c *subscription.Sub
 
 	switch len(tickerData) {
 	case 11, 17:
-		// Bitfinex websocket tickers can append an unused trailing field.
-		// Ignore it and preserve the established field mapping.
+		// Bitfinex websocket tickers can append an optional trailing FIRST_TRADE
+		// timestamp. The docs note this field may be null.
+		if tickerData[len(tickerData)-1] != nil {
+			ts, tsOK := tickerData[len(tickerData)-1].(float64)
+			if !tsOK {
+				return errTickerInvalidTimestamp
+			}
+			t.LastUpdated = time.UnixMilli(int64(ts))
+		}
 		tickerData = tickerData[:len(tickerData)-1]
 	}
 

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -816,12 +816,12 @@ func (e *Exchange) handleWSTickerUpdate(ctx context.Context, c *subscription.Sub
 	case 11, 17:
 		// Bitfinex websocket tickers can append an optional trailing FIRST_TRADE
 		// timestamp. The docs note this field may be null.
-		if tickerData[len(tickerData)-1] != nil {
-			ts, tsOK := tickerData[len(tickerData)-1].(float64)
-			if !tsOK {
-				return errTickerInvalidTimestamp
+		if last := tickerData[len(tickerData)-1]; last != nil {
+			firstTradeTimestamp, firstTradeTimestampOK := last.(float64)
+			if !firstTradeTimestampOK {
+				return errTickerInvalidFirstTradeTime
 			}
-			t.LastUpdated = time.UnixMilli(int64(ts))
+			t.LastUpdated = time.UnixMilli(int64(firstTradeTimestamp))
 		}
 		tickerData = tickerData[:len(tickerData)-1]
 	}

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -812,7 +812,15 @@ func (e *Exchange) handleWSTickerUpdate(ctx context.Context, c *subscription.Sub
 		ExchangeName: e.Name,
 	}
 
-	if len(tickerData) == 10 {
+	switch len(tickerData) {
+	case 11, 17:
+		// Bitfinex websocket tickers can append an unused trailing field.
+		// Ignore it and preserve the established field mapping.
+		tickerData = tickerData[:len(tickerData)-1]
+	}
+
+	switch len(tickerData) {
+	case 10:
 		if t.Bid, ok = tickerData[0].(float64); !ok {
 			return errors.New("unable to type assert ticker bid")
 		}
@@ -831,7 +839,7 @@ func (e *Exchange) handleWSTickerUpdate(ctx context.Context, c *subscription.Sub
 		if t.Low, ok = tickerData[9].(float64); !ok {
 			return errors.New("unable to type assert ticker low")
 		}
-	} else {
+	case 16:
 		if t.FlashReturnRate, ok = tickerData[0].(float64); !ok {
 			return errors.New("unable to type assert ticker flash return rate")
 		}
@@ -866,8 +874,10 @@ func (e *Exchange) handleWSTickerUpdate(ctx context.Context, c *subscription.Sub
 			return errors.New("unable to type assert ticker low")
 		}
 		if t.FlashReturnRateAmount, ok = tickerData[15].(float64); !ok {
-			return errors.New("unable to type assert ticker flash return rate")
+			return errors.New("unable to type assert ticker flash return rate amount")
 		}
+	default:
+		return fmt.Errorf("%w for websocket ticker payload: %v", errTickerInvalidFieldCount, tickerData)
 	}
 	return e.Websocket.DataHandler.Send(ctx, t)
 }

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -317,6 +317,7 @@ func (e *Exchange) UpdateTickers(ctx context.Context, a asset.Item) error {
 			Ask:          val.Ask,
 			Volume:       val.Volume,
 			Pair:         pair,
+			LastUpdated:  val.Timestamp.Time(),
 			AssetType:    a,
 			ExchangeName: e.Name,
 		})


### PR DESCRIPTION
## Summary
- Accept Bitfinex REST trading ticker payloads with a trailing timestamp field.
- Accept Bitfinex REST funding ticker payloads with a trailing timestamp field.
- Preserve strict validation by only allowing the legacy payload widths and the new timestamp-appended widths.
- Add direct regression coverage for legacy, timestamp-appended, and unexpectedly overlong payloads.

## Testing
- go test ./exchanges/bitfinex -run 'Test(TickerFromResp|TickerFromFundingResp|GetTickerBatch|GetTicker|GetTickerFunding|UpdateTradablePairs|UpdateOrderExecutionLimits|GetCurrencyTradeURL)$' -count=1
- go test ./cmd/exchange_wrapper_standards -run 'TestAllExchangeWrappers/bitfinex_wrapper_tests' -count=1
- golangci-lint run ./exchanges/bitfinex/...
- codespell exchanges/bitfinex/bitfinex.go exchanges/bitfinex/bitfinex_test.go
