### PR TITLE
log: reuse fields in formatted loggers

### DIFF
--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -332,11 +334,13 @@ func TestStageNewLogEvent(t *testing.T) {
 func TestGetFields(t *testing.T) {
 	mu.Lock()
 	originalConfig := globalLogConfig
+	originalLogger := logger
 	originalPool := logFieldsPool
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
 		globalLogConfig = originalConfig
+		logger = originalLogger
 		logFieldsPool = originalPool
 		mu.Unlock()
 	})
@@ -384,16 +388,23 @@ func TestGetFields(t *testing.T) {
 		botName:           "bot",
 		structuredLogging: true,
 	}
+	currentLogger := Logger{InfoHeader: "current"}
+	staleLogger := Logger{InfoHeader: "stale"}
 	mu.Lock()
 	enabled = true
-	logFieldsPool = &sync.Pool{New: func() any {
-		return &fields{logger: logger, structuredFields: ExtraFields{"stale": true}}
-	}}
+	logger = staleLogger
+	pooled := originalPool.New().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+	pooled.structuredFields = ExtraFields{"stale": true}
+	logFieldsPool = &sync.Pool{New: func() any { return pooled }}
+	logger = currentLogger
 	mu.Unlock()
 	mu.RLock()
 	f = sl.getFields()
-	mu.RUnlock()
-	require.NotNil(t, f, "getFields must return fields when logging is enabled")
+	if f == nil {
+		mu.RUnlock()
+		require.NotNil(t, f, "getFields result must not be nil when logging is enabled")
+		return
+	}
 	assert.Equal(t, sl.levels.Info, f.info, "getFields should copy the info level")
 	assert.Equal(t, sl.levels.Debug, f.debug, "getFields should copy the debug level")
 	assert.Equal(t, sl.levels.Warn, f.warn, "getFields should copy the warn level")
@@ -402,67 +413,306 @@ func TestGetFields(t *testing.T) {
 	assert.Same(t, output, f.output, "getFields should copy the output")
 	assert.Equal(t, sl.botName, f.botName, "getFields should copy the bot name")
 	assert.Equal(t, sl.structuredLogging, f.structuredLogging, "getFields should copy structured logging")
+	assert.Same(t, &logger, f.logger, "getFields should use the current logger")
+	assert.Equal(t, currentLogger, *f.logger, "getFields should return the current logger")
 	assert.Nil(t, f.structuredFields, "getFields should discard stale structured fields")
-	mu.RLock()
 	logFieldsPool.Put(f)
 	mu.RUnlock()
 }
 
-func TestLoggersDiscardStaleStructuredFields(t *testing.T) {
+func TestPooledFieldsUseCurrentLogger(t *testing.T) {
 	w := newTestBuffer()
 	sl := &SubLogger{
-		name:              "PLAIN",
-		levels:            Levels{Info: true, Debug: true, Warn: true, Error: true},
-		output:            &multiWriterHolder{writers: []io.Writer{w}},
-		structuredLogging: true,
+		name:   "CURRENT",
+		levels: Levels{Info: true},
+		output: &multiWriterHolder{writers: []io.Writer{w}},
 	}
+	enabled := true
+	currentLogger := Logger{InfoHeader: "current", Spacer: " "}
+	staleLogger := Logger{InfoHeader: "stale", Spacer: " "}
+
 	mu.Lock()
+	originalConfig := globalLogConfig
+	originalHook := customLogHook
+	originalLogger := logger
+	originalPool := logFieldsPool
+	globalLogConfig = &Config{Enabled: &enabled}
+	customLogHook = nil
+	logger = staleLogger
+	pooled := originalPool.New().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+	logFieldsPool = &sync.Pool{New: func() any { return pooled }}
+	logger = currentLogger
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		globalLogConfig = originalConfig
+		customLogHook = originalHook
+		logger = originalLogger
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
+	Infoln(sl, "message")
+	barrier := make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+	wroteOutput := false
+	select {
+	case <-w.Finished:
+		wroteOutput = true
+	default:
+	}
+	assert.True(t, wroteOutput, "Infoln should write with the current logger")
+	output := w.Read()
+	assert.Contains(t, output, currentLogger.InfoHeader, "Infoln should use the current logger header")
+	assert.NotContains(t, output, staleLogger.InfoHeader, "Infoln should not use a stale logger header")
+}
+
+func TestFieldsCustomLogHook(t *testing.T) {
+	testLogger := Logger{InfoHeader: "[INFO]", Spacer: " "}
+	mu.Lock()
+	originalHook := customLogHook
 	originalPool := logFieldsPool
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
+		customLogHook = originalHook
 		logFieldsPool = originalPool
 		mu.Unlock()
 	})
+
+	for _, tc := range []struct {
+		name             string
+		operation        string
+		hookSet          bool
+		bypass           bool
+		call             func(*fields)
+		expectedHookArgs []any
+		expectedOutput   string
+	}{
+		{name: "stageln without hook", operation: "stageln", call: func(f *fields) { f.stageln(testLogger.InfoHeader, "message", 1) }, expectedOutput: "message1"},
+		{name: "stageln hook falls through", operation: "stageln", hookSet: true, call: func(f *fields) { f.stageln(testLogger.InfoHeader, "message", 1) }, expectedHookArgs: []any{"message", 1}, expectedOutput: "message1"},
+		{name: "stageln hook bypasses", operation: "stageln", hookSet: true, bypass: true, call: func(f *fields) { f.stageln(testLogger.InfoHeader, "message", 1) }, expectedHookArgs: []any{"message", 1}},
+		{name: "stagef without hook", operation: "stagef", call: func(f *fields) { f.stagef(testLogger.InfoHeader, "formatted %s %d", "message", 1) }, expectedOutput: "formatted message 1"},
+		{name: "stagef hook falls through", operation: "stagef", hookSet: true, call: func(f *fields) { f.stagef(testLogger.InfoHeader, "formatted %s %d", "message", 1) }, expectedHookArgs: []any{"formatted message 1"}, expectedOutput: "formatted message 1"},
+		{name: "stagef hook bypasses", operation: "stagef", hookSet: true, bypass: true, call: func(f *fields) { f.stagef(testLogger.InfoHeader, "formatted %s %d", "message", 1) }, expectedHookArgs: []any{"formatted message 1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newTestBuffer()
+			var hookArgs []any
+			mu.Lock()
+			if tc.hookSet {
+				customLogHook = func(_, _ string, a ...any) bool {
+					hookArgs = append(hookArgs, a...)
+					return tc.bypass
+				}
+			} else {
+				customLogHook = nil
+			}
+			logFieldsPool = &sync.Pool{New: func() any {
+				return &fields{
+					info:   true,
+					name:   "HOOK",
+					output: &multiWriterHolder{writers: []io.Writer{w}},
+					logger: &testLogger,
+				}
+			}}
+			f := logFieldsPool.Get().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+			mu.Unlock()
+
+			mu.RLock()
+			tc.call(f)
+			mu.RUnlock()
+			barrier := make(chan struct{})
+			jobsChannel <- &job{Passback: barrier}
+			<-barrier
+			wroteOutput := false
+			select {
+			case <-w.Finished:
+				wroteOutput = true
+			default:
+			}
+			if tc.expectedOutput != "" {
+				assert.Truef(t, wroteOutput, "%s should write internal output", tc.operation)
+				assert.Containsf(t, w.Read(), tc.expectedOutput, "%s should write the correct output", tc.operation)
+			} else {
+				assert.Falsef(t, wroteOutput, "%s should bypass internal output", tc.operation)
+				assert.Emptyf(t, w.Read(), "%s should not write internal output", tc.operation)
+			}
+			assert.Equalf(t, tc.expectedHookArgs, hookArgs, "%s should pass the correct hook arguments", tc.operation)
+		})
+	}
+
+	message := []byte("before")
+	w := newTestBuffer()
+	mu.Lock()
+	customLogHook = func(_, _ string, a ...any) bool {
+		assert.Equal(t, []any{"before"}, a, "stagef should pass the formatted message to the hook")
+		copy(message, "after!")
+		return false
+	}
+	logFieldsPool = &sync.Pool{New: func() any {
+		return &fields{
+			info:   true,
+			name:   "HOOK",
+			output: &multiWriterHolder{writers: []io.Writer{w}},
+			logger: &testLogger,
+		}
+	}}
+	f := logFieldsPool.Get().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+	mu.Unlock()
+
+	mu.RLock()
+	f.stagef(testLogger.InfoHeader, "%s", message)
+	mu.RUnlock()
+	barrier := make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+	wroteSnapshot := false
+	select {
+	case <-w.Finished:
+		wroteSnapshot = true
+	default:
+	}
+	assert.True(t, wroteSnapshot, "stagef should write fall-through output")
+	output := w.Read()
+	assert.Contains(t, output, "before", "stagef should reuse the hook-formatted message")
+	assert.NotContains(t, output, "after!", "stagef should not format mutable arguments twice")
+}
+
+func TestFieldsCustomLogHookRecyclesFields(t *testing.T) {
+	previousMaxProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(previousMaxProcs) })
+	previousGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(previousGCPercent) })
+
+	testLogger := Logger{InfoHeader: "[INFO]"}
+	mu.Lock()
+	originalHook := customLogHook
+	originalPool := logFieldsPool
+	customLogHook = func(_, _ string, _ ...any) bool { return true }
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		customLogHook = originalHook
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
 	for _, tc := range []struct {
 		name string
-		log  func(*SubLogger, string)
+		call func(*fields)
 	}{
-		{name: "Infoln", log: func(sl *SubLogger, message string) { Infoln(sl, message) }},
-		{name: "Infof", log: func(sl *SubLogger, message string) { Infof(sl, "%s", message) }},
-		{name: "Debugln", log: func(sl *SubLogger, message string) { Debugln(sl, message) }},
-		{name: "Debugf", log: func(sl *SubLogger, message string) { Debugf(sl, "%s", message) }},
-		{name: "Warnln", log: func(sl *SubLogger, message string) { Warnln(sl, message) }},
-		{name: "Warnf", log: func(sl *SubLogger, message string) { Warnf(sl, "%s", message) }},
-		{name: "Errorln", log: func(sl *SubLogger, message string) { Errorln(sl, message) }},
-		{name: "Errorf", log: func(sl *SubLogger, message string) { Errorf(sl, "%s", message) }},
+		{name: "stageln", call: func(f *fields) { f.stageln(testLogger.InfoHeader, "message") }},
+		{name: "stagef", call: func(f *fields) { f.stagef(testLogger.InfoHeader, "%s", "message") }},
 	} {
-		poolMisses := 0
-		mu.Lock()
-		logFieldsPool = &sync.Pool{New: func() any {
-			poolMisses++
-			return &fields{logger: logger, structuredFields: ExtraFields{"stale": true}}
-		}}
-		mu.Unlock()
-		tc.log(nil, "ignored")
-		tc.log(sl, tc.name)
-		<-w.Finished
-		output := w.Read()
-		assert.Containsf(t, output, tc.name, "%s should write output", tc.name)
-		assert.NotContainsf(t, output, "stale", "%s should discard stale structured fields", tc.name)
-		assert.Equalf(t, 1, poolMisses, "%s should acquire one fields value", tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			const attempts = 1000
+			// Race builds may deliberately discard sync.Pool puts, so sample
+			// enough operations to distinguish drops from a missing Put path.
+			poolMisses := 0
+			mu.Lock()
+			logFieldsPool = &sync.Pool{New: func() any {
+				poolMisses++
+				return &fields{name: "HOOK", logger: &testLogger}
+			}}
+			mu.Unlock()
 
-		sl.levels = Levels{}
-		tc.log(sl, "ignored")
-		barrier := make(chan struct{})
-		jobsChannel <- &job{Passback: barrier}
-		<-barrier
-		select {
-		case <-w.Finished:
-		default:
-		}
-		assert.Emptyf(t, w.Read(), "%s should not write when disabled", tc.name)
-		sl.levels = Levels{Info: true, Debug: true, Warn: true, Error: true}
+			for range attempts {
+				mu.RLock()
+				f := logFieldsPool.Get().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+				tc.call(f)
+				mu.RUnlock()
+			}
+			assert.Lessf(t, poolMisses, attempts/2, "%s should return fields to the pool", tc.name)
+		})
+	}
+}
+
+func TestLoggersDiscardStaleStructuredFields(t *testing.T) {
+	mu.Lock()
+	originalPool := logFieldsPool
+	originalHook := customLogHook
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		logFieldsPool = originalPool
+		customLogHook = originalHook
+		mu.Unlock()
+	})
+
+	for _, tc := range []struct {
+		name                string
+		withFieldsOperation string
+		logWithFields       func(*SubLogger, ExtraFields, string)
+		logPlain            func(*SubLogger, string)
+	}{
+		{name: "Infoln", withFieldsOperation: "InfolnWithFields", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { InfolnWithFields(sl, extra, message) }, logPlain: func(sl *SubLogger, message string) { Infoln(sl, message) }},
+		{name: "Infof", withFieldsOperation: "InfoWithFieldsf", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { InfoWithFieldsf(sl, extra, "%s", message) }, logPlain: func(sl *SubLogger, message string) { Infof(sl, "%s", message) }},
+		{name: "Debugln", withFieldsOperation: "DebuglnWithFields", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { DebuglnWithFields(sl, extra, message) }, logPlain: func(sl *SubLogger, message string) { Debugln(sl, message) }},
+		{name: "Debugf", withFieldsOperation: "DebugWithFieldsf", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { DebugWithFieldsf(sl, extra, "%s", message) }, logPlain: func(sl *SubLogger, message string) { Debugf(sl, "%s", message) }},
+		{name: "Warnln", withFieldsOperation: "WarnlnWithFields", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { WarnlnWithFields(sl, extra, message) }, logPlain: func(sl *SubLogger, message string) { Warnln(sl, message) }},
+		{name: "Warnf", withFieldsOperation: "WarnWithFieldsf", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { WarnWithFieldsf(sl, extra, "%s", message) }, logPlain: func(sl *SubLogger, message string) { Warnf(sl, "%s", message) }},
+		{name: "Errorln", withFieldsOperation: "ErrorlnWithFields", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { ErrorlnWithFields(sl, extra, message) }, logPlain: func(sl *SubLogger, message string) { Errorln(sl, message) }},
+		{name: "Errorf", withFieldsOperation: "ErrorWithFieldsf", logWithFields: func(sl *SubLogger, extra ExtraFields, message string) { ErrorWithFieldsf(sl, extra, "%s", message) }, logPlain: func(sl *SubLogger, message string) { Errorf(sl, "%s", message) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newTestBuffer()
+			sl := &SubLogger{
+				name:              "PLAIN",
+				levels:            Levels{Info: true, Debug: true, Warn: true, Error: true},
+				output:            &multiWriterHolder{writers: []io.Writer{w}},
+				structuredLogging: true,
+			}
+			pooled := &fields{logger: &logger}
+			mu.Lock()
+			customLogHook = nil
+			logFieldsPool = &sync.Pool{New: func() any { return pooled }}
+			mu.Unlock()
+
+			tc.logWithFields(sl, ExtraFields{"stale": true}, "structured")
+			barrier := make(chan struct{})
+			jobsChannel <- &job{Passback: barrier}
+			<-barrier
+			wroteStructured := false
+			select {
+			case <-w.Finished:
+				wroteStructured = true
+			default:
+			}
+			assert.Truef(t, wroteStructured, "%s should write structured output", tc.withFieldsOperation)
+			assert.Containsf(t, w.Read(), "stale", "%s should write structured fields", tc.withFieldsOperation)
+
+			tc.logPlain(nil, "ignored")
+			tc.logPlain(sl, tc.name)
+			barrier = make(chan struct{})
+			jobsChannel <- &job{Passback: barrier}
+			<-barrier
+			wrotePlain := false
+			select {
+			case <-w.Finished:
+				wrotePlain = true
+			default:
+			}
+			assert.Truef(t, wrotePlain, "%s should write plain output", tc.name)
+			output := w.Read()
+			assert.Containsf(t, output, tc.name, "%s should write the correct output", tc.name)
+			assert.NotContainsf(t, output, "stale", "%s should discard stale structured fields", tc.name)
+
+			sl.setLevelsProtected(Levels{})
+			tc.logPlain(sl, "ignored")
+			barrier = make(chan struct{})
+			jobsChannel <- &job{Passback: barrier}
+			<-barrier
+			wroteDisabled := false
+			select {
+			case <-w.Finished:
+				wroteDisabled = true
+			default:
+			}
+			assert.Falsef(t, wroteDisabled, "%s should not write when disabled", tc.name)
+			assert.Emptyf(t, w.Read(), "%s should not stage disabled output", tc.name)
+		})
 	}
 }
 
@@ -817,7 +1067,7 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 	globalLogConfig.Enabled = &enabled
 	customLogHook = nil
 	logger = benchmarkLogger
-	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: benchmarkLogger} }}
+	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
 	mu.Unlock()
 	b.Cleanup(func() {
 		mu.Lock()
@@ -843,11 +1093,106 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 		{name: "Errorf", logf: Errorf},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
 			for b.Loop() {
 				tc.logf(sl, "formatted %s", "message")
 			}
 		})
 	}
+}
+
+// BenchmarkCustomLogHookBypass measures logging when a custom hook handles the
+// event and bypasses the internal logging system.
+func BenchmarkCustomLogHookBypass(b *testing.B) {
+	enabled := true
+	benchmarkLogger := Logger{
+		InfoHeader:  "[INFO]",
+		DebugHeader: "[DEBUG]",
+		WarnHeader:  "[WARN]",
+		ErrorHeader: "[ERROR]",
+	}
+	mu.Lock()
+	originalEnabled := globalLogConfig.Enabled
+	originalHook := customLogHook
+	originalLogger := logger
+	originalPool := logFieldsPool
+	globalLogConfig.Enabled = &enabled
+	customLogHook = func(_, _ string, _ ...any) bool { return true }
+	logger = benchmarkLogger
+	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
+	mu.Unlock()
+	b.Cleanup(func() {
+		mu.Lock()
+		globalLogConfig.Enabled = originalEnabled
+		customLogHook = originalHook
+		logger = originalLogger
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
+	sl := &SubLogger{name: "BENCHMARK"}
+	for _, tc := range []struct {
+		name string
+		log  func(*SubLogger)
+	}{
+		{name: "Infoln", log: func(sl *SubLogger) { Infoln(sl, "message") }},
+		{name: "Infof", log: func(sl *SubLogger) { Infof(sl, "formatted %s", "message") }},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				tc.log(sl)
+			}
+		})
+	}
+}
+
+// BenchmarkCustomLogHookFallthrough measures formatted logging when a custom
+// hook observes the event and the internal logger still handles it.
+func BenchmarkCustomLogHookFallthrough(b *testing.B) {
+	enabled := true
+	benchmarkLogger := Logger{
+		InfoHeader:                    "[INFO]",
+		Spacer:                        " ",
+		BypassJobChannelFilledWarning: true,
+	}
+	mu.Lock()
+	originalEnabled := globalLogConfig.Enabled
+	originalHook := customLogHook
+	originalLogger := logger
+	originalPool := logFieldsPool
+	globalLogConfig.Enabled = &enabled
+	customLogHook = func(_, _ string, _ ...any) bool { return false }
+	logger = benchmarkLogger
+	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
+	mu.Unlock()
+	b.Cleanup(func() {
+		mu.Lock()
+		globalLogConfig.Enabled = originalEnabled
+		customLogHook = originalHook
+		logger = originalLogger
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
+	barrier := make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+
+	sl := &SubLogger{
+		name:   "BENCHMARK",
+		levels: Levels{Info: true},
+		output: &multiWriterHolder{writers: []io.Writer{io.Discard}},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		Infof(sl, "formatted %s %d", "message", 1)
+	}
+	barrier = make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+	b.StopTimer()
 }
 
 // BenchmarkInfof-8   	 1000000	     72641 ns/op	     178 B/op	       4 allocs/op

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -325,6 +326,143 @@ func TestStageNewLogEvent(t *testing.T) {
 	<-w.Finished
 	if contents := w.Read(); contents != "header space  space out\n" { //nolint:dupword // False positive
 		t.Errorf("received: '%v' but expected: '%v'", contents, "header space  space out\n") //nolint:dupword // False positive
+	}
+}
+
+func TestGetFields(t *testing.T) {
+	mu.Lock()
+	originalConfig := globalLogConfig
+	originalPool := logFieldsPool
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		globalLogConfig = originalConfig
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
+	enabled := true
+	mu.Lock()
+	globalLogConfig = &Config{Enabled: &enabled}
+	mu.Unlock()
+	mu.RLock()
+	f := (*SubLogger)(nil).getFields()
+	mu.RUnlock()
+	assert.Nil(t, f, "getFields should return nil for a nil sublogger")
+
+	sl := &SubLogger{}
+	mu.Lock()
+	globalLogConfig = nil
+	mu.Unlock()
+	mu.RLock()
+	f = sl.getFields()
+	mu.RUnlock()
+	assert.Nil(t, f, "getFields should return nil without a global config")
+
+	mu.Lock()
+	globalLogConfig = &Config{}
+	mu.Unlock()
+	mu.RLock()
+	f = sl.getFields()
+	mu.RUnlock()
+	assert.Nil(t, f, "getFields should return nil without an enabled setting")
+
+	mu.Lock()
+	enabled = false
+	globalLogConfig.Enabled = &enabled
+	mu.Unlock()
+	mu.RLock()
+	f = sl.getFields()
+	mu.RUnlock()
+	assert.Nil(t, f, "getFields should return nil when logging is disabled")
+
+	output := &multiWriterHolder{}
+	sl = &SubLogger{
+		name:              "FIELDS",
+		levels:            Levels{Info: true, Debug: true, Warn: true, Error: true},
+		output:            output,
+		botName:           "bot",
+		structuredLogging: true,
+	}
+	mu.Lock()
+	enabled = true
+	logFieldsPool = &sync.Pool{New: func() any {
+		return &fields{logger: logger, structuredFields: ExtraFields{"stale": true}}
+	}}
+	mu.Unlock()
+	mu.RLock()
+	f = sl.getFields()
+	mu.RUnlock()
+	require.NotNil(t, f, "getFields must return fields when logging is enabled")
+	assert.Equal(t, sl.levels.Info, f.info, "getFields should copy the info level")
+	assert.Equal(t, sl.levels.Debug, f.debug, "getFields should copy the debug level")
+	assert.Equal(t, sl.levels.Warn, f.warn, "getFields should copy the warn level")
+	assert.Equal(t, sl.levels.Error, f.error, "getFields should copy the error level")
+	assert.Equal(t, sl.name, f.name, "getFields should copy the sublogger name")
+	assert.Same(t, output, f.output, "getFields should copy the output")
+	assert.Equal(t, sl.botName, f.botName, "getFields should copy the bot name")
+	assert.Equal(t, sl.structuredLogging, f.structuredLogging, "getFields should copy structured logging")
+	assert.Nil(t, f.structuredFields, "getFields should discard stale structured fields")
+	mu.RLock()
+	logFieldsPool.Put(f)
+	mu.RUnlock()
+}
+
+func TestLoggersDiscardStaleStructuredFields(t *testing.T) {
+	w := newTestBuffer()
+	sl := &SubLogger{
+		name:              "PLAIN",
+		levels:            Levels{Info: true, Debug: true, Warn: true, Error: true},
+		output:            &multiWriterHolder{writers: []io.Writer{w}},
+		structuredLogging: true,
+	}
+	mu.Lock()
+	originalPool := logFieldsPool
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+	for _, tc := range []struct {
+		name string
+		log  func(*SubLogger, string)
+	}{
+		{name: "Infoln", log: func(sl *SubLogger, message string) { Infoln(sl, message) }},
+		{name: "Infof", log: func(sl *SubLogger, message string) { Infof(sl, "%s", message) }},
+		{name: "Debugln", log: func(sl *SubLogger, message string) { Debugln(sl, message) }},
+		{name: "Debugf", log: func(sl *SubLogger, message string) { Debugf(sl, "%s", message) }},
+		{name: "Warnln", log: func(sl *SubLogger, message string) { Warnln(sl, message) }},
+		{name: "Warnf", log: func(sl *SubLogger, message string) { Warnf(sl, "%s", message) }},
+		{name: "Errorln", log: func(sl *SubLogger, message string) { Errorln(sl, message) }},
+		{name: "Errorf", log: func(sl *SubLogger, message string) { Errorf(sl, "%s", message) }},
+	} {
+		poolMisses := 0
+		mu.Lock()
+		logFieldsPool = &sync.Pool{New: func() any {
+			poolMisses++
+			return &fields{logger: logger, structuredFields: ExtraFields{"stale": true}}
+		}}
+		mu.Unlock()
+		tc.log(nil, "ignored")
+		tc.log(sl, tc.name)
+		<-w.Finished
+		output := w.Read()
+		assert.Containsf(t, output, tc.name, "%s should write output", tc.name)
+		assert.NotContainsf(t, output, "stale", "%s should discard stale structured fields", tc.name)
+		assert.Equalf(t, 1, poolMisses, "%s should acquire one fields value", tc.name)
+
+		sl.levels = Levels{}
+		tc.log(sl, "ignored")
+		barrier := make(chan struct{})
+		jobsChannel <- &job{Passback: barrier}
+		<-barrier
+		select {
+		case <-w.Finished:
+		default:
+		}
+		assert.Emptyf(t, w.Read(), "%s should not write when disabled", tc.name)
+		sl.levels = Levels{Info: true, Debug: true, Warn: true, Error: true}
 	}
 }
 
@@ -658,6 +796,57 @@ func BenchmarkInfoDisabled(b *testing.B) {
 
 	for b.Loop() {
 		Infoln(Global, "Hello this is an info benchmark")
+	}
+}
+
+// BenchmarkFormattedDisabled measures level-disabled formatted logging while
+// global logging remains enabled.
+func BenchmarkFormattedDisabled(b *testing.B) {
+	enabled := true
+	benchmarkLogger := Logger{
+		InfoHeader:  "[INFO]",
+		DebugHeader: "[DEBUG]",
+		WarnHeader:  "[WARN]",
+		ErrorHeader: "[ERROR]",
+	}
+	mu.Lock()
+	originalEnabled := globalLogConfig.Enabled
+	originalHook := customLogHook
+	originalLogger := logger
+	originalPool := logFieldsPool
+	globalLogConfig.Enabled = &enabled
+	customLogHook = nil
+	logger = benchmarkLogger
+	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: benchmarkLogger} }}
+	mu.Unlock()
+	b.Cleanup(func() {
+		mu.Lock()
+		globalLogConfig.Enabled = originalEnabled
+		customLogHook = originalHook
+		logger = originalLogger
+		logFieldsPool = originalPool
+		mu.Unlock()
+	})
+
+	barrier := make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+
+	sl := &SubLogger{}
+	for _, tc := range []struct {
+		name string
+		logf func(*SubLogger, string, ...any)
+	}{
+		{name: "Infof", logf: Infof},
+		{name: "Debugf", logf: Debugf},
+		{name: "Warnf", logf: Warnf},
+		{name: "Errorf", logf: Errorf},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				tc.logf(sl, "formatted %s", "message")
+			}
+		})
 	}
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1023,7 +1023,196 @@ func newTestBuffer() *testBuffer {
 	return &testBuffer{Finished: make(chan struct{}, 1)}
 }
 
-// 2140294	       770.0 ns/op	       0 B/op	       0 allocs/op
+func drainBenchmarkLoggerJobs() {
+	barrier := make(chan struct{})
+	jobsChannel <- &job{Passback: barrier}
+	<-barrier
+}
+
+func benchmarkLoggerState(enabled bool, levels Levels, hook CustomLogHook, writer io.Writer) (sl *SubLogger, cleanup func()) {
+	drainBenchmarkLoggerJobs()
+
+	benchmarkLogger := Logger{
+		InfoHeader:                    "[INFO]",
+		DebugHeader:                   "[DEBUG]",
+		WarnHeader:                    "[WARN]",
+		ErrorHeader:                   "[ERROR]",
+		Spacer:                        " ",
+		BypassJobChannelFilledWarning: true,
+	}
+
+	mu.Lock()
+	originalConfig := globalLogConfig
+	originalHook := customLogHook
+	originalLogger := logger
+	originalFieldsPool := logFieldsPool
+	originalJobsPool := jobsPool
+	globalLogConfig = &Config{Enabled: &enabled}
+	customLogHook = hook
+	logger = benchmarkLogger
+	logFieldsPool = &sync.Pool{New: originalFieldsPool.New}
+	jobsPool = &sync.Pool{New: originalJobsPool.New}
+	mu.Unlock()
+
+	sl = &SubLogger{
+		name:   "BENCHMARK",
+		levels: levels,
+		output: &multiWriterHolder{writers: []io.Writer{writer}},
+	}
+	cleanup = func() {
+		drainBenchmarkLoggerJobs()
+		mu.Lock()
+		globalLogConfig = originalConfig
+		customLogHook = originalHook
+		logger = originalLogger
+		logFieldsPool = originalFieldsPool
+		jobsPool = originalJobsPool
+		mu.Unlock()
+	}
+	return sl, cleanup
+}
+
+func TestBenchmarkLoggerWorkloads(t *testing.T) {
+	t.Run("GlobalDisabled", func(t *testing.T) {
+		var output strings.Builder
+		sl, cleanup := benchmarkLoggerState(false, Levels{Info: true}, nil, &output)
+		defer cleanup()
+
+		Infoln(sl, "disabled")
+		Infof(sl, "disabled %s", "formatted")
+		drainBenchmarkLoggerJobs()
+		assert.Empty(t, output.String(), "global-disabled logging should not write output")
+	})
+
+	t.Run("FormattedLevelDisabled", func(t *testing.T) {
+		var output strings.Builder
+		sl, cleanup := benchmarkLoggerState(true, Levels{}, nil, &output)
+		defer cleanup()
+
+		Infof(sl, "formatted %s", "message")
+		Debugf(sl, "formatted %s", "message")
+		Warnf(sl, "formatted %s", "message")
+		Errorf(sl, "formatted %s", "message")
+		drainBenchmarkLoggerJobs()
+		assert.Empty(t, output.String(), "level-disabled formatted logging should not write output")
+	})
+
+	t.Run("CustomHookBypass", func(t *testing.T) {
+		var output strings.Builder
+		hookCalls := 0
+		sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, func(_, _ string, _ ...any) bool {
+			hookCalls++
+			return true
+		}, &output)
+		defer cleanup()
+
+		Infoln(sl, "plain")
+		Infof(sl, "formatted %s", "message")
+		drainBenchmarkLoggerJobs()
+		assert.Equal(t, 2, hookCalls, "customLogHook should be called for both bypass operations")
+		assert.Empty(t, output.String(), "customLogHook should bypass internal output")
+	})
+
+	t.Run("CustomHookFallthrough", func(t *testing.T) {
+		var output strings.Builder
+		hookCalls := 0
+		sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, func(_, _ string, _ ...any) bool {
+			hookCalls++
+			return false
+		}, &output)
+		defer cleanup()
+
+		Infof(sl, "formatted %s %d", "message", 1)
+		drainBenchmarkLoggerJobs()
+		assert.Equal(t, 1, hookCalls, "customLogHook should be called once for fall-through logging")
+		assert.Equal(t, 1, strings.Count(output.String(), "formatted message 1"), "Infof should write the formatted message once")
+	})
+
+	t.Run("Lifecycle", func(t *testing.T) {
+		var output strings.Builder
+		sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, &output)
+		defer cleanup()
+
+		Infof(sl, "infof %d", 1)
+		Infoln(sl, "infoln")
+		drainBenchmarkLoggerJobs()
+		assert.Equal(t, 1, strings.Count(output.String(), "infof 1"), "Infof should write one lifecycle message")
+		assert.Equal(t, 1, strings.Count(output.String(), "infoln"), "Infoln should write one lifecycle message")
+	})
+
+	t.Run("StateLifecycle", func(t *testing.T) {
+		restoredHookCalls := 0
+		restoredHook := func(header, name string, _ ...any) bool {
+			restoredHookCalls++
+			return header == "restored" && name == "hook"
+		}
+		mu.Lock()
+		originalConfig := globalLogConfig
+		originalHook := customLogHook
+		originalLogger := logger
+		originalFieldsPool := logFieldsPool
+		originalJobsPool := jobsPool
+		customLogHook = restoredHook
+		mu.Unlock()
+		t.Cleanup(func() {
+			drainBenchmarkLoggerJobs()
+			mu.Lock()
+			globalLogConfig = originalConfig
+			customLogHook = originalHook
+			logger = originalLogger
+			logFieldsPool = originalFieldsPool
+			jobsPool = originalJobsPool
+			mu.Unlock()
+		})
+
+		activeHookCalls := 0
+		expectedLevels := Levels{Info: true}
+		sl, cleanup := benchmarkLoggerState(true, expectedLevels, func(_, _ string, _ ...any) bool {
+			activeHookCalls++
+			return false
+		}, io.Discard)
+
+		mu.RLock()
+		activeConfig := globalLogConfig
+		activeHook := customLogHook
+		activeLogger := logger
+		activeFieldsPool := logFieldsPool
+		activeJobsPool := jobsPool
+		mu.RUnlock()
+		cleanup()
+
+		require.NotNil(t, activeConfig, "benchmarkLoggerState must install globalLogConfig")
+		require.NotNil(t, activeConfig.Enabled, "benchmarkLoggerState must install globalLogConfig.Enabled")
+		assert.True(t, *activeConfig.Enabled, "benchmarkLoggerState should install the requested enabled state")
+		require.NotNil(t, activeHook, "benchmarkLoggerState must install customLogHook")
+		assert.False(t, activeHook("active", "hook"), "benchmarkLoggerState should install the requested customLogHook")
+		assert.Equal(t, 1, activeHookCalls, "customLogHook should be callable while benchmark state is active")
+		assert.Equal(t, Logger{InfoHeader: "[INFO]", DebugHeader: "[DEBUG]", WarnHeader: "[WARN]", ErrorHeader: "[ERROR]", Spacer: " ", BypassJobChannelFilledWarning: true}, activeLogger, "benchmarkLoggerState should install the benchmark logger")
+		assert.NotSame(t, originalFieldsPool, activeFieldsPool, "benchmarkLoggerState should install a fresh logFieldsPool")
+		assert.NotSame(t, originalJobsPool, activeJobsPool, "benchmarkLoggerState should install a fresh jobsPool")
+		assert.Equal(t, "BENCHMARK", sl.name, "benchmarkLoggerState should set the SubLogger name")
+		assert.Equal(t, expectedLevels, sl.levels, "benchmarkLoggerState should set the requested SubLogger levels")
+		require.NotNil(t, sl.output, "benchmarkLoggerState must set the SubLogger output")
+		require.Len(t, sl.output.writers, 1, "benchmarkLoggerState must set one SubLogger writer")
+		assert.Equal(t, io.Discard, sl.output.writers[0], "benchmarkLoggerState should set the requested SubLogger writer")
+
+		mu.RLock()
+		restoredConfig := globalLogConfig
+		currentHook := customLogHook
+		restoredLogger := logger
+		restoredFieldsPool := logFieldsPool
+		restoredJobsPool := jobsPool
+		mu.RUnlock()
+		assert.Same(t, originalConfig, restoredConfig, "benchmarkLoggerState should restore globalLogConfig")
+		require.NotNil(t, currentHook, "benchmarkLoggerState must restore customLogHook")
+		assert.True(t, currentHook("restored", "hook"), "benchmarkLoggerState should restore the prior customLogHook")
+		assert.Equal(t, 1, restoredHookCalls, "restored customLogHook should be callable after cleanup")
+		assert.Equal(t, originalLogger, restoredLogger, "benchmarkLoggerState should restore logger")
+		assert.Same(t, originalFieldsPool, restoredFieldsPool, "benchmarkLoggerState should restore logFieldsPool")
+		assert.Same(t, originalJobsPool, restoredJobsPool, "benchmarkLoggerState should restore jobsPool")
+	})
+}
+
 func BenchmarkNewLogEvent(b *testing.B) {
 	mw := &multiWriterHolder{writers: []io.Writer{io.Discard}}
 	for b.Loop() {
@@ -1031,57 +1220,26 @@ func BenchmarkNewLogEvent(b *testing.B) {
 	}
 }
 
-func BenchmarkInfo(b *testing.B) {
-	for b.Loop() {
-		Infoln(Global, "Hello this is an info benchmark")
-	}
-}
-
-// BenchmarkInfoDisabled-8 47124242	        24.16 ns/op	       0 B/op	       0 allocs/op
+// Benchstat medians for PR base to measured production head; no significant
+// difference detected at n=20, p=0.113 (counterbalanced fresh-process observations per revision):
+// Before: 41.41 ns/op  16 B/op  1 allocs/op; After: 41.62 ns/op  16 B/op  1 allocs/op
 func BenchmarkInfoDisabled(b *testing.B) {
-	if err := SetupDisabled(); err != nil {
-		b.Fatal(err)
-	}
-
+	sl, cleanup := benchmarkLoggerState(false, Levels{Info: true}, nil, io.Discard)
+	b.Cleanup(cleanup)
+	b.ReportAllocs()
+	b.ResetTimer()
 	for b.Loop() {
-		Infoln(Global, "Hello this is an info benchmark")
+		Infoln(sl, "Hello this is an info benchmark")
 	}
 }
 
 // BenchmarkFormattedDisabled measures level-disabled formatted logging while
 // global logging remains enabled.
+// Benchstat medians for PR base to measured production head
+// (20 counterbalanced fresh-process observations per revision):
+// Before: 216.0-221.5 ns/op  256 B/op  3 allocs/op
+// After:  109.2-114.5 ns/op   64 B/op  2 allocs/op
 func BenchmarkFormattedDisabled(b *testing.B) {
-	enabled := true
-	benchmarkLogger := Logger{
-		InfoHeader:  "[INFO]",
-		DebugHeader: "[DEBUG]",
-		WarnHeader:  "[WARN]",
-		ErrorHeader: "[ERROR]",
-	}
-	mu.Lock()
-	originalEnabled := globalLogConfig.Enabled
-	originalHook := customLogHook
-	originalLogger := logger
-	originalPool := logFieldsPool
-	globalLogConfig.Enabled = &enabled
-	customLogHook = nil
-	logger = benchmarkLogger
-	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
-	mu.Unlock()
-	b.Cleanup(func() {
-		mu.Lock()
-		globalLogConfig.Enabled = originalEnabled
-		customLogHook = originalHook
-		logger = originalLogger
-		logFieldsPool = originalPool
-		mu.Unlock()
-	})
-
-	barrier := make(chan struct{})
-	jobsChannel <- &job{Passback: barrier}
-	<-barrier
-
-	sl := &SubLogger{}
 	for _, tc := range []struct {
 		name string
 		logf func(*SubLogger, string, ...any)
@@ -1092,7 +1250,10 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 		{name: "Errorf", logf: Errorf},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
+			sl, cleanup := benchmarkLoggerState(true, Levels{}, nil, io.Discard)
+			b.Cleanup(cleanup)
 			b.ReportAllocs()
+			b.ResetTimer()
 			for b.Loop() {
 				tc.logf(sl, "formatted %s", "message")
 			}
@@ -1102,34 +1263,11 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 
 // BenchmarkCustomLogHookBypass measures logging when a custom hook handles the
 // event and bypasses the internal logging system.
+// Benchstat medians for hook-change predecessor to measured production head
+// (20 counterbalanced fresh-process observations per revision):
+// Before: Infoln 144.40 ns/op, 208 B/op, 2 allocs/op; Infof 306.5 ns/op, 264 B/op, 5 allocs/op
+// After:  Infoln  65.90 ns/op,  16 B/op, 1 allocs/op; Infof 218.5 ns/op, 72 B/op, 4 allocs/op
 func BenchmarkCustomLogHookBypass(b *testing.B) {
-	enabled := true
-	benchmarkLogger := Logger{
-		InfoHeader:  "[INFO]",
-		DebugHeader: "[DEBUG]",
-		WarnHeader:  "[WARN]",
-		ErrorHeader: "[ERROR]",
-	}
-	mu.Lock()
-	originalEnabled := globalLogConfig.Enabled
-	originalHook := customLogHook
-	originalLogger := logger
-	originalPool := logFieldsPool
-	globalLogConfig.Enabled = &enabled
-	customLogHook = func(_, _ string, _ ...any) bool { return true }
-	logger = benchmarkLogger
-	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
-	mu.Unlock()
-	b.Cleanup(func() {
-		mu.Lock()
-		globalLogConfig.Enabled = originalEnabled
-		customLogHook = originalHook
-		logger = originalLogger
-		logFieldsPool = originalPool
-		mu.Unlock()
-	})
-
-	sl := &SubLogger{name: "BENCHMARK"}
 	for _, tc := range []struct {
 		name string
 		log  func(*SubLogger)
@@ -1138,7 +1276,12 @@ func BenchmarkCustomLogHookBypass(b *testing.B) {
 		{name: "Infof", log: func(sl *SubLogger) { Infof(sl, "formatted %s", "message") }},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
+			sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, func(_, _ string, _ ...any) bool {
+				return true
+			}, io.Discard)
+			b.Cleanup(cleanup)
 			b.ReportAllocs()
+			b.ResetTimer()
 			for b.Loop() {
 				tc.log(sl)
 			}
@@ -1148,62 +1291,53 @@ func BenchmarkCustomLogHookBypass(b *testing.B) {
 
 // BenchmarkCustomLogHookFallthrough measures formatted logging when a custom
 // hook observes the event and the internal logger still handles it.
+// Benchstat medians for hook-change predecessor to measured production head
+// (20 counterbalanced fresh-process observations per revision):
+// Before: 674.6 ns/op  185 B/op  6 allocs/op
+// After:  494.3 ns/op  133 B/op  5 allocs/op
 func BenchmarkCustomLogHookFallthrough(b *testing.B) {
-	enabled := true
-	benchmarkLogger := Logger{
-		InfoHeader:                    "[INFO]",
-		Spacer:                        " ",
-		BypassJobChannelFilledWarning: true,
-	}
-	mu.Lock()
-	originalEnabled := globalLogConfig.Enabled
-	originalHook := customLogHook
-	originalLogger := logger
-	originalPool := logFieldsPool
-	globalLogConfig.Enabled = &enabled
-	customLogHook = func(_, _ string, _ ...any) bool { return false }
-	logger = benchmarkLogger
-	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
-	mu.Unlock()
-	b.Cleanup(func() {
-		mu.Lock()
-		globalLogConfig.Enabled = originalEnabled
-		customLogHook = originalHook
-		logger = originalLogger
-		logFieldsPool = originalPool
-		mu.Unlock()
-	})
-
-	barrier := make(chan struct{})
-	jobsChannel <- &job{Passback: barrier}
-	<-barrier
-
-	sl := &SubLogger{
-		name:   "BENCHMARK",
-		levels: Levels{Info: true},
-		output: &multiWriterHolder{writers: []io.Writer{io.Discard}},
-	}
+	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, func(_, _ string, _ ...any) bool {
+		return false
+	}, io.Discard)
+	b.Cleanup(cleanup)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
 		Infof(sl, "formatted %s %d", "message", 1)
 	}
-	barrier = make(chan struct{})
-	jobsChannel <- &job{Passback: barrier}
-	<-barrier
+	drainBenchmarkLoggerJobs()
 	b.StopTimer()
 }
 
+// Benchstat medians for PR base to measured production head
+// (20 counterbalanced fresh-process observations per revision):
+// Before: 765.7 ns/op  371 B/op  5 allocs/op
+// After:  552.3 ns/op  175 B/op  4 allocs/op
 func BenchmarkInfof(b *testing.B) {
+	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, io.Discard)
+	b.Cleanup(cleanup)
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := range b.N {
-		Infof(Global, "Hello this is an infof benchmark %v %v %v\n", n, 1, 2)
+		Infof(sl, "Hello this is an infof benchmark %v %v %v\n", n, 1, 2)
 	}
+	drainBenchmarkLoggerJobs()
+	b.StopTimer()
 }
 
+// Benchstat medians for PR base to measured production head; no significant
+// difference detected at n=20, p=0.551 (counterbalanced fresh-process observations per revision):
+// Before: 330.6 ns/op  114 B/op  3 allocs/op; After: 334.8 ns/op  114 B/op  3 allocs/op
 func BenchmarkInfoln(b *testing.B) {
-	for b.Loop() {
-		Infoln(Global, "Hello this is an infoln benchmark")
+	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, io.Discard)
+	b.Cleanup(cleanup)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		Infoln(sl, "Hello this is an infoln benchmark")
 	}
+	drainBenchmarkLoggerJobs()
+	b.StopTimer()
 }
 
 type testCapture struct {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1031,7 +1031,6 @@ func BenchmarkNewLogEvent(b *testing.B) {
 	}
 }
 
-// BenchmarkInfo-8   	 1000000	     64971 ns/op	      47 B/op	       1 allocs/op
 func BenchmarkInfo(b *testing.B) {
 	for b.Loop() {
 		Infoln(Global, "Hello this is an info benchmark")
@@ -1051,11 +1050,6 @@ func BenchmarkInfoDisabled(b *testing.B) {
 
 // BenchmarkFormattedDisabled measures level-disabled formatted logging while
 // global logging remains enabled.
-// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
-// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
-// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkFormattedDisabled$' -benchmem -benchtime=100ms -count=20
-// ba39f484: 109.5-114.1 ns/op across per-path medians, 64 B/op, 2 allocs/op (previous; 20 samples)
-// 948c4de7: 108.5-114.0 ns/op across per-path medians, 64 B/op, 2 allocs/op (current; 20 samples)
 func BenchmarkFormattedDisabled(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{
@@ -1108,11 +1102,6 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 
 // BenchmarkCustomLogHookBypass measures logging when a custom hook handles the
 // event and bypasses the internal logging system.
-// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
-// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
-// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkCustomLogHookBypass$' -benchmem -benchtime=500ms -count=15
-// ba39f484: Infoln 148.20 ns/op, 208 B/op, 2 allocs/op; Infof 346.2 ns/op, 264 B/op, 5 allocs/op (previous medians; 15 samples)
-// 948c4de7: Infoln 71.69 ns/op, 16 B/op, 1 alloc/op; Infof 237.5 ns/op, 72 B/op, 4 allocs/op (current medians; 15 samples)
 func BenchmarkCustomLogHookBypass(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{
@@ -1159,11 +1148,6 @@ func BenchmarkCustomLogHookBypass(b *testing.B) {
 
 // BenchmarkCustomLogHookFallthrough measures formatted logging when a custom
 // hook observes the event and the internal logger still handles it.
-// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
-// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
-// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkCustomLogHookFallthrough$' -benchmem -benchtime=500ms -count=15
-// Before snapshot reuse: 689.3 ns/op, 185 B/op, 6 allocs/op (previous median; 15 samples)
-// 948c4de7: 607.0 ns/op, 132 B/op, 5 allocs/op (current median; 15 samples)
 func BenchmarkCustomLogHookFallthrough(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{
@@ -1210,14 +1194,12 @@ func BenchmarkCustomLogHookFallthrough(b *testing.B) {
 	b.StopTimer()
 }
 
-// BenchmarkInfof-8   	 1000000	     72641 ns/op	     178 B/op	       4 allocs/op
 func BenchmarkInfof(b *testing.B) {
 	for n := range b.N {
 		Infof(Global, "Hello this is an infof benchmark %v %v %v\n", n, 1, 2)
 	}
 }
 
-// BenchmarkInfoln-8   	 1000000	     68152 ns/op	     121 B/op	       3 allocs/op
 func BenchmarkInfoln(b *testing.B) {
 	for b.Loop() {
 		Infoln(Global, "Hello this is an infoln benchmark")

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1051,6 +1051,11 @@ func BenchmarkInfoDisabled(b *testing.B) {
 
 // BenchmarkFormattedDisabled measures level-disabled formatted logging while
 // global logging remains enabled.
+// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
+// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
+// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkFormattedDisabled$' -benchmem -benchtime=100ms -count=20
+// ba39f484: 109.5-114.1 ns/op across per-path medians, 64 B/op, 2 allocs/op (previous; 20 samples)
+// 948c4de7: 108.5-114.0 ns/op across per-path medians, 64 B/op, 2 allocs/op (current; 20 samples)
 func BenchmarkFormattedDisabled(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{
@@ -1103,6 +1108,11 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 
 // BenchmarkCustomLogHookBypass measures logging when a custom hook handles the
 // event and bypasses the internal logging system.
+// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
+// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
+// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkCustomLogHookBypass$' -benchmem -benchtime=500ms -count=15
+// ba39f484: Infoln 148.20 ns/op, 208 B/op, 2 allocs/op; Infof 346.2 ns/op, 264 B/op, 5 allocs/op (previous medians; 15 samples)
+// 948c4de7: Infoln 71.69 ns/op, 16 B/op, 1 alloc/op; Infof 237.5 ns/op, 72 B/op, 4 allocs/op (current medians; 15 samples)
 func BenchmarkCustomLogHookBypass(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{
@@ -1149,6 +1159,11 @@ func BenchmarkCustomLogHookBypass(b *testing.B) {
 
 // BenchmarkCustomLogHookFallthrough measures formatted logging when a custom
 // hook observes the event and the internal logger still handles it.
+// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
+// GOAMD64=v1, Intel i7-6700K; timing is sensitive to host load):
+// GOAMD64=v1 GOMAXPROCS=1 taskset -c 7 go test ./log -run '^$' -bench '^BenchmarkCustomLogHookFallthrough$' -benchmem -benchtime=500ms -count=15
+// Before snapshot reuse: 689.3 ns/op, 185 B/op, 6 allocs/op (previous median; 15 samples)
+// 948c4de7: 607.0 ns/op, 132 B/op, 5 allocs/op (current median; 15 samples)
 func BenchmarkCustomLogHookFallthrough(b *testing.B) {
 	enabled := true
 	benchmarkLogger := Logger{

--- a/log/logger_types.go
+++ b/log/logger_types.go
@@ -29,9 +29,7 @@ var (
 	jobsPool    = &sync.Pool{New: func() any { return new(job) }}
 	jobsChannel = make(chan *job, defaultJobChannelCapacity)
 
-	// Note: Logger state within logFields will be persistent until it's garbage
-	// collected. This is a little bit more efficient.
-	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: logger} }}
+	logFieldsPool = &sync.Pool{New: func() any { return &fields{logger: &logger} }}
 
 	// LogPath system path to store log files in
 	logPath string

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -39,7 +39,7 @@ func Infof(sl *SubLogger, format string, a ...any) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if f := sl.getFields(); f != nil {
-		sl.getFields().stagef(f.logger.InfoHeader, format, a...)
+		f.stagef(f.logger.InfoHeader, format, a...)
 	}
 }
 
@@ -92,7 +92,7 @@ func Debugf(sl *SubLogger, data string, v ...any) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if f := sl.getFields(); f != nil {
-		sl.getFields().stagef(f.logger.DebugHeader, data, v...)
+		f.stagef(f.logger.DebugHeader, data, v...)
 	}
 }
 
@@ -144,7 +144,7 @@ func Warnf(sl *SubLogger, data string, v ...any) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if f := sl.getFields(); f != nil {
-		sl.getFields().stagef(f.logger.WarnHeader, data, v...)
+		f.stagef(f.logger.WarnHeader, data, v...)
 	}
 }
 
@@ -196,7 +196,7 @@ func Errorf(sl *SubLogger, data string, v ...any) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if f := sl.getFields(); f != nil {
-		sl.getFields().stagef(f.logger.ErrorHeader, data, v...)
+		f.stagef(f.logger.ErrorHeader, data, v...)
 	}
 }
 

--- a/log/loggers.go
+++ b/log/loggers.go
@@ -269,6 +269,7 @@ func (l *fields) stage(header string, deferFunc deferral) {
 // system.
 func (l *fields) stageln(header string, a ...any) {
 	if customLogHook != nil && customLogHook(header, l.name, a...) {
+		logFieldsPool.Put(l)
 		return
 	}
 	l.stage(header, func() string { return fmt.Sprint(a...) })
@@ -278,8 +279,14 @@ func (l *fields) stageln(header string, a ...any) {
 // the custom log hook if set, otherwise falls back to the library's internal
 // log system.
 func (l *fields) stagef(header, format string, a ...any) {
-	if customLogHook != nil && customLogHook(header, l.name, fmt.Sprintf(format, a...)) {
+	if customLogHook == nil {
+		l.stage(header, func() string { return fmt.Sprintf(format, a...) })
 		return
 	}
-	l.stage(header, func() string { return fmt.Sprintf(format, a...) })
+	formatted := fmt.Sprintf(format, a...)
+	if customLogHook(header, l.name, formatted) {
+		logFieldsPool.Put(l)
+		return
+	}
+	l.stage(header, func() string { return formatted })
 }

--- a/log/sublogger.go
+++ b/log/sublogger.go
@@ -43,6 +43,7 @@ func (sl *SubLogger) getFields() *fields {
 		return nil
 	}
 	f := logFieldsPool.Get().(*fields) //nolint:forcetypeassert // Not necessary from a pool
+	f.structuredFields = nil
 	f.info = sl.levels.Info
 	f.warn = sl.levels.Warn
 	f.debug = sl.levels.Debug

--- a/log/sublogger.go
+++ b/log/sublogger.go
@@ -36,8 +36,9 @@ func (sl *SubLogger) setLevels(newLevels Levels) {
 	sl.levels = newLevels
 }
 
-// getFields returns sub logger specific fields for the potential log job.
-// Note: Calling function must have mutex lock in place.
+// getFields checks out and populates sub logger fields for a potential log job.
+// The caller must hold mu's read lock until the value is returned to
+// logFieldsPool by stageln, stagef, or stage.
 func (sl *SubLogger) getFields() *fields {
 	if sl == nil || globalLogConfig == nil || globalLogConfig.Enabled == nil || !*globalLogConfig.Enabled {
 		return nil

--- a/log/sublogger_types.go
+++ b/log/sublogger_types.go
@@ -42,8 +42,8 @@ type SubLogger struct {
 	structuredLogging bool
 }
 
-// fields is used to store data in a non-global and thread-safe manner
-// so logs cannot be modified mid-log causing a data-race issue
+// fields stores per-call data while logger references configuration protected
+// by mu. Callers hold mu's read lock for the lifetime of a checked-out value.
 type fields struct {
 	info              bool
 	warn              bool
@@ -52,7 +52,7 @@ type fields struct {
 	structuredLogging bool
 	name              string
 	output            *multiWriterHolder
-	logger            Logger
+	logger            *Logger
 	botName           string
 	structuredFields  ExtraFields
 }


### PR DESCRIPTION
# PR Description

Formatted logging helpers currently check out `fields` twice: once to determine whether logging is enabled and again to stage the message. Reuse the first pooled value in `Infof`, `Debugf`, `Warnf`, and `Errorf`, removing redundant pool work.

Reset `structuredFields` when checking out a pooled value so fields from an earlier log entry cannot leak into a later one. Keep pooled values tied to the current global logger configuration, including values created before logger setup, and return values to the pool when a custom hook bypasses the internal logging system.

When a formatted custom hook falls through to the internal logger, format the message once and reuse that immutable snapshot for both consumers.

## Performance

Benchstat medians from 20 counterbalanced fresh-process observations per revision using Go 1.26.5 on linux/amd64 with `GOMAXPROCS=1`. Full-PR rows compare the PR base with the measured production head; hook rows compare the hook-change predecessor with the measured production head.

| Scope | Workload | ns/op, before to after | B/op | allocs/op | Result |
| --- | --- | ---: | ---: | ---: | --- |
| Full PR | Formatted-disabled `Infof` | 219.2 to 109.2 | 256 to 64 | 3 to 2 | -50.21%, p=0.000 |
| Full PR | Formatted-disabled `Debugf` | 221.5 to 114.5 | 256 to 64 | 3 to 2 | -48.31%, p=0.000 |
| Full PR | Formatted-disabled `Warnf` | 220.5 to 111.9 | 256 to 64 | 3 to 2 | -49.24%, p=0.000 |
| Full PR | Formatted-disabled `Errorf` | 216.0 to 109.5 | 256 to 64 | 3 to 2 | -49.31%, p=0.000 |
| Full PR | Global-disabled guard | 41.41 to 41.62 | 16 to 16 | 1 to 1 | No significant difference at n=20, p=0.113 |
| Full PR | Direct `Infof` lifecycle | 765.7 to 552.3 | 371 to 175 | 5 to 4 | -27.87%, p=0.000 |
| Full PR | Direct `Infoln` lifecycle guard | 330.6 to 334.8 | 114 to 114 | 3 to 3 | No significant difference at n=20, p=0.551 |
| Hook follow-up | Bypass `Infoln` | 144.40 to 65.90 | 208 to 16 | 2 to 1 | -54.36%, p=0.000 |
| Hook follow-up | Bypass `Infof` | 306.5 to 218.5 | 264 to 72 | 5 to 4 | -28.71%, p=0.000 |
| Hook follow-up | Fall-through `Infof` | 674.6 to 494.3 | 185 to 133 | 6 to 5 | -26.72%, p=0.000 |

These are controlled single-core logger microbenchmarks; they do not establish application-wide throughput or concurrent scaling.

No dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (non-breaking change)

## How has this been tested

- [x] `go test ./log -race -count=1`
- [x] `go test ./log -run '^(TestGetFields|TestPooledFieldsUseCurrentLogger|TestFieldsCustomLogHook|TestFieldsCustomLogHookRecyclesFields|TestLoggersDiscardStaleStructuredFields|TestBenchmarkLoggerWorkloads)$' -count=1000`
- [x] `go test ./log -run '^(TestGetFields|TestPooledFieldsUseCurrentLogger|TestFieldsCustomLogHook|TestFieldsCustomLogHookRecyclesFields|TestLoggersDiscardStaleStructuredFields|TestBenchmarkLoggerWorkloads)$' -race -count=100`
- [x] `make lint`
- [x] `make misc_checks`
- [x] `codespell`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing relevant unit tests pass locally
- [ ] GitHub Actions validation (pending updated branch)
