### PR TITLE
currency: reduce pair join allocations

### DIFF
--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -63,13 +63,14 @@ func (p Pairs) Join() string {
 	}
 
 	// Build directly to avoid allocating an intermediate string for each pair.
-	size := len(p) - 1
+	// len(p) - 1 accounts for the commas inserted between pairs.
+	outputLen := len(p) - 1
 	for i := range p {
-		size += len(p[i].Base.String()) + len(p[i].Delimiter) + len(p[i].Quote.String())
+		outputLen += len(p[i].Base.String()) + len(p[i].Delimiter) + len(p[i].Quote.String())
 	}
 
 	var joined strings.Builder
-	joined.Grow(size)
+	joined.Grow(outputLen)
 	for i := range p {
 		if i > 0 {
 			joined.WriteByte(',')

--- a/currency/pairs.go
+++ b/currency/pairs.go
@@ -55,7 +55,30 @@ func (p Pairs) Strings() []string {
 
 // Join returns a comma separated list of currency pairs
 func (p Pairs) Join() string {
-	return strings.Join(p.Strings(), ",")
+	switch len(p) {
+	case 0:
+		return ""
+	case 1:
+		return p[0].String()
+	}
+
+	// Build directly to avoid allocating an intermediate string for each pair.
+	size := len(p) - 1
+	for i := range p {
+		size += len(p[i].Base.String()) + len(p[i].Delimiter) + len(p[i].Quote.String())
+	}
+
+	var joined strings.Builder
+	joined.Grow(size)
+	for i := range p {
+		if i > 0 {
+			joined.WriteByte(',')
+		}
+		joined.WriteString(p[i].Base.String())
+		joined.WriteString(p[i].Delimiter)
+		joined.WriteString(p[i].Quote.String())
+	}
+	return joined.String()
 }
 
 // Format formats the pair list to the exchange format configuration

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -71,15 +71,39 @@ func TestPairsFromString(t *testing.T) {
 
 func TestPairsJoin(t *testing.T) {
 	t.Parallel()
-	pairs, err := NewPairsFromStrings([]string{"btc_usd", "btc_aud", "btc_ltc"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := "btc_usd,btc_aud,btc_ltc"
 
-	if pairs.Join() != expected {
-		t.Errorf("Pairs Join() error expected %s but received %s",
-			expected, pairs.Join())
+	for _, tc := range []struct {
+		name     string
+		pairs    Pairs
+		expected string
+	}{
+		{
+			name: "Empty",
+		},
+		{
+			name:     "Single",
+			pairs:    Pairs{NewPairWithDelimiter("btc", "usd", "_")},
+			expected: "btc_usd",
+		},
+		{
+			name: "Multiple",
+			pairs: Pairs{
+				NewPairWithDelimiter("btc", "usd", "_"),
+				NewPairWithDelimiter("btc", "aud", "_"),
+				NewPairWithDelimiter("btc", "ltc", "_"),
+			},
+			expected: "btc_usd,btc_aud,btc_ltc",
+		},
+		{
+			name:     "Empty pair components",
+			pairs:    Pairs{EMPTYPAIR, NewPairWithDelimiter("btc", "usd", "_")},
+			expected: ",btc_usd",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, tc.pairs.Join(), "Join should return the correct value")
+		})
 	}
 }
 
@@ -489,6 +513,22 @@ func BenchmarkPairsString(b *testing.B) {
 
 	for b.Loop() {
 		_ = pairs.Strings()
+	}
+}
+
+func BenchmarkPairsJoin(b *testing.B) {
+	pairs := Pairs{
+		NewBTCUSD(),
+		NewPair(LTC, USD),
+		NewPair(USD, NZD),
+		NewPair(LTC, USDT),
+		NewPair(LTC, DAI),
+		NewPair(USDT, XRP),
+		NewPair(DAI, XRP),
+	}
+
+	for b.Loop() {
+		_ = pairs.Join()
 	}
 }
 

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -516,9 +516,9 @@ func BenchmarkPairsString(b *testing.B) {
 	}
 }
 
-// benchstat medians (10 alternating samples per revision):
-// Current (6da7f2cc): 135.9 ns/op      64 B/op      1 allocs/op
-// Prev (301d9636):    477.8 ns/op     232 B/op      9 allocs/op
+// Benchstat medians (10 alternating samples per revision):
+// Before: 477.8 ns/op  232 B/op  9 allocs/op
+// After:  135.9 ns/op   64 B/op  1 alloc/op
 func BenchmarkPairsJoin(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -516,6 +516,9 @@ func BenchmarkPairsString(b *testing.B) {
 	}
 }
 
+// benchstat medians (10 alternating samples per revision):
+// Current (6da7f2cc): 135.9 ns/op      64 B/op      1 allocs/op
+// Prev (301d9636):    477.8 ns/op     232 B/op      9 allocs/op
 func BenchmarkPairsJoin(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),


### PR DESCRIPTION
## Summary

- build comma-separated currency-pair lists directly into one pre-sized buffer
- preserve empty, single, formatted, and partially empty pair behaviour
- add direct branch coverage and a reproducible seven-pair benchmark

## Performance

Measured `Pairs.Join` for a deterministic seven-pair workload with an identical harness, one pinned logical CPU, `GOMAXPROCS=1`, and 10 alternating observations per revision:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| time/op | 477.8 ns ±14% | 135.9 ns ±8% | -71.55% (p=0.000) |
| B/op | 232 B/op | 64 B/op | -72.41% |
| allocs/op | 9 allocs/op | 1 alloc/op | -88.89% |

The ± values are Benchstat confidence intervals for the medians.

- Relevance: this isolates the production `Pairs.Join` operation used to build comma-separated pair lists.
- Related checks: `BenchmarkPairsString`, `BenchmarkPairsFormat`, and `BenchmarkRemovePairsByFilter` had no significant timing difference detected at n=10.
- Limitations: single-host microbenchmark of one deterministic workload; it does not establish aggregate call frequency, end-to-end throughput, or tail latency.

## Validation

- `go test ./currency -run '^TestPairsJoin$' -count=100`
- `go test ./currency -count=1`
- `go test -race ./currency -count=1`
- `make lint`
- `codespell`
- `make misc_checks`
