### PR TITLE
gateio: fix type formatting

### DIFF
--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -1280,9 +1280,9 @@ type MarginAccountItem struct {
 	// Risk is the current risk rate (returned for risk-rate accounts).
 	Risk string `json:"risk"`
 	// Mmr is the current maintenance margin rate (returned for mmr accounts).
-	MaintenanceMarginRate types.Number `json:"mmr"`
-	Base  AccountBalanceInformation `json:"base"`
-	Quote AccountBalanceInformation `json:"quote"`
+	MaintenanceMarginRate types.Number              `json:"mmr"`
+	Base                  AccountBalanceInformation `json:"base"`
+	Quote                 AccountBalanceInformation `json:"quote"`
 }
 
 // AccountBalanceInformation represents currency account balance information.


### PR DESCRIPTION
# PR Description

Fixes the current `golangci-lint` formatter failure in `exchanges/gateio/gateio_types.go` by applying the expected Go struct-field alignment.

No issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] `golangci-lint run ./exchanges/gateio/...`
- [x] `go test ./exchanges/gateio`
- [x] `gofmt -l exchanges/gateio/gateio_types.go`
- [x] `git diff --check -- exchanges/gateio/gateio_types.go`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings