### PR TITLE
coinbase: support Ed25519 CDP API keys in JWT generation

### DIFF
--- a/exchanges/coinbase/coinbase.go
+++ b/exchanges/coinbase/coinbase.go
@@ -3,7 +3,9 @@ package coinbase
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -1441,11 +1443,7 @@ func (e *Exchange) GetJWT(ctx context.Context, uri string) (string, time.Time, e
 	if err != nil {
 		return "", time.Time{}, err
 	}
-	block, _ := pem.Decode([]byte(creds.Secret))
-	if block == nil {
-		return "", time.Time{}, errDecodingPrivateKey
-	}
-	privateKey, err := x509.ParseECPrivateKey(block.Bytes)
+	privateKey, alg, err := parseSigningKey(creds.Secret)
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -1456,7 +1454,7 @@ func (e *Exchange) GetJWT(ctx context.Context, uri string) (string, time.Time, e
 	head := map[string]any{
 		"kid":   creds.Key,
 		"typ":   "JWT",
-		"alg":   "ES256",
+		"alg":   alg,
 		"nonce": nonce,
 	}
 	headJSON, err := json.Marshal(head)
@@ -1481,23 +1479,71 @@ func (e *Exchange) GetJWT(ctx context.Context, uri string) (string, time.Time, e
 	}
 	bodyEnc := base64.RawURLEncoding.EncodeToString(bodyJSON)
 	signingInput := headEnc + "." + bodyEnc
-	hash := sha256.Sum256([]byte(signingInput))
-	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash[:])
+	sig, err := signJWT(privateKey, signingInput)
 	if err != nil {
 		return "", time.Time{}, err
 	}
-	n := privateKey.Params().N
-	halfN := new(big.Int).Rsh(n, 1)
-	if s.Cmp(halfN) == 1 {
-		s.Sub(n, s)
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), regTime.Add(2 * time.Minute), nil
+}
+
+// parseSigningKey decodes a CDP API secret and returns the private key with
+// the matching JWT algorithm. ECDSA keys arrive as SEC1 or PKCS#8 PEM,
+// Ed25519 keys as PKCS#8 PEM or base64, either the 64 byte private key or
+// the 32 byte seed
+func parseSigningKey(secret string) (crypto.PrivateKey, string, error) {
+	block, _ := pem.Decode([]byte(secret))
+	if block == nil {
+		raw, err := base64.StdEncoding.DecodeString(secret)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %w", errDecodingPrivateKey, err)
+		}
+		switch len(raw) {
+		case ed25519.SeedSize:
+			return ed25519.NewKeyFromSeed(raw), "EdDSA", nil
+		case ed25519.PrivateKeySize:
+			return ed25519.PrivateKey(raw), "EdDSA", nil
+		}
+		return nil, "", fmt.Errorf("%w: %d bytes is not an Ed25519 key or seed", errDecodingPrivateKey, len(raw))
 	}
-	rb := r.Bytes()
-	sb := s.Bytes()
-	sig := make([]byte, 64)
-	copy(sig[32-len(rb):32], rb)
-	copy(sig[64-len(sb):], sb)
-	sigEnc := base64.RawURLEncoding.EncodeToString(sig)
-	return signingInput + "." + sigEnc, regTime.Add(2 * time.Minute), nil
+	if ecKey, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return ecKey, "ES256", nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %w", errDecodingPrivateKey, err)
+	}
+	switch k := parsed.(type) {
+	case *ecdsa.PrivateKey:
+		return k, "ES256", nil
+	case ed25519.PrivateKey:
+		return k, "EdDSA", nil
+	}
+	return nil, "", fmt.Errorf("%w: unsupported key type %T", errDecodingPrivateKey, parsed)
+}
+
+// signJWT signs the JWT signing input with the given private key
+func signJWT(privKey crypto.PrivateKey, signingInput string) ([]byte, error) {
+	switch k := privKey.(type) {
+	case *ecdsa.PrivateKey:
+		hash := sha256.Sum256([]byte(signingInput))
+		r, s, err := ecdsa.Sign(rand.Reader, k, hash[:])
+		if err != nil {
+			return nil, err
+		}
+		n := k.Params().N
+		halfN := new(big.Int).Rsh(n, 1)
+		if s.Cmp(halfN) == 1 {
+			s.Sub(n, s)
+		}
+		sig := make([]byte, 64)
+		r.FillBytes(sig[:32])
+		s.FillBytes(sig[32:])
+		return sig, nil
+	case ed25519.PrivateKey:
+		return ed25519.Sign(k, []byte(signingInput)), nil
+	default:
+		return nil, common.GetTypeAssertError("*ecdsa.PrivateKey|ed25519.PrivateKey", privKey)
+	}
 }
 
 // GetFee returns an estimate of fee based on type of transaction

--- a/exchanges/coinbase/coinbase.go
+++ b/exchanges/coinbase/coinbase.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -1525,6 +1526,9 @@ func parseSigningKey(secret string) (crypto.PrivateKey, string, error) {
 func signJWT(privKey crypto.PrivateKey, signingInput string) ([]byte, error) {
 	switch k := privKey.(type) {
 	case *ecdsa.PrivateKey:
+		if k.Curve != elliptic.P256() {
+			return nil, fmt.Errorf("%w: ECDSA private key must use P-256", errDecodingPrivateKey)
+		}
 		hash := sha256.Sum256([]byte(signingInput))
 		r, s, err := ecdsa.Sign(rand.Reader, k, hash[:])
 		if err != nil {

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -2,6 +2,14 @@ package coinbase
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"log"
 	"net/http"
@@ -1729,6 +1737,70 @@ func TestGetJWT(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 	_, _, err := e.GetJWT(t.Context(), "a")
 	assert.NoError(t, err)
+}
+
+func TestParseSigningKey(t *testing.T) {
+	t.Parallel()
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	sec1, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	ecPKCS8, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	edPKCS8, err := x509.MarshalPKCS8PrivateKey(edKey)
+	require.NoError(t, err)
+	toPEM := func(blockType string, der []byte) string {
+		return string(pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}))
+	}
+	for _, tc := range []struct {
+		name    string
+		secret  string
+		wantAlg string
+		wantKey crypto.PrivateKey
+	}{
+		{name: "SEC1 PEM ECDSA", secret: toPEM("EC PRIVATE KEY", sec1), wantAlg: "ES256", wantKey: ecKey},
+		{name: "PKCS#8 PEM ECDSA", secret: toPEM("PRIVATE KEY", ecPKCS8), wantAlg: "ES256", wantKey: ecKey},
+		{name: "PKCS#8 PEM Ed25519", secret: toPEM("PRIVATE KEY", edPKCS8), wantAlg: "EdDSA", wantKey: edKey},
+		{name: "base64 Ed25519 private key", secret: base64.StdEncoding.EncodeToString(edKey), wantAlg: "EdDSA", wantKey: edKey},
+		{name: "base64 Ed25519 seed", secret: base64.StdEncoding.EncodeToString(edKey.Seed()), wantAlg: "EdDSA", wantKey: edKey},
+		{name: "not base64 or PEM", secret: "not a key"},
+		{name: "base64 of wrong length", secret: base64.StdEncoding.EncodeToString([]byte("short"))},
+		{name: "PEM with invalid DER", secret: toPEM("PRIVATE KEY", []byte("garbage"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			key, alg, err := parseSigningKey(tc.secret)
+			if tc.wantKey == nil {
+				assert.ErrorIs(t, err, errDecodingPrivateKey)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAlg, alg)
+			eq, ok := key.(interface{ Equal(crypto.PrivateKey) bool })
+			require.True(t, ok, "parsed key must support Equal")
+			assert.True(t, eq.Equal(tc.wantKey), "parsed key should equal the generated key")
+		})
+	}
+}
+
+func TestSignJWT(t *testing.T) {
+	t.Parallel()
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	sig, err := signJWT(ecKey, "input")
+	require.NoError(t, err)
+	assert.Len(t, sig, 64, "ECDSA signature should be raw R||S")
+
+	pub, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	sig, err = signJWT(edKey, "input")
+	require.NoError(t, err)
+	assert.True(t, ed25519.Verify(pub, []byte("input"), sig), "Ed25519 signature should verify against the public key")
+
+	_, err = signJWT("not a key", "input")
+	assert.ErrorIs(t, err, common.ErrTypeAssertFailure)
 }
 
 func TestEncodeDateRange(t *testing.T) {

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -1773,6 +1773,7 @@ func TestParseSigningKey(t *testing.T) {
 			t.Parallel()
 			key, alg, err := parseSigningKey(tc.secret)
 			if tc.wantKey == nil {
+			    require.Nil(t, key)
 				assert.ErrorIs(t, err, errDecodingPrivateKey)
 				return
 			}

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -1773,7 +1773,7 @@ func TestParseSigningKey(t *testing.T) {
 			t.Parallel()
 			key, alg, err := parseSigningKey(tc.secret)
 			if tc.wantKey == nil {
-			    require.Nil(t, key)
+				require.Nil(t, key)
 				assert.ErrorIs(t, err, errDecodingPrivateKey)
 				return
 			}
@@ -1793,6 +1793,11 @@ func TestSignJWT(t *testing.T) {
 	sig, err := signJWT(ecKey, "input")
 	require.NoError(t, err)
 	assert.Len(t, sig, 64, "ECDSA signature should be raw R||S")
+
+	p384Key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	_, err = signJWT(p384Key, "input")
+	assert.ErrorIs(t, err, errDecodingPrivateKey, "signJWT should reject non-P-256 ECDSA keys")
 
 	pub, edKey, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)


### PR DESCRIPTION
# PR Description

When creating an API key in the Coinbase CDP portal you can choose between two signature algorithms, Ed25519 and ECDSA, and Ed25519 is the preselected default. `GetJWT` assumes the secret is a SEC1 PEM encoded ECDSA key, so authentication with an Ed25519 key fails with `error decoding private key` and nothing points at the key type as the cause.

This adds Ed25519 support to JWT generation and accepts the key formats CDP secrets show up in:

- SEC1 PEM ECDSA (what the code accepted before)
- PKCS#8 PEM, holding either an ECDSA or an Ed25519 key
- base64 Ed25519, as either the 64 byte private key the portal hands out or the 32 byte seed

`parseSigningKey` detects the format and returns the key together with the matching JWT `alg` header value, `ES256` or `EdDSA`. `signJWT` holds the two signing paths. The ECDSA signing logic is what `GetJWT` did before, only moved. Errors wrap `errDecodingPrivateKey` with the underlying cause so a bad secret is diagnosable.

No new dependencies, only stdlib `crypto/ed25519`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run
- [x] Verified against the live Advanced Trade API with a real Ed25519 CDP key: `GetAllAccounts` authenticates and returns balances. Before this change the same credentials fail with `error decoding private key`.
- [x] Added a table driven `TestParseSigningKey` covering all five accepted formats plus invalid inputs, and `TestSignJWT` verifying the Ed25519 signature against its public key and the raw R||S length for ECDSA. Both run without credentials.

The existing credential gated `TestGetJWT` still covers the full path.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

----
Claude Code wrote the PR and made the commit 
