### PR TITLE
Okx, Kucoin: Fix live API tests

### DIFF
--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -73,13 +73,15 @@ func TestMain(m *testing.M) {
 
 func TestGetSymbols(t *testing.T) {
 	t.Parallel()
-	symbols, err := e.GetSymbols(t.Context(), "")
+	allSymbols, err := e.GetSymbols(t.Context(), "")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, symbols)
+	assert.NotEmpty(t, allSymbols)
+
 	// Using market string reduces the scope of what is returned.
-	symbols, err = e.GetSymbols(t.Context(), "ETF")
+	filtered, err := e.GetSymbols(t.Context(), "USDS")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, symbols, "should return all available ETF symbols")
+	assert.NotEmpty(t, filtered, "should return symbols for an active market")
+	assert.Less(t, len(filtered), len(allSymbols), "market filter should narrow the symbol list")
 }
 
 func TestGetTicker(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -465,7 +465,6 @@ func TestGetOpenInterestData(t *testing.T) {
 	require.NoError(t, err)
 	instFamily, err := e.instrumentFamilyFromInstID(instTypeOption, p[0].String())
 	require.NoError(t, err)
-	instFamily = strings.Replace(instFamily, "_UM", "", 1)
 
 	result, err := e.GetOpenInterestData(contextGenerate(), instTypeOption, uly, instFamily, instrumentID)
 	require.NoError(t, err)
@@ -6153,14 +6152,14 @@ func (e *Exchange) instrumentFamilyFromInstID(instrumentType, instID string) (st
 		}
 		for a := range insts {
 			if insts[a].InstrumentID.String() == instID {
-				return insts[a].InstrumentFamily, nil
+				return strings.Replace(insts[a].InstrumentFamily, "_UM", "", 1), nil
 			}
 		}
 	} else {
 		for _, insts := range e.instrumentsInfoMap {
 			for a := range insts {
 				if insts[a].InstrumentID.String() == instID {
-					return insts[a].InstrumentFamily, nil
+					return strings.Replace(insts[a].InstrumentFamily, "_UM", "", 1), nil
 				}
 			}
 		}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -460,10 +460,14 @@ func TestGetOpenInterestData(t *testing.T) {
 	require.NoError(t, err, "GetAvailablePairs must not error")
 	require.NotEmpty(t, p, "GetAvailablePairs must not return empty pairs")
 
+	instrumentID := strings.Replace(p[0].String(), "_UM", "", 1)
 	uly, err := e.underlyingFromInstID(instTypeOption, p[0].String())
 	require.NoError(t, err)
+	instFamily, err := e.instrumentFamilyFromInstID(instTypeOption, p[0].String())
+	require.NoError(t, err)
+	instFamily = strings.Replace(instFamily, "_UM", "", 1)
 
-	result, err := e.GetOpenInterestData(contextGenerate(), instTypeOption, uly, optionsPair.String(), p[0].String())
+	result, err := e.GetOpenInterestData(contextGenerate(), instTypeOption, uly, instFamily, instrumentID)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -460,10 +460,10 @@ func TestGetOpenInterestData(t *testing.T) {
 	require.NoError(t, err, "GetAvailablePairs must not error")
 	require.NotEmpty(t, p, "GetAvailablePairs must not return empty pairs")
 
-	instrumentID := strings.Replace(p[0].String(), "_UM", "", 1)
-	uly, err := e.underlyingFromInstID(instTypeOption, p[0].String())
+	instrumentID := p[0].String()
+	uly, err := e.underlyingFromInstID(instTypeOption, instrumentID)
 	require.NoError(t, err)
-	instFamily, err := e.instrumentFamilyFromInstID(instTypeOption, p[0].String())
+	instFamily, err := e.instrumentFamilyFromInstID(instTypeOption, instrumentID)
 	require.NoError(t, err)
 
 	result, err := e.GetOpenInterestData(contextGenerate(), instTypeOption, uly, instFamily, instrumentID)
@@ -6152,14 +6152,14 @@ func (e *Exchange) instrumentFamilyFromInstID(instrumentType, instID string) (st
 		}
 		for a := range insts {
 			if insts[a].InstrumentID.String() == instID {
-				return strings.Replace(insts[a].InstrumentFamily, "_UM", "", 1), nil
+				return insts[a].InstrumentFamily, nil
 			}
 		}
 	} else {
 		for _, insts := range e.instrumentsInfoMap {
 			for a := range insts {
 				if insts[a].InstrumentID.String() == instID {
-					return strings.Replace(insts[a].InstrumentFamily, "_UM", "", 1), nil
+					return insts[a].InstrumentFamily, nil
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Update KuCoin `TestGetSymbols` to use the active documented `USDS` market instead of `ETF`, which currently returns no symbols.
- Keep coverage for both unfiltered and market-filtered KuCoin symbol requests, and assert the filtered result is non-empty and narrower than the full symbol list.
- Update OKX `TestGetOpenInterestData` so `uly`, `instFamily`, and `instId` are derived from the same live option instrument record.
- Preserve OKX `_UM` instrument family/ID values when the selected instrument uses them, avoiding mismatched request parameters that trigger `51002`.

## Test
- `go test ./exchanges/kucoin -run '^TestGetSymbols$' -count=1`
- `go test ./exchanges/okx -run '^TestGetOpenInterestData$' -count=1`
- `go test ./exchanges/okx -run 'TestGetTickers|TestGetOpenInterestData' -count=1`
- `go test ./exchanges/kucoin -count=1`
- `go test ./exchanges/okx -count=1`
- `codespell exchanges/kucoin/kucoin_test.go exchanges/okx/okx_test.go`
- `make misc_checks`
- `make lint`
