### PR TITLE
types: reduce timestamp unmarshal allocations

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -23,6 +23,9 @@ var ErrInvalidTimestampFormat = errors.New("invalid timestamp format")
 func (t *Time) UnmarshalJSON(data []byte) error {
 	timestamp := data
 
+	if len(timestamp) == 0 {
+		return nil
+	}
 	if timestamp[0] == '"' {
 		timestamp = timestamp[1 : len(timestamp)-1]
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
@@ -21,44 +21,68 @@ var ErrInvalidTimestampFormat = errors.New("invalid timestamp format")
 
 // UnmarshalJSON deserialises json and timestamp information.
 func (t *Time) UnmarshalJSON(data []byte) error {
-	s := string(data)
+	timestamp := data
 
-	if s[0] == '"' {
-		s = s[1 : len(s)-1]
+	if timestamp[0] == '"' {
+		timestamp = timestamp[1 : len(timestamp)-1]
 	}
 
-	if s == "" || s[0] == 'n' || s == "0" {
+	if len(timestamp) == 0 || timestamp[0] == 'n' || (len(timestamp) == 1 && timestamp[0] == '0') {
 		return nil
 	}
 
-	if target := strings.Index(s, "."); target != -1 {
-		s = s[:target] + s[target+1:]
-
-		if strings.Trim(s, "0") == "" {
+	target := bytes.IndexByte(timestamp, '.')
+	length := len(timestamp)
+	if target != -1 {
+		length--
+	}
+	padding := 0
+	switch length {
+	case 12, 15, 18: // Expects a string of length 10 (seconds), 13 (milliseconds), 16 (microseconds), or 19 (nanoseconds) representing a Unix timestamp
+		padding = 1
+	case 11, 14, 17:
+		padding = 2
+	}
+	if target != -1 || padding != 0 {
+		var normalised [19]byte // A nanosecond Unix timestamp is the largest supported representation.
+		length += padding
+		var destination []byte
+		if length <= len(normalised) {
+			destination = normalised[:length]
+		} else {
+			destination = make([]byte, length)
+		}
+		if target == -1 {
+			copy(destination, timestamp)
+		} else {
+			copy(destination, timestamp[:target])
+			copy(destination[target:], timestamp[target+1:])
+		}
+		for x := length - padding; x < length; x++ {
+			destination[x] = '0'
+		}
+		timestamp = destination
+		if target != -1 && len(bytes.Trim(timestamp, "0")) == 0 {
 			return nil
 		}
 	}
 
-	switch len(s) {
-	case 8:
-		parsed, err := time.Parse("20060102", s)
+	if len(timestamp) == 8 {
+		value := string(timestamp)
+		parsed, err := time.Parse("20060102", value)
 		if err != nil {
-			return fmt.Errorf("%w error parsing %q into date: %w", ErrInvalidTimestampFormat, s, err)
+			return fmt.Errorf("%w error parsing %q into date: %w", ErrInvalidTimestampFormat, value, err)
 		}
 		*t = Time(parsed)
 		return nil
-	case 12, 15, 18: // Expects a string of length 10 (seconds), 13 (milliseconds), 16 (microseconds), or 19 (nanoseconds) representing a Unix timestamp
-		s += "0"
-	case 11, 14, 17:
-		s += "00"
 	}
 
-	unixTS, err := strconv.ParseInt(s, 10, 64)
+	unixTS, err := strconv.ParseInt(string(timestamp), 10, 64)
 	if err != nil {
 		return fmt.Errorf("error parsing unix timestamp: %w", err)
 	}
 
-	switch len(s) {
+	switch len(timestamp) {
 	case 10:
 		*t = Time(time.Unix(unixTS, 0))
 	case 13:

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -69,6 +69,12 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
+// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
+// Intel i7-6700K, warm Go build cache):
+// GOMAXPROCS=1 go test ./types -run '^$' -bench '^BenchmarkUnmarshalJSON$' -benchmem -benchtime=1s -count=15 -cpu=1
+// 4005054         304.1 ns/op       168 B/op          2 allocs/op (current; median time/op of 15 samples)
+// 6152384         195.5 ns/op       168 B/op          2 allocs/op (older historical recording; conditions
+// and statistic not retained, so it is not directly comparable)
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	var testTime Time
 	for b.Loop() {

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -69,12 +69,6 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
-// Reproduce from the repository root (Go 1.26.1, linux/amd64 WSL2,
-// Intel i7-6700K, warm Go build cache):
-// GOMAXPROCS=1 go test ./types -run '^$' -bench '^BenchmarkUnmarshalJSON$' -benchmem -benchtime=1s -count=15 -cpu=1
-// 4005054         304.1 ns/op       168 B/op          2 allocs/op (current; median time/op of 15 samples)
-// 6152384         195.5 ns/op       168 B/op          2 allocs/op (older historical recording; conditions
-// and statistic not retained, so it is not directly comparable)
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	var testTime Time
 	for b.Loop() {

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -89,6 +89,11 @@ func TestTimeUnmarshalJSONEmptyInput(t *testing.T) {
 	}
 }
 
+// Benchstat medians (20 counterbalanced fresh-process observations per revision):
+// direct/fractional Before: 119.55 ns/op  48 B/op  2 allocs/op
+// direct/fractional After:   56.73 ns/op   0 B/op  0 allocs/op
+// decoder/fractional Before: 335.3 ns/op  192 B/op  3 allocs/op
+// decoder/fractional After:  279.4 ns/op  144 B/op  1 alloc/op
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	for _, tc := range []struct {
 		name  string

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -26,7 +26,6 @@ func TestUnmarshalJSON(t *testing.T) {
 		{`"0.00000"`, time.Time{}, nil},
 		{`"0.0.0.0"`, time.Time{}, strconv.ErrSyntax},
 		{`"0.1"`, time.Time{}, ErrInvalidTimestampFormat},
-		{`"202003.25"`, time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC), nil},
 		{`"20200325"`, time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC), nil},
 		{"1628736847", time.Unix(1628736847, 0), nil},
 		{`"1628736847"`, time.Unix(1628736847, 0), nil},
@@ -69,12 +68,73 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestTimeUnmarshalJSONEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	initial := Time(time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC))
+	for _, tc := range []struct {
+		name  string
+		input []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testTime := initial
+			err := testTime.UnmarshalJSON(tc.input)
+			require.NoErrorf(t, err, "Time.UnmarshalJSON must not error for %s input", tc.name)
+			assert.Equalf(t, initial, testTime, "Time.UnmarshalJSON should preserve Time for %s input", tc.name)
+		})
+	}
+}
+
 func BenchmarkUnmarshalJSON(b *testing.B) {
-	var testTime Time
-	for b.Loop() {
-		if err := json.Unmarshal([]byte(`"1691122380942.173000"`), &testTime); err != nil {
-			b.Fatal(err)
-		}
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{"seconds", `"1628736847"`, time.Unix(1628736847, 0)},
+		{"padded_width", `"16287368473"`, time.UnixMilli(1628736847300)},
+		{"fractional", `"1691122380942.173000"`, time.Unix(0, 1691122380942173000)},
+		{"date", `"20200325"`, time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC)},
+	} {
+		data := []byte(tc.input)
+		b.Run("direct/"+tc.name, func(b *testing.B) {
+			b.StopTimer()
+			var testTime Time
+			if err := testTime.UnmarshalJSON(data); err != nil {
+				b.Fatal(err)
+			}
+			if got := testTime.Time(); !got.Equal(tc.want) {
+				b.Fatalf("UnmarshalJSON returned %v, want %v", got, tc.want)
+			}
+			b.ReportAllocs()
+			b.StartTimer()
+			for b.Loop() {
+				if err := testTime.UnmarshalJSON(data); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("decoder/"+tc.name, func(b *testing.B) {
+			b.StopTimer()
+			var testTime Time
+			if err := json.Unmarshal(data, &testTime); err != nil {
+				b.Fatal(err)
+			}
+			if got := testTime.Time(); !got.Equal(tc.want) {
+				b.Fatalf("json.Unmarshal returned %v, want %v", got, tc.want)
+			}
+			b.ReportAllocs()
+			b.StartTimer()
+			for b.Loop() {
+				if err := json.Unmarshal(data, &testTime); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -26,17 +26,28 @@ func TestUnmarshalJSON(t *testing.T) {
 		{`"0.00000"`, time.Time{}, nil},
 		{`"0.0.0.0"`, time.Time{}, strconv.ErrSyntax},
 		{`"0.1"`, time.Time{}, ErrInvalidTimestampFormat},
+		{`"202003.25"`, time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC), nil},
 		{`"20200325"`, time.Date(2020, 3, 25, 0, 0, 0, 0, time.UTC), nil},
+		{"1628736847", time.Unix(1628736847, 0), nil},
 		{`"1628736847"`, time.Unix(1628736847, 0), nil},
+		{`"-123456789.5"`, time.UnixMilli(-123456789500), nil},
 		{`"1726104395.5"`, time.UnixMilli(1726104395500), nil},
 		{`"1726104395.56"`, time.UnixMilli(1726104395560), nil},
+		{`"16287368473"`, time.UnixMilli(1628736847300), nil},
+		{`"162873684732"`, time.UnixMilli(1628736847320), nil},
 		{`"1628736847325"`, time.UnixMilli(1628736847325), nil},
+		{`"16287368473251"`, time.UnixMicro(1628736847325100), nil},
+		{`"162873684732512"`, time.UnixMicro(1628736847325120), nil},
 		{`"1628736847325123"`, time.UnixMicro(1628736847325123), nil},
 		{`"1726106210903.0"`, time.UnixMicro(1726106210903000), nil},
 		{`"1747278712.09328"`, time.UnixMicro(1747278712093280), nil},
+		{`"16062922182134578"`, time.Unix(0, 1606292218213457800), nil},
+		{`"160629221821345780"`, time.Unix(0, 1606292218213457800), nil},
 		{`"1606292218213.4578"`, time.Unix(0, 1606292218213457800), nil},
 		{`"1560516023.070651"`, time.Unix(0, 1560516023070651000), nil},
 		{`"1606292218213457800"`, time.Unix(0, 1606292218213457800), nil},
+		{`"00000000000000000000.0"`, time.Time{}, nil},
+		{`"12345678901234567890.1"`, time.Time{}, strconv.ErrRange},
 		{`"blurp"`, time.Time{}, strconv.ErrSyntax},
 		{`"123456"`, time.Time{}, ErrInvalidTimestampFormat},
 		{`"12345678"`, time.Time{}, ErrInvalidTimestampFormat},
@@ -46,15 +57,18 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 			var testTime Time
-			err := json.Unmarshal([]byte(tc.input), &testTime)
-			require.ErrorIsf(t, err, tc.expError, "Unmarshal must not error for input %q", tc.input)
-			assert.Equal(t, tc.want, testTime.Time())
+			err := testTime.UnmarshalJSON([]byte(tc.input))
+			require.ErrorIsf(t, err, tc.expError, "UnmarshalJSON must return the expected error for input %q", tc.input)
+			assert.Equalf(t, tc.want, testTime.Time(), "UnmarshalJSON should set Time correctly for input %q", tc.input)
+
+			var decoded Time
+			err = json.Unmarshal([]byte(tc.input), &decoded)
+			require.ErrorIsf(t, err, tc.expError, "json.Unmarshal must return the expected error for input %q", tc.input)
+			assert.Equalf(t, tc.want, decoded.Time(), "json.Unmarshal should set Time correctly for input %q", tc.input)
 		})
 	}
 }
 
-// 3948978         303.5 ns/op       168 B/op          2 allocs/op (current) after more stringent checks
-// 6152384         195.5 ns/op       168 B/op          2 allocs/op (previous)
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	var testTime Time
 	for b.Loop() {


### PR DESCRIPTION
## Summary

- normalise supported timestamp bytes in a bounded local buffer instead of materialising and concatenating intermediate strings
- return safely for direct nil or empty byte input without changing the receiver, while preserving existing null, zero, quoted/unquoted, and error behaviour
- extend direct and decoder coverage across supported timestamp widths, buffer boundaries, signs, and deterministic errors without treating dotted calendar dates as a supported format
- benchmark four representative quoted timestamp shapes at both the direct method and project JSON decoder boundaries

## Performance

Measured the four retained benchmark cases between the PR base (Before) and current head (After) with an identical harness and 20 counterbalanced fresh-process observations per revision on Go 1.26.5/Linux amd64 with `GOMAXPROCS=1`, a pinned CPU, PGO disabled, and one second per row:

| Path | Before time/op | After time/op | Change | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| direct/seconds | 55.67 ns ±2% | 32.10 ns ±2% | -42.34% (`p=0.000`) | 16 → 0 | 1 → 0 |
| decoder/seconds | 229.2 ns ±1% | 209.1 ns ±1% | -8.75% (`p=0.000`) | 160 → 144 | 2 → 1 |
| direct/padded_width | 97.26 ns ±2% | 40.50 ns ±2% | -58.36% (`p=0.000`) | 32 → 0 | 2 → 0 |
| decoder/padded_width | 280.3 ns ±1% | 225.5 ns ±1% | -19.55% (`p=0.000`) | 176 → 144 | 3 → 1 |
| direct/fractional | 119.55 ns ±1% | 56.73 ns ±1% | -52.54% (`p=0.000`) | 48 → 0 | 2 → 0 |
| decoder/fractional | 335.3 ns ±2% | 279.4 ns ±1% | -16.70% (`p=0.000`) | 192 → 144 | 3 → 1 |
| direct/date | 102.7 ns ±1% | 102.9 ns ±1% | no significant difference detected at n=20 (`p=0.542`) | 16 → 8 | 1 → 1 |
| decoder/date | 281.2 ns ±2% | 285.7 ns ±1% | +1.58% (`p=0.027`, exploratory) | 160 → 152 | 2 → 2 |

The `±` values are Benchstat's 95% confidence intervals for each median, and each displayed `p=0.000` is rounded rather than zero. The direct and decoder fractional rows were the preselected timing claims and both remain significant after Holm correction. The other timing rows are descriptive; allocation values were identical across all 20 observations per revision at the printed precision.

- Relevance: measures the changed timestamp parser directly and through the project decoder, including no-padding, padding, fractional normalisation, and calendar-date paths.
- Related checks: the date path retained its allocation counts while reducing B/op; its direct timing had no significant difference, while the small decoder timing increase is exploratory.
- Limitations: results are from one serial microbenchmark host and do not establish exchange/websocket throughput, multi-core scaling, or production tail latency.

## Validation

- `go test ./types -run '^(TestUnmarshalJSON|TestTimeUnmarshalJSONEmptyInput)$' -count=1000`
- `go test ./types -count=10`
- `go test -race ./types -count=1`
- `go test -tags=sonic_on ./types -count=10`
- `go test -race -tags=sonic_on ./types -count=1`
- `go test ./types -run '^$' -bench '^BenchmarkUnmarshalJSON$' -benchtime=1x -count=1`
- `make lint`
- `codespell .`
- `make misc_checks`
