### PR TITLE
exchanges/btcmarkets: fix trade pagination cursors

### DIFF
--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	errInvalidAmount = errors.New("cannot be less than or equal to zero")
-	errIDRequired    = errors.New("id is required")
+	errConflictingPaginationCursors = errors.New("BTCMarkets only supports either before or after, not both")
+	errInvalidAmount                = errors.New("cannot be less than or equal to zero")
+	errIDRequired                   = errors.New("id is required")
 )
 
 const (
@@ -115,7 +116,7 @@ func (e *Exchange) GetTicker(ctx context.Context, marketID string) (Ticker, erro
 // GetTrades returns executed trades on the exchange
 func (e *Exchange) GetTrades(ctx context.Context, marketID string, before, after, limit int64) ([]Trade, error) {
 	if before > 0 && after > 0 {
-		return nil, errors.New("BTCMarkets only supports either before or after, not both")
+		return nil, errConflictingPaginationCursors
 	}
 	var trades []Trade
 	params := url.Values{}

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -114,7 +114,7 @@ func (e *Exchange) GetTicker(ctx context.Context, marketID string) (Ticker, erro
 
 // GetTrades returns executed trades on the exchange
 func (e *Exchange) GetTrades(ctx context.Context, marketID string, before, after, limit int64) ([]Trade, error) {
-	if (before > 0) && (after >= 0) {
+	if before > 0 && after > 0 {
 		return nil, errors.New("BTCMarkets only supports either before or after, not both")
 	}
 	var trades []Trade

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -1,8 +1,13 @@
 package btcmarkets
 
 import (
+	"context"
 	"encoding/base64"
 	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -68,6 +73,77 @@ func TestGetTrades(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetTrades(t.Context(), spotTestPair.String(), 0, 0, 5)
 	assert.NoError(t, err, "GetTrades should not error")
+}
+
+func TestGetTradesPagination(t *testing.T) {
+	queryC := make(chan url.Values, 1)
+	responseErrC := make(chan error, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryC <- r.URL.Query()
+		_, err := w.Write([]byte("[]"))
+		responseErrC <- err
+	}))
+	t.Cleanup(server.Close)
+
+	client := server.Client()
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "Test server transport must be an HTTP transport")
+	transport.TLSClientConfig.ServerName = "example.com"
+	dialer := new(net.Dialer)
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+
+	ex := new(Exchange)
+	ex.SetDefaults()
+	require.NoError(t, ex.SetHTTPClient(client), "Setting the test HTTP client must not error")
+
+	for _, tc := range []struct {
+		name          string
+		before        int64
+		after         int64
+		limit         int64
+		expectedQuery url.Values
+		expectedError string
+	}{
+		{
+			name:          "No pagination",
+			expectedQuery: url.Values{},
+		},
+		{
+			name:   "Before cursor",
+			before: 78234976,
+			limit:  10,
+			expectedQuery: url.Values{
+				"before": {"78234976"},
+				"limit":  {"10"},
+			},
+		},
+		{
+			name:  "After cursor",
+			after: 78234876,
+			expectedQuery: url.Values{
+				"after": {"78234876"},
+			},
+		},
+		{
+			name:          "Both cursors",
+			before:        78234976,
+			after:         78234876,
+			expectedError: "BTCMarkets only supports either before or after, not both",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ex.GetTrades(t.Context(), spotTestPair.String(), tc.before, tc.after, tc.limit)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError, "GetTrades should reject conflicting cursors")
+				return
+			}
+			require.NoError(t, err, "GetTrades must accept valid pagination")
+			require.NoError(t, <-responseErrC, "Writing the response must not error")
+			assert.Equal(t, tc.expectedQuery, <-queryC, "GetTrades should send the expected query")
+		})
+	}
 }
 
 func TestGetOrderbook(t *testing.T) {

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -1,13 +1,8 @@
 package btcmarkets
 
 import (
-	"context"
 	"encoding/base64"
 	"log"
-	"net"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -71,77 +66,41 @@ func TestGetTicker(t *testing.T) {
 
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetTrades(t.Context(), spotTestPair.String(), 0, 0, 5)
-	assert.NoError(t, err, "GetTrades should not error")
-}
-
-func TestGetTradesPagination(t *testing.T) {
-	queryC := make(chan url.Values, 1)
-	responseErrC := make(chan error, 1)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		queryC <- r.URL.Query()
-		_, err := w.Write([]byte("[]"))
-		responseErrC <- err
-	}))
-	t.Cleanup(server.Close)
-
-	client := server.Client()
-	transport, ok := client.Transport.(*http.Transport)
-	require.True(t, ok, "Test server transport must be an HTTP transport")
-	transport.TLSClientConfig.ServerName = "example.com"
-	dialer := new(net.Dialer)
-	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
-		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
-	}
-
-	ex := new(Exchange)
-	ex.SetDefaults()
-	require.NoError(t, ex.SetHTTPClient(client), "Setting the test HTTP client must not error")
 
 	for _, tc := range []struct {
-		name          string
-		before        int64
-		after         int64
-		limit         int64
-		expectedQuery url.Values
-		expectedError string
+		name        string
+		before      int64
+		after       int64
+		limit       int64
+		expectedErr error
 	}{
 		{
-			name:          "No pagination",
-			expectedQuery: url.Values{},
+			name:  "No pagination",
+			limit: 5,
 		},
 		{
 			name:   "Before cursor",
 			before: 78234976,
-			limit:  10,
-			expectedQuery: url.Values{
-				"before": {"78234976"},
-				"limit":  {"10"},
-			},
 		},
 		{
 			name:  "After cursor",
 			after: 78234876,
-			expectedQuery: url.Values{
-				"after": {"78234876"},
-			},
 		},
 		{
-			name:          "Both cursors",
-			before:        78234976,
-			after:         78234876,
-			expectedError: "BTCMarkets only supports either before or after, not both",
+			name:        "Both cursors",
+			before:      78234976,
+			after:       78234876,
+			expectedErr: errConflictingPaginationCursors,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ex.GetTrades(t.Context(), spotTestPair.String(), tc.before, tc.after, tc.limit)
-			if tc.expectedError != "" {
-				assert.EqualError(t, err, tc.expectedError, "GetTrades should reject conflicting cursors")
+			t.Parallel()
+			_, err := e.GetTrades(t.Context(), spotTestPair.String(), tc.before, tc.after, tc.limit)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(t, err, tc.expectedErr, "GetTrades should error correctly")
 				return
 			}
-			require.NoError(t, err, "GetTrades must accept valid pagination")
-			require.NoError(t, <-responseErrC, "Writing the response must not error")
-			assert.Equal(t, tc.expectedQuery, <-queryC, "GetTrades should send the expected query")
+			assert.NoError(t, err, "GetTrades should not error")
 		})
 	}
 }


### PR DESCRIPTION
# PR Description

BTC Markets trade requests rejected before-only pagination whenever `after` was left at its zero value, even though zero is omitted from the outgoing query. This prevented callers from using a `before` cursor without also triggering the conflicting-cursor error.

This change rejects pagination only when both cursors are positive and returns a package-level sentinel for conflicts. It extends `TestGetTrades` with cases covering requests with no cursor, a before cursor, an after cursor, and conflicting cursors.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] go test ./exchanges/btcmarkets -race -count=1
- [x] go test ./exchanges/btcmarkets -run '^TestGetTrades$' -race -count=20
- [x] make misc_checks
- [x] codespell

The focused before-only pagination case fails against the base and passes after the change. The full repository race suite was not run locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Documentation changes and regeneration are not required for this pagination-validation correction. Local package tests pass. There are no dependent downstream changes.
