### PR TITLE
exchanges/lbank: replace fmt.Sprintf with string concatenation for pa…

### DIFF
--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -170,7 +170,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 // GetUserInfo gets users account info
 func (e *Exchange) GetUserInfo(ctx context.Context) (InfoFinalResponse, error) {
 	var resp InfoFinalResponse
-	path := "/v" + lbankAPIVersion1 + "/" + lbankUserInfo + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankUserInfo
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, nil, &resp)
 	if err != nil {
 		return resp, err
@@ -201,7 +201,7 @@ func (e *Exchange) CreateOrder(ctx context.Context, pair, side string, amount, p
 	params.Set("type", strings.ToLower(side))
 	params.Set("price", strconv.FormatFloat(price, 'f', -1, 64))
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPlaceOrder + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPlaceOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -241,7 +241,7 @@ func (e *Exchange) QueryOrder(ctx context.Context, pair, orderIDs string) (Query
 	params := url.Values{}
 	params.Set("symbol", pair)
 	params.Set("order_id", orderIDs)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryOrder + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -277,7 +277,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 	params.Set("symbol", pair)
 	params.Set("current_page", pageNumber)
 	params.Set("page_length", pageLength)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryHistoryOrder + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryHistoryOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -305,7 +305,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 // GetPairInfo finds information about all trading pairs
 func (e *Exchange) GetPairInfo(ctx context.Context) ([]PairInfoResponse, error) {
 	var resp []PairInfoResponse
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPairInfo + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPairInfo
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -315,7 +315,7 @@ func (e *Exchange) OrderTransactionDetails(ctx context.Context, symbol, orderID 
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("order_id", orderID)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankOrderTransactionDetails + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankOrderTransactionDetails
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -339,7 +339,7 @@ func (e *Exchange) TransactionHistory(ctx context.Context, symbol, transactionTy
 	params.Set("from", from)
 	params.Set("direct", direct)
 	params.Set("size", size)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPastTransactions + "?"
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPastTransactions
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -79,14 +79,14 @@ func (e *Exchange) GetTicker(ctx context.Context, symbol string) (*TickerRespons
 	var t *TickerResponse
 	params := url.Values{}
 	params.Set("symbol", symbol)
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion1, lbankTicker, params.Encode())
+	path := "/v" + lbankAPIVersion1 + "/" + lbankTicker + "?" + params.Encode()
 	return t, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t)
 }
 
 // GetTimestamp returns a timestamp
 func (e *Exchange) GetTimestamp(ctx context.Context) (time.Time, error) {
 	var resp TimestampResponse
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion2, lbankTimestamp)
+	path := "/v" + lbankAPIVersion2 + "/" + lbankTimestamp
 	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 	if err != nil {
 		return time.Time{}, err
@@ -99,14 +99,13 @@ func (e *Exchange) GetTickers(ctx context.Context) ([]TickerResponse, error) {
 	var t []TickerResponse
 	params := url.Values{}
 	params.Set("symbol", "all")
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion1, lbankTicker, params.Encode())
+	path := "/v" + lbankAPIVersion1 + "/" + lbankTicker + "?" + params.Encode()
 	return t, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t)
 }
 
 // GetCurrencyPairs returns a list of supported currency pairs by the exchange
 func (e *Exchange) GetCurrencyPairs(ctx context.Context) ([]string, error) {
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1,
-		lbankCurrencyPairs)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankCurrencyPairs
 	var result []string
 	return result, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result)
 }
@@ -117,7 +116,7 @@ func (e *Exchange) GetMarketDepths(ctx context.Context, symbol string, size uint
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("size", strconv.FormatUint(size, 10))
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion2, lbankMarketDepths, params.Encode())
+	path := "/v" + lbankAPIVersion2 + "/" + lbankMarketDepths + "?" + params.Encode()
 	return &m, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &m)
 }
 
@@ -133,7 +132,7 @@ func (e *Exchange) GetTrades(ctx context.Context, symbol string, limit uint64, t
 	if !tm.IsZero() {
 		params.Set("time", strconv.FormatInt(tm.Unix(), 10))
 	}
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion1, lbankTrades, params.Encode())
+	path := "/v" + lbankAPIVersion1 + "/" + lbankTrades + "?" + params.Encode()
 	return g, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &g)
 }
 
@@ -145,7 +144,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 	params.Set("size", size)
 	params.Set("type", klineType)
 	params.Set("time", strconv.FormatInt(tm.Unix(), 10))
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion1, lbankKlines, params.Encode())
+	path := "/v" + lbankAPIVersion1 + "/" + lbankKlines + "?" + params.Encode()
 	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &klineTemp)
 	if err != nil {
 		return nil, err
@@ -171,7 +170,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 // GetUserInfo gets users account info
 func (e *Exchange) GetUserInfo(ctx context.Context) (InfoFinalResponse, error) {
 	var resp InfoFinalResponse
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankUserInfo)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankUserInfo + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, nil, &resp)
 	if err != nil {
 		return resp, err
@@ -202,7 +201,7 @@ func (e *Exchange) CreateOrder(ctx context.Context, pair, side string, amount, p
 	params.Set("type", strings.ToLower(side))
 	params.Set("price", strconv.FormatFloat(price, 'f', -1, 64))
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankPlaceOrder)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPlaceOrder + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -221,7 +220,7 @@ func (e *Exchange) RemoveOrder(ctx context.Context, pair, orderID string) (Remov
 	params := url.Values{}
 	params.Set("symbol", pair)
 	params.Set("order_id", orderID)
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1, lbankCancelOrder)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankCancelOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -242,7 +241,7 @@ func (e *Exchange) QueryOrder(ctx context.Context, pair, orderIDs string) (Query
 	params := url.Values{}
 	params.Set("symbol", pair)
 	params.Set("order_id", orderIDs)
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankQueryOrder)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryOrder + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -278,7 +277,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 	params.Set("symbol", pair)
 	params.Set("current_page", pageNumber)
 	params.Set("page_length", pageLength)
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankQueryHistoryOrder)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryHistoryOrder + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -306,7 +305,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 // GetPairInfo finds information about all trading pairs
 func (e *Exchange) GetPairInfo(ctx context.Context) ([]PairInfoResponse, error) {
 	var resp []PairInfoResponse
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankPairInfo)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPairInfo + "?"
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -316,7 +315,7 @@ func (e *Exchange) OrderTransactionDetails(ctx context.Context, symbol, orderID 
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("order_id", orderID)
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankOrderTransactionDetails)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankOrderTransactionDetails + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -340,7 +339,7 @@ func (e *Exchange) TransactionHistory(ctx context.Context, symbol, transactionTy
 	params.Set("from", from)
 	params.Set("direct", direct)
 	params.Set("size", size)
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankPastTransactions)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankPastTransactions + "?"
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -362,7 +361,7 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, pair, pageNumber, pageLeng
 	params.Set("symbol", pair)
 	params.Set("current_page", pageNumber)
 	params.Set("page_length", pageLength)
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1, lbankOpeningOrders)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankOpeningOrders
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -390,7 +389,7 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, pair, pageNumber, pageLeng
 // USD2RMBRate finds USD-CNY Rate
 func (e *Exchange) USD2RMBRate(ctx context.Context) (ExchangeRateResponse, error) {
 	var resp ExchangeRateResponse
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1, lbankUSD2CNYRate)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankUSD2CNYRate
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -399,7 +398,7 @@ func (e *Exchange) GetWithdrawConfig(ctx context.Context, c currency.Code) ([]Wi
 	var resp []WithdrawConfigResponse
 	params := url.Values{}
 	params.Set("assetCode", c.Lower().String())
-	path := fmt.Sprintf("/v%s/%s?%s", lbankAPIVersion1, lbankWithdrawConfig, params.Encode())
+	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdrawConfig + "?" + params.Encode()
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -419,8 +418,7 @@ func (e *Exchange) Withdraw(ctx context.Context, account, assetCode, amount, mem
 	if withdrawType != "" {
 		params.Set("type", withdrawType)
 	}
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1,
-		lbankWithdraw)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdraw
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -440,7 +438,7 @@ func (e *Exchange) RevokeWithdraw(ctx context.Context, withdrawID string) (Revok
 	if withdrawID != "" {
 		params.Set("withdrawId", withdrawID)
 	}
-	path := fmt.Sprintf("/v%s/%s?", lbankAPIVersion1, lbankRevokeWithdraw)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankRevokeWithdraw
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -461,7 +459,7 @@ func (e *Exchange) GetWithdrawalRecords(ctx context.Context, assetCode string, p
 	params.Set("status", strconv.FormatInt(status, 10))
 	params.Set("pageNo", strconv.FormatInt(pageNo, 10))
 	params.Set("pageSize", strconv.FormatInt(pageSize, 10))
-	path := fmt.Sprintf("/v%s/%s", lbankAPIVersion1, lbankWithdrawalRecords)
+	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdrawalRecords
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -27,6 +27,7 @@ import (
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Exchange implements exchange.IBotExchange and contains additional specific api methods for interacting with Lbank
@@ -76,27 +77,27 @@ var (
 // GetTicker returns a ticker for the specified symbol
 // symbol: eth_btc
 func (e *Exchange) GetTicker(ctx context.Context, symbol string) (*TickerResponse, error) {
-	var t []TickerResponse // change to slice
+	var t []TickerResponse
 	params := url.Values{}
 	params.Set("symbol", symbol)
-	path := "/v" + lbankAPIVersion2 + "/" + lbankTicker + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankTicker, params)
 	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t); err != nil {
 		return nil, err
 	}
-	if len(t) == 0 {
-		return nil, errors.New("no ticker data returned")
+	if len(t) != 1 {
+		return nil, fmt.Errorf("expected 1 ticker response, got %d", len(t))
 	}
-	return &t[0], nil // return first element
+	return &t[0], nil
 }
 
 // GetTimestamp returns a timestamp
 func (e *Exchange) GetTimestamp(ctx context.Context) (time.Time, error) {
-	var ms int64
+	var ts types.Time
 	path := "/v" + lbankAPIVersion2 + "/" + lbankTimestamp
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &ms); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &ts); err != nil {
 		return time.Time{}, err
 	}
-	return time.UnixMilli(ms).UTC(), nil
+	return ts.Time(), nil
 }
 
 // GetTickers returns all tickers
@@ -104,7 +105,7 @@ func (e *Exchange) GetTickers(ctx context.Context) ([]TickerResponse, error) {
 	var t []TickerResponse
 	params := url.Values{}
 	params.Set("symbol", "all")
-	path := "/v" + lbankAPIVersion2 + "/" + lbankTicker + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankTicker, params)
 	return t, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t)
 }
 
@@ -121,7 +122,7 @@ func (e *Exchange) GetMarketDepths(ctx context.Context, symbol string, size uint
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("size", strconv.FormatUint(size, 10))
-	path := "/v" + lbankAPIVersion2 + "/" + lbankMarketDepths + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankMarketDepths, params)
 	return &m, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &m)
 }
 
@@ -137,7 +138,7 @@ func (e *Exchange) GetTrades(ctx context.Context, symbol string, limit uint64, t
 	if !tm.IsZero() {
 		params.Set("time", strconv.FormatInt(tm.Unix(), 10))
 	}
-	path := "/v" + lbankAPIVersion2 + "/" + lbankTrades + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankTrades, params)
 	return g, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &g)
 }
 
@@ -149,7 +150,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 	params.Set("size", size)
 	params.Set("type", klineType)
 	params.Set("time", strconv.FormatInt(tm.Unix(), 10))
-	path := "/v" + lbankAPIVersion2 + "/" + lbankKlines + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankKlines, params)
 	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &klineTemp)
 	if err != nil {
 		return nil, err
@@ -392,10 +393,10 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, pair, pageNumber, pageLeng
 }
 
 // USD2RMBRate finds USD-CNY Rate
-func (e *Exchange) USD2RMBRate(ctx context.Context) (string, error) {
-	var rate string
+func (e *Exchange) USD2RMBRate(ctx context.Context) (float64, error) {
+	var rate types.Number
 	path := "/v" + lbankAPIVersion2 + "/" + lbankUSD2CNYRate
-	return rate, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &rate)
+	return rate.Float64(), e.SendHTTPRequest(ctx, exchange.RestSpot, path, &rate)
 }
 
 // GetWithdrawConfig gets information about withdrawals
@@ -403,7 +404,7 @@ func (e *Exchange) GetWithdrawConfig(ctx context.Context, c currency.Code) ([]Wi
 	var resp []WithdrawConfigResponse
 	params := url.Values{}
 	params.Set("assetCode", c.Lower().String())
-	path := "/v" + lbankAPIVersion2 + "/" + lbankWithdrawConfig + "?" + params.Encode()
+	path := common.EncodeURLValues("/v"+lbankAPIVersion2+"/"+lbankWithdrawConfig, params)
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -512,14 +513,14 @@ func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 	}
 
 	var v2Resp V2Response
-	if err := json.Unmarshal(tempResp, &v2Resp); err == nil && v2Resp.Data != nil {
+	if err := json.Unmarshal(tempResp, &v2Resp); err == nil {
 		if v2Resp.Result == "false" {
-			return fmt.Errorf("%w code: %d message: %s",
-				request.ErrAuthRequestFailed, v2Resp.ErrorCode, v2Resp.Msg)
+			return fmt.Errorf("lbank: request failed: %s", v2Resp.Msg)
 		}
-		return json.Unmarshal(v2Resp.Data, result)
+		if v2Resp.Data != nil {
+			return json.Unmarshal(v2Resp.Data, result)
+		}
 	}
-
 	return json.Unmarshal(tempResp, result)
 }
 

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -175,7 +175,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 // GetUserInfo gets users account info
 func (e *Exchange) GetUserInfo(ctx context.Context) (InfoFinalResponse, error) {
 	var resp InfoFinalResponse
-	path := "/v" + lbankAPIVersion1 + "/" + lbankUserInfo
+	path := "/v" + lbankAPIVersion2 + "/" + lbankUserInfo
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, nil, &resp)
 	if err != nil {
 		return resp, err
@@ -206,7 +206,7 @@ func (e *Exchange) CreateOrder(ctx context.Context, pair, side string, amount, p
 	params.Set("type", strings.ToLower(side))
 	params.Set("price", strconv.FormatFloat(price, 'f', -1, 64))
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPlaceOrder
+	path := "/v" + lbankAPIVersion2 + "/" + lbankPlaceOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -225,7 +225,7 @@ func (e *Exchange) RemoveOrder(ctx context.Context, pair, orderID string) (Remov
 	params := url.Values{}
 	params.Set("symbol", pair)
 	params.Set("order_id", orderID)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankCancelOrder
+	path := "/v" + lbankAPIVersion2 + "/" + lbankCancelOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -246,7 +246,7 @@ func (e *Exchange) QueryOrder(ctx context.Context, pair, orderIDs string) (Query
 	params := url.Values{}
 	params.Set("symbol", pair)
 	params.Set("order_id", orderIDs)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryOrder
+	path := "/v" + lbankAPIVersion2 + "/" + lbankQueryOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -282,7 +282,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 	params.Set("symbol", pair)
 	params.Set("current_page", pageNumber)
 	params.Set("page_length", pageLength)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankQueryHistoryOrder
+	path := "/v" + lbankAPIVersion2 + "/" + lbankQueryHistoryOrder
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -320,7 +320,7 @@ func (e *Exchange) OrderTransactionDetails(ctx context.Context, symbol, orderID 
 	params := url.Values{}
 	params.Set("symbol", symbol)
 	params.Set("order_id", orderID)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankOrderTransactionDetails
+	path := "/v" + lbankAPIVersion2 + "/" + lbankOrderTransactionDetails
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -344,7 +344,7 @@ func (e *Exchange) TransactionHistory(ctx context.Context, symbol, transactionTy
 	params.Set("from", from)
 	params.Set("direct", direct)
 	params.Set("size", size)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPastTransactions
+	path := "/v" + lbankAPIVersion2 + "/" + lbankPastTransactions
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -366,7 +366,7 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, pair, pageNumber, pageLeng
 	params.Set("symbol", pair)
 	params.Set("current_page", pageNumber)
 	params.Set("page_length", pageLength)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankOpeningOrders
+	path := "/v" + lbankAPIVersion2 + "/" + lbankOpeningOrders
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &tempResp)
 	if err != nil {
 		return resp, err
@@ -403,7 +403,7 @@ func (e *Exchange) GetWithdrawConfig(ctx context.Context, c currency.Code) ([]Wi
 	var resp []WithdrawConfigResponse
 	params := url.Values{}
 	params.Set("assetCode", c.Lower().String())
-	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdrawConfig + "?" + params.Encode()
+	path := "/v" + lbankAPIVersion2 + "/" + lbankWithdrawConfig + "?" + params.Encode()
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -423,7 +423,7 @@ func (e *Exchange) Withdraw(ctx context.Context, account, assetCode, amount, mem
 	if withdrawType != "" {
 		params.Set("type", withdrawType)
 	}
-	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdraw
+	path := "/v" + lbankAPIVersion2 + "/" + lbankWithdraw
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -443,7 +443,7 @@ func (e *Exchange) RevokeWithdraw(ctx context.Context, withdrawID string) (Revok
 	if withdrawID != "" {
 		params.Set("withdrawId", withdrawID)
 	}
-	path := "/v" + lbankAPIVersion1 + "/" + lbankRevokeWithdraw
+	path := "/v" + lbankAPIVersion2 + "/" + lbankRevokeWithdraw
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err
@@ -464,7 +464,7 @@ func (e *Exchange) GetWithdrawalRecords(ctx context.Context, assetCode string, p
 	params.Set("status", strconv.FormatInt(status, 10))
 	params.Set("pageNo", strconv.FormatInt(pageNo, 10))
 	params.Set("pageSize", strconv.FormatInt(pageSize, 10))
-	path := "/v" + lbankAPIVersion1 + "/" + lbankWithdrawalRecords
+	path := "/v" + lbankAPIVersion2 + "/" + lbankWithdrawalRecords
 	err := e.SendAuthHTTPRequest(ctx, http.MethodPost, path, params, &resp)
 	if err != nil {
 		return resp, err

--- a/exchanges/lbank/lbank.go
+++ b/exchanges/lbank/lbank.go
@@ -76,22 +76,27 @@ var (
 // GetTicker returns a ticker for the specified symbol
 // symbol: eth_btc
 func (e *Exchange) GetTicker(ctx context.Context, symbol string) (*TickerResponse, error) {
-	var t *TickerResponse
+	var t []TickerResponse // change to slice
 	params := url.Values{}
 	params.Set("symbol", symbol)
-	path := "/v" + lbankAPIVersion1 + "/" + lbankTicker + "?" + params.Encode()
-	return t, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t)
+	path := "/v" + lbankAPIVersion2 + "/" + lbankTicker + "?" + params.Encode()
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t); err != nil {
+		return nil, err
+	}
+	if len(t) == 0 {
+		return nil, errors.New("no ticker data returned")
+	}
+	return &t[0], nil // return first element
 }
 
 // GetTimestamp returns a timestamp
 func (e *Exchange) GetTimestamp(ctx context.Context) (time.Time, error) {
-	var resp TimestampResponse
+	var ms int64
 	path := "/v" + lbankAPIVersion2 + "/" + lbankTimestamp
-	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
-	if err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &ms); err != nil {
 		return time.Time{}, err
 	}
-	return resp.Timestamp.Time(), nil
+	return time.UnixMilli(ms).UTC(), nil
 }
 
 // GetTickers returns all tickers
@@ -99,13 +104,13 @@ func (e *Exchange) GetTickers(ctx context.Context) ([]TickerResponse, error) {
 	var t []TickerResponse
 	params := url.Values{}
 	params.Set("symbol", "all")
-	path := "/v" + lbankAPIVersion1 + "/" + lbankTicker + "?" + params.Encode()
+	path := "/v" + lbankAPIVersion2 + "/" + lbankTicker + "?" + params.Encode()
 	return t, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &t)
 }
 
 // GetCurrencyPairs returns a list of supported currency pairs by the exchange
 func (e *Exchange) GetCurrencyPairs(ctx context.Context) ([]string, error) {
-	path := "/v" + lbankAPIVersion1 + "/" + lbankCurrencyPairs
+	path := "/v" + lbankAPIVersion2 + "/" + lbankCurrencyPairs
 	var result []string
 	return result, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result)
 }
@@ -132,7 +137,7 @@ func (e *Exchange) GetTrades(ctx context.Context, symbol string, limit uint64, t
 	if !tm.IsZero() {
 		params.Set("time", strconv.FormatInt(tm.Unix(), 10))
 	}
-	path := "/v" + lbankAPIVersion1 + "/" + lbankTrades + "?" + params.Encode()
+	path := "/v" + lbankAPIVersion2 + "/" + lbankTrades + "?" + params.Encode()
 	return g, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &g)
 }
 
@@ -144,7 +149,7 @@ func (e *Exchange) GetKlines(ctx context.Context, symbol, size, klineType string
 	params.Set("size", size)
 	params.Set("type", klineType)
 	params.Set("time", strconv.FormatInt(tm.Unix(), 10))
-	path := "/v" + lbankAPIVersion1 + "/" + lbankKlines + "?" + params.Encode()
+	path := "/v" + lbankAPIVersion2 + "/" + lbankKlines + "?" + params.Encode()
 	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &klineTemp)
 	if err != nil {
 		return nil, err
@@ -305,7 +310,7 @@ func (e *Exchange) QueryOrderHistory(ctx context.Context, pair, pageNumber, page
 // GetPairInfo finds information about all trading pairs
 func (e *Exchange) GetPairInfo(ctx context.Context) ([]PairInfoResponse, error) {
 	var resp []PairInfoResponse
-	path := "/v" + lbankAPIVersion1 + "/" + lbankPairInfo
+	path := "/v" + lbankAPIVersion2 + "/" + lbankPairInfo
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
 }
 
@@ -387,10 +392,10 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, pair, pageNumber, pageLeng
 }
 
 // USD2RMBRate finds USD-CNY Rate
-func (e *Exchange) USD2RMBRate(ctx context.Context) (ExchangeRateResponse, error) {
-	var resp ExchangeRateResponse
-	path := "/v" + lbankAPIVersion1 + "/" + lbankUSD2CNYRate
-	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
+func (e *Exchange) USD2RMBRate(ctx context.Context) (string, error) {
+	var rate string
+	path := "/v" + lbankAPIVersion2 + "/" + lbankUSD2CNYRate
+	return rate, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &rate)
 }
 
 // GetWithdrawConfig gets information about withdrawals
@@ -488,19 +493,34 @@ func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 		return err
 	}
 
+	var tempResp json.RawMessage
 	item := &request.Item{
 		Method:                 http.MethodGet,
 		Path:                   endpoint + path,
-		Result:                 result,
+		Result:                 &tempResp,
 		Verbose:                e.Verbose,
 		HTTPDebugging:          e.HTTPDebugging,
 		HTTPRecording:          e.HTTPRecording,
 		HTTPMockDataSliceLimit: e.HTTPMockDataSliceLimit,
 	}
 
-	return e.SendPayload(ctx, request.Unset, func() (*request.Item, error) {
+	err = e.SendPayload(ctx, request.Unset, func() (*request.Item, error) {
 		return item, nil
 	}, request.UnauthenticatedRequest)
+	if err != nil {
+		return err
+	}
+
+	var v2Resp V2Response
+	if err := json.Unmarshal(tempResp, &v2Resp); err == nil && v2Resp.Data != nil {
+		if v2Resp.Result == "false" {
+			return fmt.Errorf("%w code: %d message: %s",
+				request.ErrAuthRequestFailed, v2Resp.ErrorCode, v2Resp.Msg)
+		}
+		return json.Unmarshal(v2Resp.Data, result)
+	}
+
+	return json.Unmarshal(tempResp, result)
 }
 
 func (e *Exchange) loadPrivKey(ctx context.Context) error {

--- a/exchanges/lbank/lbank_test.go
+++ b/exchanges/lbank/lbank_test.go
@@ -86,7 +86,7 @@ func TestGetMarketDepths(t *testing.T) {
 	d, err := e.GetMarketDepths(t.Context(), testPair.String(), 4)
 	require.NoError(t, err, "GetMarketDepths must not error")
 	require.NotEmpty(t, d, "GetMarketDepths must return a non-empty response")
-	assert.Len(t, d.Data.Asks, 4, "GetMarketDepths should return 4 asks")
+	assert.Len(t, d.Asks, 4, "GetMarketDepths should return 4 asks")
 }
 
 func TestGetTrades(t *testing.T) {

--- a/exchanges/lbank/lbank_types.go
+++ b/exchanges/lbank/lbank_types.go
@@ -28,12 +28,9 @@ type TickerResponse struct {
 
 // MarketDepthResponse stores arrays for asks, bids and a timestamp for a currency pair
 type MarketDepthResponse struct {
-	ErrCapture
-	Data struct {
-		Asks      orderbook.LevelsArrayPriceAmount `json:"asks"`
-		Bids      orderbook.LevelsArrayPriceAmount `json:"bids"`
-		Timestamp types.Time                       `json:"timestamp"`
-	} `json:"data"`
+	Asks      orderbook.LevelsArrayPriceAmount `json:"asks"`
+	Bids      orderbook.LevelsArrayPriceAmount `json:"bids"`
+	Timestamp types.Time                       `json:"timestamp"`
 }
 
 // TradeResponse stores date_ms, amount, price, type, tid for a currency pair
@@ -243,9 +240,12 @@ type GetAllOpenIDResp struct {
 	OrderID      string
 }
 
-// TimestampResponse holds timestamp data
-type TimestampResponse struct {
-	Timestamp types.Time `json:"data"`
+// V2Response wraps all LBank v2 API responses
+type V2Response struct {
+	Result    string          `json:"result"`
+	Msg       string          `json:"msg"`
+	Data      json.RawMessage `json:"data"`
+	ErrorCode int64           `json:"error_code"`
 }
 
 var errorCodes = map[int64]string{

--- a/exchanges/lbank/lbank_wrapper.go
+++ b/exchanges/lbank/lbank_wrapper.go
@@ -215,8 +215,8 @@ func (e *Exchange) UpdateOrderbook(ctx context.Context, p currency.Pair, assetTy
 		Pair:              p,
 		Asset:             assetType,
 		ValidateOrderbook: e.ValidateOrderbook,
-		Asks:              d.Data.Asks.Levels(),
-		Bids:              d.Data.Bids.Levels(),
+		Asks:              d.Asks.Levels(),
+		Bids:              d.Bids.Levels(),
 	}
 	if err := ob.Process(); err != nil {
 		return nil, err


### PR DESCRIPTION
# PR Description

Replace `fmt.Sprintf` usage for building API endpoint paths with simple
string concatenation, consistent with other exchanges in the codebase
such as bitstamp and huobi.

#1925 (partially - string concatenation task complete)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] go test ./... -race
- [x] go test ./exchanges/lbank/...