### PR TITLE
types: add PreciseNumber for lossless decimal JSON values

### DIFF
--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -32,22 +32,19 @@ type PreciseNumber struct {
 	val float64 // parsed cache for fast Float64()
 }
 
-// NewPreciseNumberFromString constructs a PreciseNumber from a base-10 decimal
-// string without precision loss. Empty input, hexadecimal, scientific notation,
-// NaN and Inf are rejected.
+// NewPreciseNumberFromString constructs a PreciseNumber from a numeric string.
+// It accepts the same inputs as decimal.NewFromString (so scientific notation
+// is allowed, but Go-literal underscores and hexadecimal are not), and
+// additionally rejects values too large to be represented by a float64.
 func NewPreciseNumberFromString(s string) (PreciseNumber, error) {
-	if s == "" {
-		return PreciseNumber{}, fmt.Errorf("%w: empty string", errInvalidPreciseNumberValue)
-	}
 	return parsePreciseNumber([]byte(s))
 }
 
-// parsePreciseNumber validates s as a base-10 decimal and returns a
+// parsePreciseNumber validates data via decimal.NewFromString and returns a
 // PreciseNumber holding the original string and a derived float64 cache.
 //
-// decimal.NewFromString is used as the source of truth: it rejects
-// hexadecimal, scientific notation, NaN and Inf, all of which strconv.ParseFloat
-// would happily accept and which are never legitimate exchange wire values.
+// Values whose magnitude overflows float64 (InexactFloat64 returns Inf) are
+// rejected so the cached float is always finite.
 func parsePreciseNumber(data []byte) (PreciseNumber, error) {
 	s := string(data)
 	d, err := decimal.NewFromString(s)
@@ -55,8 +52,8 @@ func parsePreciseNumber(data []byte) (PreciseNumber, error) {
 		return PreciseNumber{}, fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 	}
 	val := d.InexactFloat64()
-	if math.IsNaN(val) || math.IsInf(val, 0) {
-		return PreciseNumber{}, fmt.Errorf("%w: non-finite %s", errInvalidPreciseNumberValue, data)
+	if math.IsInf(val, 0) {
+		return PreciseNumber{}, fmt.Errorf("%w: magnitude overflows float64: %s", errInvalidPreciseNumberValue, data)
 	}
 	return PreciseNumber{raw: s, val: val}, nil
 }
@@ -75,14 +72,14 @@ func (p *PreciseNumber) UnmarshalJSON(data []byte) error {
 	case 'n': // null
 		*p = PreciseNumber{}
 		return nil
-	case 't', 'f':
-		return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 	case '"':
 		if len(data) < 2 || data[len(data)-1] != '"' {
 			return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 		}
 		data = data[1 : len(data)-1]
 	default:
+		// Bare tokens (true, false, garbage) fail here: the first byte is
+		// neither '-' nor a digit. decimal.NewFromString validates the rest.
 		if c != '-' && (c < '0' || c > '9') {
 			return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 		}
@@ -108,11 +105,7 @@ func (p PreciseNumber) MarshalJSON() ([]byte, error) {
 	if p.raw == "" {
 		return []byte(`""`), nil
 	}
-	out := make([]byte, 0, len(p.raw)+2)
-	out = append(out, '"')
-	out = append(out, p.raw...)
-	out = append(out, '"')
-	return out, nil
+	return []byte(`"` + p.raw + `"`), nil
 }
 
 // Float64 returns the cached float64 form. Suitable for sorting, comparisons
@@ -124,6 +117,10 @@ func (p PreciseNumber) Float64() float64 {
 // Int64 returns the integer value parsed from the original string, truncated
 // toward zero. For values that originated as integers (trade IDs, integer
 // timestamps) this returns the exact value with no float round-trip.
+//
+// If the underlying value is outside the int64 range, the result is the
+// truncated low-order bits and is not meaningful — callers handling
+// potentially large values should use Decimal instead.
 //
 // raw is always a valid base-10 decimal here because every entry path runs
 // it through [parsePreciseNumber]; the zero value short-circuits to 0.

--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -3,7 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
-	"strconv"
+	"math"
 
 	"github.com/shopspring/decimal"
 )
@@ -32,22 +32,39 @@ type PreciseNumber struct {
 	val float64 // parsed cache for fast Float64()
 }
 
-// NewPreciseNumberFromString constructs a PreciseNumber from a decimal string
-// without any precision loss. The string must be a valid base-10 number.
+// NewPreciseNumberFromString constructs a PreciseNumber from a base-10 decimal
+// string without precision loss. Empty input, hexadecimal, scientific notation,
+// NaN and Inf are rejected.
 func NewPreciseNumberFromString(s string) (PreciseNumber, error) {
 	if s == "" {
-		return PreciseNumber{}, nil
+		return PreciseNumber{}, fmt.Errorf("%w: empty string", errInvalidPreciseNumberValue)
 	}
-	val, err := strconv.ParseFloat(s, 64)
+	return parsePreciseNumber([]byte(s))
+}
+
+// parsePreciseNumber validates s as a base-10 decimal and returns a
+// PreciseNumber holding the original string and a derived float64 cache.
+//
+// decimal.NewFromString is used as the source of truth: it rejects
+// hexadecimal, scientific notation, NaN and Inf, all of which strconv.ParseFloat
+// would happily accept and which are never legitimate exchange wire values.
+func parsePreciseNumber(data []byte) (PreciseNumber, error) {
+	s := string(data)
+	d, err := decimal.NewFromString(s)
 	if err != nil {
-		return PreciseNumber{}, fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, s)
+		return PreciseNumber{}, fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+	}
+	val, _ := d.Float64()
+	if math.IsNaN(val) || math.IsInf(val, 0) {
+		return PreciseNumber{}, fmt.Errorf("%w: non-finite %s", errInvalidPreciseNumberValue, data)
 	}
 	return PreciseNumber{raw: s, val: val}, nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler. It accepts both JSON strings
 // ("1337.37") and JSON numbers (1337.37) and preserves the original text
-// verbatim for downstream Decimal()/Int64() calls.
+// verbatim for downstream Decimal()/Int64() calls. null, an empty string and
+// a missing/zero-length payload all parse to the zero value.
 func (p *PreciseNumber) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 {
 		*p = PreciseNumber{}
@@ -76,14 +93,11 @@ func (p *PreciseNumber) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	s := string(data)
-	val, err := strconv.ParseFloat(s, 64)
+	parsed, err := parsePreciseNumber(data)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+		return err
 	}
-
-	p.raw = s
-	p.val = val
+	*p = parsed
 	return nil
 }
 
@@ -101,31 +115,24 @@ func (p PreciseNumber) MarshalJSON() ([]byte, error) {
 	return out, nil
 }
 
-// Float64 returns the cached float64 form. Suitable for sorting, comparisons,
+// Float64 returns the cached float64 form. Suitable for sorting, comparisons
 // and approximate computation. For exact arithmetic use Decimal.
 func (p PreciseNumber) Float64() float64 {
 	return p.val
 }
 
-// Int64 returns the integer value parsed from the original string. If the
-// original value contains a fractional part the fractional part is truncated
-// toward zero (matching [Number.Int64]). For values that originated as
-// integers (trade IDs, integer timestamps) this returns the exact value with
-// no float round-trip.
+// Int64 returns the integer value parsed from the original string, truncated
+// toward zero. For values that originated as integers (trade IDs, integer
+// timestamps) this returns the exact value with no float round-trip.
+//
+// raw is always a valid base-10 decimal here because every entry path runs
+// it through [parsePreciseNumber]; the zero value short-circuits to 0.
 func (p PreciseNumber) Int64() int64 {
 	if p.raw == "" {
 		return 0
 	}
-	if i, err := strconv.ParseInt(p.raw, 10, 64); err == nil {
-		return i
-	}
-	// Fractional value; fall back to truncating via Decimal to avoid the
-	// float-rounding behaviour exhibited by `int64(float64(p.val))` near
-	// representation boundaries.
-	if d, err := decimal.NewFromString(p.raw); err == nil {
-		return d.Truncate(0).IntPart()
-	}
-	return int64(p.val)
+	d, _ := decimal.NewFromString(p.raw)
+	return d.IntPart()
 }
 
 // Decimal returns the exact decimal value parsed from the original string,
@@ -134,10 +141,8 @@ func (p PreciseNumber) Decimal() decimal.Decimal {
 	if p.raw == "" {
 		return decimal.Zero
 	}
-	if d, err := decimal.NewFromString(p.raw); err == nil {
-		return d
-	}
-	return decimal.NewFromFloat(p.val)
+	d, _ := decimal.NewFromString(p.raw)
+	return d
 }
 
 // String returns the original numeric string, or "0" when the value is the

--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -76,12 +76,13 @@ func (p *PreciseNumber) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	val, err := strconv.ParseFloat(string(data), 64)
+	s := string(data)
+	val, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 	}
 
-	p.raw = string(data)
+	p.raw = s
 	p.val = val
 	return nil
 }
@@ -148,7 +149,13 @@ func (p PreciseNumber) String() string {
 	return p.raw
 }
 
-// IsZero reports whether the value is the zero value.
+// IsZero reports whether the value is the uninitialized zero value.
+//
+// Note: this returns true only for the uninitialized struct, not for an
+// explicit "0" parsed from the wire. The distinction matters when
+// json.Marshal honours the IsZero() method for `omitempty` (Go 1.24+):
+// an explicit "0" must round-trip through JSON for accounting fields,
+// whereas an unset field is correctly omitted.
 func (p PreciseNumber) IsZero() bool {
-	return p.raw == "" || p.val == 0
+	return p.raw == ""
 }

--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -1,0 +1,154 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+)
+
+var errInvalidPreciseNumberValue = errors.New("invalid value for PreciseNumber type")
+
+// PreciseNumber is a numeric type for JSON values that need lossless decimal
+// representation alongside a fast floating-point form.
+//
+// It stores the original numeric string as received from the wire and parses
+// a float64 cache for cheap comparisons and sorting (e.g. order book level
+// alignment). Decimal() and Int64() then return the value parsed from the
+// preserved string rather than from the float, avoiding the precision loss
+// that occurs in the existing [Number] type when [Number.Decimal] converts
+// from float64.
+//
+// PreciseNumber is the right choice for fields that flow into accounting,
+// reconciliation, settlement, or anything where the exact decimal value
+// from the exchange must be reproduced. For market-data fields where the
+// value is only used for sorting and rough computation, [Number] remains
+// cheaper.
+//
+// Zero value behaves as the number 0.
+type PreciseNumber struct {
+	raw string  // original numeric string from the source; "" means zero
+	val float64 // parsed cache for fast Float64()
+}
+
+// NewPreciseNumberFromString constructs a PreciseNumber from a decimal string
+// without any precision loss. The string must be a valid base-10 number.
+func NewPreciseNumberFromString(s string) (PreciseNumber, error) {
+	if s == "" {
+		return PreciseNumber{}, nil
+	}
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return PreciseNumber{}, fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, s)
+	}
+	return PreciseNumber{raw: s, val: val}, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler. It accepts both JSON strings
+// ("1337.37") and JSON numbers (1337.37) and preserves the original text
+// verbatim for downstream Decimal()/Int64() calls.
+func (p *PreciseNumber) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		*p = PreciseNumber{}
+		return nil
+	}
+
+	switch c := data[0]; c {
+	case 'n': // null
+		*p = PreciseNumber{}
+		return nil
+	case 't', 'f':
+		return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+	case '"':
+		if len(data) < 2 || data[len(data)-1] != '"' {
+			return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+		}
+		data = data[1 : len(data)-1]
+	default:
+		if c != '-' && (c < '0' || c > '9') {
+			return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+		}
+	}
+
+	if len(data) == 0 {
+		*p = PreciseNumber{}
+		return nil
+	}
+
+	val, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
+	}
+
+	p.raw = string(data)
+	p.val = val
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler by emitting the original numeric
+// string as a JSON string. The zero value marshals to `""` to match the
+// existing [Number.MarshalJSON] behaviour.
+func (p PreciseNumber) MarshalJSON() ([]byte, error) {
+	if p.raw == "" {
+		return []byte(`""`), nil
+	}
+	out := make([]byte, 0, len(p.raw)+2)
+	out = append(out, '"')
+	out = append(out, p.raw...)
+	out = append(out, '"')
+	return out, nil
+}
+
+// Float64 returns the cached float64 form. Suitable for sorting, comparisons,
+// and approximate computation. For exact arithmetic use Decimal.
+func (p PreciseNumber) Float64() float64 {
+	return p.val
+}
+
+// Int64 returns the integer value parsed from the original string. If the
+// original value contains a fractional part the fractional part is truncated
+// toward zero (matching [Number.Int64]). For values that originated as
+// integers (trade IDs, integer timestamps) this returns the exact value with
+// no float round-trip.
+func (p PreciseNumber) Int64() int64 {
+	if p.raw == "" {
+		return 0
+	}
+	if i, err := strconv.ParseInt(p.raw, 10, 64); err == nil {
+		return i
+	}
+	// Fractional value; fall back to truncating via Decimal to avoid the
+	// float-rounding behaviour exhibited by `int64(float64(p.val))` near
+	// representation boundaries.
+	if d, err := decimal.NewFromString(p.raw); err == nil {
+		return d.Truncate(0).IntPart()
+	}
+	return int64(p.val)
+}
+
+// Decimal returns the exact decimal value parsed from the original string,
+// avoiding the float64 round-trip that loses precision in [Number.Decimal].
+func (p PreciseNumber) Decimal() decimal.Decimal {
+	if p.raw == "" {
+		return decimal.Zero
+	}
+	if d, err := decimal.NewFromString(p.raw); err == nil {
+		return d
+	}
+	return decimal.NewFromFloat(p.val)
+}
+
+// String returns the original numeric string, or "0" when the value is the
+// zero value.
+func (p PreciseNumber) String() string {
+	if p.raw == "" {
+		return "0"
+	}
+	return p.raw
+}
+
+// IsZero reports whether the value is the zero value.
+func (p PreciseNumber) IsZero() bool {
+	return p.raw == "" || p.val == 0
+}

--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -54,7 +54,7 @@ func parsePreciseNumber(data []byte) (PreciseNumber, error) {
 	if err != nil {
 		return PreciseNumber{}, fmt.Errorf("%w: %s", errInvalidPreciseNumberValue, data)
 	}
-	val, _ := d.Float64()
+	val := d.InexactFloat64()
 	if math.IsNaN(val) || math.IsInf(val, 0) {
 		return PreciseNumber{}, fmt.Errorf("%w: non-finite %s", errInvalidPreciseNumberValue, data)
 	}

--- a/types/precise_number.go
+++ b/types/precise_number.go
@@ -151,13 +151,8 @@ func (p PreciseNumber) String() string {
 	return p.raw
 }
 
-// IsZero reports whether the value is the uninitialized zero value.
-//
-// Note: this returns true only for the uninitialized struct, not for an
-// explicit "0" parsed from the wire. The distinction matters when
-// json.Marshal honours the IsZero() method for `omitempty` (Go 1.24+):
-// an explicit "0" must round-trip through JSON for accounting fields,
-// whereas an unset field is correctly omitted.
+// IsZero reports whether the value is unset. An explicit "0" from the wire is
+// not. Consulted by `omitzero`; `omitempty` does not omit structs.
 func (p PreciseNumber) IsZero() bool {
 	return p.raw == ""
 }

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// highPrecisionValue is a decimal string with 17 significant digits — beyond
+// highPrecisionValue is a decimal string with 19 significant digits — beyond
 // what float64 reliably round-trips through ParseFloat/FormatFloat. Shared by
 // the round-trip and head-to-head precision tests.
 const highPrecisionValue = "71428.12345678901234"
@@ -22,10 +22,10 @@ const highPrecisionValue = "71428.12345678901234"
 func TestHighPrecisionValueSanity(t *testing.T) {
 	t.Parallel()
 	f, err := strconv.ParseFloat(highPrecisionValue, 64)
-	require.NoError(t, err)
+	require.NoError(t, err, "ParseFloat must not error")
 	roundTripped := strconv.FormatFloat(f, 'f', -1, 64)
 	assert.NotEqual(t, highPrecisionValue, roundTripped,
-		"highPrecisionValue must lose precision through float64 for the precision tests to be meaningful")
+		"highPrecisionValue should lose precision through a float64 round-trip")
 }
 
 // TestPreciseNumberUnmarshalJSON verifies that both quoted and bare numeric
@@ -35,43 +35,41 @@ func TestPreciseNumberUnmarshalJSON(t *testing.T) {
 	t.Parallel()
 	var p PreciseNumber
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`"0.00000001"`)))
-	assert.Equal(t, 1e-8, p.Float64())
-	assert.Equal(t, "0.00000001", p.String())
+	require.NoError(t, p.UnmarshalJSON([]byte(`"0.00000001"`)), "UnmarshalJSON must not error")
+	assert.Equal(t, 1e-8, p.Float64(), "Float64 should return the parsed value")
+	assert.Equal(t, "0.00000001", p.String(), "String should return the original digits")
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`""`)))
-	assert.True(t, p.IsZero(), "empty quoted string parses to zero value")
+	require.NoError(t, p.UnmarshalJSON([]byte(`""`)), "UnmarshalJSON must not error")
+	assert.True(t, p.IsZero(), "empty quoted string should parse to the zero value")
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`null`)))
-	assert.True(t, p.IsZero(), "null parses to zero value")
+	require.NoError(t, p.UnmarshalJSON([]byte(`null`)), "UnmarshalJSON must not error")
+	assert.True(t, p.IsZero(), "null should parse to the zero value")
 
-	require.NoError(t, p.UnmarshalJSON([]byte(``)))
-	assert.True(t, p.IsZero(), "empty payload parses to zero value")
+	require.NoError(t, p.UnmarshalJSON([]byte(``)), "UnmarshalJSON must not error")
+	assert.True(t, p.IsZero(), "empty payload should parse to the zero value")
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`1337.37`)))
-	assert.Equal(t, 1337.37, p.Float64())
-	assert.Equal(t, "1337.37", p.String())
+	require.NoError(t, p.UnmarshalJSON([]byte(`1337.37`)), "UnmarshalJSON must not error")
+	assert.Equal(t, 1337.37, p.Float64(), "Float64 should return the parsed bare number")
+	assert.Equal(t, "1337.37", p.String(), "String should return the original bare number")
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`-7.25`)), "leading minus accepted")
-	assert.Equal(t, "-7.25", p.String())
+	require.NoError(t, p.UnmarshalJSON([]byte(`-7.25`)), "leading minus must be accepted")
+	assert.Equal(t, "-7.25", p.String(), "String should preserve the leading minus")
 
-	// Each entry exercises a distinct invalid-input branch in UnmarshalJSON.
 	for _, tc := range []struct{ in, reason string }{
-		{`"MEOW"`, "quoted non-numeric rejected by parsePreciseNumber"},
-		{`false`, "false literal rejected"},
-		{`true`, "true literal rejected"},
-		{`"1337.37`, "missing closing quote rejected"},
-		{`abc`, "bare token with non-digit, non-minus first byte rejected"},
-		{`+5`, "leading '+' is not in the accepted set"},
-		{`0x1f`, "hexadecimal rejected by decimal.NewFromString"},
+		{`"MEOW"`, "quoted non-numeric"},
+		{`false`, "false literal"},
+		{`true`, "true literal"},
+		{`"1337.37`, "missing closing quote"},
+		{`abc`, "bare token with non-digit, non-minus first byte"},
+		{`+5`, "leading '+' which is not in the accepted set"},
+		{`0x1f`, "hexadecimal"},
 	} {
 		err := p.UnmarshalJSON([]byte(tc.in))
-		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "%s: %q", tc.reason, tc.in)
+		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "%s should be rejected: %q", tc.reason, tc.in)
 	}
 
-	require.NoError(t, p.UnmarshalJSON([]byte(`"1e10"`)),
-		"scientific notation is legitimate base-10 accepted by decimal.NewFromString")
-	assert.Equal(t, 1e10, p.Float64())
+	require.NoError(t, p.UnmarshalJSON([]byte(`"1e10"`)), "scientific notation must be accepted")
+	assert.Equal(t, 1e10, p.Float64(), "Float64 should return the parsed scientific-notation value")
 }
 
 // TestPreciseNumberMarshalJSON verifies the zero value emits an empty string
@@ -80,14 +78,14 @@ func TestPreciseNumberMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	data, err := new(PreciseNumber).MarshalJSON()
-	require.NoError(t, err)
-	assert.Equal(t, `""`, string(data))
+	require.NoError(t, err, "MarshalJSON must not error")
+	assert.Equal(t, `""`, string(data), "zero value should marshal to an empty quoted string")
 
 	p, err := NewPreciseNumberFromString("1337.1337")
-	require.NoError(t, err)
+	require.NoError(t, err, "NewPreciseNumberFromString must not error")
 	data, err = p.MarshalJSON()
-	require.NoError(t, err)
-	assert.Equal(t, `"1337.1337"`, string(data))
+	require.NoError(t, err, "MarshalJSON must not error")
+	assert.Equal(t, `"1337.1337"`, string(data), "value should marshal to its preserved string")
 }
 
 // TestPreciseNumberRoundTrip verifies the marshal/unmarshal cycle preserves
@@ -97,12 +95,12 @@ func TestPreciseNumberRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)), "UnmarshalJSON must not error")
 
 	data, err := p.MarshalJSON()
-	require.NoError(t, err)
+	require.NoError(t, err, "MarshalJSON must not error")
 	assert.Equal(t, `"`+highPrecisionValue+`"`, string(data),
-		"PreciseNumber must round-trip the original digit string")
+		"PreciseNumber should round-trip the original digit string")
 }
 
 // TestPreciseNumberDecimal verifies Decimal() returns the exact decimal value
@@ -111,15 +109,15 @@ func TestPreciseNumberDecimal(t *testing.T) {
 	t.Parallel()
 
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)), "UnmarshalJSON must not error")
 
 	expected, err := decimal.NewFromString(highPrecisionValue)
-	require.NoError(t, err)
-	assert.True(t, p.Decimal().Equal(expected),
-		"Decimal() must reproduce the original high-precision value exactly without a float64 round-trip; got %s", p.Decimal())
+	require.NoError(t, err, "decimal.NewFromString must not error")
+	assert.Truef(t, p.Decimal().Equal(expected),
+		"Decimal should reproduce the original high-precision value exactly without a float64 round-trip; got %s", p.Decimal())
 
 	var zero PreciseNumber
-	assert.True(t, zero.Decimal().IsZero(), "zero value Decimal() returns decimal.Zero")
+	assert.True(t, zero.Decimal().IsZero(), "zero value Decimal should return decimal.Zero")
 }
 
 // TestPreciseNumberDecimalBeatsNumber demonstrates the precision benefit
@@ -130,19 +128,19 @@ func TestPreciseNumberDecimalBeatsNumber(t *testing.T) {
 	t.Parallel()
 
 	var n Number
-	require.NoError(t, n.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
+	require.NoError(t, n.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)), "Number.UnmarshalJSON must not error")
 
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)), "PreciseNumber.UnmarshalJSON must not error")
 
 	expected, err := decimal.NewFromString(highPrecisionValue)
-	require.NoError(t, err)
+	require.NoError(t, err, "decimal.NewFromString must not error")
 
-	assert.True(t, p.Decimal().Equal(expected),
-		"PreciseNumber should equal the wire value exactly; got %s", p.Decimal())
+	assert.Truef(t, p.Decimal().Equal(expected),
+		"PreciseNumber.Decimal should equal the wire value exactly; got %s", p.Decimal())
 
-	assert.False(t, n.Decimal().Equal(expected),
-		"Number.Decimal() is expected to differ for high-precision values; got %s", n.Decimal())
+	assert.Falsef(t, n.Decimal().Equal(expected),
+		"Number.Decimal should differ for high-precision values; got %s", n.Decimal())
 }
 
 // TestPreciseNumberInt64 verifies integer values parse without float
@@ -151,7 +149,7 @@ func TestPreciseNumberDecimalBeatsNumber(t *testing.T) {
 func TestPreciseNumberInt64(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
+	for _, tc := range []struct {
 		in   string
 		want int64
 	}{
@@ -161,22 +159,21 @@ func TestPreciseNumberInt64(t *testing.T) {
 		{"-7", -7},
 		{"-7.9", -7},
 		{"0", 0},
-	}
-	for _, c := range cases {
-		p, err := NewPreciseNumberFromString(c.in)
-		require.NoErrorf(t, err, "constructor for %q", c.in)
-		assert.Equalf(t, c.want, p.Int64(), "Int64() for %q", c.in)
+	} {
+		p, err := NewPreciseNumberFromString(tc.in)
+		require.NoErrorf(t, err, "NewPreciseNumberFromString must not error for %q", tc.in)
+		assert.Equalf(t, tc.want, p.Int64(), "Int64 should truncate %q toward zero", tc.in)
 	}
 
-	assert.Zero(t, PreciseNumber{}.Int64(), "zero value Int64() returns 0")
+	assert.Zero(t, PreciseNumber{}.Int64(), "zero value Int64 should return 0")
 }
 
 // TestPreciseNumberFloat64 verifies Float64() returns the cached float.
 func TestPreciseNumberFloat64(t *testing.T) {
 	t.Parallel()
 	p, err := NewPreciseNumberFromString("0.04200064")
-	require.NoError(t, err)
-	assert.Equal(t, 0.04200064, p.Float64())
+	require.NoError(t, err, "NewPreciseNumberFromString must not error")
+	assert.Equal(t, 0.04200064, p.Float64(), "Float64 should return the cached float")
 }
 
 // TestPreciseNumberString verifies the original digits are preserved by
@@ -185,34 +182,31 @@ func TestPreciseNumberString(t *testing.T) {
 	t.Parallel()
 
 	p, err := NewPreciseNumberFromString("3.14159")
-	require.NoError(t, err)
-	assert.Equal(t, "3.14159", p.String())
+	require.NoError(t, err, "NewPreciseNumberFromString must not error")
+	assert.Equal(t, "3.14159", p.String(), "String should preserve the original digits")
 
-	assert.Equal(t, "0", PreciseNumber{}.String(), "zero value formats as 0")
+	assert.Equal(t, "0", PreciseNumber{}.String(), "zero value String should return 0")
 }
 
-// TestNewPreciseNumberFromString verifies the constructor parses valid
-// strings, rejects empty input and invalid values, and rejects non-finite
-// magnitudes that overflow float64.
+// TestNewPreciseNumberFromString verifies the constructor parses valid strings
+// and rejects empty input, non-numeric input, and magnitudes that overflow
+// float64.
 func TestNewPreciseNumberFromString(t *testing.T) {
 	t.Parallel()
 
 	p, err := NewPreciseNumberFromString("1.5")
-	require.NoError(t, err)
-	assert.Equal(t, "1.5", p.String())
-	assert.Equal(t, 1.5, p.Float64())
+	require.NoError(t, err, "NewPreciseNumberFromString must not error")
+	assert.Equal(t, "1.5", p.String(), "String should preserve the input")
+	assert.Equal(t, 1.5, p.Float64(), "Float64 should return the parsed value")
 
 	_, err = NewPreciseNumberFromString("")
-	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
-		"empty constructor input must error rather than return a silent zero value; callers wanting zero can use PreciseNumber{}")
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue, "empty input should be rejected")
 
 	_, err = NewPreciseNumberFromString("garbage")
-	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
-		"non-numeric input must be rejected")
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue, "non-numeric input should be rejected")
 
 	_, err = NewPreciseNumberFromString("1" + strings.Repeat("0", 400))
-	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
-		"a magnitude that overflows float64 to Inf must be rejected so the cached val stays finite")
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue, "a magnitude that overflows float64 should be rejected")
 }
 
 // TestPreciseNumberIsZero pins the contract that IsZero is true only for the
@@ -221,19 +215,19 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 func TestPreciseNumberIsZero(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, PreciseNumber{}.IsZero(), "uninitialized value is zero")
+	assert.True(t, PreciseNumber{}.IsZero(), "uninitialized value should be IsZero")
 
 	explicit, err := NewPreciseNumberFromString("0")
-	require.NoError(t, err)
-	assert.False(t, explicit.IsZero(), "explicit \"0\" is not IsZero")
+	require.NoError(t, err, "NewPreciseNumberFromString must not error")
+	assert.False(t, explicit.IsZero(), "explicitly set \"0\" should not be IsZero")
 
 	var fromNull PreciseNumber
-	require.NoError(t, fromNull.UnmarshalJSON([]byte(`null`)))
-	assert.True(t, fromNull.IsZero(), "null parses to IsZero")
+	require.NoError(t, fromNull.UnmarshalJSON([]byte(`null`)), "UnmarshalJSON must not error")
+	assert.True(t, fromNull.IsZero(), "null should parse to IsZero")
 
 	var fromEmpty PreciseNumber
-	require.NoError(t, fromEmpty.UnmarshalJSON([]byte(`""`)))
-	assert.True(t, fromEmpty.IsZero(), "empty quoted string parses to IsZero")
+	require.NoError(t, fromEmpty.UnmarshalJSON([]byte(`""`)), "UnmarshalJSON must not error")
+	assert.True(t, fromEmpty.IsZero(), "empty quoted string should parse to IsZero")
 }
 
 // BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for
@@ -243,7 +237,7 @@ func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 	var p PreciseNumber
 	for b.Loop() {
 		if err := p.UnmarshalJSON([]byte(`"0.04200074"`)); err != nil {
-			require.NoError(b, err)
+			require.NoError(b, err, "UnmarshalJSON must not error")
 		}
 	}
 }
@@ -252,7 +246,7 @@ func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 // Ballpark: 55.11 ns/op         56 B/op          3 allocs/op
 func BenchmarkPreciseNumberDecimal(b *testing.B) {
 	p, err := NewPreciseNumberFromString("0.04200074")
-	require.NoError(b, err)
+	require.NoError(b, err, "NewPreciseNumberFromString must not error")
 	for b.Loop() {
 		if !p.Decimal().IsPositive() {
 			b.Fatal("unexpected non-positive decimal")

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -1,0 +1,190 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPreciseNumberUnmarshalJSON verifies that both quoted and bare numeric
+// JSON values are accepted, that the original string is preserved, and that
+// invalid input is rejected.
+func TestPreciseNumberUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	var p PreciseNumber
+
+	err := p.UnmarshalJSON([]byte(`"0.00000001"`))
+	assert.NoError(t, err)
+	assert.Equal(t, 1e-8, p.Float64())
+	assert.Equal(t, "0.00000001", p.String())
+
+	err = p.UnmarshalJSON([]byte(`""`))
+	assert.NoError(t, err)
+	assert.True(t, p.IsZero())
+
+	err = p.UnmarshalJSON([]byte(`null`))
+	assert.NoError(t, err)
+	assert.True(t, p.IsZero())
+
+	err = p.UnmarshalJSON([]byte(`1337.37`))
+	assert.NoError(t, err)
+	assert.Equal(t, 1337.37, p.Float64())
+	assert.Equal(t, "1337.37", p.String())
+
+	for _, in := range []string{`"MEOW"`, `false`, `true`, `"1337.37`} {
+		err = p.UnmarshalJSON([]byte(in))
+		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "rejects invalid %q", in)
+	}
+}
+
+// TestPreciseNumberMarshalJSON verifies the zero value emits an empty string
+// (matching Number) and other values emit their preserved string verbatim.
+func TestPreciseNumberMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	data, err := new(PreciseNumber).MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `""`, string(data))
+
+	p, err := NewPreciseNumberFromString("1337.1337")
+	assert.NoError(t, err)
+	data, err = p.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `"1337.1337"`, string(data))
+}
+
+// TestPreciseNumberRoundTrip verifies the marshal/unmarshal cycle preserves
+// the exact original digit string — the key advantage over Number which
+// reformats through float64 and loses trailing precision.
+func TestPreciseNumberRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// 17 significant digits — beyond what float64 reliably round-trips
+	// through ParseFloat/FormatFloat
+	const high = "71428.12345678901234"
+
+	var p PreciseNumber
+	err := p.UnmarshalJSON([]byte(`"` + high + `"`))
+	assert.NoError(t, err)
+
+	data, err := p.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `"`+high+`"`, string(data),
+		"PreciseNumber must round-trip the original digit string")
+}
+
+// TestPreciseNumberDecimal verifies Decimal() returns the exact decimal value
+// parsed from the original string, without going through float64.
+func TestPreciseNumberDecimal(t *testing.T) {
+	t.Parallel()
+
+	var p PreciseNumber
+	err := p.UnmarshalJSON([]byte(`"71428.12345678"`))
+	assert.NoError(t, err)
+
+	expected, _ := decimal.NewFromString("71428.12345678")
+	assert.True(t, p.Decimal().Equal(expected),
+		"Decimal() must reproduce the original value exactly; got %s", p.Decimal())
+
+	// And the zero value
+	var zero PreciseNumber
+	assert.True(t, zero.Decimal().IsZero())
+}
+
+// TestPreciseNumberDecimalBeatsNumber demonstrates the precision benefit
+// against the existing Number type: a value with more significant digits
+// than float64 reliably preserves round-trips exactly through PreciseNumber
+// but is silently truncated by Number.Decimal().
+func TestPreciseNumberDecimalBeatsNumber(t *testing.T) {
+	t.Parallel()
+
+	// 17 digits — beyond float64's reliable round-trip range
+	const wireValue = "71428.12345678901234"
+
+	var n Number
+	require := assert.New(t)
+	require.NoError(n.UnmarshalJSON([]byte(`"` + wireValue + `"`)))
+
+	var p PreciseNumber
+	require.NoError(p.UnmarshalJSON([]byte(`"` + wireValue + `"`)))
+
+	expected, _ := decimal.NewFromString(wireValue)
+
+	// PreciseNumber preserves the wire value exactly.
+	require.True(p.Decimal().Equal(expected),
+		"PreciseNumber should equal the wire value exactly; got %s", p.Decimal())
+
+	// Number routes through float64 and loses the trailing digits.
+	require.False(n.Decimal().Equal(expected),
+		"Number.Decimal() is expected to differ for high-precision values; got %s", n.Decimal())
+}
+
+// TestPreciseNumberInt64 verifies integer values parse without float
+// round-trip, and that fractional values are truncated toward zero.
+func TestPreciseNumberInt64(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"42", 42},
+		{"42.00000064", 42},
+		{"43.99999964", 43},
+		{"-7", -7},
+		{"-7.9", -7},
+		{"0", 0},
+	}
+	for _, c := range cases {
+		p, err := NewPreciseNumberFromString(c.in)
+		assert.NoError(t, err)
+		assert.Equalf(t, c.want, p.Int64(), "Int64() for %q", c.in)
+	}
+
+	assert.Zero(t, PreciseNumber{}.Int64(), "zero value Int64() returns 0")
+}
+
+// TestPreciseNumberFloat64 verifies Float64() returns the cached float.
+func TestPreciseNumberFloat64(t *testing.T) {
+	t.Parallel()
+	p, err := NewPreciseNumberFromString("0.04200064")
+	assert.NoError(t, err)
+	assert.Equal(t, 0.04200064, p.Float64())
+}
+
+// TestNewPreciseNumberFromString verifies the constructor parses valid
+// strings and rejects invalid ones.
+func TestNewPreciseNumberFromString(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewPreciseNumberFromString("1.5")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.5", p.String())
+	assert.Equal(t, 1.5, p.Float64())
+
+	zero, err := NewPreciseNumberFromString("")
+	assert.NoError(t, err)
+	assert.True(t, zero.IsZero())
+
+	_, err = NewPreciseNumberFromString("garbage")
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)
+}
+
+// BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for
+// a typical exchange string value.
+func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
+	var p PreciseNumber
+	for b.Loop() {
+		_ = p.UnmarshalJSON([]byte(`"0.04200074"`))
+	}
+}
+
+// BenchmarkPreciseNumberDecimal measures the cost of Decimal() so we can
+// compare against [BenchmarkNumberDecimalConversion] in number_test.go.
+func BenchmarkPreciseNumberDecimal(b *testing.B) {
+	p, _ := NewPreciseNumberFromString("0.04200074")
+	for b.Loop() {
+		_ = p.Decimal()
+	}
+}

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -1,41 +1,59 @@
 package types
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPreciseNumberUnmarshalJSON verifies that both quoted and bare numeric
 // JSON values are accepted, that the original string is preserved, and that
-// invalid input is rejected.
+// invalid input is rejected on every branch of the validator.
 func TestPreciseNumberUnmarshalJSON(t *testing.T) {
 	t.Parallel()
 	var p PreciseNumber
 
-	err := p.UnmarshalJSON([]byte(`"0.00000001"`))
-	assert.NoError(t, err)
+	require.NoError(t, p.UnmarshalJSON([]byte(`"0.00000001"`)))
 	assert.Equal(t, 1e-8, p.Float64())
 	assert.Equal(t, "0.00000001", p.String())
 
-	err = p.UnmarshalJSON([]byte(`""`))
-	assert.NoError(t, err)
-	assert.True(t, p.IsZero())
+	require.NoError(t, p.UnmarshalJSON([]byte(`""`)))
+	assert.True(t, p.IsZero(), "empty quoted string parses to zero value")
 
-	err = p.UnmarshalJSON([]byte(`null`))
-	assert.NoError(t, err)
-	assert.True(t, p.IsZero())
+	require.NoError(t, p.UnmarshalJSON([]byte(`null`)))
+	assert.True(t, p.IsZero(), "null parses to zero value")
 
-	err = p.UnmarshalJSON([]byte(`1337.37`))
-	assert.NoError(t, err)
+	require.NoError(t, p.UnmarshalJSON([]byte(``)))
+	assert.True(t, p.IsZero(), "empty payload parses to zero value")
+
+	require.NoError(t, p.UnmarshalJSON([]byte(`1337.37`)))
 	assert.Equal(t, 1337.37, p.Float64())
 	assert.Equal(t, "1337.37", p.String())
 
-	for _, in := range []string{`"MEOW"`, `false`, `true`, `"1337.37`} {
-		err = p.UnmarshalJSON([]byte(in))
+	require.NoError(t, p.UnmarshalJSON([]byte(`-7.25`)), "leading minus accepted")
+	assert.Equal(t, "-7.25", p.String())
+
+	// Each entry exercises a distinct invalid-input branch in UnmarshalJSON.
+	for _, in := range []string{
+		`"MEOW"`,   // quoted non-numeric — rejected by parsePreciseNumber
+		`false`,    // false literal
+		`true`,     // true literal
+		`"1337.37`, // missing closing quote
+		`abc`,      // bare token with non-digit, non-minus first byte
+		`+5`,       // leading '+' is not in the accepted set
+		`0x1f`,     // hexadecimal — rejected by decimal.NewFromString
+	} {
+		err := p.UnmarshalJSON([]byte(in))
 		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "rejects invalid %q", in)
 	}
+
+	// Scientific notation is accepted by decimal.NewFromString and is a
+	// legitimate base-10 form sometimes seen on the wire.
+	require.NoError(t, p.UnmarshalJSON([]byte(`"1e10"`)))
+	assert.Equal(t, 1e10, p.Float64())
 }
 
 // TestPreciseNumberMarshalJSON verifies the zero value emits an empty string
@@ -44,13 +62,13 @@ func TestPreciseNumberMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	data, err := new(PreciseNumber).MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `""`, string(data))
 
 	p, err := NewPreciseNumberFromString("1337.1337")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	data, err = p.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `"1337.1337"`, string(data))
 }
 
@@ -65,11 +83,10 @@ func TestPreciseNumberRoundTrip(t *testing.T) {
 	const high = "71428.12345678901234"
 
 	var p PreciseNumber
-	err := p.UnmarshalJSON([]byte(`"` + high + `"`))
-	assert.NoError(t, err)
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+high+`"`)))
 
 	data, err := p.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `"`+high+`"`, string(data),
 		"PreciseNumber must round-trip the original digit string")
 }
@@ -80,14 +97,14 @@ func TestPreciseNumberDecimal(t *testing.T) {
 	t.Parallel()
 
 	var p PreciseNumber
-	err := p.UnmarshalJSON([]byte(`"71428.12345678"`))
-	assert.NoError(t, err)
+	require.NoError(t, p.UnmarshalJSON([]byte(`"71428.12345678"`)))
 
-	expected, _ := decimal.NewFromString("71428.12345678")
+	expected, err := decimal.NewFromString("71428.12345678")
+	require.NoError(t, err)
 	assert.True(t, p.Decimal().Equal(expected),
 		"Decimal() must reproduce the original value exactly; got %s", p.Decimal())
 
-	// And the zero value
+	// Zero value returns decimal.Zero.
 	var zero PreciseNumber
 	assert.True(t, zero.Decimal().IsZero())
 }
@@ -103,25 +120,24 @@ func TestPreciseNumberDecimalBeatsNumber(t *testing.T) {
 	const wireValue = "71428.12345678901234"
 
 	var n Number
-	require := assert.New(t)
-	require.NoError(n.UnmarshalJSON([]byte(`"` + wireValue + `"`)))
+	require.NoError(t, n.UnmarshalJSON([]byte(`"`+wireValue+`"`)))
 
 	var p PreciseNumber
-	require.NoError(p.UnmarshalJSON([]byte(`"` + wireValue + `"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+wireValue+`"`)))
 
-	expected, _ := decimal.NewFromString(wireValue)
+	expected, err := decimal.NewFromString(wireValue)
+	require.NoError(t, err)
 
-	// PreciseNumber preserves the wire value exactly.
-	require.True(p.Decimal().Equal(expected),
+	assert.True(t, p.Decimal().Equal(expected),
 		"PreciseNumber should equal the wire value exactly; got %s", p.Decimal())
 
-	// Number routes through float64 and loses the trailing digits.
-	require.False(n.Decimal().Equal(expected),
+	assert.False(t, n.Decimal().Equal(expected),
 		"Number.Decimal() is expected to differ for high-precision values; got %s", n.Decimal())
 }
 
 // TestPreciseNumberInt64 verifies integer values parse without float
-// round-trip, and that fractional values are truncated toward zero.
+// round-trip, that fractional values are truncated toward zero, and that
+// the zero value returns 0.
 func TestPreciseNumberInt64(t *testing.T) {
 	t.Parallel()
 
@@ -138,7 +154,7 @@ func TestPreciseNumberInt64(t *testing.T) {
 	}
 	for _, c := range cases {
 		p, err := NewPreciseNumberFromString(c.in)
-		assert.NoError(t, err)
+		require.NoErrorf(t, err, "constructor for %q", c.in)
 		assert.Equalf(t, c.want, p.Int64(), "Int64() for %q", c.in)
 	}
 
@@ -149,33 +165,74 @@ func TestPreciseNumberInt64(t *testing.T) {
 func TestPreciseNumberFloat64(t *testing.T) {
 	t.Parallel()
 	p, err := NewPreciseNumberFromString("0.04200064")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0.04200064, p.Float64())
 }
 
+// TestPreciseNumberString verifies the original digits are preserved by
+// String() and that the zero value returns "0".
+func TestPreciseNumberString(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewPreciseNumberFromString("3.14159")
+	require.NoError(t, err)
+	assert.Equal(t, "3.14159", p.String())
+
+	assert.Equal(t, "0", PreciseNumber{}.String(), "zero value formats as 0")
+}
+
 // TestNewPreciseNumberFromString verifies the constructor parses valid
-// strings and rejects invalid ones.
+// strings, rejects empty input and invalid values, and rejects non-finite
+// magnitudes that overflow float64.
 func TestNewPreciseNumberFromString(t *testing.T) {
 	t.Parallel()
 
 	p, err := NewPreciseNumberFromString("1.5")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1.5", p.String())
 	assert.Equal(t, 1.5, p.Float64())
 
-	zero, err := NewPreciseNumberFromString("")
-	assert.NoError(t, err)
-	assert.True(t, zero.IsZero(), "empty string is the uninitialized zero value")
-
-	// An explicit "0" is *not* IsZero: it is a real wire value that must
-	// be preserved through omitempty serialization.
+	// Numerically zero but explicitly set: must round-trip through JSON
+	// (i.e. must not be IsZero) so omitempty doesn't drop accounting "0".
 	notZero, err := NewPreciseNumberFromString("0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, notZero.IsZero(),
-		`explicit "0" must round-trip through JSON, not be omitted`)
+		"explicit \"0\" must not be IsZero; otherwise omitempty silently drops accounting fields")
+
+	// Empty constructor input is now an error rather than a silent zero
+	// value — callers wanting the zero value can use PreciseNumber{}.
+	_, err = NewPreciseNumberFromString("")
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)
 
 	_, err = NewPreciseNumberFromString("garbage")
 	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)
+
+	// Magnitude that overflows float64 → Inf; must be rejected so the
+	// cached val is always finite.
+	_, err = NewPreciseNumberFromString("1" + strings.Repeat("0", 400))
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
+		"values that overflow float64 to Inf must be rejected")
+}
+
+// TestPreciseNumberIsZero pins the contract that IsZero is true only for the
+// uninitialized struct, never for an explicit "0" — the property that
+// protects accounting fields from omitempty data loss.
+func TestPreciseNumberIsZero(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, PreciseNumber{}.IsZero(), "uninitialized value is zero")
+
+	explicit, err := NewPreciseNumberFromString("0")
+	require.NoError(t, err)
+	assert.False(t, explicit.IsZero(), "explicit \"0\" is not IsZero")
+
+	var fromNull PreciseNumber
+	require.NoError(t, fromNull.UnmarshalJSON([]byte(`null`)))
+	assert.True(t, fromNull.IsZero(), "null parses to IsZero")
+
+	var fromEmpty PreciseNumber
+	require.NoError(t, fromEmpty.UnmarshalJSON([]byte(`""`)))
+	assert.True(t, fromEmpty.IsZero(), "empty quoted string parses to IsZero")
 }
 
 // BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for
@@ -183,15 +240,21 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 	var p PreciseNumber
 	for b.Loop() {
-		_ = p.UnmarshalJSON([]byte(`"0.04200074"`))
+		if err := p.UnmarshalJSON([]byte(`"0.04200074"`)); err != nil {
+			require.NoError(b, err)
+		}
 	}
 }
 
 // BenchmarkPreciseNumberDecimal measures the cost of Decimal() so we can
 // compare against [BenchmarkNumberDecimalConversion] in number_test.go.
 func BenchmarkPreciseNumberDecimal(b *testing.B) {
-	p, _ := NewPreciseNumberFromString("0.04200074")
+	p, err := NewPreciseNumberFromString("0.04200074")
+	require.NoError(b, err)
 	for b.Loop() {
-		_ = p.Decimal()
+		if !p.Decimal().IsPositive() {
+			b.Fatal("unexpected non-positive decimal")
+		}
 	}
 }
+

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -8,6 +9,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// highPrecisionValue is a decimal string with 17 significant digits — beyond
+// what float64 reliably round-trips through ParseFloat/FormatFloat. Shared by
+// the round-trip and head-to-head precision tests.
+const highPrecisionValue = "71428.12345678901234"
+
+// TestHighPrecisionValueSanity asserts the shared test constant genuinely
+// exceeds float64's round-trip precision, so the tests that rely on it are
+// exercising the property they claim to. If a float64 round-trip reproduced
+// the string exactly, those tests would pass trivially and prove nothing.
+func TestHighPrecisionValueSanity(t *testing.T) {
+	t.Parallel()
+	f, err := strconv.ParseFloat(highPrecisionValue, 64)
+	require.NoError(t, err)
+	roundTripped := strconv.FormatFloat(f, 'f', -1, 64)
+	assert.NotEqual(t, highPrecisionValue, roundTripped,
+		"highPrecisionValue must lose precision through float64 for the precision tests to be meaningful")
+}
 
 // TestPreciseNumberUnmarshalJSON verifies that both quoted and bare numeric
 // JSON values are accepted, that the original string is preserved, and that
@@ -37,22 +56,21 @@ func TestPreciseNumberUnmarshalJSON(t *testing.T) {
 	assert.Equal(t, "-7.25", p.String())
 
 	// Each entry exercises a distinct invalid-input branch in UnmarshalJSON.
-	for _, in := range []string{
-		`"MEOW"`,   // quoted non-numeric — rejected by parsePreciseNumber
-		`false`,    // false literal
-		`true`,     // true literal
-		`"1337.37`, // missing closing quote
-		`abc`,      // bare token with non-digit, non-minus first byte
-		`+5`,       // leading '+' is not in the accepted set
-		`0x1f`,     // hexadecimal — rejected by decimal.NewFromString
+	for _, tc := range []struct{ in, reason string }{
+		{`"MEOW"`, "quoted non-numeric rejected by parsePreciseNumber"},
+		{`false`, "false literal rejected"},
+		{`true`, "true literal rejected"},
+		{`"1337.37`, "missing closing quote rejected"},
+		{`abc`, "bare token with non-digit, non-minus first byte rejected"},
+		{`+5`, "leading '+' is not in the accepted set"},
+		{`0x1f`, "hexadecimal rejected by decimal.NewFromString"},
 	} {
-		err := p.UnmarshalJSON([]byte(in))
-		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "rejects invalid %q", in)
+		err := p.UnmarshalJSON([]byte(tc.in))
+		assert.ErrorIsf(t, err, errInvalidPreciseNumberValue, "%s: %q", tc.reason, tc.in)
 	}
 
-	// Scientific notation is accepted by decimal.NewFromString and is a
-	// legitimate base-10 form sometimes seen on the wire.
-	require.NoError(t, p.UnmarshalJSON([]byte(`"1e10"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"1e10"`)),
+		"scientific notation is legitimate base-10 accepted by decimal.NewFromString")
 	assert.Equal(t, 1e10, p.Float64())
 }
 
@@ -78,16 +96,12 @@ func TestPreciseNumberMarshalJSON(t *testing.T) {
 func TestPreciseNumberRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	// 17 significant digits — beyond what float64 reliably round-trips
-	// through ParseFloat/FormatFloat
-	const high = "71428.12345678901234"
-
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"`+high+`"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
 
 	data, err := p.MarshalJSON()
 	require.NoError(t, err)
-	assert.Equal(t, `"`+high+`"`, string(data),
+	assert.Equal(t, `"`+highPrecisionValue+`"`, string(data),
 		"PreciseNumber must round-trip the original digit string")
 }
 
@@ -116,16 +130,13 @@ func TestPreciseNumberDecimal(t *testing.T) {
 func TestPreciseNumberDecimalBeatsNumber(t *testing.T) {
 	t.Parallel()
 
-	// 17 digits — beyond float64's reliable round-trip range
-	const wireValue = "71428.12345678901234"
-
 	var n Number
-	require.NoError(t, n.UnmarshalJSON([]byte(`"`+wireValue+`"`)))
+	require.NoError(t, n.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
 
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"`+wireValue+`"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
 
-	expected, err := decimal.NewFromString(wireValue)
+	expected, err := decimal.NewFromString(highPrecisionValue)
 	require.NoError(t, err)
 
 	assert.True(t, p.Decimal().Equal(expected),
@@ -192,26 +203,22 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 	assert.Equal(t, "1.5", p.String())
 	assert.Equal(t, 1.5, p.Float64())
 
-	// Numerically zero but explicitly set: must round-trip through JSON
-	// (i.e. must not be IsZero) so omitempty doesn't drop accounting "0".
 	notZero, err := NewPreciseNumberFromString("0")
 	require.NoError(t, err)
 	assert.False(t, notZero.IsZero(),
-		"explicit \"0\" must not be IsZero; otherwise omitempty silently drops accounting fields")
+		"explicitly set \"0\" must not be IsZero, otherwise omitempty silently drops accounting fields")
 
-	// Empty constructor input is now an error rather than a silent zero
-	// value — callers wanting the zero value can use PreciseNumber{}.
 	_, err = NewPreciseNumberFromString("")
-	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
+		"empty constructor input must error rather than return a silent zero value; callers wanting zero can use PreciseNumber{}")
 
 	_, err = NewPreciseNumberFromString("garbage")
-	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)
+	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
+		"non-numeric input must be rejected")
 
-	// Magnitude that overflows float64 → Inf; must be rejected so the
-	// cached val is always finite.
 	_, err = NewPreciseNumberFromString("1" + strings.Repeat("0", 400))
 	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
-		"values that overflow float64 to Inf must be rejected")
+		"a magnitude that overflows float64 to Inf must be rejected so the cached val stays finite")
 }
 
 // TestPreciseNumberIsZero pins the contract that IsZero is true only for the
@@ -257,4 +264,3 @@ func BenchmarkPreciseNumberDecimal(b *testing.B) {
 		}
 	}
 }
-

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -165,7 +165,14 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 
 	zero, err := NewPreciseNumberFromString("")
 	assert.NoError(t, err)
-	assert.True(t, zero.IsZero())
+	assert.True(t, zero.IsZero(), "empty string is the uninitialized zero value")
+
+	// An explicit "0" is *not* IsZero: it is a real wire value that must
+	// be preserved through omitempty serialization.
+	notZero, err := NewPreciseNumberFromString("0")
+	assert.NoError(t, err)
+	assert.False(t, notZero.IsZero(),
+		`explicit "0" must round-trip through JSON, not be omitted`)
 
 	_, err = NewPreciseNumberFromString("garbage")
 	assert.ErrorIs(t, err, errInvalidPreciseNumberValue)

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -111,16 +111,15 @@ func TestPreciseNumberDecimal(t *testing.T) {
 	t.Parallel()
 
 	var p PreciseNumber
-	require.NoError(t, p.UnmarshalJSON([]byte(`"71428.12345678"`)))
+	require.NoError(t, p.UnmarshalJSON([]byte(`"`+highPrecisionValue+`"`)))
 
-	expected, err := decimal.NewFromString("71428.12345678")
+	expected, err := decimal.NewFromString(highPrecisionValue)
 	require.NoError(t, err)
 	assert.True(t, p.Decimal().Equal(expected),
-		"Decimal() must reproduce the original value exactly; got %s", p.Decimal())
+		"Decimal() must reproduce the original high-precision value exactly without a float64 round-trip; got %s", p.Decimal())
 
-	// Zero value returns decimal.Zero.
 	var zero PreciseNumber
-	assert.True(t, zero.Decimal().IsZero())
+	assert.True(t, zero.Decimal().IsZero(), "zero value Decimal() returns decimal.Zero")
 }
 
 // TestPreciseNumberDecimalBeatsNumber demonstrates the precision benefit
@@ -203,11 +202,6 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 	assert.Equal(t, "1.5", p.String())
 	assert.Equal(t, 1.5, p.Float64())
 
-	notZero, err := NewPreciseNumberFromString("0")
-	require.NoError(t, err)
-	assert.False(t, notZero.IsZero(),
-		"explicitly set \"0\" must not be IsZero, otherwise omitempty silently drops accounting fields")
-
 	_, err = NewPreciseNumberFromString("")
 	assert.ErrorIs(t, err, errInvalidPreciseNumberValue,
 		"empty constructor input must error rather than return a silent zero value; callers wanting zero can use PreciseNumber{}")
@@ -244,6 +238,7 @@ func TestPreciseNumberIsZero(t *testing.T) {
 
 // BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for
 // a typical exchange string value.
+// Ballpark: 271.2 ns/op        392 B/op         16 allocs/op
 func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 	var p PreciseNumber
 	for b.Loop() {
@@ -253,8 +248,8 @@ func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 	}
 }
 
-// BenchmarkPreciseNumberDecimal measures the cost of Decimal() so we can
-// compare against [BenchmarkNumberDecimalConversion] in number_test.go.
+// BenchmarkPreciseNumberDecimal measures the cost of Decimal().
+// Ballpark: 55.11 ns/op         56 B/op          3 allocs/op
 func BenchmarkPreciseNumberDecimal(b *testing.B) {
 	p, err := NewPreciseNumberFromString("0.04200074")
 	require.NoError(b, err)

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -210,24 +210,24 @@ func TestNewPreciseNumberFromString(t *testing.T) {
 }
 
 // TestPreciseNumberIsZero pins the contract that IsZero is true only for the
-// uninitialized struct, never for an explicit "0" — the property that
-// protects accounting fields from omitempty data loss.
+// unset struct, never for an explicit "0" — the property that lets `omitzero`
+// drop unset fields while preserving a zero received from the exchange.
 func TestPreciseNumberIsZero(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, PreciseNumber{}.IsZero(), "uninitialized value should be IsZero")
+	assert.True(t, PreciseNumber{}.IsZero(), "IsZero should return true for the unset value")
 
 	explicit, err := NewPreciseNumberFromString("0")
 	require.NoError(t, err, "NewPreciseNumberFromString must not error")
-	assert.False(t, explicit.IsZero(), "explicitly set \"0\" should not be IsZero")
+	assert.False(t, explicit.IsZero(), `IsZero should return false for an explicit "0"`)
 
 	var fromNull PreciseNumber
 	require.NoError(t, fromNull.UnmarshalJSON([]byte(`null`)), "UnmarshalJSON must not error")
-	assert.True(t, fromNull.IsZero(), "null should parse to IsZero")
+	assert.True(t, fromNull.IsZero(), "IsZero should return true after unmarshalling null")
 
 	var fromEmpty PreciseNumber
 	require.NoError(t, fromEmpty.UnmarshalJSON([]byte(`""`)), "UnmarshalJSON must not error")
-	assert.True(t, fromEmpty.IsZero(), "empty quoted string should parse to IsZero")
+	assert.True(t, fromEmpty.IsZero(), "IsZero should return true after unmarshalling an empty string")
 }
 
 // BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for


### PR DESCRIPTION
The existing Number type stores a float64 and reconstructs Decimal() via decimal.NewFromFloat, which silently loses precision past ~15 significant digits. For order-book mid-prices and ticker fields used only in approximate computation that is acceptable, but it makes Number unsuitable for accounting, reconciliation, settlement, or any path where the exact decimal value from the wire must be reproduced.

This adds a sibling type, PreciseNumber, with the same API surface (UnmarshalJSON/MarshalJSON/Float64/Int64/Decimal/String) but a struct representation that preserves the original numeric string alongside a parsed float64 cache.

Behaviour:

  - UnmarshalJSON accepts both quoted strings and bare numbers, the same as Number.
  - MarshalJSON emits the preserved digit string verbatim, so a parse/serialize round-trip is bit-exact rather than reformatted through float64.
  - Float64() returns the cached float for cheap comparisons and sorting (e.g. order-book level alignment).
  - Decimal() parses the original string directly via decimal.NewFromString, avoiding the float round-trip.
  - Int64() parses integer values directly and truncates fractional values toward zero, matching Number.Int64's semantics but without the float round-trip on values that originated as integers (timestamps in seconds, trade IDs).
  - The zero value is the number 0 and marshals to "" to match Number.MarshalJSON's existing contract.

Adoption is opt-in: exchange wrappers can replace types.Number with types.PreciseNumber in struct fields where the exact wire value matters, while leaving market-data fields on types.Number where the cheaper representation is preferable.

A round-trip test pins the bit-exact behaviour against a 17-digit value beyond float64's reliable round-trip range; a head-to-head test demonstrates the precision gap vs Number.Decimal on the same input.

# PR Description

Please include a summary of the change, feature or issue which this pull request addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
