### PR TITLE
coinbase: map order not found errors

### DIFF
--- a/exchanges/coinbase/coinbase.go
+++ b/exchanges/coinbase/coinbase.go
@@ -97,6 +97,8 @@ const (
 
 	defaultOrderFillCount = 3000       // Largest number of fills the exchange will let one retrieve in a request, found through experimentation
 	defaultOrderCount     = 2147483647 // int32 limit, largest number of orders the exchange will let one retrieve in a request, found through experimentation
+
+	unknownCancelOrderFailure = "UNKNOWN_CANCEL_ORDER"
 )
 
 // Constants defining whether a transfer is a deposit or withdrawal, used to simplify interactions with a few endpoints
@@ -363,7 +365,8 @@ func (e *Exchange) CancelOrders(ctx context.Context, orderIDs []string) ([]Order
 	resp := struct {
 		Results []OrderCancelDetail `json:"results"`
 	}{}
-	return resp.Results, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, http.MethodPost, path, nil, cancelOrdersReqBase{OrderIDs: orderIDs}, true, &resp)
+	err := e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, http.MethodPost, path, nil, cancelOrdersReqBase{OrderIDs: orderIDs}, true, &resp)
+	return resp.Results, classifyOrderNotFound(err)
 }
 
 // ClosePosition closes a position by client order ID, product ID, and size
@@ -471,7 +474,7 @@ func (e *Exchange) GetOrderByID(ctx context.Context, orderID, clientOID string, 
 	resp := struct {
 		Order GetOrderResponse `json:"order"`
 	}{}
-	return &resp.Order, e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, http.MethodGet, path, vals, nil, true, &resp)
+	return &resp.Order, classifyOrderNotFound(e.SendAuthenticatedHTTPRequest(ctx, exchange.RestSpot, http.MethodGet, path, vals, nil, true, &resp))
 }
 
 // ListFills returns information on recent order fills
@@ -1356,6 +1359,34 @@ func (e *Exchange) SendHTTPRequest(ctx context.Context, ep exchange.URL, path st
 	}, request.UnauthenticatedRequest)
 }
 
+type responseError struct {
+	response ErrorResponse
+	err      error
+}
+
+func (e *responseError) Error() string { return e.err.Error() }
+
+func (e *responseError) Unwrap() error { return e.err }
+
+func classifyOrderNotFound(err error) error {
+	var responseErr *responseError
+	if errors.As(err, &responseErr) && responseErr.response.ErrorType == "NOT_FOUND" {
+		return fmt.Errorf("%w: %w", order.ErrOrderNotFound, err)
+	}
+	return err
+}
+
+func parseResponseError(err error, raw json.RawMessage) error {
+	if !errors.Is(err, request.ErrBadStatus) {
+		return err
+	}
+	var response ErrorResponse
+	if json.Unmarshal(raw, &response) != nil || response.ErrorType == "" {
+		return err
+	}
+	return &responseError{response: response, err: err}
+}
+
 // SendAuthenticatedHTTPRequest sends an authenticated HTTP request
 func (e *Exchange) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange.URL, method, path string, queryParams url.Values, payload any, isVersion3 bool, result any) (err error) {
 	endpoint, err := e.API.Endpoints.GetURL(ep)
@@ -1398,7 +1429,7 @@ func (e *Exchange) SendAuthenticatedHTTPRequest(ctx context.Context, ep exchange
 		rateLim = V3Rate
 	}
 	if err := e.SendPayload(ctx, rateLim, newRequest, request.AuthenticatedRequest); err != nil {
-		return err
+		return parseResponseError(err, interim)
 	}
 	// Doing this error handling because the docs indicate that errors can be returned even with a 200 status code, and that these errors can be buried in the JSON returned
 	singleErrCap := struct {

--- a/exchanges/coinbase/coinbase.go
+++ b/exchanges/coinbase/coinbase.go
@@ -1369,8 +1369,7 @@ func (e *responseError) Error() string { return e.err.Error() }
 func (e *responseError) Unwrap() error { return e.err }
 
 func classifyOrderNotFound(err error) error {
-	var responseErr *responseError
-	if errors.As(err, &responseErr) && responseErr.response.ErrorType == "NOT_FOUND" {
+	if responseErr, ok := errors.AsType[*responseError](err); ok && responseErr.response.ErrorType == "NOT_FOUND" {
 		return fmt.Errorf("%w: %w", order.ErrOrderNotFound, err)
 	}
 	return err

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -3,6 +3,7 @@ package coinbase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/futures"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
@@ -259,6 +261,28 @@ func TestCancelOrders(t *testing.T) {
 	resp, err := e.CancelOrders(t.Context(), orderSlice)
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp, errExpectedNonEmpty)
+}
+
+func TestClassifyOrderNotFound(t *testing.T) {
+	t.Parallel()
+	body := json.RawMessage(`{"error":"NOT_FOUND","message":"fixture"}`)
+	err := classifyOrderNotFound(parseResponseError(fmt.Errorf("%w raw response: %s", request.ErrBadStatus, body), body))
+	assert.ErrorIs(t, err, order.ErrOrderNotFound, "error should wrap order not found")
+	assert.ErrorIs(t, err, request.ErrBadStatus, "error should preserve the request failure")
+	assert.ErrorContains(t, err, string(body), "error should preserve the raw Coinbase response")
+
+	body = json.RawMessage(`{"error":"INVALID_ARGUMENT","message":"fixture"}`)
+	err = classifyOrderNotFound(parseResponseError(fmt.Errorf("%w raw response: %s", request.ErrBadStatus, body), body))
+	assert.NotErrorIs(t, err, order.ErrOrderNotFound, "invalid argument should not prove order absence")
+	assert.ErrorIs(t, err, request.ErrBadStatus, "error should preserve the request failure")
+	assert.ErrorContains(t, err, string(body), "error should preserve the raw Coinbase response")
+}
+
+func TestCancelOrderResultError(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, cancelOrderResultError(OrderCancelDetail{Success: true}, "order-id"))
+	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: unknownCancelOrderFailure}, "order-id"), order.ErrOrderNotFound)
+	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: "INVALID_CANCEL_REQUEST"}, "order-id"), errOrderFailedToCancel)
 }
 
 func TestClosePosition(t *testing.T) {

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -280,9 +280,9 @@ func TestClassifyOrderNotFound(t *testing.T) {
 
 func TestCancelOrderResultError(t *testing.T) {
 	t.Parallel()
-	assert.NoError(t, cancelOrderResultError(OrderCancelDetail{Success: true}, "order-id"))
-	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: unknownCancelOrderFailure}, "order-id"), order.ErrOrderNotFound)
-	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: "INVALID_CANCEL_REQUEST"}, "order-id"), errOrderFailedToCancel)
+	assert.NoError(t, cancelOrderResultError(OrderCancelDetail{Success: true}, "order-id"), "successful cancellation should not error")
+	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: unknownCancelOrderFailure}, "order-id"), order.ErrOrderNotFound, "unknown order should return order not found")
+	assert.ErrorIs(t, cancelOrderResultError(OrderCancelDetail{FailureReason: "INVALID_CANCEL_REQUEST"}, "order-id"), errOrderFailedToCancel, "other cancellation failures should return the generic cancellation error")
 }
 
 func TestClosePosition(t *testing.T) {

--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -278,6 +278,22 @@ func TestClassifyOrderNotFound(t *testing.T) {
 	assert.ErrorContains(t, err, string(body), "error should preserve the raw Coinbase response")
 }
 
+func TestParseResponseError(t *testing.T) {
+	t.Parallel()
+	unrelatedErr := errors.New("unrelated error")
+	assert.Same(t, unrelatedErr, parseResponseError(unrelatedErr, nil), "unrelated errors should be returned unchanged")
+
+	badStatusErr := fmt.Errorf("%w: fixture", request.ErrBadStatus)
+	assert.Same(t, badStatusErr, parseResponseError(badStatusErr, json.RawMessage(`{`)), "invalid JSON should return the original error")
+	assert.Same(t, badStatusErr, parseResponseError(badStatusErr, json.RawMessage(`{"message":"fixture"}`)), "a missing error type should return the original error")
+
+	err := parseResponseError(badStatusErr, json.RawMessage(`{"error":"NOT_FOUND","message":"fixture"}`))
+	responseErr, ok := errors.AsType[*responseError](err)
+	require.True(t, ok, "a structured error response must be wrapped")
+	assert.Equal(t, ErrorResponse{ErrorType: "NOT_FOUND", Message: "fixture"}, responseErr.response, "parsed response should match")
+	assert.ErrorIs(t, err, badStatusErr, "wrapped response should preserve the original error")
+}
+
 func TestCancelOrderResultError(t *testing.T) {
 	t.Parallel()
 	assert.NoError(t, cancelOrderResultError(OrderCancelDetail{Success: true}, "order-id"), "successful cancellation should not error")

--- a/exchanges/coinbase/coinbase_wrapper.go
+++ b/exchanges/coinbase/coinbase_wrapper.go
@@ -505,15 +505,25 @@ func (e *Exchange) CancelOrder(ctx context.Context, o *order.Cancel) error {
 	if err := o.Validate(o.StandardCancel()); err != nil {
 		return err
 	}
-	canSlice := []order.Cancel{*o}
-	resp, err := e.CancelBatchOrders(ctx, canSlice)
+	results, err := e.CancelOrders(ctx, []string{o.OrderID})
 	if err != nil {
 		return err
 	}
-	if resp.Status[o.OrderID] != order.Cancelled.String() {
+	if len(results) != 1 {
 		return fmt.Errorf("%w %v", errOrderFailedToCancel, o.OrderID)
 	}
-	return nil
+	return cancelOrderResultError(results[0], o.OrderID)
+}
+
+func cancelOrderResultError(result OrderCancelDetail, orderID string) error {
+	switch {
+	case result.Success:
+		return nil
+	case result.FailureReason == unknownCancelOrderFailure:
+		return fmt.Errorf("%w %v", order.ErrOrderNotFound, orderID)
+	default:
+		return fmt.Errorf("%w %v", errOrderFailedToCancel, orderID)
+	}
 }
 
 // CancelBatchOrders cancels orders by their corresponding ID numbers


### PR DESCRIPTION
## Summary

GoCryptoTrader has a sentinel error for a missing order, `order.ErrOrderNotFound`, and other exchange wrappers return it when the venue says an order does not exist. Coinbase never does. No matter what you do with a nonexistent order ID, `errors.Is(err, order.ErrOrderNotFound)` always comes back false.

A missing order can surface in two places, looking it up and cancelling it, and it turned out the Coinbase code loses the information in both. While tracing the cancel path I also hit a second, unrelated bug: `CancelOrders` silently throws away every cancellation result. This PR fixes all of it.

### "order not found" deserves its own error

Of all the ways an exchange call can fail, "this order does not exist at the venue" is the one failure with a definite meaning. A timeout, a 5xx or a rate limit tells you nothing about the order and must be retried. A not-found tells you the venue no longer knows the order, so reconciliation can settle it and cancel logic knows there is nothing left to cancel. That distinction only works if callers can test for it with `errors.Is(err, order.ErrOrderNotFound)`. Today the only options for Coinbase are string-matching error text or treating every failure the same.

### How Coinbase reports a missing order

Coinbase reports it in two different shapes, and the old code lost both:

1. **Lookup.** Requesting a well-formed but nonexistent order ID returns a non-2xx response whose JSON body carries the error code `NOT_FOUND`. Our request layer flattens that into a generic error wrapping `request.ErrBadStatus`, with the body only present as formatted text. The structured error code is gone by the time a caller sees the error.

2. **Cancel.** There is no HTTP error at all. The `batch_cancel` endpoint answers 200 with per-item results, and a missing order shows up as `success=false` with `failure_reason` set to `UNKNOWN_CANCEL_ORDER`. This comes from Coinbase's [generated OpenAPI contract](https://github.com/coinbase-samples/advanced-sdk-ts/blob/main/apiSpec/retail-public-api-spec.json#L5646-L5677). Transport-level status handling can never classify this case, because at the HTTP level nothing went wrong. It has to be read out of the decoded per-item results.

### The bug found along the way: `CancelOrders` returned before decoding

Point 2 is where I hit the second bug. To classify a missing order on the cancel path you need the decoded per-item results, and it turns out callers never got them:

```go
return resp.Results, e.SendAuthenticatedHTTPRequest(ctx, ..., &resp)
```

Go evaluates return operands left to right. `resp.Results` is read first, while it is still the zero value, and only then does `SendAuthenticatedHTTPRequest` run and decode the response into `resp`. So `CancelOrders` performed the cancellation but always returned an empty slice, no matter what Coinbase answered. Downstream, `CancelBatchOrders` prefills its status map with a failure value and then updates it from the (empty) results, which means `CancelOrder` could report a generic cancellation failure even when the cancel actually succeeded. This is fixed first, because everything else on the cancel path depends on actually having the results.

## What changed

**Request layer.** `SendAuthenticatedHTTPRequest` already captures the raw non-2xx body before returning the bad-status error. On failure it now parses that body into the existing `ErrorResponse` model and returns a small unexported wrapper (`responseError`) that carries the parsed response and unwraps to the original error. Nothing about existing behavior changes: `errors.Is(err, request.ErrBadStatus)` still holds and the raw response text is still in the message. The parsed error code is just no longer thrown away.

**Lookup.** `GetOrderByID` passes its error through `classifyOrderNotFound`, which maps an exactly parsed `NOT_FOUND` code to an error wrapping `order.ErrOrderNotFound`. `GetOrderInfo` inherits this. `INVALID_ARGUMENT` is deliberately not mapped: a malformed ID is a caller bug, not evidence the order is absent, and I verified live that a malformed ID produces `INVALID_ARGUMENT` rather than `NOT_FOUND`.

**Cancel, before and after.** The old single-order path was `CancelOrder -> CancelBatchOrders -> CancelOrders`, apparently for reuse. Even without the empty-slice bug it lost information: `CancelBatchOrders` reduces each item to a status string and drops `failure_reason`, so `CancelOrder` could never tell a missing order apart from any other failure. Now:

- `CancelOrders` performs the request first, then returns the actual decoded results, with the same top-level `NOT_FOUND` classification on the error.
- `CancelOrder` calls `CancelOrders` directly with its one ID and interprets the single result: success is nil, exactly `UNKNOWN_CANCEL_ORDER` wraps `order.ErrOrderNotFound`, and any other per-item failure keeps the existing generic `errOrderFailedToCancel`.
- `CancelBatchOrders` keeps its per-item status map and no batch-level sentinel, but now builds the map from real decoded items instead of the empty slice.

### Why the mapping sits at the order call sites, not in the transport

Coinbase uses `NOT_FOUND` for resources other than orders, so the transport must not translate it globally. The CI wrapper test demonstrated this nicely: an order-book request for a test futures product came back with

```json
{"error":"NOT_FOUND","error_details":"no pricebook found","message":"no pricebook found"}
```

That is a missing price book, not a missing order, and mapping it to `order.ErrOrderNotFound` would be wrong. So the transport only parses and preserves the structured code, and each order endpoint decides what it means there.

All matching is on exact parsed fields, never on formatted error text, so reworded messages cannot silently change classification.

## Type of change

- Bug fix

## Testing

- `TestClassifyOrderNotFound` covers the lookup classifier: `NOT_FOUND` maps, `INVALID_ARGUMENT` does not, and the error chain plus raw response text are preserved.
- `TestParseResponseError` covers the request-layer parsing: unrelated errors pass through untouched, invalid JSON or a missing error code returns the original error, and a structured response is wrapped while still unwrapping to the original error.
- `TestCancelOrderResultError` covers the single-cancel helper: nil on success, the sentinel on `UNKNOWN_CANCEL_ORDER`, the generic error otherwise.
- `go test -race -count=1 ./exchanges/coinbase`, `golangci-lint run ./exchanges/coinbase`, `make misc_checks` and `go build ./...` all pass. Under `make check` the coinbase package passes with no race reports; three unrelated tests fail in my environment on live-network conditions and fail identically without this change.
- Live verification, stated honestly: the malformed-ID lookup returning a structured `INVALID_ARGUMENT` body was observed against the real API. The `UNKNOWN_CANCEL_ORDER` mapping follows the OpenAPI contract; I did not run a live cancellation of a missing order.
