### PR TITLE
okx: fix stale SOL-USD futures instrument test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ __debug_bin
 coverage.txt
 wrapperconfig.json
 .history/
+.codex

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -409,7 +409,13 @@ func TestGetInstrument(t *testing.T) {
 		Underlying:     "SOL-USD",
 	})
 	require.NoError(t, err)
-	assert.Empty(t, resp, "Should get back no instruments for SOL-USD futures")
+	require.NotEmpty(t, resp, "GetInstruments must return live instruments for SOL-USD futures")
+	for _, inst := range resp {
+		assert.Equal(t, instTypeFutures, inst.InstrumentType, "InstrumentType should be correct")
+		assert.Equal(t, "SOL-USD", inst.Underlying, "Underlying should be correct")
+		assert.NotEmpty(t, inst.InstrumentID, "InstrumentID should not be empty")
+		assert.NotEmpty(t, inst.State, "State should not be empty")
+	}
 
 	result, err := e.GetInstruments(contextGenerate(), &InstrumentsFetchParams{
 		InstrumentType: instTypeSpot,

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -413,7 +413,7 @@ func TestGetInstrument(t *testing.T) {
 	for i := range resp {
 		assert.Equal(t, instTypeFutures, resp[i].InstrumentType, "InstrumentType should be correct")
 		assert.Equal(t, "SOL-USD", resp[i].Underlying, "Underlying should be correct")
-		assert.False(t, resp[i].InstrumentID.IsEmpty(), "InstrumentID should not be empty")
+		assert.True(t, resp[i].InstrumentID.IsPopulated(), "InstrumentID should be populated")
 		assert.NotEmpty(t, resp[i].State, "State should not be empty")
 	}
 

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -410,11 +410,11 @@ func TestGetInstrument(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, resp, "GetInstruments must return live instruments for SOL-USD futures")
-	for _, inst := range resp {
-		assert.Equal(t, instTypeFutures, inst.InstrumentType, "InstrumentType should be correct")
-		assert.Equal(t, "SOL-USD", inst.Underlying, "Underlying should be correct")
-		assert.NotEmpty(t, inst.InstrumentID, "InstrumentID should not be empty")
-		assert.NotEmpty(t, inst.State, "State should not be empty")
+	for i := range resp {
+		assert.Equal(t, instTypeFutures, resp[i].InstrumentType, "InstrumentType should be correct")
+		assert.Equal(t, "SOL-USD", resp[i].Underlying, "Underlying should be correct")
+		assert.False(t, resp[i].InstrumentID.IsEmpty(), "InstrumentID should not be empty")
+		assert.NotEmpty(t, resp[i].State, "State should not be empty")
 	}
 
 	result, err := e.GetInstruments(contextGenerate(), &InstrumentsFetchParams{


### PR DESCRIPTION
## Summary
- Update `TestGetInstrument` to reflect current OKX futures instrument data for `SOL-USD`
- Replace the stale empty-response assertion with checks that returned instruments are `FUTURES` entries for `SOL-USD`
- Ignore local `.codex` workspace state in `.gitignore`

## Testing
- `go test ./exchanges/okx -run ^TestGetInstrument -count=1`
- `golangci-lint run ./exchanges/okx/...`
- `codespell exchanges/okx/okx_test.go`
- `make misc_checks`