### PR TITLE
refactor: modernize sync/atomic usage with typed atomic apis

### DIFF
--- a/engine/communication_manager.go
+++ b/engine/communication_manager.go
@@ -14,7 +14,7 @@ const CommunicationsManagerName = "communications"
 
 // CommunicationManager ensures operations of communications
 type CommunicationManager struct {
-	started  int32
+	started  atomic.Bool
 	shutdown chan struct{}
 	relayMsg chan base.Event
 	comms    *communications.Communications
@@ -42,7 +42,7 @@ func (m *CommunicationManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // Start runs the subsystem
@@ -50,7 +50,7 @@ func (m *CommunicationManager) Start() error {
 	if m == nil {
 		return fmt.Errorf("communications manager server %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("communications manager %w", ErrSubSystemAlreadyStarted)
 	}
 	log.Debugf(log.CommunicationMgr, "Communications manager %s", MsgSubSystemStarting)
@@ -72,11 +72,11 @@ func (m *CommunicationManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("communications manager server %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("communications manager %w", ErrSubSystemNotStarted)
 	}
 	defer func() {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 	}()
 	close(m.shutdown)
 	log.Debugf(log.CommunicationMgr, "Communications manager %s", MsgSubSystemShuttingDown)

--- a/engine/communication_manager_test.go
+++ b/engine/communication_manager_test.go
@@ -43,7 +43,7 @@ func TestIsRunning(t *testing.T) {
 	if !m.IsRunning() {
 		t.Error("expected true")
 	}
-	m.started = 0
+	m.started.Store(false)
 	if m.IsRunning() {
 		t.Error("expected false")
 	}
@@ -65,7 +65,7 @@ func TestStart(t *testing.T) {
 	err = m.Start()
 	assert.NoError(t, err)
 
-	m.started = 1
+	m.started.Store(true)
 	err = m.Start()
 	assert.ErrorIs(t, err, ErrSubSystemAlreadyStarted)
 }
@@ -85,7 +85,7 @@ func TestGetStatus(t *testing.T) {
 	_, err = m.GetStatus()
 	assert.NoError(t, err)
 
-	m.started = 0
+	m.started.Store(false)
 	_, err = m.GetStatus()
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 }

--- a/engine/connection_manager.go
+++ b/engine/connection_manager.go
@@ -17,7 +17,7 @@ var errConnectionCheckerIsNil = errors.New("connection checker is nil")
 
 // connectionManager manages the connchecker
 type connectionManager struct {
-	started int32
+	started atomic.Bool
 	conn    *connchecker.Checker
 	cfg     *config.ConnectionMonitorConfig
 }
@@ -27,7 +27,7 @@ func (m *connectionManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // setupConnectionManager creates a connection manager
@@ -54,7 +54,7 @@ func (m *connectionManager) Start() error {
 	if m == nil {
 		return fmt.Errorf("connection manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("connection manager %w", ErrSubSystemAlreadyStarted)
 	}
 
@@ -64,7 +64,7 @@ func (m *connectionManager) Start() error {
 		m.cfg.PublicDomainList,
 		m.cfg.CheckInterval)
 	if err != nil {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 		return err
 	}
 
@@ -77,11 +77,11 @@ func (m *connectionManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("connection manager: %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("connection manager: %w", ErrSubSystemNotStarted)
 	}
 	defer func() {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 	}()
 	if m.conn == nil {
 		return fmt.Errorf("connection manager: %w", errConnectionCheckerIsNil)

--- a/engine/connection_manager_test.go
+++ b/engine/connection_manager_test.go
@@ -31,7 +31,7 @@ func TestConnectionMonitorIsRunning(t *testing.T) {
 	if !m.IsRunning() {
 		t.Error("expected true")
 	}
-	m.started = 0
+	m.started.Store(false)
 	if m.IsRunning() {
 		t.Error("expected false")
 	}
@@ -59,7 +59,9 @@ func TestConnectionMonitorStart(t *testing.T) {
 
 func TestConnectionMonitorStop(t *testing.T) {
 	t.Parallel()
-	err := (&connectionManager{started: 1}).Stop()
+	connectionCheckerless := &connectionManager{}
+	connectionCheckerless.started.Store(true)
+	err := connectionCheckerless.Stop()
 	assert.ErrorIs(t, err, errConnectionCheckerIsNil)
 
 	m, err := setupConnectionManager(&config.ConnectionMonitorConfig{})

--- a/engine/currency_state_manager.go
+++ b/engine/currency_state_manager.go
@@ -29,7 +29,7 @@ var enabled = &gctrpc.GenericResponse{Status: "enabled"}
 
 // CurrencyStateManager manages currency states
 type CurrencyStateManager struct {
-	started  int32
+	started  atomic.Bool
 	shutdown chan struct{}
 	wg       sync.WaitGroup
 	iExchangeManager
@@ -61,7 +61,7 @@ func (c *CurrencyStateManager) Start(ctx context.Context) error {
 		return fmt.Errorf("%s %w", CurrencyStateManagementName, ErrNilSubsystem)
 	}
 
-	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
+	if !c.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("%s %w", CurrencyStateManagementName, ErrSubSystemAlreadyStarted)
 	}
 	c.wg.Add(1)
@@ -75,7 +75,7 @@ func (c *CurrencyStateManager) Stop() error {
 	if c == nil {
 		return fmt.Errorf("%s %w", CurrencyStateManagementName, ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&c.started) == 0 {
+	if !c.started.Load() {
 		return fmt.Errorf("%s %w", CurrencyStateManagementName, ErrSubSystemNotStarted)
 	}
 
@@ -84,7 +84,7 @@ func (c *CurrencyStateManager) Stop() error {
 	c.wg.Wait()
 	c.shutdown = make(chan struct{})
 	log.Debugf(log.ExchangeSys, "Currency state manager %s", MsgSubSystemShutdown)
-	atomic.StoreInt32(&c.started, 0)
+	c.started.Store(false)
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (c *CurrencyStateManager) IsRunning() bool {
 	if c == nil {
 		return false
 	}
-	return atomic.LoadInt32(&c.started) == 1
+	return c.started.Load()
 }
 
 func (c *CurrencyStateManager) monitor(ctx context.Context) {

--- a/engine/currency_state_manager_test.go
+++ b/engine/currency_state_manager_test.go
@@ -125,6 +125,12 @@ func (f *fakerino) GetBase() *exchange.Base {
 	return &exchange.Base{States: currencystate.NewCurrencyStates()}
 }
 
+func startedCurrencyStateManager(em iExchangeManager) *CurrencyStateManager {
+	c := &CurrencyStateManager{iExchangeManager: em}
+	c.started.Store(true)
+	return c
+}
+
 func TestCurrencyStateManagerIsRunning(t *testing.T) {
 	t.Parallel()
 	err := (*CurrencyStateManager)(nil).Stop()
@@ -133,13 +139,15 @@ func TestCurrencyStateManagerIsRunning(t *testing.T) {
 	err = (&CurrencyStateManager{}).Stop()
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	err = (&CurrencyStateManager{started: 1, shutdown: make(chan struct{})}).Stop()
+	startedManager := startedCurrencyStateManager(nil)
+	startedManager.shutdown = make(chan struct{})
+	err = startedManager.Stop()
 	require.NoError(t, err)
 
 	err = (*CurrencyStateManager)(nil).Start(t.Context())
 	require.ErrorIs(t, err, ErrNilSubsystem)
 
-	err = (&CurrencyStateManager{started: 1}).Start(t.Context())
+	err = startedCurrencyStateManager(nil).Start(t.Context())
 	require.ErrorIs(t, err, ErrSubSystemAlreadyStarted)
 
 	man := &CurrencyStateManager{
@@ -187,22 +195,13 @@ func TestGetAllRPC(t *testing.T) {
 	_, err := (*CurrencyStateManager)(nil).GetAllRPC("")
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-	}).GetAllRPC("")
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeOne: true}).GetAllRPC("")
 	require.ErrorIs(t, err, errManager)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeTwo: true},
-	}).GetAllRPC("")
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeTwo: true}).GetAllRPC("")
 	require.ErrorIs(t, err, errExchange)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{},
-	}).GetAllRPC("")
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{}).GetAllRPC("")
 	require.NoError(t, err)
 }
 
@@ -211,22 +210,13 @@ func TestCanWithdrawRPC(t *testing.T) {
 	_, err := (*CurrencyStateManager)(nil).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-	}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeOne: true}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errManager)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeTwo: true},
-	}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeTwo: true}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errExchange)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{},
-	}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{}).CanWithdrawRPC("", currency.EMPTYCODE, asset.Empty)
 	require.NoError(t, err)
 }
 
@@ -235,22 +225,13 @@ func TestCanDepositRPC(t *testing.T) {
 	_, err := (*CurrencyStateManager)(nil).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-	}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeOne: true}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errManager)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeTwo: true},
-	}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeTwo: true}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errExchange)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{},
-	}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{}).CanDepositRPC("", currency.EMPTYCODE, asset.Empty)
 	require.NoError(t, err)
 }
 
@@ -259,22 +240,13 @@ func TestCanTradeRPC(t *testing.T) {
 	_, err := (*CurrencyStateManager)(nil).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-	}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeOne: true}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errManager)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeTwo: true},
-	}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeTwo: true}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
 	require.ErrorIs(t, err, errExchange)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{},
-	}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{}).CanTradeRPC("", currency.EMPTYCODE, asset.Empty)
 	require.NoError(t, err)
 }
 
@@ -283,22 +255,13 @@ func TestCanTradePairRPC(t *testing.T) {
 	_, err := (*CurrencyStateManager)(nil).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeOne: true},
-	}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeOne: true}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
 	require.ErrorIs(t, err, errManager)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{ErrorMeTwo: true},
-	}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{ErrorMeTwo: true}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
 	require.ErrorIs(t, err, errExchange)
 
-	_, err = (&CurrencyStateManager{
-		started:          1,
-		iExchangeManager: &fakeExchangeManagerino{},
-	}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
+	_, err = startedCurrencyStateManager(&fakeExchangeManagerino{}).CanTradePairRPC("", currency.EMPTYPAIR, asset.Empty)
 	require.NoError(t, err)
 }
 

--- a/engine/database_connection.go
+++ b/engine/database_connection.go
@@ -18,7 +18,7 @@ const DatabaseConnectionManagerName = "database"
 
 // DatabaseConnectionManager holds the database connection and its status
 type DatabaseConnectionManager struct {
-	started  int32
+	started  atomic.Bool
 	shutdown chan struct{}
 	cfg      database.Config
 	wg       sync.WaitGroup
@@ -30,12 +30,12 @@ func (m *DatabaseConnectionManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // GetInstance returns a limited scoped database instance
 func (m *DatabaseConnectionManager) GetInstance() database.IDatabase {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func SetupDatabaseConnectionManager(cfg *database.Config) (*DatabaseConnectionMa
 
 // IsConnected is an exported check to verify if the database is connected
 func (m *DatabaseConnectionManager) IsConnected() bool {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return false
 	}
 	return m.dbConn.IsConnected()
@@ -75,12 +75,12 @@ func (m *DatabaseConnectionManager) Start(wg *sync.WaitGroup) (err error) {
 	if m == nil {
 		return fmt.Errorf("%s %w", DatabaseConnectionManagerName, ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("database manager %w", ErrSubSystemAlreadyStarted)
 	}
 	defer func() {
 		if err != nil {
-			atomic.CompareAndSwapInt32(&m.started, 1, 0)
+			m.started.CompareAndSwap(true, false)
 		}
 	}()
 
@@ -125,11 +125,11 @@ func (m *DatabaseConnectionManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("%s %w", DatabaseConnectionManagerName, ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("%s %w", DatabaseConnectionManagerName, ErrSubSystemNotStarted)
 	}
 	defer func() {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 	}()
 
 	err := m.dbConn.CloseConnection()
@@ -170,7 +170,7 @@ func (m *DatabaseConnectionManager) checkConnection() error {
 	if m == nil {
 		return fmt.Errorf("%s %w", DatabaseConnectionManagerName, ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("%s %w", DatabaseConnectionManagerName, ErrSubSystemNotStarted)
 	}
 	if !m.cfg.Enabled {

--- a/engine/datahistory_manager.go
+++ b/engine/datahistory_manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -80,7 +79,7 @@ func (m *DataHistoryManager) Start(ctx context.Context) error {
 	if m.databaseConnectionInstance == nil {
 		return errNilDatabaseConnectionManager
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return ErrSubSystemAlreadyStarted
 	}
 	m.shutdown = make(chan struct{})
@@ -95,7 +94,7 @@ func (m *DataHistoryManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // Stop stops the subsystem
@@ -103,7 +102,7 @@ func (m *DataHistoryManager) Stop() error {
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 1, 0) {
+	if !m.started.CompareAndSwap(true, false) {
 		return ErrSubSystemNotStarted
 	}
 	close(m.shutdown)
@@ -116,7 +115,7 @@ func (m *DataHistoryManager) retrieveJobs() ([]*DataHistoryJob, error) {
 	if m == nil {
 		return nil, ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, ErrSubSystemNotStarted
 	}
 	dbJobs, err := m.jobDB.GetAllIncompleteJobsAndResults()
@@ -148,7 +147,7 @@ func (m *DataHistoryManager) PrepareJobs() ([]*DataHistoryJob, error) {
 	if m == nil {
 		return nil, ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, ErrSubSystemNotStarted
 	}
 	jobs, err := m.retrieveJobs()
@@ -173,7 +172,7 @@ func (m *DataHistoryManager) compareJobsToData(jobs ...*DataHistoryJob) error {
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted
 	}
 	var err error
@@ -256,14 +255,14 @@ func (m *DataHistoryManager) runJobs(ctx context.Context) error {
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted
 	}
 
-	if !atomic.CompareAndSwapInt32(&m.processing, 0, 1) {
+	if !m.processing.CompareAndSwap(false, true) {
 		return fmt.Errorf("cannot process jobs, %w", ErrSubSystemAlreadyStarted)
 	}
-	defer atomic.StoreInt32(&m.processing, 0)
+	defer m.processing.Store(false)
 
 	validJobs, err := m.PrepareJobs()
 	if err != nil {
@@ -303,7 +302,7 @@ func (m *DataHistoryManager) runJob(ctx context.Context, job *DataHistoryJob) er
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted
 	}
 	if job == nil {
@@ -1056,7 +1055,7 @@ func (m *DataHistoryManager) CheckCandleIssue(job *DataHistoryJob, multiplier in
 	if m == nil {
 		return ErrNilSubsystem.Error(), false
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted.Error(), false
 	}
 	if job == nil {
@@ -1095,7 +1094,7 @@ func (m *DataHistoryManager) SetJobRelationship(prerequisiteJobNickname, jobNick
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted
 	}
 	if jobNickname == "" {
@@ -1301,7 +1300,7 @@ func (m *DataHistoryManager) GetByID(id uuid.UUID) (*DataHistoryJob, error) {
 	if m == nil {
 		return nil, ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, ErrSubSystemNotStarted
 	}
 	if id == uuid.Nil {
@@ -1325,7 +1324,7 @@ func (m *DataHistoryManager) GetByNickname(nickname string, fullDetails bool) (*
 	if m == nil {
 		return nil, ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, ErrSubSystemNotStarted
 	}
 	if fullDetails {
@@ -1360,7 +1359,7 @@ func (m *DataHistoryManager) GetAllJobStatusBetween(start, end time.Time) ([]*Da
 	if m == nil {
 		return nil, ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, ErrSubSystemNotStarted
 	}
 	if err := common.StartEndTimeCheck(start, end); err != nil {
@@ -1386,7 +1385,7 @@ func (m *DataHistoryManager) SetJobStatus(nickname, id string, status dataHistor
 	if m == nil {
 		return ErrNilSubsystem
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return ErrSubSystemNotStarted
 	}
 	if nickname == "" && id == "" {

--- a/engine/datahistory_manager_test.go
+++ b/engine/datahistory_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,9 +45,9 @@ func TestSetupDataHistoryManager(t *testing.T) {
 
 	dbInst.SetConnected(true)
 	dbCM := &DatabaseConnectionManager{
-		dbConn:  dbInst,
-		started: 1,
+		dbConn: dbInst,
 	}
+	dbCM.started.Store(true)
 	err = dbInst.SetSQLiteConnection(&sql.DB{})
 	assert.NoError(t, err)
 
@@ -63,11 +62,11 @@ func TestSetupDataHistoryManager(t *testing.T) {
 func TestDataHistoryManagerIsRunning(t *testing.T) {
 	t.Parallel()
 	m, _ := createDHM(t)
-	m.started = 0
+	m.started.Store(false)
 	if m.IsRunning() {
 		t.Error("expected false")
 	}
-	m.started = 1
+	m.started.Store(true)
 	if !m.IsRunning() {
 		t.Error("expected true")
 	}
@@ -80,7 +79,7 @@ func TestDataHistoryManagerIsRunning(t *testing.T) {
 func TestDataHistoryManagerStart(t *testing.T) {
 	t.Parallel()
 	m, _ := createDHM(t)
-	m.started = 0
+	m.started.Store(false)
 	err := m.Start(t.Context())
 	assert.NoError(t, err)
 
@@ -220,7 +219,7 @@ func TestSetJobStatus(t *testing.T) {
 	err = m.SetJobStatus(dhj.Nickname, "", dataHistoryStatusRemoved)
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	err = m.SetJobStatus("", dhj.ID.String(), 0)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -253,7 +252,7 @@ func TestGetByNickname(t *testing.T) {
 	_, err = m.GetByNickname(dhj.Nickname, false)
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	_, err = m.GetByNickname("test123", false)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -286,7 +285,7 @@ func TestGetByID(t *testing.T) {
 	_, err = m.GetByID(dhj.ID)
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	_, err = m.GetByID(dhj.ID)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -317,7 +316,7 @@ func TestRetrieveJobs(t *testing.T) {
 		t.Error("expected job")
 	}
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	_, err = m.retrieveJobs()
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -357,7 +356,7 @@ func TestGetActiveJobs(t *testing.T) {
 		t.Error("expected 0 jobs")
 	}
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	_, err = m.GetActiveJobs()
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -449,7 +448,7 @@ func TestGetAllJobStatusBetween(t *testing.T) {
 	_, err = m.GetAllJobStatusBetween(time.Now().Add(-time.Hour), time.Now().Add(-time.Minute*30))
 	assert.NoError(t, err)
 
-	m.started = 0
+	m.started.Store(false)
 	_, err = m.GetAllJobStatusBetween(time.Now().Add(-time.Hour), time.Now().Add(-time.Minute*30))
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -467,7 +466,7 @@ func TestPrepareJobs(t *testing.T) {
 	if len(jobs) != 1 {
 		t.Errorf("expected 1 job, received %v", len(jobs))
 	}
-	m.started = 0
+	m.started.Store(false)
 	_, err = m.PrepareJobs()
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -599,7 +598,7 @@ func TestCompareJobsToData(t *testing.T) {
 		}
 	})
 
-	m.started = 0
+	m.started.Store(false)
 	err = m.compareJobsToData(dhj)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -760,7 +759,7 @@ func TestRunJobSkipsPersistenceWhenStoppedDuringRun(t *testing.T) {
 	m.tradeSaver = dataHistoryTradeSaver
 	m.tradeLoader = dataHistoryTraderLoader
 	m.candleSaver = func(i *kline.Item, _ bool) (uint64, error) {
-		atomic.StoreInt32(&m.started, 0)
+		m.started.Store(false)
 		if i == nil {
 			return 0, nil
 		}
@@ -817,7 +816,7 @@ func TestGenerateJobSummaryTest(t *testing.T) {
 		t.Error("expected result ranges")
 	}
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	_, err = m.GenerateJobSummary("TestGenerateJobSummary")
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -832,7 +831,7 @@ func TestRunJobs(t *testing.T) {
 	err := m.runJobs(t.Context())
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	err = m.runJobs(t.Context())
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -980,13 +979,13 @@ func createDHM(t *testing.T) (*DataHistoryManager, *datahistoryjob.DataHistoryJo
 		databaseConnectionInstance: &dataBaseConnection{},
 		jobDB:                      &dataHistoryJobService{job: j},
 		jobResultDB:                dataHistoryJobResultService{},
-		started:                    1,
 		exchangeManager:            em,
 		candleLoader:               dataHistoryCandleLoader,
 		interval:                   time.NewTicker(time.Minute),
 		verbose:                    true,
 		maxResultInsertions:        defaultMaxResultInsertions,
 	}
+	m.started.Store(true)
 	return m, j
 }
 
@@ -1222,7 +1221,7 @@ func TestSetJobRelationship(t *testing.T) {
 	err = m.SetJobRelationship("", "")
 	assert.ErrorIs(t, err, errNicknameUnset)
 
-	m.started = 0
+	m.started.Store(false)
 	err = m.SetJobRelationship("", "")
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
@@ -1282,7 +1281,7 @@ func TestCheckCandleIssue(t *testing.T) {
 		t.Errorf("expected %v received %v", true, replace)
 	}
 
-	m.started = 0
+	m.started.Store(false)
 	issue, replace = m.CheckCandleIssue(nil, 0, 0, 0, "")
 	if issue != ErrSubSystemNotStarted.Error() {
 		t.Errorf("expected %v received %v", ErrSubSystemNotStarted, issue)
@@ -1343,7 +1342,7 @@ func TestSaveCandlesInBatches(t *testing.T) {
 	err := dhm.saveCandlesInBatches(nil, nil, nil)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	dhm.started = 1
+	dhm.started.Store(true)
 	err = dhm.saveCandlesInBatches(nil, nil, nil)
 	assert.ErrorIs(t, err, errNilJob)
 

--- a/engine/datahistory_manager_types.go
+++ b/engine/datahistory_manager_types.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -127,8 +128,8 @@ const (
 type DataHistoryManager struct {
 	exchangeManager            iExchangeManager
 	databaseConnectionInstance database.IDatabase
-	started                    int32
-	processing                 int32
+	started                    atomic.Bool
+	processing                 atomic.Bool
 	shutdown                   chan struct{}
 	interval                   *time.Ticker
 	jobDB                      datahistoryjob.IDBService

--- a/engine/event_manager.go
+++ b/engine/event_manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/communications/base"
@@ -41,7 +40,7 @@ func (m *eventManager) Start() error {
 	if m == nil {
 		return fmt.Errorf("event manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("event manager %w", ErrSubSystemAlreadyStarted)
 	}
 	log.Debugf(log.EventMgr, "Event Manager started. SleepDelay: %v\n", m.sleepDelay.String())
@@ -55,7 +54,7 @@ func (m *eventManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // Stop attempts to shutdown the subsystem
@@ -63,7 +62,7 @@ func (m *eventManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("event manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 1, 0) {
+	if !m.started.CompareAndSwap(true, false) {
 		return fmt.Errorf("event manager %w", ErrSubSystemNotStarted)
 	}
 	close(m.shutdown)
@@ -109,7 +108,7 @@ func (m *eventManager) Add(exchange, item string, condition EventConditionParams
 	if m == nil {
 		return 0, fmt.Errorf("event manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return 0, fmt.Errorf("event manager %w", ErrSubSystemNotStarted)
 	}
 	err := m.isValidEvent(exchange, item, condition, action)
@@ -137,7 +136,7 @@ func (m *eventManager) Add(exchange, item string, condition EventConditionParams
 
 // Remove deletes an event by its ID
 func (m *eventManager) Remove(eventID int64) bool {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return false
 	}
 	m.m.Lock()
@@ -154,7 +153,7 @@ func (m *eventManager) Remove(eventID int64) bool {
 // getEventCounter displays the amount of total events on the chain and the
 // events that have been executed.
 func (m *eventManager) getEventCounter() (total, executed int) {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return 0, 0
 	}
 	m.m.Lock()
@@ -174,7 +173,7 @@ func (m *eventManager) checkEventCondition(e *Event) error {
 	if m == nil {
 		return fmt.Errorf("event manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("event manager %w", ErrSubSystemNotStarted)
 	}
 	if e == nil {

--- a/engine/event_manager_test.go
+++ b/engine/event_manager_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"errors"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,7 +124,7 @@ func TestEventManagerIsRunning(t *testing.T) {
 	startTestEventManager(t, m)
 
 	assert.True(t, m.IsRunning(), "IsRunning should return true when started")
-	atomic.StoreInt32(&m.started, 0)
+	m.started.Store(false)
 	assert.False(t, m.IsRunning(), "IsRunning should return false when stopped")
 	m = nil
 	assert.False(t, m.IsRunning(), "IsRunning should return false for nil manager")
@@ -502,7 +501,7 @@ func TestExecuteEventVerbose(t *testing.T) {
 				verbose: true,
 				comms:   comms,
 			}
-			atomic.StoreInt32(&m.started, 1)
+			m.started.Store(true)
 			event := newPriceEvent(exchangeName, tc.threshold)
 			event.ID = 1
 			m.events = []Event{event}

--- a/engine/event_manager_types.go
+++ b/engine/event_manager_types.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -63,7 +64,7 @@ type Event struct {
 
 // eventManager holds communication manager data
 type eventManager struct {
-	started         int32
+	started         atomic.Bool
 	comms           iCommsManager
 	events          []Event
 	verbose         bool

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"sync/atomic"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
@@ -37,7 +36,7 @@ func (m *ntpManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.started) == 1
+	return m.started.Load()
 }
 
 // Start runs the subsystem
@@ -45,7 +44,7 @@ func (m *ntpManager) Start() error {
 	if m == nil {
 		return fmt.Errorf("ntp manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("NTP manager %w", ErrSubSystemAlreadyStarted)
 	}
 	if m.level == 0 && m.loggingEnabled {
@@ -59,7 +58,7 @@ func (m *ntpManager) Start() error {
 				break check
 			case ErrSubSystemNotStarted:
 				log.Debugln(log.TimeMgr, "NTP manager: User disabled NTP prompts. Exiting.")
-				atomic.CompareAndSwapInt32(&m.started, 1, 0)
+				m.started.CompareAndSwap(true, false)
 				return nil
 			default:
 				if i == m.retryLimit-1 {
@@ -69,7 +68,7 @@ func (m *ntpManager) Start() error {
 		}
 	}
 	if m.level != 1 {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 		return errNTPManagerDisabled
 	}
 	m.shutdown = make(chan struct{})
@@ -83,12 +82,12 @@ func (m *ntpManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("ntp manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("NTP manager %w", ErrSubSystemNotStarted)
 	}
 	defer func() {
 		log.Debugf(log.TimeMgr, "NTP manager %s", MsgSubSystemShutdown)
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 	}()
 	log.Debugf(log.TimeMgr, "NTP manager %s", MsgSubSystemShuttingDown)
 	close(m.shutdown)
@@ -120,7 +119,7 @@ func (m *ntpManager) FetchNTPTime() (time.Time, error) {
 	if m == nil {
 		return time.Time{}, fmt.Errorf("ntp manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return time.Time{}, fmt.Errorf("NTP manager %w", ErrSubSystemNotStarted)
 	}
 	return m.checkTimeInPools(), nil
@@ -129,7 +128,7 @@ func (m *ntpManager) FetchNTPTime() (time.Time, error) {
 // processTime determines the difference between system time and NTP time
 // to discover discrepancies
 func (m *ntpManager) processTime() error {
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("NTP manager %w", ErrSubSystemNotStarted)
 	}
 	NTPTime, err := m.FetchNTPTime()

--- a/engine/ntp_manager_types.go
+++ b/engine/ntp_manager_types.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"sync/atomic"
 	"time"
 )
 
@@ -19,7 +20,7 @@ var (
 
 // ntpManager starts the NTP manager
 type ntpManager struct {
-	started                   int32
+	started                   atomic.Bool
 	shutdown                  chan struct{}
 	level                     int64
 	allowedDifference         time.Duration

--- a/engine/order_manager.go
+++ b/engine/order_manager.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -65,7 +64,7 @@ func SetupOrderManager(exchangeManager iExchangeManager, communicationsManager i
 
 // IsRunning safely checks whether the subsystem is running
 func (m *OrderManager) IsRunning() bool {
-	return m != nil && atomic.LoadInt32(&m.started) == 1
+	return m != nil && m.started.Load()
 }
 
 // Start runs the subsystem
@@ -73,7 +72,7 @@ func (m *OrderManager) Start(ctx context.Context) error {
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("order manager %w", ErrSubSystemAlreadyStarted)
 	}
 	log.Debugln(log.OrderMgr, "Order manager starting...")
@@ -88,12 +87,12 @@ func (m *OrderManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	log.Debugln(log.OrderMgr, "Order manager shutting down...")
 	close(m.shutdown)
-	atomic.CompareAndSwapInt32(&m.started, 1, 0)
+	m.started.CompareAndSwap(true, false)
 	return nil
 }
 
@@ -151,7 +150,7 @@ func (m *OrderManager) cancelAllOrders(ctx context.Context, exchanges []exchange
 	if m == nil {
 		return
 	}
-	if requireRunning && atomic.LoadInt32(&m.started) == 0 {
+	if requireRunning && !m.started.Load() {
 		return
 	}
 
@@ -190,7 +189,7 @@ func (m *OrderManager) cancel(ctx context.Context, cancel *order.Cancel, require
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if requireRunning && atomic.LoadInt32(&m.started) == 0 {
+	if requireRunning && !m.started.Load() {
 		return fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	var err error
@@ -259,7 +258,7 @@ func (m *OrderManager) GetFuturesPositionsForExchange(exch string, item asset.It
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if !item.IsFutures() {
@@ -275,7 +274,7 @@ func (m *OrderManager) GetOpenFuturesPosition(exch string, item asset.Item, pair
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if !item.IsFutures() {
@@ -293,7 +292,7 @@ func (m *OrderManager) GetAllOpenFuturesPositions() ([]futures.Position, error) 
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if !m.activelyTrackFuturesPositions {
@@ -308,7 +307,7 @@ func (m *OrderManager) ClearFuturesTracking(exch string, item asset.Item, pair c
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if !item.IsFutures() {
@@ -325,7 +324,7 @@ func (m *OrderManager) UpdateOpenPositionUnrealisedPNL(e string, item asset.Item
 	if m == nil {
 		return decimal.Zero, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return decimal.Zero, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if !item.IsFutures() {
@@ -341,7 +340,7 @@ func (m *OrderManager) GetOrderInfo(ctx context.Context, exchangeName, orderID s
 	if m == nil {
 		return order.Detail{}, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return order.Detail{}, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 
@@ -407,7 +406,7 @@ func (m *OrderManager) Modify(ctx context.Context, mod *order.Modify) (*order.Mo
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 
@@ -477,7 +476,7 @@ func (m *OrderManager) Submit(ctx context.Context, newOrder *order.Submit) (*Ord
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if newOrder == nil {
@@ -528,7 +527,7 @@ func (m *OrderManager) SubmitFakeOrder(newOrder *order.Submit, resultingOrder *o
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if newOrder == nil {
@@ -563,7 +562,7 @@ func (m *OrderManager) SubmitFakeOrder(newOrder *order.Submit, resultingOrder *o
 // but a status of "" or ANY will include all
 // the time adds contexts for when the snapshot is relevant for
 func (m *OrderManager) GetOrdersSnapshot(s order.Status) []order.Detail {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return nil
 	}
 	var os []order.Detail
@@ -585,7 +584,7 @@ func (m *OrderManager) GetOrdersFiltered(f *order.Filter) ([]order.Detail, error
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	return m.orderStore.getFilteredOrders(f)
@@ -597,7 +596,7 @@ func (m *OrderManager) GetOrdersActive(f *order.Filter) ([]order.Detail, error) 
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	return m.orderStore.getActiveOrders(f), nil
@@ -650,10 +649,10 @@ func (m *OrderManager) processSubmittedOrder(newOrderResp *order.SubmitResponse)
 // processOrders iterates over all exchange orders via API
 // and adds them to the internal order store
 func (m *OrderManager) processOrders(ctx context.Context) {
-	if !atomic.CompareAndSwapInt32(&m.processingOrders, 0, 1) {
+	if !m.processingOrders.CompareAndSwap(false, true) {
 		return
 	}
-	defer atomic.StoreInt32(&m.processingOrders, 0)
+	defer m.processingOrders.Store(false)
 	exchanges, err := m.orderStore.exchangeManager.GetExchanges()
 	if err != nil {
 		log.Errorf(log.OrderMgr, "order manager cannot get exchanges: %v", err)
@@ -871,7 +870,7 @@ func (m *OrderManager) FetchAndUpdateExchangeOrder(ctx context.Context, exch exc
 
 // Exists checks whether an order exists in the order store
 func (m *OrderManager) Exists(o *order.Detail) bool {
-	return m != nil && atomic.LoadInt32(&m.started) != 0 && m.orderStore.exists(o)
+	return m != nil && m.started.Load() && m.orderStore.exists(o)
 }
 
 // Add adds an order to the orderstore
@@ -879,7 +878,7 @@ func (m *OrderManager) Add(o *order.Detail) error {
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 
@@ -891,7 +890,7 @@ func (m *OrderManager) GetByExchangeAndID(exchangeName, id string) (*order.Detai
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	return m.orderStore.getByExchangeAndID(exchangeName, id)
@@ -902,7 +901,7 @@ func (m *OrderManager) UpdateExistingOrder(od *order.Detail) error {
 	if m == nil {
 		return fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	return m.orderStore.updateExisting(od)
@@ -913,7 +912,7 @@ func (m *OrderManager) UpsertOrder(od *order.Detail) (resp *OrderUpsertResponse,
 	if m == nil {
 		return nil, fmt.Errorf("order manager %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return nil, fmt.Errorf("order manager %w", ErrSubSystemNotStarted)
 	}
 	if od == nil {

--- a/engine/order_manager_test.go
+++ b/engine/order_manager_test.go
@@ -280,7 +280,7 @@ func OrdersSetup(t *testing.T) *OrderManager {
 	m, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{})
 	assert.NoError(t, err)
 
-	m.started = 1
+	m.started.Store(true)
 	return m
 }
 
@@ -568,7 +568,7 @@ func TestOrderManagerGracefulShutdownUsesBoundedContextWhenRuntimeCancelled(t *t
 
 	m, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{CancelOrdersOnShutdown: true})
 	require.NoError(t, err)
-	m.started = 1
+	m.started.Store(true)
 
 	require.NoError(t, m.orderStore.add(&order.Detail{
 		Exchange:  testExchange,
@@ -860,7 +860,7 @@ func TestProcessOrders(t *testing.T) {
 	m, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{})
 	assert.NoError(t, err)
 
-	m.started = 1
+	m.started.Store(true)
 	pairs := currency.Pairs{
 		currency.Pair{Base: currency.BTC, Quote: currency.USD},
 	}
@@ -1255,7 +1255,7 @@ func TestGetFuturesPositionsForExchange(t *testing.T) {
 	_, err := o.GetFuturesPositionsForExchange("test", asset.Spot, cp)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	o.orderStore.futuresPositionController = futures.SetupPositionController()
 	_, err = o.GetFuturesPositionsForExchange("test", asset.Spot, cp)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
@@ -1294,7 +1294,7 @@ func TestClearFuturesPositionsForExchange(t *testing.T) {
 	err := o.ClearFuturesTracking("test", asset.Spot, cp)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	o.orderStore.futuresPositionController = futures.SetupPositionController()
 	err = o.ClearFuturesTracking("test", asset.Spot, cp)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
@@ -1336,7 +1336,7 @@ func TestUpdateOpenPositionUnrealisedPNL(t *testing.T) {
 	_, err := o.UpdateOpenPositionUnrealisedPNL("test", asset.Spot, cp, 1, time.Now())
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	o.orderStore.futuresPositionController = futures.SetupPositionController()
 	_, err = o.UpdateOpenPositionUnrealisedPNL("test", asset.Spot, cp, 1, time.Now())
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
@@ -1375,7 +1375,7 @@ func TestSubmitFakeOrder(t *testing.T) {
 	_, err := o.SubmitFakeOrder(nil, resp, false)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	_, err = o.SubmitFakeOrder(nil, resp, false)
 	assert.ErrorIs(t, err, errNilOrder)
 
@@ -1417,7 +1417,7 @@ func TestGetOrdersSnapshot(t *testing.T) {
 	t.Parallel()
 	o := &OrderManager{}
 	o.GetOrdersSnapshot(order.AnyStatus)
-	o.started = 1
+	o.started.Store(true)
 	o.orderStore.Orders = make(map[string][]*order.Detail)
 	o.orderStore.Orders[testExchange] = []*order.Detail{
 		{
@@ -1481,7 +1481,7 @@ func TestOrderManagerExists(t *testing.T) {
 	if o.Exists(nil) {
 		t.Error("expected false")
 	}
-	o.started = 1
+	o.started.Store(true)
 	if o.Exists(nil) {
 		t.Error("expected false")
 	}
@@ -1498,7 +1498,7 @@ func TestOrderManagerAdd(t *testing.T) {
 	err := o.Add(nil)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	err = o.Add(nil)
 	assert.ErrorIs(t, err, errNilOrder)
 
@@ -1513,11 +1513,11 @@ func TestGetAllOpenFuturesPositions(t *testing.T) {
 	o, err := SetupOrderManager(NewExchangeManager(), &CommunicationManager{}, wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	o.started = 0
+	o.started.Store(false)
 	_, err = o.GetAllOpenFuturesPositions()
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	o.activelyTrackFuturesPositions = true
 	o.orderStore.futuresPositionController = futures.SetupPositionController()
 	_, err = o.GetAllOpenFuturesPositions()
@@ -1534,12 +1534,12 @@ func TestGetOpenFuturesPosition(t *testing.T) {
 	o, err := SetupOrderManager(NewExchangeManager(), &CommunicationManager{}, wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	o.started = 0
+	o.started.Store(false)
 	cp := currency.NewPair(currency.BTC, currency.PERP)
 	_, err = o.GetOpenFuturesPosition(testExchange, asset.Spot, cp)
 	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	o.started = 1
+	o.started.Store(true)
 	_, err = o.GetOpenFuturesPosition(testExchange, asset.Spot, cp)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
 
@@ -1581,7 +1581,7 @@ func TestGetOpenFuturesPosition(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	o.started = 1
+	o.started.Store(true)
 
 	_, err = o.GetOpenFuturesPosition(testExchange, asset.Spot, cp)
 	assert.ErrorIs(t, err, futures.ErrNotFuturesAsset)
@@ -1659,7 +1659,7 @@ func TestProcessFuturesPositions(t *testing.T) {
 	o, err = SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{ActivelyTrackFuturesPositions: true, FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	o.started = 1
+	o.started.Store(true)
 
 	err = o.processFuturesPositions(t.Context(), fakeExchange, nil)
 	assert.ErrorIs(t, err, common.ErrNilPointer)

--- a/engine/order_manager_types.go
+++ b/engine/order_manager_types.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -42,8 +43,8 @@ type orderManagerConfig struct {
 
 // OrderManager processes and stores orders across enabled exchanges
 type OrderManager struct {
-	started                       int32
-	processingOrders              int32
+	started                       atomic.Bool
+	processingOrders              atomic.Bool
 	shutdown                      chan struct{}
 	orderStore                    store
 	cfg                           orderManagerConfig

--- a/engine/portfolio_manager.go
+++ b/engine/portfolio_manager.go
@@ -24,8 +24,8 @@ var PortfolioSleepDelay = time.Minute
 // portfolioManager routinely retrieves a user's holdings through exchange APIs as well
 // as through addresses provided in the config
 type portfolioManager struct {
-	started               int32
-	processing            int32
+	started               atomic.Bool
+	processing            atomic.Bool
 	portfolioManagerDelay time.Duration
 	exchangeManager       *ExchangeManager
 	shutdown              chan struct{}
@@ -56,7 +56,7 @@ func setupPortfolioManager(e *ExchangeManager, portfolioManagerDelay time.Durati
 
 // IsRunning safely checks whether the subsystem is running
 func (m *portfolioManager) IsRunning() bool {
-	return m != nil && atomic.LoadInt32(&m.started) == 1
+	return m != nil && m.started.Load()
 }
 
 // Start runs the subsystem
@@ -67,7 +67,7 @@ func (m *portfolioManager) Start(ctx context.Context, wg *sync.WaitGroup) error 
 	if wg == nil {
 		return errNilWaitGroup
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("portfolio manager %w", ErrSubSystemAlreadyStarted)
 	}
 
@@ -83,11 +83,11 @@ func (m *portfolioManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("portfolio manager %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 1, 0) {
+	if !m.started.CompareAndSwap(true, false) {
 		return fmt.Errorf("portfolio manager %w", ErrSubSystemNotStarted)
 	}
 	defer func() {
-		atomic.CompareAndSwapInt32(&m.started, 1, 0)
+		m.started.CompareAndSwap(true, false)
 	}()
 
 	log.Debugf(log.PortfolioMgr, "Portfolio manager %s", MsgSubSystemShuttingDown)
@@ -119,7 +119,7 @@ func (m *portfolioManager) run(ctx context.Context, wg *sync.WaitGroup) {
 
 // processPortfolio updates portfolio holdings
 func (m *portfolioManager) processPortfolio(ctx context.Context) {
-	if !atomic.CompareAndSwapInt32(&m.processing, 0, 1) {
+	if !m.processing.CompareAndSwap(false, true) {
 		return
 	}
 	m.m.Lock()
@@ -137,7 +137,7 @@ func (m *portfolioManager) processPortfolio(ctx context.Context) {
 
 		log.Debugf(log.PortfolioMgr, "Portfolio manager: Successfully updated address balance for %s address(es) %s", key, value)
 	}
-	atomic.CompareAndSwapInt32(&m.processing, 1, 0)
+	m.processing.CompareAndSwap(true, false)
 }
 
 // updateExchangeBalances calls UpdateAccountBalance on each exchange, and transfers the account balances into portfolio

--- a/engine/rpcserver_test.go
+++ b/engine/rpcserver_test.go
@@ -1292,7 +1292,7 @@ func TestGetOrders(t *testing.T) {
 	om, err := SetupOrderManager(em, engerino.CommunicationsManager, &wg, &config.OrderManager{})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{Engine: &Engine{ExchangeManager: em, OrderManager: om}}
 
 	p := &gctrpc.CurrencyPair{
@@ -1387,7 +1387,7 @@ func TestGetOrder(t *testing.T) {
 	om, err := SetupOrderManager(em, engerino.CommunicationsManager, &wg, &config.OrderManager{})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	assert.NoError(t, err)
 
 	s := RPCServer{Engine: &Engine{ExchangeManager: em, OrderManager: om}}
@@ -1807,7 +1807,7 @@ func TestGetManagedOrders(t *testing.T) {
 	om, err := SetupOrderManager(em, engerino.CommunicationsManager, &wg, &config.OrderManager{})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{Engine: &Engine{ExchangeManager: em, OrderManager: om}}
 
 	p := &gctrpc.CurrencyPair{
@@ -2081,7 +2081,7 @@ func TestCurrencyStateTradingPair(t *testing.T) {
 
 	s := RPCServer{Engine: &Engine{
 		ExchangeManager:      em,
-		currencyStateManager: &CurrencyStateManager{started: 1, iExchangeManager: em},
+		currencyStateManager: getDummyStateManager(em),
 	}}
 
 	_, err = s.CurrencyStateTradingPair(t.Context(),
@@ -2091,6 +2091,12 @@ func TestCurrencyStateTradingPair(t *testing.T) {
 			Asset:    "spot",
 		})
 	require.NoError(t, err)
+}
+
+func getDummyStateManager(em *ExchangeManager) *CurrencyStateManager {
+	csm := &CurrencyStateManager{iExchangeManager: em}
+	csm.started.Store(true)
+	return csm
 }
 
 func TestGetFuturesPositionsOrders(t *testing.T) {
@@ -2136,15 +2142,12 @@ func TestGetFuturesPositionsOrders(t *testing.T) {
 	om, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
-			OrderManager: om,
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
+			OrderManager:         om,
 		},
 	}
 
@@ -2209,10 +2212,8 @@ func TestGetCollateral(t *testing.T) {
 
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started: 1, iExchangeManager: em,
-			},
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
 		},
 	}
 
@@ -2351,11 +2352,8 @@ func TestGetTechnicalAnalysis(t *testing.T) {
 
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
 		},
 	}
 
@@ -2585,10 +2583,8 @@ func TestGetMarginRatesHistory(t *testing.T) {
 
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started: 1, iExchangeManager: em,
-			},
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
 		},
 	}
 	_, err = s.GetMarginRatesHistory(t.Context(), nil)
@@ -2724,15 +2720,12 @@ func TestGetFundingRates(t *testing.T) {
 	om, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
-			OrderManager: om,
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
+			OrderManager:         om,
 		},
 	}
 
@@ -2820,15 +2813,12 @@ func TestGetLatestFundingRate(t *testing.T) {
 	om, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
-			OrderManager: om,
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
+			OrderManager:         om,
 		},
 	}
 
@@ -2910,15 +2900,12 @@ func TestGetManagedPosition(t *testing.T) {
 	om, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
-			OrderManager: om,
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
+			OrderManager:         om,
 		},
 	}
 	_, err = s.GetManagedPosition(t.Context(), nil)
@@ -2948,7 +2935,7 @@ func TestGetManagedPosition(t *testing.T) {
 	s.OrderManager, err = SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	s.OrderManager.started = 1
+	s.OrderManager.started.Store(true)
 	s.OrderManager.activelyTrackFuturesPositions = true
 	_, err = s.GetManagedPosition(t.Context(), request)
 	assert.ErrorIs(t, err, futures.ErrPositionNotFound)
@@ -3034,15 +3021,12 @@ func TestGetAllManagedPositions(t *testing.T) {
 	om, err := SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour})
 	assert.NoError(t, err)
 
-	om.started = 1
+	om.started.Store(true)
 	s := RPCServer{
 		Engine: &Engine{
-			ExchangeManager: em,
-			currencyStateManager: &CurrencyStateManager{
-				started:          1,
-				iExchangeManager: em,
-			},
-			OrderManager: om,
+			ExchangeManager:      em,
+			currencyStateManager: getDummyStateManager(em),
+			OrderManager:         om,
 		},
 	}
 	_, err = s.GetAllManagedPositions(t.Context(), nil)
@@ -3052,7 +3036,7 @@ func TestGetAllManagedPositions(t *testing.T) {
 	s.OrderManager, err = SetupOrderManager(em, &CommunicationManager{}, &wg, &config.OrderManager{FuturesTrackingSeekDuration: time.Hour, ActivelyTrackFuturesPositions: true})
 	assert.NoError(t, err)
 
-	s.OrderManager.started = 1
+	s.OrderManager.started.Store(true)
 	_, err = s.GetAllManagedPositions(t.Context(), request)
 	assert.ErrorIs(t, err, futures.ErrNoPositionsFound)
 

--- a/engine/sync_manager.go
+++ b/engine/sync_manager.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	createdCounter         int64
-	removedCounter         int64
+	createdCounter         atomic.Int64
+	removedCounter         atomic.Int64
 	errNoSyncItemsEnabled  = errors.New("no sync items enabled")
 	errUnknownSyncItem     = errors.New("unknown sync item")
 	errCouldNotSyncNewData = errors.New("could not sync new data")
@@ -105,7 +105,7 @@ func SetupSyncManager(c *config.SyncManagerConfig, exchangeManager iExchangeMana
 
 // IsRunning safely checks whether the subsystem is running
 func (m *SyncManager) IsRunning() bool {
-	return m != nil && atomic.LoadInt32(&m.started) == 1
+	return m != nil && m.started.Load()
 }
 
 // Start runs the subsystem
@@ -113,7 +113,7 @@ func (m *SyncManager) Start(ctx context.Context) error {
 	if m == nil {
 		return fmt.Errorf("exchange CurrencyPairSyncer %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 0, 1) {
+	if !m.started.CompareAndSwap(false, true) {
 		return ErrSubSystemAlreadyStarted
 	}
 	if !m.config.SynchronizeTicker &&
@@ -192,22 +192,22 @@ func (m *SyncManager) Start(ctx context.Context) error {
 		}
 	}
 
-	if atomic.CompareAndSwapInt32(&m.initSyncStarted, 0, 1) {
+	if m.initSyncStarted.CompareAndSwap(false, true) {
 		if m.config.LogInitialSyncEvents {
 			log.Debugf(log.SyncMgr,
 				"Exchange CurrencyPairSyncer initial sync started. %d items to process.",
-				atomic.LoadInt64(&createdCounter))
+				createdCounter.Load())
 		}
 		m.initSyncStartTime = time.Now()
 	}
 
 	go func() {
 		m.initSyncWG.Wait()
-		if atomic.CompareAndSwapInt32(&m.initSyncCompleted, 0, 1) {
+		if m.initSyncCompleted.CompareAndSwap(false, true) {
 			if m.config.LogInitialSyncEvents {
 				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync is complete.")
 				log.Debugf(log.SyncMgr, "Exchange CurrencyPairSyncer initial sync took %v [%v sync items].",
-					time.Since(m.initSyncStartTime), atomic.LoadInt64(&createdCounter))
+					time.Since(m.initSyncStartTime), createdCounter.Load())
 			}
 
 			if !m.config.SynchronizeContinuously {
@@ -221,7 +221,7 @@ func (m *SyncManager) Start(ctx context.Context) error {
 		}
 	}()
 
-	if atomic.LoadInt32(&m.initSyncCompleted) == 1 && !m.config.SynchronizeContinuously {
+	if m.initSyncCompleted.Load() && !m.config.SynchronizeContinuously {
 		return nil
 	}
 
@@ -237,7 +237,7 @@ func (m *SyncManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("exchange CurrencyPairSyncer %w", ErrNilSubsystem)
 	}
-	if !atomic.CompareAndSwapInt32(&m.started, 1, 0) {
+	if !m.started.CompareAndSwap(true, false) {
 		return fmt.Errorf("exchange CurrencyPairSyncer %w", ErrSubSystemNotStarted)
 	}
 	close(m.shutdown)
@@ -293,9 +293,9 @@ func (m *SyncManager) add(k key.ExchangeAssetPair, s syncBase) *currencyPairSync
 				c.trackers[SyncItemTicker].IsUsingWebsocket,
 				c.trackers[SyncItemTicker].IsUsingREST)
 		}
-		if atomic.LoadInt32(&m.initSyncCompleted) != 1 {
+		if !m.initSyncCompleted.Load() {
 			m.initSyncWG.Add(1)
-			atomic.AddInt64(&createdCounter, 1)
+			createdCounter.Add(1)
 		}
 	}
 
@@ -308,9 +308,9 @@ func (m *SyncManager) add(k key.ExchangeAssetPair, s syncBase) *currencyPairSync
 				c.trackers[SyncItemOrderbook].IsUsingWebsocket,
 				c.trackers[SyncItemOrderbook].IsUsingREST)
 		}
-		if atomic.LoadInt32(&m.initSyncCompleted) != 1 {
+		if !m.initSyncCompleted.Load() {
 			m.initSyncWG.Add(1)
-			atomic.AddInt64(&createdCounter, 1)
+			createdCounter.Add(1)
 		}
 	}
 
@@ -323,9 +323,9 @@ func (m *SyncManager) add(k key.ExchangeAssetPair, s syncBase) *currencyPairSync
 				c.trackers[SyncItemTrade].IsUsingWebsocket,
 				c.trackers[SyncItemTrade].IsUsingREST)
 		}
-		if atomic.LoadInt32(&m.initSyncCompleted) != 1 {
+		if !m.initSyncCompleted.Load() {
 			m.initSyncWG.Add(1)
-			atomic.AddInt64(&createdCounter, 1)
+			createdCounter.Add(1)
 		}
 	}
 
@@ -344,10 +344,10 @@ func (m *SyncManager) WebsocketUpdate(exchangeName string, p currency.Pair, a as
 	if m == nil {
 		return fmt.Errorf("exchange CurrencyPairSyncer %w", ErrNilSubsystem)
 	}
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("exchange CurrencyPairSyncer %w", ErrSubSystemNotStarted)
 	}
-	if atomic.LoadInt32(&m.initSyncStarted) != 1 {
+	if !m.initSyncStarted.Load() {
 		return nil
 	}
 
@@ -419,15 +419,15 @@ func (m *SyncManager) update(c *currencyPairSyncAgent, syncType syncItemType, er
 		s.NumErrors++
 	}
 	s.HaveData = true
-	if atomic.LoadInt32(&m.initSyncCompleted) != 1 && !origHadData {
-		removedCount := atomic.AddInt64(&removedCounter, 1)
+	if !m.initSyncCompleted.Load() && !origHadData {
+		removedCount := removedCounter.Add(1)
 		if m.config.LogInitialSyncEvents {
 			log.Debugf(log.SyncMgr, "%s %s sync complete %v [%d/%d].",
 				c.Key.Exchange,
 				syncType,
 				m.FormatCurrency(c.Pair),
 				removedCount,
-				atomic.LoadInt64(&createdCounter))
+				createdCounter.Load())
 		}
 		m.initSyncWG.Done()
 	}
@@ -492,7 +492,7 @@ func (m *SyncManager) worker(ctx context.Context) {
 						continue
 					}
 					for i := range enabledPairs {
-						if atomic.LoadInt32(&m.started) == 0 {
+						if !m.started.Load() {
 							return
 						}
 
@@ -703,7 +703,7 @@ func printConvertCurrencyFormat(origPrice float64, origCurrency, displayCurrency
 
 // PrintTickerSummary outputs the ticker results
 func (m *SyncManager) PrintTickerSummary(result *ticker.Price, protocol string, err error) {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return
 	}
 	if !m.config.SynchronizeTicker {
@@ -778,7 +778,7 @@ func (m *SyncManager) PrintTickerSummary(result *ticker.Price, protocol string, 
 // FormatCurrency is a method that formats and returns a currency pair
 // based on the user currency display preferences
 func (m *SyncManager) FormatCurrency(cp currency.Pair) string {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return ""
 	}
 	return m.format.Format(cp)
@@ -790,7 +790,7 @@ const (
 
 // PrintOrderbookSummary outputs orderbook results
 func (m *SyncManager) PrintOrderbookSummary(result *orderbook.Book, protocol string, err error) {
-	if m == nil || atomic.LoadInt32(&m.started) == 0 {
+	if m == nil || !m.started.Load() {
 		return
 	}
 	if !m.config.SynchronizeOrderbook {
@@ -869,7 +869,7 @@ func (m *SyncManager) WaitForInitialSync() error {
 	}
 
 	m.inService.Wait()
-	if atomic.LoadInt32(&m.started) == 0 {
+	if !m.started.Load() {
 		return fmt.Errorf("sync manager %w", ErrSubSystemNotStarted)
 	}
 

--- a/engine/sync_manager_test.go
+++ b/engine/sync_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -146,8 +145,8 @@ func TestSyncManagerSyncTickerUsesRuntimeContextCancellation(t *testing.T) {
 		TimeoutWebsocket:    time.Second,
 	}, em, &config.RemoteControlConfig{}, false)
 	require.NoError(t, err)
-	atomic.StoreInt32(&m.started, 1)
-	atomic.StoreInt32(&m.initSyncCompleted, 1)
+	m.started.Store(true)
+	m.initSyncCompleted.Store(true)
 
 	runtimeCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -216,7 +215,7 @@ func TestPrintTickerSummary(t *testing.T) {
 	m, err = SetupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 1)
+	m.started.Store(true)
 	m.PrintTickerSummary(&ticker.Price{
 		Pair: currency.NewBTCUSDT(),
 	}, "REST", nil)
@@ -256,7 +255,7 @@ func TestPrintOrderbookSummary(t *testing.T) {
 	m, err = SetupSyncManager(&config.SyncManagerConfig{SynchronizeTrades: true, SynchronizeContinuously: true, FiatDisplayCurrency: currency.USD, PairFormatDisplay: &currency.EMPTYFORMAT}, em, &config.RemoteControlConfig{}, false)
 	assert.NoError(t, err)
 
-	atomic.StoreInt32(&m.started, 1)
+	m.started.Store(true)
 	m.PrintOrderbookSummary(&orderbook.Book{
 		Pair: currency.NewPair(currency.AUD, currency.USD),
 	}, "REST", nil)
@@ -291,7 +290,7 @@ func TestWaitForInitialSync(t *testing.T) {
 	err = m.WaitForInitialSync()
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	m.started = 1
+	m.started.Store(true)
 	err = m.WaitForInitialSync()
 	require.NoError(t, err)
 }
@@ -306,12 +305,12 @@ func TestSyncManagerWebsocketUpdate(t *testing.T) {
 	err = m.WebsocketUpdate("", currency.EMPTYPAIR, 1, 47, nil)
 	require.ErrorIs(t, err, ErrSubSystemNotStarted)
 
-	m.started = 1
+	m.started.Store(true)
 	// not started initial sync
 	err = m.WebsocketUpdate("", currency.EMPTYPAIR, 1, 47, nil)
 	require.NoError(t, err)
 
-	m.initSyncStarted = 1
+	m.initSyncStarted.Store(true)
 	// orderbook not enabled
 	err = m.WebsocketUpdate("", currency.EMPTYPAIR, asset.Spot, SyncItemOrderbook, nil)
 	require.NoError(t, err)

--- a/engine/sync_manager_types.go
+++ b/engine/sync_manager_types.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common/key"
@@ -29,9 +30,9 @@ type currencyPairSyncAgent struct {
 
 // SyncManager stores the exchange currency pair syncer object
 type SyncManager struct {
-	initSyncCompleted              int32
-	initSyncStarted                int32
-	started                        int32
+	initSyncCompleted              atomic.Bool
+	initSyncStarted                atomic.Bool
+	started                        atomic.Bool
 	shutdown                       chan bool
 	format                         currency.PairFormat
 	initSyncStartTime              time.Time

--- a/engine/websocketroutine_manager.go
+++ b/engine/websocketroutine_manager.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -61,7 +60,7 @@ func (m *WebsocketRoutineManager) Start(ctx context.Context) error {
 	connectionCtx, connectionCancel := context.WithCancel(ctx)
 
 	m.mu.Lock()
-	if !atomic.CompareAndSwapInt32(&m.state, stoppedState, startingState) {
+	if !m.state.CompareAndSwap(stoppedState, startingState) {
 		m.mu.Unlock()
 		connectionCancel()
 		return ErrSubSystemAlreadyStarted
@@ -73,7 +72,7 @@ func (m *WebsocketRoutineManager) Start(ctx context.Context) error {
 	go func() {
 		m.websocketRoutine(connectionCtx)
 		// It's okay for this to fail, just means shutdown has started
-		atomic.CompareAndSwapInt32(&m.state, startingState, readyState)
+		m.state.CompareAndSwap(startingState, readyState)
 	}()
 	return nil
 }
@@ -83,7 +82,7 @@ func (m *WebsocketRoutineManager) IsRunning() bool {
 	if m == nil {
 		return false
 	}
-	return atomic.LoadInt32(&m.state) == readyState
+	return m.state.Load() == readyState
 }
 
 // Stop attempts to shutdown the subsystem
@@ -93,11 +92,11 @@ func (m *WebsocketRoutineManager) Stop() error {
 	}
 
 	m.mu.Lock()
-	if atomic.LoadInt32(&m.state) == stoppedState {
+	if m.state.Load() == stoppedState {
 		m.mu.Unlock()
 		return fmt.Errorf("websocket routine manager %w", ErrSubSystemNotStarted)
 	}
-	atomic.StoreInt32(&m.state, stoppedState)
+	m.state.Store(stoppedState)
 	if m.connectionCancel != nil {
 		m.connectionCancel()
 		m.connectionCancel = nil
@@ -181,7 +180,7 @@ func (m *WebsocketRoutineManager) websocketDataReceiver(ws *websocket.Manager) e
 		return errNilWebsocket
 	}
 
-	if atomic.LoadInt32(&m.state) == stoppedState {
+	if m.state.Load() == stoppedState {
 		return errRoutineManagerNotStarted
 	}
 
@@ -381,7 +380,7 @@ func (m *WebsocketRoutineManager) websocketDataHandler(exchName string, data any
 // FormatCurrency is a method that formats and returns a currency pair
 // based on the user currency display preferences
 func (m *WebsocketRoutineManager) FormatCurrency(p currency.Pair) currency.Pair {
-	if m == nil || atomic.LoadInt32(&m.state) == stoppedState {
+	if m == nil || m.state.Load() == stoppedState {
 		return p
 	}
 	return p.Format(*m.currencyConfig.CurrencyPairFormat)
@@ -390,7 +389,7 @@ func (m *WebsocketRoutineManager) FormatCurrency(p currency.Pair) currency.Pair 
 // printOrderSummary this function will be deprecated when a order manager
 // update is done.
 func (m *WebsocketRoutineManager) printOrderSummary(o *order.Detail, isUpdate bool) {
-	if m == nil || atomic.LoadInt32(&m.state) == stoppedState || o == nil {
+	if m == nil || m.state.Load() == stoppedState || o == nil {
 		return
 	}
 

--- a/engine/websocketroutine_manager_test.go
+++ b/engine/websocketroutine_manager_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -78,7 +77,7 @@ func TestWebsocketRoutineManagerIsRunning(t *testing.T) {
 	err = m.Start(t.Context())
 	assert.NoError(t, err)
 
-	for atomic.LoadInt32(&m.state) == startingState {
+	for m.state.Load() == startingState {
 		<-time.After(time.Second / 100)
 	}
 	if !m.IsRunning() {
@@ -122,7 +121,7 @@ func TestWebsocketRoutineManagerConcurrentStartStop(t *testing.T) {
 		}()
 		wg.Wait()
 
-		if atomic.LoadInt32(&m.state) != stoppedState {
+		if m.state.Load() != stoppedState {
 			require.NoError(t, m.Stop())
 		}
 		assert.Nil(t, m.connectionCancel)
@@ -285,7 +284,7 @@ func TestRegisterWebsocketDataHandlerWithFunctionality(t *testing.T) {
 	}
 
 	mock := websocket.NewManager()
-	m.state = readyState
+	m.state.Store(readyState)
 	err = m.websocketDataReceiver(mock)
 	if err != nil {
 		t.Fatal(err)

--- a/engine/websocketroutine_manager_types.go
+++ b/engine/websocketroutine_manager_types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
 )
@@ -26,7 +27,7 @@ const (
 
 // WebsocketRoutineManager is used to process websocket updates from a unified location
 type WebsocketRoutineManager struct {
-	state            int32
+	state            atomic.Int32
 	verbose          bool
 	exchangeManager  iExchangeManager
 	orderManager     iOrderManager


### PR DESCRIPTION
# PR Description

Replace legacy sync/atomic function-based API (AddInt32, LoadInt32, etc.) 
with Go 1.19+ typed atomic types (atomic.Int32, atomic.Int64, etc.).

This change:
- Improves code readability by removing explicit address-of operators
- Enhances type safety at compile-time
- Provides better API ergonomics with method-based access
- Aligns with modern Go best practices (More info https://github.com/golang/go/issues/50860)

The transformation is source-compatible and requires Go 1.19 or later.



#

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [x] go test ./... -race
- [x] golangci-lint run
- [ ] Test X

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
