### PR TITLE
exchanges/OKX, GateIO: Fix premium kline params and order limits

### DIFF
--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -1937,24 +1937,35 @@ func (e *Exchange) PremiumIndexKLine(ctx context.Context, settleCurrency currenc
 	if contract.IsEmpty() {
 		return nil, currency.ErrCurrencyPairEmpty
 	}
+	intervalString, err := getIntervalString(interval)
+	if err != nil {
+		return nil, err
+	}
+	from, to = defaultPremiumIndexKLineTimeRange(from, to, time.Now(), interval)
 	params := url.Values{}
 	params.Set("contract", contract.String())
-	if from.IsZero() {
+	if !from.IsZero() {
 		params.Set("from", strconv.FormatInt(from.Unix(), 10))
 	}
-	if to.IsZero() {
+	if !to.IsZero() {
 		params.Set("to", strconv.FormatInt(to.Unix(), 10))
 	}
 	if limit > 0 {
 		params.Set("limit", strconv.FormatInt(limit, 10))
 	}
-	intervalString, err := getIntervalString(interval)
-	if err != nil {
-		return nil, err
-	}
 	params.Set("interval", intervalString)
 	var resp []FuturesPremiumIndexKLineResponse
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, publicPremiumIndexEPL, common.EncodeURLValues(futuresPath+settleCurrency.Item.Lower+"/premium_index", params), &resp)
+}
+
+func defaultPremiumIndexKLineTimeRange(from, to, now time.Time, interval kline.Interval) (adjustedFrom, adjustedTo time.Time) {
+	if to.IsZero() {
+		to = now.UTC()
+	}
+	if from.IsZero() {
+		from = to.Add(-2 * interval.Duration())
+	}
+	return from, to
 }
 
 // GetFuturesTickers retrieves futures ticker information for a specific settle and contract info.

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -1941,7 +1941,6 @@ func (e *Exchange) PremiumIndexKLine(ctx context.Context, settleCurrency currenc
 	if err != nil {
 		return nil, err
 	}
-	from, to = defaultPremiumIndexKLineTimeRange(from, to, time.Now(), interval)
 	params := url.Values{}
 	params.Set("contract", contract.String())
 	if !from.IsZero() {
@@ -1956,16 +1955,6 @@ func (e *Exchange) PremiumIndexKLine(ctx context.Context, settleCurrency currenc
 	params.Set("interval", intervalString)
 	var resp []FuturesPremiumIndexKLineResponse
 	return resp, e.SendHTTPRequest(ctx, exchange.RestSpot, publicPremiumIndexEPL, common.EncodeURLValues(futuresPath+settleCurrency.Item.Lower+"/premium_index", params), &resp)
-}
-
-func defaultPremiumIndexKLineTimeRange(from, to, now time.Time, interval kline.Interval) (adjustedFrom, adjustedTo time.Time) {
-	if to.IsZero() {
-		to = now.UTC()
-	}
-	if from.IsZero() {
-		from = to.Add(-2 * interval.Duration())
-	}
-	return from, to
 }
 
 // GetFuturesTickers retrieves futures ticker information for a specific settle and contract info.

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -22,6 +25,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
+	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/fundingrate"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/futures"
@@ -971,6 +975,106 @@ func TestPremiumIndexKLine(t *testing.T) {
 	assert.NoError(t, err, "PremiumIndexKLine should not error for CoinMarginedFutures")
 	_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, getPair(t, asset.USDTMarginedFutures), time.Time{}, time.Time{}, 0, kline.OneWeek)
 	assert.NoError(t, err, "PremiumIndexKLine should not error for USDTMarginedFutures")
+}
+
+func TestDefaultPremiumIndexKLineTimeRange(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.June, 17, 12, 30, 0, 0, time.FixedZone("test", 3600))
+	from := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
+	defaultFrom := now.UTC().Add(-2 * kline.OneWeek.Duration())
+	defaultTo := now.UTC()
+
+	for _, tc := range []struct {
+		name string
+		from time.Time
+		to   time.Time
+		expF time.Time
+		expT time.Time
+	}{
+		{name: "empty", expF: defaultFrom, expT: defaultTo},
+		{name: "from only", from: from, expF: from, expT: defaultTo},
+		{name: "to only", to: to, expF: to.Add(-2 * kline.OneWeek.Duration()), expT: to},
+		{name: "from and to", from: from, to: to, expF: from, expT: to},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotFrom, gotTo := defaultPremiumIndexKLineTimeRange(tc.from, tc.to, now, kline.OneWeek)
+			assert.Equal(t, tc.expF, gotFrom, "from should use the expected premium index range")
+			assert.Equal(t, tc.expT, gotTo, "to should use the expected premium index range")
+		})
+	}
+}
+
+func TestPremiumIndexKLineRequestTimeRange(t *testing.T) {
+	t.Parallel()
+	ex := new(Exchange)
+	require.NoError(t, testexch.Setup(ex), "Setup must not error")
+
+	requests := make(chan struct {
+		path  string
+		query url.Values
+	}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- struct {
+			path  string
+			query url.Values
+		}{
+			path:  r.URL.Path,
+			query: r.URL.Query(),
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/"), "SetRunningURL must not error")
+	contract := currency.NewBTCUSDT()
+	readRequest := func() struct {
+		path  string
+		query url.Values
+	} {
+		t.Helper()
+		select {
+		case got := <-requests:
+			return got
+		case <-time.After(time.Second):
+			require.FailNow(t, "PremiumIndexKLine must send a request")
+		}
+		return struct {
+			path  string
+			query url.Values
+		}{}
+	}
+
+	_, err := ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
+	require.NoError(t, err, "PremiumIndexKLine must not error")
+	got := readRequest()
+
+	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
+	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
+	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
+	assert.Empty(t, got.query.Get("limit"), "limit should not be set when omitted")
+
+	fromUnix, err := strconv.ParseInt(got.query.Get("from"), 10, 64)
+	require.NoError(t, err, "from must be a unix timestamp")
+	toUnix, err := strconv.ParseInt(got.query.Get("to"), 10, 64)
+	require.NoError(t, err, "to must be a unix timestamp")
+	assert.NotEqual(t, time.Time{}.Unix(), fromUnix, "from should not use the zero time unix value")
+	assert.NotEqual(t, time.Time{}.Unix(), toUnix, "to should not use the zero time unix value")
+	assert.Equal(t, int64((2 * kline.OneWeek.Duration()).Seconds()), toUnix-fromUnix, "default time range should span two intervals")
+	assert.WithinDuration(t, time.Now().UTC(), time.Unix(toUnix, 0).UTC(), time.Minute, "to should default close to now")
+
+	expFrom := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	expTo := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
+	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, expFrom, expTo, 10, kline.OneWeek)
+	require.NoError(t, err, "PremiumIndexKLine must not error with supplied bounds")
+	got = readRequest()
+	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
+	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
+	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
+	assert.Equal(t, strconv.FormatInt(expFrom.Unix(), 10), got.query.Get("from"), "from should use the supplied unix timestamp")
+	assert.Equal(t, strconv.FormatInt(expTo.Unix(), 10), got.query.Get("to"), "to should use the supplied unix timestamp")
+	assert.Equal(t, "10", got.query.Get("limit"), "limit should be set when supplied")
 }
 
 func TestGetFutureTickers(t *testing.T) {

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -971,39 +971,12 @@ func TestGetFuturesCandlesticks(t *testing.T) {
 
 func TestPremiumIndexKLine(t *testing.T) {
 	t.Parallel()
-	_, err := e.PremiumIndexKLine(t.Context(), currency.BTC, getPair(t, asset.CoinMarginedFutures), time.Time{}, time.Time{}, 0, kline.OneWeek)
+	to := time.Now().UTC()
+	from := to.Add(-2 * kline.OneWeek.Duration())
+	_, err := e.PremiumIndexKLine(t.Context(), currency.BTC, getPair(t, asset.CoinMarginedFutures), from, to, 0, kline.OneWeek)
 	assert.NoError(t, err, "PremiumIndexKLine should not error for CoinMarginedFutures")
-	_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, getPair(t, asset.USDTMarginedFutures), time.Time{}, time.Time{}, 0, kline.OneWeek)
+	_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, getPair(t, asset.USDTMarginedFutures), from, to, 0, kline.OneWeek)
 	assert.NoError(t, err, "PremiumIndexKLine should not error for USDTMarginedFutures")
-}
-
-func TestDefaultPremiumIndexKLineTimeRange(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2026, time.June, 17, 12, 30, 0, 0, time.FixedZone("test", 3600))
-	from := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
-	defaultFrom := now.UTC().Add(-2 * kline.OneWeek.Duration())
-	defaultTo := now.UTC()
-
-	for _, tc := range []struct {
-		name string
-		from time.Time
-		to   time.Time
-		expF time.Time
-		expT time.Time
-	}{
-		{name: "empty", expF: defaultFrom, expT: defaultTo},
-		{name: "from only", from: from, expF: from, expT: defaultTo},
-		{name: "to only", to: to, expF: to.Add(-2 * kline.OneWeek.Duration()), expT: to},
-		{name: "from and to", from: from, to: to, expF: from, expT: to},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			gotFrom, gotTo := defaultPremiumIndexKLineTimeRange(tc.from, tc.to, now, kline.OneWeek)
-			assert.Equal(t, tc.expF, gotFrom, "from should use the expected premium index range")
-			assert.Equal(t, tc.expT, gotTo, "to should use the expected premium index range")
-		})
-	}
 }
 
 func TestPremiumIndexKLineRequestTimeRange(t *testing.T) {
@@ -1029,6 +1002,14 @@ func TestPremiumIndexKLineRequestTimeRange(t *testing.T) {
 
 	require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/"), "SetRunningURL must not error")
 	contract := currency.NewBTCUSDT()
+
+	_, err := ex.PremiumIndexKLine(t.Context(), currency.Code{}, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
+	assert.ErrorIs(t, err, errEmptyOrInvalidSettlementCurrency, "empty settlement currency should return expected error")
+	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, currency.Pair{}, time.Time{}, time.Time{}, 0, kline.OneWeek)
+	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "empty contract should return expected error")
+	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.FiveDay)
+	assert.ErrorIs(t, err, kline.ErrUnsupportedInterval, "unsupported interval should return expected error")
+
 	readRequest := func() struct {
 		path  string
 		query url.Values
@@ -1046,23 +1027,26 @@ func TestPremiumIndexKLineRequestTimeRange(t *testing.T) {
 		}{}
 	}
 
-	_, err := ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
+	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
 	require.NoError(t, err, "PremiumIndexKLine must not error")
 	got := readRequest()
 
 	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
 	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
 	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
+	assert.Empty(t, got.query.Get("from"), "from should not be set when omitted")
+	assert.Empty(t, got.query.Get("to"), "to should not be set when omitted")
 	assert.Empty(t, got.query.Get("limit"), "limit should not be set when omitted")
 
-	fromUnix, err := strconv.ParseInt(got.query.Get("from"), 10, 64)
-	require.NoError(t, err, "from must be a unix timestamp")
-	toUnix, err := strconv.ParseInt(got.query.Get("to"), 10, 64)
-	require.NoError(t, err, "to must be a unix timestamp")
-	assert.NotEqual(t, time.Time{}.Unix(), fromUnix, "from should not use the zero time unix value")
-	assert.NotEqual(t, time.Time{}.Unix(), toUnix, "to should not use the zero time unix value")
-	assert.Equal(t, int64((2 * kline.OneWeek.Duration()).Seconds()), toUnix-fromUnix, "default time range should span two intervals")
-	assert.WithinDuration(t, time.Now().UTC(), time.Unix(toUnix, 0).UTC(), time.Minute, "to should default close to now")
+	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 10, kline.OneWeek)
+	require.NoError(t, err, "PremiumIndexKLine must not error with supplied limit")
+	got = readRequest()
+	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
+	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
+	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
+	assert.Empty(t, got.query.Get("from"), "from should not be set when omitted")
+	assert.Empty(t, got.query.Get("to"), "to should not be set when omitted")
+	assert.Equal(t, "10", got.query.Get("limit"), "limit should be set when supplied")
 
 	expFrom := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
 	expTo := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -25,7 +22,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
-	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/fundingrate"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/futures"
@@ -973,92 +969,31 @@ func TestPremiumIndexKLine(t *testing.T) {
 	t.Parallel()
 	to := time.Now().UTC()
 	from := to.Add(-2 * kline.OneWeek.Duration())
-	_, err := e.PremiumIndexKLine(t.Context(), currency.BTC, getPair(t, asset.CoinMarginedFutures), from, to, 0, kline.OneWeek)
-	assert.NoError(t, err, "PremiumIndexKLine should not error for CoinMarginedFutures")
-	_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, getPair(t, asset.USDTMarginedFutures), from, to, 0, kline.OneWeek)
-	assert.NoError(t, err, "PremiumIndexKLine should not error for USDTMarginedFutures")
-}
 
-func TestPremiumIndexKLineRequestTimeRange(t *testing.T) {
-	t.Parallel()
-	ex := new(Exchange)
-	require.NoError(t, testexch.Setup(ex), "Setup must not error")
+	t.Run("live request", func(t *testing.T) {
+		t.Parallel()
+		coinMarginedContract := getPair(t, asset.CoinMarginedFutures)
+		usdtMarginedContract := getPair(t, asset.USDTMarginedFutures)
+		_, err := e.PremiumIndexKLine(t.Context(), currency.BTC, coinMarginedContract, from, to, 0, kline.OneWeek)
+		assert.NoError(t, err, "PremiumIndexKLine should not error for CoinMarginedFutures")
+		_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, usdtMarginedContract, from, to, 0, kline.OneWeek)
+		assert.NoError(t, err, "PremiumIndexKLine should not error for USDTMarginedFutures")
+		_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, usdtMarginedContract, time.Time{}, time.Time{}, 1, kline.OneWeek)
+		assert.NoError(t, err, "PremiumIndexKLine should not error with supplied limit")
+		_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, usdtMarginedContract, from, to, 1, kline.OneWeek)
+		assert.NoError(t, err, "PremiumIndexKLine should not error with supplied bounds and limit")
+	})
 
-	requests := make(chan struct {
-		path  string
-		query url.Values
-	}, 2)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests <- struct {
-			path  string
-			query url.Values
-		}{
-			path:  r.URL.Path,
-			query: r.URL.Query(),
-		}
-		_, _ = w.Write([]byte(`[]`))
-	}))
-	t.Cleanup(server.Close)
-
-	require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/"), "SetRunningURL must not error")
-	contract := currency.NewBTCUSDT()
-
-	_, err := ex.PremiumIndexKLine(t.Context(), currency.Code{}, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
-	assert.ErrorIs(t, err, errEmptyOrInvalidSettlementCurrency, "empty settlement currency should return expected error")
-	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, currency.Pair{}, time.Time{}, time.Time{}, 0, kline.OneWeek)
-	assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "empty contract should return expected error")
-	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.FiveDay)
-	assert.ErrorIs(t, err, kline.ErrUnsupportedInterval, "unsupported interval should return expected error")
-
-	readRequest := func() struct {
-		path  string
-		query url.Values
-	} {
-		t.Helper()
-		select {
-		case got := <-requests:
-			return got
-		case <-time.After(time.Second):
-			require.FailNow(t, "PremiumIndexKLine must send a request")
-		}
-		return struct {
-			path  string
-			query url.Values
-		}{}
-	}
-
-	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
-	require.NoError(t, err, "PremiumIndexKLine must not error")
-	got := readRequest()
-
-	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
-	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
-	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
-	assert.Empty(t, got.query.Get("from"), "from should not be set when omitted")
-	assert.Empty(t, got.query.Get("to"), "to should not be set when omitted")
-	assert.Empty(t, got.query.Get("limit"), "limit should not be set when omitted")
-
-	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 10, kline.OneWeek)
-	require.NoError(t, err, "PremiumIndexKLine must not error with supplied limit")
-	got = readRequest()
-	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
-	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
-	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
-	assert.Empty(t, got.query.Get("from"), "from should not be set when omitted")
-	assert.Empty(t, got.query.Get("to"), "to should not be set when omitted")
-	assert.Equal(t, "10", got.query.Get("limit"), "limit should be set when supplied")
-
-	expFrom := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
-	expTo := time.Date(2026, time.June, 8, 0, 0, 0, 0, time.UTC)
-	_, err = ex.PremiumIndexKLine(t.Context(), currency.USDT, contract, expFrom, expTo, 10, kline.OneWeek)
-	require.NoError(t, err, "PremiumIndexKLine must not error with supplied bounds")
-	got = readRequest()
-	assert.Equal(t, "/futures/usdt/premium_index", got.path, "PremiumIndexKLine should use the expected path")
-	assert.Equal(t, contract.String(), got.query.Get("contract"), "contract should be set")
-	assert.Equal(t, "7d", got.query.Get("interval"), "interval should be set")
-	assert.Equal(t, strconv.FormatInt(expFrom.Unix(), 10), got.query.Get("from"), "from should use the supplied unix timestamp")
-	assert.Equal(t, strconv.FormatInt(expTo.Unix(), 10), got.query.Get("to"), "to should use the supplied unix timestamp")
-	assert.Equal(t, "10", got.query.Get("limit"), "limit should be set when supplied")
+	t.Run("validation", func(t *testing.T) {
+		t.Parallel()
+		contract := currency.NewBTCUSDT()
+		_, err := e.PremiumIndexKLine(t.Context(), currency.Code{}, contract, time.Time{}, time.Time{}, 0, kline.OneWeek)
+		assert.ErrorIs(t, err, errEmptyOrInvalidSettlementCurrency, "empty settlement currency should return expected error")
+		_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, currency.Pair{}, time.Time{}, time.Time{}, 0, kline.OneWeek)
+		assert.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "empty contract should return expected error")
+		_, err = e.PremiumIndexKLine(t.Context(), currency.USDT, contract, time.Time{}, time.Time{}, 0, kline.FiveDay)
+		assert.ErrorIs(t, err, kline.ErrUnsupportedInterval, "unsupported interval should return expected error")
+	})
 }
 
 func TestGetFutureTickers(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -36,6 +36,7 @@ import (
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 	testsubs "github.com/thrasher-corp/gocryptotrader/internal/testing/subscriptions"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
+	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
 // Please supply your own keys here to do authenticated endpoint testing
@@ -3394,6 +3395,48 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 		t.Parallel()
 		require.ErrorIs(t, e.UpdateOrderExecutionLimits(t.Context(), asset.Binary), asset.ErrNotSupported)
 	})
+}
+
+func TestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments(t *testing.T) {
+	exch := &Exchange{}
+	exch.SetDefaults()
+	exch.Name = "OkxTestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments"
+
+	livePair := currency.NewPairWithDelimiter("BTC", "USDT", "-")
+	inactivePair := currency.NewPairWithDelimiter("ETH", "USDT", "-")
+	require.NoError(t, exch.loadInstrumentOrderExecutionLimits(asset.Futures, []Instrument{
+		{
+			InstrumentID:     livePair,
+			State:            instrumentStateLive,
+			TickSize:         types.Number(0.1),
+			MinimumOrderSize: types.Number(1),
+		},
+		{
+			InstrumentID:     inactivePair,
+			State:            "preopen",
+			TickSize:         types.Number(0.01),
+			MinimumOrderSize: types.Number(2),
+		},
+		{
+			InstrumentID:     currency.EMPTYPAIR,
+			State:            instrumentStateLive,
+			TickSize:         types.Number(0.01),
+			MinimumOrderSize: types.Number(2),
+		},
+	}), "loadInstrumentOrderExecutionLimits must skip inactive and empty instruments")
+
+	loadedLimit, err := exch.GetOrderExecutionLimits(asset.Futures, livePair)
+	require.NoError(t, err, "GetOrderExecutionLimits must not error for live instrument")
+	assert.Equal(t, 0.1, loadedLimit.PriceStepIncrementSize, "PriceStepIncrementSize should be set from live instrument")
+	assert.Equal(t, 1.0, loadedLimit.MinimumBaseAmount, "MinimumBaseAmount should be set from live instrument")
+
+	_, err = exch.GetOrderExecutionLimits(asset.Futures, inactivePair)
+	require.ErrorIs(t, err, limits.ErrOrderLimitNotFound, "inactive instruments must not be loaded")
+
+	require.ErrorIs(t, exch.loadInstrumentOrderExecutionLimits(asset.Futures, []Instrument{
+		{InstrumentID: inactivePair, State: "preopen"},
+		{InstrumentID: currency.EMPTYPAIR, State: instrumentStateLive},
+	}), common.ErrNoResponse, "no live populated instruments should return no response")
 }
 
 func TestUpdateTicker(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3436,7 +3436,10 @@ func TestLoadInstrumentOrderExecutionLimits(t *testing.T) {
 	require.ErrorIs(t, exch.loadInstrumentOrderExecutionLimits(asset.Futures, []Instrument{
 		{InstrumentID: inactivePair, State: "preopen"},
 		{InstrumentID: currency.EMPTYPAIR, State: instrumentStateLive},
-	}), common.ErrNoResponse, "no live populated instruments should return no response")
+	}), common.ErrInvalidResponse, "all filtered instruments must return invalid response")
+
+	require.ErrorIs(t, exch.loadInstrumentOrderExecutionLimits(asset.Futures, nil),
+		common.ErrNoResponse, "empty instrument slice must return no response")
 }
 
 func TestUpdateTicker(t *testing.T) {

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3397,10 +3397,10 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 	})
 }
 
-func TestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments(t *testing.T) {
+func TestLoadInstrumentOrderExecutionLimits(t *testing.T) {
 	exch := &Exchange{}
 	exch.SetDefaults()
-	exch.Name = "OkxTestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments"
+	exch.Name = "OkxTestLoadInstrumentOrderExecutionLimits"
 
 	livePair := currency.NewPairWithDelimiter("BTC", "USDT", "-")
 	inactivePair := currency.NewPairWithDelimiter("ETH", "USDT", "-")
@@ -3423,7 +3423,7 @@ func TestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments(t *t
 			TickSize:         types.Number(0.01),
 			MinimumOrderSize: types.Number(2),
 		},
-	}), "loadInstrumentOrderExecutionLimits must skip inactive and empty instruments")
+	}), "loadInstrumentOrderExecutionLimits must load live instruments and skip inactive or empty instruments")
 
 	loadedLimit, err := exch.GetOrderExecutionLimits(asset.Futures, livePair)
 	require.NoError(t, err, "GetOrderExecutionLimits must not error for live instrument")

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -3400,7 +3400,7 @@ func TestUpdateOrderExecutionLimits(t *testing.T) {
 func TestLoadInstrumentOrderExecutionLimits(t *testing.T) {
 	exch := &Exchange{}
 	exch.SetDefaults()
-	exch.Name = "OkxTestLoadInstrumentOrderExecutionLimits"
+	exch.Name = t.Name()
 
 	livePair := currency.NewPairWithDelimiter("BTC", "USDT", "-")
 	inactivePair := currency.NewPairWithDelimiter("ETH", "USDT", "-")

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	websocketResponseMaxLimit = time.Second * 3
+	instrumentStateLive       = "live"
 )
 
 // SetDefaults sets the basic defaults for Okx
@@ -296,7 +297,7 @@ func (e *Exchange) FetchTradablePairs(ctx context.Context, a asset.Item) (curren
 		}
 		pairs := make([]currency.Pair, 0, len(insts))
 		for x := range insts {
-			if insts[x].State != "live" {
+			if insts[x].State != instrumentStateLive {
 				continue
 			}
 			pairs = append(pairs, insts[x].InstrumentID.Format(format))
@@ -307,7 +308,7 @@ func (e *Exchange) FetchTradablePairs(ctx context.Context, a asset.Item) (curren
 		if err != nil {
 			return nil, err
 		}
-		spreadInstruments, err := e.GetPublicSpreads(ctx, "", "", "", "live")
+		spreadInstruments, err := e.GetPublicSpreads(ctx, "", "", "", instrumentStateLive)
 		if err != nil {
 			return nil, fmt.Errorf("%w asset type: %v", err, a)
 		}
@@ -345,20 +346,9 @@ func (e *Exchange) UpdateOrderExecutionLimits(ctx context.Context, a asset.Item)
 		if err != nil {
 			return err
 		}
-		if len(insts) == 0 {
-			return common.ErrNoResponse
-		}
-		l := make([]limits.MinMaxLevel, len(insts))
-		for i := range insts {
-			l[i] = limits.MinMaxLevel{
-				Key:                    key.NewExchangeAssetPair(e.Name, a, insts[i].InstrumentID),
-				PriceStepIncrementSize: insts[i].TickSize.Float64(),
-				MinimumBaseAmount:      insts[i].MinimumOrderSize.Float64(),
-			}
-		}
-		return limits.Load(l)
+		return e.loadInstrumentOrderExecutionLimits(a, insts)
 	case asset.Spread:
-		insts, err := e.GetPublicSpreads(ctx, "", "", "", "live")
+		insts, err := e.GetPublicSpreads(ctx, "", "", "", instrumentStateLive)
 		if err != nil {
 			return err
 		}
@@ -378,6 +368,24 @@ func (e *Exchange) UpdateOrderExecutionLimits(ctx context.Context, a asset.Item)
 	default:
 		return fmt.Errorf("%w %q", asset.ErrNotSupported, a)
 	}
+}
+
+func (e *Exchange) loadInstrumentOrderExecutionLimits(a asset.Item, insts []Instrument) error {
+	l := make([]limits.MinMaxLevel, 0, len(insts))
+	for i := range insts {
+		if insts[i].State != instrumentStateLive || insts[i].InstrumentID.IsEmpty() {
+			continue
+		}
+		l = append(l, limits.MinMaxLevel{
+			Key:                    key.NewExchangeAssetPair(e.Name, a, insts[i].InstrumentID),
+			PriceStepIncrementSize: insts[i].TickSize.Float64(),
+			MinimumBaseAmount:      insts[i].MinimumOrderSize.Float64(),
+		})
+	}
+	if len(l) == 0 {
+		return common.ErrNoResponse
+	}
+	return limits.Load(l)
 }
 
 // UpdateTicker updates and returns the ticker for a currency pair

--- a/exchanges/okx/okx_wrapper.go
+++ b/exchanges/okx/okx_wrapper.go
@@ -371,6 +371,9 @@ func (e *Exchange) UpdateOrderExecutionLimits(ctx context.Context, a asset.Item)
 }
 
 func (e *Exchange) loadInstrumentOrderExecutionLimits(a asset.Item, insts []Instrument) error {
+	if len(insts) == 0 {
+		return common.ErrNoResponse
+	}
 	l := make([]limits.MinMaxLevel, 0, len(insts))
 	for i := range insts {
 		if insts[i].State != instrumentStateLive || insts[i].InstrumentID.IsEmpty() {
@@ -383,7 +386,7 @@ func (e *Exchange) loadInstrumentOrderExecutionLimits(a asset.Item, insts []Inst
 		})
 	}
 	if len(l) == 0 {
-		return common.ErrNoResponse
+		return common.ErrInvalidResponse
 	}
 	return limits.Load(l)
 }


### PR DESCRIPTION
## Summary
- Fix GateIO `PremiumIndexKLine` time parameter handling so supplied `from`/`to` values are sent instead of zero-time Unix values.
- Preserve omitted `from`/`to` bounds so callers control whether GateIO receives explicit bounds, `limit`, or neither.
- Simplify `TestPremiumIndexKLine` coverage into live request and validation subtests without the local HTTP mock.
- Skip inactive or empty OKX instruments when loading order execution limits, matching live tradable instrument handling and avoiding preopen empty `instId` rows.

## Tests
- `go test ./exchanges/gateio -run 'TestPremiumIndexKLine' -count=1`
- `go test ./exchanges/gateio -count=1`
- `go test ./exchanges/okx -run 'TestUpdateOrderExecutionLimits|TestLoadInstrumentOrderExecutionLimitsSkipsInactiveAndEmptyInstruments' -count=1`
- `go test ./exchanges/okx -count=1`
- `golangci-lint run ./exchanges/gateio`
- `golangci-lint run ./exchanges/okx`
- `make lint`
- `codespell`
- `./scripts/misc_checks.sh`
- `git diff --check`