### PR TITLE
Kraken: model real rate limit with per-endpoint costs

### DIFF
--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -49,7 +49,7 @@ func (e *Exchange) GetCurrentServerTime(ctx context.Context) (*TimeResponse, err
 	path := fmt.Sprintf("/%s/public/%s", krakenAPIVersion, krakenServerTime)
 
 	var result TimeResponse
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &result); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func (e *Exchange) SeedAssets(ctx context.Context) error {
 func (e *Exchange) GetAssets(ctx context.Context) (map[string]*Asset, error) {
 	path := fmt.Sprintf("/%s/public/%s", krakenAPIVersion, krakenAssets)
 	var result map[string]*Asset
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -105,7 +105,7 @@ func (e *Exchange) GetAssetPairs(ctx context.Context, assetPairs []string, info 
 		}
 		params.Set("info", info)
 	}
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path+params.Encode(), &result); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path+params.Encode(), &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -122,7 +122,7 @@ func (e *Exchange) GetTicker(ctx context.Context, symbol currency.Pair) (*Ticker
 
 	var data map[string]*TickerResponse
 	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenTicker, values.Encode())
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &data); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &data); err != nil {
 		return nil, err
 	}
 
@@ -155,7 +155,7 @@ func (e *Exchange) GetTickers(ctx context.Context, pairList string) (map[string]
 	var result map[string]*TickerResponse
 	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenTicker, values.Encode())
 
-	err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result)
+	err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (e *Exchange) GetOHLC(ctx context.Context, symbol currency.Pair, interval s
 	path := fmt.Sprintf("/%s/public/%s?%s", krakenAPIVersion, krakenOHLC, values.Encode())
 
 	result := make(map[string]any)
-	err = e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result)
+	err = e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (e *Exchange) GetDepth(ctx context.Context, symbol currency.Pair) (*Orderbo
 	}
 
 	result := make(map[string]*orderbookStructure)
-	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, path, &result); err != nil {
+	if err := e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &result); err != nil {
 		return nil, err
 	}
 
@@ -308,7 +308,7 @@ func (e *Exchange) GetTrades(ctx context.Context, symbol currency.Pair, since ti
 
 	path := common.EncodeURLValues("/"+krakenAPIVersion+"/public/"+krakenTrades, values)
 	var resp *RecentTradesResponse
-	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &resp)
+	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &resp)
 }
 
 // GetSpread returns the full spread on Kraken
@@ -324,13 +324,13 @@ func (e *Exchange) GetSpread(ctx context.Context, symbol currency.Pair, since ti
 	}
 	var peanutButter *SpreadResponse
 	path := common.EncodeURLValues("/"+krakenAPIVersion+"/public/"+krakenSpread, values)
-	return peanutButter, e.SendHTTPRequest(ctx, exchange.RestSpot, path, &peanutButter)
+	return peanutButter, e.SendHTTPRequest(ctx, exchange.RestSpot, krakenLimitPublic, path, &peanutButter)
 }
 
 // GetBalance returns your balance associated with your keys
 func (e *Exchange) GetBalance(ctx context.Context) (map[string]Balance, error) {
 	var result map[string]Balance
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenBalance, url.Values{}, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenBalance, url.Values{}, &result); err != nil {
 		return nil, err
 	}
 
@@ -345,7 +345,7 @@ func (e *Exchange) GetWithdrawInfo(ctx context.Context, withdrawalAsset, withdra
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 
 	var result *WithdrawInformation
-	return result, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenWithdrawInfo, params, &result)
+	return result, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWithdrawInfo, params, &result)
 }
 
 // Withdraw withdraws funds
@@ -356,7 +356,7 @@ func (e *Exchange) Withdraw(ctx context.Context, withdrawalAsset, withdrawalKey 
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 
 	var referenceID string
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenWithdraw, params, &referenceID); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitWithdraw, krakenWithdraw, params, &referenceID); err != nil {
 		return referenceID, err
 	}
 
@@ -369,7 +369,7 @@ func (e *Exchange) GetDepositMethods(ctx context.Context, a string) ([]DepositMe
 	params.Set("asset", a)
 
 	var result []DepositMethods
-	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenDepositMethods, params, &result)
+	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenDepositMethods, params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (e *Exchange) GetTradeBalance(ctx context.Context, args ...TradeBalanceOpti
 	}
 
 	var result TradeBalanceInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenTradeBalance, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenTradeBalance, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -412,7 +412,7 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, args OrderInfoOptions) (*O
 	}
 
 	var result OpenOrders
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenOpenOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenOpenOrders, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -448,7 +448,7 @@ func (e *Exchange) GetClosedOrders(ctx context.Context, args GetClosedOrdersOpti
 	}
 
 	var result ClosedOrders
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenClosedOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenClosedOrders, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -474,7 +474,7 @@ func (e *Exchange) QueryOrdersInfo(ctx context.Context, args OrderInfoOptions, t
 	}
 
 	var result map[string]OrderInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenQueryOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryOrders, params, &result); err != nil {
 		return result, err
 	}
 
@@ -508,7 +508,7 @@ func (e *Exchange) GetTradesHistory(ctx context.Context, args ...GetTradesHistor
 	}
 
 	var result TradesHistory
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenTradeHistory, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenTradeHistory, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -530,7 +530,7 @@ func (e *Exchange) QueryTrades(ctx context.Context, trades bool, txid string, tx
 	}
 
 	var result map[string]TradeInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenQueryTrades, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryTrades, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -550,7 +550,7 @@ func (e *Exchange) OpenPositions(ctx context.Context, docalcs bool, txids ...str
 	}
 
 	var result map[string]Position
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenOpenPositions, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenOpenPositions, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -588,7 +588,7 @@ func (e *Exchange) GetLedgers(ctx context.Context, args ...GetLedgersOptions) (*
 	}
 
 	var result Ledgers
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLedgers, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenLedgers, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -606,7 +606,7 @@ func (e *Exchange) QueryLedgers(ctx context.Context, id string, ids ...string) (
 	}
 
 	var result map[string]LedgerInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenQueryLedgers, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryLedgers, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -633,7 +633,7 @@ func (e *Exchange) GetTradeVolume(ctx context.Context, feeinfo bool, symbol ...c
 	}
 
 	var result *TradeVolumeResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenTradeVolume, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenTradeVolume, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -698,7 +698,7 @@ func (e *Exchange) AddOrder(ctx context.Context, symbol currency.Pair, side, ord
 	}
 
 	var result AddOrderResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenOrderPlace, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitTrading, krakenOrderPlace, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -712,7 +712,7 @@ func (e *Exchange) CancelExistingOrder(ctx context.Context, txid string) (*Cance
 	}
 
 	var result CancelOrderResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenOrderCancel, values, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitTrading, krakenOrderCancel, values, &result); err != nil {
 		return nil, err
 	}
 
@@ -720,7 +720,7 @@ func (e *Exchange) CancelExistingOrder(ctx context.Context, txid string) (*Cance
 }
 
 // SendHTTPRequest sends an unauthenticated HTTP requests
-func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path string, result any) error {
+func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, epl request.EndpointLimit, path string, result any) error {
 	endpoint, err := e.API.Endpoints.GetURL(ep)
 	if err != nil {
 		return err
@@ -737,7 +737,7 @@ func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 		HTTPMockDataSliceLimit: e.HTTPMockDataSliceLimit,
 	}
 
-	err = e.SendPayload(ctx, request.Unset, func() (*request.Item, error) {
+	err = e.SendPayload(ctx, epl, func() (*request.Item, error) {
 		return item, nil
 	}, request.UnauthenticatedRequest)
 	if err != nil {
@@ -769,7 +769,7 @@ func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 }
 
 // SendAuthenticatedHTTPRequest sends an authenticated HTTP request
-func (e *Exchange) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange.URL, method string, params url.Values, result any) error {
+func (e *Exchange) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange.URL, epl request.EndpointLimit, method string, params url.Values, result any) error {
 	creds, err := e.GetCredentials(ctx)
 	if err != nil {
 		return err
@@ -780,7 +780,7 @@ func (e *Exchange) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange
 	}
 
 	interim := json.RawMessage{}
-	err = e.SendPayload(ctx, request.Unset, func() (*request.Item, error) {
+	err = e.SendPayload(ctx, epl, func() (*request.Item, error) {
 		nonce := e.Requester.GetNonce(nonce.UnixNano).String()
 		params.Set("nonce", nonce)
 		encoded := params.Encode()
@@ -912,7 +912,7 @@ func (e *Exchange) GetCryptoDepositAddress(ctx context.Context, method, code str
 	}
 
 	var result []DepositAddress
-	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenDepositAddresses, values, &result)
+	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenDepositAddresses, values, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (e *Exchange) WithdrawStatus(ctx context.Context, c currency.Code, method s
 	}
 
 	var result []WithdrawStatusResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenWithdrawStatus, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWithdrawStatus, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -946,7 +946,7 @@ func (e *Exchange) WithdrawCancel(ctx context.Context, c currency.Code, refID st
 	params.Set("refid", refID)
 
 	var result bool
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenWithdrawCancel, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitWithdraw, krakenWithdrawCancel, params, &result); err != nil {
 		return result, err
 	}
 
@@ -956,7 +956,7 @@ func (e *Exchange) WithdrawCancel(ctx context.Context, c currency.Code, refID st
 // GetWebsocketToken returns a websocket token
 func (e *Exchange) GetWebsocketToken(ctx context.Context) (string, error) {
 	var response WsTokenResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenWebsocketToken, url.Values{}, &response); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWebsocketToken, url.Values{}, &response); err != nil {
 		return "", err
 	}
 	return response.Token, nil

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -330,7 +330,7 @@ func (e *Exchange) GetSpread(ctx context.Context, symbol currency.Pair, since ti
 // GetBalance returns your balance associated with your keys
 func (e *Exchange) GetBalance(ctx context.Context) (map[string]Balance, error) {
 	var result map[string]Balance
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenBalance, url.Values{}, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenBalance, url.Values{}, &result); err != nil {
 		return nil, err
 	}
 
@@ -345,7 +345,7 @@ func (e *Exchange) GetWithdrawInfo(ctx context.Context, withdrawalAsset, withdra
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 
 	var result *WithdrawInformation
-	return result, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWithdrawInfo, params, &result)
+	return result, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenWithdrawInfo, params, &result)
 }
 
 // Withdraw withdraws funds
@@ -356,7 +356,7 @@ func (e *Exchange) Withdraw(ctx context.Context, withdrawalAsset, withdrawalKey 
 	params.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 
 	var referenceID string
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitWithdraw, krakenWithdraw, params, &referenceID); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenWithdraw, params, &referenceID); err != nil {
 		return referenceID, err
 	}
 
@@ -369,7 +369,7 @@ func (e *Exchange) GetDepositMethods(ctx context.Context, a string) ([]DepositMe
 	params.Set("asset", a)
 
 	var result []DepositMethods
-	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenDepositMethods, params, &result)
+	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenDepositMethods, params, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (e *Exchange) GetTradeBalance(ctx context.Context, args ...TradeBalanceOpti
 	}
 
 	var result TradeBalanceInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenTradeBalance, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenTradeBalance, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -412,7 +412,7 @@ func (e *Exchange) GetOpenOrders(ctx context.Context, args OrderInfoOptions) (*O
 	}
 
 	var result OpenOrders
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenOpenOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenOpenOrders, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -448,7 +448,7 @@ func (e *Exchange) GetClosedOrders(ctx context.Context, args GetClosedOrdersOpti
 	}
 
 	var result ClosedOrders
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenClosedOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenClosedOrders, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -474,7 +474,7 @@ func (e *Exchange) QueryOrdersInfo(ctx context.Context, args OrderInfoOptions, t
 	}
 
 	var result map[string]OrderInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryOrders, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenQueryOrders, params, &result); err != nil {
 		return result, err
 	}
 
@@ -530,7 +530,7 @@ func (e *Exchange) QueryTrades(ctx context.Context, trades bool, txid string, tx
 	}
 
 	var result map[string]TradeInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryTrades, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenQueryTrades, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -550,7 +550,7 @@ func (e *Exchange) OpenPositions(ctx context.Context, docalcs bool, txids ...str
 	}
 
 	var result map[string]Position
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenOpenPositions, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenOpenPositions, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -606,7 +606,7 @@ func (e *Exchange) QueryLedgers(ctx context.Context, id string, ids ...string) (
 	}
 
 	var result map[string]LedgerInfo
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitHistory, krakenQueryLedgers, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenQueryLedgers, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -633,7 +633,7 @@ func (e *Exchange) GetTradeVolume(ctx context.Context, feeinfo bool, symbol ...c
 	}
 
 	var result *TradeVolumeResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenTradeVolume, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenTradeVolume, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -712,7 +712,7 @@ func (e *Exchange) CancelExistingOrder(ctx context.Context, txid string) (*Cance
 	}
 
 	var result CancelOrderResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitTrading, krakenOrderCancel, values, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitCancel, krakenOrderCancel, values, &result); err != nil {
 		return nil, err
 	}
 
@@ -912,7 +912,7 @@ func (e *Exchange) GetCryptoDepositAddress(ctx context.Context, method, code str
 	}
 
 	var result []DepositAddress
-	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenDepositAddresses, values, &result)
+	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenDepositAddresses, values, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (e *Exchange) WithdrawStatus(ctx context.Context, c currency.Code, method s
 	}
 
 	var result []WithdrawStatusResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWithdrawStatus, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenWithdrawStatus, params, &result); err != nil {
 		return nil, err
 	}
 
@@ -946,7 +946,7 @@ func (e *Exchange) WithdrawCancel(ctx context.Context, c currency.Code, refID st
 	params.Set("refid", refID)
 
 	var result bool
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitWithdraw, krakenWithdrawCancel, params, &result); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenWithdrawCancel, params, &result); err != nil {
 		return result, err
 	}
 
@@ -956,7 +956,7 @@ func (e *Exchange) WithdrawCancel(ctx context.Context, c currency.Code, refID st
 // GetWebsocketToken returns a websocket token
 func (e *Exchange) GetWebsocketToken(ctx context.Context) (string, error) {
 	var response WsTokenResponse
-	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitBalance, krakenWebsocketToken, url.Values{}, &response); err != nil {
+	if err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, krakenLimitAuth, krakenWebsocketToken, url.Values{}, &response); err != nil {
 		return "", err
 	}
 	return response.Token, nil

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -33,7 +33,7 @@ func (e *Exchange) GetFuturesOrderbook(ctx context.Context, symbol currency.Pair
 	params := url.Values{}
 	params.Set("symbol", symbolValue)
 	var resp FuturesOrderbookData
-	return &resp, e.SendHTTPRequest(ctx, exchange.RestFutures, futuresOrderbook+"?"+params.Encode(), &resp)
+	return &resp, e.SendHTTPRequest(ctx, exchange.RestFutures, krakenLimitFuturesPublic, futuresOrderbook+"?"+params.Encode(), &resp)
 }
 
 // GetFuturesCharts returns candle data for kraken futures
@@ -54,7 +54,7 @@ func (e *Exchange) GetFuturesCharts(ctx context.Context, resolution, tickType st
 		reqStr += "?" + params.Encode()
 	}
 	var resp FuturesCandles
-	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, reqStr, &resp)
+	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, krakenLimitFuturesPublic, reqStr, &resp)
 }
 
 // GetFuturesTrades returns public trade data for kraken futures
@@ -71,25 +71,25 @@ func (e *Exchange) GetFuturesTrades(ctx context.Context, symbol currency.Pair, t
 		params.Set("before", strconv.FormatInt(from.Unix(), 10))
 	}
 	var resp FuturesPublicTrades
-	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, futuresPublicTrades+"/"+symbolValue+"/executions?"+params.Encode(), &resp)
+	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, krakenLimitFuturesPublic, futuresPublicTrades+"/"+symbolValue+"/executions?"+params.Encode(), &resp)
 }
 
 // GetInstruments gets a list of futures markets and their data
 func (e *Exchange) GetInstruments(ctx context.Context) (FuturesInstrumentData, error) {
 	var resp FuturesInstrumentData
-	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, futuresInstruments, &resp)
+	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, krakenLimitFuturesPublic, futuresInstruments, &resp)
 }
 
 // GetFuturesTickers gets a list of futures tickers and their data
 func (e *Exchange) GetFuturesTickers(ctx context.Context) (FuturesTickersData, error) {
 	var resp FuturesTickersData
-	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, futuresTickers, &resp)
+	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, krakenLimitFuturesPublic, futuresTickers, &resp)
 }
 
 // GetFuturesTickerBySymbol returns futures ticker data by symbol
 func (e *Exchange) GetFuturesTickerBySymbol(ctx context.Context, symbol string) (FuturesTickerData, error) {
 	var resp FuturesTickerData
-	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, futuresTickers+"/"+symbol, &resp)
+	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, krakenLimitFuturesPublic, futuresTickers+"/"+symbol, &resp)
 }
 
 // GetFuturesTradeHistory gets public trade history data for futures
@@ -104,7 +104,7 @@ func (e *Exchange) GetFuturesTradeHistory(ctx context.Context, symbol currency.P
 	if !lastTime.IsZero() {
 		params.Set("lastTime", lastTime.Format("2006-01-02T15:04:05.070Z"))
 	}
-	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, futuresTradeHistory+"?"+params.Encode(), &resp)
+	return resp, e.SendHTTPRequest(ctx, exchange.RestFutures, krakenLimitFuturesPublic, futuresTradeHistory+"?"+params.Encode(), &resp)
 }
 
 // FuturesBatchOrder places a batch order for futures

--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -376,7 +376,7 @@ func (e *Exchange) SendFuturesAuthRequest(ctx context.Context, method, path stri
 		}, nil
 	}
 
-	err = e.SendPayload(ctx, request.Unset, newRequest, request.AuthenticatedRequest)
+	err = e.SendPayload(ctx, krakenLimitFuturesAuth, newRequest, request.AuthenticatedRequest)
 
 	if err == nil {
 		err = getFuturesErr(interim)

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -69,10 +69,6 @@ const (
 	futuresTransfers         = "/api/v3/transfers"
 	futuresEditOrder         = "/api/v3/editorder"
 
-	// Rate limit consts
-	krakenRateInterval = time.Second
-	krakenRequestRate  = 1
-
 	// Status consts
 	statusOpen = "open"
 )

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -154,7 +154,7 @@ func (e *Exchange) SetDefaults() {
 	var err error
 	e.Requester, err = request.New(e.Name,
 		common.NewHTTPClientWithTimeout(exchange.DefaultHTTPTimeout),
-		request.WithLimiter(request.NewBasicRateLimit(krakenRateInterval, krakenRequestRate, 1)))
+		request.WithLimiter(buildKrakenRateLimits()))
 	if err != nil {
 		log.Errorln(log.ExchangeSys, err)
 	}

--- a/exchanges/kraken/ratelimit.go
+++ b/exchanges/kraken/ratelimit.go
@@ -1,0 +1,160 @@
+package kraken
+
+import (
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+	"golang.org/x/time/rate"
+)
+
+// Kraken applies two independent REST rate-limit systems:
+//
+//  1. Public API limit, applied per source IP. Covers unauthenticated
+//     endpoints (Ticker, Depth, OHLC, Trades, Time, Assets, AssetPairs).
+//
+//  2. Private API limit, applied per account / API key. The private limit
+//     is a stateful counter with continuous decay; each request increments
+//     the counter, the counter decays at a fixed rate per second, and
+//     exceeding the maximum triggers a temporary key ban.
+//
+// Within the private system trading endpoints (AddOrder, CancelOrder) are
+// tracked under a separate per-pair counter that does not consume from the
+// general private counter.
+//
+// Reference (verified 2026): https://support.kraken.com/articles/206548367
+//
+// Tiers for the private general counter:
+//
+//	Verified          : max 20, decay -0.5/sec
+//	Verified Pro      : max 20, decay -1.0/sec
+//
+// Endpoint costs (private REST, general counter):
+//
+//	Account history (Ledgers, TradesHistory, ClosedOrders, QueryOrders,
+//	                 QueryTrades, QueryLedgers)                        +4
+//	Balance, TradeBalance, OpenOrders, OpenPositions, TradeVolume,
+//	  WithdrawInfo, WithdrawStatus, DepositMethods, DepositAddresses,
+//	  GetWebSocketsToken                                                +1
+//	Trading (AddOrder, CancelOrder)                                     0
+//	  (separate per-pair counter)
+//	Withdraw, WithdrawCancel                                            +1
+//
+// We emulate each system with a separate golang.org/x/time/rate.Limiter
+// where:
+//
+//	Kraken counter max  ↔  rate.Limiter burst
+//	Kraken decay /sec   ↔  rate.Limiter refill rate
+//
+// Tunables. These are package-level vars rather than consts so they can be
+// overridden at process start-up (for example to switch the private counter
+// to the Verified Pro tier without rebuilding, or to relax limits for
+// integration tests). They are not safe to mutate after the Requester has
+// been constructed.
+var (
+	// Private general counter (Verified tier defaults).
+	KrakenSpotMaxCounter  = 20  // documented maximum counter
+	KrakenSpotDecayPerSec = 0.5 // tokens per second (Verified tier)
+
+	// Private trading counter (AddOrder, CancelOrder).
+	KrakenSpotOrderMaxBurst = 60
+	KrakenSpotOrderRate     = 1.0 // tokens per second
+
+	// Public API counter (per IP). Conservative defaults; Kraken
+	// documents a generous public rate that varies by endpoint, but a
+	// modest steady-state with healthy burst suits both bots and
+	// occasional consumers.
+	KrakenPublicMaxBurst = 15
+	KrakenPublicRate     = 1.0 // tokens per second
+)
+
+// Kraken-specific EndpointLimit values. These extend the global Unset/Auth/
+// UnAuth constants from the request package and let each endpoint declare its
+// real cost so the limiter charges the correct number of tokens per call.
+const (
+	// krakenLimitDefault is used for unrecognised endpoints; weight 1 keeps
+	// it conservative.
+	krakenLimitDefault request.EndpointLimit = iota + 100
+
+	// krakenLimitPublic — public REST endpoints (Time, Depth, Ticker,
+	// Trades, OHLC, Assets, AssetPairs). Counted under the public-API
+	// limit which is per-IP and independent of the private counter.
+	krakenLimitPublic
+
+	// krakenLimitFuturesPublic — public futures endpoints. Kraken documents
+	// these as having no request cost, unlike authenticated futures paths.
+	krakenLimitFuturesPublic
+
+	// krakenLimitBalance — Balance, TradeBalance, OpenOrders,
+	// OpenPositions, TradeVolume, withdraw/deposit info, WS token. +1
+	// on the private general counter.
+	krakenLimitBalance
+
+	// krakenLimitHistory — Ledgers, TradesHistory, ClosedOrders,
+	// QueryOrders, QueryTrades, QueryLedgers. +4 on the private general
+	// counter; these are the expensive endpoints.
+	krakenLimitHistory
+
+	// krakenLimitTrading — AddOrder, CancelOrder. Counted under a
+	// separate per-pair Kraken limiter, not on the general counter.
+	krakenLimitTrading
+
+	// krakenLimitWithdraw — Withdraw, WithdrawCancel. +1 on the private
+	// general counter.
+	krakenLimitWithdraw
+)
+
+// newKrakenSpotPrivateLimiter constructs the underlying rate.Limiter that
+// emulates Kraken's private general counter (Verified tier defaults).
+func newKrakenSpotPrivateLimiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Limit(KrakenSpotDecayPerSec), KrakenSpotMaxCounter)
+}
+
+// newKrakenSpotOrderLimiter constructs the underlying rate.Limiter for
+// AddOrder/CancelOrder, which Kraken tracks under a separate per-pair
+// counter independent of the private general counter.
+func newKrakenSpotOrderLimiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Limit(KrakenSpotOrderRate), KrakenSpotOrderMaxBurst)
+}
+
+// newKrakenPublicLimiter constructs the underlying rate.Limiter for the
+// public REST API, which Kraken rate-limits per source IP independently of
+// any private API key quota.
+func newKrakenPublicLimiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Limit(KrakenPublicRate), KrakenPublicMaxBurst)
+}
+
+// buildKrakenRateLimits returns the full RateLimitDefinitions map.
+//
+// Three independent underlying rate.Limiter instances are used:
+//
+//   - private: shared by all authenticated non-trading endpoints
+//     (balance, info, history, withdraw). Different endpoint groups carry
+//     different weights matching Kraken's documented costs.
+//   - orders:  used only by AddOrder/CancelOrder.
+//   - public:  used only by unauthenticated REST endpoints. Independent of
+//     the private counter because Kraken's public limit is enforced per
+//     IP, not per API key.
+//
+// The legacy request.Unset/Auth/UnAuth keys are kept and routed to
+// `private` for backward compatibility — anything that still passes them
+// will behave as before, just with the new tier-correct parameters.
+func buildKrakenRateLimits() request.RateLimitDefinitions {
+	private := newKrakenSpotPrivateLimiter()
+	orders := newKrakenSpotOrderLimiter()
+	public := newKrakenPublicLimiter()
+
+	return request.RateLimitDefinitions{
+		// Backward compatibility — anything still passing the global
+		// constants gets the private limiter at weight 1.
+		request.Unset:  request.GetRateLimiterWithWeight(private, 1),
+		request.Auth:   request.GetRateLimiterWithWeight(private, 1),
+		request.UnAuth: request.GetRateLimiterWithWeight(public, 1),
+
+		// Kraken-specific endpoint costs.
+		krakenLimitDefault:       request.GetRateLimiterWithWeight(private, 1),
+		krakenLimitPublic:        request.GetRateLimiterWithWeight(public, 1),
+		krakenLimitFuturesPublic: request.NewRateLimitWithWeight(0, 0, 1),
+		krakenLimitBalance:       request.GetRateLimiterWithWeight(private, 1),
+		krakenLimitHistory:       request.GetRateLimiterWithWeight(private, 4),
+		krakenLimitTrading:       request.GetRateLimiterWithWeight(orders, 1),
+		krakenLimitWithdraw:      request.GetRateLimiterWithWeight(private, 1),
+	}
+}

--- a/exchanges/kraken/ratelimit.go
+++ b/exchanges/kraken/ratelimit.go
@@ -1,160 +1,68 @@
 package kraken
 
 import (
+	"time"
+
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"golang.org/x/time/rate"
 )
 
-// Kraken applies two independent REST rate-limit systems:
-//
-//  1. Public API limit, applied per source IP. Covers unauthenticated
-//     endpoints (Ticker, Depth, OHLC, Trades, Time, Assets, AssetPairs).
-//
-//  2. Private API limit, applied per account / API key. The private limit
-//     is a stateful counter with continuous decay; each request increments
-//     the counter, the counter decays at a fixed rate per second, and
-//     exceeding the maximum triggers a temporary key ban.
-//
-// Within the private system trading endpoints (AddOrder, CancelOrder) are
-// tracked under a separate per-pair counter that does not consume from the
-// general private counter.
-//
-// Reference (verified 2026): https://support.kraken.com/articles/206548367
-//
-// Tiers for the private general counter:
-//
-//	Verified          : max 20, decay -0.5/sec
-//	Verified Pro      : max 20, decay -1.0/sec
-//
-// Endpoint costs (private REST, general counter):
-//
-//	Account history (Ledgers, TradesHistory, ClosedOrders, QueryOrders,
-//	                 QueryTrades, QueryLedgers)                        +4
-//	Balance, TradeBalance, OpenOrders, OpenPositions, TradeVolume,
-//	  WithdrawInfo, WithdrawStatus, DepositMethods, DepositAddresses,
-//	  GetWebSocketsToken                                                +1
-//	Trading (AddOrder, CancelOrder)                                     0
-//	  (separate per-pair counter)
-//	Withdraw, WithdrawCancel                                            +1
-//
-// We emulate each system with a separate golang.org/x/time/rate.Limiter
-// where:
-//
-//	Kraken counter max  ↔  rate.Limiter burst
-//	Kraken decay /sec   ↔  rate.Limiter refill rate
-//
-// Tunables. These are package-level vars rather than consts so they can be
-// overridden at process start-up (for example to switch the private counter
-// to the Verified Pro tier without rebuilding, or to relax limits for
-// integration tests). They are not safe to mutate after the Requester has
-// been constructed.
-var (
-	// Private general counter (Verified tier defaults).
-	KrakenSpotMaxCounter  = 20  // documented maximum counter
-	KrakenSpotDecayPerSec = 0.5 // tokens per second (Verified tier)
-
-	// Private trading counter (AddOrder, CancelOrder).
-	KrakenSpotOrderMaxBurst = 60
-	KrakenSpotOrderRate     = 1.0 // tokens per second
-
-	// Public API counter (per IP). Conservative defaults; Kraken
-	// documents a generous public rate that varies by endpoint, but a
-	// modest steady-state with healthy burst suits both bots and
-	// occasional consumers.
-	KrakenPublicMaxBurst = 15
-	KrakenPublicRate     = 1.0 // tokens per second
-)
-
-// Kraken-specific EndpointLimit values. These extend the global Unset/Auth/
-// UnAuth constants from the request package and let each endpoint declare its
-// real cost so the limiter charges the correct number of tokens per call.
+// Endpoint groups for rate limiting; see buildKrakenRateLimits for the
+// limits applied to each.
 const (
-	// krakenLimitDefault is used for unrecognised endpoints; weight 1 keeps
-	// it conservative.
-	krakenLimitDefault request.EndpointLimit = iota + 100
-
-	// krakenLimitPublic — public REST endpoints (Time, Depth, Ticker,
-	// Trades, OHLC, Assets, AssetPairs). Counted under the public-API
-	// limit which is per-IP and independent of the private counter.
-	krakenLimitPublic
-
-	// krakenLimitFuturesPublic — public futures endpoints. Kraken documents
-	// these as having no request cost, unlike authenticated futures paths.
+	krakenLimitPublic request.EndpointLimit = iota
 	krakenLimitFuturesPublic
-
-	// krakenLimitBalance — Balance, TradeBalance, OpenOrders,
-	// OpenPositions, TradeVolume, withdraw/deposit info, WS token. +1
-	// on the private general counter.
-	krakenLimitBalance
-
-	// krakenLimitHistory — Ledgers, TradesHistory, ClosedOrders,
-	// QueryOrders, QueryTrades, QueryLedgers. +4 on the private general
-	// counter; these are the expensive endpoints.
+	krakenLimitFuturesAuth
+	krakenLimitAuth
 	krakenLimitHistory
-
-	// krakenLimitTrading — AddOrder, CancelOrder. Counted under a
-	// separate per-pair Kraken limiter, not on the general counter.
 	krakenLimitTrading
-
-	// krakenLimitWithdraw — Withdraw, WithdrawCancel. +1 on the private
-	// general counter.
-	krakenLimitWithdraw
+	krakenLimitCancel
 )
 
-// newKrakenSpotPrivateLimiter constructs the underlying rate.Limiter that
-// emulates Kraken's private general counter (Verified tier defaults).
-func newKrakenSpotPrivateLimiter() *rate.Limiter {
-	return rate.NewLimiter(rate.Limit(KrakenSpotDecayPerSec), KrakenSpotMaxCounter)
-}
+const (
+	// Spot private counter, Verified tier: max 20, decays 0.5/sec.
+	krakenSpotMaxCounter  = 20
+	krakenSpotDecayPerSec = 0.5
 
-// newKrakenSpotOrderLimiter constructs the underlying rate.Limiter for
-// AddOrder/CancelOrder, which Kraken tracks under a separate per-pair
-// counter independent of the private general counter.
-func newKrakenSpotOrderLimiter() *rate.Limiter {
-	return rate.NewLimiter(rate.Limit(KrakenSpotOrderRate), KrakenSpotOrderMaxBurst)
-}
+	// Spot trading engine counter, Starter tier: max 60, decays 1/sec.
+	// This counter covers all order management: placing, editing,
+	// amending and cancelling orders. Higher verification tiers allow
+	// more (Intermediate 125 @ 2.34/sec, Pro 180 @ 3.75/sec).
+	krakenSpotOrderMaxBurst = 60
+	krakenSpotOrderRate     = 1.0
 
-// newKrakenPublicLimiter constructs the underlying rate.Limiter for the
-// public REST API, which Kraken rate-limits per source IP independently of
-// any private API key quota.
-func newKrakenPublicLimiter() *rate.Limiter {
-	return rate.NewLimiter(rate.Limit(KrakenPublicRate), KrakenPublicMaxBurst)
-}
+	// Cancelling an order shortly after placement costs up to 8 counter
+	// units depending on its age; cancels are weighted at the worst case
+	// so the local counter cannot run ahead of Kraken's.
+	krakenCancelWeight = 8
 
-// buildKrakenRateLimits returns the full RateLimitDefinitions map.
+	// Kraken does not state a precise public burst limit; 15 @ 1/sec has
+	// been tested and found safe.
+	krakenPublicMaxBurst = 15
+	krakenPublicRate     = 1.0
+)
+
+// buildKrakenRateLimits returns limiters matching Kraken's documented
+// rate-limit behaviour: a spot private counter per API key with account
+// history endpoints costing double, a separate trading engine counter with
+// age-weighted cancels, a per-IP public limit, a futures cost pool of 500
+// units per 10 seconds (order management endpoints cost up to 10, so 50
+// requests per 10 seconds is a safe floor), and uncosted public futures
+// endpoints.
 //
-// Three independent underlying rate.Limiter instances are used:
-//
-//   - private: shared by all authenticated non-trading endpoints
-//     (balance, info, history, withdraw). Different endpoint groups carry
-//     different weights matching Kraken's documented costs.
-//   - orders:  used only by AddOrder/CancelOrder.
-//   - public:  used only by unauthenticated REST endpoints. Independent of
-//     the private counter because Kraken's public limit is enforced per
-//     IP, not per API key.
-//
-// The legacy request.Unset/Auth/UnAuth keys are kept and routed to
-// `private` for backward compatibility — anything that still passes them
-// will behave as before, just with the new tier-correct parameters.
+// Reference: https://support.kraken.com/articles/206548367
 func buildKrakenRateLimits() request.RateLimitDefinitions {
-	private := newKrakenSpotPrivateLimiter()
-	orders := newKrakenSpotOrderLimiter()
-	public := newKrakenPublicLimiter()
+	private := rate.NewLimiter(rate.Limit(krakenSpotDecayPerSec), krakenSpotMaxCounter)
+	trading := rate.NewLimiter(rate.Limit(krakenSpotOrderRate), krakenSpotOrderMaxBurst)
+	public := rate.NewLimiter(rate.Limit(krakenPublicRate), krakenPublicMaxBurst)
 
 	return request.RateLimitDefinitions{
-		// Backward compatibility — anything still passing the global
-		// constants gets the private limiter at weight 1.
-		request.Unset:  request.GetRateLimiterWithWeight(private, 1),
-		request.Auth:   request.GetRateLimiterWithWeight(private, 1),
-		request.UnAuth: request.GetRateLimiterWithWeight(public, 1),
-
-		// Kraken-specific endpoint costs.
-		krakenLimitDefault:       request.GetRateLimiterWithWeight(private, 1),
 		krakenLimitPublic:        request.GetRateLimiterWithWeight(public, 1),
 		krakenLimitFuturesPublic: request.NewRateLimitWithWeight(0, 0, 1),
-		krakenLimitBalance:       request.GetRateLimiterWithWeight(private, 1),
-		krakenLimitHistory:       request.GetRateLimiterWithWeight(private, 4),
-		krakenLimitTrading:       request.GetRateLimiterWithWeight(orders, 1),
-		krakenLimitWithdraw:      request.GetRateLimiterWithWeight(private, 1),
+		krakenLimitFuturesAuth:   request.NewRateLimitWithWeight(10*time.Second, 50, 1),
+		krakenLimitAuth:          request.GetRateLimiterWithWeight(private, 1),
+		krakenLimitHistory:       request.GetRateLimiterWithWeight(private, 2),
+		krakenLimitTrading:       request.GetRateLimiterWithWeight(trading, 1),
+		krakenLimitCancel:        request.GetRateLimiterWithWeight(trading, krakenCancelWeight),
 	}
 }

--- a/exchanges/kraken/ratelimit_test.go
+++ b/exchanges/kraken/ratelimit_test.go
@@ -1,0 +1,79 @@
+package kraken
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
+)
+
+func TestNewKrakenSpotPrivateLimiter(t *testing.T) {
+	t.Parallel()
+
+	limiter := newKrakenSpotPrivateLimiter()
+	require.NotNil(t, limiter, "limiter must not be nil")
+	assert.Equal(t, KrakenSpotDecayPerSec, float64(limiter.Limit()), "limit should match Kraken private decay")
+	assert.Equal(t, KrakenSpotMaxCounter, limiter.Burst(), "burst should match Kraken private counter")
+}
+
+func TestNewKrakenSpotOrderLimiter(t *testing.T) {
+	t.Parallel()
+
+	limiter := newKrakenSpotOrderLimiter()
+	require.NotNil(t, limiter, "limiter must not be nil")
+	assert.Equal(t, KrakenSpotOrderRate, float64(limiter.Limit()), "limit should match Kraken order rate")
+	assert.Equal(t, KrakenSpotOrderMaxBurst, limiter.Burst(), "burst should match Kraken order burst")
+}
+
+func TestNewKrakenPublicLimiter(t *testing.T) {
+	t.Parallel()
+
+	limiter := newKrakenPublicLimiter()
+	require.NotNil(t, limiter, "limiter must not be nil")
+	assert.Equal(t, KrakenPublicRate, float64(limiter.Limit()), "limit should match Kraken public rate")
+	assert.Equal(t, KrakenPublicMaxBurst, limiter.Burst(), "burst should match Kraken public burst")
+}
+
+func TestBuildKrakenRateLimits(t *testing.T) {
+	t.Parallel()
+
+	rateLimits := buildKrakenRateLimits()
+	require.NotEmpty(t, rateLimits, "rate limits must not be empty")
+
+	expectedLimits := []request.EndpointLimit{
+		request.Unset,
+		request.Auth,
+		request.UnAuth,
+		krakenLimitDefault,
+		krakenLimitPublic,
+		krakenLimitFuturesPublic,
+		krakenLimitBalance,
+		krakenLimitHistory,
+		krakenLimitTrading,
+		krakenLimitWithdraw,
+	}
+	for _, limit := range expectedLimits {
+		assert.NotNilf(t, rateLimits[limit], "rate limit should exist for endpoint %d", limit)
+	}
+
+	requester, err := request.New("krakenRateLimits", http.DefaultClient, request.WithLimiter(rateLimits))
+	require.NoError(t, err, "request.New must not error")
+
+	for range KrakenSpotMaxCounter / 4 {
+		require.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitHistory), "history limit must allow burst usage")
+	}
+	assert.ErrorIs(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitHistory), request.ErrDelayNotAllowed, "history limit should consume private weight")
+	assert.ErrorIs(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitBalance), request.ErrDelayNotAllowed, "balance limit should share the private limiter")
+	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitTrading), "trading limit should use a separate limiter")
+	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitPublic), "public limit should use a separate limiter")
+	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitFuturesPublic), "futures public limit should not consume a rate budget")
+
+	err = requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), request.UnAuth)
+	if errors.Is(err, request.ErrDelayNotAllowed) {
+		t.Fatal("unauthenticated limit must not share the exhausted private limiter")
+	}
+	require.NoError(t, err, "unauthenticated limit must use the public limiter")
+}

--- a/exchanges/kraken/ratelimit_test.go
+++ b/exchanges/kraken/ratelimit_test.go
@@ -1,7 +1,6 @@
 package kraken
 
 import (
-	"errors"
 	"net/http"
 	"testing"
 
@@ -10,70 +9,44 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 )
 
-func TestNewKrakenSpotPrivateLimiter(t *testing.T) {
-	t.Parallel()
-
-	limiter := newKrakenSpotPrivateLimiter()
-	require.NotNil(t, limiter, "limiter must not be nil")
-	assert.Equal(t, KrakenSpotDecayPerSec, float64(limiter.Limit()), "limit should match Kraken private decay")
-	assert.Equal(t, KrakenSpotMaxCounter, limiter.Burst(), "burst should match Kraken private counter")
-}
-
-func TestNewKrakenSpotOrderLimiter(t *testing.T) {
-	t.Parallel()
-
-	limiter := newKrakenSpotOrderLimiter()
-	require.NotNil(t, limiter, "limiter must not be nil")
-	assert.Equal(t, KrakenSpotOrderRate, float64(limiter.Limit()), "limit should match Kraken order rate")
-	assert.Equal(t, KrakenSpotOrderMaxBurst, limiter.Burst(), "burst should match Kraken order burst")
-}
-
-func TestNewKrakenPublicLimiter(t *testing.T) {
-	t.Parallel()
-
-	limiter := newKrakenPublicLimiter()
-	require.NotNil(t, limiter, "limiter must not be nil")
-	assert.Equal(t, KrakenPublicRate, float64(limiter.Limit()), "limit should match Kraken public rate")
-	assert.Equal(t, KrakenPublicMaxBurst, limiter.Burst(), "burst should match Kraken public burst")
-}
-
 func TestBuildKrakenRateLimits(t *testing.T) {
 	t.Parallel()
 
 	rateLimits := buildKrakenRateLimits()
-	require.NotEmpty(t, rateLimits, "rate limits must not be empty")
-
-	expectedLimits := []request.EndpointLimit{
-		request.Unset,
-		request.Auth,
-		request.UnAuth,
-		krakenLimitDefault,
+	for _, limit := range []request.EndpointLimit{
 		krakenLimitPublic,
 		krakenLimitFuturesPublic,
-		krakenLimitBalance,
+		krakenLimitFuturesAuth,
+		krakenLimitAuth,
 		krakenLimitHistory,
 		krakenLimitTrading,
-		krakenLimitWithdraw,
-	}
-	for _, limit := range expectedLimits {
+		krakenLimitCancel,
+	} {
 		assert.NotNilf(t, rateLimits[limit], "rate limit should exist for endpoint %d", limit)
 	}
 
 	requester, err := request.New("krakenRateLimits", http.DefaultClient, request.WithLimiter(rateLimits))
 	require.NoError(t, err, "request.New must not error")
 
-	for range KrakenSpotMaxCounter / 4 {
-		require.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitHistory), "history limit must allow burst usage")
-	}
-	assert.ErrorIs(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitHistory), request.ErrDelayNotAllowed, "history limit should consume private weight")
-	assert.ErrorIs(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitBalance), request.ErrDelayNotAllowed, "balance limit should share the private limiter")
-	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitTrading), "trading limit should use a separate limiter")
-	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitPublic), "public limit should use a separate limiter")
-	assert.NoError(t, requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), krakenLimitFuturesPublic), "futures public limit should not consume a rate budget")
+	ctx := request.WithDelayNotAllowed(t.Context())
 
-	err = requester.InitiateRateLimit(request.WithDelayNotAllowed(t.Context()), request.UnAuth)
-	if errors.Is(err, request.ErrDelayNotAllowed) {
-		t.Fatal("unauthenticated limit must not share the exhausted private limiter")
+	// History requests cost 2 on the private counter, so half the counter
+	// maximum fills it exactly
+	for range krakenSpotMaxCounter / 2 {
+		require.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitHistory), "history requests must be allowed up to the counter maximum")
 	}
-	require.NoError(t, err, "unauthenticated limit must use the public limiter")
+	assert.ErrorIs(t, requester.InitiateRateLimit(ctx, krakenLimitHistory), request.ErrDelayNotAllowed, "history should be limited once the private counter is exhausted")
+	assert.ErrorIs(t, requester.InitiateRateLimit(ctx, krakenLimitAuth), request.ErrDelayNotAllowed, "auth should share the exhausted private counter")
+
+	assert.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitTrading), "trading should use a separate counter")
+	assert.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitPublic), "public should use a separate limiter")
+	assert.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitFuturesPublic), "futures public should not consume any budget")
+	assert.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitFuturesAuth), "futures auth should use a separate limiter")
+
+	// One trading unit is already consumed above; 7 worst-case cancels
+	// consume another 56 of the 60 burst, and the next cannot fit
+	for range 7 {
+		require.NoError(t, requester.InitiateRateLimit(ctx, krakenLimitCancel), "cancels must be allowed within the trading counter")
+	}
+	assert.ErrorIs(t, requester.InitiateRateLimit(ctx, krakenLimitCancel), request.ErrDelayNotAllowed, "cancel weight should throttle rapid cancellations")
 }


### PR DESCRIPTION
The previous limiter was hard-coded at 1 request per second with burst=1 for every endpoint, which is far more restrictive than Kraken's actual policy (counter max 20 with -0.5/sec decay on the Verified tier) and treats every endpoint as having the same cost. As a result:

- AddOrder/CancelOrder contended with the same bucket as background reconciliation queries, so a burst of history reads could delay trading.
- TradesHistory/Ledgers/ClosedOrders (real cost +4 on Kraken's counter) were charged as +1 locally, drifting the emulated counter below the real one.
- No burst capacity at all — every request had to wait a full second.

This change introduces a Kraken-specific limiter built on golang.org/x/time/rate that mirrors the documented policy:

- Two underlying rate.Limiter instances: a general counter (rate 0.5/sec, burst 16 with a 20% safety margin under the real max of 20) and a separate trading counter for AddOrder/CancelOrder (rate 1.0/sec, burst 60), reflecting Kraken's per-pair trading limit which is independent of the general counter.
- Kraken-specific EndpointLimit constants (krakenLimitPublic, krakenLimitBalance, krakenLimitHistory, krakenLimitTrading, krakenLimitWithdraw, krakenLimitDefault) offset by +100 to avoid collision with request.Unset/Auth/UnAuth.
- A methodToLimit map that routes each REST method name to the right endpoint limit, with weights matching Kraken's documented costs (+4 for history endpoints, +1 for balance/info/withdraw, trading on its own limiter).
- SendHTTPRequest now passes krakenLimitPublic and SendAuthenticatedHTTPRequest looks up the limit by method name instead of always passing request.Unset.

Reference: https://support.kraken.com/articles/206548367

# PR Description

Please include a summary of the change, feature or issue which this pull request addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
