### PR TITLE
websocket: Prevent connect test teardown race

### DIFF
--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -1416,6 +1416,7 @@ func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
 	m.exchangeName = "test"
 	m.useMultiConnectionManagement = true
 	m.MaxSubscriptionsPerConnection = 1
+	m.trafficTimeout = time.Minute
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1466,6 +1467,7 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	m.exchangeName = "test"
 	m.useMultiConnectionManagement = true
 	m.MaxSubscriptionsPerConnection = 2
+	m.trafficTimeout = time.Minute
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1537,6 +1539,7 @@ func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
 	m.exchangeName = "test"
 	m.useMultiConnectionManagement = true
 	m.MaxSubscriptionsPerConnection = 2
+	m.trafficTimeout = time.Minute
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Prevent raw websocket test managers from starting zero-duration traffic monitors.
- Initialise all three affected successful-`Connect` fixtures with a production-valid traffic timeout.
- Keep production websocket behaviour unchanged.

## Root cause

The tests construct `Manager` instances without calling `Setup`, leaving `trafficTimeout` at zero. `Connect` starts the traffic monitor before completing subscription setup, so `time.After(0)` can trigger an asynchronous shutdown as soon as the manager becomes connected. If shutdown wins the scheduling race, it clears the subscription stores before the assertions run.

## Impact

This removes a scheduling-dependent websocket test failure observed on macOS CI and protects the two adjacent fixtures with the same lifecycle pattern.

## Validation

- `go test ./exchange/websocket -run 'TestConnect(TracksOnExistingConnectionBeforeNewConnection|ReducesTrackedSubscriptionsBeforeBatching|PreBatchTrackedSubscriptionsAutoRecordState)$' -race -count=100`
- `go test ./exchange/websocket -race -count=1`
- `make lint`
- `codespell exchange/websocket/subscriptions_test.go`
- `make misc_checks`
