### PR TITLE
cmd/benchcheck: Add new centralised benchmark tool 

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,58 @@
+name: benchmarks
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1-5'
+  workflow_dispatch:
+env:
+  GO_VERSION: 1.26.x
+
+jobs:
+  gate:
+    name: allocation gate
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check allocations against baseline
+        run: make bench
+
+  trend:
+    name: ns/op trend
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && github.repository == 'thrasher-corp/gocryptotrader'
+      && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: benchmarks-history
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch existing history
+        run: bash ./scripts/bench_history.sh fetch series.jsonl
+
+      - name: Run benchmarks and append to history
+        run: make bench_trend BENCH_SERIES=series.jsonl
+
+      - name: Publish history
+        env:
+          BENCH_HISTORY_LABEL: ${{ github.sha }}
+          GIT_AUTHOR_NAME: 'github-actions[bot]'
+          GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+        run: bash ./scripts/bench_history.sh publish series.jsonl

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,58 @@
+name: benchmarks
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1-5'
+  workflow_dispatch:
+env:
+  GO_VERSION: 1.26.x
+
+jobs:
+  gate:
+    name: allocation gate
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check allocations against baseline
+        run: make bench BENCHCHECK_FLAGS=-warn
+
+  trend:
+    name: ns/op trend
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && github.repository == 'thrasher-corp/gocryptotrader'
+      && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: benchmarks-history
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch existing history
+        run: ./scripts/bench_history.sh fetch series.jsonl
+
+      - name: Run benchmarks and append to history
+        run: make bench_trend BENCH_SERIES=series.jsonl
+
+      - name: Publish history
+        env:
+          BENCH_HISTORY_LABEL: ${{ github.sha }}
+          GIT_AUTHOR_NAME: 'github-actions[bot]'
+          GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+        run: ./scripts/bench_history.sh publish series.jsonl

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check allocations against baseline
-        run: make bench BENCHCHECK_FLAGS=-warn
+        run: make bench
 
   trend:
     name: ns/op trend
@@ -45,7 +45,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Fetch existing history
-        run: ./scripts/bench_history.sh fetch series.jsonl
+        run: bash ./scripts/bench_history.sh fetch series.jsonl
 
       - name: Run benchmarks and append to history
         run: make bench_trend BENCH_SERIES=series.jsonl
@@ -55,4 +55,4 @@ jobs:
           BENCH_HISTORY_LABEL: ${{ github.sha }}
           GIT_AUTHOR_NAME: 'github-actions[bot]'
           GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com'
-        run: ./scripts/bench_history.sh publish series.jsonl
+        run: bash ./scripts/bench_history.sh publish series.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ vendor/
 gocryptotrader
 /backtester/backtester
 cmd/gctcli/gctcli
+/benchcheck
+cmd/benchcheck/benchcheck
 backtester/backtester
 backtester/btcli/btcli
 *.exe
@@ -48,3 +50,5 @@ coverage.txt
 wrapperconfig.json
 .history/
 .codex
+benchmarks/series.jsonl
+.bench-output*.txt

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,25 @@ DRIVER ?= psql
 RACE_FLAG := $(if $(NO_RACE_TEST),,-race)
 CONFIG_FLAG = $(if $(CONFIG),-config $(CONFIG),)
 
-.PHONY: all lint lint_docker misc_checks check test build install fmt gofumpt update_deps
+.PHONY: all lint lint_docker misc_checks check test build install fmt gofumpt update_deps bench bench_update bench_trend check_bench_pkgs bench_pkg
+
+# Edit benchmarks/packages.txt to change which packages are benchmarked.
+BENCH_PKGS = $(shell go run ./cmd/benchcheck -list)
+
+# BENCH_FLAGS must stay identical between bench and bench_update, so recorded and compared values
+# are produced the same way.
+#
+# BENCH_SAMPLES must stay odd: benchcheck compares the median, and an even count has no middle
+# sample. -cpu and -p pin what a scheduler-sensitive benchmark measures, so CI and a developer's
+# machine agree; keep -cpu single valued, or `-cpu 1,4` files two populations under one key.
+BENCH_SAMPLES = 7
+BENCH_FLAGS = -run '^$$' -bench . -benchmem -benchtime 100ms -count $(BENCH_SAMPLES) -cpu 4 -p 1 -timeout 20m
+
+# BENCH_TREND_FLAGS feed the scheduled ns/op history, where tight confidence intervals do matter and
+# a long runtime is affordable. Never use these for the PR gate; they take over ten minutes.
+BENCH_TREND_SAMPLES = 15
+BENCH_TREND_FLAGS = -run '^$$' -bench . -benchmem -benchtime 1s -count $(BENCH_TREND_SAMPLES) -cpu 4 -p 1 -timeout 60m
+BENCH_SERIES = benchmarks/series.jsonl
 
 all: check build
 
@@ -27,6 +45,50 @@ misc_checks:
 	bash ./scripts/misc_checks.sh
 
 check: lint misc_checks test
+
+# $(shell) swallows the exit status, so a benchcheck that fails to build or a missing packages.txt
+# would leave BENCH_PKGS empty. go test would then benchmark the current directory instead and the
+# run would fail later with a misleading "no benchmark results".
+check_bench_pkgs:
+	@test -n "$(BENCH_PKGS)" || { \
+		echo "no benchmark packages resolved; check benchmarks/packages.txt and 'go run ./cmd/benchcheck -list'"; \
+		exit 1; \
+	}
+
+# BENCHCHECK_FLAGS lets CI add -warn without restating BENCH_FLAGS, so the flags have one home.
+BENCHCHECK_FLAGS ?=
+
+# go test writes to a file rather than a pipe so a failing run aborts the target; through a pipe
+# benchcheck reads partial output and, with -update, saves a baseline before go test's exit status
+# is known. The PID keeps two terminals in one checkout off the same file, and the file is removed
+# on success and left for inspection on failure. .gitignore covers the pattern.
+bench: check_bench_pkgs
+	out=.bench-output-$@-$$$$.txt && \
+		go test $(BENCH_FLAGS) $(BENCH_PKGS) > $$out && \
+		go run ./cmd/benchcheck -samples $(BENCH_SAMPLES) $(BENCHCHECK_FLAGS) < $$out && \
+		rm -f $$out
+
+# Measures one package with the gate's exact flags, for auditing a package before gating it.
+# Usage: make bench_pkg PKG=./currency/
+bench_pkg:
+	@test -n "$(PKG)" || { echo "set PKG, e.g. make bench_pkg PKG=./currency/"; exit 1; }
+	go test $(BENCH_FLAGS) $(PKG)
+
+bench_update: check_bench_pkgs
+	out=.bench-output-$@-$$$$.txt && \
+		go test $(BENCH_FLAGS) $(BENCH_PKGS) > $$out && \
+		go run ./cmd/benchcheck -samples $(BENCH_SAMPLES) -update -prune < $$out && \
+		rm -f $$out
+
+# -warn keeps a benchmark that reported the wrong number of samples from discarding the whole run:
+# benchcheck drops that record and appends the rest. A ten minute measurement should not be lost to
+# one short benchmark.
+bench_trend: check_bench_pkgs
+	out=.bench-output-$@-$$$$.txt && \
+		go test $(BENCH_TREND_FLAGS) $(BENCH_PKGS) > $$out && \
+		sha=$$(git rev-parse HEAD) && \
+		go run ./cmd/benchcheck -samples $(BENCH_TREND_SAMPLES) -series $(BENCH_SERIES) -commit "$$sha" -warn < $$out && \
+		rm -f $$out
 
 test:
 	go test $(RACE_FLAG) -coverprofile=coverage.txt -covermode=atomic  ./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,33 @@ DRIVER ?= psql
 RACE_FLAG := $(if $(NO_RACE_TEST),,-race)
 CONFIG_FLAG = $(if $(CONFIG),-config $(CONFIG),)
 
-.PHONY: all lint lint_docker misc_checks check test build install fmt gofumpt update_deps
+.PHONY: all lint lint_docker misc_checks check test build install fmt gofumpt update_deps bench bench_update bench_trend check_bench_pkgs bench_pkg
+
+# Edit benchmarks/packages.txt to change which packages are benchmarked.
+BENCH_PKGS = $(shell go run ./cmd/benchcheck -list)
+
+# BENCH_FLAGS gates allocations on every PR and must stay identical between bench and bench_update
+# so recorded and compared values are produced the same way. It is deliberately cheap: allocs/op is
+# per-iteration and reproducible, so a longer benchtime or a higher count buys the gate nothing.
+#
+# -cpu 4 pins GOMAXPROCS inside each test binary so a benchmark measures the same parallelism on CI
+# as on a developer's machine. It does not pin -p, the number of package binaries run concurrently,
+# which still defaults to the host's core count, so a scheduler-sensitive benchmark could still vary
+# between machines; -p 1 closes that gap by running one package binary at a time.
+BENCH_FLAGS = -run '^$$' -bench . -benchmem -benchtime 100ms -count 6 -cpu 4 -p 1 -timeout 20m
+
+# BENCH_TREND_FLAGS feed the scheduled ns/op history, where tight confidence intervals do matter and
+# a long runtime is affordable. Never use these for the PR gate; they take over ten minutes.
+BENCH_TREND_FLAGS = -run '^$$' -bench . -benchmem -benchtime 1s -count 15 -cpu 4 -p 1 -timeout 60m
+BENCH_SERIES = benchmarks/series.jsonl
+
+# go test writes to a file rather than a pipe so a failing run aborts the target. In a pipeline the
+# two processes run concurrently, so benchcheck could read partial output and, with -update, save a
+# pruned baseline before the shell ever saw go test's exit status.
+#
+# Named per target ($@): a single shared path lets `make -j2 bench bench_trend`, or two terminals,
+# truncate and read the same file at once, so one run parses the other's partial output.
+BENCH_OUT = .bench-output-$@.txt
 
 all: check build
 
@@ -27,6 +53,37 @@ misc_checks:
 	bash ./scripts/misc_checks.sh
 
 check: lint misc_checks test
+
+# $(shell) swallows the exit status, so a benchcheck that fails to build or a missing packages.txt
+# would leave BENCH_PKGS empty. go test would then benchmark the current directory instead and the
+# run would fail later with a misleading "no benchmark results".
+check_bench_pkgs:
+	@test -n "$(BENCH_PKGS)" || { \
+		echo "no benchmark packages resolved; check benchmarks/packages.txt and 'go run ./cmd/benchcheck -list'"; \
+		exit 1; \
+	}
+
+# BENCHCHECK_FLAGS lets CI add -warn without restating BENCH_FLAGS, so the flags have one home.
+BENCHCHECK_FLAGS ?=
+
+bench: check_bench_pkgs
+	go test $(BENCH_FLAGS) $(BENCH_PKGS) > $(BENCH_OUT)
+	go run ./cmd/benchcheck $(BENCHCHECK_FLAGS) < $(BENCH_OUT)
+
+# Measures one package with the gate's exact flags, for auditing a package before gating it.
+# Usage: make bench_pkg PKG=./currency/
+bench_pkg:
+	@test -n "$(PKG)" || { echo "set PKG, e.g. make bench_pkg PKG=./currency/"; exit 1; }
+	go test $(BENCH_FLAGS) $(PKG)
+
+bench_update: check_bench_pkgs
+	go test $(BENCH_FLAGS) $(BENCH_PKGS) > $(BENCH_OUT)
+	go run ./cmd/benchcheck -update -prune < $(BENCH_OUT)
+
+bench_trend: check_bench_pkgs
+	go test $(BENCH_TREND_FLAGS) $(BENCH_PKGS) > $(BENCH_OUT)
+	sha=$$(git rev-parse HEAD) && \
+		go run ./cmd/benchcheck -series $(BENCH_SERIES) -commit "$$sha" -warn < $(BENCH_OUT)
 
 test:
 	go test $(RACE_FLAG) -coverprofile=coverage.txt -covermode=atomic  ./...

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,256 @@
+{
+  "common.BenchmarkCounter": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 4.58
+  },
+  "common/math.BenchmarkDecimalPercentageDifference": {
+    "allocs": 27,
+    "bytes": 792,
+    "ns_hint": 1233
+  },
+  "common/math.BenchmarkPercentageDifference": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 0.72
+  },
+  "common/timedmutex.BenchmarkTimedMutexTime": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 819.7
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeLinearInteraction": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 101.7
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeUnlockNotPrimed": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 1.94
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeUnlockPrimed": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 26.6
+  },
+  "config.BenchmarkUpdateConfig": {
+    "allocs": 40490,
+    "allocs_tolerance": 0.001,
+    "bytes": 9897592,
+    "ns_hint": 18414186,
+    "reason": "40490 on almost every sample but 40491 has been observed; the tolerance is a few dozen allocations against a 40k budget, far below any real regression"
+  },
+  "currency.BenchmarkFindDifferences": {
+    "allocs": 2,
+    "bytes": 288,
+    "ns_hint": 653
+  },
+  "currency.BenchmarkFindMatchingPairsBetween": {
+    "allocs": 2,
+    "bytes": 944,
+    "ns_hint": 808
+  },
+  "currency.BenchmarkGetCrypto": {
+    "allocs": 1,
+    "bytes": 48,
+    "ns_hint": 143.9
+  },
+  "currency.BenchmarkNewCode": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 99.4
+  },
+  "currency.BenchmarkPairsFormat": {
+    "allocs": 1,
+    "bytes": 352,
+    "ns_hint": 209.1
+  },
+  "currency.BenchmarkPairsString": {
+    "allocs": 7,
+    "bytes": 56,
+    "ns_hint": 252.6
+  },
+  "currency.BenchmarkRemovePairsByFilter": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 26.6
+  },
+  "dispatch.BenchmarkSubscribe": {
+    "allocs": 1,
+    "bytes": 158,
+    "bytes_tolerance": 0.1,
+    "ns_hint": 206,
+    "reason": "worker goroutines make B/op scheduler dependent; observed 151-161 across runs"
+  },
+  "encoding/json.BenchmarkUnmarshal": {
+    "allocs": 24,
+    "bytes": 816,
+    "ns_hint": 2048
+  },
+  "exchanges/gateio.BenchmarkMessageID": {
+    "allocs": 2,
+    "bytes": 48,
+    "ns_hint": 183.6
+  },
+  "exchanges/gateio.BenchmarkTimeInForceFromString": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 41
+  },
+  "exchanges/okx.BenchmarkMessageID": {
+    "allocs": 2,
+    "bytes": 48,
+    "ns_hint": 178.8
+  },
+  "exchanges/order.BenchmarkFilterOrdersByPairs": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 121.7
+  },
+  "exchanges/order.BenchmarkFilterOrdersBySide": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 67
+  },
+  "exchanges/order.BenchmarkFilterOrdersByTimeRange": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 322
+  },
+  "exchanges/order.BenchmarkFilterOrdersByType": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 66.7
+  },
+  "exchanges/order.BenchmarkIsActive": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 1.94
+  },
+  "exchanges/order.BenchmarkIsInactive": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 166.2
+  },
+  "exchanges/order.BenchmarkStringToOrderSide": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 42.9
+  },
+  "exchanges/order.BenchmarkStringToOrderStatus": {
+    "allocs": 1,
+    "bytes": 24,
+    "ns_hint": 159.6
+  },
+  "exchanges/order.BenchmarkStringToOrderType": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 48.2
+  },
+  "exchanges/order.BenchmarkStringToTimeInForce": {
+    "allocs": 13,
+    "bytes": 272,
+    "ns_hint": 1704
+  },
+  "exchanges/orderbook.BenchmarkDeleteByID": {
+    "allocs": 1,
+    "bytes": 480,
+    "ns_hint": 308.6
+  },
+  "exchanges/orderbook.BenchmarkLoad": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 17
+  },
+  "exchanges/orderbook.BenchmarkProcess": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 282.3
+  },
+  "exchanges/orderbook.BenchmarkRetrieve": {
+    "allocs": 1,
+    "bytes": 480,
+    "ns_hint": 220.8
+  },
+  "exchanges/orderbook.BenchmarkReverse": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 2241
+  },
+  "exchanges/orderbook.BenchmarkSortAsksAscending": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3469
+  },
+  "exchanges/orderbook.BenchmarkSortAsksDecending": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3513
+  },
+  "exchanges/orderbook.BenchmarkSortAsksStandard": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 109298
+  },
+  "exchanges/orderbook.BenchmarkSortBidsAscending": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3510
+  },
+  "exchanges/orderbook.BenchmarkSortBidsDescending": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3492
+  },
+  "exchanges/orderbook.BenchmarkSortBidsStandard": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 111746
+  },
+  "exchanges/orderbook.BenchmarkUpdateByID": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 25.2
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByID_asks": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 58.3
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByID_bids": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 76.4
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByPrice_Amend": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 7.59
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByPrice_Insert_Delete": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 57.2
+  },
+  "exchanges/request.BenchmarkGetNonce": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 116.5
+  },
+  "types.BenchmarkNumberMarshalJSON": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 109.8
+  },
+  "types.BenchmarkNumberUnmarshalJSON": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 77.1
+  },
+  "types.BenchmarkUnmarshalJSON": {
+    "allocs": 4,
+    "bytes": 216,
+    "ns_hint": 376.4
+  }
+}

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,544 @@
+{
+  "common.BenchmarkCounter": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 4.6
+  },
+  "common/math.BenchmarkDecimalPercentageDifference": {
+    "allocs": 27,
+    "bytes": 792,
+    "ns_hint": 1375
+  },
+  "common/math.BenchmarkPercentageDifference": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 0.74
+  },
+  "common/timedmutex.BenchmarkTimedMutexTime": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 821.5
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeLinearInteraction": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 102
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeUnlockNotPrimed": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 1.96
+  },
+  "common/timedmutex.BenchmarkTimedMutexTimeUnlockPrimed": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 26.7
+  },
+  "config.BenchmarkUpdateConfig": {
+    "allocs": 40538,
+    "bytes": 9898890,
+    "ns_hint": 16867142,
+    "allocs_tolerance": 0.00003,
+    "reason": "40538 on almost every sample, 40539 on roughly one in twenty; the tolerance is sized to admit exactly one extra allocation and reject two"
+  },
+  "currency.BenchmarkFindDifferences": {
+    "allocs": 2,
+    "bytes": 288,
+    "ns_hint": 645.4
+  },
+  "currency.BenchmarkFindMatchingPairsBetween": {
+    "allocs": 2,
+    "bytes": 944,
+    "ns_hint": 875.7
+  },
+  "currency.BenchmarkGetCrypto": {
+    "allocs": 1,
+    "bytes": 48,
+    "ns_hint": 154.5
+  },
+  "currency.BenchmarkNewCode": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 101.7
+  },
+  "currency.BenchmarkPairsFormat": {
+    "allocs": 1,
+    "bytes": 352,
+    "ns_hint": 230
+  },
+  "currency.BenchmarkPairsJoin": {
+    "allocs": 1,
+    "bytes": 64,
+    "ns_hint": 131.2
+  },
+  "currency.BenchmarkPairsString": {
+    "allocs": 7,
+    "bytes": 56,
+    "ns_hint": 256
+  },
+  "currency.BenchmarkRemovePairsByFilter": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 27.1
+  },
+  "dispatch.BenchmarkSubscribe": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 127.4
+  },
+  "encoding/json.BenchmarkUnmarshal": {
+    "allocs": 24,
+    "bytes": 816,
+    "ns_hint": 2062
+  },
+  "exchange/websocket/buffer.BenchmarkApplyPendingUpdates/1": {
+    "allocs": 2,
+    "bytes": 96,
+    "ns_hint": 503
+  },
+  "exchange/websocket/buffer.BenchmarkApplyPendingUpdates/2": {
+    "allocs": 3,
+    "bytes": 144,
+    "ns_hint": 646.6
+  },
+  "exchange/websocket/buffer.BenchmarkApplyPendingUpdates/256": {
+    "allocs": 257,
+    "bytes": 12336,
+    "ns_hint": 48561
+  },
+  "exchange/websocket/buffer.BenchmarkApplyPendingUpdates/64": {
+    "allocs": 65,
+    "bytes": 3120,
+    "ns_hint": 12819
+  },
+  "exchange/websocket/buffer.BenchmarkApplyPendingUpdates/8": {
+    "allocs": 9,
+    "bytes": 432,
+    "ns_hint": 1811
+  },
+  "exchange/websocket/buffer.BenchmarkBufferPerformance": {
+    "allocs": 0,
+    "bytes": 4,
+    "ns_hint": 407.8
+  },
+  "exchange/websocket/buffer.BenchmarkBufferSortingByIDPerformance": {
+    "allocs": 0,
+    "bytes": 4,
+    "ns_hint": 423.3
+  },
+  "exchange/websocket/buffer.BenchmarkBufferSortingPerformance": {
+    "allocs": 0,
+    "bytes": 4,
+    "ns_hint": 421
+  },
+  "exchange/websocket/buffer.BenchmarkLoadSnapshotExistingHolder": {
+    "allocs": 1,
+    "bytes": 48,
+    "ns_hint": 200.9
+  },
+  "exchange/websocket/buffer.BenchmarkNoBufferPerformance": {
+    "allocs": 1,
+    "bytes": 48,
+    "ns_hint": 576
+  },
+  "exchanges/alert.BenchmarkAlert": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 4.78
+  },
+  "exchanges/alert.BenchmarkWait": {
+    "allocs": 1,
+    "bytes": 32,
+    "ns_hint": 686.9
+  },
+  "exchanges/binance.BenchmarkWsHandleData/BalanceUpdate": {
+    "allocs": 12,
+    "bytes": 528,
+    "ns_hint": 3509
+  },
+  "exchanges/binance.BenchmarkWsHandleData/Depth": {
+    "allocs": 24,
+    "bytes": 1040,
+    "ns_hint": 6321
+  },
+  "exchanges/binance.BenchmarkWsHandleData/ExecutionReport": {
+    "allocs": 53,
+    "bytes": 75512,
+    "ns_hint": 42899
+  },
+  "exchanges/binance.BenchmarkWsHandleData/Kline": {
+    "allocs": 16,
+    "bytes": 904,
+    "ns_hint": 8515
+  },
+  "exchanges/binance.BenchmarkWsHandleData/ListStatus": {
+    "allocs": 23,
+    "bytes": 1000,
+    "ns_hint": 7926
+  },
+  "exchanges/binance.BenchmarkWsHandleData/OutboundAccountPosition": {
+    "allocs": 35,
+    "bytes": 1080,
+    "ns_hint": 7497
+  },
+  "exchanges/binance.BenchmarkWsHandleData/Ticker": {
+    "allocs": 11,
+    "bytes": 832,
+    "ns_hint": 9438
+  },
+  "exchanges/binance.BenchmarkWsHandleData/Trade": {
+    "allocs": 2,
+    "bytes": 40,
+    "ns_hint": 1276
+  },
+  "exchanges/currencystate.BenchmarkGetCurrencyStateSnapshot/1": {
+    "allocs": 2,
+    "bytes": 51,
+    "ns_hint": 197
+  },
+  "exchanges/currencystate.BenchmarkGetCurrencyStateSnapshot/32": {
+    "allocs": 2,
+    "bytes": 1888,
+    "ns_hint": 1646
+  },
+  "exchanges/currencystate.BenchmarkGetCurrencyStateSnapshot/512": {
+    "allocs": 2,
+    "bytes": 28800,
+    "ns_hint": 19894
+  },
+  "exchanges/gateio.BenchmarkMessageID": {
+    "allocs": 2,
+    "bytes": 48,
+    "ns_hint": 185
+  },
+  "exchanges/gateio.BenchmarkTimeInForceFromString": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 40.2
+  },
+  "exchanges/kucoin.BenchmarkIntervalToString": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 15.9
+  },
+  "exchanges/okx.BenchmarkMessageID": {
+    "allocs": 2,
+    "bytes": 48,
+    "ns_hint": 173.3
+  },
+  "exchanges/order.BenchmarkFilterOrdersByPairs": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 125.2
+  },
+  "exchanges/order.BenchmarkFilterOrdersBySide": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 67.6
+  },
+  "exchanges/order.BenchmarkFilterOrdersByTimeRange": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 322.6
+  },
+  "exchanges/order.BenchmarkFilterOrdersByType": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 67.6
+  },
+  "exchanges/order.BenchmarkIsActive": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 1.95
+  },
+  "exchanges/order.BenchmarkIsInactive": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 162.7
+  },
+  "exchanges/order.BenchmarkStringToOrderSide": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 45.7
+  },
+  "exchanges/order.BenchmarkStringToOrderStatus": {
+    "allocs": 1,
+    "bytes": 24,
+    "ns_hint": 164.4
+  },
+  "exchanges/order.BenchmarkStringToOrderType": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 49.1
+  },
+  "exchanges/order.BenchmarkStringToTimeInForce": {
+    "allocs": 13,
+    "bytes": 272,
+    "ns_hint": 1755
+  },
+  "exchanges/orderbook.BenchmarkDeleteByID": {
+    "allocs": 1,
+    "bytes": 480,
+    "ns_hint": 315.5
+  },
+  "exchanges/orderbook.BenchmarkInsertUpdates/Collision": {
+    "allocs": 3,
+    "bytes": 104,
+    "ns_hint": 641
+  },
+  "exchanges/orderbook.BenchmarkInsertUpdates/MiddleFreshCopy": {
+    "allocs": 1,
+    "bytes": 21760,
+    "ns_hint": 8448
+  },
+  "exchanges/orderbook.BenchmarkInsertUpdates/MiddleSpareCapacity": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 477.9
+  },
+  "exchanges/orderbook.BenchmarkInsertUpdates/TailSpareCapacity": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 583.2
+  },
+  "exchanges/orderbook.BenchmarkLoad": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 17.1
+  },
+  "exchanges/orderbook.BenchmarkProcess": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 283.9
+  },
+  "exchanges/orderbook.BenchmarkProcessUpdateInsertDelete": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 713
+  },
+  "exchanges/orderbook.BenchmarkRetrieve": {
+    "allocs": 1,
+    "bytes": 480,
+    "ns_hint": 231.5
+  },
+  "exchanges/orderbook.BenchmarkReverse": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 2265
+  },
+  "exchanges/orderbook.BenchmarkSortAsksAscending": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 2233
+  },
+  "exchanges/orderbook.BenchmarkSortAsksDescending": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 11771
+  },
+  "exchanges/orderbook.BenchmarkSortAsksLateInversion": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 24546
+  },
+  "exchanges/orderbook.BenchmarkSortAsksNaN/after-inversion": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 4104
+  },
+  "exchanges/orderbook.BenchmarkSortAsksNaN/early": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3536
+  },
+  "exchanges/orderbook.BenchmarkSortAsksNaN/late": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 4457
+  },
+  "exchanges/orderbook.BenchmarkSortAsksStandard": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 122965
+  },
+  "exchanges/orderbook.BenchmarkSortBidsAscending": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 12626
+  },
+  "exchanges/orderbook.BenchmarkSortBidsDescending": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 2227
+  },
+  "exchanges/orderbook.BenchmarkSortBidsLateInversion": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 20948
+  },
+  "exchanges/orderbook.BenchmarkSortBidsNaN/after-inversion": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 4133
+  },
+  "exchanges/orderbook.BenchmarkSortBidsNaN/early": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 3523
+  },
+  "exchanges/orderbook.BenchmarkSortBidsNaN/late": {
+    "allocs": 3,
+    "bytes": 152,
+    "ns_hint": 4473
+  },
+  "exchanges/orderbook.BenchmarkSortBidsStandard": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 123396
+  },
+  "exchanges/orderbook.BenchmarkUpdateByID": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 25.7
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByID_asks": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 58.7
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByID_bids": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 76.9
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByPrice_Amend": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 7.42
+  },
+  "exchanges/orderbook.BenchmarkUpdateInsertByPrice_Insert_Delete": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 57.4
+  },
+  "exchanges/request.BenchmarkGetNonce": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 118.2
+  },
+  "log.BenchmarkCustomLogHookBypass/Infof": {
+    "allocs": 4,
+    "bytes": 72,
+    "ns_hint": 204.8
+  },
+  "log.BenchmarkCustomLogHookBypass/Infoln": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 54.7
+  },
+  "log.BenchmarkCustomLogHookFallthrough": {
+    "allocs": 6,
+    "bytes": 144,
+    "ns_hint": 1099
+  },
+  "log.BenchmarkFormattedDisabled/Debugf": {
+    "allocs": 2,
+    "bytes": 64,
+    "ns_hint": 106.8
+  },
+  "log.BenchmarkFormattedDisabled/Errorf": {
+    "allocs": 2,
+    "bytes": 64,
+    "ns_hint": 99.7
+  },
+  "log.BenchmarkFormattedDisabled/Infof": {
+    "allocs": 2,
+    "bytes": 64,
+    "ns_hint": 97.4
+  },
+  "log.BenchmarkFormattedDisabled/Warnf": {
+    "allocs": 2,
+    "bytes": 64,
+    "ns_hint": 101.8
+  },
+  "log.BenchmarkInfoDisabled": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 36.1
+  },
+  "log.BenchmarkInfof": {
+    "allocs": 4,
+    "bytes": 216,
+    "ns_hint": 1156
+  },
+  "log.BenchmarkInfoln": {
+    "allocs": 4,
+    "bytes": 144,
+    "ns_hint": 897.1
+  },
+  "log.BenchmarkNewLogEvent": {
+    "allocs": 1,
+    "bytes": 32,
+    "ns_hint": 570.9
+  },
+  "types.BenchmarkNumberMarshalJSON": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 112.9
+  },
+  "types.BenchmarkNumberUnmarshalJSON": {
+    "allocs": 1,
+    "bytes": 16,
+    "ns_hint": 76.1
+  },
+  "types.BenchmarkPreciseNumberDecimal": {
+    "allocs": 3,
+    "bytes": 56,
+    "ns_hint": 132.7
+  },
+  "types.BenchmarkPreciseNumberUnmarshalJSON": {
+    "allocs": 16,
+    "bytes": 392,
+    "ns_hint": 793.3
+  },
+  "types.BenchmarkUnmarshalJSON/decoder/date": {
+    "allocs": 2,
+    "bytes": 152,
+    "ns_hint": 315.8
+  },
+  "types.BenchmarkUnmarshalJSON/decoder/fractional": {
+    "allocs": 1,
+    "bytes": 144,
+    "ns_hint": 293.4
+  },
+  "types.BenchmarkUnmarshalJSON/decoder/padded_width": {
+    "allocs": 1,
+    "bytes": 144,
+    "ns_hint": 240.6
+  },
+  "types.BenchmarkUnmarshalJSON/decoder/seconds": {
+    "allocs": 1,
+    "bytes": 144,
+    "ns_hint": 227.7
+  },
+  "types.BenchmarkUnmarshalJSON/direct/date": {
+    "allocs": 1,
+    "bytes": 8,
+    "ns_hint": 115
+  },
+  "types.BenchmarkUnmarshalJSON/direct/fractional": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 63.2
+  },
+  "types.BenchmarkUnmarshalJSON/direct/padded_width": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 46
+  },
+  "types.BenchmarkUnmarshalJSON/direct/seconds": {
+    "allocs": 0,
+    "bytes": 0,
+    "ns_hint": 37.7
+  }
+}

--- a/benchmarks/packages.txt
+++ b/benchmarks/packages.txt
@@ -1,0 +1,40 @@
+# Packages benchmarked by `make bench`. One package per line, relative to the module root.
+#
+# A trailing "gated" marks a package in which every benchmark must have an entry in baseline.json,
+# so a new `func Benchmark` fails CI until it is seeded with `make bench_update`. Benchmarks in
+# unmarked packages are still checked whenever they already have a baseline entry; the marker only
+# makes that coverage mandatory.
+#
+# Gate a package once its benchmarks are hermetic - no network, no shared state between benchmarks,
+# no writes to stdout during measurement, and reproducible allocation counts. Verify with:
+#   make bench_pkg PKG=./<pkg>/
+# run a few times over, and confirm allocs/op does not move. That target uses the gate's own
+# BENCH_FLAGS, so the measurement matches; a hand-written go test line drifts from it and -cpu/-p in
+# particular change what a scheduler-sensitive benchmark reports.
+
+common                     gated
+common/math                gated
+common/timedmutex          gated
+currency                   gated
+dispatch                   gated
+encoding/json              gated
+exchange/websocket/buffer  gated
+exchanges/alert            gated
+exchanges/binance          gated
+exchanges/currencystate    gated
+exchanges/kucoin           gated
+exchanges/order            gated
+exchanges/orderbook        gated
+exchanges/request          gated
+log                        gated
+types                      gated
+
+# Benchmarked and checked against the baseline, but not gated:
+config                     # near-deterministic; entry carries a small allocs tolerance
+exchanges/gateio           # seeded, but the package's benchmarks are not yet audited for hermeticity
+exchanges/okx              # as above
+
+# Not benchmarked at all, and why. Note that a baseline "ignore" only skips comparison - it does not
+# stop the benchmark running - so a benchmark that is unsafe to execute must be excluded here.
+#
+# Nothing is currently excluded.

--- a/benchmarks/packages.txt
+++ b/benchmarks/packages.txt
@@ -1,0 +1,54 @@
+# Packages benchmarked by `make bench`. One package per line, relative to the module root.
+#
+# A trailing "gated" marks a package in which every benchmark must have an entry in baseline.json,
+# so a new `func Benchmark` fails CI until it is seeded with `make bench_update`. Benchmarks in
+# unmarked packages are still checked whenever they already have a baseline entry; the marker only
+# makes that coverage mandatory.
+#
+# Gate a package once its benchmarks are hermetic - no network, no shared state between benchmarks,
+# no writes to stdout during measurement, and reproducible allocation counts. Verify with:
+#   make bench_pkg PKG=./<pkg>/
+# run a few times over, and confirm allocs/op does not move. That target uses the gate's own
+# BENCH_FLAGS, so the measurement matches; a hand-written go test line drifts from it and -cpu/-p in
+# particular change what a scheduler-sensitive benchmark reports.
+
+common                     gated
+common/math                gated
+common/timedmutex          gated
+currency                   gated
+dispatch                   gated
+encoding/json              gated
+exchanges/order            gated
+exchanges/orderbook        gated
+exchanges/request          gated
+types                      gated
+
+# Benchmarked and checked against the baseline, but not gated:
+config                     # near-deterministic; entry carries a small allocs tolerance
+exchanges/gateio           # seeded, but the package's benchmarks are not yet audited for hermeticity
+exchanges/okx              # as above
+
+# Not benchmarked at all, and why. Note that a baseline "ignore" only skips comparison - it does not
+# stop the benchmark running - so a benchmark that is unsafe to execute must be excluded here.
+#
+#   exchanges/alert           - BenchmarkWait calls Wait(nil) and never reads the reply, so each
+#                               iteration leaks the goroutine that alert.hold documents as leakable.
+#                               Harmless at 100ms, but the scheduled 1s x 15 run accumulates millions
+#                               and can exhaust memory. Excluding the package also drops
+#                               BenchmarkAlert, which is otherwise fine
+#   exchange/websocket/buffer - every benchmark fails with "channel buffer is full: failed to relay
+#                               <*orderbook.Depth>" once it runs enough iterations. They pass at
+#                               -benchtime 10x and fail at 100ms, alone or together, so the relay
+#                               channel simply overruns rather than this being shared state
+#   exchanges/binance         - BenchmarkWsHandleData is hermetic and its output is clean, but its
+#                               counts are not reproducible: allocs/op moves between 198 and 209 and
+#                               B/op by around 20% even at a fixed iteration count, so no tolerance
+#                               gates anything useful. Would need wsHandleData itself to take the
+#                               same path every iteration
+#   exchanges/kucoin          - its TestMain calls getFirstTradablePairOfAssets unconditionally, so
+#                               the package fetches tradable pairs from the live KuCoin API even
+#                               under -run '^$'. A rate limit or outage would fail the whole gate
+#                               job, for one benchmark that allocates nothing
+#   log                       - the logger writes to stdout during measurement, which interleaves
+#                               into the result lines and corrupts them; route the benchmarks at
+#                               io.Discard (as BenchmarkNewLogEvent already does) to re-enable

--- a/cmd/benchcheck/README.md
+++ b/cmd/benchcheck/README.md
@@ -1,0 +1,145 @@
+# benchcheck
+
+`benchcheck` gates benchmark allocations against a checked-in baseline, so that allocation counts in
+GoCryptoTrader ratchet downwards over time instead of drifting up unnoticed.
+
+## Usage
+
+```bash
+make bench                      # check the current tree against benchmarks/baseline.json
+make bench_update               # fold the current measurements back into the baseline
+make bench_pkg PKG=./currency/  # measure one package with the gate's exact flags
+make bench_trend                # long-run measurements appended to the ns/op history
+```
+
+`make bench` fails when a benchmark allocates **more** than its recorded budget, and equally when it
+allocates **less**. The second case is the point of the tool: an improvement is only permanent once
+it has been written back with `make bench_update`, which makes every optimisation a new floor and
+turns the baseline into a ratchet rather than a ceiling that only ever moves up.
+
+Each budget is compared against the **median** of the samples, not any single one, so one unlucky
+run does not trip the gate. Per-entry tolerances are applied on top of that median.
+
+## What is gated, and what is not
+
+| Metric | Reproducibility | Treatment |
+| --- | --- | --- |
+| `allocs/op` | Reproducible and machine independent | Hard gate; an increase in the median fails, unless the entry carries a tolerance |
+| `B/op` | Near-reproducible | Hard gate with a 1% default tolerance |
+| `ns/op` | Depends on the host and its current load | **Never gated**; recorded as an advisory `ns_hint` and tracked in the scheduled history |
+
+Timings are not gated because they move substantially between runs on a shared CI runner, in a way
+that has nothing to do with the code under test. A gate on `ns/op` would either flap constantly or
+be set so loose it catches nothing. Allocation counts do not have that problem: `allocs/op` is
+identical across every sample for all but a handful of the benchmarks measured. That is what makes
+them worth gating and timings not.
+
+"Reproducible" is not the same as "constant", but most movement between runs is a defect in the
+benchmark rather than a fact about the code. A loop that stages work on a queue and never waits for
+it leaves the amount the worker happened to finish to chance; a loop that accumulates state measures
+a structure that grows as the run goes on, and pays its amortised growth wherever the run stopped.
+Both move `B/op`. Waiting for the work, or releasing what the iteration acquired, removes the
+movement rather than accommodating it, and is what nearly every entry here does.
+
+Reach for a per-entry tolerance only once the movement is in the code under test, and size it to the
+range actually observed rather than to a round number: a tolerance is a fraction of the budget, so on
+a large budget an innocuous-looking `0.001` is worth dozens of allocations.
+
+One caveat on reading `allocs/op`: the testing package reports it as `MemAllocs / N` in **integer**
+arithmetic, so it is a truncated average rather than a count. A benchmark allocating once every
+tenth iteration reports `0`, and one allocating on nine iterations in ten still reports `0`. A zero
+in the baseline therefore means "under one allocation per operation", not "allocation free", and a
+regression of less than a whole allocation per operation cannot move the number at all. `B/op` is
+the finer-grained of the two gated metrics for exactly that reason, and is what catches sub-integer
+movement — worth remembering before widening a `bytes_tolerance`.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `benchmarks/baseline.json` | The budgets. Checked in, so widening one is a visible line in a PR diff that a reviewer has to approve |
+| `benchmarks/packages.txt` | Which packages are benchmarked, and which are `gated` |
+| `scripts/bench_history.sh` | Fetches and publishes the ns/op history branch |
+| `scripts/bench_history_test.sh` | Exercises that script against a throwaway repository; run by `misc_checks.sh` |
+
+A package marked `gated` requires every one of its benchmarks to have a baseline entry, so a new
+`func Benchmark` fails CI until it is seeded. Benchmarks in unmarked packages are still checked
+whenever they already have an entry; the marker only makes that coverage mandatory.
+
+One benchmark escapes that: one that calls `b.Skip` emits no result line at all without `-v`, so a
+new skipping benchmark is invisible here rather than untracked. A skip is still caught the moment
+the benchmark has an entry — it then reads as missing — so this only hides one that never had one.
+
+`packages.txt` is the source of truth for coverage: which packages are gated, which are only checked
+against an entry they already have, and which are excluded along with the reason why.
+
+## Updating the baseline
+
+`-update` never deletes. A run that selected a subset of benchmarks looks, from the output alone,
+exactly like a full run in which the rest disappeared, so deleting on that evidence would destroy
+the baseline. Entries with no matching result are reported and kept.
+
+`make bench_update` passes `-prune`, which does delete them. That is safe there and only there,
+because `BENCH_FLAGS` uses `-bench .` and therefore matches everything. Pass `-prune` by hand only
+when the same is true of your own invocation.
+
+## Escape hatches
+
+Both require a `reason`, enforced by `Baseline.Validate`, and a tolerance must be in `[0, 1)`:
+
+```jsonc
+{
+  "dispatch.BenchmarkSubscribe": {
+    "allocs": 1,
+    "bytes": 156,
+    "bytes_tolerance": 0.1,           // widen one metric's budget
+    "reason": "worker goroutines make B/op scheduler dependent; observed 151-161 across runs"
+  },
+  "some/pkg.BenchmarkExample": {
+    "ignore": true,                   // drop the benchmark from the gate entirely
+    "reason": "why no tolerance can work here"
+  }
+}
+```
+
+Prefer a tolerance to `ignore`: an ignored benchmark still costs CI time but tells nobody anything.
+Note that `ignore` only skips *comparison* — the benchmark still runs, so one that is unsafe to
+execute must be excluded from `packages.txt` instead.
+
+## Flag settings
+
+`BENCH_FLAGS` in the Makefile is the single definition of how a benchmark is measured; the workflow
+calls `make` rather than restating it, and `make bench_pkg` reuses it so an audit of one package
+matches the gate.
+
+It pins `-cpu 4` and `-p 1` so that CI and a developer's machine measure the same thing whatever the
+host's core count: `-cpu` fixes GOMAXPROCS inside each test binary, and `-p` stops several package
+binaries competing for the same cores. Without both, scheduler-dependent benchmarks record different
+values on each machine and the baseline is only valid on the one that produced it.
+
+`-count 7 -benchtime 100ms` is deliberately cheap, a couple of minutes for the whole repository. A
+longer benchtime buys the allocation gate nothing, because `allocs/op` is per-iteration and
+reproducible. The `bench_trend` target uses `-count 15 -benchtime 1s` instead, because tight
+confidence intervals do matter for the `ns/op` history and a long runtime is affordable on a
+scheduled run.
+
+Both counts are **odd, and must stay odd**. The compared value is the median, and an even count has
+no middle sample, so `median` falls back to the lower of the two middles. That is biased, and biased
+asymmetrically for a gate that fails on improvement as well as regression: at six samples three low
+ones move the value while four high ones are needed to.
+
+The count is also passed to benchcheck as `-samples`, which rejects any benchmark that did not
+report exactly that many measurements. A truncated run, or a result line that failed to parse, would
+otherwise shift which sample sits in the middle with nothing to notice it. `bench_trend` pairs
+`-samples` with `-warn`, which drops the offending records and appends the rest rather than losing a
+ten minute measurement to one short benchmark.
+
+Keep `-cpu` single valued. benchcheck strips the `-N` suffix Go appends to result names, so `-cpu
+1,4` files two populations under one key and `-samples` cannot tell that from a single clean run.
+
+## The ns/op history
+
+`make bench_trend` appends one JSON line per benchmark to a series file. In CI a scheduled job
+publishes it to the `benchmarks-history` branch, which is append-only: `bench_history.sh` refuses to
+publish a series that does not extend what is already there, so a run built from a stale fetch
+cannot silently drop another run's records.

--- a/cmd/benchcheck/README.md
+++ b/cmd/benchcheck/README.md
@@ -1,0 +1,132 @@
+# benchcheck
+
+`benchcheck` gates benchmark allocations against a checked-in baseline, so that allocation counts in
+GoCryptoTrader ratchet downwards over time instead of drifting up unnoticed.
+
+## Usage
+
+```bash
+make bench                      # check the current tree against benchmarks/baseline.json
+make bench_update               # fold the current measurements back into the baseline
+make bench_pkg PKG=./currency/  # measure one package with the gate's exact flags
+make bench_trend                # long-run measurements appended to the ns/op history
+```
+
+`make bench` fails when a benchmark allocates **more** than its recorded budget, and equally when it
+allocates **less**. The second case is the point of the tool: an improvement is only permanent once
+it has been written back with `make bench_update`, which makes every optimisation a new floor and
+turns the baseline into a ratchet rather than a ceiling that only ever moves up.
+
+Each budget is compared against the **median** of the samples, not any single one, so one unlucky
+run does not trip the gate. Per-entry tolerances are applied on top of that median.
+
+## What is gated, and what is not
+
+| Metric | Reproducibility | Treatment |
+| --- | --- | --- |
+| `allocs/op` | Reproducible and machine independent | Hard gate; an increase in the median fails, unless the entry carries a tolerance |
+| `B/op` | Near-reproducible | Hard gate with a 1% default tolerance |
+| `ns/op` | Depends on the host and its current load | **Never gated**; recorded as an advisory `ns_hint` and tracked in the scheduled history |
+
+Timings are not gated because they move substantially between runs on a shared CI runner, in a way
+that has nothing to do with the code under test. A gate on `ns/op` would either flap constantly or
+be set so loose it catches nothing. Allocation counts do not have that problem: when the baseline was
+seeded, `allocs/op` was identical across every sample for all but one of the benchmarks measured.
+That is what makes them worth gating and timings not.
+
+"Reproducible" is not the same as "constant". A few benchmarks move by one or two allocations between
+runs; those carry a per-entry tolerance with the observed range recorded as its reason. Benchmarks
+that move more than that are excluded outright rather than given a tolerance wide enough to be
+meaningless.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `benchmarks/baseline.json` | The budgets. Checked in, so widening one is a visible line in a PR diff that a reviewer has to approve |
+| `benchmarks/packages.txt` | Which packages are benchmarked, and which are `gated` |
+| `scripts/bench_history.sh` | Fetches and publishes the ns/op history branch |
+| `scripts/bench_history_test.sh` | Exercises that script against a throwaway repository; run by `misc_checks.sh` |
+
+A package marked `gated` requires every one of its benchmarks to have a baseline entry, so a new
+`func Benchmark` fails CI until it is seeded. Benchmarks in unmarked packages are still checked
+whenever they already have an entry; the marker only makes that coverage mandatory.
+
+The repository currently holds 63 benchmarks, of which 50 are in the baseline. The gap is the
+packages excluded below.
+
+## Updating the baseline
+
+`-update` never deletes. A run that selected a subset of benchmarks looks, from the output alone,
+exactly like a full run in which the rest disappeared, so deleting on that evidence would destroy
+the baseline. Entries with no matching result are reported and kept.
+
+`make bench_update` passes `-prune`, which does delete them. That is safe there and only there,
+because `BENCH_FLAGS` uses `-bench .` and therefore matches everything. Pass `-prune` by hand only
+when the same is true of your own invocation.
+
+## Escape hatches
+
+Both require a `reason`, enforced by `Baseline.Validate`, and a tolerance must be in `[0, 1)`:
+
+```jsonc
+{
+  "dispatch.BenchmarkSubscribe": {
+    "allocs": 1,
+    "bytes": 158,
+    "bytes_tolerance": 0.1,           // widen one metric's budget
+    "reason": "worker goroutines make B/op scheduler dependent; observed 151-161 across runs"
+  },
+  "some/pkg.BenchmarkExample": {
+    "ignore": true,                   // drop the benchmark from the gate entirely
+    "reason": "why no tolerance can work here"
+  }
+}
+```
+
+Prefer a tolerance to `ignore`: an ignored benchmark still costs CI time but tells nobody anything.
+Note that `ignore` only skips *comparison* — the benchmark still runs, so one that is unsafe to
+execute must be excluded from `packages.txt` instead. Nothing in the current baseline uses `ignore`.
+
+## Flag settings
+
+`BENCH_FLAGS` in the Makefile is the single definition of how a benchmark is measured; the workflow
+calls `make` rather than restating it, and `make bench_pkg` reuses it so an audit of one package
+matches the gate.
+
+It pins `-cpu 4` and `-p 1` so that CI and a developer's machine measure the same thing whatever the
+host's core count: `-cpu` fixes GOMAXPROCS inside each test binary, and `-p` stops several package
+binaries competing for the same cores. Without both, scheduler-dependent benchmarks record different
+values on each machine and the baseline is only valid on the one that produced it.
+
+`-count 6 -benchtime 100ms` is deliberately cheap (~45s). A longer benchtime or higher count buys
+the allocation gate nothing, because `allocs/op` is per-iteration and reproducible. The
+`bench_trend` target uses `-count 15 -benchtime 1s` instead, because tight confidence intervals do
+matter for the `ns/op` history and a long runtime is affordable on a scheduled run.
+
+## The ns/op history
+
+`make bench_trend` appends one JSON line per benchmark to a series file. In CI a scheduled job
+publishes it to the `benchmarks-history` branch, which is append-only: `bench_history.sh` refuses to
+publish a series that does not extend what is already there, so a run built from a stale fetch
+cannot silently drop another run's records.
+
+## Known exclusions
+
+Recorded in `benchmarks/packages.txt`, repeated here for visibility:
+
+- `exchanges/kucoin` — its `TestMain` calls `getFirstTradablePairOfAssets` unconditionally, so the
+  package fetches tradable pairs from the live KuCoin API even under `-run '^$'`. A rate limit or
+  outage would fail the whole gate job, for one benchmark that allocates nothing.
+- `log` — the logger writes to stdout during measurement, and those writes interleave into the
+  result lines and corrupt them. Route the benchmarks at `io.Discard`, as `BenchmarkNewLogEvent`
+  already does, to re-enable the package.
+- `exchange/websocket/buffer` — every benchmark fails with `channel buffer is full: failed to relay
+  <*orderbook.Depth>` once it runs enough iterations. They pass at `-benchtime 10x` and fail at
+  `100ms`, alone or together, so the relay channel simply overruns.
+- `exchanges/alert` — `BenchmarkWait` calls `Wait(nil)` and never reads the reply, leaking the
+  goroutine that `alert.hold` documents as leakable. Harmless at 100ms, but the scheduled `1s × 15` run
+  accumulates millions and can exhaust memory.
+- `exchanges/binance` — `BenchmarkWsHandleData` is hermetic and its output is clean, but its counts
+  are not reproducible: `allocs/op` moves between 198 and 209 and `B/op` by around 20% even at a
+  fixed iteration count, so no tolerance gates anything useful.

--- a/cmd/benchcheck/baseline.go
+++ b/cmd/benchcheck/baseline.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+// Entry is the recorded budget for a single benchmark. Allocs and Bytes are gated; NSHint is
+// advisory, because ns/op on a shared CI runner is too noisy to compare against a stored value.
+//
+// The tolerances are fractional per-benchmark overrides, for counts that are not reproducible.
+// Ignore drops a benchmark from the gate entirely; prefer a tolerance, since an ignored benchmark
+// still costs CI time and tells nobody anything. Both require a Reason.
+type Entry struct {
+	Allocs          uint64  `json:"allocs"`
+	Bytes           uint64  `json:"bytes"`
+	NSHint          float64 `json:"ns_hint,omitempty"`
+	AllocsTolerance float64 `json:"allocs_tolerance,omitempty"`
+	BytesTolerance  float64 `json:"bytes_tolerance,omitempty"`
+	Ignore          bool    `json:"ignore,omitempty"`
+	Reason          string  `json:"reason,omitempty"`
+}
+
+// Baseline maps a benchmark key to its recorded budget
+type Baseline map[string]*Entry
+
+var (
+	errNullEntry            = errors.New("baseline entry is null")
+	errToleranceNeedsReason = errors.New("tolerance override requires a reason")
+	errToleranceOutOfRange  = errors.New("tolerance out of range")
+	errUnknownMarker        = errors.New("unknown package marker")
+	errNoBaseline           = errors.New("baseline file does not exist")
+	errNoPackageList        = errors.New("package list does not exist")
+	errEmptyPackageList     = errors.New("package list names no packages")
+	errBadPackagePath       = errors.New("package path is not a package inside this module")
+)
+
+// LoadBaseline reads a baseline file. seeding permits an absent file so the first -update can
+// create one; in check mode it must be an error, since an empty baseline passes any numbers at all.
+func LoadBaseline(path string, seeding bool) (Baseline, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		if seeding {
+			return Baseline{}, nil
+		}
+		return nil, fmt.Errorf("%w: %s", errNoBaseline, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reading baseline: %w", err)
+	}
+	var b Baseline
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("error parsing baseline %q: %w", path, err)
+	}
+	if b == nil {
+		// A file containing literal null unmarshals to a nil map, which -update would then panic on
+		b = Baseline{}
+	}
+	return b, nil
+}
+
+// Validate rejects tolerance overrides that carry no justification, so that widening a budget
+// cannot be slipped through as a one-character diff
+func (b Baseline) Validate() error {
+	for _, key := range sortedKeys(b) {
+		e := b[key]
+		if e == nil {
+			return fmt.Errorf("%w: %s", errNullEntry, key)
+		}
+		// Trimmed, or " " buys the same exemption as a justification while reviewing as an empty diff
+		if (e.AllocsTolerance != 0 || e.BytesTolerance != 0 || e.Ignore) && strings.TrimSpace(e.Reason) == "" {
+			return fmt.Errorf("%w: %s", errToleranceNeedsReason, key)
+		}
+		if err := validTolerance(e.AllocsTolerance); err != nil {
+			return fmt.Errorf("%s allocs_tolerance: %w", key, err)
+		}
+		if err := validTolerance(e.BytesTolerance); err != nil {
+			return fmt.Errorf("%s bytes_tolerance: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// validTolerance rejects tolerances that would invert or disable the gate. A negative value reports
+// an unchanged benchmark as a regression; a value of 1 or more puts the lower bound at or below zero
+// so the ratchet can never fire; NaN makes every comparison false.
+func validTolerance(t float64) error {
+	if math.IsNaN(t) || t < 0 || t >= 1 {
+		return fmt.Errorf("%w: %v is not in [0, 1)", errToleranceOutOfRange, t)
+	}
+	return nil
+}
+
+// Save writes the baseline with sorted keys and a trailing newline so diffs stay reviewable. It
+// renames a temporary file from the same directory into place, which keeps an interrupted run from
+// truncating the baseline; the same directory because rename is only atomic within a filesystem.
+// Concurrent updates are still unsafe - the last rename wins.
+func (b Baseline) Save(path string) error {
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error encoding baseline: %w", err)
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp")
+	if err != nil {
+		return fmt.Errorf("error creating temporary baseline: %w", err)
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp) // No-op once the rename has succeeded
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		f.Close()
+		return fmt.Errorf("error writing temporary baseline: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error closing temporary baseline: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o644); err != nil {
+		return fmt.Errorf("error setting baseline permissions: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("error replacing baseline: %w", err)
+	}
+	return nil
+}
+
+// Update folds results into the baseline, preserving any hand-written reason, and returns the keys
+// it pruned. Callers set allowPrune only when the run covered every configured package: a filtered
+// run reports a subset, and pruning on that evidence deletes the rest of the package.
+//
+// scope is the set of packages the run was meant to cover, and must be the same set Compare uses to
+// report a benchmark missing, or a package whose last benchmark was deleted is failed by one and
+// unreachable by the other.
+func (b Baseline) Update(results map[string]*Result, allowPrune bool, scope map[string]bool) []string {
+	var pruned []string
+	if len(scope) == 0 {
+		scope = seenPackages(results)
+	}
+	if allowPrune {
+		for _, key := range sortedKeys(b) {
+			if _, ok := results[key]; !ok && packageOf(key, scope) != "" {
+				delete(b, key)
+				pruned = append(pruned, key)
+			}
+		}
+	}
+	for key, r := range results {
+		e, ok := b[key]
+		if !ok {
+			e = &Entry{}
+			b[key] = e
+		}
+		if e.Ignore {
+			continue
+		}
+		e.Allocs = uint64(median(r.Allocs))
+		e.Bytes = uint64(median(r.Bytes))
+		e.NSHint = roundNS(median(r.NS))
+	}
+	return pruned
+}
+
+// roundNS trims ns/op to three significant-ish digits; it is advisory, and storing full precision
+// would produce baseline churn on every update for no benefit
+func roundNS(ns float64) float64 {
+	switch {
+	case ns >= 1000:
+		return float64(int64(ns))
+	case ns >= 10:
+		return float64(int64(ns*10)) / 10
+	default:
+		return float64(int64(ns*100)) / 100
+	}
+}
+
+// Packages is the benchmarked package list, in file order, with the packages whose benchmarks must
+// all appear in the baseline flagged as gated
+type Packages struct {
+	List  []string
+	Gated map[string]bool
+}
+
+// LoadPackages reads the benchmarked package list. Each line is a package path relative to the
+// module root, optionally followed by the word "gated"; blank lines and # comments are ignored.
+// Entries are reduced to the form go test reports, via canonicalPackage.
+func LoadPackages(path string) (*Packages, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		// Not tolerated: an empty list leaves Gated empty, so a mistyped -packages path would let a
+		// new benchmark in a gated package through with no baseline entry and no finding.
+		return nil, fmt.Errorf("%w: %s", errNoPackageList, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reading package list: %w", err)
+	}
+	defer f.Close()
+
+	pkgs := &Packages{Gated: map[string]bool{}}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line, _, _ := strings.Cut(sc.Text(), "#")
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		pkg, err := canonicalPackage(fields[0])
+		if err != nil {
+			return nil, err
+		}
+		if len(fields) > 1 {
+			if fields[1] != "gated" {
+				return nil, fmt.Errorf("%w: %q on package %q", errUnknownMarker, fields[1], pkg)
+			}
+			pkgs.Gated[pkg] = true
+		}
+		pkgs.List = append(pkgs.List, pkg)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("error reading package list: %w", err)
+	}
+	// Same reasoning as an absent file: a list that names nothing gates nothing, and -list then
+	// hands go test no packages at all
+	if len(pkgs.List) == 0 {
+		return nil, fmt.Errorf("%w: %s", errEmptyPackageList, path)
+	}
+	return pkgs, nil
+}
+
+// canonicalPackage reduces a package list entry to the path go test prints in its pkg: header,
+// which is the only form the gated and configured lookups ever see. An entry that resolves to a
+// different string runs its benchmarks and gates none of them.
+//
+// Cleaning handles redundant separators and "." elements. What it cannot resolve is refused: "..."
+// covers several packages under one lookup key, and a path leaving the module has no header to
+// match. So is anything outside a Go import path's character set, because -list is interpolated
+// into go test unquoted and the shell rewrites the rest - "'currency'" loses its quotes,
+// "currenc[y]" globs.
+func canonicalPackage(entry string) (string, error) {
+	root := strings.TrimSuffix(modulePrefix, "/")
+	pkg := pathpkg.Clean(entry)
+	// Cleaning erases the module boundary, so a module-qualified entry is checked against it before
+	// the prefix comes off: ".../gocryptotrader/../../../currency" cleans to a real package and
+	// would otherwise be accepted as one, silently naming something the entry never spelled.
+	if strings.HasPrefix(entry, root) && pkg != root && !strings.HasPrefix(pkg, modulePrefix) {
+		return "", fmt.Errorf("%w: %q traverses outside the module", errBadPackagePath, entry)
+	}
+	if pkg == root || pkg == "." {
+		return "", fmt.Errorf("%w: %q resolves to the module root", errBadPackagePath, entry)
+	}
+	pkg = strings.TrimPrefix(pkg, modulePrefix)
+	switch {
+	case strings.Contains(pkg, "..."):
+		return "", fmt.Errorf("%w: %q is a wildcard, which covers several packages under one entry", errBadPackagePath, entry)
+	case strings.HasPrefix(pkg, "/"), strings.HasPrefix(pkg, ".."):
+		return "", fmt.Errorf("%w: %q resolves outside the module", errBadPackagePath, entry)
+	}
+	for _, r := range pkg {
+		if !importPathRune(r) {
+			return "", fmt.Errorf("%w: %q contains %q, which the shell would rewrite before go test saw it",
+				errBadPackagePath, entry, string(r))
+		}
+	}
+	return pkg, nil
+}
+
+// importPathRune reports whether r may appear in a Go import path. The set is x/mod/module's
+// importPathOK, which is alphanumerics plus "-._~+", together with the element separator. None of
+// those carry meaning to a shell, which is the property the caller needs.
+func importPathRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	case r == '/', r == '.', r == '-', r == '_', r == '~', r == '+':
+		return true
+	}
+	return false
+}
+
+// packageOf resolves a baseline key to one of the known packages, returning "" when none matches.
+// Keys cannot be split on the final dot: both package paths and subbenchmark names contain dots,
+// so matching against the known set is the only unambiguous attribution.
+func packageOf(key string, known map[string]bool) string {
+	for pkg := range known {
+		if strings.HasPrefix(key, pkg+".") {
+			return pkg
+		}
+	}
+	return ""
+}
+
+func seenPackages(results map[string]*Result) map[string]bool {
+	seen := make(map[string]bool)
+	for _, r := range results {
+		seen[r.Pkg] = true
+	}
+	return seen
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	return slices.Sorted(maps.Keys(m))
+}
+
+// configuredSet turns the ordered package list into a set for lookups
+func configuredSet(list []string) map[string]bool {
+	set := make(map[string]bool, len(list))
+	for _, p := range list {
+		set[p] = true
+	}
+	return set
+}

--- a/cmd/benchcheck/baseline.go
+++ b/cmd/benchcheck/baseline.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+// Entry is the recorded budget for a single benchmark. Allocs and Bytes are gated; NSHint is
+// advisory only, because ns/op on a shared CI runner is too noisy to compare against a stored value.
+//
+// AllocsTolerance and BytesTolerance are fractional per-benchmark overrides for benchmarks whose
+// counts are not reproducible — typically those that spawn goroutines, where the scheduler decides
+// how much of the work is attributed to the measured iterations.
+//
+// Ignore drops a benchmark from the gate entirely and stops -update from recording values for it,
+// for benchmarks too non-deterministic to carry any budget. Prefer a tolerance where one works: an
+// ignored benchmark is measured by CI but tells nobody anything.
+//
+// Ignore and both tolerances must carry a Reason.
+type Entry struct {
+	Allocs          uint64  `json:"allocs"`
+	Bytes           uint64  `json:"bytes"`
+	NSHint          float64 `json:"ns_hint,omitempty"`
+	AllocsTolerance float64 `json:"allocs_tolerance,omitempty"`
+	BytesTolerance  float64 `json:"bytes_tolerance,omitempty"`
+	Ignore          bool    `json:"ignore,omitempty"`
+	Reason          string  `json:"reason,omitempty"`
+}
+
+// Baseline maps a benchmark key to its recorded budget
+type Baseline map[string]*Entry
+
+var (
+	errNullEntry            = errors.New("baseline entry is null")
+	errToleranceNeedsReason = errors.New("tolerance override requires a reason")
+	errToleranceOutOfRange  = errors.New("tolerance out of range")
+	errUnknownMarker        = errors.New("unknown package marker")
+	errNoBaseline           = errors.New("baseline file does not exist")
+	errNoPackageList        = errors.New("package list does not exist")
+)
+
+// LoadBaseline reads a baseline file. seeding permits an absent file, so the first -update run can
+// create one; in check mode an absent file must be an error, because an empty baseline compares
+// clean against any numbers at all and a mistyped -baseline path would silently pass everything.
+func LoadBaseline(path string, seeding bool) (Baseline, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		if seeding {
+			return Baseline{}, nil
+		}
+		return nil, fmt.Errorf("%w: %s", errNoBaseline, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reading baseline: %w", err)
+	}
+	var b Baseline
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("error parsing baseline %q: %w", path, err)
+	}
+	if b == nil {
+		// A file containing literal null unmarshals to a nil map, which -update would then panic on
+		b = Baseline{}
+	}
+	return b, nil
+}
+
+// Validate rejects tolerance overrides that carry no justification, so that widening a budget
+// cannot be slipped through as a one-character diff
+func (b Baseline) Validate() error {
+	for _, key := range sortedKeys(b) {
+		e := b[key]
+		if e == nil {
+			return fmt.Errorf("%w: %s", errNullEntry, key)
+		}
+		if (e.AllocsTolerance != 0 || e.BytesTolerance != 0 || e.Ignore) && e.Reason == "" {
+			return fmt.Errorf("%w: %s", errToleranceNeedsReason, key)
+		}
+		if err := validTolerance(e.AllocsTolerance); err != nil {
+			return fmt.Errorf("%s allocs_tolerance: %w", key, err)
+		}
+		if err := validTolerance(e.BytesTolerance); err != nil {
+			return fmt.Errorf("%s bytes_tolerance: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// validTolerance rejects tolerances that would invert or disable the gate. A negative value reports
+// an unchanged benchmark as a regression; a value of 1 or more puts the lower bound at or below zero
+// so the ratchet can never fire; NaN makes every comparison false.
+func validTolerance(t float64) error {
+	if math.IsNaN(t) || t < 0 || t >= 1 {
+		return fmt.Errorf("%w: %v is not in [0, 1)", errToleranceOutOfRange, t)
+	}
+	return nil
+}
+
+// Save writes the baseline with sorted keys and a trailing newline so diffs stay reviewable
+func (b Baseline) Save(path string) error {
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error encoding baseline: %w", err)
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+// Update folds results into the baseline, preserving any hand-written reason. Benchmarks that have
+// disappeared from a package present in the results are removed; packages absent from the results
+// are left untouched so that updating from a partial run does not discard unrelated entries.
+// A filtered run (-bench selecting one benchmark, or a package that failed early) reports only a
+// subset, and pruning on that evidence would delete every other entry in the package. Pruning is
+// therefore gated on allowPrune, which callers set only when the run covered every configured
+// package; a partial run updates the values it measured and leaves the rest alone.
+// Pruned keys are returned rather than silently dropped. A benchmark that skips at runtime emits no
+// result at all — Go only marks it under -v — so it is indistinguishable here from one that was
+// deleted, and its budget would vanish without trace. Reporting makes that visible in CI output.
+func (b Baseline) Update(results map[string]*Result, allowPrune bool) []string {
+	var pruned []string
+	seen := seenPackages(results)
+	if allowPrune {
+		for _, key := range sortedKeys(b) {
+			if _, ok := results[key]; !ok && packageOf(key, seen) != "" {
+				delete(b, key)
+				pruned = append(pruned, key)
+			}
+		}
+	}
+	for key, r := range results {
+		e, ok := b[key]
+		if !ok {
+			e = &Entry{}
+			b[key] = e
+		}
+		if e.Ignore {
+			continue
+		}
+		e.Allocs = uint64(median(r.Allocs))
+		e.Bytes = uint64(median(r.Bytes))
+		e.NSHint = roundNS(median(r.NS))
+	}
+	return pruned
+}
+
+// roundNS trims ns/op to three significant-ish digits; it is advisory, and storing full precision
+// would produce baseline churn on every update for no benefit
+func roundNS(ns float64) float64 {
+	switch {
+	case ns >= 1000:
+		return float64(int64(ns))
+	case ns >= 10:
+		return float64(int64(ns*10)) / 10
+	default:
+		return float64(int64(ns*100)) / 100
+	}
+}
+
+// Packages is the benchmarked package list, in file order, with the packages whose benchmarks must
+// all appear in the baseline flagged as gated
+type Packages struct {
+	List  []string
+	Gated map[string]bool
+}
+
+// LoadPackages reads the benchmarked package list. Each line is a package path relative to the
+// module root, optionally followed by the word "gated"; blank lines, # comments and trailing
+// # comments are ignored.
+func LoadPackages(path string) (*Packages, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		// Not tolerated: an empty list leaves Gated empty, so a mistyped -packages path would let a
+		// new benchmark in a gated package through with no baseline entry and no finding.
+		return nil, fmt.Errorf("%w: %s", errNoPackageList, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reading package list: %w", err)
+	}
+	defer f.Close()
+
+	pkgs := &Packages{Gated: map[string]bool{}}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line, _, _ := strings.Cut(sc.Text(), "#")
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		pkg := strings.TrimPrefix(fields[0], modulePrefix)
+		if len(fields) > 1 {
+			if fields[1] != "gated" {
+				return nil, fmt.Errorf("%w: %q on package %q", errUnknownMarker, fields[1], pkg)
+			}
+			pkgs.Gated[pkg] = true
+		}
+		pkgs.List = append(pkgs.List, pkg)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("error reading package list: %w", err)
+	}
+	return pkgs, nil
+}
+
+// packageOf resolves a baseline key to one of the packages that actually reported results. Keys
+// cannot be split on the final dot: package paths legitimately contain dots (for example
+// currency/forexprovider/exchangeratesapi.io) and so do subbenchmark names, so matching against the
+// known set is the only unambiguous attribution. An unmatched key belongs to a package that did not
+// run, which is exactly what the callers need to know.
+func packageOf(key string, known map[string]bool) string {
+	for pkg := range known {
+		if strings.HasPrefix(key, pkg+".") {
+			return pkg
+		}
+	}
+	return ""
+}
+
+func seenPackages(results map[string]*Result) map[string]bool {
+	seen := make(map[string]bool)
+	for _, r := range results {
+		seen[r.Pkg] = true
+	}
+	return seen
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	return slices.Sorted(maps.Keys(m))
+}
+
+// configuredSet turns the ordered package list into a set for lookups
+func configuredSet(list []string) map[string]bool {
+	set := make(map[string]bool, len(list))
+	for _, p := range list {
+		set[p] = true
+	}
+	return set
+}

--- a/cmd/benchcheck/baseline_test.go
+++ b/cmd/benchcheck/baseline_test.go
@@ -1,0 +1,561 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePackages creates the package list that run() now requires, covering the packages used by the
+// sample output in these tests
+func writePackages(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "packages.txt")
+	body := "currency\nexchanges/orderbook\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600), "writing the package list must not error")
+	return path
+}
+
+func TestLoadBaselineMissingFile(t *testing.T) {
+	t.Parallel()
+	b, err := LoadBaseline(filepath.Join(t.TempDir(), "absent.json"), true)
+	require.NoError(t, err, "LoadBaseline must not error when the file is absent")
+	assert.Empty(t, b, "an absent baseline should load as empty so the first -update can seed it")
+}
+
+func TestLoadBaselineInvalid(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	require.NoError(t, os.WriteFile(path, []byte("{nope"), 0o600), "writing the fixture must not error")
+	_, err := LoadBaseline(path, false)
+	assert.ErrorContains(t, err, "error parsing baseline", "an unparsable baseline should report the path")
+}
+
+func TestBaselineSaveAndLoad(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	in := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16, NSHint: 1050, Reason: "interned lookup"}}
+	require.NoError(t, in.Save(path), "Save must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the saved baseline must not error")
+	assert.True(t, bytes.HasSuffix(data, []byte("\n")), "the baseline should end with a newline")
+
+	out, err := LoadBaseline(path, false)
+	require.NoError(t, err, "LoadBaseline must not error")
+	assert.Equal(t, in, out, "a saved baseline should round-trip")
+}
+
+func TestBaselineUpdate(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"currency.BenchmarkNewCode":         {Allocs: 9, Bytes: 99, Reason: "keep me"},
+		"currency.BenchmarkGone":            {Allocs: 1, Bytes: 8},
+		"exchanges/orderbook.BenchmarkSort": {Allocs: 1, Bytes: 8},
+	}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true, nil)
+
+	require.Contains(t, base, "currency.BenchmarkNewCode", "the updated benchmark must remain")
+	entry := base["currency.BenchmarkNewCode"]
+	assert.Equal(t, uint64(2), entry.Allocs, "allocs should be taken from the run")
+	assert.Equal(t, uint64(16), entry.Bytes, "bytes should be taken from the run")
+	assert.Equal(t, "keep me", entry.Reason, "a hand-written reason should be preserved across updates")
+
+	assert.NotContains(t, base, "currency.BenchmarkGone", "a benchmark absent from a package that ran should be dropped")
+	assert.Contains(t, base, "exchanges/orderbook.BenchmarkSort", "a package that did not run should be left untouched")
+}
+
+func TestBaselineUpdatePrunesVanishedPackage(t *testing.T) {
+	t.Parallel()
+	// A package whose last benchmark was deleted reports nothing at all, so it never appears in the
+	// results. Compare still fails on its orphaned entry, so if pruning cannot reach it, `make
+	// bench` demands a `make bench_update` that changes nothing and the gate stays red for good.
+	base := Baseline{
+		"common.BenchmarkCounter":   {Allocs: 0, Bytes: 0},
+		"currency.BenchmarkNewCode": {Allocs: 1, Bytes: 8},
+	}
+	got := resultsOf(result("currency", "BenchmarkNewCode", 1, 8))
+	configured := map[string]bool{"common": true, "currency": true}
+
+	pruned := base.Update(got, true, configured)
+	assert.Equal(t, []string{"common.BenchmarkCounter"}, pruned, "the vanished package's entry should be pruned")
+	assert.NotContains(t, base, "common.BenchmarkCounter", "and removed from the baseline")
+	assert.Empty(t, Compare(base, got, configured, nil, 0.01), "the gate should then be clean")
+
+	// A package outside the configured scope is still left alone, so updating from a run that only
+	// covered some packages does not delete the rest.
+	outOfScope := Baseline{"exchanges/okx.BenchmarkMessageID": {Allocs: 2, Bytes: 48}}
+	assert.Empty(t, outOfScope.Update(got, true, configured), "an unconfigured package should not be pruned")
+	assert.Contains(t, outOfScope, "exchanges/okx.BenchmarkMessageID", "and should keep its entry")
+}
+
+func TestBaselineUpdateSeedsNewEntries(t *testing.T) {
+	t.Parallel()
+	base := Baseline{}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true, nil)
+	require.Contains(t, base, "currency.BenchmarkNewCode", "an unseen benchmark must be added")
+	assert.Equal(t, float64(100), base["currency.BenchmarkNewCode"].NSHint, "the advisory ns hint should be recorded")
+}
+
+func TestBaselineValidate(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, Baseline{"a.B": {Allocs: 1}}.Validate(), "an entry without tolerances should not need a reason")
+	assert.NoError(t, Baseline{"a.B": {BytesTolerance: 0.1, Reason: "noisy"}}.Validate(),
+		"a justified tolerance should validate")
+
+	assert.ErrorIs(t, Baseline{"a.B": {BytesTolerance: 0.1}}.Validate(), errToleranceNeedsReason,
+		"a bytes tolerance without a reason should be rejected")
+	assert.ErrorIs(t, Baseline{"a.B": {AllocsTolerance: 0.1}}.Validate(), errToleranceNeedsReason,
+		"an allocs tolerance without a reason should be rejected")
+	assert.ErrorIs(t, Baseline{"a.B": nil}.Validate(), errNullEntry, "a null entry should be rejected")
+
+	// A blank reason reviews as an empty diff while buying the same exemption as a justification
+	assert.ErrorIs(t, Baseline{"a.B": {Ignore: true, Reason: "  \t"}}.Validate(), errToleranceNeedsReason,
+		"a whitespace-only reason should not satisfy the justification requirement")
+}
+
+func TestBaselineUpdatePreservesTolerances(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 9, BytesTolerance: 0.15, Reason: "noisy"}}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true, nil)
+	entry := base["currency.BenchmarkNewCode"]
+	assert.Equal(t, 0.15, entry.BytesTolerance, "a tolerance override should survive an update")
+	assert.Equal(t, uint64(2), entry.Allocs, "the measured value should still be refreshed")
+}
+
+func TestBaselineUpdateSkipsIgnored(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"exchanges/alert.BenchmarkWait": {Allocs: 4, Bytes: 778, Ignore: true, Reason: "non-deterministic"}}
+	_ = base.Update(resultsOf(result("exchanges/alert", "BenchmarkWait", 99, 9999)), true, nil)
+	entry := base["exchanges/alert.BenchmarkWait"]
+	assert.Equal(t, uint64(4), entry.Allocs, "an ignored benchmark should keep its recorded allocs")
+	assert.Equal(t, uint64(778), entry.Bytes, "an ignored benchmark should keep its recorded bytes")
+	assert.True(t, entry.Ignore, "the ignore flag should survive an update")
+}
+
+func TestRoundNS(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, float64(3556), roundNS(3556.482), "values over 1000 should drop the fraction")
+	assert.Equal(t, 210.9, roundNS(210.94), "values over 10 should keep one decimal")
+	assert.Equal(t, 1.23, roundNS(1.2345), "small values should keep two decimals")
+}
+
+func TestLoadPackages(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	body := "# comment\n\ncurrency    gated\nconfig      # not hermetic\n" +
+		"github.com/thrasher-corp/gocryptotrader/types  gated\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600), "writing the fixture must not error")
+
+	pkgs, err := LoadPackages(path)
+	require.NoError(t, err, "LoadPackages must not error")
+	assert.Equal(t, []string{"currency", "config", "types"}, pkgs.List,
+		"packages should be returned in file order with the module prefix stripped")
+	assert.Equal(t, map[string]bool{"currency": true, "types": true}, pkgs.Gated,
+		"only packages carrying the gated marker should be gated")
+}
+
+// TestCanonicalPackage pins every spelling go test resolves to a package while the gated and
+// configured lookups, which only ever see the pkg: header, would miss it and gate nothing.
+func TestCanonicalPackage(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		entry string
+		want  string
+		err   error
+	}{
+		{entry: "currency", want: "currency"},
+		{entry: "exchanges/order/", want: "exchanges/order"},
+		{entry: "exchanges/order//", want: "exchanges/order"},
+		{entry: "./currency", want: "currency"},
+		{entry: "././currency", want: "currency"},
+		{entry: "currency/./", want: "currency"},
+		{entry: "exchange//websocket/buffer", want: "exchange/websocket/buffer"},
+		{entry: "currency/../types", want: "types"},
+		{entry: modulePrefix + "types", want: "types"},
+		{entry: modulePrefix + "types/", want: "types"},
+		{entry: modulePrefix + "/currency", want: "currency"},
+		{entry: "currency/forexprovider/exchangeratesapi.io", want: "currency/forexprovider/exchangeratesapi.io"},
+		{entry: strings.TrimSuffix(modulePrefix, "/"), err: errBadPackagePath},
+		// Cleaning erases the module boundary, so these must be caught before the prefix comes off:
+		// the second cleans to a real package the entry never named
+		{entry: modulePrefix + "../outside", err: errBadPackagePath},
+		{entry: modulePrefix + "../../../currency", err: errBadPackagePath},
+		// -list is interpolated into go test unquoted, so the shell rewrites these into a real
+		// package after the gate has already filed them under the spelling in the file
+		{entry: "'currency'", err: errBadPackagePath},
+		{entry: `"currency"`, err: errBadPackagePath},
+		{entry: "typ[e]s", err: errBadPackagePath},
+		{entry: "typ*s", err: errBadPackagePath},
+		{entry: "$CURRENCY", err: errBadPackagePath},
+		{entry: "currency;rm", err: errBadPackagePath},
+		{entry: `currency\`, err: errBadPackagePath},
+		{entry: "currency/...", err: errBadPackagePath},
+		{entry: "./...", err: errBadPackagePath},
+		{entry: "./", err: errBadPackagePath},
+		{entry: ".", err: errBadPackagePath},
+		{entry: "../outside", err: errBadPackagePath},
+		{entry: "/abs/path", err: errBadPackagePath},
+	} {
+		t.Run(tc.entry, func(t *testing.T) {
+			t.Parallel()
+			got, err := canonicalPackage(tc.entry)
+			if tc.err != nil {
+				assert.ErrorIs(t, err, tc.err, "an entry go test resolves elsewhere should be refused")
+				return
+			}
+			require.NoError(t, err, "canonicalPackage must not error")
+			assert.Equal(t, tc.want, got, "the entry should reduce to the path go test reports")
+		})
+	}
+}
+
+// TestListOutputSurvivesTheShell pins the property the gate actually depends on: make interpolates
+// -list into the go test command unquoted, so an accepted entry must mean the same thing after the
+// shell has had it. Any entry whose emitted argument the shell would rewrite must be refused, or
+// go test measures one package while the gate waits on a name nothing reports.
+func TestListOutputSurvivesTheShell(t *testing.T) {
+	t.Parallel()
+	for _, entry := range []string{
+		"currency", "exchanges/order/", "./currency", "currency/./", "exchange//websocket/buffer",
+		"currency/forexprovider/exchangeratesapi.io", modulePrefix + "types",
+		"'currency'", `"currency"`, "typ[e]s", "typ*s", "$CURRENCY", "types dispatch", "currency;rm",
+		"currency`x`", "currency|x", "typ?s", "currency&", "types~x", "~currency", "currency\\",
+		"cmd/g++", "foo+bar", "a-b_c.d~e/f",
+	} {
+		t.Run(entry, func(t *testing.T) {
+			t.Parallel()
+			pkg, err := canonicalPackage(entry)
+			if err != nil {
+				return // refused, so it never reaches the shell
+			}
+			arg := "./" + pkg + "/"
+			for _, sh := range []string{"sh", "bash", "dash"} {
+				if _, err := exec.LookPath(sh); err != nil {
+					continue
+				}
+				// Interpolated unquoted on purpose: that is what make does, and reproducing it is
+				// the only way to check the emitted argument against a real shell rather than
+				// against the same assumption the code was written from. Run from the module root
+				// so a glob has the real package tree to expand against; from this package's own
+				// directory nothing matches and a globbing entry would pass by accident.
+				cmd := exec.CommandContext(t.Context(), sh, "-c", "printf %s "+arg)
+				cmd.Dir = filepath.Join("..", "..")
+				out, shErr := cmd.CombinedOutput()
+				require.NoErrorf(t, shErr, "%s must accept the emitted argument", sh)
+				assert.Equalf(t, arg, string(out),
+					"an accepted entry should reach go test as the exact path the gate recorded, under %s", sh)
+			}
+		})
+	}
+}
+
+func TestLoadPackagesCanonicalises(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("exchanges/order/  gated\ncurrency/./  gated\n"), 0o600),
+		"writing the fixture must not error")
+
+	pkgs, err := LoadPackages(path)
+	require.NoError(t, err, "LoadPackages must not error")
+	assert.Equal(t, []string{"exchanges/order", "currency"}, pkgs.List, "entries should be canonicalised")
+	assert.Equal(t, map[string]bool{"exchanges/order": true, "currency": true}, pkgs.Gated,
+		"a noncanonical entry should still gate the package go test actually runs")
+
+	bad := filepath.Join(dir, "bad.txt")
+	require.NoError(t, os.WriteFile(bad, []byte("currency/...  gated\n"), 0o600), "writing the fixture must not error")
+	_, err = LoadPackages(bad)
+	assert.ErrorIs(t, err, errBadPackagePath, "a wildcard entry should be refused rather than gating one of its packages")
+}
+
+func TestLoadPackagesEmpty(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("# only comments\n\n"), 0o600), "writing the fixture must not error")
+	_, err := LoadPackages(path)
+	assert.ErrorIs(t, err, errEmptyPackageList,
+		"a list naming no packages should error rather than silently gate nothing")
+}
+
+func TestLoadPackagesUnknownMarker(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("currency  gatd\n"), 0o600), "writing the fixture must not error")
+	_, err := LoadPackages(path)
+	assert.ErrorIs(t, err, errUnknownMarker, "a mistyped marker should be rejected rather than silently ignored")
+}
+
+func TestLoadPackagesMissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := LoadPackages(filepath.Join(t.TempDir(), "absent.txt"))
+	assert.ErrorIs(t, err, errNoPackageList,
+		"an absent package list must error rather than silently gate nothing")
+}
+
+func TestLoadBaselineMissingInCheckMode(t *testing.T) {
+	t.Parallel()
+	_, err := LoadBaseline(filepath.Join(t.TempDir(), "absent.json"), false)
+	assert.ErrorIs(t, err, errNoBaseline,
+		"an absent baseline must error in check mode; an empty one passes any numbers")
+}
+
+func TestRunList(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("currency gated\nconfig\n"), 0o600), "writing the fixture must not error")
+
+	var out bytes.Buffer
+	require.NoError(t, run(strings.NewReader(""), &out, &options{packagesPath: path, list: true}), "-list must not error")
+	assert.Equal(t, "./currency/ ./config/\n", out.String(), "-list should emit go test package arguments in file order")
+}
+
+func TestPackageOf(t *testing.T) {
+	t.Parallel()
+	known := map[string]bool{
+		"exchanges/orderbook":                        true,
+		"currency/forexprovider/exchangeratesapi.io": true,
+	}
+	assert.Equal(t, "exchanges/orderbook", packageOf("exchanges/orderbook.BenchmarkProcess", known),
+		"a key should resolve to its reporting package")
+	assert.Equal(t, "currency/forexprovider/exchangeratesapi.io",
+		packageOf("currency/forexprovider/exchangeratesapi.io.BenchmarkGetRates", known),
+		"a package path containing dots should resolve correctly")
+	assert.Equal(t, "exchanges/orderbook", packageOf("exchanges/orderbook.BenchmarkSort/case.1", known),
+		"a subbenchmark name containing dots should resolve to its package")
+	assert.Empty(t, packageOf("currency.BenchmarkNewCode", known), "a package that did not run should not resolve")
+	assert.Empty(t, packageOf("nodot", known), "a key without a package prefix should yield no package")
+}
+
+func TestBaselineUpdateWithoutPruneKeepsEntries(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"currency.BenchmarkNewCode": {Allocs: 9, Bytes: 99},
+		"currency.BenchmarkOther":   {Allocs: 1, Bytes: 8},
+	}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), false, nil)
+	assert.Contains(t, base, "currency.BenchmarkOther",
+		"a partial run must not delete entries it simply did not select")
+	assert.Equal(t, uint64(2), base["currency.BenchmarkNewCode"].Allocs, "measured entries should still be refreshed")
+}
+
+func TestLoadBaselineNullFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	require.NoError(t, os.WriteFile(path, []byte("null"), 0o600), "writing the fixture must not error")
+
+	b, err := LoadBaseline(path, false)
+	require.NoError(t, err, "a null baseline must not error")
+	require.NotNil(t, b, "a null baseline must load as an empty map, not a nil one")
+	b.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), false, nil)
+	assert.Contains(t, b, "currency.BenchmarkNewCode", "updating a null baseline should not panic")
+}
+
+func TestValidateToleranceRange(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		tol  float64
+	}{
+		{"negative reports an unchanged benchmark as a regression", -0.01},
+		{"one puts the ratchet lower bound at zero", 1},
+		{"above one disables the gate", 2},
+		{"NaN makes every comparison false", math.NaN()},
+	} {
+		err := Baseline{"a.B": {BytesTolerance: tc.tol, Reason: "x"}}.Validate()
+		assert.ErrorIsf(t, err, errToleranceOutOfRange, "a bytes tolerance that is %s should be rejected", tc.name)
+		err = Baseline{"a.B": {AllocsTolerance: tc.tol, Reason: "x"}}.Validate()
+		assert.ErrorIsf(t, err, errToleranceOutOfRange, "an allocs tolerance that is %s should be rejected", tc.name)
+	}
+	assert.NoError(t, Baseline{"a.B": {BytesTolerance: 0.99, Reason: "x"}}.Validate(),
+		"a tolerance just inside the range should be accepted")
+}
+
+func TestRunUpdateThenCheck(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		update:         true,
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, run(strings.NewReader(sampleOutput), &out, o), "seeding the baseline must not error")
+	assert.Contains(t, out.String(), "recorded 3 benchmarks", "the update should report what it recorded")
+
+	out.Reset()
+	o.update = false
+	require.NoError(t, run(strings.NewReader(sampleOutput), &out, o),
+		"checking the same output against the seeded baseline must not error")
+	assert.Contains(t, out.String(), "3 benchmarks within budget", "a clean check should say so")
+}
+
+func TestRunReportsRegression(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+	}
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 0, Bytes: 0}}
+	require.NoError(t, base.Save(o.baselinePath), "seeding the baseline must not error")
+
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n"
+
+	var out bytes.Buffer
+	err := run(strings.NewReader(in), &out, o)
+	assert.ErrorContains(t, err, "2 findings", "a regression should fail the run")
+	assert.Contains(t, out.String(), "regression", "the finding should be printed")
+
+	out.Reset()
+	o.warn = true
+	assert.NoError(t, run(strings.NewReader(in), &out, o), "warn mode should not fail the run")
+	assert.Contains(t, out.String(), "warn mode", "warn mode should be flagged in the output")
+}
+
+func TestRunUpdateDoesNotPruneWithoutFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		update:         true,
+	}
+	// Every configured package reports one benchmark, which a filtered `-bench BenchmarkOne` run
+	// also satisfies. Inferring a complete run from that deleted 51 real entries.
+	require.NoError(t, os.WriteFile(o.packagesPath, []byte("currency\nexchanges/orderbook\n"), 0o600),
+		"writing the fixture must not error")
+	base := Baseline{
+		"currency.BenchmarkNewCode":          {Allocs: 1, Bytes: 8},
+		"currency.BenchmarkOther":            {Allocs: 2, Bytes: 16},
+		"exchanges/orderbook.BenchmarkSort":  {Allocs: 3, Bytes: 24},
+		"exchanges/orderbook.BenchmarkOther": {Allocs: 4, Bytes: 32},
+	}
+	require.NoError(t, base.Save(o.baselinePath), "seeding the baseline must not error")
+
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-4   \t 100\t 10 ns/op\t 8 B/op\t 1 allocs/op\n" +
+		"pkg: github.com/thrasher-corp/gocryptotrader/exchanges/orderbook\n" +
+		"BenchmarkSort-4   \t 100\t 10 ns/op\t 24 B/op\t 3 allocs/op\n"
+	require.NoError(t, run(strings.NewReader(in), &bytes.Buffer{}, o), "update must not error")
+
+	after, err := LoadBaseline(o.baselinePath, false)
+	require.NoError(t, err, "reloading the baseline must not error")
+	assert.Len(t, after, 4, "a filtered run should not delete the entries it did not select")
+
+	o.prune = true
+	require.NoError(t, run(strings.NewReader(in), &bytes.Buffer{}, o), "update with -prune must not error")
+	after, err = LoadBaseline(o.baselinePath, false)
+	require.NoError(t, err, "reloading the baseline must not error")
+	assert.Len(t, after, 2, "-prune should delete unmatched entries when the caller vouches for the run")
+}
+
+func TestRunRejectsBadGlobalTolerance(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: math.NaN(),
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	err := run(strings.NewReader(sampleOutput), &bytes.Buffer{}, o)
+	assert.ErrorIs(t, err, errToleranceOutOfRange,
+		"a NaN global tolerance would disable every B/op comparison and must be rejected")
+}
+
+func TestRunRejectsShortSampleCount(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		samples:        7,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	var out bytes.Buffer
+	err := run(strings.NewReader(sampleOutput), &out, o)
+	assert.ErrorIs(t, err, errSampleCount, "a run with too few samples should not be compared against the baseline")
+	assert.Contains(t, out.String(), "currency.BenchmarkNewCode reported", "the offending benchmark should be named")
+}
+
+func TestRunWarnSkipsShortSampleCounts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		samples:        2,
+		warn:           true,
+		update:         true,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	require.NoError(t, run(strings.NewReader(sampleOutput), &bytes.Buffer{}, o), "warn mode must not fail on a short benchmark")
+
+	base, err := LoadBaseline(o.baselinePath, false)
+	require.NoError(t, err, "loading the baseline must not error")
+	assert.Contains(t, base, "exchanges/orderbook.BenchmarkProcess", "the complete benchmark should still be recorded")
+	assert.NotContains(t, base, "currency.BenchmarkNewCode", "a benchmark with the wrong sample count should not be recorded")
+}
+
+func TestRunRejectsNegativeSamples(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		samples:        -1,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	assert.ErrorIs(t, run(strings.NewReader(sampleOutput), &bytes.Buffer{}, o), errNegativeSamples,
+		"a negative -samples must be rejected")
+}
+
+func TestSaveLeavesPreviousBaselineOnFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.json")
+	require.NoError(t, Baseline{"a.BenchmarkOne": {Allocs: 1, Bytes: 16}}.Save(path), "the first save must not error")
+	before, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the saved baseline must not error")
+
+	// NaN cannot be encoded, so the marshal fails after the caller has already committed to saving
+	err = Baseline{"a.BenchmarkOne": {Allocs: 1, Bytes: 16, BytesTolerance: math.NaN()}}.Save(path)
+	require.Error(t, err, "saving an unencodable baseline must error")
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err, "the previous baseline must still be readable")
+	assert.Equal(t, before, after, "a failed save should leave the previous baseline untouched")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "reading the baseline directory must not error")
+	assert.Len(t, entries, 1, "a failed save should not leave a temporary file behind")
+}
+
+func TestRunNoResults(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	assert.ErrorIs(t, run(strings.NewReader("PASS\n"), &bytes.Buffer{}, o), errNoResults,
+		"empty input should return errNoResults")
+}

--- a/cmd/benchcheck/baseline_test.go
+++ b/cmd/benchcheck/baseline_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePackages creates the package list that run() now requires, covering the packages used by the
+// sample output in these tests
+func writePackages(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "packages.txt")
+	body := "currency\nexchanges/orderbook\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600), "writing the package list must not error")
+	return path
+}
+
+func TestLoadBaselineMissingFile(t *testing.T) {
+	t.Parallel()
+	b, err := LoadBaseline(filepath.Join(t.TempDir(), "absent.json"), true)
+	require.NoError(t, err, "LoadBaseline must not error when the file is absent")
+	assert.Empty(t, b, "an absent baseline should load as empty so the first -update can seed it")
+}
+
+func TestLoadBaselineInvalid(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	require.NoError(t, os.WriteFile(path, []byte("{nope"), 0o600), "writing the fixture must not error")
+	_, err := LoadBaseline(path, false)
+	assert.ErrorContains(t, err, "error parsing baseline", "an unparsable baseline should report the path")
+}
+
+func TestBaselineSaveAndLoad(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	in := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16, NSHint: 1050, Reason: "interned lookup"}}
+	require.NoError(t, in.Save(path), "Save must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the saved baseline must not error")
+	assert.True(t, bytes.HasSuffix(data, []byte("\n")), "the baseline should end with a newline")
+
+	out, err := LoadBaseline(path, false)
+	require.NoError(t, err, "LoadBaseline must not error")
+	assert.Equal(t, in, out, "a saved baseline should round-trip")
+}
+
+func TestBaselineUpdate(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"currency.BenchmarkNewCode":         {Allocs: 9, Bytes: 99, Reason: "keep me"},
+		"currency.BenchmarkGone":            {Allocs: 1, Bytes: 8},
+		"exchanges/orderbook.BenchmarkSort": {Allocs: 1, Bytes: 8},
+	}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true)
+
+	require.Contains(t, base, "currency.BenchmarkNewCode", "the updated benchmark must remain")
+	entry := base["currency.BenchmarkNewCode"]
+	assert.Equal(t, uint64(2), entry.Allocs, "allocs should be taken from the run")
+	assert.Equal(t, uint64(16), entry.Bytes, "bytes should be taken from the run")
+	assert.Equal(t, "keep me", entry.Reason, "a hand-written reason should be preserved across updates")
+
+	assert.NotContains(t, base, "currency.BenchmarkGone", "a benchmark absent from a package that ran should be dropped")
+	assert.Contains(t, base, "exchanges/orderbook.BenchmarkSort", "a package that did not run should be left untouched")
+}
+
+func TestBaselineUpdateSeedsNewEntries(t *testing.T) {
+	t.Parallel()
+	base := Baseline{}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true)
+	require.Contains(t, base, "currency.BenchmarkNewCode", "an unseen benchmark must be added")
+	assert.Equal(t, float64(100), base["currency.BenchmarkNewCode"].NSHint, "the advisory ns hint should be recorded")
+}
+
+func TestBaselineValidate(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, Baseline{"a.B": {Allocs: 1}}.Validate(), "an entry without tolerances should not need a reason")
+	assert.NoError(t, Baseline{"a.B": {BytesTolerance: 0.1, Reason: "noisy"}}.Validate(),
+		"a justified tolerance should validate")
+
+	assert.ErrorIs(t, Baseline{"a.B": {BytesTolerance: 0.1}}.Validate(), errToleranceNeedsReason,
+		"a bytes tolerance without a reason should be rejected")
+	assert.ErrorIs(t, Baseline{"a.B": {AllocsTolerance: 0.1}}.Validate(), errToleranceNeedsReason,
+		"an allocs tolerance without a reason should be rejected")
+	assert.ErrorIs(t, Baseline{"a.B": nil}.Validate(), errNullEntry, "a null entry should be rejected")
+}
+
+func TestBaselineUpdatePreservesTolerances(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 9, BytesTolerance: 0.15, Reason: "noisy"}}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), true)
+	entry := base["currency.BenchmarkNewCode"]
+	assert.Equal(t, 0.15, entry.BytesTolerance, "a tolerance override should survive an update")
+	assert.Equal(t, uint64(2), entry.Allocs, "the measured value should still be refreshed")
+}
+
+func TestBaselineUpdateSkipsIgnored(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"exchanges/alert.BenchmarkWait": {Allocs: 4, Bytes: 778, Ignore: true, Reason: "non-deterministic"}}
+	_ = base.Update(resultsOf(result("exchanges/alert", "BenchmarkWait", 99, 9999)), true)
+	entry := base["exchanges/alert.BenchmarkWait"]
+	assert.Equal(t, uint64(4), entry.Allocs, "an ignored benchmark should keep its recorded allocs")
+	assert.Equal(t, uint64(778), entry.Bytes, "an ignored benchmark should keep its recorded bytes")
+	assert.True(t, entry.Ignore, "the ignore flag should survive an update")
+}
+
+func TestRoundNS(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, float64(3556), roundNS(3556.482), "values over 1000 should drop the fraction")
+	assert.Equal(t, 210.9, roundNS(210.94), "values over 10 should keep one decimal")
+	assert.Equal(t, 1.23, roundNS(1.2345), "small values should keep two decimals")
+}
+
+func TestLoadPackages(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	body := "# comment\n\ncurrency    gated\nconfig      # not hermetic\n" +
+		"github.com/thrasher-corp/gocryptotrader/types  gated\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600), "writing the fixture must not error")
+
+	pkgs, err := LoadPackages(path)
+	require.NoError(t, err, "LoadPackages must not error")
+	assert.Equal(t, []string{"currency", "config", "types"}, pkgs.List,
+		"packages should be returned in file order with the module prefix stripped")
+	assert.Equal(t, map[string]bool{"currency": true, "types": true}, pkgs.Gated,
+		"only packages carrying the gated marker should be gated")
+}
+
+func TestLoadPackagesUnknownMarker(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("currency  gatd\n"), 0o600), "writing the fixture must not error")
+	_, err := LoadPackages(path)
+	assert.ErrorIs(t, err, errUnknownMarker, "a mistyped marker should be rejected rather than silently ignored")
+}
+
+func TestLoadPackagesMissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := LoadPackages(filepath.Join(t.TempDir(), "absent.txt"))
+	assert.ErrorIs(t, err, errNoPackageList,
+		"an absent package list must error rather than silently gate nothing")
+}
+
+func TestLoadBaselineMissingInCheckMode(t *testing.T) {
+	t.Parallel()
+	_, err := LoadBaseline(filepath.Join(t.TempDir(), "absent.json"), false)
+	assert.ErrorIs(t, err, errNoBaseline,
+		"an absent baseline must error in check mode; an empty one passes any numbers")
+}
+
+func TestRunList(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "packages.txt")
+	require.NoError(t, os.WriteFile(path, []byte("currency gated\nconfig\n"), 0o600), "writing the fixture must not error")
+
+	var out bytes.Buffer
+	require.NoError(t, run(strings.NewReader(""), &out, &options{packagesPath: path, list: true}), "-list must not error")
+	assert.Equal(t, "./currency/ ./config/\n", out.String(), "-list should emit go test package arguments in file order")
+}
+
+func TestPackageOf(t *testing.T) {
+	t.Parallel()
+	known := map[string]bool{
+		"exchanges/orderbook":                        true,
+		"currency/forexprovider/exchangeratesapi.io": true,
+	}
+	assert.Equal(t, "exchanges/orderbook", packageOf("exchanges/orderbook.BenchmarkProcess", known),
+		"a key should resolve to its reporting package")
+	assert.Equal(t, "currency/forexprovider/exchangeratesapi.io",
+		packageOf("currency/forexprovider/exchangeratesapi.io.BenchmarkGetRates", known),
+		"a package path containing dots should resolve correctly")
+	assert.Equal(t, "exchanges/orderbook", packageOf("exchanges/orderbook.BenchmarkSort/case.1", known),
+		"a subbenchmark name containing dots should resolve to its package")
+	assert.Empty(t, packageOf("currency.BenchmarkNewCode", known), "a package that did not run should not resolve")
+	assert.Empty(t, packageOf("nodot", known), "a key without a package prefix should yield no package")
+}
+
+func TestBaselineUpdateWithoutPruneKeepsEntries(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"currency.BenchmarkNewCode": {Allocs: 9, Bytes: 99},
+		"currency.BenchmarkOther":   {Allocs: 1, Bytes: 8},
+	}
+	_ = base.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), false)
+	assert.Contains(t, base, "currency.BenchmarkOther",
+		"a partial run must not delete entries it simply did not select")
+	assert.Equal(t, uint64(2), base["currency.BenchmarkNewCode"].Allocs, "measured entries should still be refreshed")
+}
+
+func TestLoadBaselineNullFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	require.NoError(t, os.WriteFile(path, []byte("null"), 0o600), "writing the fixture must not error")
+
+	b, err := LoadBaseline(path, false)
+	require.NoError(t, err, "a null baseline must not error")
+	require.NotNil(t, b, "a null baseline must load as an empty map, not a nil one")
+	b.Update(resultsOf(result("currency", "BenchmarkNewCode", 2, 16)), false)
+	assert.Contains(t, b, "currency.BenchmarkNewCode", "updating a null baseline should not panic")
+}
+
+func TestValidateToleranceRange(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		tol  float64
+	}{
+		{"negative reports an unchanged benchmark as a regression", -0.01},
+		{"one puts the ratchet lower bound at zero", 1},
+		{"above one disables the gate", 2},
+		{"NaN makes every comparison false", math.NaN()},
+	} {
+		err := Baseline{"a.B": {BytesTolerance: tc.tol, Reason: "x"}}.Validate()
+		assert.ErrorIsf(t, err, errToleranceOutOfRange, "a bytes tolerance that is %s should be rejected", tc.name)
+		err = Baseline{"a.B": {AllocsTolerance: tc.tol, Reason: "x"}}.Validate()
+		assert.ErrorIsf(t, err, errToleranceOutOfRange, "an allocs tolerance that is %s should be rejected", tc.name)
+	}
+	assert.NoError(t, Baseline{"a.B": {BytesTolerance: 0.99, Reason: "x"}}.Validate(),
+		"a tolerance just inside the range should be accepted")
+}
+
+func TestRunUpdateThenCheck(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		update:         true,
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, run(strings.NewReader(sampleOutput), &out, o), "seeding the baseline must not error")
+	assert.Contains(t, out.String(), "recorded 3 benchmarks", "the update should report what it recorded")
+
+	out.Reset()
+	o.update = false
+	require.NoError(t, run(strings.NewReader(sampleOutput), &out, o),
+		"checking the same output against the seeded baseline must not error")
+	assert.Contains(t, out.String(), "3 benchmarks within budget", "a clean check should say so")
+}
+
+func TestRunReportsRegression(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+	}
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 0, Bytes: 0}}
+	require.NoError(t, base.Save(o.baselinePath), "seeding the baseline must not error")
+
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n"
+
+	var out bytes.Buffer
+	err := run(strings.NewReader(in), &out, o)
+	assert.ErrorContains(t, err, "2 findings", "a regression should fail the run")
+	assert.Contains(t, out.String(), "regression", "the finding should be printed")
+
+	out.Reset()
+	o.warn = true
+	assert.NoError(t, run(strings.NewReader(in), &out, o), "warn mode should not fail the run")
+	assert.Contains(t, out.String(), "warn mode", "warn mode should be flagged in the output")
+}
+
+func TestRunUpdateDoesNotPruneWithoutFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		update:         true,
+	}
+	// Every configured package reports one benchmark, which a filtered `-bench BenchmarkOne` run
+	// also satisfies. Inferring a complete run from that deleted 51 real entries.
+	require.NoError(t, os.WriteFile(o.packagesPath, []byte("currency\nexchanges/orderbook\n"), 0o600),
+		"writing the fixture must not error")
+	base := Baseline{
+		"currency.BenchmarkNewCode":          {Allocs: 1, Bytes: 8},
+		"currency.BenchmarkOther":            {Allocs: 2, Bytes: 16},
+		"exchanges/orderbook.BenchmarkSort":  {Allocs: 3, Bytes: 24},
+		"exchanges/orderbook.BenchmarkOther": {Allocs: 4, Bytes: 32},
+	}
+	require.NoError(t, base.Save(o.baselinePath), "seeding the baseline must not error")
+
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-4   \t 100\t 10 ns/op\t 8 B/op\t 1 allocs/op\n" +
+		"pkg: github.com/thrasher-corp/gocryptotrader/exchanges/orderbook\n" +
+		"BenchmarkSort-4   \t 100\t 10 ns/op\t 24 B/op\t 3 allocs/op\n"
+	require.NoError(t, run(strings.NewReader(in), &bytes.Buffer{}, o), "update must not error")
+
+	after, err := LoadBaseline(o.baselinePath, false)
+	require.NoError(t, err, "reloading the baseline must not error")
+	assert.Len(t, after, 4, "a filtered run should not delete the entries it did not select")
+
+	o.prune = true
+	require.NoError(t, run(strings.NewReader(in), &bytes.Buffer{}, o), "update with -prune must not error")
+	after, err = LoadBaseline(o.baselinePath, false)
+	require.NoError(t, err, "reloading the baseline must not error")
+	assert.Len(t, after, 2, "-prune should delete unmatched entries when the caller vouches for the run")
+}
+
+func TestRunRejectsBadGlobalTolerance(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: math.NaN(),
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	err := run(strings.NewReader(sampleOutput), &bytes.Buffer{}, o)
+	assert.ErrorIs(t, err, errToleranceOutOfRange,
+		"a NaN global tolerance would disable every B/op comparison and must be rejected")
+}
+
+func TestRunNoResults(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	assert.ErrorIs(t, run(strings.NewReader("PASS\n"), &bytes.Buffer{}, o), errNoResults,
+		"empty input should return errNoResults")
+}

--- a/cmd/benchcheck/compare.go
+++ b/cmd/benchcheck/compare.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+)
+
+// Kind classifies a comparison finding
+type Kind uint8
+
+// Finding kinds, ordered so that the most actionable sort first
+const (
+	// Regression is a benchmark that now allocates more than its recorded budget
+	Regression Kind = iota
+	// Missing is a baseline entry whose benchmark was not produced by a package that did run
+	Missing
+	// Untracked is a benchmark in a gated package with no baseline entry
+	Untracked
+	// Stale is a benchmark that beat its recorded budget; the baseline needs tightening
+	Stale
+)
+
+func (k Kind) String() string {
+	switch k {
+	case Regression:
+		return "regression"
+	case Missing:
+		return "missing"
+	case Untracked:
+		return "untracked"
+	case Stale:
+		return "stale"
+	default:
+		return "unknown"
+	}
+}
+
+// Finding is a single discrepancy between a benchmark run and the baseline
+type Finding struct {
+	Kind Kind
+	Key  string
+	Msg  string
+}
+
+func (f Finding) String() string {
+	return fmt.Sprintf("%-10s %s: %s", f.Kind, f.Key, f.Msg)
+}
+
+// Compare checks results against the baseline. A regression fails because the code got worse, a
+// stale entry because it got better and the budget must be tightened to keep the improvement, which
+// is what makes the baseline ratchet down rather than act as a ceiling.
+//
+// configured is the set of packages the run was meant to cover, from packages.txt. Missing
+// detection keys off it rather than the packages that reported, so a package whose last benchmark
+// was deleted is still caught; a deliberately filtered run therefore reports what it skipped.
+func Compare(base Baseline, results map[string]*Result, configured, gated map[string]bool, bytesTolerance float64) []Finding {
+	var findings []Finding
+	for _, key := range sortedKeys(results) {
+		r := results[key]
+		entry, ok := base[key]
+		if !ok {
+			if gated[r.Pkg] {
+				findings = append(findings, Finding{Untracked, key, fmt.Sprintf(
+					"benchmark in gated package %s has no baseline entry; run 'make bench_update'", r.Pkg)})
+			}
+			continue
+		}
+		if entry.Ignore {
+			continue
+		}
+		findings = append(findings, compareMetric(key, "allocs/op", entry.Allocs, r.Allocs, entry.AllocsTolerance)...)
+		findings = append(findings, compareMetric(key, "B/op", entry.Bytes, r.Bytes, cmp.Or(entry.BytesTolerance, bytesTolerance))...)
+	}
+
+	// Fall back to the packages that reported when no package list is configured, so a bare
+	// invocation with no packages.txt still detects renames within the packages it did see.
+	scope := configured
+	if len(scope) == 0 {
+		scope = seenPackages(results)
+	}
+	for _, key := range sortedKeys(base) {
+		if _, ok := results[key]; ok || packageOf(key, scope) == "" {
+			continue
+		}
+		// Ignore drops a benchmark from the gate entirely, which has to include the missing check;
+		// otherwise deleting an ignored benchmark fails the build it was meant to be exempt from
+		if base[key].Ignore {
+			continue
+		}
+		findings = append(findings, Finding{Missing, key, "baseline entry has no matching benchmark; " +
+			"it was renamed or deleted, run 'make bench_update'"})
+	}
+	return findings
+}
+
+// compareMetric checks one metric's median against its budget, ignoring movement inside tolerance
+func compareMetric(key, unit string, budget uint64, samples []float64, tolerance float64) []Finding {
+	if len(samples) == 0 {
+		return nil
+	}
+	got := uint64(median(samples))
+	switch {
+	case float64(got) > float64(budget)*(1+tolerance):
+		return []Finding{{Regression, key, fmt.Sprintf("%s %d -> %d", unit, budget, got)}}
+	case float64(got) < float64(budget)*(1-tolerance):
+		return []Finding{{Stale, key, fmt.Sprintf("%s improved %d -> %d; run 'make bench_update'", unit, budget, got)}}
+	}
+	return nil
+}

--- a/cmd/benchcheck/compare.go
+++ b/cmd/benchcheck/compare.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+)
+
+// Kind classifies a comparison finding
+type Kind uint8
+
+// Finding kinds, ordered so that the most actionable sort first
+const (
+	// Regression is a benchmark that now allocates more than its recorded budget
+	Regression Kind = iota
+	// Missing is a baseline entry whose benchmark was not produced by a package that did run
+	Missing
+	// Untracked is a benchmark in a gated package with no baseline entry
+	Untracked
+	// Stale is a benchmark that beat its recorded budget; the baseline needs tightening
+	Stale
+)
+
+func (k Kind) String() string {
+	switch k {
+	case Regression:
+		return "regression"
+	case Missing:
+		return "missing"
+	case Untracked:
+		return "untracked"
+	case Stale:
+		return "stale"
+	default:
+		return "unknown"
+	}
+}
+
+// Finding is a single discrepancy between a benchmark run and the baseline
+type Finding struct {
+	Kind Kind
+	Key  string
+	Msg  string
+}
+
+func (f Finding) String() string {
+	return fmt.Sprintf("%-10s %s: %s", f.Kind, f.Key, f.Msg)
+}
+
+// Compare checks results against the baseline. Regressions fail because the code got worse;
+// stale entries fail because the code got better and the budget must be tightened to keep the
+// improvement, which is what makes the baseline ratchet downwards rather than act as a ceiling that
+// only ever moves up.
+// configured is the set of packages the run was meant to cover, from packages.txt. Missing
+// detection uses it rather than the packages that actually reported: a package whose last benchmark
+// is deleted produces no results at all, so keying off what reported would let its baseline entry
+// linger unnoticed. A deliberately filtered run will therefore report the benchmarks it skipped.
+func Compare(base Baseline, results map[string]*Result, configured, gated map[string]bool, bytesTolerance float64) []Finding {
+	var findings []Finding
+	for _, key := range sortedKeys(results) {
+		r := results[key]
+		entry, ok := base[key]
+		if !ok {
+			if gated[r.Pkg] {
+				findings = append(findings, Finding{Untracked, key, fmt.Sprintf(
+					"benchmark in gated package %s has no baseline entry; run 'make bench_update'", r.Pkg)})
+			}
+			continue
+		}
+		if entry.Ignore {
+			continue
+		}
+		findings = append(findings, compareMetric(key, "allocs/op", entry.Allocs, r.Allocs, entry.AllocsTolerance)...)
+		findings = append(findings, compareMetric(key, "B/op", entry.Bytes, r.Bytes, cmp.Or(entry.BytesTolerance, bytesTolerance))...)
+	}
+
+	// Fall back to the packages that reported when no package list is configured, so a bare
+	// invocation with no packages.txt still detects renames within the packages it did see.
+	scope := configured
+	if len(scope) == 0 {
+		scope = seenPackages(results)
+	}
+	for _, key := range sortedKeys(base) {
+		if _, ok := results[key]; ok || packageOf(key, scope) == "" {
+			continue
+		}
+		// Ignore drops a benchmark from the gate entirely, which has to include the missing check;
+		// otherwise deleting an ignored benchmark fails the build it was meant to be exempt from
+		if base[key].Ignore {
+			continue
+		}
+		findings = append(findings, Finding{Missing, key, "baseline entry has no matching benchmark; " +
+			"it was renamed or deleted, run 'make bench_update'"})
+	}
+	return findings
+}
+
+// compareMetric checks one metric's median against its budget, ignoring movement inside tolerance
+func compareMetric(key, unit string, budget uint64, samples []float64, tolerance float64) []Finding {
+	if len(samples) == 0 {
+		return nil
+	}
+	got := uint64(median(samples))
+	switch {
+	case float64(got) > float64(budget)*(1+tolerance):
+		return []Finding{{Regression, key, fmt.Sprintf("%s %d -> %d", unit, budget, got)}}
+	case float64(got) < float64(budget)*(1-tolerance):
+		return []Finding{{Stale, key, fmt.Sprintf("%s improved %d -> %d; run 'make bench_update'", unit, budget, got)}}
+	}
+	return nil
+}

--- a/cmd/benchcheck/compare_test.go
+++ b/cmd/benchcheck/compare_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func result(pkg, name string, allocs, bytes float64) *Result {
+	return &Result{Pkg: pkg, Name: name, NS: []float64{100}, Bytes: []float64{bytes}, Allocs: []float64{allocs}}
+}
+
+func resultsOf(rs ...*Result) map[string]*Result {
+	m := make(map[string]*Result, len(rs))
+	for _, r := range rs {
+		m[r.Key()] = r
+	}
+	return m
+}
+
+func TestCompareWithinBudget(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16}}
+	got := resultsOf(result("currency", "BenchmarkNewCode", 2, 16))
+	assert.Empty(t, Compare(base, got, nil, nil, 0.01), "a benchmark matching its baseline should produce no findings")
+}
+
+func TestCompareRegression(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16}}
+	got := resultsOf(result("currency", "BenchmarkNewCode", 3, 32))
+	findings := Compare(base, got, nil, nil, 0.01)
+	require.Len(t, findings, 2, "both allocs and bytes regressions must be reported")
+	for _, f := range findings {
+		assert.Equal(t, Regression, f.Kind, "an increase should be reported as a regression")
+	}
+	assert.Contains(t, findings[0].Msg, "allocs/op 2 -> 3", "the message should show the delta")
+}
+
+func TestCompareStaleRatchetsDown(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16}}
+	got := resultsOf(result("currency", "BenchmarkNewCode", 1, 8))
+	findings := Compare(base, got, nil, nil, 0.01)
+	require.Len(t, findings, 2, "an improvement in both metrics must be reported so the baseline is tightened")
+	for _, f := range findings {
+		assert.Equal(t, Stale, f.Kind, "an improvement should be reported as stale")
+		assert.Contains(t, f.Msg, "bench_update", "a stale finding should tell the user how to fix it")
+	}
+}
+
+func TestCompareBytesTolerance(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 1000}}
+	assert.Empty(t, Compare(base, resultsOf(result("currency", "BenchmarkNewCode", 2, 1005)), nil, nil, 0.01),
+		"B/op movement inside the tolerance should not be reported")
+	assert.Len(t, Compare(base, resultsOf(result("currency", "BenchmarkNewCode", 2, 1020)), nil, nil, 0.01), 1,
+		"B/op movement outside the tolerance should be reported")
+}
+
+func TestComparePerEntryTolerance(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"exchanges/alert.BenchmarkWait": {
+		Allocs: 10, Bytes: 736, BytesTolerance: 0.15, Reason: "goroutine scheduling",
+	}}
+	assert.Empty(t, Compare(base, resultsOf(result("exchanges/alert", "BenchmarkWait", 10, 795)), nil, nil, 0.01),
+		"a per-entry tolerance should override the global one")
+	assert.Len(t, Compare(base, resultsOf(result("exchanges/alert", "BenchmarkWait", 10, 900)), nil, nil, 0.01), 1,
+		"movement beyond the per-entry tolerance should still be reported")
+	assert.Len(t, Compare(base, resultsOf(result("exchanges/alert", "BenchmarkWait", 11, 736)), nil, nil, 0.01), 1,
+		"a bytes tolerance should not loosen the allocs gate")
+}
+
+func TestCompareAllocsTolerance(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"config.BenchmarkUpdateConfig": {
+		Allocs: 40731, AllocsTolerance: 0.001, Bytes: 9934399, BytesTolerance: 0.01, Reason: "config file IO",
+	}}
+	assert.Empty(t, Compare(base, resultsOf(result("config", "BenchmarkUpdateConfig", 40732, 9934985)), nil, nil, 0.01),
+		"an allocs tolerance should absorb small run-to-run drift")
+	assert.Len(t, Compare(base, resultsOf(result("config", "BenchmarkUpdateConfig", 41500, 9934399)), nil, nil, 0.01), 1,
+		"an allocs tolerance should not hide a real regression")
+}
+
+func TestCompareIgnore(t *testing.T) {
+	t.Parallel()
+	base := Baseline{"exchanges/alert.BenchmarkWait": {Allocs: 4, Bytes: 778, Ignore: true, Reason: "non-deterministic"}}
+	assert.Empty(t, Compare(base, resultsOf(result("exchanges/alert", "BenchmarkWait", 99, 9999)), nil, map[string]bool{"exchanges/alert": true}, 0.01),
+		"an ignored benchmark should produce no findings however far it moves")
+}
+
+func TestCompareUntrackedOnlyInGatedPackages(t *testing.T) {
+	t.Parallel()
+	got := resultsOf(result("currency", "BenchmarkNewCode", 2, 16))
+	assert.Empty(t, Compare(Baseline{}, got, nil, nil, 0.01), "an unlisted package should not require baseline entries")
+
+	findings := Compare(Baseline{}, got, nil, map[string]bool{"currency": true}, 0.01)
+	require.Len(t, findings, 1, "a gated package must require a baseline entry for every benchmark")
+	assert.Equal(t, Untracked, findings[0].Kind, "a missing entry in a gated package should be untracked")
+}
+
+func TestCompareMissingOnlyForRunPackages(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"currency.BenchmarkNewCode":         {Allocs: 2, Bytes: 16},
+		"currency.BenchmarkGone":            {Allocs: 1, Bytes: 8},
+		"exchanges/orderbook.BenchmarkSort": {Allocs: 1, Bytes: 8},
+	}
+	got := resultsOf(result("currency", "BenchmarkNewCode", 2, 16))
+	findings := Compare(base, got, nil, nil, 0.01)
+	require.Len(t, findings, 1, "only benchmarks from packages that actually ran must be reported missing")
+	assert.Equal(t, Missing, findings[0].Kind, "a vanished benchmark should be reported as missing")
+	assert.Equal(t, "currency.BenchmarkGone", findings[0].Key, "the missing benchmark should be the one that ran but did not report")
+}
+
+func TestCompareIgnoredBenchmarkNotReportedMissing(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"exchanges/alert.BenchmarkWait":  {Allocs: 4, Bytes: 778, Ignore: true, Reason: "non-deterministic"},
+		"exchanges/alert.BenchmarkAlert": {Allocs: 0, Bytes: 0},
+	}
+	got := resultsOf(result("exchanges/alert", "BenchmarkAlert", 0, 0))
+	assert.Empty(t, Compare(base, got, nil, nil, 0.01),
+		"deleting an ignored benchmark should not fail the gate it is exempt from")
+}
+
+func TestCompareDetectsDeletedLastBenchmarkInPackage(t *testing.T) {
+	t.Parallel()
+	base := Baseline{
+		"common.BenchmarkCounter":   {Allocs: 0, Bytes: 0},
+		"currency.BenchmarkNewCode": {Allocs: 2, Bytes: 16},
+	}
+	// common's only benchmark was deleted, so common reports nothing at all. Keying missing
+	// detection off the packages that reported would let its entry linger unnoticed forever.
+	got := resultsOf(result("currency", "BenchmarkNewCode", 2, 16))
+	configured := map[string]bool{"common": true, "currency": true}
+
+	findings := Compare(base, got, configured, nil, 0.01)
+	require.Len(t, findings, 1, "the vanished package's entry must be reported")
+	assert.Equal(t, Missing, findings[0].Kind, "it should be reported as missing")
+	assert.Equal(t, "common.BenchmarkCounter", findings[0].Key, "the missing key should be the deleted benchmark")
+
+	assert.Empty(t, Compare(base, got, nil, nil, 0.01),
+		"with no configured list, only packages that reported are considered")
+}
+
+func TestKindString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "regression", Regression.String(), "Regression should stringify")
+	assert.Equal(t, "missing", Missing.String(), "Missing should stringify")
+	assert.Equal(t, "untracked", Untracked.String(), "Untracked should stringify")
+	assert.Equal(t, "stale", Stale.String(), "Stale should stringify")
+	assert.Equal(t, "unknown", Kind(255).String(), "an out of range kind should stringify as unknown")
+}

--- a/cmd/benchcheck/main.go
+++ b/cmd/benchcheck/main.go
@@ -1,0 +1,144 @@
+// benchcheck compares `go test -bench` output against a checked-in baseline of per-benchmark
+// allocation budgets, failing on any regression and on any improvement that has not been folded
+// back into the baseline.
+//
+// Normally invoked through the Makefile, which owns the measurement flags:
+//
+//	make bench          # check
+//	make bench_update   # record, pruning entries with no result
+//	make bench_trend    # append to the ns/op history
+//
+// Called directly, read from a file rather than a pipe. In a pipeline both processes run at once,
+// so this can read partial output and, with -update, save a baseline before the shell has seen
+// whether go test succeeded:
+//
+//	go test -run '^$' -bench . -benchmem -count 6 -cpu 4 -p 1 ./currency/ > out.txt
+//	benchcheck < out.txt
+//	benchcheck -list
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+var errNoResults = errors.New("no benchmark results found on stdin")
+
+type options struct {
+	baselinePath   string
+	packagesPath   string
+	seriesPath     string
+	commit         string
+	update         bool
+	prune          bool
+	list           bool
+	bytesTolerance float64
+	warn           bool
+}
+
+func main() {
+	var o options
+	flag.StringVar(&o.baselinePath, "baseline", "benchmarks/baseline.json", "path to the baseline file")
+	flag.StringVar(&o.packagesPath, "packages", "benchmarks/packages.txt", "path to the benchmarked package list")
+	flag.StringVar(&o.seriesPath, "series", "", "append the results to this JSON lines history file")
+	flag.StringVar(&o.commit, "commit", "", "commit SHA to label series records with")
+	flag.BoolVar(&o.update, "update", false, "fold the results into the baseline instead of checking them")
+	flag.BoolVar(&o.prune, "prune", false, "with -update, delete baseline entries with no result; only safe when -bench matched every benchmark")
+	flag.BoolVar(&o.list, "list", false, "print the benchmarked packages as go test arguments and exit")
+	flag.Float64Var(&o.bytesTolerance, "bytes-tolerance", 0.01, "fractional B/op movement to ignore")
+	flag.BoolVar(&o.warn, "warn", false, "report findings but always exit 0")
+	flag.Parse()
+
+	if err := run(os.Stdin, os.Stdout, &o); err != nil {
+		fmt.Fprintln(os.Stderr, "benchcheck:", err)
+		os.Exit(1)
+	}
+}
+
+func run(in io.Reader, out io.Writer, o *options) error {
+	pkgs, err := LoadPackages(o.packagesPath)
+	if err != nil {
+		return err
+	}
+	if o.list {
+		args := make([]string, len(pkgs.List))
+		for i, p := range pkgs.List {
+			args[i] = "./" + p + "/"
+		}
+		fmt.Fprintln(out, strings.Join(args, " "))
+		return nil
+	}
+
+	results, err := Parse(in)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return errNoResults
+	}
+
+	base, err := LoadBaseline(o.baselinePath, o.update)
+	if err != nil {
+		return err
+	}
+	if err := base.Validate(); err != nil {
+		return err
+	}
+	// The per-entry overrides are validated by Validate; the global flag reached the comparison
+	// unchecked, so -bytes-tolerance NaN disabled every B/op comparison silently.
+	if err := validTolerance(o.bytesTolerance); err != nil {
+		return fmt.Errorf("-bytes-tolerance: %w", err)
+	}
+
+	// Appended only once nothing else can reject the run. Writing first meant an invalid baseline or
+	// tolerance appended a full run and then exited non-zero, so the obvious retry duplicated it.
+	if o.seriesPath != "" {
+		if err := AppendSeries(o.seriesPath, o.commit, results, time.Now()); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "benchcheck: appended %d records to %s\n", len(results), o.seriesPath)
+	}
+
+	if o.update {
+		// Pruning is opt-in rather than inferred. "every package reported something" is not
+		// evidence of a full run: `-bench BenchmarkOne` across every package satisfies it while
+		// selecting a single benchmark each, and deleting on that basis destroys the baseline.
+		// Only the caller knows whether -bench matched everything, so only the caller may say so.
+		if !o.prune {
+			for _, key := range sortedKeys(base) {
+				if _, ok := results[key]; !ok && packageOf(key, seenPackages(results)) != "" {
+					fmt.Fprintf(out, "benchcheck: %s has no result in this run; keeping it (pass -prune to delete)\n", key)
+				}
+			}
+		}
+		for _, key := range base.Update(results, o.prune) {
+			fmt.Fprintf(out, "benchcheck: pruned %s\n", key)
+		}
+		if err := base.Save(o.baselinePath); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "benchcheck: recorded %d benchmarks in %s\n", len(results), o.baselinePath)
+		return nil
+	}
+
+	findings := Compare(base, results, configuredSet(pkgs.List), pkgs.Gated, o.bytesTolerance)
+	slices.SortStableFunc(findings, func(a, b Finding) int { return int(a.Kind) - int(b.Kind) })
+	for _, f := range findings {
+		fmt.Fprintln(out, f)
+	}
+	if len(findings) == 0 {
+		fmt.Fprintf(out, "benchcheck: %d benchmarks within budget\n", len(results))
+		return nil
+	}
+	if o.warn {
+		fmt.Fprintf(out, "benchcheck: %d findings (warn mode)\n", len(findings))
+		return nil
+	}
+	return fmt.Errorf("%d findings", len(findings))
+}

--- a/cmd/benchcheck/main.go
+++ b/cmd/benchcheck/main.go
@@ -1,0 +1,181 @@
+// benchcheck compares `go test -bench` output against a checked-in baseline of per-benchmark
+// allocation budgets, failing on any regression and on any improvement that has not been folded
+// back into the baseline.
+//
+// Normally invoked through the Makefile, which owns the measurement flags:
+//
+//	make bench          # check
+//	make bench_update   # record, pruning entries with no result
+//	make bench_trend    # append to the ns/op history
+//
+// Called directly, read from a file rather than a pipe. In a pipeline both processes run at once,
+// so this can read partial output and, with -update, save a baseline before the shell has seen
+// whether go test succeeded:
+//
+//	go test -run '^$' -bench . -benchmem -count 7 -cpu 4 -p 1 ./currency/ > out.txt
+//	benchcheck -samples 7 < out.txt
+//	benchcheck -list
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	errNoResults     = errors.New("no benchmark results found on stdin")
+	errWarnWithPrune = errors.New("-warn cannot be combined with -update -prune: a benchmark dropped by -warn would be pruned as though it had been deleted")
+)
+
+type options struct {
+	baselinePath   string
+	packagesPath   string
+	seriesPath     string
+	commit         string
+	update         bool
+	prune          bool
+	list           bool
+	bytesTolerance float64
+	samples        int
+	warn           bool
+}
+
+func main() {
+	var o options
+	flag.StringVar(&o.baselinePath, "baseline", "benchmarks/baseline.json", "path to the baseline file")
+	flag.StringVar(&o.packagesPath, "packages", "benchmarks/packages.txt", "path to the benchmarked package list")
+	flag.StringVar(&o.seriesPath, "series", "", "append the results to this JSON lines history file")
+	flag.StringVar(&o.commit, "commit", "", "commit SHA to label series records with")
+	flag.BoolVar(&o.update, "update", false, "fold the results into the baseline instead of checking them")
+	flag.BoolVar(&o.prune, "prune", false, "with -update, delete baseline entries with no result; only safe when -bench matched every benchmark")
+	flag.BoolVar(&o.list, "list", false, "print the benchmarked packages as go test arguments and exit")
+	flag.Float64Var(&o.bytesTolerance, "bytes-tolerance", 0.01, "fractional B/op movement to ignore")
+	flag.IntVar(&o.samples, "samples", 0, "reject benchmarks not reporting exactly this many samples; zero disables the check")
+	flag.BoolVar(&o.warn, "warn", false, "report findings but always exit 0")
+	flag.Parse()
+
+	if err := run(os.Stdin, os.Stdout, &o); err != nil {
+		fmt.Fprintln(os.Stderr, "benchcheck:", err)
+		os.Exit(1)
+	}
+}
+
+func run(in io.Reader, out io.Writer, o *options) error {
+	pkgs, err := LoadPackages(o.packagesPath)
+	if err != nil {
+		return err
+	}
+	if o.list {
+		args := make([]string, len(pkgs.List))
+		for i, p := range pkgs.List {
+			args[i] = "./" + p + "/"
+		}
+		fmt.Fprintln(out, strings.Join(args, " "))
+		return nil
+	}
+
+	if o.samples < 0 {
+		return fmt.Errorf("-samples: %w: %d", errNegativeSamples, o.samples)
+	}
+	// -warn drops a benchmark that reported the wrong sample count, which -prune then reads as a
+	// benchmark that no longer exists and deletes the budget for. The benchmark is still there and
+	// still measured; only its budget is gone, and the next run records whatever it now allocates.
+	if o.warn && o.update && o.prune {
+		return errWarnWithPrune
+	}
+
+	results, err := Parse(in)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return errNoResults
+	}
+
+	// A median only means anything when every benchmark contributed the same number of samples.
+	// Warn mode drops the offenders instead of failing: the trend run measures for ten minutes and
+	// records one line per benchmark, so a single short benchmark should cost its own record rather
+	// than every other benchmark's.
+	mismatched, err := SampleCountMismatches(results, o.samples)
+	if err != nil {
+		return err
+	}
+	if len(mismatched) > 0 {
+		for _, key := range mismatched {
+			fmt.Fprintf(out, "benchcheck: %s reported %s\n", key, describeSamples(results[key], o.samples))
+		}
+		if !o.warn {
+			return fmt.Errorf("%w: %d of %d benchmarks", errSampleCount, len(mismatched), len(results))
+		}
+		for _, key := range mismatched {
+			delete(results, key)
+		}
+		if len(results) == 0 {
+			return errNoResults
+		}
+	}
+
+	base, err := LoadBaseline(o.baselinePath, o.update)
+	if err != nil {
+		return err
+	}
+	if err := base.Validate(); err != nil {
+		return err
+	}
+	// Validate covers the per-entry overrides; the global flag needs the same range check, or
+	// -bytes-tolerance NaN disables every B/op comparison silently
+	if err := validTolerance(o.bytesTolerance); err != nil {
+		return fmt.Errorf("-bytes-tolerance: %w", err)
+	}
+
+	// Appended only once nothing else can reject the run. Writing first meant an invalid baseline or
+	// tolerance appended a full run and then exited non-zero, so the obvious retry duplicated it.
+	if o.seriesPath != "" {
+		if err := AppendSeries(o.seriesPath, o.commit, results, time.Now()); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "benchcheck: appended %d records to %s\n", len(results), o.seriesPath)
+	}
+
+	configured := configuredSet(pkgs.List)
+	if o.update {
+		// Pruning is opt-in rather than inferred: "every package reported something" is satisfied
+		// by -bench selecting one benchmark each, and deleting on that basis destroys the baseline
+		if !o.prune {
+			for _, key := range sortedKeys(base) {
+				if _, ok := results[key]; !ok && packageOf(key, configured) != "" {
+					fmt.Fprintf(out, "benchcheck: %s has no result in this run; keeping it (pass -prune to delete)\n", key)
+				}
+			}
+		}
+		for _, key := range base.Update(results, o.prune, configured) {
+			fmt.Fprintf(out, "benchcheck: pruned %s\n", key)
+		}
+		if err := base.Save(o.baselinePath); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "benchcheck: recorded %d benchmarks in %s\n", len(results), o.baselinePath)
+		return nil
+	}
+
+	findings := Compare(base, results, configured, pkgs.Gated, o.bytesTolerance)
+	slices.SortStableFunc(findings, func(a, b Finding) int { return int(a.Kind) - int(b.Kind) })
+	for _, f := range findings {
+		fmt.Fprintln(out, f)
+	}
+	if len(findings) == 0 {
+		fmt.Fprintf(out, "benchcheck: %d benchmarks within budget\n", len(results))
+		return nil
+	}
+	if o.warn {
+		fmt.Fprintf(out, "benchcheck: %d findings (warn mode)\n", len(findings))
+		return nil
+	}
+	return fmt.Errorf("%d findings", len(findings))
+}

--- a/cmd/benchcheck/parse.go
+++ b/cmd/benchcheck/parse.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var (
+	errNoPackageContext = errors.New("benchmark result with no preceding pkg: header")
+	errNoMemoryMetrics  = errors.New("benchmark result without B/op and allocs/op")
+	errBadMeasurement   = errors.New("benchmark measurement is not a finite, non-negative number")
+	errSampleCount      = errors.New("benchmark did not produce the expected number of samples")
+	errNegativeSamples  = errors.New("expected sample count cannot be negative")
+)
+
+const modulePrefix = "github.com/thrasher-corp/gocryptotrader/"
+
+// Result holds every sample recorded for a single benchmark across all -count runs
+type Result struct {
+	Pkg    string
+	Name   string
+	NS     []float64
+	Bytes  []float64
+	Allocs []float64
+}
+
+// Key returns the baseline key for a result, in the form "exchanges/orderbook.BenchmarkProcess"
+func (r *Result) Key() string {
+	return r.Pkg + "." + r.Name
+}
+
+// Parse reads `go test -bench` output and aggregates the samples for each benchmark. Package
+// attribution comes from the "pkg:" header Go emits before each package's results, so the input
+// must not be filtered through anything that strips those lines.
+func Parse(r io.Reader) (map[string]*Result, error) {
+	results := make(map[string]*Result)
+	var pkg string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if p, ok := strings.CutPrefix(line, "pkg:"); ok {
+			pkg = strings.TrimPrefix(strings.TrimSpace(p), modulePrefix)
+			continue
+		}
+		name, metrics, ok := parseBenchLine(line)
+		if !ok {
+			continue
+		}
+		// A key such as ".BenchmarkX" matches no baseline entry and no gated package, so an
+		// unattributed result would pass the gate rather than fail it
+		if pkg == "" {
+			return nil, fmt.Errorf("%w: %s", errNoPackageContext, name)
+		}
+		res, ok := results[pkg+"."+name]
+		if !ok {
+			res = &Result{Pkg: pkg, Name: name}
+			results[res.Key()] = res
+		}
+		// A line without -benchmem carries no B/op or allocs/op. Recording it would leave the
+		// gated metrics empty, which compareMetric skips, so the gate would silently pass.
+		b, hasBytes := metrics["B/op"]
+		a, hasAllocs := metrics["allocs/op"]
+		if !hasBytes || !hasAllocs {
+			return nil, fmt.Errorf("%w: %s.%s (is -benchmem set?)", errNoMemoryMetrics, pkg, name)
+		}
+		for unit, v := range metrics {
+			if math.IsNaN(v) {
+				return nil, fmt.Errorf("%w: %s.%s has a non-finite or negative %s", errBadMeasurement, pkg, name, unit)
+			}
+		}
+		if v, ok := metrics["ns/op"]; ok {
+			res.NS = append(res.NS, v)
+		}
+		res.Bytes = append(res.Bytes, b)
+		res.Allocs = append(res.Allocs, a)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// SampleCountMismatches reports the benchmarks whose sample count is not expected, in key order.
+// The compared value is a median, so it only means anything when every benchmark contributed the
+// same number of samples.
+//
+// ns/op is exempt when absent entirely, since a benchmark may suppress it with
+// b.ReportMetric(0, "ns/op"); a partial count is still a mismatch.
+func SampleCountMismatches(results map[string]*Result, expected int) ([]string, error) {
+	if expected == 0 {
+		return nil, nil
+	}
+	if expected < 0 {
+		return nil, fmt.Errorf("%w: %d", errNegativeSamples, expected)
+	}
+	var mismatched []string
+	for _, key := range sortedKeys(results) {
+		r := results[key]
+		if len(r.Bytes) != expected || len(r.Allocs) != expected || (len(r.NS) != 0 && len(r.NS) != expected) {
+			mismatched = append(mismatched, key)
+		}
+	}
+	return mismatched, nil
+}
+
+// describeSamples renders a mismatched result's counts for an error or warning line
+func describeSamples(r *Result, expected int) string {
+	return fmt.Sprintf("ns/op=%d B/op=%d allocs/op=%d, expected %d", len(r.NS), len(r.Bytes), len(r.Allocs), expected)
+}
+
+// parseBenchLine extracts the benchmark name and its value/unit pairs from a single result line,
+// reporting false for any line that is not a well-formed benchmark result
+func parseBenchLine(line string) (name string, metrics map[string]float64, ok bool) {
+	f := strings.Fields(line)
+	if len(f) < 4 || !strings.HasPrefix(f[0], "Benchmark") {
+		return "", nil, false
+	}
+	// The iteration count separates a result line from output such as "--- FAIL: BenchmarkX"
+	if _, err := strconv.ParseUint(f[1], 10, 64); err != nil {
+		return "", nil, false
+	}
+	pairs := f[2:]
+	if len(pairs)%2 != 0 {
+		return "", nil, false
+	}
+	metrics = make(map[string]float64, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		v, err := strconv.ParseFloat(pairs[i], 64)
+		if err != nil {
+			return "", nil, false
+		}
+		// NaN and infinities parse cleanly but convert to nonsense budgets via uint64, and a
+		// negative measurement is not something the testing package emits. Recorded rather than
+		// skipped: silently dropping the line removes its package from the results entirely, and
+		// with any other package still parsing, the gate would report success.
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+			metrics[pairs[i+1]] = math.NaN()
+			continue
+		}
+		metrics[pairs[i+1]] = v
+	}
+	return trimProcSuffix(f[0]), metrics, true
+}
+
+// trimProcSuffix removes the -N GOMAXPROCS suffix that the testing package appends to result names
+func trimProcSuffix(name string) string {
+	i := strings.LastIndexByte(name, '-')
+	if i <= 0 {
+		return name
+	}
+	if _, err := strconv.ParseUint(name[i+1:], 10, 64); err != nil {
+		return name
+	}
+	return name[:i]
+}
+
+// median returns the middle sample, rather than a mean, so one noisy iteration on a shared CI
+// runner cannot move the compared value.
+//
+// The measurement flags use an odd count so a real middle sample exists. An even count takes the
+// lower of the two middles, which stays whole but is biased low and asymmetrically so; it is a
+// fallback for hand-run invocations rather than a path the gate takes.
+func median(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	s := slices.Clone(samples)
+	slices.Sort(s)
+	return s[(len(s)-1)/2]
+}

--- a/cmd/benchcheck/parse.go
+++ b/cmd/benchcheck/parse.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var (
+	errNoPackageContext = errors.New("benchmark result with no preceding pkg: header")
+	errNoMemoryMetrics  = errors.New("benchmark result without B/op and allocs/op")
+	errBadMeasurement   = errors.New("benchmark measurement is not a finite, non-negative number")
+)
+
+const modulePrefix = "github.com/thrasher-corp/gocryptotrader/"
+
+// Result holds every sample recorded for a single benchmark across all -count runs
+type Result struct {
+	Pkg    string
+	Name   string
+	NS     []float64
+	Bytes  []float64
+	Allocs []float64
+}
+
+// Key returns the baseline key for a result, in the form "exchanges/orderbook.BenchmarkProcess"
+func (r *Result) Key() string {
+	return r.Pkg + "." + r.Name
+}
+
+// Parse reads `go test -bench` output and aggregates the samples for each benchmark. Package
+// attribution comes from the "pkg:" header Go emits before each package's results, so the input
+// must not be filtered through anything that strips those lines.
+func Parse(r io.Reader) (map[string]*Result, error) {
+	results := make(map[string]*Result)
+	var pkg string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if p, ok := strings.CutPrefix(line, "pkg:"); ok {
+			pkg = strings.TrimPrefix(strings.TrimSpace(p), modulePrefix)
+			continue
+		}
+		name, metrics, ok := parseBenchLine(line)
+		if !ok {
+			continue
+		}
+		// Without a pkg: header the result cannot be attributed, and a key such as ".BenchmarkX"
+		// silently matches no baseline entry and no gated package, so the gate would pass anything
+		if pkg == "" {
+			return nil, fmt.Errorf("%w: %s", errNoPackageContext, name)
+		}
+		res, ok := results[pkg+"."+name]
+		if !ok {
+			res = &Result{Pkg: pkg, Name: name}
+			results[res.Key()] = res
+		}
+		// A line without -benchmem carries no B/op or allocs/op. Recording it would leave the
+		// gated metrics empty, which compareMetric skips, so the gate would silently pass.
+		b, hasBytes := metrics["B/op"]
+		a, hasAllocs := metrics["allocs/op"]
+		if !hasBytes || !hasAllocs {
+			return nil, fmt.Errorf("%w: %s.%s (is -benchmem set?)", errNoMemoryMetrics, pkg, name)
+		}
+		for unit, v := range metrics {
+			if math.IsNaN(v) {
+				return nil, fmt.Errorf("%w: %s.%s has a non-finite or negative %s", errBadMeasurement, pkg, name, unit)
+			}
+		}
+		if v, ok := metrics["ns/op"]; ok {
+			res.NS = append(res.NS, v)
+		}
+		res.Bytes = append(res.Bytes, b)
+		res.Allocs = append(res.Allocs, a)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// parseBenchLine extracts the benchmark name and its value/unit pairs from a single result line,
+// reporting false for any line that is not a well-formed benchmark result
+func parseBenchLine(line string) (name string, metrics map[string]float64, ok bool) {
+	f := strings.Fields(line)
+	if len(f) < 4 || !strings.HasPrefix(f[0], "Benchmark") {
+		return "", nil, false
+	}
+	// The iteration count separates a result line from output such as "--- FAIL: BenchmarkX"
+	if _, err := strconv.ParseUint(f[1], 10, 64); err != nil {
+		return "", nil, false
+	}
+	pairs := f[2:]
+	if len(pairs)%2 != 0 {
+		return "", nil, false
+	}
+	metrics = make(map[string]float64, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		v, err := strconv.ParseFloat(pairs[i], 64)
+		if err != nil {
+			return "", nil, false
+		}
+		// NaN and infinities parse cleanly but convert to nonsense budgets via uint64, and a
+		// negative measurement is not something the testing package emits. Recorded rather than
+		// skipped: silently dropping the line removes its package from the results entirely, and
+		// with any other package still parsing, the gate would report success.
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+			metrics[pairs[i+1]] = math.NaN()
+			continue
+		}
+		metrics[pairs[i+1]] = v
+	}
+	return trimProcSuffix(f[0]), metrics, true
+}
+
+// trimProcSuffix removes the -N GOMAXPROCS suffix that the testing package appends to result names
+func trimProcSuffix(name string) string {
+	i := strings.LastIndexByte(name, '-')
+	if i <= 0 {
+		return name
+	}
+	if _, err := strconv.ParseUint(name[i+1:], 10, 64); err != nil {
+		return name
+	}
+	return name[:i]
+}
+
+// median returns the middle sample, taking the lower of the two middles for an even sample count so
+// that alloc and byte counts stay whole numbers. Samples are a median rather than a mean because a
+// single noisy iteration on a shared CI runner should not move the compared value.
+func median(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	s := slices.Clone(samples)
+	slices.Sort(s)
+	return s[(len(s)-1)/2]
+}

--- a/cmd/benchcheck/parse_test.go
+++ b/cmd/benchcheck/parse_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleOutput = `goos: linux
+goarch: amd64
+pkg: github.com/thrasher-corp/gocryptotrader/exchanges/orderbook
+cpu: AMD Ryzen 9 5950X 16-Core Processor
+BenchmarkProcess-8   	 5572401	       210.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkProcess-8   	 5570000	       213.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSortAsksDecending-8   	  361266	      3556 ns/op	      24 B/op	       1 allocs/op
+PASS
+ok  	github.com/thrasher-corp/gocryptotrader/exchanges/orderbook	3.140s
+goos: linux
+goarch: amd64
+pkg: github.com/thrasher-corp/gocryptotrader/currency
+BenchmarkNewCode-8   	 1000000	      1050 ns/op	      16 B/op	       2 allocs/op
+PASS
+ok  	github.com/thrasher-corp/gocryptotrader/currency	1.200s
+`
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	results, err := Parse(strings.NewReader(sampleOutput))
+	require.NoError(t, err, "Parse must not error")
+	require.Len(t, results, 3, "Parse must return one result per benchmark")
+
+	proc := results["exchanges/orderbook.BenchmarkProcess"]
+	require.NotNil(t, proc, "BenchmarkProcess must be present")
+	assert.Equal(t, "exchanges/orderbook", proc.Pkg, "Pkg should have the module prefix stripped")
+	assert.Equal(t, "BenchmarkProcess", proc.Name, "Name should have the GOMAXPROCS suffix stripped")
+	assert.Equal(t, []float64{210.9, 213.1}, proc.NS, "every -count sample should be retained")
+	assert.Equal(t, []float64{0, 0}, proc.Bytes, "B/op samples should be retained")
+	assert.Equal(t, []float64{0, 0}, proc.Allocs, "allocs/op samples should be retained")
+
+	code := results["currency.BenchmarkNewCode"]
+	require.NotNil(t, code, "results must be attributed to the package of the preceding pkg: header")
+	assert.Equal(t, "currency", code.Pkg, "Pkg should track the most recent pkg: header")
+}
+
+func TestParseIgnoresNonResultLines(t *testing.T) {
+	t.Parallel()
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"--- FAIL: BenchmarkNewCode\n" +
+		"BenchmarkNewCode-8\n" +
+		"BenchmarkNewCode-8   \t notanumber\t      1050 ns/op\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n" +
+		"FAIL\n"
+	results, err := Parse(strings.NewReader(in))
+	require.NoError(t, err, "Parse must not error")
+	require.Len(t, results, 1, "only the well-formed result line must be parsed")
+	assert.Equal(t, []float64{2}, results["currency.BenchmarkNewCode"].Allocs, "the well-formed line should be recorded")
+}
+
+func TestParseRequiresMemoryMetrics(t *testing.T) {
+	t.Parallel()
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errNoMemoryMetrics,
+		"a result without -benchmem should error rather than silently leave the gated metrics empty")
+}
+
+func TestParseRequiresPackageContext(t *testing.T) {
+	t.Parallel()
+	in := "BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errNoPackageContext,
+		"a result with no pkg: header cannot be attributed and must not be silently accepted")
+}
+
+func TestParseRejectsNonFiniteAndNegative(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"NaN", "+Inf", "-1"} {
+		in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+			"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       " + bad + " allocs/op\n"
+		_, err := Parse(strings.NewReader(in))
+		assert.ErrorIsf(t, err, errBadMeasurement, "a %s measurement should be rejected", bad)
+	}
+}
+
+func TestParseBadMeasurementDoesNotVanish(t *testing.T) {
+	t.Parallel()
+	// Skipping the line instead of failing removes its package from the results entirely. With any
+	// other package still parsing, the run stays non-empty and the gate reports success.
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/common\n" +
+		"BenchmarkCounter-4   \t 100\t 10 ns/op\t 0 B/op\t NaN allocs/op\n" +
+		"pkg: github.com/thrasher-corp/gocryptotrader/exchanges/okx\n" +
+		"BenchmarkMessageID-4   \t 100\t 175 ns/op\t 48 B/op\t 2 allocs/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errBadMeasurement,
+		"a bad measurement must fail the run even when another package parses cleanly")
+}
+
+func TestParseNoResults(t *testing.T) {
+	t.Parallel()
+	results, err := Parse(strings.NewReader("PASS\nok  \tgithub.com/x/y\t0.1s\n"))
+	require.NoError(t, err, "Parse must not error on benchmark-free output")
+	assert.Empty(t, results, "output with no benchmarks should yield no results")
+}
+
+func TestTrimProcSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ in, exp string }{
+		{"BenchmarkProcess-8", "BenchmarkProcess"},
+		{"BenchmarkProcess-128", "BenchmarkProcess"},
+		{"BenchmarkProcess", "BenchmarkProcess"},
+		{"BenchmarkUpdateInsertByID_asks-8", "BenchmarkUpdateInsertByID_asks"},
+		{"BenchmarkSort-Ascending", "BenchmarkSort-Ascending"},
+	} {
+		assert.Equalf(t, tc.exp, trimProcSuffix(tc.in), "trimProcSuffix should handle %s", tc.in)
+	}
+}
+
+func TestMedian(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, median(nil), "median of no samples should be zero")
+	assert.Equal(t, 3.0, median([]float64{3}), "median of one sample should be that sample")
+	assert.Equal(t, 2.0, median([]float64{3, 1, 2}), "median should ignore sample order")
+	assert.Equal(t, 2.0, median([]float64{1, 2, 3, 4}), "an even count should take the lower middle to stay whole")
+	assert.Equal(t, 10.0, median([]float64{10, 10, 10, 10, 20, 20, 20}), "three high samples of seven should not move the median")
+	assert.Equal(t, 20.0, median([]float64{10, 10, 10, 20, 20, 20, 20}), "four high samples of seven should move the median")
+}
+
+func TestSampleCountMismatches(t *testing.T) {
+	t.Parallel()
+	full := func(n int) *Result {
+		return &Result{NS: make([]float64, n), Bytes: make([]float64, n), Allocs: make([]float64, n)}
+	}
+	noNS := &Result{Bytes: make([]float64, 7), Allocs: make([]float64, 7)}
+	shortNS := &Result{NS: make([]float64, 6), Bytes: make([]float64, 7), Allocs: make([]float64, 7)}
+
+	for _, tc := range []struct {
+		name     string
+		expected int
+		results  map[string]*Result
+		want     []string
+		err      error
+	}{
+		{name: "disabled", results: map[string]*Result{"a.BenchmarkOne": full(6)}},
+		{name: "complete", expected: 7, results: map[string]*Result{"a.BenchmarkOne": full(7)}},
+		{
+			name: "suppressed ns/op is not a mismatch", expected: 7,
+			results: map[string]*Result{"a.BenchmarkOne": noNS},
+		},
+		{
+			name: "partial ns/op is a mismatch", expected: 7,
+			results: map[string]*Result{"a.BenchmarkOne": shortNS}, want: []string{"a.BenchmarkOne"},
+		},
+		{
+			name: "reported in key order", expected: 7,
+			results: map[string]*Result{"b.BenchmarkTwo": full(6), "a.BenchmarkOne": full(5), "c.BenchmarkThree": full(7)},
+			want:    []string{"a.BenchmarkOne", "b.BenchmarkTwo"},
+		},
+		{name: "negative expected count", expected: -1, results: map[string]*Result{"a.BenchmarkOne": full(7)}, err: errNegativeSamples},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := SampleCountMismatches(tc.results, tc.expected)
+			if tc.err != nil {
+				assert.ErrorIs(t, err, tc.err, "SampleCountMismatches should return the expected error")
+				return
+			}
+			require.NoError(t, err, "SampleCountMismatches must not error")
+			assert.Equal(t, tc.want, got, "SampleCountMismatches should report the expected benchmarks")
+		})
+	}
+}
+
+func TestResultKey(t *testing.T) {
+	t.Parallel()
+	r := &Result{Pkg: "exchanges/orderbook", Name: "BenchmarkProcess"}
+	assert.Equal(t, "exchanges/orderbook.BenchmarkProcess", r.Key(), "Key should join package and name")
+}

--- a/cmd/benchcheck/parse_test.go
+++ b/cmd/benchcheck/parse_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleOutput = `goos: linux
+goarch: amd64
+pkg: github.com/thrasher-corp/gocryptotrader/exchanges/orderbook
+cpu: AMD Ryzen 9 5950X 16-Core Processor
+BenchmarkProcess-8   	 5572401	       210.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkProcess-8   	 5570000	       213.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSortAsksDecending-8   	  361266	      3556 ns/op	      24 B/op	       1 allocs/op
+PASS
+ok  	github.com/thrasher-corp/gocryptotrader/exchanges/orderbook	3.140s
+goos: linux
+goarch: amd64
+pkg: github.com/thrasher-corp/gocryptotrader/currency
+BenchmarkNewCode-8   	 1000000	      1050 ns/op	      16 B/op	       2 allocs/op
+PASS
+ok  	github.com/thrasher-corp/gocryptotrader/currency	1.200s
+`
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	results, err := Parse(strings.NewReader(sampleOutput))
+	require.NoError(t, err, "Parse must not error")
+	require.Len(t, results, 3, "Parse must return one result per benchmark")
+
+	proc := results["exchanges/orderbook.BenchmarkProcess"]
+	require.NotNil(t, proc, "BenchmarkProcess must be present")
+	assert.Equal(t, "exchanges/orderbook", proc.Pkg, "Pkg should have the module prefix stripped")
+	assert.Equal(t, "BenchmarkProcess", proc.Name, "Name should have the GOMAXPROCS suffix stripped")
+	assert.Equal(t, []float64{210.9, 213.1}, proc.NS, "every -count sample should be retained")
+	assert.Equal(t, []float64{0, 0}, proc.Bytes, "B/op samples should be retained")
+	assert.Equal(t, []float64{0, 0}, proc.Allocs, "allocs/op samples should be retained")
+
+	code := results["currency.BenchmarkNewCode"]
+	require.NotNil(t, code, "results must be attributed to the package of the preceding pkg: header")
+	assert.Equal(t, "currency", code.Pkg, "Pkg should track the most recent pkg: header")
+}
+
+func TestParseIgnoresNonResultLines(t *testing.T) {
+	t.Parallel()
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"--- FAIL: BenchmarkNewCode\n" +
+		"BenchmarkNewCode-8\n" +
+		"BenchmarkNewCode-8   \t notanumber\t      1050 ns/op\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n" +
+		"FAIL\n"
+	results, err := Parse(strings.NewReader(in))
+	require.NoError(t, err, "Parse must not error")
+	require.Len(t, results, 1, "only the well-formed result line must be parsed")
+	assert.Equal(t, []float64{2}, results["currency.BenchmarkNewCode"].Allocs, "the well-formed line should be recorded")
+}
+
+func TestParseRequiresMemoryMetrics(t *testing.T) {
+	t.Parallel()
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+		"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errNoMemoryMetrics,
+		"a result without -benchmem should error rather than silently leave the gated metrics empty")
+}
+
+func TestParseRequiresPackageContext(t *testing.T) {
+	t.Parallel()
+	in := "BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       2 allocs/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errNoPackageContext,
+		"a result with no pkg: header cannot be attributed and must not be silently accepted")
+}
+
+func TestParseRejectsNonFiniteAndNegative(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"NaN", "+Inf", "-1"} {
+		in := "pkg: github.com/thrasher-corp/gocryptotrader/currency\n" +
+			"BenchmarkNewCode-8   \t 1000000\t      1050 ns/op\t      16 B/op\t       " + bad + " allocs/op\n"
+		_, err := Parse(strings.NewReader(in))
+		assert.ErrorIsf(t, err, errBadMeasurement, "a %s measurement should be rejected", bad)
+	}
+}
+
+func TestParseBadMeasurementDoesNotVanish(t *testing.T) {
+	t.Parallel()
+	// Skipping the line instead of failing removes its package from the results entirely. With any
+	// other package still parsing, the run stays non-empty and the gate reports success.
+	in := "pkg: github.com/thrasher-corp/gocryptotrader/common\n" +
+		"BenchmarkCounter-4   \t 100\t 10 ns/op\t 0 B/op\t NaN allocs/op\n" +
+		"pkg: github.com/thrasher-corp/gocryptotrader/exchanges/okx\n" +
+		"BenchmarkMessageID-4   \t 100\t 175 ns/op\t 48 B/op\t 2 allocs/op\n"
+	_, err := Parse(strings.NewReader(in))
+	assert.ErrorIs(t, err, errBadMeasurement,
+		"a bad measurement must fail the run even when another package parses cleanly")
+}
+
+func TestParseNoResults(t *testing.T) {
+	t.Parallel()
+	results, err := Parse(strings.NewReader("PASS\nok  \tgithub.com/x/y\t0.1s\n"))
+	require.NoError(t, err, "Parse must not error on benchmark-free output")
+	assert.Empty(t, results, "output with no benchmarks should yield no results")
+}
+
+func TestTrimProcSuffix(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ in, exp string }{
+		{"BenchmarkProcess-8", "BenchmarkProcess"},
+		{"BenchmarkProcess-128", "BenchmarkProcess"},
+		{"BenchmarkProcess", "BenchmarkProcess"},
+		{"BenchmarkUpdateInsertByID_asks-8", "BenchmarkUpdateInsertByID_asks"},
+		{"BenchmarkSort-Ascending", "BenchmarkSort-Ascending"},
+	} {
+		assert.Equalf(t, tc.exp, trimProcSuffix(tc.in), "trimProcSuffix should handle %s", tc.in)
+	}
+}
+
+func TestMedian(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, median(nil), "median of no samples should be zero")
+	assert.Equal(t, 3.0, median([]float64{3}), "median of one sample should be that sample")
+	assert.Equal(t, 2.0, median([]float64{3, 1, 2}), "median should ignore sample order")
+	assert.Equal(t, 2.0, median([]float64{1, 2, 3, 4}), "an even count should take the lower middle to stay whole")
+}
+
+func TestResultKey(t *testing.T) {
+	t.Parallel()
+	r := &Result{Pkg: "exchanges/orderbook", Name: "BenchmarkProcess"}
+	assert.Equal(t, "exchanges/orderbook.BenchmarkProcess", r.Key(), "Key should join package and name")
+}

--- a/cmd/benchcheck/series.go
+++ b/cmd/benchcheck/series.go
@@ -15,15 +15,15 @@ import (
 // the least contaminated by scheduler noise, which makes it the better estimator when reading the
 // ns/op trend across runs on different machines.
 type SeriesRecord struct {
-	Timestamp   time.Time `json:"ts"`
-	Commit      string    `json:"commit,omitempty"`
-	Package     string    `json:"pkg"`
-	Benchmark   string    `json:"bench"`
-	Samples     int       `json:"samples"`
-	NSMedian    float64   `json:"ns_median"`
-	NSMin       float64   `json:"ns_min"`
-	BytesMedian uint64    `json:"bytes_median"`
-	AllocsMedn  uint64    `json:"allocs_median"`
+	Timestamp    time.Time `json:"ts"`
+	Commit       string    `json:"commit,omitempty"`
+	Package      string    `json:"pkg"`
+	Benchmark    string    `json:"bench"`
+	Samples      int       `json:"samples"`
+	NSMedian     float64   `json:"ns_median"`
+	NSMin        float64   `json:"ns_min"`
+	BytesMedian  uint64    `json:"bytes_median"`
+	AllocsMedian uint64    `json:"allocs_median"`
 }
 
 // AppendSeries appends one record per benchmark to path, creating it if absent. Records are only
@@ -45,15 +45,15 @@ func AppendSeries(path, commit string, results map[string]*Result, now time.Time
 	for _, key := range sortedKeys(results) {
 		r := results[key]
 		rec := &SeriesRecord{
-			Timestamp:   now.UTC(),
-			Commit:      commit,
-			Package:     r.Pkg,
-			Benchmark:   r.Name,
-			Samples:     len(r.NS),
-			NSMedian:    median(r.NS),
-			NSMin:       minimum(r.NS),
-			BytesMedian: uint64(median(r.Bytes)),
-			AllocsMedn:  uint64(median(r.Allocs)),
+			Timestamp:    now.UTC(),
+			Commit:       commit,
+			Package:      r.Pkg,
+			Benchmark:    r.Name,
+			Samples:      len(r.NS),
+			NSMedian:     median(r.NS),
+			NSMin:        minimum(r.NS),
+			BytesMedian:  uint64(median(r.Bytes)),
+			AllocsMedian: uint64(median(r.Allocs)),
 		}
 		line, err := json.Marshal(rec)
 		if err != nil {

--- a/cmd/benchcheck/series.go
+++ b/cmd/benchcheck/series.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+// SeriesRecord is one benchmark's measurements from one run, appended to the series file as a
+// single JSON line so history can be charted without re-running anything.
+//
+// Median is the value the gate compares; Min is carried alongside it because the fastest sample is
+// the least contaminated by scheduler noise, which makes it the better estimator when reading the
+// ns/op trend across runs on different machines.
+type SeriesRecord struct {
+	Timestamp    time.Time `json:"ts"`
+	Commit       string    `json:"commit,omitempty"`
+	Package      string    `json:"pkg"`
+	Benchmark    string    `json:"bench"`
+	Samples      int       `json:"samples"`
+	NSMedian     float64   `json:"ns_median"`
+	NSMin        float64   `json:"ns_min"`
+	BytesMedian  uint64    `json:"bytes_median"`
+	AllocsMedian uint64    `json:"allocs_median"`
+}
+
+// AppendSeries appends one record per benchmark to path, creating it if absent. Records are only
+// ever appended, never rewritten, so the file is an append-only history and merges cleanly.
+func AppendSeries(path, commit string, results map[string]*Result, now time.Time) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("error opening series file: %w", err)
+	}
+	defer f.Close()
+
+	// An existing file whose last line is unterminated would otherwise have the next record
+	// concatenated onto it, producing a line that is not valid JSON. The append-only prefix check
+	// in scripts/bench_history.sh cannot catch that: the damaged line is still a byte prefix.
+	if err := terminateLastLine(f, path); err != nil {
+		return err
+	}
+
+	for _, key := range sortedKeys(results) {
+		r := results[key]
+		rec := &SeriesRecord{
+			Timestamp: now.UTC(),
+			Commit:    commit,
+			Package:   r.Pkg,
+			Benchmark: r.Name,
+			// Allocs rather than NS: a benchmark may suppress ns/op with b.ReportMetric(0, "ns/op"),
+			// which would otherwise record a full run as zero samples
+			Samples:      len(r.Allocs),
+			NSMedian:     median(r.NS),
+			NSMin:        minimum(r.NS),
+			BytesMedian:  uint64(median(r.Bytes)),
+			AllocsMedian: uint64(median(r.Allocs)),
+		}
+		line, err := json.Marshal(rec)
+		if err != nil {
+			return fmt.Errorf("error encoding series record for %s: %w", key, err)
+		}
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("error writing series record for %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// terminateLastLine writes a newline if path is non-empty and does not already end with one
+func terminateLastLine(f *os.File, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("error inspecting series file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil
+	}
+	r, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error reading series file: %w", err)
+	}
+	defer r.Close()
+
+	last := make([]byte, 1)
+	if _, err := r.ReadAt(last, info.Size()-1); err != nil {
+		return fmt.Errorf("error reading end of series file: %w", err)
+	}
+	if last[0] == '\n' {
+		return nil
+	}
+	if _, err := f.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("error terminating series file: %w", err)
+	}
+	return nil
+}
+
+func minimum(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	m := samples[0]
+	for _, v := range samples[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}

--- a/cmd/benchcheck/series.go
+++ b/cmd/benchcheck/series.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+// SeriesRecord is one benchmark's measurements from one run, appended to the series file as a
+// single JSON line so history can be charted without re-running anything.
+//
+// Median is the value the gate compares; Min is carried alongside it because the fastest sample is
+// the least contaminated by scheduler noise, which makes it the better estimator when reading the
+// ns/op trend across runs on different machines.
+type SeriesRecord struct {
+	Timestamp   time.Time `json:"ts"`
+	Commit      string    `json:"commit,omitempty"`
+	Package     string    `json:"pkg"`
+	Benchmark   string    `json:"bench"`
+	Samples     int       `json:"samples"`
+	NSMedian    float64   `json:"ns_median"`
+	NSMin       float64   `json:"ns_min"`
+	BytesMedian uint64    `json:"bytes_median"`
+	AllocsMedn  uint64    `json:"allocs_median"`
+}
+
+// AppendSeries appends one record per benchmark to path, creating it if absent. Records are only
+// ever appended, never rewritten, so the file is an append-only history and merges cleanly.
+func AppendSeries(path, commit string, results map[string]*Result, now time.Time) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("error opening series file: %w", err)
+	}
+	defer f.Close()
+
+	// An existing file whose last line is unterminated would otherwise have the next record
+	// concatenated onto it, producing a line that is not valid JSON. The append-only prefix check
+	// in scripts/bench_history.sh cannot catch that: the damaged line is still a byte prefix.
+	if err := terminateLastLine(f, path); err != nil {
+		return err
+	}
+
+	for _, key := range sortedKeys(results) {
+		r := results[key]
+		rec := &SeriesRecord{
+			Timestamp:   now.UTC(),
+			Commit:      commit,
+			Package:     r.Pkg,
+			Benchmark:   r.Name,
+			Samples:     len(r.NS),
+			NSMedian:    median(r.NS),
+			NSMin:       minimum(r.NS),
+			BytesMedian: uint64(median(r.Bytes)),
+			AllocsMedn:  uint64(median(r.Allocs)),
+		}
+		line, err := json.Marshal(rec)
+		if err != nil {
+			return fmt.Errorf("error encoding series record for %s: %w", key, err)
+		}
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("error writing series record for %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// terminateLastLine writes a newline if path is non-empty and does not already end with one
+func terminateLastLine(f *os.File, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("error inspecting series file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil
+	}
+	r, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error reading series file: %w", err)
+	}
+	defer r.Close()
+
+	last := make([]byte, 1)
+	if _, err := r.ReadAt(last, info.Size()-1); err != nil {
+		return fmt.Errorf("error reading end of series file: %w", err)
+	}
+	if last[0] == '\n' {
+		return nil
+	}
+	if _, err := f.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("error terminating series file: %w", err)
+	}
+	return nil
+}
+
+func minimum(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	m := samples[0]
+	for _, v := range samples[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}

--- a/cmd/benchcheck/series_test.go
+++ b/cmd/benchcheck/series_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+func TestAppendSeries(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+
+	r := &Result{Pkg: "currency", Name: "BenchmarkNewCode", NS: []float64{110, 98, 104}, Bytes: []float64{8, 8, 8}, Allocs: []float64{1, 1, 1}}
+	require.NoError(t, AppendSeries(path, "abc123", resultsOf(r), now), "AppendSeries must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 1, "one record per benchmark must be written")
+
+	var rec SeriesRecord
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &rec), "the record must be valid JSON")
+	assert.Equal(t, "currency", rec.Package, "the package should be recorded")
+	assert.Equal(t, "BenchmarkNewCode", rec.Benchmark, "the benchmark name should be recorded")
+	assert.Equal(t, "abc123", rec.Commit, "the commit should be recorded")
+	assert.Equal(t, now, rec.Timestamp, "the timestamp should be recorded in UTC")
+	assert.Equal(t, 3, rec.Samples, "the sample count should be recorded")
+	assert.Equal(t, float64(104), rec.NSMedian, "the median ns should be recorded")
+	assert.Equal(t, float64(98), rec.NSMin, "the fastest sample should be recorded alongside the median")
+	assert.Equal(t, uint64(8), rec.BytesMedian, "the median bytes should be recorded")
+	assert.Equal(t, uint64(1), rec.AllocsMedn, "the median allocs should be recorded")
+}
+
+func TestAppendSeriesAppends(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	got := resultsOf(result("currency", "BenchmarkNewCode", 1, 8), result("types", "BenchmarkNumberMarshalJSON", 1, 16))
+
+	for range 3 {
+		require.NoError(t, AppendSeries(path, "abc123", got, time.Now()), "AppendSeries must not error")
+	}
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	assert.Len(t, strings.Split(strings.TrimSpace(string(data)), "\n"), 6,
+		"repeated runs must append rather than overwrite, giving history")
+}
+
+func TestAppendSeriesTerminatesUnterminatedFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	// A history whose last line has no newline: appending straight onto it produces a line that is
+	// not valid JSON, and the byte-prefix guard in bench_history.sh cannot see it because the
+	// damaged line is still a prefix of the new content.
+	require.NoError(t, os.WriteFile(path, []byte(`{"ts":"2026-07-29T01:00:00Z","bench":"A"}`), 0o600),
+		"writing the fixture must not error")
+
+	require.NoError(t, AppendSeries(path, "abc", resultsOf(result("currency", "BenchmarkNewCode", 1, 8)), time.Now()),
+		"AppendSeries must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 2, "the record must land on its own line")
+	for i, ln := range lines {
+		var v map[string]any
+		assert.NoErrorf(t, json.Unmarshal([]byte(ln), &v), "line %d should be valid JSON", i+1)
+	}
+}
+
+func TestMinimum(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, minimum(nil), "the minimum of no samples should be zero")
+	assert.Equal(t, 2.0, minimum([]float64{5, 2, 9}), "the minimum should be the smallest sample")
+}
+
+func TestRunWritesSeries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		seriesPath:     filepath.Join(dir, "series.jsonl"),
+		commit:         "deadbeef",
+		bytesTolerance: 0.01,
+		warn:           true,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	require.NoError(t, run(strings.NewReader(sampleOutput), &strings.Builder{}, o), "run must not error in warn mode")
+
+	data, err := os.ReadFile(o.seriesPath)
+	require.NoError(t, err, "the series file must have been written")
+	assert.Len(t, strings.Split(strings.TrimSpace(string(data)), "\n"), 3, "one record per benchmark should be appended")
+	assert.Contains(t, string(data), "deadbeef", "records should carry the supplied commit")
+}

--- a/cmd/benchcheck/series_test.go
+++ b/cmd/benchcheck/series_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
+)
+
+func TestAppendSeries(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+
+	r := &Result{Pkg: "currency", Name: "BenchmarkNewCode", NS: []float64{110, 98, 104}, Bytes: []float64{8, 8, 8}, Allocs: []float64{1, 1, 1}}
+	require.NoError(t, AppendSeries(path, "abc123", resultsOf(r), now), "AppendSeries must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 1, "one record per benchmark must be written")
+
+	var rec SeriesRecord
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &rec), "the record must be valid JSON")
+	assert.Equal(t, "currency", rec.Package, "the package should be recorded")
+	assert.Equal(t, "BenchmarkNewCode", rec.Benchmark, "the benchmark name should be recorded")
+	assert.Equal(t, "abc123", rec.Commit, "the commit should be recorded")
+	assert.Equal(t, now, rec.Timestamp, "the timestamp should be recorded in UTC")
+	assert.Equal(t, 3, rec.Samples, "the sample count should be recorded")
+	assert.Equal(t, float64(104), rec.NSMedian, "the median ns should be recorded")
+	assert.Equal(t, float64(98), rec.NSMin, "the fastest sample should be recorded alongside the median")
+	assert.Equal(t, uint64(8), rec.BytesMedian, "the median bytes should be recorded")
+	assert.Equal(t, uint64(1), rec.AllocsMedian, "the median allocs should be recorded")
+}
+
+func TestAppendSeriesAppends(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	got := resultsOf(result("currency", "BenchmarkNewCode", 1, 8), result("types", "BenchmarkNumberMarshalJSON", 1, 16))
+
+	for range 3 {
+		require.NoError(t, AppendSeries(path, "abc123", got, time.Now()), "AppendSeries must not error")
+	}
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	assert.Len(t, strings.Split(strings.TrimSpace(string(data)), "\n"), 6,
+		"repeated runs must append rather than overwrite, giving history")
+}
+
+func TestAppendSeriesTerminatesUnterminatedFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	// A history whose last line has no newline: appending straight onto it produces a line that is
+	// not valid JSON, and the byte-prefix guard in bench_history.sh cannot see it because the
+	// damaged line is still a prefix of the new content.
+	require.NoError(t, os.WriteFile(path, []byte(`{"ts":"2026-07-29T01:00:00Z","bench":"A"}`), 0o600),
+		"writing the fixture must not error")
+
+	require.NoError(t, AppendSeries(path, "abc", resultsOf(result("currency", "BenchmarkNewCode", 1, 8)), time.Now()),
+		"AppendSeries must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 2, "the record must land on its own line")
+	for i, ln := range lines {
+		var v map[string]any
+		assert.NoErrorf(t, json.Unmarshal([]byte(ln), &v), "line %d should be valid JSON", i+1)
+	}
+}
+
+func TestAppendSeriesCountsAllocationSamples(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "series.jsonl")
+	// A benchmark may suppress ns/op with b.ReportMetric(0, "ns/op"), which SampleCountMismatches
+	// deliberately tolerates. Counting NS would then file a full run as zero samples.
+	r := &Result{Pkg: "currency", Name: "BenchmarkNewCode", Bytes: []float64{8, 8, 8}, Allocs: []float64{1, 1, 1}}
+	require.NoError(t, AppendSeries(path, "abc", resultsOf(r), time.Now()), "AppendSeries must not error")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading the series file must not error")
+	var rec SeriesRecord
+	require.NoError(t, json.Unmarshal(data, &rec), "the record must be valid JSON")
+	assert.Equal(t, 3, rec.Samples, "the allocation sample count should be recorded when ns/op is suppressed")
+}
+
+func TestRunRejectsWarnWithPrune(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		bytesTolerance: 0.01,
+		update:         true,
+		prune:          true,
+		warn:           true,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	// -warn drops a short-sampled benchmark, and -prune would then delete its budget as though the
+	// benchmark had been removed
+	assert.ErrorIs(t, run(strings.NewReader(sampleOutput), &strings.Builder{}, o), errWarnWithPrune,
+		"-warn with -update -prune should be refused rather than silently dropping budgets")
+}
+
+func TestMinimum(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, minimum(nil), "the minimum of no samples should be zero")
+	assert.Equal(t, 2.0, minimum([]float64{5, 2, 9}), "the minimum should be the smallest sample")
+}
+
+func TestRunWritesSeries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &options{
+		baselinePath:   filepath.Join(dir, "baseline.json"),
+		packagesPath:   writePackages(t, dir),
+		seriesPath:     filepath.Join(dir, "series.jsonl"),
+		commit:         "deadbeef",
+		bytesTolerance: 0.01,
+		warn:           true,
+	}
+	require.NoError(t, Baseline{}.Save(o.baselinePath), "seeding an empty baseline must not error")
+	require.NoError(t, run(strings.NewReader(sampleOutput), &strings.Builder{}, o), "run must not error in warn mode")
+
+	data, err := os.ReadFile(o.seriesPath)
+	require.NoError(t, err, "the series file must have been written")
+	assert.Len(t, strings.Split(strings.TrimSpace(string(data)), "\n"), 3, "one record per benchmark should be appended")
+	assert.Contains(t, string(data), "deadbeef", "records should carry the supplied commit")
+}

--- a/cmd/benchcheck/series_test.go
+++ b/cmd/benchcheck/series_test.go
@@ -35,7 +35,7 @@ func TestAppendSeries(t *testing.T) {
 	assert.Equal(t, float64(104), rec.NSMedian, "the median ns should be recorded")
 	assert.Equal(t, float64(98), rec.NSMin, "the fastest sample should be recorded alongside the median")
 	assert.Equal(t, uint64(8), rec.BytesMedian, "the median bytes should be recorded")
-	assert.Equal(t, uint64(1), rec.AllocsMedn, "the median allocs should be recorded")
+	assert.Equal(t, uint64(1), rec.AllocsMedian, "the median allocs should be recorded")
 }
 
 func TestAppendSeriesAppends(t *testing.T) {

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -650,7 +650,6 @@ func TestCounter(t *testing.T) {
 	require.Equal(t, int64(2), c.IncrementAndGet())
 }
 
-// 683185328	         1.787 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkCounter(b *testing.B) {
 	c := Counter{}
 	for b.Loop() {

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -50,7 +50,6 @@ func TestPercentageDifference(t *testing.T) {
 	require.True(t, math.IsNaN(PercentageDifference(0.0, 0.0)))
 }
 
-// 1000000000	         0.2215 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkPercentageDifference(b *testing.B) {
 	for b.Loop() {
 		PercentageDifference(1.469, 1.471)
@@ -67,7 +66,6 @@ func TestPercentageDifferenceDecimal(t *testing.T) {
 	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.Zero, decimal.Zero).String())
 }
 
-// 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op
 func BenchmarkDecimalPercentageDifference(b *testing.B) {
 	d1, d2 := decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)
 	for b.Loop() {

--- a/common/timedmutex/timed_mutex_test.go
+++ b/common/timedmutex/timed_mutex_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-// 1000000	        1074 ns/op	     136 B/op	       4 allocs/op (prev)
-// 2423571	       503.9 ns/op	       0 B/op	       0 allocs/op (current)
 func BenchmarkTimedMutexTime(b *testing.B) {
 	tm := NewTimedMutex(0)
 	for b.Loop() {
@@ -14,8 +12,6 @@ func BenchmarkTimedMutexTime(b *testing.B) {
 	}
 }
 
-// 352309195	         3.194 ns/op	       0 B/op	       0 allocs/op (prev)
-// 927051118	         1.298 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkTimedMutexTimeUnlockNotPrimed(b *testing.B) {
 	tm := NewTimedMutex(0)
 	for b.Loop() {
@@ -23,8 +19,6 @@ func BenchmarkTimedMutexTimeUnlockNotPrimed(b *testing.B) {
 	}
 }
 
-// 95322825				15.51 ns/op	       0 B/op	       0 allocs/op (prev)
-// 239158972			4.621 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkTimedMutexTimeUnlockPrimed(b *testing.B) {
 	tm := NewTimedMutex(0)
 	tm.LockForDuration()
@@ -33,8 +27,6 @@ func BenchmarkTimedMutexTimeUnlockPrimed(b *testing.B) {
 	}
 }
 
-// 1000000	         1193 ns/op	     136 B/op	       4 allocs/op (prev)
-// 38592405	        36.12 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkTimedMutexTimeLinearInteraction(b *testing.B) {
 	tm := NewTimedMutex(0)
 	for b.Loop() {

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -637,9 +637,6 @@ func TestItemString(t *testing.T) {
 	assert.Equal(t, "HWORLD", newItem.String())
 }
 
-// 28848025	        40.84 ns/op	       8 B/op	       1 allocs/op // Current
-//
-//	546290	      2192 ns/op	       8 B/op	       1 allocs/op // Previous
 func BenchmarkNewCode(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -382,8 +382,6 @@ codes:
 	}
 }
 
-// Current: 6176922	       260.0 ns/op	      48 B/op	       1 allocs/op
-// Prior: 2575473	       474.2 ns/op	     112 B/op	       3 allocs/op
 func BenchmarkGetCrypto(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -474,8 +472,6 @@ func TestGetStablesMatch(t *testing.T) {
 	}
 }
 
-// Current: 5594431	       217.4 ns/op	     168 B/op	       8 allocs/op
-// Prev:  3490366	       373.4 ns/op	     296 B/op	      11 allocs/op
 func BenchmarkPairsString(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -492,8 +488,6 @@ func BenchmarkPairsString(b *testing.B) {
 	}
 }
 
-// Current:  6691011	       184.6 ns/op	     352 B/op	       1 allocs/op
-// Prev:  3746151	       317.1 ns/op	     720 B/op	       4 allocs/op
 func BenchmarkPairsFormat(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -512,8 +506,6 @@ func BenchmarkPairsFormat(b *testing.B) {
 	}
 }
 
-// current: 13075897	       100.4 ns/op	     352 B/op	       1 allocs/o
-// prev: 8188616	       148.0 ns/op	     336 B/op	       3 allocs/op
 func BenchmarkRemovePairsByFilter(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -848,9 +840,6 @@ func TestFindPairDifferences(t *testing.T) {
 	require.False(t, diff.FormatDifference)
 }
 
-// 2208139	       509.3 ns/op	     288 B/op	       2 allocs/op (current)
-//
-// 1614865	       712.5 ns/op	     336 B/op	       8 allocs/op (prev)
 func BenchmarkFindDifferences(b *testing.B) {
 	original, err := NewPairsFromStrings([]string{"ETH-USD", "LTC-USD", "ETH-USD"})
 	require.NoError(b, err)

--- a/currency/pairs_test.go
+++ b/currency/pairs_test.go
@@ -406,8 +406,6 @@ codes:
 	}
 }
 
-// Current: 6176922	       260.0 ns/op	      48 B/op	       1 allocs/op
-// Prior: 2575473	       474.2 ns/op	     112 B/op	       3 allocs/op
 func BenchmarkGetCrypto(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -498,8 +496,6 @@ func TestGetStablesMatch(t *testing.T) {
 	}
 }
 
-// Current: 5594431	       217.4 ns/op	     168 B/op	       8 allocs/op
-// Prev:  3490366	       373.4 ns/op	     296 B/op	      11 allocs/op
 func BenchmarkPairsString(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -516,9 +512,6 @@ func BenchmarkPairsString(b *testing.B) {
 	}
 }
 
-// Benchstat medians (10 alternating samples per revision):
-// Before: 477.8 ns/op  232 B/op  9 allocs/op
-// After:  135.9 ns/op   64 B/op  1 alloc/op
 func BenchmarkPairsJoin(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -535,8 +528,6 @@ func BenchmarkPairsJoin(b *testing.B) {
 	}
 }
 
-// Current:  6691011	       184.6 ns/op	     352 B/op	       1 allocs/op
-// Prev:  3746151	       317.1 ns/op	     720 B/op	       4 allocs/op
 func BenchmarkPairsFormat(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -555,8 +546,6 @@ func BenchmarkPairsFormat(b *testing.B) {
 	}
 }
 
-// current: 13075897	       100.4 ns/op	     352 B/op	       1 allocs/o
-// prev: 8188616	       148.0 ns/op	     336 B/op	       3 allocs/op
 func BenchmarkRemovePairsByFilter(b *testing.B) {
 	pairs := Pairs{
 		NewBTCUSD(),
@@ -891,9 +880,6 @@ func TestFindPairDifferences(t *testing.T) {
 	require.False(t, diff.FormatDifference)
 }
 
-// 2208139	       509.3 ns/op	     288 B/op	       2 allocs/op (current)
-//
-// 1614865	       712.5 ns/op	     336 B/op	       8 allocs/op (prev)
 func BenchmarkFindDifferences(b *testing.B) {
 	original, err := NewPairsFromStrings([]string{"ETH-USD", "LTC-USD", "ETH-USD"})
 	require.NoError(b, err)

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -405,18 +405,30 @@ func TestMuxPublish(t *testing.T) {
 	assert.NoError(t, err, "stop should not error")
 }
 
-// 13636467	        84.26 ns/op	     141 B/op	       1 allocs/op
 func BenchmarkSubscribe(b *testing.B) {
 	d := NewDispatcher()
-	err := d.start(0, 0)
+	// Explicit rather than 0, 0: the defaulting path warns through the global logger, which go test
+	// would interleave into the result lines the moment a caller enables it
+	err := d.start(DefaultMaxWorkers, DefaultJobsLimit)
 	require.NoError(b, err, "start must not error")
+	// Each -count sample starts another set of relayers, so an unstopped dispatcher leaves them
+	// blocked for the rest of the run
+	b.Cleanup(func() { assert.NoError(b, d.stop(), "stop should not error") })
 	mux := GetNewMux(d)
 	newID, err := mux.GetID()
 	require.NoError(b, err, "GetID must not error")
 
+	// Unsubscribing keeps the route's subscriber slice at a steady length. Left to accumulate it
+	// grows by one channel per iteration and never shrinks, so the amortised cost of growing it
+	// lands differently depending on where in the doubling curve the run stopped, and B/op moves
+	// between runs. It also means the benchmark measures a subscriber list no caller would have.
 	for b.Loop() {
-		_, err := mux.Subscribe(newID)
+		pipe, err := mux.Subscribe(newID)
 		if err != nil {
+			b.Error(err)
+			continue
+		}
+		if err := pipe.Release(); err != nil {
 			b.Error(err)
 		}
 	}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -405,7 +405,6 @@ func TestMuxPublish(t *testing.T) {
 	assert.NoError(t, err, "stop should not error")
 }
 
-// 13636467	        84.26 ns/op	     141 B/op	       1 allocs/op
 func BenchmarkSubscribe(b *testing.B) {
 	d := NewDispatcher()
 	err := d.start(0, 0)

--- a/encoding/json/benchmark_test.go
+++ b/encoding/json/benchmark_test.go
@@ -2,8 +2,10 @@ package json
 
 import "testing"
 
-// BenchmarkUnmarshal-16  838503    1282 ns/op   816 B/op  24 allocs/op (encoding/json)
-// BenchmarkUnmarshal-16  1859184   653.3 ns/op  900 B/op  18 allocs/op (bytedance/sonic) Usage: go test --tags=sonic -bench=BenchmarkUnmarshal -v
+// BenchmarkUnmarshal measures whichever JSON implementation is compiled in. To measure
+// bytedance/sonic rather than encoding/json:
+//
+//	go test --tags=sonic -bench=BenchmarkUnmarshal -v
 func BenchmarkUnmarshal(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {

--- a/encoding/json/benchmark_test.go
+++ b/encoding/json/benchmark_test.go
@@ -2,8 +2,10 @@ package json
 
 import "testing"
 
-// BenchmarkUnmarshal-16  838503    1282 ns/op   816 B/op  24 allocs/op (encoding/json)
-// BenchmarkUnmarshal-16  1859184   653.3 ns/op  900 B/op  18 allocs/op (bytedance/sonic) Usage: go test --tags=sonic -bench=BenchmarkUnmarshal -v
+// BenchmarkUnmarshal measures whichever JSON implementation is compiled in. To measure
+// bytedance/sonic rather than encoding/json:
+//
+//	go test -tags sonic_on -bench=BenchmarkUnmarshal -v
 func BenchmarkUnmarshal(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {

--- a/encoding/json/benchmark_test.go
+++ b/encoding/json/benchmark_test.go
@@ -5,7 +5,7 @@ import "testing"
 // BenchmarkUnmarshal measures whichever JSON implementation is compiled in. To measure
 // bytedance/sonic rather than encoding/json:
 //
-//	go test --tags=sonic -bench=BenchmarkUnmarshal -v
+//	go test -tags sonic_on -bench=BenchmarkUnmarshal -v
 func BenchmarkUnmarshal(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {

--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -42,14 +42,7 @@ func BenchmarkLoadSnapshotExistingHolder(b *testing.B) {
 	}
 }
 
-// Benchstat medians (20 counterbalanced fresh-process observations per revision).
-// The timed region includes LoadSnapshot, applyPendingUpdates, and relay drain.
-// 64 updates:
-// Before: 18.58 µs/op  3120 B/op  65 allocs/op
-// After:  16.66 µs/op  3120 B/op  65 allocs/op
-// 256 updates:
-// Before: 74.13 µs/op  12336 B/op  257 allocs/op
-// After:  65.87 µs/op  12336 B/op  257 allocs/op
+// BenchmarkApplyPendingUpdates times LoadSnapshot, applyPendingUpdates and the relay drain together.
 func BenchmarkApplyPendingUpdates(b *testing.B) {
 	for _, updateCount := range []uint{1, 2, 8, 64, 256} {
 		benchmarkName := strconv.FormatUint(uint64(updateCount), 10)

--- a/exchange/websocket/buffer/buffer_test.go
+++ b/exchange/websocket/buffer/buffer_test.go
@@ -30,7 +30,12 @@ var (
 	offset = common.Counter{}
 )
 
-const exchangeName = "exchangeTest"
+const (
+	exchangeName = "exchangeTest"
+	// benchmarkBufferLimit is the number of updates a buffered benchmark accumulates before the
+	// holder flushes and publishes, matching the cadence its loop drains the relay at
+	benchmarkBufferLimit = 10
+)
 
 // getExclusivePair returns a currency pair with a unique ID for testing as books are centralised and changes will affect other tests
 func getExclusivePair() (currency.Pair, error) {
@@ -70,112 +75,86 @@ func createSnapshot(pair currency.Pair) (holder *Orderbook, asks, bids orderbook
 	return holder, asks, bids, err
 }
 
+// benchmarkOrderbook builds a holder whose relay the benchmark drains itself, and pre-sizes the
+// update buffer the way Setup does in production.
+//
+// createSnapshot leaves the relay to a reader goroutine, but Relay.Send is non-blocking and errors
+// once the channel is full, so a reader that cannot keep up fails the benchmark instead of slowing
+// it down. Draining inline makes the loop self-pacing and hermetic at any benchtime. A bufferLimit
+// of zero leaves buffering disabled and publishes on every update.
+func benchmarkOrderbook(b *testing.B, bufferLimit int) (*Orderbook, *stream.Relay, *orderbook.Update) {
+	b.Helper()
+	cp, err := getExclusivePair()
+	require.NoError(b, err, "getExclusivePair must not error")
+
+	holder, asks, bids, err := createSnapshot(cp)
+	require.NoError(b, err, "createSnapshot must not error")
+
+	holder.dataHandler.Close() // Ends the reader goroutine createSnapshot spawned
+	relay := stream.NewRelay(1)
+	holder.dataHandler = relay
+	b.Cleanup(relay.Close)
+
+	if bufferLimit > 0 {
+		holder.bufferEnabled = true
+		holder.obBufferLimit = bufferLimit
+		// LoadSnapshot sized the buffer from obBufferLimit while it was still zero, so without this
+		// the first flush's worth of appends would grow the slice inside the measured loop
+		holder.ob[key.PairAsset{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}].buffer = make([]orderbook.Update, 0, bufferLimit)
+	}
+
+	return holder, relay, &orderbook.Update{
+		Bids:       bids,
+		Asks:       asks,
+		Pair:       cp,
+		UpdateTime: time.Now(),
+		Asset:      asset.Spot,
+	}
+}
+
+// benchmarkUpdates drives the update loop, receiving the book the holder publishes every drainEvery
+// updates. A buffered holder only publishes once its buffer is full, so matching drainEvery to the
+// buffer limit keeps the capacity-one relay from ever filling.
+func benchmarkUpdates(b *testing.B, o *Orderbook, relay *stream.Relay, update *orderbook.Update, drainEvery int) {
+	b.Helper()
+	var updates int
+	for b.Loop() {
+		randomIndex := rand.Intn(4) //nolint:gosec // no need to import crypto/rand for testing
+		update.Asks = itemArray[randomIndex]
+		update.Bids = itemArray[randomIndex]
+		require.NoError(b, o.Update(update), "Update must not error")
+		updates++
+		if updates%drainEvery == 0 {
+			<-relay.C
+		}
+	}
+}
+
 // BenchmarkBufferPerformance demonstrates buffer more performant than multi
 // process calls
-// 890016	      1688 ns/op	     416 B/op	       3 allocs/op
 func BenchmarkBufferPerformance(b *testing.B) {
-	cp, err := getExclusivePair()
-	require.NoError(b, err)
-
-	holder, asks, bids, err := createSnapshot(cp)
-	require.NoError(b, err)
-
-	holder.bufferEnabled = true
-	update := &orderbook.Update{
-		Bids:       bids,
-		Asks:       asks,
-		Pair:       cp,
-		UpdateTime: time.Now(),
-		Asset:      asset.Spot,
-	}
-	for b.Loop() {
-		randomIndex := rand.Intn(4) //nolint:gosec // no need to import crypto/rand for testing
-		update.Asks = itemArray[randomIndex]
-		update.Bids = itemArray[randomIndex]
-		require.NoError(b, holder.Update(update))
-	}
+	holder, relay, update := benchmarkOrderbook(b, benchmarkBufferLimit)
+	benchmarkUpdates(b, holder, relay, update, benchmarkBufferLimit)
 }
 
-// BenchmarkBufferSortingPerformance benchmark
-//
-//	613964	      2093 ns/op	     440 B/op	       4 allocs/op
 func BenchmarkBufferSortingPerformance(b *testing.B) {
-	cp, err := getExclusivePair()
-	require.NoError(b, err)
-
-	holder, asks, bids, err := createSnapshot(cp)
-	require.NoError(b, err)
-
-	holder.bufferEnabled = true
+	holder, relay, update := benchmarkOrderbook(b, benchmarkBufferLimit)
 	holder.sortBuffer = true
-	update := &orderbook.Update{
-		Bids:       bids,
-		Asks:       asks,
-		Pair:       cp,
-		UpdateTime: time.Now(),
-		Asset:      asset.Spot,
-	}
-	for b.Loop() {
-		randomIndex := rand.Intn(4) //nolint:gosec // no need to import crypto/rand for testing
-		update.Asks = itemArray[randomIndex]
-		update.Bids = itemArray[randomIndex]
-		require.NoError(b, holder.Update(update))
-	}
+	benchmarkUpdates(b, holder, relay, update, benchmarkBufferLimit)
 }
 
-// 914500	      1599 ns/op	     440 B/op	       4 allocs/op
 func BenchmarkBufferSortingByIDPerformance(b *testing.B) {
-	cp, err := getExclusivePair()
-	require.NoError(b, err)
-
-	holder, asks, bids, err := createSnapshot(cp)
-	require.NoError(b, err)
-
-	holder.bufferEnabled = true
+	holder, relay, update := benchmarkOrderbook(b, benchmarkBufferLimit)
 	holder.sortBuffer = true
 	holder.sortBufferByUpdateIDs = true
-	update := &orderbook.Update{
-		Bids:       bids,
-		Asks:       asks,
-		Pair:       cp,
-		UpdateTime: time.Now(),
-		Asset:      asset.Spot,
-	}
-
-	for b.Loop() {
-		randomIndex := rand.Intn(4) //nolint:gosec // no need to import crypto/rand for testing
-		update.Asks = itemArray[randomIndex]
-		update.Bids = itemArray[randomIndex]
-		require.NoError(b, holder.Update(update))
-	}
+	benchmarkUpdates(b, holder, relay, update, benchmarkBufferLimit)
 }
 
 // BenchmarkNoBufferPerformance demonstrates orderbook process more performant
 // than buffer
-//   122659	     12792 ns/op	     972 B/op	       7 allocs/op PRIOR
-//  1225924	      1028 ns/op	     240 B/op	       2 allocs/op CURRENT
-
 func BenchmarkNoBufferPerformance(b *testing.B) {
-	cp, err := getExclusivePair()
-	require.NoError(b, err)
-
-	obl, asks, bids, err := createSnapshot(cp)
-	require.NoError(b, err)
-
-	update := &orderbook.Update{
-		Bids:       bids,
-		Asks:       asks,
-		Pair:       cp,
-		UpdateTime: time.Now(),
-		Asset:      asset.Spot,
-	}
-
-	for b.Loop() {
-		randomIndex := rand.Intn(4) //nolint:gosec // no need to import crypto/rand for testing
-		update.Asks = itemArray[randomIndex]
-		update.Bids = itemArray[randomIndex]
-		require.NoError(b, obl.Update(update))
-	}
+	obl, relay, update := benchmarkOrderbook(b, 0)
+	benchmarkUpdates(b, obl, relay, update, 1)
 }
 
 // TestHittingTheBuffer logic test

--- a/exchange/websocket/buffer/buffer_test.go
+++ b/exchange/websocket/buffer/buffer_test.go
@@ -71,7 +71,6 @@ func createSnapshot(pair currency.Pair) (holder *Orderbook, asks, bids orderbook
 
 // BenchmarkBufferPerformance demonstrates buffer more performant than multi
 // process calls
-// 890016	      1688 ns/op	     416 B/op	       3 allocs/op
 func BenchmarkBufferPerformance(b *testing.B) {
 	cp, err := getExclusivePair()
 	require.NoError(b, err)
@@ -95,9 +94,6 @@ func BenchmarkBufferPerformance(b *testing.B) {
 	}
 }
 
-// BenchmarkBufferSortingPerformance benchmark
-//
-//	613964	      2093 ns/op	     440 B/op	       4 allocs/op
 func BenchmarkBufferSortingPerformance(b *testing.B) {
 	cp, err := getExclusivePair()
 	require.NoError(b, err)
@@ -122,7 +118,6 @@ func BenchmarkBufferSortingPerformance(b *testing.B) {
 	}
 }
 
-// 914500	      1599 ns/op	     440 B/op	       4 allocs/op
 func BenchmarkBufferSortingByIDPerformance(b *testing.B) {
 	cp, err := getExclusivePair()
 	require.NoError(b, err)
@@ -151,9 +146,6 @@ func BenchmarkBufferSortingByIDPerformance(b *testing.B) {
 
 // BenchmarkNoBufferPerformance demonstrates orderbook process more performant
 // than buffer
-//   122659	     12792 ns/op	     972 B/op	       7 allocs/op PRIOR
-//  1225924	      1028 ns/op	     240 B/op	       2 allocs/op CURRENT
-
 func BenchmarkNoBufferPerformance(b *testing.B) {
 	cp, err := getExclusivePair()
 	require.NoError(b, err)

--- a/exchanges/alert/alert_test.go
+++ b/exchanges/alert/alert_test.go
@@ -93,8 +93,6 @@ func isLeaky(t *testing.T, a *Notice, ch chan struct{}) {
 	}
 }
 
-// 120801772	         9.334 ns/op	       0 B/op	       0 allocs/op // PREV
-// 146173060	         9.154 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkAlert(b *testing.B) {
 	n := Notice{}
 	for b.Loop() {
@@ -102,14 +100,18 @@ func BenchmarkAlert(b *testing.B) {
 	}
 }
 
-// BenchmarkWait benchmark
-//
-// 150352	      9916 ns/op	     681 B/op	       4 allocs/op // PREV
-// 87436	     14724 ns/op	     682 B/op	       4 allocs/op // CURRENT
+// BenchmarkWait kicks every waiter rather than passing a nil kick channel. hold only returns when
+// one of its two channels fires, so an unkicked waiter that is never alerted leaks its routine and
+// its wait-group count for the life of the run; at a long benchtime that accumulates millions.
+// Receiving the reply also returns the channel to the pool, which is the path being measured.
 func BenchmarkWait(b *testing.B) {
 	n := Notice{}
+	kick := make(chan struct{})
+	close(kick)
 	for b.Loop() {
-		n.Wait(nil)
+		if !<-n.Wait(kick) {
+			b.Fatal("Wait must report the kick rather than an alert")
+		}
 	}
 }
 

--- a/exchanges/alert/alert_test.go
+++ b/exchanges/alert/alert_test.go
@@ -93,8 +93,6 @@ func isLeaky(t *testing.T, a *Notice, ch chan struct{}) {
 	}
 }
 
-// 120801772	         9.334 ns/op	       0 B/op	       0 allocs/op // PREV
-// 146173060	         9.154 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkAlert(b *testing.B) {
 	n := Notice{}
 	for b.Loop() {
@@ -102,10 +100,6 @@ func BenchmarkAlert(b *testing.B) {
 	}
 }
 
-// BenchmarkWait benchmark
-//
-// 150352	      9916 ns/op	     681 B/op	       4 allocs/op // PREV
-// 87436	     14724 ns/op	     682 B/op	       4 allocs/op // CURRENT
 func BenchmarkWait(b *testing.B) {
 	n := Notice{}
 	for b.Loop() {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1955,26 +1955,98 @@ func TestGetDepositAddress(t *testing.T) {
 	}
 }
 
-func BenchmarkWsHandleData(bb *testing.B) {
-	bb.ReportAllocs()
-	ap, err := e.CurrencyPairs.GetPairs(asset.Spot, false)
-	require.NoError(bb, err)
-	err = e.CurrencyPairs.StorePairs(asset.Spot, ap, true)
-	require.NoError(bb, err)
+// BenchmarkWsHandleData measures each message type separately, so a regression names the handler it
+// came from instead of moving one aggregate figure.
+func BenchmarkWsHandleData(b *testing.B) {
+	e := new(Exchange)
+	require.NoError(b, testexch.Setup(e), "Test instance Setup must not error")
+
+	pair, err := e.MatchSymbolWithAvailablePairs("BNBBTC", asset.Spot, false)
+	require.NoError(b, err, "MatchSymbolWithAvailablePairs must not error")
+	// Only the fixture's own pair is enabled. Enabling every available spot pair made the execution
+	// report scan them all while resolving its symbol, which measured the pair manager rather than
+	// the handler.
+	//
+	// ExecutionReport still costs far more than its siblings, and that is real rather than an
+	// artefact of this setup: resolving a symbol calls GetPairs for the enabled pairs, and
+	// Pairs.ContainsAll clones the whole available list to do it, so every execution report copies
+	// every available pair. Keeping the available list at its configured size measures what
+	// production actually pays.
+	require.NoError(b, e.CurrencyPairs.StorePairs(asset.Spot, currency.Pairs{pair}, true), "StorePairs must not error")
+	// Symbol resolution walks the enabled assets, and a map's iteration order is not fixed, so
+	// leaving the others enabled makes the work per iteration vary run to run
+	for _, a := range e.CurrencyPairs.GetAssetTypes(true) {
+		if a != asset.Spot {
+			require.NoErrorf(b, e.CurrencyPairs.SetAssetEnabled(a, false), "SetAssetEnabled must not error for %s", a)
+		}
+	}
+
+	// The depth lines route through e.obm, which is otherwise only built when the websocket
+	// connects, so without it the benchmark dereferences a nil orderbookManager. It is constructed
+	// directly rather than via setupOrderbookManager because that also starts the synchronisation
+	// workers, which seed order books over REST and outlive the benchmark: they exit only on
+	// websocket shutdown, so their errors land on stdout mid-result-line and corrupt the output.
+	//
+	// The state is seeded mid-synchronisation so the depth line takes one repeatable path:
+	// stageWsUpdate rejects an update whose first ID is not lastUpdateID+1, and the fixture opens at
+	// 157, so the loop restores 156 each iteration. fetchingBook stops a REST fetch being queued.
+	depth := &update{
+		buffer:       make(chan *WebsocketDepthStream, 1),
+		fetchingBook: true,
+		lastUpdateID: 156,
+	}
+	e.obm = &orderbookManager{
+		state: map[currency.Code]map[currency.Code]map[asset.Item]*update{
+			pair.Base: {pair.Quote: {asset.Spot: depth}},
+		},
+		jobs: make(chan job, maxWSOrderbookJobs),
+	}
 
 	data, err := os.ReadFile("testdata/wsHandleData.json")
-	require.NoError(bb, err)
+	require.NoError(b, err, "ReadFile must not error")
 	lines := bytes.Split(data, []byte("\n"))
-	require.Len(bb, lines, 8)
-	go func() {
-		for {
-			<-e.Websocket.DataHandler.C
-		}
-	}()
-	for bb.Loop() {
-		for x := range lines {
-			assert.NoError(bb, e.wsHandleData(bb.Context(), lines[x]))
-		}
+	require.Len(b, lines, 8, "the fixture must hold one line per message type")
+
+	for _, tc := range []struct {
+		name   string
+		line   []byte
+		relays bool
+		depth  bool
+	}{
+		{name: "Ticker", line: lines[0], relays: true},
+		{name: "Kline", line: lines[1], relays: true},
+		// Trades are only relayed when trade data saving or streaming is enabled, which the default
+		// test config leaves off
+		{name: "Trade", line: lines[2]},
+		{name: "Depth", line: lines[3], depth: true},
+		{name: "BalanceUpdate", line: lines[4], relays: true},
+		{name: "ListStatus", line: lines[5], relays: true},
+		{name: "ExecutionReport", line: lines[6], relays: true},
+		{name: "OutboundAccountPosition", line: lines[7], relays: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := b.Context()
+			for b.Loop() {
+				require.NoError(b, e.wsHandleData(ctx, tc.line), "wsHandleData must not error")
+				if tc.depth {
+					<-depth.buffer
+					depth.lastUpdateID = 156
+				}
+				// Relay.Send has already queued the payload by the time it returns, so a
+				// non-blocking receive cannot lose a race with it. Draining every iteration keeps
+				// the relay from filling and turning a later Send into an error.
+				select {
+				case <-e.Websocket.DataHandler.C:
+					if !tc.relays {
+						b.Fatal("wsHandleData must not relay this message")
+					}
+				default:
+					if tc.relays {
+						b.Fatal("wsHandleData must relay this message")
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -1957,6 +1957,21 @@ func TestGetDepositAddress(t *testing.T) {
 
 func BenchmarkWsHandleData(bb *testing.B) {
 	bb.ReportAllocs()
+	ctx := bb.Context()
+	e := new(Exchange)
+	require.NoError(bb, testexch.Setup(e), "Test instance Setup must not error")
+	// The depth lines route through e.obm, which is otherwise only built when the websocket
+	// connects, so without it the benchmark dereferences a nil orderbookManager. It is constructed
+	// directly rather than via setupOrderbookManager because that also starts the synchronisation
+	// workers, which seed order books over REST and outlive the benchmark: they exit only on
+	// websocket shutdown, so their errors land on stdout mid-result-line and corrupt the output.
+	// Queueing a job is non-blocking, so with nothing draining the channel this measures the
+	// wsHandleData path alone.
+	e.obm = &orderbookManager{
+		state: make(map[currency.Code]map[currency.Code]map[asset.Item]*update),
+		jobs:  make(chan job, maxWSOrderbookJobs),
+	}
+
 	ap, err := e.CurrencyPairs.GetPairs(asset.Spot, false)
 	require.NoError(bb, err)
 	err = e.CurrencyPairs.StorePairs(asset.Spot, ap, true)
@@ -1968,12 +1983,16 @@ func BenchmarkWsHandleData(bb *testing.B) {
 	require.Len(bb, lines, 8)
 	go func() {
 		for {
-			<-e.Websocket.DataHandler.C
+			select {
+			case <-e.Websocket.DataHandler.C:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 	for bb.Loop() {
 		for x := range lines {
-			assert.NoError(bb, e.wsHandleData(bb.Context(), lines[x]))
+			assert.NoError(bb, e.wsHandleData(ctx, lines[x]))
 		}
 	}
 }

--- a/exchanges/gateio/gateio_wrapper_test.go
+++ b/exchanges/gateio/gateio_wrapper_test.go
@@ -332,7 +332,6 @@ func TestEarliestTime(t *testing.T) {
 	}
 }
 
-// 7610378	       143.3 ns/op	      48 B/op	       2 allocs/op
 func BenchmarkMessageID(b *testing.B) {
 	for b.Loop() {
 		_ = e.MessageID()

--- a/exchanges/gateio/gateio_wrapper_test.go
+++ b/exchanges/gateio/gateio_wrapper_test.go
@@ -334,7 +334,6 @@ func TestEarliestTime(t *testing.T) {
 	}
 }
 
-// 7610378	       143.3 ns/op	      48 B/op	       2 allocs/op
 func BenchmarkMessageID(b *testing.B) {
 	for b.Loop() {
 		_ = e.MessageID()

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,9 +46,15 @@ var apiCredentials = &accounts.Credentials{
 }
 
 var (
-	e                                                         *Exchange
-	spotTradablePair, marginTradablePair, futuresTradablePair currency.Pair
-	assertToTradablePairMap                                   map[asset.Item]currency.Pair
+	e *Exchange
+
+	// Bootstrapped on first use rather than in TestMain, which must not make API calls: the pairs
+	// come from a live KuCoin request, and TestMain runs for every invocation of this package
+	// including `-run '^$' -bench .`, where no test needs them at all. Read them through the
+	// accessors below so the fetch happens once, only for the tests that actually want a pair.
+	tradablePairsOnce                 sync.Once
+	spotPair, marginPair, futuresPair currency.Pair
+	tradablePairsByAsset              map[asset.Item]currency.Pair
 )
 
 func TestMain(m *testing.M) {
@@ -64,14 +71,48 @@ func TestMain(m *testing.M) {
 		e.Websocket.SetCanUseAuthenticatedEndpoints(true)
 	}
 
-	getFirstTradablePairOfAssets(context.Background())
-	assertToTradablePairMap = map[asset.Item]currency.Pair{
-		asset.Spot:    spotTradablePair,
-		asset.Margin:  marginTradablePair,
-		asset.Futures: futuresTradablePair,
-	}
-
 	os.Exit(m.Run())
+}
+
+// loadTradablePairs fetches the first tradable pair of each asset once per run
+func loadTradablePairs(tb testing.TB) {
+	tb.Helper()
+	tradablePairsOnce.Do(func() {
+		getFirstTradablePairOfAssets(context.Background())
+		tradablePairsByAsset = map[asset.Item]currency.Pair{
+			asset.Spot:    spotPair,
+			asset.Margin:  marginPair,
+			asset.Futures: futuresPair,
+		}
+	})
+}
+
+// spotTradablePair returns the first enabled spot pair, fetching it on first use
+func spotTradablePair(tb testing.TB) currency.Pair {
+	tb.Helper()
+	loadTradablePairs(tb)
+	return spotPair
+}
+
+// marginTradablePair returns the first enabled margin pair, fetching it on first use
+func marginTradablePair(tb testing.TB) currency.Pair {
+	tb.Helper()
+	loadTradablePairs(tb)
+	return marginPair
+}
+
+// futuresTradablePair returns the first enabled futures pair, fetching it on first use
+func futuresTradablePair(tb testing.TB) currency.Pair {
+	tb.Helper()
+	loadTradablePairs(tb)
+	return futuresPair
+}
+
+// assertToTradablePairMap returns the per-asset tradable pairs, fetching them on first use
+func assertToTradablePairMap(tb testing.TB) map[asset.Item]currency.Pair {
+	tb.Helper()
+	loadTradablePairs(tb)
+	return tradablePairsByAsset
 }
 
 func TestGetSymbols(t *testing.T) {
@@ -92,7 +133,7 @@ func TestGetTicker(t *testing.T) {
 	_, err := e.GetTicker(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetTicker(t.Context(), spotTradablePair.String())
+	result, err := e.GetTicker(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -124,7 +165,7 @@ func TestGet24hrStats(t *testing.T) {
 	_, err := e.Get24hrStats(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.Get24hrStats(t.Context(), spotTradablePair.String())
+	result, err := e.Get24hrStats(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -140,7 +181,7 @@ func TestGetPartOrderbook20(t *testing.T) {
 	_, err := e.GetPartOrderbook20(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetPartOrderbook20(t.Context(), spotTradablePair.String())
+	result, err := e.GetPartOrderbook20(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -150,7 +191,7 @@ func TestGetPartOrderbook100(t *testing.T) {
 	_, err := e.GetPartOrderbook100(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetPartOrderbook100(t.Context(), spotTradablePair.String())
+	result, err := e.GetPartOrderbook100(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -161,7 +202,7 @@ func TestGetOrderbook(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetOrderbook(t.Context(), spotTradablePair.String())
+	_, err = e.GetOrderbook(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 }
 
@@ -171,13 +212,13 @@ func TestGetOrderbookAuthenticatedV1(t *testing.T) {
 	_, err := e.GetOrderbookAuthenticatedV1(t.Context(), "", asset.Spot, "20")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), spotTradablePair.String(), asset.Spot, "10")
+	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), spotTradablePair(t).String(), asset.Spot, "10")
 	assert.ErrorIs(t, err, errInvalidLimit)
 
-	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), futuresTradablePair.String(), asset.Futures, "50")
+	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), futuresTradablePair(t).String(), asset.Futures, "50")
 	assert.ErrorIs(t, err, errInvalidLimit)
 
-	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), spotTradablePair.String(), asset.Margin, "20")
+	_, err = e.GetOrderbookAuthenticatedV1(t.Context(), spotTradablePair(t).String(), asset.Margin, "20")
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
@@ -188,8 +229,8 @@ func TestGetOrderbookAuthenticatedV1(t *testing.T) {
 		asset  asset.Item
 		limit  string
 	}{
-		{name: "spot", symbol: spotTradablePair.String(), asset: asset.Spot, limit: "20"},
-		{name: "futures", symbol: futuresTradablePair.String(), asset: asset.Futures, limit: "20"},
+		{name: "spot", symbol: spotTradablePair(t).String(), asset: asset.Spot, limit: "20"},
+		{name: "futures", symbol: futuresTradablePair(t).String(), asset: asset.Futures, limit: "20"},
 	} {
 		t.Run(tt.name+"_"+tt.symbol, func(t *testing.T) {
 			t.Parallel()
@@ -209,7 +250,7 @@ func TestGetTradeHistory(t *testing.T) {
 	_, err := e.GetTradeHistory(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	_, err = e.GetTradeHistory(t.Context(), spotTradablePair.String())
+	_, err = e.GetTradeHistory(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 }
 
@@ -235,14 +276,14 @@ func TestGetKlines(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetKlines(t.Context(), "", "1week", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.GetKlines(t.Context(), spotTradablePair.String(), "invalid-period", time.Time{}, time.Time{})
+	_, err = e.GetKlines(t.Context(), spotTradablePair(t).String(), "invalid-period", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, errInvalidPeriod)
 
-	result, err := e.GetKlines(t.Context(), spotTradablePair.String(), "1week", time.Time{}, time.Time{})
+	result, err := e.GetKlines(t.Context(), spotTradablePair(t).String(), "1week", time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetKlines(t.Context(), spotTradablePair.String(), "5min", time.Now().Add(-time.Hour*1), time.Now())
+	result, err = e.GetKlines(t.Context(), spotTradablePair(t).String(), "5min", time.Now().Add(-time.Hour*1), time.Now())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -290,7 +331,7 @@ func TestGetMarkPrice(t *testing.T) {
 	_, err := e.GetMarkPrice(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetMarkPrice(t.Context(), marginTradablePair.String())
+	result, err := e.GetMarkPrice(t.Context(), marginTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -364,13 +405,13 @@ func TestPostBorrowOrder(t *testing.T) {
 
 func TestGetMarginBorrowingHistory(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetMarginBorrowingHistory(t.Context(), currency.EMPTYCODE, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err := e.GetMarginBorrowingHistory(t.Context(), currency.EMPTYCODE, true, marginTradablePair(t).String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 	_, err = e.GetMarginBorrowingHistory(t.Context(), currency.BTC, true, "", "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetMarginBorrowingHistory(t.Context(), currency.BTC, true, marginTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err = e.GetMarginBorrowingHistory(t.Context(), currency.BTC, true, marginTradablePair(t).String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	assert.NoError(t, err)
 }
 
@@ -402,11 +443,11 @@ func TestGetCrossIsolatedMarginInterestRecords(t *testing.T) {
 
 func TestGetRepaymentHistory(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetRepaymentHistory(t.Context(), currency.EMPTYCODE, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	_, err := e.GetRepaymentHistory(t.Context(), currency.EMPTYCODE, true, spotTradablePair(t).String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	require.ErrorIs(t, err, currency.ErrCurrencyCodeEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetRepaymentHistory(t.Context(), currency.BTC, true, spotTradablePair.String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
+	result, err := e.GetRepaymentHistory(t.Context(), currency.BTC, true, spotTradablePair(t).String(), "", time.Time{}, time.Now().Add(-time.Hour*80), 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -436,7 +477,7 @@ func TestGetSingleIsolatedMarginAccountInfo(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetSingleIsolatedMarginAccountInfo(t.Context(), spotTradablePair.String())
+	result, err := e.GetSingleIsolatedMarginAccountInfo(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -468,7 +509,7 @@ func TestPostOrder(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = e.PostOrder(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair,
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t),
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
@@ -480,12 +521,12 @@ func TestPostOrder(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 	_, err = e.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 	_, err = e.PostOrder(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t), Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -494,7 +535,7 @@ func TestPostOrder(t *testing.T) {
 	result, err := e.PostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(),
 		Side:          "buy",
-		Symbol:        spotTradablePair,
+		Symbol:        spotTradablePair(t),
 		OrderType:     "limit",
 		Size:          0.005,
 		Price:         1000,
@@ -516,7 +557,7 @@ func TestPostOrderTest(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = e.PostOrderTest(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair,
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t),
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
@@ -528,12 +569,12 @@ func TestPostOrderTest(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 	_, err = e.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 	_, err = e.PostOrderTest(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t), Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -542,7 +583,7 @@ func TestPostOrderTest(t *testing.T) {
 	result, err := e.PostOrderTest(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(),
 		Side:          "buy",
-		Symbol:        spotTradablePair,
+		Symbol:        spotTradablePair(t),
 		OrderType:     "limit",
 		Size:          0.005,
 		Price:         1000,
@@ -563,7 +604,7 @@ func TestHandlePostOrder(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair,
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t),
 		OrderType: "",
 	}, "")
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
@@ -575,34 +616,34 @@ func TestHandlePostOrder(t *testing.T) {
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "OCO", Size: 0.1,
 	}, "")
 	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "limit", Size: 0.1,
 	}, "")
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "limit", Size: 0, Price: 1000,
 	}, "")
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
 		ClientOrderID: customID.String(), Side: "buy",
-		Symbol:    spotTradablePair,
+		Symbol:    spotTradablePair(t),
 		OrderType: "limit", Size: .1, Price: 1000, VisibleSize: -1,
 	}, "")
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 
 	_, err = e.HandlePostOrder(t.Context(), &SpotOrderParam{
-		ClientOrderID: customID.String(), Symbol: spotTradablePair, Side: "buy",
+		ClientOrderID: customID.String(), Symbol: spotTradablePair(t), Side: "buy",
 		OrderType: "market", Price: 234565,
 	}, "")
 	require.ErrorIs(t, err, errSizeOrFundIsRequired)
@@ -616,7 +657,7 @@ func TestPostMarginOrder(t *testing.T) {
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = e.PostMarginOrder(t.Context(), &MarginOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair(t),
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
@@ -627,12 +668,12 @@ func TestPostMarginOrder(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 	_, err = e.PostMarginOrder(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
-		Symbol:    marginTradablePair,
+		Symbol:    marginTradablePair(t),
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 	_, err = e.PostMarginOrder(t.Context(), &MarginOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair(t), Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -642,7 +683,7 @@ func TestPostMarginOrder(t *testing.T) {
 	result, err := e.PostMarginOrder(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
-			Side:          "buy", Symbol: marginTradablePair,
+			Side:          "buy", Symbol: marginTradablePair(t),
 			Price: 1000, Size: 0.1, PostOnly: true,
 		})
 	assert.NoError(t, err)
@@ -652,7 +693,7 @@ func TestPostMarginOrder(t *testing.T) {
 	result, err = e.PostMarginOrder(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
-			Side:          "buy", Symbol: marginTradablePair,
+			Side:          "buy", Symbol: marginTradablePair(t),
 			OrderType: "market", Funds: 1234,
 			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true,
 		})
@@ -668,7 +709,7 @@ func TestPostMarginOrderTest(t *testing.T) {
 	})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = e.PostMarginOrderTest(t.Context(), &MarginOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair(t),
 		OrderType: "",
 	})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
@@ -679,12 +720,12 @@ func TestPostMarginOrderTest(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 	_, err = e.PostMarginOrderTest(t.Context(), &MarginOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy",
-		Symbol:    marginTradablePair,
+		Symbol:    marginTradablePair(t),
 		OrderType: "limit", Size: 0.1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 	_, err = e.PostMarginOrderTest(t.Context(), &MarginOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair, Side: "buy",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Symbol: marginTradablePair(t), Side: "buy",
 		OrderType: "limit", Price: 234565,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -694,7 +735,7 @@ func TestPostMarginOrderTest(t *testing.T) {
 	result, err := e.PostMarginOrderTest(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
-			Side:          "buy", Symbol: marginTradablePair,
+			Side:          "buy", Symbol: marginTradablePair(t),
 			Price: 1000, Size: 0.1, PostOnly: true,
 		})
 	assert.NoError(t, err)
@@ -704,7 +745,7 @@ func TestPostMarginOrderTest(t *testing.T) {
 	result, err = e.PostMarginOrderTest(t.Context(),
 		&MarginOrderParam{
 			ClientOrderID: "5bd6e9286d99522a52e458de",
-			Side:          "buy", Symbol: marginTradablePair,
+			Side:          "buy", Symbol: marginTradablePair(t),
 			OrderType: "market", Funds: 1234,
 			Remark: "remark", MarginModel: "cross", Price: 1000, PostOnly: true, AutoBorrow: true,
 		})
@@ -716,30 +757,30 @@ func TestPostBulkOrder(t *testing.T) {
 	t.Parallel()
 	_, err := e.PostBulkOrder(t.Context(), "", []OrderRequest{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{})
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{})
 	require.ErrorIs(t, err, common.ErrEmptyParams)
 
 	arg := OrderRequest{
 		Size: 0.01,
 	}
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	arg.ClientOID = "3d07008668054da6b3cb12e432c2b13a"
 	arg.Size = 0
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 
 	arg.Side = "Sell"
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
 	arg.Price = 1000
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{arg})
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{arg})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	_, err = e.PostBulkOrder(t.Context(), spotTradablePair.String(), []OrderRequest{
+	_, err = e.PostBulkOrder(t.Context(), spotTradablePair(t).String(), []OrderRequest{
 		{
 			ClientOID: "3d07008668054da6b3cb12e432c2b13a",
 			Side:      "buy",
@@ -839,7 +880,7 @@ func TestGetFills(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetFills(t.Context(), "5c35c02703aa673ceec2a168", spotTradablePair.String(), "buy", "limit", SpotTradeType, time.Now().Add(-time.Hour*12), time.Now())
+	result, err = e.GetFills(t.Context(), "5c35c02703aa673ceec2a168", spotTradablePair(t).String(), "buy", "limit", SpotTradeType, time.Now().Add(-time.Hour*12), time.Now())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -860,15 +901,15 @@ func TestGetRecentFills(t *testing.T) {
 
 func TestPostStopOrder(t *testing.T) {
 	t.Parallel()
-	_, err := e.PostStopOrder(t.Context(), "", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	_, err := e.PostStopOrder(t.Context(), "", "buy", spotTradablePair(t).String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
-	_, err = e.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	_, err = e.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "", spotTradablePair(t).String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 	_, err = e.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "buy", "", "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "buy", spotTradablePair.String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
+	result, err := e.PostStopOrder(t.Context(), "5bd6e9286d99522a52e458de", "buy", spotTradablePair(t).String(), "", "", "entry", "CO", SpotTradeType, "", 0.1, 1, 10, 0, 0, 0, true, false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -886,11 +927,11 @@ func TestCancelStopOrder(t *testing.T) {
 
 func TestCancelStopOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelStopOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
+	_, err := e.CancelStopOrderByClientOrderID(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelStopOrderByClientOrderID(t.Context(), "5bd6e9286d99522a52e458de", spotTradablePair.String())
+	result, err := e.CancelStopOrderByClientOrderID(t.Context(), "5bd6e9286d99522a52e458de", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -979,7 +1020,7 @@ func TestGetCrossMarginAccountsDetail(t *testing.T) {
 func TestGetIsolatedMarginAccountDetail(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetIsolatedMarginAccountDetail(t.Context(), marginTradablePair.String(), "BTC", "")
+	result, err := e.GetIsolatedMarginAccountDetail(t.Context(), marginTradablePair(t).String(), "BTC", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1450,7 +1491,7 @@ func TestGetFuturesOrderbook(t *testing.T) {
 	_, err := e.GetFuturesOrderbook(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetFuturesOrderbook(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesOrderbook(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1489,7 +1530,7 @@ func TestGetFuturesInterestRate(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetFuturesInterestRate(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	result, err := e.GetFuturesInterestRate(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
+	result, err := e.GetFuturesInterestRate(t.Context(), futuresTradablePair(t).String(), time.Time{}, time.Time{}, false, false, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1498,7 +1539,7 @@ func TestGetFuturesIndexList(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetFuturesIndexList(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 10)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	result, err := e.GetFuturesIndexList(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 10)
+	result, err := e.GetFuturesIndexList(t.Context(), futuresTradablePair(t).String(), time.Time{}, time.Time{}, false, false, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1508,7 +1549,7 @@ func TestGetFuturesCurrentMarkPrice(t *testing.T) {
 	_, err := e.GetFuturesCurrentMarkPrice(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetFuturesCurrentMarkPrice(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesCurrentMarkPrice(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1518,7 +1559,7 @@ func TestGetFuturesPremiumIndex(t *testing.T) {
 	_, err := e.GetFuturesPremiumIndex(t.Context(), "", time.Time{}, time.Time{}, false, false, 0, 0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetFuturesPremiumIndex(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, false, false, 0, 0)
+	result, err := e.GetFuturesPremiumIndex(t.Context(), futuresTradablePair(t).String(), time.Time{}, time.Time{}, false, false, 0, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1536,7 +1577,7 @@ func TestGetFuturesCurrentFundingRate(t *testing.T) {
 	_, err := e.GetFuturesCurrentFundingRate(t.Context(), "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetFuturesCurrentFundingRate(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesCurrentFundingRate(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1546,7 +1587,7 @@ func TestGetPublicFundingRate(t *testing.T) {
 	_, err := e.GetPublicFundingRate(t.Context(), "", time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetPublicFundingRate(t.Context(), futuresTradablePair.String(), time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
+	result, err := e.GetPublicFundingRate(t.Context(), futuresTradablePair(t).String(), time.Now().Add(-time.Hour*24*30), time.Now().Add(-time.Hour*5))
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1586,12 +1627,12 @@ func TestGetFuturesKline(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetFuturesKline(t.Context(), 0, "XBTUSDTM", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, kline.ErrInvalidInterval)
-	_, err = e.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Seconds()), futuresTradablePair.String(), time.Time{}, time.Time{})
+	_, err = e.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Seconds()), futuresTradablePair(t).String(), time.Time{}, time.Time{})
 	require.ErrorIs(t, err, kline.ErrUnsupportedInterval)
 	_, err = e.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Minutes()), "", time.Time{}, time.Time{})
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
-	result, err := e.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Minutes()), futuresTradablePair.String(), time.Time{}, time.Time{})
+	result, err := e.GetFuturesKline(t.Context(), int64(kline.ThirtyMin.Duration().Minutes()), futuresTradablePair(t).String(), time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1609,20 +1650,20 @@ func TestPostFuturesOrder(t *testing.T) {
 
 	// With Stop order configuration
 	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, errInvalidStopPriceType)
 
 	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
 	assert.NoError(t, err)
@@ -1630,14 +1671,14 @@ func TestPostFuturesOrder(t *testing.T) {
 
 	// Limit Orders
 	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t),
 		OrderType: "limit", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
-	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
+	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	result, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
 	assert.NoError(t, err)
@@ -1645,12 +1686,12 @@ func TestPostFuturesOrder(t *testing.T) {
 
 	// Market Orders
 	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t),
 		OrderType: "market", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	_, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "market", Remark: "10",
 		Size: 1, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -1658,7 +1699,7 @@ func TestPostFuturesOrder(t *testing.T) {
 	result, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de",
 		Side:          "buy",
-		Symbol:        futuresTradablePair,
+		Symbol:        futuresTradablePair(t),
 		OrderType:     "limit",
 		Remark:        "10",
 		Stop:          "",
@@ -1687,45 +1728,45 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 
 	// With Stop order configuration
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, errInvalidStopPriceType)
 
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", TimeInForce: "", Size: 1, Price: 1000, StopPrice: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
 	assert.NoError(t, err)
 
 	// Limit Orders
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t),
 		OrderType: "limit", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
-	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
+	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10", Price: 1000, Leverage: 1, VisibleSize: 0})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "limit", Remark: "10",
 		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
 	})
 	assert.NoError(t, err)
 
 	// Market Orders
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair,
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t),
 		OrderType: "market", Remark: "10", Leverage: 1,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
-		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "market", Remark: "10",
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair(t), OrderType: "market", Remark: "10",
 		Size: 0, Leverage: 1, VisibleSize: 0,
 	})
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
@@ -1733,7 +1774,7 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de",
 		Side:          "buy",
-		Symbol:        futuresTradablePair,
+		Symbol:        futuresTradablePair(t),
 		OrderType:     "limit",
 		Remark:        "10",
 		Stop:          "",
@@ -1754,7 +1795,7 @@ func TestPostFuturesOrderTest(t *testing.T) {
 	response, err := e.PostFuturesOrderTest(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de",
 		Side:          "buy",
-		Symbol:        futuresTradablePair,
+		Symbol:        futuresTradablePair(t),
 		OrderType:     "market",
 		Remark:        "10",
 		Stop:          "",
@@ -1779,7 +1820,7 @@ func TestPlaceMultipleFuturesOrders(t *testing.T) {
 		{
 			ClientOrderID: "5c52e11203aa677f33e491",
 			Side:          "buy",
-			Symbol:        futuresTradablePair,
+			Symbol:        futuresTradablePair(t),
 			OrderType:     "limit",
 			Price:         2150,
 			Size:          2,
@@ -1788,7 +1829,7 @@ func TestPlaceMultipleFuturesOrders(t *testing.T) {
 		{
 			ClientOrderID: "5c52e11203aa677f33e492",
 			Side:          "buy",
-			Symbol:        futuresTradablePair,
+			Symbol:        futuresTradablePair(t),
 			OrderType:     "limit",
 			Price:         32150,
 			Size:          2,
@@ -1814,11 +1855,11 @@ func TestCancelFuturesOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
 	_, err := e.CancelFuturesOrderByClientOrderID(t.Context(), "", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair.String(), "")
+	_, err = e.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair(t).String(), "")
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair.String(), "5bd6e9286d99522a52e458de")
+	result, err := e.CancelFuturesOrderByClientOrderID(t.Context(), futuresTradablePair(t).String(), "5bd6e9286d99522a52e458de")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1826,7 +1867,7 @@ func TestCancelFuturesOrderByClientOrderID(t *testing.T) {
 func TestCancelAllFuturesOpenOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelMultipleFuturesLimitOrders(t.Context(), futuresTradablePair.String())
+	result, err := e.CancelMultipleFuturesLimitOrders(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1834,7 +1875,7 @@ func TestCancelAllFuturesOpenOrders(t *testing.T) {
 func TestCancelAllFuturesStopOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelAllFuturesStopOrders(t.Context(), futuresTradablePair.String())
+	result, err := e.CancelAllFuturesStopOrders(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1858,7 +1899,7 @@ func TestGetUntriggeredFuturesStopOrders(t *testing.T) {
 func TestGetFuturesRecentCompletedOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesRecentCompletedOrders(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesRecentCompletedOrders(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1907,7 +1948,7 @@ func TestGetFuturesOpenOrderStats(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesOpenOrderStats(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesOpenOrderStats(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1918,7 +1959,7 @@ func TestGetFuturesPosition(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesPosition(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesPosition(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1937,7 +1978,7 @@ func TestSetAutoDepositMargin(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.SetAutoDepositMargin(t.Context(), futuresTradablePair.String(), true)
+	result, err := e.SetAutoDepositMargin(t.Context(), futuresTradablePair(t).String(), true)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1948,7 +1989,7 @@ func TestGetMaxWithdrawMargin(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetMaxWithdrawMargin(t.Context(), futuresTradablePair.String())
+	result, err := e.GetMaxWithdrawMargin(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1977,7 +2018,7 @@ func TestAddMargin(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.AddMargin(t.Context(), futuresTradablePair.String(), "6200c9b83aecfb000152dasfdee", 1)
+	result, err := e.AddMargin(t.Context(), futuresTradablePair(t).String(), "6200c9b83aecfb000152dasfdee", 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1988,7 +2029,7 @@ func TestGetFuturesRiskLimitLevel(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesRiskLimitLevel(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesRiskLimitLevel(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1999,7 +2040,7 @@ func TestUpdateRiskLmitLevel(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.FuturesUpdateRiskLmitLevel(t.Context(), futuresTradablePair.String(), 2)
+	result, err := e.FuturesUpdateRiskLmitLevel(t.Context(), futuresTradablePair(t).String(), 2)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2010,7 +2051,7 @@ func TestGetFuturesFundingHistory(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesFundingHistory(t.Context(), futuresTradablePair.String(), 0, 0, true, true, time.Time{}, time.Time{})
+	result, err := e.GetFuturesFundingHistory(t.Context(), futuresTradablePair(t).String(), 0, 0, true, true, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2104,7 +2145,7 @@ func TestUpdateOrderbook(t *testing.T) {
 	t.Parallel()
 	var result *orderbook.Book
 	var err error
-	for assetType, tp := range assertToTradablePairMap {
+	for assetType, tp := range assertToTradablePairMap(t) {
 		result, err = e.UpdateOrderbook(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -2198,7 +2239,7 @@ func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
 	var result *ticker.Price
 	var err error
-	for assetType, tp := range assertToTradablePairMap {
+	for assetType, tp := range assertToTradablePairMap(t) {
 		result, err = e.UpdateTicker(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -2210,7 +2251,7 @@ func TestGetHistoricCandles(t *testing.T) {
 	endTime := time.Now().Add(-time.Hour * 3)
 	var result *kline.Item
 	var err error
-	for assetType, tp := range assertToTradablePairMap {
+	for assetType, tp := range assertToTradablePairMap(t) {
 		result, err = e.GetHistoricCandles(t.Context(), tp, assetType, kline.OneHour, startTime, endTime)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -2220,15 +2261,15 @@ func TestGetHistoricCandles(t *testing.T) {
 func TestGetHistoricCandlesExtended(t *testing.T) {
 	startTime := time.Now().Add(-time.Hour * 48 * 10)
 	endTime := time.Now().Add(-time.Hour * 1)
-	result, err := e.GetHistoricCandlesExtended(t.Context(), futuresTradablePair, asset.Futures, kline.FifteenMin, startTime, endTime)
+	result, err := e.GetHistoricCandlesExtended(t.Context(), futuresTradablePair(t), asset.Futures, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetHistoricCandlesExtended(t.Context(), spotTradablePair, asset.Spot, kline.FifteenMin, startTime, endTime)
+	result, err = e.GetHistoricCandlesExtended(t.Context(), spotTradablePair(t), asset.Spot, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetHistoricCandlesExtended(t.Context(), marginTradablePair, asset.Margin, kline.FifteenMin, startTime, endTime)
+	result, err = e.GetHistoricCandlesExtended(t.Context(), marginTradablePair(t), asset.Margin, kline.FifteenMin, startTime, endTime)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2246,7 +2287,7 @@ func TestGetRecentTrades(t *testing.T) {
 	t.Parallel()
 	var result []trade.Data
 	var err error
-	for assetType, tp := range assertToTradablePairMap {
+	for assetType, tp := range assertToTradablePairMap(t) {
 		result, err = e.GetRecentTrades(t.Context(), tp, assetType)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -2257,7 +2298,7 @@ func TestGetOrderHistory(t *testing.T) {
 	t.Parallel()
 	getOrdersRequest := order.MultiOrderRequest{
 		Type:      order.Limit,
-		Pairs:     []currency.Pair{futuresTradablePair},
+		Pairs:     []currency.Pair{futuresTradablePair(t)},
 		AssetType: asset.Binary,
 		Side:      order.AnySide,
 	}
@@ -2276,7 +2317,7 @@ func TestGetOrderHistory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
+	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair(t)}
 	result, err = e.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -2287,14 +2328,14 @@ func TestGetOrderHistory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
+	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair(t)}
 	result, err = e.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
 	getOrdersRequest.AssetType = asset.Margin
 	getOrdersRequest.Type = order.Stop
-	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair}
+	getOrdersRequest.Pairs = []currency.Pair{spotTradablePair(t)}
 	result, err = e.GetOrderHistory(t.Context(), &getOrdersRequest)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -2444,15 +2485,15 @@ func TestGetOrderInfo(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 	var result *order.Detail
 	var err error
-	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", futuresTradablePair, asset.Futures)
+	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", futuresTradablePair(t), asset.Futures)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", spotTradablePair, asset.Spot)
+	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", spotTradablePair(t), asset.Spot)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", marginTradablePair, asset.Margin)
+	result, err = e.GetOrderInfo(t.Context(), "54541241349183409134134133", marginTradablePair(t), asset.Margin)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -2506,7 +2547,7 @@ func TestWithdrawCryptocurrencyFunds(t *testing.T) {
 func TestSubmitOrder(t *testing.T) {
 	t.Parallel()
 	orderSubmission := &order.Submit{
-		Pair:          futuresTradablePair,
+		Pair:          futuresTradablePair(t),
 		Exchange:      e.Name,
 		Side:          order.Bid,
 		Type:          order.Limit,
@@ -2520,7 +2561,7 @@ func TestSubmitOrder(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	orderSubmission.AssetType = asset.Futures
-	orderSubmission.Pair = futuresTradablePair
+	orderSubmission.Pair = futuresTradablePair(t)
 	result, err := e.SubmitOrder(t.Context(), orderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -2535,7 +2576,7 @@ func TestSubmitOrder(t *testing.T) {
 	spotOrderSubmission := &order.Submit{
 		Side:          order.Buy,
 		AssetType:     asset.Spot,
-		Pair:          spotTradablePair,
+		Pair:          spotTradablePair(t),
 		Type:          order.Limit,
 		Price:         1,
 		Amount:        100000,
@@ -2581,7 +2622,7 @@ func TestSubmitOrder(t *testing.T) {
 	marginOrderSubmission := &order.Submit{
 		Side:          order.Buy,
 		AssetType:     asset.Margin,
-		Pair:          marginTradablePair,
+		Pair:          marginTradablePair(t),
 		Type:          order.Limit,
 		Price:         1,
 		Amount:        100000,
@@ -2598,7 +2639,7 @@ func TestCancelOrder(t *testing.T) {
 	orderCancellation := &order.Cancel{
 		OrderID:   "1",
 		AccountID: "1",
-		Pair:      futuresTradablePair,
+		Pair:      futuresTradablePair(t),
 		AssetType: asset.Options,
 	}
 	err := e.CancelOrder(t.Context(), orderCancellation)
@@ -2618,7 +2659,7 @@ func TestCancelOrder(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
 	orderCancellation.AssetType = asset.Spot
-	orderCancellation.Pair = spotTradablePair
+	orderCancellation.Pair = spotTradablePair(t)
 	err = e.CancelOrder(t.Context(), orderCancellation)
 	assert.NoError(t, err)
 
@@ -2838,18 +2879,18 @@ func getFirstTradablePairOfAssets(ctx context.Context) {
 	if err != nil {
 		log.Fatalf("Kucoin %v, trying to get %v enabled pairs error", err, asset.Spot)
 	}
-	spotTradablePair = enabledPairs[0]
+	spotPair = enabledPairs[0]
 	enabledPairs, err = e.GetEnabledPairs(asset.Margin)
 	if err != nil {
 		log.Fatalf("Kucoin %v, trying to get %v enabled pairs error", err, asset.Margin)
 	}
-	marginTradablePair = enabledPairs[0]
+	marginPair = enabledPairs[0]
 	enabledPairs, err = e.GetEnabledPairs(asset.Futures)
 	if err != nil {
 		log.Fatalf("Kucoin %v, trying to get %v enabled pairs error", err, asset.Futures)
 	}
-	futuresTradablePair = enabledPairs[0]
-	futuresTradablePair.Delimiter = ""
+	futuresPair = enabledPairs[0]
+	futuresPair.Delimiter = ""
 }
 
 func TestUpdateAccountBalances(t *testing.T) {
@@ -3027,8 +3068,8 @@ func TestGetOpenInterest(t *testing.T) {
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	resp, err := ku.GetOpenInterest(t.Context(), key.PairAsset{
-		Base:  futuresTradablePair.Base.Item,
-		Quote: futuresTradablePair.Quote.Item,
+		Base:  futuresTradablePair(t).Base.Item,
+		Quote: futuresTradablePair(t).Quote.Item,
 		Asset: asset.Futures,
 	})
 	assert.NoError(t, err)
@@ -3040,8 +3081,8 @@ func TestGetOpenInterest(t *testing.T) {
 	resp, err = ku.GetOpenInterest(
 		t.Context(),
 		key.PairAsset{
-			Base:  futuresTradablePair.Base.Item,
-			Quote: futuresTradablePair.Quote.Item,
+			Base:  futuresTradablePair(t).Base.Item,
+			Quote: futuresTradablePair(t).Quote.Item,
 			Asset: asset.Futures,
 		},
 		key.PairAsset{
@@ -3066,7 +3107,7 @@ func TestValidatePlaceOrderParams(t *testing.T) {
 	arg.Size = 1
 	err = arg.ValidatePlaceOrderParams()
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	arg.Symbol = spotTradablePair
+	arg.Symbol = spotTradablePair(t)
 	err = arg.ValidatePlaceOrderParams()
 	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
 	arg.OrderType = "limit"
@@ -3092,7 +3133,7 @@ func TestSpotHFPlaceOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.HFSpotPlaceOrder(t.Context(), &PlaceHFParam{
 		TimeInForce: "GTT",
-		Symbol:      spotTradablePair,
+		Symbol:      spotTradablePair(t),
 		OrderType:   "limit",
 		Side:        order.Sell.String(),
 		Price:       1234,
@@ -3110,7 +3151,7 @@ func TestSpotPlaceHFOrderTest(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.SpotPlaceHFOrderTest(t.Context(), &PlaceHFParam{
 		TimeInForce: "GTT",
-		Symbol:      spotTradablePair,
+		Symbol:      spotTradablePair(t),
 		OrderType:   "limit",
 		Side:        order.Sell.String(),
 		Price:       1234,
@@ -3144,7 +3185,7 @@ func TestPlaceMultipleOrders(t *testing.T) {
 	result, err := e.PlaceMultipleOrders(t.Context(), []PlaceHFParam{
 		{
 			TimeInForce: "GTT",
-			Symbol:      spotTradablePair,
+			Symbol:      spotTradablePair(t),
 			OrderType:   "limit",
 			Side:        order.Sell.String(),
 			Price:       1234,
@@ -3177,7 +3218,7 @@ func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 	result, err := e.SyncPlaceMultipleHFOrders(t.Context(), []PlaceHFParam{
 		{
 			TimeInForce: "GTT",
-			Symbol:      spotTradablePair,
+			Symbol:      spotTradablePair(t),
 			OrderType:   "limit",
 			Side:        order.Sell.String(),
 			Price:       1234,
@@ -3189,7 +3230,7 @@ func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 			OrderType:     "limit",
 			Price:         0.01,
 			Size:          1,
-			Symbol:        spotTradablePair,
+			Symbol:        spotTradablePair(t),
 		},
 		{
 			ClientOrderID: "37245dbe6e134b5c97732bfb36cd4a9d",
@@ -3197,7 +3238,7 @@ func TestSyncPlaceMultipleHFOrders(t *testing.T) {
 			OrderType:     "limit",
 			Price:         0.01,
 			Size:          1,
-			Symbol:        spotTradablePair,
+			Symbol:        spotTradablePair(t),
 		},
 	})
 	assert.NoError(t, err)
@@ -3214,7 +3255,7 @@ func TestModifyHFOrder(t *testing.T) {
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.ModifyHFOrder(t.Context(), &ModifyHFOrderParam{
-		Symbol:        spotTradablePair,
+		Symbol:        spotTradablePair(t),
 		ClientOrderID: "4314oiu5345u2y554x",
 		OrderID:       "4314oiu5345u2y554x",
 		NewPrice:      1234,
@@ -3226,67 +3267,67 @@ func TestModifyHFOrder(t *testing.T) {
 
 func TestCancelHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelHFOrder(t.Context(), "", spotTradablePair.String())
+	_, err := e.CancelHFOrder(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.CancelHFOrder(t.Context(), "630625dbd9180300014c8d52", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelHFOrder(t.Context(), "630625dbd9180300014c8d52", spotTradablePair.String())
+	result, err := e.CancelHFOrder(t.Context(), "630625dbd9180300014c8d52", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSyncCancelHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := e.SyncCancelHFOrder(t.Context(), "", spotTradablePair.String())
+	_, err := e.SyncCancelHFOrder(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.SyncCancelHFOrder(t.Context(), "12312312", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.SyncCancelHFOrder(t.Context(), "641d67ea162d47000160bfb8", spotTradablePair.String())
+	result, err := e.SyncCancelHFOrder(t.Context(), "641d67ea162d47000160bfb8", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestSyncCancelHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.SyncCancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
+	_, err := e.SyncCancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = e.SyncCancelHFOrderByClientOrderID(t.Context(), "cliend-order-id", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.SyncCancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair.String())
+	result, err := e.SyncCancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair.String())
+	_, err := e.CancelHFOrderByClientOrderID(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 	_, err = e.CancelHFOrderByClientOrderID(t.Context(), "cliend-order-id", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair.String())
+	result, err := e.CancelHFOrderByClientOrderID(t.Context(), "client-order-id", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelSpecifiedNumberHFOrdersByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "", spotTradablePair.String(), 10.0)
+	_, err := e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "", spotTradablePair(t).String(), 10.0)
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", "", 10.0)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair.String(), 0)
+	_, err = e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair(t).String(), 0)
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair.String(), 10.0)
+	result, err := e.CancelSpecifiedNumberHFOrdersByOrderID(t.Context(), "1", spotTradablePair(t).String(), 10.0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3297,7 +3338,7 @@ func TestCancelAllHFOrdersBySymbol(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelAllHFOrdersBySymbol(t.Context(), spotTradablePair.String())
+	result, err := e.CancelAllHFOrdersBySymbol(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3319,7 +3360,7 @@ func TestGetActiveHFOrders(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetActiveHFOrders(t.Context(), spotTradablePair.String())
+	_, err = e.GetActiveHFOrders(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 }
 
@@ -3336,33 +3377,33 @@ func TestGetHFCompletedOrderList(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetHFCompletedOrderList(t.Context(), spotTradablePair.String(), "sell", "limit", "", time.Time{}, time.Now(), 0)
+	result, err := e.GetHFCompletedOrderList(t.Context(), spotTradablePair(t).String(), "sell", "limit", "", time.Time{}, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetHFOrderDetailsByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetHFOrderDetailsByOrderID(t.Context(), "", spotTradablePair.String())
+	_, err := e.GetHFOrderDetailsByOrderID(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.GetHFOrderDetailsByOrderID(t.Context(), "1234567", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetHFOrderDetailsByOrderID(t.Context(), "1234567", spotTradablePair.String())
+	result, err := e.GetHFOrderDetailsByOrderID(t.Context(), "1234567", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetHFOrderDetailsByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetHFOrderDetailsByClientOrderID(t.Context(), "", spotTradablePair.String())
+	_, err := e.GetHFOrderDetailsByClientOrderID(t.Context(), "", spotTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.GetHFOrderDetailsByClientOrderID(t.Context(), "1234567", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetHFOrderDetailsByClientOrderID(t.Context(), "6d539dc614db312", spotTradablePair.String())
+	result, err := e.GetHFOrderDetailsByClientOrderID(t.Context(), "6d539dc614db312", spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3392,7 +3433,7 @@ func TestGetHFFilledList(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetHFFilledList(t.Context(), "", spotTradablePair.String(), "sell", "market", "", time.Time{}, time.Now(), 0)
+	result, err := e.GetHFFilledList(t.Context(), "", spotTradablePair(t).String(), "sell", "market", "", time.Time{}, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3406,7 +3447,7 @@ func TestPlaceOCOOrder(t *testing.T) {
 	_, err = e.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
-	arg.Symbol = spotTradablePair
+	arg.Symbol = spotTradablePair(t)
 	_, err = e.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrSideIsInvalid)
 
@@ -3430,12 +3471,12 @@ func TestPlaceOCOOrder(t *testing.T) {
 	_, err = e.PlaceOCOOrder(t.Context(), arg)
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
-	cpDetail, err := e.GetTicker(t.Context(), spotTradablePair.String())
+	cpDetail, err := e.GetTicker(t.Context(), spotTradablePair(t).String())
 	assert.NoError(t, err)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.PlaceOCOOrder(t.Context(), &OCOOrderParams{
-		Symbol:        spotTradablePair,
+		Symbol:        spotTradablePair(t),
 		Side:          order.Buy.String(),
 		Price:         cpDetail.Price - 3,
 		Size:          1,
@@ -3473,7 +3514,7 @@ func TestCancelOrderByClientOrderID(t *testing.T) {
 func TestCancelMultipleOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelOCOMultipleOrders(t.Context(), []string{}, spotTradablePair.String())
+	result, err := e.CancelOCOMultipleOrders(t.Context(), []string{}, spotTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3512,13 +3553,13 @@ func TestGetOrderDetailsByOrderID(t *testing.T) {
 
 func TestGetOCOOrderList(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetOCOOrderList(t.Context(), 9, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	_, err := e.GetOCOOrderList(t.Context(), 9, 0, spotTradablePair(t).String(), time.Time{}, time.Now(), []string{})
 	require.ErrorIs(t, err, errPageSizeRequired)
-	_, err = e.GetOCOOrderList(t.Context(), 10, 0, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	_, err = e.GetOCOOrderList(t.Context(), 10, 0, spotTradablePair(t).String(), time.Time{}, time.Now(), []string{})
 	require.ErrorIs(t, err, errCurrentPageRequired)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetOCOOrderList(t.Context(), 10, 2, spotTradablePair.String(), time.Time{}, time.Now(), []string{})
+	result, err := e.GetOCOOrderList(t.Context(), 10, 2, spotTradablePair(t).String(), time.Time{}, time.Now(), []string{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3540,7 +3581,7 @@ func TestSendPlaceMarginHFOrder(t *testing.T) {
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty)
 
-	arg.Symbol = marginTradablePair
+	arg.Symbol = marginTradablePair(t)
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
@@ -3558,7 +3599,7 @@ func TestPlaceMarginHFOrder(t *testing.T) {
 	result, err := e.PlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{
 		ClientOrderID:       "first-order",
 		Side:                "sell",
-		Symbol:              marginTradablePair,
+		Symbol:              marginTradablePair(t),
 		OrderType:           "market",
 		SelfTradePrevention: "CB",
 		Price:               1234,
@@ -3577,7 +3618,7 @@ func TestPlaceMarginHFOrderTest(t *testing.T) {
 	result, err := e.PlaceMarginHFOrderTest(t.Context(), &PlaceMarginHFOrderParam{
 		ClientOrderID:       "first-order",
 		Side:                "sell",
-		Symbol:              marginTradablePair,
+		Symbol:              marginTradablePair(t),
 		OrderType:           "market",
 		SelfTradePrevention: "CB",
 		Price:               1234,
@@ -3589,26 +3630,26 @@ func TestPlaceMarginHFOrderTest(t *testing.T) {
 
 func TestCancelMarginHFOrderByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelMarginHFOrderByOrderID(t.Context(), "", marginTradablePair.String())
+	_, err := e.CancelMarginHFOrderByOrderID(t.Context(), "", marginTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.CancelMarginHFOrderByOrderID(t.Context(), "order-id-here", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelMarginHFOrderByOrderID(t.Context(), "order-id-here", marginTradablePair.String())
+	result, err := e.CancelMarginHFOrderByOrderID(t.Context(), "order-id-here", marginTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestCancelMarginHFOrderByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.CancelMarginHFOrderByClientOrderID(t.Context(), "", marginTradablePair.String())
+	_, err := e.CancelMarginHFOrderByClientOrderID(t.Context(), "", marginTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 	_, err = e.CancelMarginHFOrderByClientOrderID(t.Context(), "order-id-here", "")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelMarginHFOrderByClientOrderID(t.Context(), "order-id-here", marginTradablePair.String())
+	result, err := e.CancelMarginHFOrderByClientOrderID(t.Context(), "order-id-here", marginTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3617,15 +3658,15 @@ func TestCancelAllMarginHFOrdersBySymbol(t *testing.T) {
 	t.Parallel()
 	_, err := e.CancelAllMarginHFOrdersBySymbol(t.Context(), "", "MARGIN_TRADE")
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "")
+	_, err = e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair(t).String(), "")
 	require.ErrorIs(t, err, errTradeTypeMissing)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	result, err := e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "MARGIN_TRADE")
+	result, err := e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair(t).String(), "MARGIN_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	result, err = e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair.String(), "MARGIN_ISOLATED_TRADE")
+	result, err = e.CancelAllMarginHFOrdersBySymbol(t.Context(), marginTradablePair(t).String(), "MARGIN_ISOLATED_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3633,54 +3674,54 @@ func TestCancelAllMarginHFOrdersBySymbol(t *testing.T) {
 func TestGetActiveMarginHFOrders(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetActiveMarginHFOrders(t.Context(), marginTradablePair.String(), "MARGIN_TRADE")
+	result, err := e.GetActiveMarginHFOrders(t.Context(), marginTradablePair(t).String(), "MARGIN_TRADE")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetFilledHFMarginOrders(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetFilledHFMarginOrders(t.Context(), spotTradablePair.String(), "", "sell", "limit", time.Time{}, time.Now(), 0, 20)
+	_, err := e.GetFilledHFMarginOrders(t.Context(), spotTradablePair(t).String(), "", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	require.ErrorIs(t, err, errTradeTypeMissing)
 	_, err = e.GetFilledHFMarginOrders(t.Context(), "", "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetFilledHFMarginOrders(t.Context(), marginTradablePair.String(), "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
+	_, err = e.GetFilledHFMarginOrders(t.Context(), marginTradablePair(t).String(), "MARGIN_TRADE", "sell", "limit", time.Time{}, time.Now(), 0, 20)
 	assert.NoError(t, err)
 }
 
 func TestGetMarginHFOrderDetailByOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetMarginHFOrderDetailByOrderID(t.Context(), "", marginTradablePair.String())
+	_, err := e.GetMarginHFOrderDetailByOrderID(t.Context(), "", marginTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetMarginHFOrderDetailByOrderID(t.Context(), "243432432423the-order-id", marginTradablePair.String())
+	_, err = e.GetMarginHFOrderDetailByOrderID(t.Context(), "243432432423the-order-id", marginTradablePair(t).String())
 	assert.Truef(t, errors.Is(err, order.ErrOrderNotFound) || err == nil, "GetMarginHFOrderDetailByOrderID should not error: %s", err)
 }
 
 func TestGetMarginHFOrderDetailByClientOrderID(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetMarginHFOrderDetailByClientOrderID(t.Context(), "", marginTradablePair.String())
+	_, err := e.GetMarginHFOrderDetailByClientOrderID(t.Context(), "", marginTradablePair(t).String())
 	require.ErrorIs(t, err, order.ErrOrderIDNotSet)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetMarginHFOrderDetailByClientOrderID(t.Context(), "the-client-order-id", marginTradablePair.String())
+	result, err := e.GetMarginHFOrderDetailByClientOrderID(t.Context(), "the-client-order-id", marginTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetMarginHFTradeFills(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetMarginHFTradeFills(t.Context(), "", marginTradablePair.String(), "", "sell", "", time.Time{}, time.Now(), 0, 30)
+	_, err := e.GetMarginHFTradeFills(t.Context(), "", marginTradablePair(t).String(), "", "sell", "", time.Time{}, time.Now(), 0, 30)
 	require.ErrorIs(t, err, errTradeTypeMissing)
 
 	_, err = e.GetMarginHFTradeFills(t.Context(), "", "", "MARGIN_TRADE", "sell", "", time.Time{}, time.Now(), 0, 30)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetMarginHFTradeFills(t.Context(), "12312312", marginTradablePair.String(), "MARGIN_TRADE", "sell", "market", time.Time{}, time.Now(), 0, 30)
+	_, err = e.GetMarginHFTradeFills(t.Context(), "12312312", marginTradablePair(t).String(), "MARGIN_TRADE", "sell", "market", time.Time{}, time.Now(), 0, 30)
 	assert.NoError(t, err)
 }
 
@@ -3799,7 +3840,7 @@ func testInstance(tb testing.TB) *Exchange {
 func TestGetTradingPairActualFees(t *testing.T) {
 	t.Parallel()
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetTradingPairActualFees(t.Context(), []string{spotTradablePair.String()})
+	result, err := e.GetTradingPairActualFees(t.Context(), []string{spotTradablePair(t).String()})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3810,18 +3851,18 @@ func TestGetFuturesTradingPairsActualFees(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetFuturesTradingPairsActualFees(t.Context(), futuresTradablePair.String())
+	result, err := e.GetFuturesTradingPairsActualFees(t.Context(), futuresTradablePair(t).String())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestGetPositionHistory(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetPositionHistory(t.Context(), futuresTradablePair.String(), time.Now(), time.Now().Add(-time.Hour*5), 0, 10)
+	_, err := e.GetPositionHistory(t.Context(), futuresTradablePair(t).String(), time.Now(), time.Now().Add(-time.Hour*5), 0, 10)
 	require.ErrorIs(t, err, common.ErrStartAfterEnd)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetPositionHistory(t.Context(), futuresTradablePair.String(), time.Time{}, time.Time{}, 0, 10)
+	result, err := e.GetPositionHistory(t.Context(), futuresTradablePair(t).String(), time.Time{}, time.Time{}, 0, 10)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3830,13 +3871,13 @@ func TestGetMaximumOpenPositionSize(t *testing.T) {
 	t.Parallel()
 	_, err := e.GetMaximumOpenPositionSize(t.Context(), "", 1, 1)
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
-	_, err = e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 0., 1)
+	_, err = e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair(t).String(), 0., 1)
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
-	_, err = e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 1, 0)
+	_, err = e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair(t).String(), 1, 0)
 	require.ErrorIs(t, err, errInvalidLeverage)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	result, err := e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair.String(), 1, 1)
+	result, err := e.GetMaximumOpenPositionSize(t.Context(), futuresTradablePair(t).String(), 1, 1)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -3971,13 +4012,13 @@ func TestGetMarginPairsConfigurations(t *testing.T) {
 	require.ErrorIs(t, err, currency.ErrSymbolStringEmpty)
 
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
-	_, err = e.GetMarginPairsConfigurations(t.Context(), marginTradablePair.String())
+	_, err = e.GetMarginPairsConfigurations(t.Context(), marginTradablePair(t).String())
 	assert.NoError(t, err)
 }
 
 func TestModifyLeverageMultiplier(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
-	err := e.ModifyLeverageMultiplier(t.Context(), spotTradablePair.String(), 1, true)
+	err := e.ModifyLeverageMultiplier(t.Context(), spotTradablePair(t).String(), 1, true)
 	assert.NoError(t, err)
 }
 
@@ -4115,7 +4156,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 	t.Parallel()
 	r := &fundingrate.HistoricalRatesRequest{
 		Asset:     asset.Spot,
-		Pair:      futuresTradablePair,
+		Pair:      futuresTradablePair(t),
 		StartDate: time.Now().Add(-time.Hour * 24 * 2),
 		EndDate:   time.Now(),
 	}
@@ -4127,7 +4168,7 @@ func TestGetHistoricalFundingRates(t *testing.T) {
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
 	r.Asset = asset.Futures
-	r.Pair = futuresTradablePair
+	r.Pair = futuresTradablePair(t)
 	result, err := e.GetHistoricalFundingRates(t.Context(), r)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/exchanges/kucoin/kucoin_websocket_test.go
+++ b/exchanges/kucoin/kucoin_websocket_test.go
@@ -461,14 +461,14 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 		t.Parallel()
 		ku := testInstance(t)
 		ku.Name += "-TestProcessFuturesOrderbookLevel2"
-		require.False(t, futuresTradablePair.IsEmpty(), "futuresTradablePair must be initialised")
+		require.False(t, futuresTradablePair(t).IsEmpty(), "futuresTradablePair must be initialised")
 
 		const updateID = int64(18)
 		ku.wsOBUpdateMgr = buffer.NewUpdateManager(&buffer.UpdateManagerParams{
 			FetchDelay:    0,
 			FetchDeadline: buffer.DefaultWSOrderbookUpdateDeadline,
 			FetchOrderbook: func(_ context.Context, p currency.Pair, a asset.Item) (*orderbook.Book, error) {
-				if !p.Equal(futuresTradablePair) {
+				if !p.Equal(futuresTradablePair(t)) {
 					return nil, fmt.Errorf("unexpected pair %s", p)
 				}
 				if a != asset.Futures {
@@ -476,7 +476,7 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 				}
 				return &orderbook.Book{
 					Exchange:     ku.Name,
-					Pair:         futuresTradablePair,
+					Pair:         futuresTradablePair(t),
 					Asset:        asset.Futures,
 					Bids:         orderbook.Levels{{Price: 4990, Amount: 1, ID: updateID - 1}},
 					Asks:         orderbook.Levels{{Price: 5010, Amount: 1, ID: updateID - 1}},
@@ -489,15 +489,15 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 			BufferInstance:     &ku.Websocket.Orderbook,
 		})
 
-		err := ku.processFuturesOrderbookLevel2(t.Context(), validPayload, futuresTradablePair.String())
+		err := ku.processFuturesOrderbookLevel2(t.Context(), validPayload, futuresTradablePair(t).String())
 		require.NoError(t, err, "processFuturesOrderbookLevel2 must not error for buy updates")
 
 		require.Eventually(t, func() bool {
-			id, err := ku.Websocket.Orderbook.LastUpdateID(futuresTradablePair, asset.Futures)
+			id, err := ku.Websocket.Orderbook.LastUpdateID(futuresTradablePair(t), asset.Futures)
 			return err == nil && id == updateID
 		}, time.Second*5, time.Millisecond*50, "futures orderbook buy update must eventually sync")
 
-		book, err := ku.Websocket.Orderbook.GetOrderbook(futuresTradablePair, asset.Futures)
+		book, err := ku.Websocket.Orderbook.GetOrderbook(futuresTradablePair(t), asset.Futures)
 		require.NoError(t, err, "GetOrderbook must not error for futures buy updates")
 		require.NotEmpty(t, book.Bids, "bids must not be empty after processing a buy update")
 		assert.Equal(t, updateID, book.LastUpdateID, "LastUpdateID should be updated from the websocket sequence")
@@ -509,14 +509,14 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 		t.Parallel()
 		ku := testInstance(t)
 		ku.Name += "-TestProcessFuturesOrderbookLevel2Sell"
-		require.False(t, futuresTradablePair.IsEmpty(), "futuresTradablePair must be initialised")
+		require.False(t, futuresTradablePair(t).IsEmpty(), "futuresTradablePair must be initialised")
 
 		const updateID = int64(18)
 		ku.wsOBUpdateMgr = buffer.NewUpdateManager(&buffer.UpdateManagerParams{
 			FetchDelay:    0,
 			FetchDeadline: buffer.DefaultWSOrderbookUpdateDeadline,
 			FetchOrderbook: func(_ context.Context, p currency.Pair, a asset.Item) (*orderbook.Book, error) {
-				if !p.Equal(futuresTradablePair) {
+				if !p.Equal(futuresTradablePair(t)) {
 					return nil, fmt.Errorf("unexpected pair %s", p)
 				}
 				if a != asset.Futures {
@@ -524,7 +524,7 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 				}
 				return &orderbook.Book{
 					Exchange:     ku.Name,
-					Pair:         futuresTradablePair,
+					Pair:         futuresTradablePair(t),
 					Asset:        asset.Futures,
 					Bids:         orderbook.Levels{{Price: 4990, Amount: 1, ID: updateID - 1}},
 					Asks:         orderbook.Levels{{Price: 5010, Amount: 1, ID: updateID - 1}},
@@ -537,15 +537,15 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 			BufferInstance:     &ku.Websocket.Orderbook,
 		})
 
-		err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,sell,83","timestamp":1551770400000}`), futuresTradablePair.String())
+		err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,sell,83","timestamp":1551770400000}`), futuresTradablePair(t).String())
 		require.NoError(t, err, "processFuturesOrderbookLevel2 must not error for sell updates")
 
 		require.Eventually(t, func() bool {
-			id, err := ku.Websocket.Orderbook.LastUpdateID(futuresTradablePair, asset.Futures)
+			id, err := ku.Websocket.Orderbook.LastUpdateID(futuresTradablePair(t), asset.Futures)
 			return err == nil && id == updateID
 		}, time.Second*5, time.Millisecond*50, "futures orderbook sell update must eventually sync")
 
-		book, err := ku.Websocket.Orderbook.GetOrderbook(futuresTradablePair, asset.Futures)
+		book, err := ku.Websocket.Orderbook.GetOrderbook(futuresTradablePair(t), asset.Futures)
 		require.NoError(t, err, "GetOrderbook must not error for futures sell updates")
 		require.NotEmpty(t, book.Asks, "asks must not be empty after processing a sell update")
 		assert.Equal(t, updateID, book.LastUpdateID, "LastUpdateID should be updated from the websocket sequence")
@@ -565,35 +565,35 @@ func TestProcessFuturesOrderbookLevel2(t *testing.T) {
 		t.Run("invalid_json", func(t *testing.T) {
 			t.Parallel()
 			ku := testInstance(t)
-			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":`), futuresTradablePair.String())
+			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":`), futuresTradablePair(t).String())
 			require.Error(t, err)
 		})
 
 		t.Run("invalid_change_format", func(t *testing.T) {
 			t.Parallel()
 			ku := testInstance(t)
-			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,buy","timestamp":1551770400000}`), futuresTradablePair.String())
+			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,buy","timestamp":1551770400000}`), futuresTradablePair(t).String())
 			require.ErrorContains(t, err, "unexpected orderbook change format")
 		})
 
 		t.Run("invalid_price", func(t *testing.T) {
 			t.Parallel()
 			ku := testInstance(t)
-			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"bad,buy,83","timestamp":1551770400000}`), futuresTradablePair.String())
+			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"bad,buy,83","timestamp":1551770400000}`), futuresTradablePair(t).String())
 			require.ErrorContains(t, err, "invalid syntax")
 		})
 
 		t.Run("invalid_amount", func(t *testing.T) {
 			t.Parallel()
 			ku := testInstance(t)
-			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,buy,bad","timestamp":1551770400000}`), futuresTradablePair.String())
+			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,buy,bad","timestamp":1551770400000}`), futuresTradablePair(t).String())
 			require.ErrorContains(t, err, "invalid syntax")
 		})
 
 		t.Run("invalid_side", func(t *testing.T) {
 			t.Parallel()
 			ku := testInstance(t)
-			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,hold,83","timestamp":1551770400000}`), futuresTradablePair.String())
+			err := ku.processFuturesOrderbookLevel2(t.Context(), []byte(`{"sequence":18,"change":"5000.0,hold,83","timestamp":1551770400000}`), futuresTradablePair(t).String())
 			require.ErrorContains(t, err, "unexpected orderbook side")
 		})
 	})
@@ -896,7 +896,7 @@ func TestProcessFuturesKline(t *testing.T) {
 	ku := new(Exchange)
 	require.NoError(t, testexch.Setup(ku), "Test instance Setup must not error")
 
-	data := fmt.Sprintf(`{"symbol":%q,"candles":["1714964400","63815.1","63890.8","63928.5","63797.8","17553.0","17553"],"time":1714964823722}`, futuresTradablePair.String())
+	data := fmt.Sprintf(`{"symbol":%q,"candles":["1714964400","63815.1","63890.8","63928.5","63797.8","17553.0","17553"],"time":1714964823722}`, futuresTradablePair(t).String())
 	err := ku.processFuturesKline(t.Context(), []byte(data), "1hour")
 	require.NoError(t, err)
 
@@ -907,7 +907,7 @@ func TestProcessFuturesKline(t *testing.T) {
 		assert.Equal(t, &kline.Item{
 			Asset:    asset.Futures,
 			Exchange: ku.Name,
-			Pair:     futuresTradablePair,
+			Pair:     futuresTradablePair(t),
 			Interval: kline.OneHour,
 			Candles: []kline.Candle{{
 				Time:   time.Unix(1714964400, 0),

--- a/exchanges/okx/okx_wrapper_test.go
+++ b/exchanges/okx/okx_wrapper_test.go
@@ -17,7 +17,6 @@ func TestMessageID(t *testing.T) {
 	require.Len(t, u.String(), 36, "UUID v7 string representation must be 36 characters long")
 }
 
-// 7696807	       153.1 ns/op	      48 B/op	       2 allocs/op
 func BenchmarkMessageID(b *testing.B) {
 	e := new(Exchange)
 	for b.Loop() {

--- a/exchanges/order/orders_test.go
+++ b/exchanges/order/orders_test.go
@@ -448,10 +448,6 @@ var filterOrdersByTypeBenchmark = &[]Detail{
 	{Type: Limit},
 }
 
-// BenchmarkFilterOrdersByType benchmark
-//
-// 392455	      3226 ns/op	   15840 B/op	       5 allocs/op // PREV
-// 9486490	       109.5 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkFilterOrdersByType(b *testing.B) {
 	for b.Loop() {
 		FilterOrdersByType(filterOrdersByTypeBenchmark, Limit)
@@ -494,10 +490,6 @@ var filterOrdersBySideBenchmark = &[]Detail{
 	{Side: Ask},
 }
 
-// BenchmarkFilterOrdersBySide benchmark
-//
-// 372594	      3049 ns/op	   15840 B/op	       5 allocs/op // PREV
-// 7412187	       148.8 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkFilterOrdersBySide(b *testing.B) {
 	for b.Loop() {
 		FilterOrdersBySide(filterOrdersBySideBenchmark, Ask)
@@ -559,10 +551,6 @@ var filterOrdersByTimeRangeBenchmark = &[]Detail{
 	{Date: time.Unix(100, 0)},
 }
 
-// BenchmarkFilterOrdersByTimeRange benchmark
-//
-// 390822	      3335 ns/op	   15840 B/op	       5 allocs/op // PREV
-// 6201034	       172.1 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkFilterOrdersByTimeRange(b *testing.B) {
 	for b.Loop() {
 		err := FilterOrdersByTimeRange(filterOrdersByTimeRangeBenchmark, time.Unix(50, 0), time.Unix(150, 0))
@@ -631,10 +619,6 @@ var filterOrdersByPairsBenchmark = &[]Detail{
 	{Pair: currency.NewBTCUSD()},
 }
 
-// BenchmarkFilterOrdersByPairs benchmark
-//
-// 400032	      2977 ns/op	   15840 B/op	       5 allocs/op // PREV
-// 6977242	       172.8 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkFilterOrdersByPairs(b *testing.B) {
 	pairs := []currency.Pair{currency.NewBTCUSD()}
 	for b.Loop() {
@@ -795,8 +779,6 @@ func TestStringToOrderSide(t *testing.T) {
 
 var sideBenchmark Side
 
-// 9756914	       126.7 ns/op	       0 B/op	       0 allocs/op // PREV
-// 25200660	        57.63 ns/op	       3 B/op	       1 allocs/op // CURRENT
 func BenchmarkStringToOrderSide(b *testing.B) {
 	for b.Loop() {
 		sideBenchmark, _ = StringToOrderSide("any")
@@ -870,8 +852,6 @@ func TestStringToOrderType(t *testing.T) {
 
 var typeBenchmark Type
 
-// 5703705	       299.9 ns/op	       0 B/op	       0 allocs/op // PREV
-// 16353608	        81.23 ns/op	       8 B/op	       1 allocs/op // CURRENT
 func BenchmarkStringToOrderType(b *testing.B) {
 	for b.Loop() {
 		typeBenchmark, _ = StringToOrderType("trigger")
@@ -943,8 +923,6 @@ func TestStringToOrderStatus(t *testing.T) {
 
 var statusBenchmark Status
 
-// 3569052	       351.8 ns/op	       0 B/op	       0 allocs/op // PREV
-// 11126791	       101.9 ns/op	      24 B/op	       1 allocs/op // CURRENT
 func BenchmarkStringToOrderStatus(b *testing.B) {
 	for b.Loop() {
 		statusBenchmark, _ = StringToOrderStatus("market_unavailable")
@@ -1327,8 +1305,6 @@ func TestIsActive(t *testing.T) {
 
 var activeBenchmark = Detail{Status: Pending, Amount: 1}
 
-// 610732089	         2.414 ns/op	       0 B/op	       0 allocs/op // PREV
-// 1000000000	         1.188 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkIsActive(b *testing.B) {
 	for b.Loop() {
 		if !activeBenchmark.IsActive() {
@@ -1392,7 +1368,6 @@ func TestIsInactive(t *testing.T) {
 
 var inactiveBenchmark = Detail{Status: Closed, Amount: 1}
 
-// 1000000000	         1.043 ns/op	       0 B/op	       0 allocs/op // CURRENT
 func BenchmarkIsInactive(b *testing.B) {
 	for b.Loop() {
 		require.True(b, inactiveBenchmark.IsInactive())

--- a/exchanges/order/timeinforce_test.go
+++ b/exchanges/order/timeinforce_test.go
@@ -163,7 +163,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Equal(t, "IOC", target.TimeInForce.String())
 }
 
-// BenchmarkStringToTimeInForce-8            416595              2834 ns/op            1368 B/op         81 allocs/op
 func BenchmarkStringToTimeInForce(b *testing.B) {
 	for b.Loop() {
 		for k := range timeInForceStringToValueMap {

--- a/exchanges/orderbook/incremental_updates_bench_test.go
+++ b/exchanges/orderbook/incremental_updates_bench_test.go
@@ -5,9 +5,6 @@ import (
 	"time"
 )
 
-// Benchstat medians for PR base to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// Before: 5021.0 ns/op  10880 B/op  1 allocs/op; After: 688.1 ns/op  0 B/op  0 allocs/op
 func BenchmarkProcessUpdateInsertDelete(b *testing.B) {
 	depth := NewDepth(id)
 	if err := depth.LoadSnapshot(newSnapshot(256)); err != nil {

--- a/exchanges/orderbook/levels_bench_test.go
+++ b/exchanges/orderbook/levels_bench_test.go
@@ -2,8 +2,6 @@ package orderbook
 
 import "testing"
 
-// 27906781	        42.4 ns/op	       0 B/op	       0 allocs/op (old)
-// 84119028	        13.87 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkLoad(b *testing.B) {
 	ts := Levels{}
 	for b.Loop() {
@@ -11,8 +9,6 @@ func BenchmarkLoad(b *testing.B) {
 	}
 }
 
-// 46043871	        25.9 ns/op	       0 B/op	       0 allocs/op (old)
-// 63445401	        18.51 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateByID(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -33,7 +29,6 @@ func BenchmarkUpdateByID(b *testing.B) {
 	}
 }
 
-// 26724331	        44.69 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkDeleteByID(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -55,7 +50,6 @@ func BenchmarkDeleteByID(b *testing.B) {
 	}
 }
 
-// 8384302	       150.9 ns/op	     480 B/op	       1 allocs/op
 func BenchmarkRetrieve(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -73,8 +67,6 @@ func BenchmarkRetrieve(b *testing.B) {
 	}
 }
 
-// 134830672	         9.83 ns/op	       0 B/op	       0 allocs/op (old)
-// 206689897	         5.761 ns/op	   0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateInsertByPrice_Amend(b *testing.B) {
 	a := askLevels{}
 	a.load(ask)
@@ -95,8 +87,6 @@ func BenchmarkUpdateInsertByPrice_Amend(b *testing.B) {
 	}
 }
 
-// 49763002	        24.9 ns/op	       0 B/op	       0 allocs/op (old)
-// 25662849	        45.32 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateInsertByPrice_Insert_Delete(b *testing.B) {
 	a := askLevels{}
 
@@ -118,7 +108,6 @@ func BenchmarkUpdateInsertByPrice_Insert_Delete(b *testing.B) {
 	}
 }
 
-// 21614455	        81.74 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkUpdateInsertByID_asks(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -139,7 +128,6 @@ func BenchmarkUpdateInsertByID_asks(b *testing.B) {
 	}
 }
 
-// 20328886	        59.94 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkUpdateInsertByID_bids(b *testing.B) {
 	bids := Levels{}
 	bidsSnapshot := Levels{
@@ -161,12 +149,6 @@ func BenchmarkUpdateInsertByID_bids(b *testing.B) {
 	}
 }
 
-// Benchstat medians for PR base to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// MiddleFreshCopy: Before 11.156 µs/op, 32640 B/op, 2 allocs/op; After 7.631 µs/op, 21760 B/op, 1 allocs/op
-// MiddleSpareCapacity: Before 4643.0 ns/op, 10880 B/op, 1 allocs/op; After 462.4 ns/op, 0 B/op, 0 allocs/op
-// TailSpareCapacity guard: no significant difference at n=20, p=0.774; 565.1 vs 566.1 ns/op, 0 B/op, 0 allocs/op
-// Collision guard: no significant difference at n=20, p=0.899; both ~626 ns/op, 104 B/op, 3 allocs/op
 func BenchmarkInsertUpdates(b *testing.B) {
 	const (
 		levelCount = 256

--- a/exchanges/orderbook/levels_test.go
+++ b/exchanges/orderbook/levels_test.go
@@ -99,8 +99,6 @@ func TestLoad(t *testing.T) {
 	Check(t, list, 0, 0, 0)
 }
 
-// 27906781	        42.4 ns/op	       0 B/op	       0 allocs/op (old)
-// 84119028	        13.87 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkLoad(b *testing.B) {
 	ts := Levels{}
 	for b.Loop() {
@@ -244,8 +242,6 @@ func TestUpdateInsertByPrice(t *testing.T) {
 	Check(t, b, 6, 36, 6)
 }
 
-// 134830672	         9.83 ns/op	       0 B/op	       0 allocs/op (old)
-// 206689897	         5.761 ns/op	   0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateInsertByPrice_Amend(b *testing.B) {
 	a := askLevels{}
 	a.load(ask)
@@ -266,8 +262,6 @@ func BenchmarkUpdateInsertByPrice_Amend(b *testing.B) {
 	}
 }
 
-// 49763002	        24.9 ns/op	       0 B/op	       0 allocs/op (old)
-// 25662849	        45.32 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateInsertByPrice_Insert_Delete(b *testing.B) {
 	a := askLevels{}
 
@@ -338,8 +332,6 @@ func TestUpdateByID(t *testing.T) {
 	}
 }
 
-// 46043871	        25.9 ns/op	       0 B/op	       0 allocs/op (old)
-// 63445401	        18.51 ns/op	       0 B/op	       0 allocs/op (new)
 func BenchmarkUpdateByID(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -407,7 +399,6 @@ func TestDeleteByID(t *testing.T) {
 	}
 }
 
-// 26724331	        44.69 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkDeleteByID(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -682,7 +673,6 @@ func TestUpdateInsertByIDAsk(t *testing.T) {
 	Check(t, a, 14, 87, 7)
 }
 
-// 21614455	        81.74 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkUpdateInsertByID_asks(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{
@@ -953,7 +943,6 @@ func TestUpdateInsertByIDBids(t *testing.T) {
 	Check(t, b, 14, 87, 7)
 }
 
-// 20328886	        59.94 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkUpdateInsertByID_bids(b *testing.B) {
 	bids := Levels{}
 	bidsSnapshot := Levels{
@@ -1836,7 +1825,6 @@ func TestFinalizeFields(t *testing.T) {
 	assert.InDelta(t, 717.0, mov.SlippageCost, 0.000000001, "SlippageCost should be correct")
 }
 
-// 8384302	       150.9 ns/op	     480 B/op	       1 allocs/op
 func BenchmarkRetrieve(b *testing.B) {
 	asks := Levels{}
 	asksSnapshot := Levels{

--- a/exchanges/orderbook/orderbook_bench_test.go
+++ b/exchanges/orderbook/orderbook_bench_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 )
 
-// 705985	      1856 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkReverse(b *testing.B) {
 	lvls := levelsFixture()
 	if len(lvls) != 1000 {
@@ -160,8 +159,6 @@ func BenchmarkSortBidsDescending(b *testing.B) {
 	}
 }
 
-// 5572401	       210.9 ns/op	       0 B/op	       0 allocs/op (current)
-// 3748009	       312.7 ns/op	      32 B/op	       1 allocs/op (previous)
 func BenchmarkProcess(b *testing.B) {
 	book := &Book{
 		Pair:     currency.NewBTCUSD(),

--- a/exchanges/orderbook/orderbook_test.go
+++ b/exchanges/orderbook/orderbook_test.go
@@ -437,7 +437,6 @@ func TestReverse(t *testing.T) {
 	assert.NoError(t, b.Validate())
 }
 
-// 705985	      1856 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkReverse(b *testing.B) {
 	lvls := levelsFixture()
 	if len(lvls) != 1000 {
@@ -449,8 +448,6 @@ func BenchmarkReverse(b *testing.B) {
 	}
 }
 
-// 361266	      3556 ns/op	      24 B/op	       1 allocs/op (old)
-// 385783	      3000 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortAsksDecending(b *testing.B) {
 	lvls := levelsFixture()
 	bucket := make(Levels, len(lvls))
@@ -460,8 +457,6 @@ func BenchmarkSortAsksDecending(b *testing.B) {
 	}
 }
 
-// 266998	      4292 ns/op	      40 B/op	       2 allocs/op (old)
-// 372396	      3001 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortBidsAscending(b *testing.B) {
 	lvls := levelsFixture()
 	lvls.Reverse()
@@ -472,8 +467,6 @@ func BenchmarkSortBidsAscending(b *testing.B) {
 	}
 }
 
-// 22119	     46532 ns/op	      35 B/op	       1 allocs/op (old)
-// 16233	     76951 ns/op	     167 B/op	       3 allocs/op (new)
 func BenchmarkSortAsksStandard(b *testing.B) {
 	lvls := levelsFixtureRandom()
 	bucket := make(Levels, len(lvls))
@@ -483,8 +476,6 @@ func BenchmarkSortAsksStandard(b *testing.B) {
 	}
 }
 
-// 19504	     62518 ns/op	      53 B/op	       2 allocs/op (old)
-// 15698	     72859 ns/op	     168 B/op	       3 allocs/op (new)
 func BenchmarkSortBidsStandard(b *testing.B) {
 	lvls := levelsFixtureRandom()
 	bucket := make(Levels, len(lvls))
@@ -494,8 +485,6 @@ func BenchmarkSortBidsStandard(b *testing.B) {
 	}
 }
 
-// 376708	      3559 ns/op	      24 B/op 		   1 allocs/op (old)
-// 377113	      3020 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortAsksAscending(b *testing.B) {
 	lvls := levelsFixture()
 	bucket := make(Levels, len(lvls))
@@ -505,8 +494,6 @@ func BenchmarkSortAsksAscending(b *testing.B) {
 	}
 }
 
-// 262874	      4364 ns/op	      40 B/op	       2 allocs/op (old)
-// 401788	      3348 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortBidsDescending(b *testing.B) {
 	lvls := levelsFixture()
 	lvls.Reverse()
@@ -540,8 +527,6 @@ func TestCheckAlignment(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// 5572401	       210.9 ns/op	       0 B/op	       0 allocs/op (current)
-// 3748009	       312.7 ns/op	      32 B/op	       1 allocs/op (previous)
 func BenchmarkProcess(b *testing.B) {
 	book := &Book{
 		Pair:     currency.NewBTCUSD(),

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -573,8 +573,6 @@ func TestGetNonce(t *testing.T) {
 	assert.NotEqual(t, n2, n4)
 }
 
-// 40532461	       30.29 ns/op	       0 B/op	       0 allocs/op (prev)
-// 45329203	       26.53 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkGetNonce(b *testing.B) {
 	r, err := New("test", new(http.Client), WithLimiter(globalshell))
 	require.NoError(b, err)

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -1315,8 +1315,6 @@ func TestGetNonce(t *testing.T) {
 	assert.NotEqual(t, n2, n4)
 }
 
-// 40532461	       30.29 ns/op	       0 B/op	       0 allocs/op (prev)
-// 45329203	       26.53 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkGetNonce(b *testing.B) {
 	r, err := New("test", new(http.Client), WithLimiter(globalshell))
 	require.NoError(b, err)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1213,16 +1213,18 @@ func TestBenchmarkLoggerWorkloads(t *testing.T) {
 	})
 }
 
+// BenchmarkNewLogEvent waits for each staged event to be written, which holds the job pool in a
+// steady state and stops the jobs channel filling; StageLogEvent's filled-channel warning goes to
+// the standard logger, which go test interleaves into the result lines.
 func BenchmarkNewLogEvent(b *testing.B) {
-	mw := &multiWriterHolder{writers: []io.Writer{io.Discard}}
+	w := newTestBuffer()
+	mw := &multiWriterHolder{writers: []io.Writer{w}}
 	for b.Loop() {
 		mw.StageLogEvent(func() string { return "somedata" }, "header", "sublog", "||", "", "", time.RFC3339, true, false, false, nil)
+		<-w.Finished
 	}
 }
 
-// Benchstat medians for PR base to measured production head; no significant
-// difference detected at n=20, p=0.113 (counterbalanced fresh-process observations per revision):
-// Before: 41.41 ns/op  16 B/op  1 allocs/op; After: 41.62 ns/op  16 B/op  1 allocs/op
 func BenchmarkInfoDisabled(b *testing.B) {
 	sl, cleanup := benchmarkLoggerState(false, Levels{Info: true}, nil, io.Discard)
 	b.Cleanup(cleanup)
@@ -1235,10 +1237,6 @@ func BenchmarkInfoDisabled(b *testing.B) {
 
 // BenchmarkFormattedDisabled measures level-disabled formatted logging while
 // global logging remains enabled.
-// Benchstat medians for PR base to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// Before: 216.0-221.5 ns/op  256 B/op  3 allocs/op
-// After:  109.2-114.5 ns/op   64 B/op  2 allocs/op
 func BenchmarkFormattedDisabled(b *testing.B) {
 	for _, tc := range []struct {
 		name string
@@ -1263,10 +1261,6 @@ func BenchmarkFormattedDisabled(b *testing.B) {
 
 // BenchmarkCustomLogHookBypass measures logging when a custom hook handles the
 // event and bypasses the internal logging system.
-// Benchstat medians for hook-change predecessor to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// Before: Infoln 144.40 ns/op, 208 B/op, 2 allocs/op; Infof 306.5 ns/op, 264 B/op, 5 allocs/op
-// After:  Infoln  65.90 ns/op,  16 B/op, 1 allocs/op; Infof 218.5 ns/op, 72 B/op, 4 allocs/op
 func BenchmarkCustomLogHookBypass(b *testing.B) {
 	for _, tc := range []struct {
 		name string
@@ -1291,53 +1285,38 @@ func BenchmarkCustomLogHookBypass(b *testing.B) {
 
 // BenchmarkCustomLogHookFallthrough measures formatted logging when a custom
 // hook observes the event and the internal logger still handles it.
-// Benchstat medians for hook-change predecessor to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// Before: 674.6 ns/op  185 B/op  6 allocs/op
-// After:  494.3 ns/op  133 B/op  5 allocs/op
 func BenchmarkCustomLogHookFallthrough(b *testing.B) {
+	w := newTestBuffer()
 	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, func(_, _ string, _ ...any) bool {
 		return false
-	}, io.Discard)
+	}, w)
 	b.Cleanup(cleanup)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		Infof(sl, "formatted %s %d", "message", 1)
+		<-w.Finished
 	}
-	drainBenchmarkLoggerJobs()
-	b.StopTimer()
 }
 
-// Benchstat medians for PR base to measured production head
-// (20 counterbalanced fresh-process observations per revision):
-// Before: 765.7 ns/op  371 B/op  5 allocs/op
-// After:  552.3 ns/op  175 B/op  4 allocs/op
 func BenchmarkInfof(b *testing.B) {
-	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, io.Discard)
+	w := newTestBuffer()
+	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, w)
 	b.Cleanup(cleanup)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := range b.N {
+	n := 0
+	for b.Loop() {
 		Infof(sl, "Hello this is an infof benchmark %v %v %v\n", n, 1, 2)
+		<-w.Finished
+		n++
 	}
-	drainBenchmarkLoggerJobs()
-	b.StopTimer()
 }
 
-// Benchstat medians for PR base to measured production head; no significant
-// difference detected at n=20, p=0.551 (counterbalanced fresh-process observations per revision):
-// Before: 330.6 ns/op  114 B/op  3 allocs/op; After: 334.8 ns/op  114 B/op  3 allocs/op
 func BenchmarkInfoln(b *testing.B) {
-	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, io.Discard)
+	w := newTestBuffer()
+	sl, cleanup := benchmarkLoggerState(true, Levels{Info: true}, nil, w)
 	b.Cleanup(cleanup)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		Infoln(sl, "Hello this is an infoln benchmark")
+		<-w.Finished
 	}
-	drainBenchmarkLoggerJobs()
-	b.StopTimer()
 }
 
 type testCapture struct {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -635,7 +635,6 @@ func newTestBuffer() *testBuffer {
 	return &testBuffer{Finished: make(chan struct{}, 1)}
 }
 
-// 2140294	       770.0 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkNewLogEvent(b *testing.B) {
 	mw := &multiWriterHolder{writers: []io.Writer{io.Discard}}
 	for b.Loop() {
@@ -643,14 +642,12 @@ func BenchmarkNewLogEvent(b *testing.B) {
 	}
 }
 
-// BenchmarkInfo-8   	 1000000	     64971 ns/op	      47 B/op	       1 allocs/op
 func BenchmarkInfo(b *testing.B) {
 	for b.Loop() {
 		Infoln(Global, "Hello this is an info benchmark")
 	}
 }
 
-// BenchmarkInfoDisabled-8 47124242	        24.16 ns/op	       0 B/op	       0 allocs/op
 func BenchmarkInfoDisabled(b *testing.B) {
 	if err := SetupDisabled(); err != nil {
 		b.Fatal(err)
@@ -661,14 +658,12 @@ func BenchmarkInfoDisabled(b *testing.B) {
 	}
 }
 
-// BenchmarkInfof-8   	 1000000	     72641 ns/op	     178 B/op	       4 allocs/op
 func BenchmarkInfof(b *testing.B) {
 	for n := range b.N {
 		Infof(Global, "Hello this is an infof benchmark %v %v %v\n", n, 1, 2)
 	}
 }
 
-// BenchmarkInfoln-8   	 1000000	     68152 ns/op	     121 B/op	       3 allocs/op
 func BenchmarkInfoln(b *testing.B) {
 	for b.Loop() {
 		Infoln(Global, "Hello this is an infoln benchmark")

--- a/scripts/bench_history.sh
+++ b/scripts/bench_history.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# bench_history.sh — fetch and publish the benchmark ns/op history branch.
+#
+# Kept out of the workflow YAML so the git plumbing can be tested locally against a throwaway
+# repository rather than only by waiting for the scheduled run. See scripts/bench_history_test.sh.
+#
+# Usage:
+#   bench_history.sh fetch   <series-file>   # write existing history to <series-file>
+#   bench_history.sh publish <series-file>   # commit and push <series-file> onto the history branch
+#
+# Environment:
+#   BENCH_HISTORY_REMOTE  remote name or URL          (default: origin)
+#   BENCH_HISTORY_BRANCH  branch holding the history  (default: benchmarks-history)
+#   BENCH_HISTORY_PATH    path within that branch     (default: benchmarks/series.jsonl)
+#   BENCH_HISTORY_LABEL   text appended to the commit subject (default: local)
+
+set -euo pipefail
+
+REMOTE="${BENCH_HISTORY_REMOTE:-origin}"
+BRANCH="${BENCH_HISTORY_BRANCH:-benchmarks-history}"
+BRANCH_PATH="${BENCH_HISTORY_PATH:-benchmarks/series.jsonl}"
+LABEL="${BENCH_HISTORY_LABEL:-local}"
+
+# Global rather than a local in cmd_publish: the EXIT trap runs after the function has returned, so
+# a local would already be out of scope and `set -u` would abort inside the trap itself.
+WORKTREE=""
+cleanup() {
+    [[ -n "$WORKTREE" ]] || return 0
+    git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+    rm -rf "$WORKTREE"
+}
+trap cleanup EXIT
+
+die() {
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        echo "::error::$1"
+    else
+        echo "bench_history: $1" >&2
+    fi
+    exit 1
+}
+
+# resolve_branch_state sets BRANCH_STATE to exists or absent, or dies. git ls-remote --exit-code
+# returns 2 for "no matching ref" and other non-zero codes for transport failures. Collapsing the
+# two would let a transient network error look like a first run, and the history would then be
+# published over the real one.
+#
+# It assigns to a global rather than echoing a value, because a caller would have to invoke it in a
+# command substitution and `exit` inside one only leaves the subshell — the transport failure would
+# be swallowed and treated as "absent", which is the exact bug this guards against.
+BRANCH_STATE=""
+resolve_branch_state() {
+    local rc=0
+    git ls-remote --exit-code --heads "$REMOTE" "$BRANCH" >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+        0) BRANCH_STATE=exists ;;
+        2) BRANCH_STATE=absent ;;
+        *) die "could not determine whether $BRANCH exists on $REMOTE (git ls-remote exit $rc)" ;;
+    esac
+}
+
+cmd_fetch() {
+    local out="$1"
+    resolve_branch_state
+    if [[ "$BRANCH_STATE" != exists ]]; then
+        echo "bench_history: no $BRANCH branch yet, starting a new history"
+        : > "$out"
+        return 0
+    fi
+    git fetch --quiet --force "$REMOTE" "$BRANCH:$BRANCH"
+    # The branch can exist without the series file, after a BENCH_HISTORY_PATH change or a branch
+    # created by hand. assert_extends_published already treats that as an empty history; without the
+    # same treatment here git show aborts the job, and does so on every scheduled run thereafter.
+    if git cat-file -e "$BRANCH:$BRANCH_PATH" 2>/dev/null; then
+        git show "$BRANCH:$BRANCH_PATH" > "$out"
+    else
+        echo "bench_history: $BRANCH holds no $BRANCH_PATH yet, starting a new history"
+        : > "$out"
+    fi
+}
+
+# assert_extends_published refuses to publish a series that does not begin with what is already on
+# the branch. Publishing copies the file wholesale, so a series built from a fetch that predates
+# another run's push would silently drop that run's records — the push itself would still be a clean
+# fast-forward, so nothing else would catch it. The history is append-only by construction, and this
+# is the invariant that makes that true.
+# Compared as a byte prefix rather than by line count: a published file with no trailing newline
+# makes `wc -l` undercount, which would reject a perfectly good append and keep rejecting it
+# forever. Bytes also make truncation (a candidate shorter than what is published) a mismatch.
+assert_extends_published() {
+    local series="$1" published published_size series_size
+    published="$(mktemp)"
+    # A read failure must not look like an empty history: treating it as empty skips the whole
+    # prefix check and publishes straight over whatever is there. Only a genuinely absent path is
+    # an empty history, so the two are distinguished before deciding.
+    if git cat-file -e "$BRANCH:$BRANCH_PATH" 2>/dev/null; then
+        if ! git show "$BRANCH:$BRANCH_PATH" > "$published" 2>/dev/null; then
+            rm -f "$published"
+            die "cannot read $BRANCH:$BRANCH_PATH; refusing to publish without verifying the existing history"
+        fi
+    else
+        : > "$published"
+    fi
+    published_size="$(wc -c < "$published" | tr -d ' ')"
+    series_size="$(wc -c < "$series" | tr -d ' ')"
+
+    if [[ "$published_size" -gt 0 ]]; then
+        if [[ "$series_size" -lt "$published_size" ]] || \
+           ! head -c "$published_size" "$series" | cmp -s - "$published"; then
+            rm -f "$published"
+            die "$series does not extend the published history: it diverges within the first $published_size bytes of $BRANCH. It was built from a stale fetch, and publishing it would drop already-recorded runs."
+        fi
+    fi
+    rm -f "$published"
+}
+
+cmd_publish() {
+    local series="$1"
+    [[ -s "$series" ]] || die "$series is empty, refusing to publish an empty history"
+
+    # git worktree add requires the path not to exist yet. Declared separately so a mktemp failure
+    # is not masked by the exit status of the local declaration itself.
+    local work staged
+    work="$(mktemp -du)"
+
+    # Committing onto the branch's own history, rather than re-creating an orphan root each run,
+    # keeps every previous commit reachable and makes a stale push a fast-forward failure.
+    resolve_branch_state
+    if [[ "$BRANCH_STATE" == exists ]]; then
+        git fetch --quiet --force "$REMOTE" "$BRANCH:$BRANCH"
+        assert_extends_published "$series"
+        git worktree add --quiet "$work" "$BRANCH"
+    else
+        git worktree add --quiet --detach "$work"
+    fi
+    # Recorded only once the worktree exists. mktemp -du reserves nothing, so if another process
+    # won the path and the add failed, cleanup would otherwise rm -rf a directory we never created.
+    WORKTREE="$work"
+
+    if [[ "$BRANCH_STATE" != exists ]]; then
+        git -C "$work" checkout --quiet --orphan "$BRANCH"
+        # checkout --orphan stages the previous branch's tree; drop it so the history branch holds
+        # only the series file. Assigned separately because a failing ls-files inside a test would
+        # look like "no files staged", silently committing the whole master tree into the history.
+        if ! staged="$(git -C "$work" ls-files)"; then
+            die "cannot list the staged files in $work"
+        fi
+        if [[ -n "$staged" ]]; then
+            git -C "$work" rm -rfq --cached .
+        fi
+    fi
+
+    mkdir -p "$work/$(dirname "$BRANCH_PATH")"
+    cp "$series" "$work/$BRANCH_PATH"
+
+    # -f because the series file is gitignored for local runs; without it the add is refused
+    git -C "$work" add -f "$BRANCH_PATH"
+    if git -C "$work" diff --cached --quiet; then
+        echo "bench_history: no new records, nothing to publish"
+        return 0
+    fi
+    git -C "$work" -c user.name="${GIT_AUTHOR_NAME:-github-actions[bot]}" \
+        -c user.email="${GIT_AUTHOR_EMAIL:-github-actions[bot]@users.noreply.github.com}" \
+        commit --quiet -m "benchmarks: append history for $LABEL"
+
+    # No --force: a concurrent run that already pushed makes this a non-fast-forward, and the job
+    # fails loudly instead of silently discarding the other run's records.
+    git -C "$work" push --quiet "$REMOTE" "$BRANCH:$BRANCH"
+    echo "bench_history: published $(wc -l < "$series") records to $BRANCH"
+}
+
+case "${1:-}" in
+    fetch)   [[ $# -eq 2 ]] || die "usage: bench_history.sh fetch <series-file>";   cmd_fetch "$2" ;;
+    publish) [[ $# -eq 2 ]] || die "usage: bench_history.sh publish <series-file>"; cmd_publish "$2" ;;
+    *)       die "usage: bench_history.sh {fetch|publish} <series-file>" ;;
+esac

--- a/scripts/bench_history.sh
+++ b/scripts/bench_history.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# bench_history.sh — fetch and publish the benchmark ns/op history branch.
+#
+# Kept out of the workflow YAML so the git plumbing can be tested locally against a throwaway
+# repository rather than only by waiting for the scheduled run. See scripts/bench_history_test.sh.
+#
+# Usage:
+#   bench_history.sh fetch   <series-file>   # write existing history to <series-file>
+#   bench_history.sh publish <series-file>   # commit and push <series-file> onto the history branch
+#
+# Environment:
+#   BENCH_HISTORY_REMOTE  remote name or URL          (default: origin)
+#   BENCH_HISTORY_BRANCH  branch holding the history  (default: benchmarks-history)
+#   BENCH_HISTORY_PATH    path within that branch     (default: benchmarks/series.jsonl)
+#   BENCH_HISTORY_LABEL   text appended to the commit subject (default: local)
+
+set -euo pipefail
+
+REMOTE="${BENCH_HISTORY_REMOTE:-origin}"
+BRANCH="${BENCH_HISTORY_BRANCH:-benchmarks-history}"
+BRANCH_PATH="${BENCH_HISTORY_PATH:-benchmarks/series.jsonl}"
+LABEL="${BENCH_HISTORY_LABEL:-local}"
+
+# Global rather than a local in cmd_publish: the EXIT trap runs after the function has returned, so
+# a local would already be out of scope and `set -u` would abort inside the trap itself.
+WORKTREE=""
+cleanup() {
+    [[ -n "$WORKTREE" ]] || return 0
+    git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+    rm -rf "$WORKTREE"
+}
+trap cleanup EXIT
+
+die() {
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        echo "::error::$1"
+    else
+        echo "bench_history: $1" >&2
+    fi
+    exit 1
+}
+
+# resolve_branch_state sets BRANCH_STATE to exists or absent, or dies. git ls-remote --exit-code
+# returns 2 for "no matching ref" and other non-zero codes for transport failures. Collapsing the
+# two would let a transient network error look like a first run, and the history would then be
+# published over the real one.
+#
+# It assigns to a global rather than echoing a value, because a caller would have to invoke it in a
+# command substitution and `exit` inside one only leaves the subshell — the transport failure would
+# be swallowed and treated as "absent", which is the exact bug this guards against.
+BRANCH_STATE=""
+resolve_branch_state() {
+    local rc=0
+    git ls-remote --exit-code --heads "$REMOTE" "$BRANCH" >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+        0) BRANCH_STATE=exists ;;
+        2) BRANCH_STATE=absent ;;
+        *) die "could not determine whether $BRANCH exists on $REMOTE (git ls-remote exit $rc)" ;;
+    esac
+}
+
+cmd_fetch() {
+    local out="$1"
+    resolve_branch_state
+    if [[ "$BRANCH_STATE" == exists ]]; then
+        git fetch --quiet --force "$REMOTE" "$BRANCH:$BRANCH"
+        git show "$BRANCH:$BRANCH_PATH" > "$out"
+    else
+        echo "bench_history: no $BRANCH branch yet, starting a new history"
+        : > "$out"
+    fi
+}
+
+# assert_extends_published refuses to publish a series that does not begin with what is already on
+# the branch. Publishing copies the file wholesale, so a series built from a fetch that predates
+# another run's push would silently drop that run's records — the push itself would still be a clean
+# fast-forward, so nothing else would catch it. The history is append-only by construction, and this
+# is the invariant that makes that true.
+# Compared as a byte prefix rather than by line count: a published file with no trailing newline
+# makes `wc -l` undercount, which would reject a perfectly good append and keep rejecting it
+# forever. Bytes also make truncation (a candidate shorter than what is published) a mismatch.
+assert_extends_published() {
+    local series="$1" published published_size series_size
+    published="$(mktemp)"
+    # A read failure must not look like an empty history: treating it as empty skips the whole
+    # prefix check and publishes straight over whatever is there. Only a genuinely absent path is
+    # an empty history, so the two are distinguished before deciding.
+    if git cat-file -e "$BRANCH:$BRANCH_PATH" 2>/dev/null; then
+        if ! git show "$BRANCH:$BRANCH_PATH" > "$published" 2>/dev/null; then
+            rm -f "$published"
+            die "cannot read $BRANCH:$BRANCH_PATH; refusing to publish without verifying the existing history"
+        fi
+    else
+        : > "$published"
+    fi
+    published_size="$(wc -c < "$published" | tr -d ' ')"
+    series_size="$(wc -c < "$series" | tr -d ' ')"
+
+    if [[ "$published_size" -gt 0 ]]; then
+        if [[ "$series_size" -lt "$published_size" ]] || \
+           ! head -c "$published_size" "$series" | cmp -s - "$published"; then
+            rm -f "$published"
+            die "$series does not extend the published history: it diverges within the first $published_size bytes of $BRANCH. It was built from a stale fetch, and publishing it would drop already-recorded runs."
+        fi
+    fi
+    rm -f "$published"
+}
+
+cmd_publish() {
+    local series="$1"
+    [[ -s "$series" ]] || die "$series is empty, refusing to publish an empty history"
+
+    # git worktree add requires the path not to exist yet. Declared separately so a mktemp failure
+    # is not masked by the exit status of the local declaration itself.
+    local work staged
+    work="$(mktemp -du)"
+
+    # Committing onto the branch's own history, rather than re-creating an orphan root each run,
+    # keeps every previous commit reachable and makes a stale push a fast-forward failure.
+    resolve_branch_state
+    if [[ "$BRANCH_STATE" == exists ]]; then
+        git fetch --quiet --force "$REMOTE" "$BRANCH:$BRANCH"
+        assert_extends_published "$series"
+        git worktree add --quiet "$work" "$BRANCH"
+    else
+        git worktree add --quiet --detach "$work"
+    fi
+    # Recorded only once the worktree exists. mktemp -du reserves nothing, so if another process
+    # won the path and the add failed, cleanup would otherwise rm -rf a directory we never created.
+    WORKTREE="$work"
+
+    if [[ "$BRANCH_STATE" != exists ]]; then
+        git -C "$work" checkout --quiet --orphan "$BRANCH"
+        # checkout --orphan stages the previous branch's tree; drop it so the history branch holds
+        # only the series file. Assigned separately because a failing ls-files inside a test would
+        # look like "no files staged", silently committing the whole master tree into the history.
+        if ! staged="$(git -C "$work" ls-files)"; then
+            die "cannot list the staged files in $work"
+        fi
+        if [[ -n "$staged" ]]; then
+            git -C "$work" rm -rfq --cached .
+        fi
+    fi
+
+    mkdir -p "$work/$(dirname "$BRANCH_PATH")"
+    cp "$series" "$work/$BRANCH_PATH"
+
+    # -f because the series file is gitignored for local runs; without it the add is refused
+    git -C "$work" add -f "$BRANCH_PATH"
+    if git -C "$work" diff --cached --quiet; then
+        echo "bench_history: no new records, nothing to publish"
+        return 0
+    fi
+    git -C "$work" -c user.name="${GIT_AUTHOR_NAME:-github-actions[bot]}" \
+        -c user.email="${GIT_AUTHOR_EMAIL:-github-actions[bot]@users.noreply.github.com}" \
+        commit --quiet -m "benchmarks: append history for $LABEL"
+
+    # No --force: a concurrent run that already pushed makes this a non-fast-forward, and the job
+    # fails loudly instead of silently discarding the other run's records.
+    git -C "$work" push --quiet "$REMOTE" "$BRANCH:$BRANCH"
+    echo "bench_history: published $(wc -l < "$series") records to $BRANCH"
+}
+
+case "${1:-}" in
+    fetch)   [[ $# -eq 2 ]] || die "usage: bench_history.sh fetch <series-file>";   cmd_fetch "$2" ;;
+    publish) [[ $# -eq 2 ]] || die "usage: bench_history.sh publish <series-file>"; cmd_publish "$2" ;;
+    *)       die "usage: bench_history.sh {fetch|publish} <series-file>" ;;
+esac

--- a/scripts/bench_history_test.sh
+++ b/scripts/bench_history_test.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# bench_history_test.sh — exercises scripts/bench_history.sh against a throwaway local repository.
+#
+# The publish sequence is the part of the trend job most likely to break and the part a unit test
+# cannot reach, so it is tested here against real git rather than only by the scheduled run.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HISTORY_SH="$SCRIPT_DIR/bench_history.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+FAILURES=0
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}----${NC} $1"; }
+
+check() { # check <description> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi
+}
+
+# must runs a step that is expected to succeed and fails the suite if it does not. Without it a
+# publish that pushes correctly and then exits non-zero still satisfies the content assertions that
+# follow, so the harness would report success for a run the workflow would have failed. Silent on
+# success: these are preconditions, not the properties under test.
+must() { # must <description> <command...>
+    local desc="$1" rc=0
+    shift
+    "$@" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" -eq 0 ]] || fail "$desc (exited $rc)"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export BENCH_HISTORY_REMOTE="$TMP/remote.git"
+export BENCH_HISTORY_BRANCH="benchmarks-history"
+export BENCH_HISTORY_PATH="benchmarks/series.jsonl"
+export GIT_AUTHOR_NAME="test"; export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test"; export GIT_COMMITTER_EMAIL="test@example.com"
+
+git init --quiet --bare "$BENCH_HISTORY_REMOTE"
+
+# A working repository standing in for the checked-out project. It deliberately carries tracked
+# files and a .gitignore covering the series path, because the real repository has both: an empty
+# fixture has no tree to leak onto the history branch and no ignore rule to trip over, so the
+# orphan-index cleanup and the forced add could both be deleted with every check still passing.
+WORK="$TMP/work"
+git init --quiet -b master "$WORK"
+mkdir -p "$WORK/cmd/thing"
+echo "package main" > "$WORK/cmd/thing/main.go"
+echo "# project" > "$WORK/README.md"
+printf 'benchmarks/series.jsonl\n' > "$WORK/.gitignore"
+git -C "$WORK" add -A
+git -C "$WORK" commit --quiet -m "initial"
+# Every publish below runs against the current directory. A failed cd would leave them operating on
+# the real repository, creating worktrees and branches in it, so this must be fatal.
+cd "$WORK" || { echo "cannot cd to $WORK" >&2; exit 1; }
+
+record() { echo "{\"ts\":\"2026-07-29T0$1:00:00Z\",\"bench\":\"BenchmarkX\",\"ns_median\":$2}"; }
+
+# ---------------------------------------------------------------------------
+info "1. first run creates the branch"
+# ---------------------------------------------------------------------------
+must "initial fetch" "$HISTORY_SH" fetch series.jsonl
+check "fetch with no branch yields an empty series" "0" "$(wc -l < series.jsonl | tr -d ' ')"
+record 1 100 >> series.jsonl
+must "seeding publish" "$HISTORY_SH" publish series.jsonl
+check "branch now exists" "1" "$(git ls-remote --heads "$BENCH_HISTORY_REMOTE" "$BENCH_HISTORY_BRANCH" | wc -l | tr -d ' ')"
+check "one record published" "1" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+# Without the orphan-index cleanup the whole master tree rides along onto the history branch, and
+# without the forced add the ignored series file is refused and nothing is published at all.
+check "history branch holds only the series file" "$BENCH_HISTORY_PATH" \
+    "$(git -C "$BENCH_HISTORY_REMOTE" ls-tree -r --name-only "$BENCH_HISTORY_BRANCH" | tr '\n' ' ' | sed 's/ $//')"
+
+# ---------------------------------------------------------------------------
+info "2. second run appends and preserves commit history"
+# ---------------------------------------------------------------------------
+rm -f series.jsonl
+must "second fetch" "$HISTORY_SH" fetch series.jsonl
+check "fetch returns the existing record" "1" "$(wc -l < series.jsonl | tr -d ' ')"
+record 2 90 >> series.jsonl
+must "appending publish" "$HISTORY_SH" publish series.jsonl
+check "both records present" "2" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+check "history has two commits, not a re-orphaned root" "2" "$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+check "earliest record survived" "1" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | grep -c 'T01:')"
+
+# ---------------------------------------------------------------------------
+info "3. a series built from a stale fetch is refused, not silently published"
+# ---------------------------------------------------------------------------
+# publish re-fetches before committing, so a stale run's push is still a clean fast-forward and git
+# raises nothing. The danger is therefore not a rejected push but an accepted one: the file is
+# copied wholesale, so records the stale run never saw would be dropped without any error.
+STALE="$TMP/stale"
+git clone --quiet "$WORK" "$STALE"
+# Series as it would look to a run that fetched before record 2 landed
+printf '%s\n%s\n' "$(record 1 100)" "$(record 9 999)" > "$STALE/series.jsonl"
+( cd "$STALE" && "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+stale_rc=$?
+check "stale publish exits non-zero" "1" "$([[ $stale_rc -ne 0 ]] && echo 1 || echo 0)"
+published="$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH")"
+check "remote still holds both real records" "2" "$(echo "$published" | wc -l | tr -d ' ')"
+check "the record the stale run never saw survived" "1" "$(echo "$published" | grep -c 'T02:')"
+check "the stale run's record never landed" "0" "$(echo "$published" | grep -c 'T09:')"
+
+# A run that legitimately extends the published history is still accepted
+rm -f series.jsonl && must "fetch before genuine append" "$HISTORY_SH" fetch series.jsonl
+record 3 80 >> series.jsonl
+must "genuine append publish" "$HISTORY_SH" publish series.jsonl
+check "a genuine append is still accepted" "3" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "4. an unreachable remote is fatal, not treated as a first run"
+# ---------------------------------------------------------------------------
+out="$(BENCH_HISTORY_REMOTE="$TMP/does-not-exist.git" "$HISTORY_SH" fetch probe.jsonl 2>&1)"
+probe_rc=$?
+check "fetch against a broken remote exits non-zero" "1" "$([[ $probe_rc -ne 0 ]] && echo 1 || echo 0)"
+check "and says so rather than reporting a new history" "1" "$(echo "$out" | grep -c 'could not determine')"
+
+# ---------------------------------------------------------------------------
+info "5. an empty series is refused"
+# ---------------------------------------------------------------------------
+: > empty.jsonl
+empty_rc=0
+"$HISTORY_SH" publish empty.jsonl >/dev/null 2>&1 || empty_rc=$?
+check "publishing an empty series exits non-zero" "1" "$([[ $empty_rc -ne 0 ]] && echo 1 || echo 0)"
+
+# Against an existing history the prefix check rejects an empty series anyway, so that alone does
+# not exercise the guard. A first publish has nothing to compare against, and is the only case where
+# the guard is what stops an empty history being created.
+#
+# A distinct branch name is essential: reusing BENCH_HISTORY_BRANCH would hit the local branch left
+# by the earlier tests, and `checkout --orphan` would refuse on the name collision instead. The test
+# would then pass whether or not the guard existed.
+git init --quiet --bare "$TMP/firstrun.git"
+: > first.jsonl
+first_rc=0
+BENCH_HISTORY_REMOTE="$TMP/firstrun.git" BENCH_HISTORY_BRANCH=firstrun \
+    "$HISTORY_SH" publish first.jsonl >/dev/null 2>&1 || first_rc=$?
+check "an empty first publish exits non-zero" "1" "$([[ $first_rc -ne 0 ]] && echo 1 || echo 0)"
+check "and creates no history branch" "0" \
+    "$(git ls-remote --heads "$TMP/firstrun.git" firstrun | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "6. republishing identical records is a no-op"
+# ---------------------------------------------------------------------------
+before="$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+rm -f series.jsonl && must "fetch before no-op publish" "$HISTORY_SH" fetch series.jsonl
+must "no-op publish" "$HISTORY_SH" publish series.jsonl
+check "no empty commit is created" "$before" "$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+
+# ---------------------------------------------------------------------------
+info "7. a published file with no trailing newline still accepts an append"
+# ---------------------------------------------------------------------------
+# Comparing by line count rather than bytes silently miscounts such a file and would reject every
+# subsequent append forever, so this pins the prefix comparison to bytes.
+# Two records with no newline after the last: `wc -l` reports 1 where the file really holds 2, so a
+# line-based prefix check compares the wrong amount and rejects the append. A single record would
+# not discriminate, because `wc -l` returns 0 there and any `> 0` guard skips the check entirely.
+NL="$TMP/nonewline"
+git init --quiet --bare "$TMP/nl.git"
+git init --quiet -b master "$NL"
+git -C "$NL" commit --quiet --allow-empty -m init
+printf '%s\n%s' "$(record 1 100)" "$(record 2 90)" > "$NL/series.jsonl"
+( cd "$NL" && BENCH_HISTORY_REMOTE="$TMP/nl.git" BENCH_HISTORY_BRANCH=h "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+check "seeding a newline-less history succeeds" "0" "$?"
+
+printf '%s\n%s\n%s\n' "$(record 1 100)" "$(record 2 90)" "$(record 3 80)" > "$NL/series.jsonl"
+( cd "$NL" && BENCH_HISTORY_REMOTE="$TMP/nl.git" BENCH_HISTORY_BRANCH=h "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+check "append onto a newline-less history is accepted" "0" "$?"
+check "and all three records are stored" "3" "$(git -C "$TMP/nl.git" show "h:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "8. a truncated series is refused"
+# ---------------------------------------------------------------------------
+printf '%s\n' "$(record 1 100)" > "$WORK/truncated.jsonl"
+"$HISTORY_SH" publish truncated.jsonl >/dev/null 2>&1
+trunc_rc=$?
+check "publishing fewer records than are published fails" "1" "$([[ $trunc_rc -ne 0 ]] && echo 1 || echo 0)"
+check "the full history survives truncation" "3" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "9. a run that loses the race between the prefix check and the push is rejected"
+# ---------------------------------------------------------------------------
+# A pre-push hook advances the remote after assert_extends_published has already passed, which is
+# the one window the prefix check cannot cover.
+#
+# Note what this does and does not prove. git plans the ref update before running the hook, so the
+# remote moving underneath fails git's own ref-lock compare-and-swap ("incorrect old value
+# provided"). That rejection happens with or without --force, because --force overrides the
+# fast-forward check and not the CAS. So this pins the end-to-end property — a run that loses the
+# race does not clobber the winner — but it does not exercise the choice of an unforced push.
+# Check 10 covers that separately.
+cat > "$WORK/.git/hooks/pre-push" <<HOOK
+#!/usr/bin/env bash
+# git exports GIT_DIR and friends into hooks, which would silently redirect the nested git commands
+# below onto the pushing repository instead of the clone
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+[[ -e "$TMP/raced" ]] && exit 0
+: > "$TMP/raced"
+d="\$(mktemp -d)"
+git clone -q --branch "$BENCH_HISTORY_BRANCH" "$BENCH_HISTORY_REMOTE" "\$d"
+echo '{"ts":"2026-07-29T08:00:00Z","bench":"BenchmarkRace"}' >> "\$d/$BENCH_HISTORY_PATH"
+git -C "\$d" add -A
+git -C "\$d" -c user.name=race -c user.email=race@example.com commit -qm "competing run"
+git -C "\$d" push -q origin "$BENCH_HISTORY_BRANCH"
+rm -rf "\$d"
+exit 0
+HOOK
+chmod +x "$WORK/.git/hooks/pre-push"
+
+rm -f series.jsonl && must "fetch before race" "$HISTORY_SH" fetch series.jsonl
+record 4 70 >> series.jsonl
+"$HISTORY_SH" publish series.jsonl >/dev/null 2>&1
+race_rc=$?
+rm -f "$WORK/.git/hooks/pre-push"
+check "losing the push race fails rather than overwriting" "1" "$([[ $race_rc -ne 0 ]] && echo 1 || echo 0)"
+check "the competing run's record survived" "1" \
+    "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | grep -c 'BenchmarkRace')"
+
+# ---------------------------------------------------------------------------
+info "10. the push is not forced"
+# ---------------------------------------------------------------------------
+# A source assertion rather than a behavioural one, and deliberately so: as check 9 shows, git's
+# ref-lock CAS masks the difference in every race this harness can construct, so no black-box test
+# here distinguishes a forced push from an unforced one. The property still matters — --force would
+# discard a competing run's commits in any window the CAS does not cover — so it is pinned here
+# where it can at least not be reintroduced silently.
+# Covers --force, a bundled short flag such as -qf, and a leading + on the refspec, all of which
+# force-update. Matching only "--force" would let the other two through.
+check "publish does not force-push" "0" \
+    "$(grep -cE 'git[^#]*push([^#]*(--force|--mirror)|[^#]*[[:space:]]-[a-zA-Z]*f|[^#]*[[:space:]]"?\+)' "$SCRIPT_DIR/bench_history.sh")"
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo -e "${GREEN}All bench history checks passed!${NC}"
+    exit 0
+fi
+echo -e "${RED}${FAILURES} check(s) failed.${NC}"
+exit 1

--- a/scripts/bench_history_test.sh
+++ b/scripts/bench_history_test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# bench_history_test.sh — exercises scripts/bench_history.sh against a throwaway local repository.
+#
+# The publish sequence is the part of the trend job most likely to break and the part a unit test
+# cannot reach, so it is tested here against real git rather than only by the scheduled run.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HISTORY_SH="$SCRIPT_DIR/bench_history.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+FAILURES=0
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}----${NC} $1"; }
+
+check() { # check <description> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi
+}
+
+# must runs a step that is expected to succeed and fails the suite if it does not. Without it a
+# publish that pushes correctly and then exits non-zero still satisfies the content assertions that
+# follow, so the harness would report success for a run the workflow would have failed. Silent on
+# success: these are preconditions, not the properties under test.
+must() { # must <description> <command...>
+    local desc="$1" rc=0
+    shift
+    "$@" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" -eq 0 ]] || fail "$desc (exited $rc)"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export BENCH_HISTORY_REMOTE="$TMP/remote.git"
+export BENCH_HISTORY_BRANCH="benchmarks-history"
+export BENCH_HISTORY_PATH="benchmarks/series.jsonl"
+export GIT_AUTHOR_NAME="test"; export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test"; export GIT_COMMITTER_EMAIL="test@example.com"
+
+git init --quiet --bare "$BENCH_HISTORY_REMOTE"
+
+# A working repository standing in for the checked-out project. It deliberately carries tracked
+# files and a .gitignore covering the series path, because the real repository has both: an empty
+# fixture has no tree to leak onto the history branch and no ignore rule to trip over, so the
+# orphan-index cleanup and the forced add could both be deleted with every check still passing.
+WORK="$TMP/work"
+git init --quiet -b master "$WORK"
+mkdir -p "$WORK/cmd/thing"
+echo "package main" > "$WORK/cmd/thing/main.go"
+echo "# project" > "$WORK/README.md"
+printf 'benchmarks/series.jsonl\n' > "$WORK/.gitignore"
+git -C "$WORK" add -A
+git -C "$WORK" commit --quiet -m "initial"
+# Every publish below runs against the current directory. A failed cd would leave them operating on
+# the real repository, creating worktrees and branches in it, so this must be fatal.
+cd "$WORK" || { echo "cannot cd to $WORK" >&2; exit 1; }
+
+record() { echo "{\"ts\":\"2026-07-29T0$1:00:00Z\",\"bench\":\"BenchmarkX\",\"ns_median\":$2}"; }
+
+# ---------------------------------------------------------------------------
+info "1. first run creates the branch"
+# ---------------------------------------------------------------------------
+must "initial fetch" "$HISTORY_SH" fetch series.jsonl
+check "fetch with no branch yields an empty series" "0" "$(wc -l < series.jsonl | tr -d ' ')"
+record 1 100 >> series.jsonl
+must "seeding publish" "$HISTORY_SH" publish series.jsonl
+check "branch now exists" "1" "$(git ls-remote --heads "$BENCH_HISTORY_REMOTE" "$BENCH_HISTORY_BRANCH" | wc -l | tr -d ' ')"
+check "one record published" "1" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+# Without the orphan-index cleanup the whole master tree rides along onto the history branch, and
+# without the forced add the ignored series file is refused and nothing is published at all.
+check "history branch holds only the series file" "$BENCH_HISTORY_PATH" \
+    "$(git -C "$BENCH_HISTORY_REMOTE" ls-tree -r --name-only "$BENCH_HISTORY_BRANCH" | tr '\n' ' ' | sed 's/ $//')"
+
+# ---------------------------------------------------------------------------
+info "2. second run appends and preserves commit history"
+# ---------------------------------------------------------------------------
+rm -f series.jsonl
+must "second fetch" "$HISTORY_SH" fetch series.jsonl
+check "fetch returns the existing record" "1" "$(wc -l < series.jsonl | tr -d ' ')"
+record 2 90 >> series.jsonl
+must "appending publish" "$HISTORY_SH" publish series.jsonl
+check "both records present" "2" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+check "history has two commits, not a re-orphaned root" "2" "$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+check "earliest record survived" "1" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | grep -c 'T01:')"
+
+# ---------------------------------------------------------------------------
+info "3. a series built from a stale fetch is refused, not silently published"
+# ---------------------------------------------------------------------------
+# publish re-fetches before committing, so a stale run's push is still a clean fast-forward and git
+# raises nothing. The danger is therefore not a rejected push but an accepted one: the file is
+# copied wholesale, so records the stale run never saw would be dropped without any error.
+STALE="$TMP/stale"
+git clone --quiet "$WORK" "$STALE"
+# Series as it would look to a run that fetched before record 2 landed
+printf '%s\n%s\n' "$(record 1 100)" "$(record 9 999)" > "$STALE/series.jsonl"
+( cd "$STALE" && "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+stale_rc=$?
+check "stale publish exits non-zero" "1" "$([[ $stale_rc -ne 0 ]] && echo 1 || echo 0)"
+published="$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH")"
+check "remote still holds both real records" "2" "$(echo "$published" | wc -l | tr -d ' ')"
+check "the record the stale run never saw survived" "1" "$(echo "$published" | grep -c 'T02:')"
+check "the stale run's record never landed" "0" "$(echo "$published" | grep -c 'T09:')"
+
+# A run that legitimately extends the published history is still accepted
+rm -f series.jsonl && must "fetch before genuine append" "$HISTORY_SH" fetch series.jsonl
+record 3 80 >> series.jsonl
+must "genuine append publish" "$HISTORY_SH" publish series.jsonl
+check "a genuine append is still accepted" "3" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "4. an unreachable remote is fatal, not treated as a first run"
+# ---------------------------------------------------------------------------
+out="$(BENCH_HISTORY_REMOTE="$TMP/does-not-exist.git" "$HISTORY_SH" fetch probe.jsonl 2>&1)"
+probe_rc=$?
+check "fetch against a broken remote exits non-zero" "1" "$([[ $probe_rc -ne 0 ]] && echo 1 || echo 0)"
+check "and says so rather than reporting a new history" "1" "$(echo "$out" | grep -c 'could not determine')"
+
+# ---------------------------------------------------------------------------
+info "4b. a history branch without the series file reads as an empty history"
+# ---------------------------------------------------------------------------
+# publish already tolerates this, so fetch must too; otherwise the scheduled job aborts here on
+# every run until someone fixes the branch by hand.
+git init --quiet --bare "$TMP/nopath.git"
+NP="$TMP/nopath"
+git init --quiet -b master "$NP"
+git -C "$NP" commit --quiet --allow-empty -m init
+git -C "$NP" checkout --quiet --orphan h
+echo placeholder > "$NP/README"
+git -C "$NP" add README
+git -C "$NP" commit --quiet -m "branch without the series path"
+git -C "$NP" push --quiet "$TMP/nopath.git" h:h
+# Back to master: git refuses to fetch a branch that is currently checked out, which the real job
+# never hits because it runs from master
+git -C "$NP" checkout --quiet master
+nopath_rc=0
+( cd "$NP" && BENCH_HISTORY_REMOTE="$TMP/nopath.git" BENCH_HISTORY_BRANCH=h \
+    "$HISTORY_SH" fetch fetched.jsonl ) >/dev/null 2>&1 || nopath_rc=$?
+check "fetch succeeds against a branch with no series file" "0" "$nopath_rc"
+check "and yields an empty series" "0" "$(wc -c < "$NP/fetched.jsonl" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "5. an empty series is refused"
+# ---------------------------------------------------------------------------
+: > empty.jsonl
+empty_rc=0
+"$HISTORY_SH" publish empty.jsonl >/dev/null 2>&1 || empty_rc=$?
+check "publishing an empty series exits non-zero" "1" "$([[ $empty_rc -ne 0 ]] && echo 1 || echo 0)"
+
+# Against an existing history the prefix check rejects an empty series anyway, so that alone does
+# not exercise the guard. A first publish has nothing to compare against, and is the only case where
+# the guard is what stops an empty history being created.
+#
+# A distinct branch name is essential: reusing BENCH_HISTORY_BRANCH would hit the local branch left
+# by the earlier tests, and `checkout --orphan` would refuse on the name collision instead. The test
+# would then pass whether or not the guard existed.
+git init --quiet --bare "$TMP/firstrun.git"
+: > first.jsonl
+first_rc=0
+BENCH_HISTORY_REMOTE="$TMP/firstrun.git" BENCH_HISTORY_BRANCH=firstrun \
+    "$HISTORY_SH" publish first.jsonl >/dev/null 2>&1 || first_rc=$?
+check "an empty first publish exits non-zero" "1" "$([[ $first_rc -ne 0 ]] && echo 1 || echo 0)"
+check "and creates no history branch" "0" \
+    "$(git ls-remote --heads "$TMP/firstrun.git" firstrun | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "6. republishing identical records is a no-op"
+# ---------------------------------------------------------------------------
+before="$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+rm -f series.jsonl && must "fetch before no-op publish" "$HISTORY_SH" fetch series.jsonl
+must "no-op publish" "$HISTORY_SH" publish series.jsonl
+check "no empty commit is created" "$before" "$(git -C "$BENCH_HISTORY_REMOTE" rev-list --count "$BENCH_HISTORY_BRANCH")"
+
+# ---------------------------------------------------------------------------
+info "7. a published file with no trailing newline still accepts an append"
+# ---------------------------------------------------------------------------
+# Comparing by line count rather than bytes silently miscounts such a file and would reject every
+# subsequent append forever, so this pins the prefix comparison to bytes.
+# Two records with no newline after the last: `wc -l` reports 1 where the file really holds 2, so a
+# line-based prefix check compares the wrong amount and rejects the append. A single record would
+# not discriminate, because `wc -l` returns 0 there and any `> 0` guard skips the check entirely.
+NL="$TMP/nonewline"
+git init --quiet --bare "$TMP/nl.git"
+git init --quiet -b master "$NL"
+git -C "$NL" commit --quiet --allow-empty -m init
+printf '%s\n%s' "$(record 1 100)" "$(record 2 90)" > "$NL/series.jsonl"
+( cd "$NL" && BENCH_HISTORY_REMOTE="$TMP/nl.git" BENCH_HISTORY_BRANCH=h "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+check "seeding a newline-less history succeeds" "0" "$?"
+
+printf '%s\n%s\n%s\n' "$(record 1 100)" "$(record 2 90)" "$(record 3 80)" > "$NL/series.jsonl"
+( cd "$NL" && BENCH_HISTORY_REMOTE="$TMP/nl.git" BENCH_HISTORY_BRANCH=h "$HISTORY_SH" publish series.jsonl ) >/dev/null 2>&1
+check "append onto a newline-less history is accepted" "0" "$?"
+check "and all three records are stored" "3" "$(git -C "$TMP/nl.git" show "h:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "8. a truncated series is refused"
+# ---------------------------------------------------------------------------
+printf '%s\n' "$(record 1 100)" > "$WORK/truncated.jsonl"
+"$HISTORY_SH" publish truncated.jsonl >/dev/null 2>&1
+trunc_rc=$?
+check "publishing fewer records than are published fails" "1" "$([[ $trunc_rc -ne 0 ]] && echo 1 || echo 0)"
+check "the full history survives truncation" "3" "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+info "9. a run that loses the race between the prefix check and the push is rejected"
+# ---------------------------------------------------------------------------
+# A pre-push hook advances the remote after assert_extends_published has already passed, which is
+# the one window the prefix check cannot cover.
+#
+# Note what this does and does not prove. git plans the ref update before running the hook, so the
+# remote moving underneath fails git's own ref-lock compare-and-swap ("incorrect old value
+# provided"). That rejection happens with or without --force, because --force overrides the
+# fast-forward check and not the CAS. So this pins the end-to-end property — a run that loses the
+# race does not clobber the winner — but it does not exercise the choice of an unforced push.
+# Check 10 covers that separately.
+cat > "$WORK/.git/hooks/pre-push" <<HOOK
+#!/usr/bin/env bash
+# git exports GIT_DIR and friends into hooks, which would silently redirect the nested git commands
+# below onto the pushing repository instead of the clone
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+[[ -e "$TMP/raced" ]] && exit 0
+: > "$TMP/raced"
+d="\$(mktemp -d)"
+git clone -q --branch "$BENCH_HISTORY_BRANCH" "$BENCH_HISTORY_REMOTE" "\$d"
+echo '{"ts":"2026-07-29T08:00:00Z","bench":"BenchmarkRace"}' >> "\$d/$BENCH_HISTORY_PATH"
+git -C "\$d" add -A
+git -C "\$d" -c user.name=race -c user.email=race@example.com commit -qm "competing run"
+git -C "\$d" push -q origin "$BENCH_HISTORY_BRANCH"
+rm -rf "\$d"
+exit 0
+HOOK
+chmod +x "$WORK/.git/hooks/pre-push"
+
+rm -f series.jsonl && must "fetch before race" "$HISTORY_SH" fetch series.jsonl
+record 4 70 >> series.jsonl
+"$HISTORY_SH" publish series.jsonl >/dev/null 2>&1
+race_rc=$?
+rm -f "$WORK/.git/hooks/pre-push"
+check "losing the push race fails rather than overwriting" "1" "$([[ $race_rc -ne 0 ]] && echo 1 || echo 0)"
+check "the competing run's record survived" "1" \
+    "$(git -C "$BENCH_HISTORY_REMOTE" show "$BENCH_HISTORY_BRANCH:$BENCH_HISTORY_PATH" | grep -c 'BenchmarkRace')"
+
+# ---------------------------------------------------------------------------
+info "10. the push is not forced"
+# ---------------------------------------------------------------------------
+# A source assertion rather than a behavioural one, and deliberately so: as check 9 shows, git's
+# ref-lock CAS masks the difference in every race this harness can construct, so no black-box test
+# here distinguishes a forced push from an unforced one. The property still matters — --force would
+# discard a competing run's commits in any window the CAS does not cover — so it is pinned here
+# where it can at least not be reintroduced silently.
+# Covers --force, a bundled short flag such as -qf, and a leading + on the refspec, all of which
+# force-update. Matching only "--force" would let the other two through.
+check "publish does not force-push" "0" \
+    "$(grep -cE 'git[^#]*push([^#]*(--force|--mirror)|[^#]*[[:space:]]-[a-zA-Z]*f|[^#]*[[:space:]]"?\+)' "$SCRIPT_DIR/bench_history.sh")"
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo -e "${GREEN}All bench history checks passed!${NC}"
+    exit 0
+fi
+echo -e "${RED}${FAILURES} check(s) failed.${NC}"
+exit 1

--- a/scripts/misc_checks.sh
+++ b/scripts/misc_checks.sh
@@ -277,6 +277,63 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 9. Benchmark results pasted into comments
+# ---------------------------------------------------------------------------
+# benchmarks/baseline.json is the single source of truth for benchmark numbers, and `make bench`
+# verifies it on every run.
+#
+# The leading digit is what separates a pasted measurement from prose naming a unit ("carries no
+# B/op or allocs/op") or a literal such as metrics["ns/op"]. Anchored on a comment marker rather
+# than the line start, so a measurement tacked onto a statement is caught too.
+info "Check for benchmark results stored in comments"
+if ere_grep '(//|/\*|^[[:space:]]*\*).*[0-9][[:space:]]*((n|u|µ|m)?s/op|B/op|allocs/op|[KMGT]?B/s)' '*.go' 0 '.'; then
+    fail "Remove benchmark results from comments; benchmarks/baseline.json records them, run 'make bench_update'"
+else
+    pass "No benchmark results stored in comments"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. Benchmark history publish logic
+# ---------------------------------------------------------------------------
+info "Check benchmark history publish logic"
+# Run once and keep the output: re-running to show it would waste the work and, if the test ever
+# became non-deterministic, could pass on the second run and report a failure with nothing printed.
+if [[ ! -f "$SCRIPT_DIR/bench_history_test.sh" ]]; then
+    fail "scripts/bench_history_test.sh is missing"
+elif history_output="$(bash "$SCRIPT_DIR/bench_history_test.sh" 2>&1)"; then
+    pass "Benchmark history fetch/publish behaves correctly"
+else
+    echo "$history_output"
+    fail "Benchmark history checks failed, see output above"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. Shell scripts
+# ---------------------------------------------------------------------------
+# -S warning skips the info-level SC2016 notices about single-quoted perl bodies in this file, which
+# are deliberate, while still catching the class of bug that actually bites: unquoted expansions,
+# a failed cd leaving the script in the wrong directory, and exit codes read indirectly.
+info "Check shell scripts with shellcheck"
+# Discovered rather than globbed: an unmatched glob is passed to shellcheck verbatim, which then
+# fails on the literal path and reports it as a finding. Discovery also covers scripts added later.
+# A read loop rather than mapfile, which macOS's bash 3.2 does not have.
+shell_scripts=()
+while IFS= read -r script; do
+    shell_scripts+=("$script")
+done < <(find "$REPO_ROOT" -name '*.sh' -not -path '*/.git/*' -not -path '*/vendor/*' | sort)
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    info "Skipping shellcheck (not installed)"
+elif [[ "${#shell_scripts[@]}" -eq 0 ]]; then
+    fail "No shell scripts found to check"
+elif shellcheck_output="$(shellcheck -S warning "${shell_scripts[@]}" 2>&1)"; then
+    pass "Shell scripts are shellcheck clean (${#shell_scripts[@]} files)"
+else
+    echo "$shellcheck_output"
+    fail "Fix the shellcheck findings above"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/misc_checks.sh
+++ b/scripts/misc_checks.sh
@@ -277,6 +277,64 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 9. Benchmark results pasted into comments
+# ---------------------------------------------------------------------------
+# benchmarks/baseline.json is the single source of truth for benchmark numbers and it is verified
+# on every run by `make bench`
+#
+# A digit immediately before the unit is what a pasted measurement looks like; prose naming a unit
+# ("carries no B/op or allocs/op") has no leading digit, and a literal such as metrics["ns/op"] has
+# a quote there. Anchored on a comment marker rather than the line start, so /* ... */ blocks,
+# their continuation lines, and a measurement tacked onto the end of a statement are all caught.
+info "Check for benchmark results stored in comments"
+if ere_grep '(//|/\*|^[[:space:]]*\*).*[0-9][[:space:]]*(ns/op|B/op|allocs/op)' '*.go' 0 '.'; then
+    fail "Remove benchmark results from comments; benchmarks/baseline.json records them, run 'make bench_update'"
+else
+    pass "No benchmark results stored in comments"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. Benchmark history publish logic
+# ---------------------------------------------------------------------------
+info "Check benchmark history publish logic"
+# Run once and keep the output: re-running to show it would waste the work and, if the test ever
+# became non-deterministic, could pass on the second run and report a failure with nothing printed.
+if [[ ! -f "$SCRIPT_DIR/bench_history_test.sh" ]]; then
+    fail "scripts/bench_history_test.sh is missing"
+elif history_output="$(bash "$SCRIPT_DIR/bench_history_test.sh" 2>&1)"; then
+    pass "Benchmark history fetch/publish behaves correctly"
+else
+    echo "$history_output"
+    fail "Benchmark history checks failed, see output above"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. Shell scripts
+# ---------------------------------------------------------------------------
+# -S warning skips the info-level SC2016 notices about single-quoted perl bodies in this file, which
+# are deliberate, while still catching the class of bug that actually bites: unquoted expansions,
+# a failed cd leaving the script in the wrong directory, and exit codes read indirectly.
+info "Check shell scripts with shellcheck"
+# Discovered rather than globbed: an unmatched glob is passed to shellcheck verbatim, which then
+# fails on the literal path and reports it as a finding. Discovery also covers scripts added later.
+# A read loop rather than mapfile, which macOS's bash 3.2 does not have.
+shell_scripts=()
+while IFS= read -r script; do
+    shell_scripts+=("$script")
+done < <(find "$REPO_ROOT" -name '*.sh' -not -path '*/.git/*' -not -path '*/vendor/*' | sort)
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    info "Skipping shellcheck (not installed)"
+elif [[ "${#shell_scripts[@]}" -eq 0 ]]; then
+    fail "No shell scripts found to check"
+elif shellcheck_output="$(shellcheck -S warning "${shell_scripts[@]}" 2>&1)"; then
+    pass "Shell scripts are shellcheck clean (${#shell_scripts[@]} files)"
+else
+    echo "$shellcheck_output"
+    fail "Fix the shellcheck findings above"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -70,7 +70,6 @@ func TestNumberInt64(t *testing.T) {
 }
 
 // BenchmarkNumberUnmarshalJSON provides a barebones benchmark of Unmarshaling a string value
-// Ballpark: 42.78 ns/op        16 B/op          1 allocs/op
 func BenchmarkNumberUnmarshalJSON(b *testing.B) {
 	var n Number
 	for b.Loop() {
@@ -79,7 +78,6 @@ func BenchmarkNumberUnmarshalJSON(b *testing.B) {
 }
 
 // BenchmarkNumberMarshalJSON provides a barebones benchmark of Marshaling a string value
-// Ballpark: 118.2 ns/op            56 B/op          3 allocs/op
 func BenchmarkNumberMarshalJSON(b *testing.B) {
 	for b.Loop() {
 		_, _ = Number(1337.1337).MarshalJSON()

--- a/types/precise_number_test.go
+++ b/types/precise_number_test.go
@@ -232,7 +232,6 @@ func TestPreciseNumberIsZero(t *testing.T) {
 
 // BenchmarkPreciseNumberUnmarshalJSON measures the cost of UnmarshalJSON for
 // a typical exchange string value.
-// Ballpark: 271.2 ns/op        392 B/op         16 allocs/op
 func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 	var p PreciseNumber
 	for b.Loop() {
@@ -243,7 +242,6 @@ func BenchmarkPreciseNumberUnmarshalJSON(b *testing.B) {
 }
 
 // BenchmarkPreciseNumberDecimal measures the cost of Decimal().
-// Ballpark: 55.11 ns/op         56 B/op          3 allocs/op
 func BenchmarkPreciseNumberDecimal(b *testing.B) {
 	p, err := NewPreciseNumberFromString("0.04200074")
 	require.NoError(b, err, "NewPreciseNumberFromString must not error")

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -89,11 +89,6 @@ func TestTimeUnmarshalJSONEmptyInput(t *testing.T) {
 	}
 }
 
-// Benchstat medians (20 counterbalanced fresh-process observations per revision):
-// direct/fractional Before: 119.55 ns/op  48 B/op  2 allocs/op
-// direct/fractional After:   56.73 ns/op   0 B/op  0 allocs/op
-// decoder/fractional Before: 335.3 ns/op  192 B/op  3 allocs/op
-// decoder/fractional After:  279.4 ns/op  144 B/op  1 alloc/op
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	for _, tc := range []struct {
 		name  string

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -53,8 +53,6 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
-// 3948978         303.5 ns/op       168 B/op          2 allocs/op (current) after more stringent checks
-// 6152384         195.5 ns/op       168 B/op          2 allocs/op (previous)
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	var testTime Time
 	for b.Loop() {


### PR DESCRIPTION
# PR Description

Adds a new benchcheck tool to record benchmark result series over time, plus flags whenever it creeps upwards. It stores it in a branch daily for now since GHA cache expires after 7 days of non-use and are immutable. It also rids all comments and enforces it in misc_checks so that we all use the new centralised tool

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
