### PR TITLE
cmd/dbseed: migrate load test to testify

### DIFF
--- a/cmd/dbseed/dbseed_test.go
+++ b/cmd/dbseed/dbseed_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/core"
 	"github.com/urfave/cli/v2"
 )
@@ -38,7 +39,5 @@ func TestLoad(t *testing.T) {
 	fs := &flag.FlagSet{}
 	fs.String("config", testConfig, "")
 	newCtx := cli.NewContext(testApp, fs, &cli.Context{})
-	if err := load(newCtx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, load(newCtx), "load must not error")
 }


### PR DESCRIPTION
# PR Description

The `cmd/dbseed` `TestLoad` test used a raw fatal branch when `load` returned an error. This replaces that branch with Testify's `require.NoError` and an operation-specific failure message, preserving the same fatal control flow while improving failure diagnostics.

No production code, test input, setup, or coverage changed.

No linked issue.

## Type of change

- [x] Test refactor (no production behaviour change)

## How has this been tested

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] go test ./cmd/dbseed -race -count=1
- [x] go test ./cmd/dbseed -run '^TestLoad$' -count=50
- [x] go test ./cmd/dbseed -run '^TestLoad$' -race -count=20
- [x] make misc_checks
- [x] codespell

The test list remains `TestLoad`, the atomic coverage profile is unchanged at 11.3%, and five local 50-count timing runs had identical 1.68-second before/after medians. The full repository race suite and GitHub Actions have not run.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Comments and documentation changes are not applicable to this assertion-only test refactor. It preserves the existing direct test rather than adding a new one. The focused and package tests pass locally, but the complete repository suite and GitHub Actions have not run. There are no dependent downstream changes.