### PR TITLE
exchange/websocket/buffer: reduce pending update lookup overhead

### DIFF
--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
+// Benchstat medians (20 counterbalanced fresh-process observations per revision).
+// The timed region includes LoadSnapshot, applyPendingUpdates, and relay drain.
+// 64 updates:
+// Before: 18.58 µs/op  3120 B/op  65 allocs/op
+// After:  16.66 µs/op  3120 B/op  65 allocs/op
+// 256 updates:
+// Before: 74.13 µs/op  12336 B/op  257 allocs/op
+// After:  65.87 µs/op  12336 B/op  257 allocs/op
 func BenchmarkApplyPendingUpdates(b *testing.B) {
 	for _, updateCount := range []uint{1, 2, 8, 64, 256} {
 		benchmarkName := strconv.FormatUint(uint64(updateCount), 10)

--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
+// Benchstat medians (20 counterbalanced fresh-process observations per revision):
+// 64 updates:
+// Before: 18.61 µs/op  3120 B/op  65 allocs/op
+// After:  16.51 µs/op  3120 B/op  65 allocs/op
+// 256 updates:
+// Before: 74.16 µs/op  12336 B/op  257 allocs/op
+// After:  65.69 µs/op  12336 B/op  257 allocs/op
 func BenchmarkApplyPendingUpdates(b *testing.B) {
 	for _, updateCount := range []uint{1, 2, 8, 64, 256} {
 		benchmarkName := strconv.FormatUint(uint64(updateCount), 10)

--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -13,13 +13,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
-// Benchstat medians (20 counterbalanced fresh-process observations per revision):
-// 64 updates:
-// Before: 18.61 µs/op  3120 B/op  65 allocs/op
-// After:  16.51 µs/op  3120 B/op  65 allocs/op
-// 256 updates:
-// Before: 74.16 µs/op  12336 B/op  257 allocs/op
-// After:  65.69 µs/op  12336 B/op  257 allocs/op
 func BenchmarkApplyPendingUpdates(b *testing.B) {
 	for _, updateCount := range []uint{1, 2, 8, 64, 256} {
 		benchmarkName := strconv.FormatUint(uint64(updateCount), 10)

--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -1,0 +1,101 @@
+package buffer
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/thrasher-corp/gocryptotrader/common/key"
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchange/stream"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
+)
+
+func BenchmarkApplyPendingUpdates(b *testing.B) {
+	for _, updateCount := range []uint{1, 2, 8, 64, 256} {
+		benchmarkName := strconv.FormatUint(uint64(updateCount), 10)
+		b.Run(benchmarkName, func(b *testing.B) {
+			// Reserve one payload for the snapshot and one for each update.
+			relay := stream.NewRelay(updateCount + 1)
+			exchangeName := "Benchmark-" + benchmarkName
+
+			ob := &Orderbook{
+				exchangeName: exchangeName,
+				ob:           make(map[key.PairAsset]*orderbookHolder),
+				dataHandler:  relay,
+			}
+			manager := NewUpdateManager(&UpdateManagerParams{
+				FetchDeadline: time.Second,
+				FetchOrderbook: func(context.Context, currency.Pair, asset.Item) (*orderbook.Book, error) {
+					return nil, orderbook.ErrDepthNotFound
+				},
+				CheckPendingUpdate: func(_, _ int64, _ *orderbook.Update) (bool, error) {
+					return false, nil
+				},
+				BufferInstance: ob,
+			})
+			pair := currency.NewBTCUSD()
+			now := time.Unix(1, 0)
+			book := &orderbook.Book{
+				Exchange:     exchangeName,
+				Pair:         pair,
+				Asset:        asset.Spot,
+				LastUpdated:  now,
+				LastUpdateID: 0,
+			}
+			updates := make([]pendingUpdate, updateCount)
+			for i := range updates {
+				updateID := int64(i + 1)
+				updates[i] = pendingUpdate{
+					firstUpdateID: updateID,
+					update: &orderbook.Update{
+						Pair:       pair,
+						Asset:      asset.Spot,
+						UpdateID:   updateID,
+						UpdateTime: now,
+						AllowEmpty: true,
+					},
+				}
+			}
+			cache := updateCache{updates: updates}
+
+			if err := ob.LoadSnapshot(book); err != nil {
+				b.Fatal(err)
+			}
+			cache.state = cacheStateQueuing
+			if err := manager.applyPendingUpdates(&cache); err != nil {
+				b.Fatal(err)
+			}
+			if cache.state != cacheStateSynced {
+				b.Fatalf("applyPendingUpdates cache state = %d, want %d", cache.state, cacheStateSynced)
+			}
+			lastUpdateID, err := ob.LastUpdateID(pair, asset.Spot)
+			if err != nil {
+				b.Fatal(err)
+			}
+			expectedLastUpdateID := updates[len(updates)-1].update.UpdateID
+			if lastUpdateID != expectedLastUpdateID {
+				b.Fatalf("LastUpdateID = %d, want %d", lastUpdateID, expectedLastUpdateID)
+			}
+			for range updateCount + 1 {
+				<-relay.C
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := ob.LoadSnapshot(book); err != nil {
+					b.Fatal(err)
+				}
+				cache.state = cacheStateQueuing
+				if err := manager.applyPendingUpdates(&cache); err != nil {
+					b.Fatal(err)
+				}
+				for range updateCount + 1 {
+					<-relay.C
+				}
+			}
+		})
+	}
+}

--- a/exchange/websocket/buffer/apply_pending_updates_bench_test.go
+++ b/exchange/websocket/buffer/apply_pending_updates_bench_test.go
@@ -13,6 +13,35 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 )
 
+// BenchmarkLoadSnapshotExistingHolder guards the shared-lock fast path against accidental serialisation.
+func BenchmarkLoadSnapshotExistingHolder(b *testing.B) {
+	relay := stream.NewRelay(1)
+	pair := currency.NewBTCUSD()
+	book := &orderbook.Book{
+		Exchange:    "BenchmarkLoadSnapshotExistingHolder",
+		Pair:        pair,
+		Asset:       asset.Spot,
+		LastUpdated: time.Unix(1, 0),
+	}
+	ob := &Orderbook{
+		exchangeName: book.Exchange,
+		ob:           make(map[key.PairAsset]*orderbookHolder),
+		dataHandler:  relay,
+	}
+	if err := ob.LoadSnapshot(book); err != nil {
+		b.Fatal(err)
+	}
+	<-relay.C
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := ob.LoadSnapshot(book); err != nil {
+			b.Fatal(err)
+		}
+		<-relay.C
+	}
+}
+
 // Benchstat medians (20 counterbalanced fresh-process observations per revision).
 // The timed region includes LoadSnapshot, applyPendingUpdates, and relay drain.
 // 64 updates:

--- a/exchange/websocket/buffer/buffer.go
+++ b/exchange/websocket/buffer/buffer.go
@@ -53,20 +53,25 @@ func (o *Orderbook) LoadSnapshot(book *orderbook.Book) error {
 	}
 
 	bookKey := key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}
-	o.m.Lock()
+	o.m.RLock()
 	holder, ok := o.ob[bookKey]
+	o.m.RUnlock()
 	if !ok {
-		// Associate orderbook pointer with local exchange depth map
-		depth, err := orderbook.DeployDepth(book.Exchange, book.Pair, book.Asset)
-		if err != nil {
-			o.m.Unlock()
-			return err
+		o.m.Lock()
+		holder, ok = o.ob[bookKey]
+		if !ok {
+			// Associate orderbook pointer with local exchange depth map
+			depth, err := orderbook.DeployDepth(book.Exchange, book.Pair, book.Asset)
+			if err != nil {
+				o.m.Unlock()
+				return err
+			}
+			depth.AssignOptions(book)
+			holder = &orderbookHolder{ob: depth, buffer: make([]orderbook.Update, 0, o.obBufferLimit)}
+			o.ob[bookKey] = holder
 		}
-		depth.AssignOptions(book)
-		holder = &orderbookHolder{ob: depth, buffer: make([]orderbook.Update, 0, o.obBufferLimit)}
-		o.ob[bookKey] = holder
+		o.m.Unlock()
 	}
-	o.m.Unlock()
 
 	book.RestSnapshot = false
 	if err := holder.ob.LoadSnapshot(book); err != nil {
@@ -86,7 +91,11 @@ func (o *Orderbook) Update(u *orderbook.Update) error {
 	if !ok {
 		return fmt.Errorf("%w for Exchange %s CurrencyPair: %s AssetType: %s", orderbook.ErrDepthNotFound, o.exchangeName, u.Pair, u.Asset)
 	}
+	return o.updateHolder(holder, u)
+}
 
+// updateHolder avoids repeating the map lookup when the caller already has the holder for the update key.
+func (o *Orderbook) updateHolder(holder *orderbookHolder, u *orderbook.Update) error {
 	if o.bufferEnabled {
 		if processed, err := o.processBufferUpdate(holder, u); err != nil || !processed {
 			return err

--- a/exchange/websocket/buffer/buffer.go
+++ b/exchange/websocket/buffer/buffer.go
@@ -52,11 +52,10 @@ func (o *Orderbook) LoadSnapshot(book *orderbook.Book) error {
 		return err
 	}
 
-	o.m.RLock()
-	holder, ok := o.ob[key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}]
-	o.m.RUnlock()
+	bookKey := key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}
+	o.m.Lock()
+	holder, ok := o.ob[bookKey]
 	if !ok {
-		o.m.Lock()
 		// Associate orderbook pointer with local exchange depth map
 		depth, err := orderbook.DeployDepth(book.Exchange, book.Pair, book.Asset)
 		if err != nil {
@@ -65,9 +64,9 @@ func (o *Orderbook) LoadSnapshot(book *orderbook.Book) error {
 		}
 		depth.AssignOptions(book)
 		holder = &orderbookHolder{ob: depth, buffer: make([]orderbook.Update, 0, o.obBufferLimit)}
-		o.ob[key.PairAsset{Base: book.Pair.Base.Item, Quote: book.Pair.Quote.Item, Asset: book.Asset}] = holder
-		o.m.Unlock()
+		o.ob[bookKey] = holder
 	}
+	o.m.Unlock()
 
 	book.RestSnapshot = false
 	if err := holder.ob.LoadSnapshot(book); err != nil {

--- a/exchange/websocket/buffer/buffer_test.go
+++ b/exchange/websocket/buffer/buffer_test.go
@@ -425,6 +425,86 @@ func TestRunUpdateWithoutAnyUpdates(t *testing.T) {
 	require.ErrorIs(t, err, orderbook.ErrEmptyUpdate)
 }
 
+func TestUpdateHolder(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		bufferEnabled bool
+		bufferLimit   int
+		allowEmpty    bool
+		updateID      int64
+		relayFull     bool
+		wantUpdateID  int64
+		wantBufferLen int
+		wantRelayLen  int
+		wantErr       error
+		wantErrText   string
+		wantLastIDErr error
+	}{
+		{name: "unbuffered", allowEmpty: true, updateID: 69421, wantUpdateID: 69421, wantRelayLen: 1},
+		{name: "unbuffered invalid", wantErr: orderbook.ErrEmptyUpdate, wantLastIDErr: orderbook.ErrOrderbookInvalid},
+		{name: "buffered pending", bufferEnabled: true, bufferLimit: 2, allowEmpty: true, updateID: 69421, wantUpdateID: 69420, wantBufferLen: 1},
+		{name: "buffered applied", bufferEnabled: true, bufferLimit: 1, allowEmpty: true, updateID: 69421, wantUpdateID: 69421, wantRelayLen: 1},
+		{name: "buffered invalid", bufferEnabled: true, bufferLimit: 1, wantErr: orderbook.ErrEmptyUpdate, wantLastIDErr: orderbook.ErrOrderbookInvalid},
+		{name: "relay full", allowEmpty: true, updateID: 69421, relayFull: true, wantUpdateID: 69421, wantRelayLen: 1, wantErrText: "channel buffer is full"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cp, err := getExclusivePair()
+			require.NoError(t, err, "getExclusivePair must not error")
+			relay := stream.NewRelay(1)
+			obl := &Orderbook{exchangeName: exchangeName, ob: make(map[key.PairAsset]*orderbookHolder), dataHandler: relay}
+			err = obl.LoadSnapshot(&orderbook.Book{
+				Exchange:     exchangeName,
+				Pair:         cp,
+				Asset:        asset.Spot,
+				LastUpdated:  time.Now(),
+				LastUpdateID: 69420,
+			})
+			require.NoError(t, err, "LoadSnapshot must not error")
+			<-relay.C
+
+			bookKey := key.PairAsset{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}
+			holder := obl.ob[bookKey]
+			require.NotNil(t, holder, "LoadSnapshot must install an orderbook holder")
+			delete(obl.ob, bookKey)
+			obl.bufferEnabled = tc.bufferEnabled
+			obl.obBufferLimit = tc.bufferLimit
+			if tc.relayFull {
+				require.NoError(t, relay.Send(t.Context(), "full"), "Send must not error while filling the relay")
+			}
+
+			err = obl.updateHolder(holder, &orderbook.Update{
+				Pair:       cp,
+				Asset:      asset.Spot,
+				AllowEmpty: tc.allowEmpty,
+				UpdateID:   tc.updateID,
+				UpdateTime: time.Now(),
+			})
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr, "updateHolder must return the expected error")
+			case tc.wantErrText != "":
+				require.ErrorContains(t, err, tc.wantErrText, "updateHolder must return the expected relay error")
+			default:
+				require.NoError(t, err, "updateHolder must not error")
+			}
+
+			lastUpdateID, err := holder.ob.LastUpdateID()
+			if tc.wantLastIDErr != nil {
+				require.ErrorIs(t, err, tc.wantLastIDErr, "LastUpdateID must return the expected holder error")
+			} else {
+				require.NoError(t, err, "LastUpdateID must not error")
+				assert.Equal(t, tc.wantUpdateID, lastUpdateID, "updateHolder should leave the expected update ID")
+			}
+			assert.Len(t, holder.buffer, tc.wantBufferLen, "updateHolder should leave the expected buffered-update count")
+			assert.Len(t, relay.C, tc.wantRelayLen, "updateHolder should leave the expected relayed-update count")
+		})
+	}
+}
+
 // TestRunSnapshotWithNoData logic test
 func TestRunSnapshotWithNoData(t *testing.T) {
 	t.Parallel()
@@ -472,6 +552,13 @@ func TestLoadSnapshot(t *testing.T) {
 	snapShot1.Pair = cp
 	snapShot1.LastUpdated = time.Now()
 	require.NoError(t, obl.LoadSnapshot(&snapShot1))
+	bookKey := key.PairAsset{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}
+	existingHolder := obl.ob[bookKey]
+	require.NotNil(t, existingHolder, "LoadSnapshot must install an orderbook holder")
+	snapShot1.LastUpdateID = 1
+	snapShot1.LastUpdated = time.Now()
+	require.NoError(t, obl.LoadSnapshot(&snapShot1), "LoadSnapshot must not error for an existing holder")
+	assert.Same(t, existingHolder, obl.ob[bookKey], "LoadSnapshot should reuse an existing holder")
 }
 
 func TestLoadSnapshotConcurrentHolderStability(t *testing.T) {

--- a/exchange/websocket/buffer/buffer_test.go
+++ b/exchange/websocket/buffer/buffer_test.go
@@ -3,6 +3,7 @@ package buffer
 import (
 	"math/rand"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -471,6 +472,49 @@ func TestLoadSnapshot(t *testing.T) {
 	snapShot1.Pair = cp
 	snapShot1.LastUpdated = time.Now()
 	require.NoError(t, obl.LoadSnapshot(&snapShot1))
+}
+
+func TestLoadSnapshotConcurrentHolderStability(t *testing.T) {
+	t.Parallel()
+
+	cp, err := getExclusivePair()
+	require.NoError(t, err, "getExclusivePair must not error")
+
+	const snapshotCount = 16
+	obl := Orderbook{
+		dataHandler:  stream.NewRelay(snapshotCount),
+		exchangeName: exchangeName,
+		ob:           make(map[key.PairAsset]*orderbookHolder),
+	}
+	bookKey := key.PairAsset{Base: cp.Base.Item, Quote: cp.Quote.Item, Asset: asset.Spot}
+	start := make(chan struct{})
+	errs := make([]error, snapshotCount)
+	holders := make([]*orderbookHolder, snapshotCount)
+	var wg sync.WaitGroup
+	for i := range snapshotCount {
+		wg.Go(func() {
+			<-start
+			errs[i] = obl.LoadSnapshot(&orderbook.Book{
+				Exchange:     exchangeName,
+				Pair:         cp,
+				Asset:        asset.Spot,
+				LastUpdated:  time.Unix(int64(i+1), 0),
+				LastUpdateID: int64(i + 1),
+			})
+			obl.m.RLock()
+			holders[i] = obl.ob[bookKey]
+			obl.m.RUnlock()
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	require.NotNil(t, holders[0], "LoadSnapshot must retain an orderbook holder")
+	for i := range snapshotCount {
+		require.NoErrorf(t, errs[i], "LoadSnapshot must not error for concurrent snapshot %d", i)
+		assert.Samef(t, holders[0], holders[i], "LoadSnapshot should retain one holder for concurrent snapshot %d", i)
+	}
+	require.Len(t, obl.ob, 1, "LoadSnapshot must retain one orderbook entry")
 }
 
 // TestFlushBuffer logic test

--- a/exchange/websocket/buffer/ob_update_manager.go
+++ b/exchange/websocket/buffer/ob_update_manager.go
@@ -27,6 +27,7 @@ const (
 )
 
 var (
+	errPendingUpdateKeyMismatch = errors.New("pending update key mismatch")
 	errPendingUpdatesNotApplied = errors.New("pending updates not applied")
 	errUnhandledCacheState      = errors.New("unhandled cache state")
 )
@@ -241,13 +242,11 @@ func (m *UpdateManager) syncOrderbook(ctx context.Context, cache *updateCache, p
 // assumes lock already active on cache
 func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
 	var updated bool
-	var lastKey key.PairAsset
-	var lastHolder *orderbookHolder
+	var pendingKey key.PairAsset
+	var holder *orderbookHolder
 	for _, data := range cache.updates {
 		currentKey := key.PairAsset{Base: data.update.Pair.Base.Item, Quote: data.update.Pair.Quote.Item, Asset: data.update.Asset}
-		// Read the live update ID on every iteration because buffering or skipped
-		// updates can leave it unchanged, while avoiding repeated map lookups.
-		if lastHolder == nil || currentKey != lastKey {
+		if holder == nil {
 			if data.update.Pair.IsEmpty() {
 				return currency.ErrCurrencyPairEmpty
 			}
@@ -256,14 +255,18 @@ func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
 			}
 			m.ob.m.RLock()
 			var ok bool
-			lastHolder, ok = m.ob.ob[currentKey]
+			holder, ok = m.ob.ob[currentKey]
 			m.ob.m.RUnlock()
 			if !ok {
 				return fmt.Errorf("%s %w: %s.%s", m.ob.exchangeName, orderbook.ErrDepthNotFound, data.update.Asset, data.update.Pair)
 			}
-			lastKey = currentKey
+			pendingKey = currentKey
+		} else if currentKey != pendingKey {
+			return fmt.Errorf("%w: expected %s.%s, got %s.%s", errPendingUpdateKeyMismatch, pendingKey.Asset, pendingKey.Pair(), currentKey.Asset, currentKey.Pair())
 		}
-		bookLastUpdateID, err := lastHolder.ob.LastUpdateID()
+		// Read the live update ID on every iteration because buffering or skipped
+		// updates can leave it unchanged, while avoiding repeated map lookups.
+		bookLastUpdateID, err := holder.ob.LastUpdateID()
 		if err != nil {
 			return err
 		}

--- a/exchange/websocket/buffer/ob_update_manager.go
+++ b/exchange/websocket/buffer/ob_update_manager.go
@@ -241,8 +241,29 @@ func (m *UpdateManager) syncOrderbook(ctx context.Context, cache *updateCache, p
 // assumes lock already active on cache
 func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
 	var updated bool
+	var lastKey key.PairAsset
+	var lastHolder *orderbookHolder
 	for _, data := range cache.updates {
-		bookLastUpdateID, err := m.ob.LastUpdateID(data.update.Pair, data.update.Asset)
+		currentKey := key.PairAsset{Base: data.update.Pair.Base.Item, Quote: data.update.Pair.Quote.Item, Asset: data.update.Asset}
+		// Read the live update ID on every iteration because buffering or skipped
+		// updates can leave it unchanged, while avoiding repeated map lookups.
+		if lastHolder == nil || currentKey != lastKey {
+			if data.update.Pair.IsEmpty() {
+				return currency.ErrCurrencyPairEmpty
+			}
+			if !data.update.Asset.IsValid() {
+				return asset.ErrInvalidAsset
+			}
+			m.ob.m.RLock()
+			var ok bool
+			lastHolder, ok = m.ob.ob[currentKey]
+			m.ob.m.RUnlock()
+			if !ok {
+				return fmt.Errorf("%s %w: %s.%s", m.ob.exchangeName, orderbook.ErrDepthNotFound, data.update.Asset, data.update.Pair)
+			}
+			lastKey = currentKey
+		}
+		bookLastUpdateID, err := lastHolder.ob.LastUpdateID()
 		if err != nil {
 			return err
 		}

--- a/exchange/websocket/buffer/ob_update_manager.go
+++ b/exchange/websocket/buffer/ob_update_manager.go
@@ -241,31 +241,35 @@ func (m *UpdateManager) syncOrderbook(ctx context.Context, cache *updateCache, p
 // applyPendingUpdates applies all pending updates to the orderbook
 // assumes lock already active on cache
 func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
-	var updated bool
-	var pendingKey key.PairAsset
-	var holder *orderbookHolder
-	for _, data := range cache.updates {
+	if len(cache.updates) == 0 {
+		return errPendingUpdatesNotApplied
+	}
+
+	firstUpdate := cache.updates[0].update
+	if firstUpdate.Pair.IsEmpty() {
+		return currency.ErrCurrencyPairEmpty
+	}
+	if !firstUpdate.Asset.IsValid() {
+		return asset.ErrInvalidAsset
+	}
+
+	pendingKey := key.PairAsset{Base: firstUpdate.Pair.Base.Item, Quote: firstUpdate.Pair.Quote.Item, Asset: firstUpdate.Asset}
+	for _, data := range cache.updates[1:] {
 		currentKey := key.PairAsset{Base: data.update.Pair.Base.Item, Quote: data.update.Pair.Quote.Item, Asset: data.update.Asset}
-		if holder == nil {
-			if data.update.Pair.IsEmpty() {
-				return currency.ErrCurrencyPairEmpty
-			}
-			if !data.update.Asset.IsValid() {
-				return asset.ErrInvalidAsset
-			}
-			m.ob.m.RLock()
-			var ok bool
-			holder, ok = m.ob.ob[currentKey]
-			m.ob.m.RUnlock()
-			if !ok {
-				return fmt.Errorf("%s %w: %s.%s", m.ob.exchangeName, orderbook.ErrDepthNotFound, data.update.Asset, data.update.Pair)
-			}
-			pendingKey = currentKey
-		} else if currentKey != pendingKey {
+		if currentKey != pendingKey {
 			return fmt.Errorf("%w: expected %s.%s, got %s.%s", errPendingUpdateKeyMismatch, pendingKey.Asset, pendingKey.Pair(), currentKey.Asset, currentKey.Pair())
 		}
-		// Read the live update ID on every iteration because buffering or skipped
-		// updates can leave it unchanged, while avoiding repeated map lookups.
+	}
+
+	m.ob.m.RLock()
+	holder, ok := m.ob.ob[pendingKey]
+	m.ob.m.RUnlock()
+	if !ok {
+		return fmt.Errorf("%s %w: %s.%s", m.ob.exchangeName, orderbook.ErrDepthNotFound, firstUpdate.Asset, firstUpdate.Pair)
+	}
+
+	var updated bool
+	for _, data := range cache.updates {
 		bookLastUpdateID, err := holder.ob.LastUpdateID()
 		if err != nil {
 			return err
@@ -283,7 +287,7 @@ func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
 			return fmt.Errorf("apply pending updates %w: last update ID %d, first update ID %d", ErrOrderbookSnapshotOutdated, bookLastUpdateID, data.firstUpdateID)
 		}
 
-		if err := m.ob.Update(data.update); err != nil {
+		if err := m.ob.updateHolder(holder, data.update); err != nil {
 			return err
 		}
 

--- a/exchange/websocket/buffer/ob_update_manager.go
+++ b/exchange/websocket/buffer/ob_update_manager.go
@@ -29,6 +29,7 @@ const (
 var (
 	errPendingUpdateKeyMismatch = errors.New("pending update key mismatch")
 	errPendingUpdatesNotApplied = errors.New("pending updates not applied")
+	errUpdatesNotSupplied       = errors.New("updates not supplied")
 	errUnhandledCacheState      = errors.New("unhandled cache state")
 )
 
@@ -242,7 +243,7 @@ func (m *UpdateManager) syncOrderbook(ctx context.Context, cache *updateCache, p
 // assumes lock already active on cache
 func (m *UpdateManager) applyPendingUpdates(cache *updateCache) error {
 	if len(cache.updates) == 0 {
-		return errPendingUpdatesNotApplied
+		return errUpdatesNotSupplied
 	}
 
 	firstUpdate := cache.updates[0].update

--- a/exchange/websocket/buffer/ob_update_manager_test.go
+++ b/exchange/websocket/buffer/ob_update_manager_test.go
@@ -407,7 +407,10 @@ func TestApplyPendingUpdates(t *testing.T) {
 	m := NewUpdateManager(&tp)
 	pair := currency.NewPair(currency.LTC, currency.USDT)
 
-	err := m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
+	err := m.applyPendingUpdates(&updateCache{})
+	require.ErrorIs(t, err, errPendingUpdatesNotApplied, "applyPendingUpdates must error when the pending-update queue is empty")
+
+	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Asset: asset.Spot}},
 	}})
 	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "applyPendingUpdates must error when the currency pair is empty")
@@ -499,6 +502,7 @@ func TestApplyPendingUpdatesKeyMismatch(t *testing.T) {
 			m := NewUpdateManager(&tp)
 			err := m.ob.LoadSnapshot(&orderbook.Book{Pair: tc.pendingPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
 			require.NoError(t, err, "LoadSnapshot must not error for the pending-update key")
+			<-m.ob.dataHandler.C
 			cache := &updateCache{
 				state: cacheStateQueuing,
 				updates: []pendingUpdate{
@@ -510,6 +514,10 @@ func TestApplyPendingUpdatesKeyMismatch(t *testing.T) {
 			err = m.applyPendingUpdates(cache)
 			require.ErrorIs(t, err, errPendingUpdateKeyMismatch, "applyPendingUpdates must error when pending update keys differ")
 			assert.Contains(t, err.Error(), tc.wantContext, "applyPendingUpdates error should identify the mismatched pending-update key")
+			lastUpdateID, lastUpdateErr := m.ob.LastUpdateID(tc.pendingPair, asset.Spot)
+			require.NoError(t, lastUpdateErr, "LastUpdateID must not error after rejecting mismatched pending updates")
+			assert.Equal(t, int64(10), lastUpdateID, "applyPendingUpdates should reject a mismatched queue before applying an update")
+			assert.Empty(t, m.ob.dataHandler.C, "applyPendingUpdates should reject a mismatched queue before publishing an update")
 			assert.Equal(t, cacheStateQueuing, cache.state, "applyPendingUpdates should not sync pending updates with different keys")
 		})
 	}

--- a/exchange/websocket/buffer/ob_update_manager_test.go
+++ b/exchange/websocket/buffer/ob_update_manager_test.go
@@ -408,7 +408,7 @@ func TestApplyPendingUpdates(t *testing.T) {
 	pair := currency.NewPair(currency.LTC, currency.USDT)
 
 	err := m.applyPendingUpdates(&updateCache{})
-	require.ErrorIs(t, err, errPendingUpdatesNotApplied, "applyPendingUpdates must error when the pending-update queue is empty")
+	require.ErrorIs(t, err, errUpdatesNotSupplied, "applyPendingUpdates must error when the pending-update queue is empty")
 
 	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Asset: asset.Spot}},

--- a/exchange/websocket/buffer/ob_update_manager_test.go
+++ b/exchange/websocket/buffer/ob_update_manager_test.go
@@ -470,29 +470,49 @@ func TestApplyPendingUpdates(t *testing.T) {
 		{firstUpdateID: 1339, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 1339, AllowEmpty: true, UpdateTime: time.Now()}},
 	}})
 	require.ErrorIs(t, err, ErrOrderbookSnapshotOutdated, "applyPendingUpdates must error when a later pending update is out of sequence")
+}
 
-	firstPair, err := currency.NewPairFromStrings("PENDMIXONE", "USDT")
-	require.NoError(t, err, "NewPairFromStrings must not error for the first mixed pair")
-	secondPair, err := currency.NewPairFromStrings("PENDMIXTWO", "BTC")
-	require.NoError(t, err, "NewPairFromStrings must not error for the second mixed pair")
-	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: firstPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now()})
-	require.NoError(t, err, "LoadSnapshot must not error for the first mixed-pair snapshot")
-	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: secondPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
-	require.NoError(t, err, "LoadSnapshot must not error for the second mixed-pair snapshot")
+func TestApplyPendingUpdatesKeyMismatch(t *testing.T) {
+	t.Parallel()
 
-	cache = &updateCache{updates: []pendingUpdate{
-		{firstUpdateID: 1, update: &orderbook.Update{Pair: firstPair, Asset: asset.Spot, UpdateID: 1, AllowEmpty: true, UpdateTime: time.Now()}},
-		{firstUpdateID: 11, update: &orderbook.Update{Pair: secondPair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
-	}}
-	err = m.applyPendingUpdates(cache)
-	require.NoError(t, err, "applyPendingUpdates must not error when pending updates use different orderbooks")
-	assert.Equal(t, cacheStateSynced, cache.state, "applyPendingUpdates should sync mixed-orderbook pending updates")
-	firstUpdateID, err := m.ob.LastUpdateID(firstPair, asset.Spot)
-	require.NoError(t, err, "LastUpdateID must not error for the first mixed-pair orderbook")
-	assert.Equal(t, int64(1), firstUpdateID, "LastUpdateID should return the correct first mixed-pair update ID")
-	secondUpdateID, err := m.ob.LastUpdateID(secondPair, asset.Spot)
-	require.NoError(t, err, "LastUpdateID must not error for the second mixed-pair orderbook")
-	assert.Equal(t, int64(11), secondUpdateID, "LastUpdateID should return the correct second mixed-pair update ID")
+	pairMismatchKey, err := currency.NewPairFromStrings("PENDKEYPAIR", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error for the pair-mismatch pending-update key")
+	assetMismatchKey, err := currency.NewPairFromStrings("PENDKEYASSET", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error for the asset-mismatch pending-update key")
+	otherPair, err := currency.NewPairFromStrings("PENDOTHER", "BTC")
+	require.NoError(t, err, "NewPairFromStrings must not error for the mismatched pending-update key")
+
+	for _, tc := range []struct {
+		name        string
+		pendingPair currency.Pair
+		updatePair  currency.Pair
+		updateAsset asset.Item
+		wantContext string
+	}{
+		{name: "pair", pendingPair: pairMismatchKey, updatePair: otherPair, updateAsset: asset.Spot, wantContext: otherPair.String()},
+		{name: "asset", pendingPair: assetMismatchKey, updatePair: assetMismatchKey, updateAsset: asset.Futures, wantContext: asset.Futures.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tp := newTestParams()
+			m := NewUpdateManager(&tp)
+			err := m.ob.LoadSnapshot(&orderbook.Book{Pair: tc.pendingPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+			require.NoError(t, err, "LoadSnapshot must not error for the pending-update key")
+			cache := &updateCache{
+				state: cacheStateQueuing,
+				updates: []pendingUpdate{
+					{firstUpdateID: 11, update: &orderbook.Update{Pair: tc.pendingPair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+					{firstUpdateID: 12, update: &orderbook.Update{Pair: tc.updatePair, Asset: tc.updateAsset, UpdateID: 12, AllowEmpty: true, UpdateTime: time.Now()}},
+				},
+			}
+
+			err = m.applyPendingUpdates(cache)
+			require.ErrorIs(t, err, errPendingUpdateKeyMismatch, "applyPendingUpdates must error when pending update keys differ")
+			assert.Contains(t, err.Error(), tc.wantContext, "applyPendingUpdates error should identify the mismatched pending-update key")
+			assert.Equal(t, cacheStateQueuing, cache.state, "applyPendingUpdates should not sync pending updates with different keys")
+		})
+	}
 }
 
 func TestApplyPendingUpdatesCachedHolderAfterSkip(t *testing.T) {

--- a/exchange/websocket/buffer/ob_update_manager_test.go
+++ b/exchange/websocket/buffer/ob_update_manager_test.go
@@ -408,12 +408,22 @@ func TestApplyPendingUpdates(t *testing.T) {
 	pair := currency.NewPair(currency.LTC, currency.USDT)
 
 	err := m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
+		{update: &orderbook.Update{Asset: asset.Spot}},
+	}})
+	require.ErrorIs(t, err, currency.ErrCurrencyPairEmpty, "applyPendingUpdates must error when the currency pair is empty")
+
+	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
+		{update: &orderbook.Update{Pair: pair}},
+	}})
+	require.ErrorIs(t, err, asset.ErrInvalidAsset, "applyPendingUpdates must error when the asset is invalid")
+
+	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Pair: pair, Asset: asset.Spot}},
 	}})
-	require.ErrorIs(t, err, orderbook.ErrDepthNotFound, "must error due to depth not found when calling fetch orderbook")
+	require.ErrorIs(t, err, orderbook.ErrDepthNotFound, "applyPendingUpdates must error when the orderbook depth is not found")
 
 	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now()})
-	require.NoError(t, err)
+	require.NoError(t, err, "LoadSnapshot must not error")
 
 	expectedErr := errors.New("test error")
 	m.checkPendingUpdate = func(_, _ int64, _ *orderbook.Update) (bool, error) {
@@ -422,7 +432,7 @@ func TestApplyPendingUpdates(t *testing.T) {
 	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Pair: pair, Asset: asset.Spot}},
 	}})
-	require.ErrorIs(t, err, expectedErr, "must error due to checkPendingUpdate returning an error")
+	require.ErrorIs(t, err, expectedErr, "applyPendingUpdates must return the pending-update check error")
 
 	m.checkPendingUpdate = func(_, _ int64, _ *orderbook.Update) (bool, error) {
 		return true, nil
@@ -430,7 +440,7 @@ func TestApplyPendingUpdates(t *testing.T) {
 	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Pair: pair, Asset: asset.Spot}},
 	}})
-	require.ErrorIs(t, err, errPendingUpdatesNotApplied, "must error due to pending updates not applied when skipped")
+	require.ErrorIs(t, err, errPendingUpdatesNotApplied, "applyPendingUpdates must error when every pending update is skipped")
 
 	m.checkPendingUpdate = func(_, _ int64, _ *orderbook.Update) (bool, error) {
 		return false, nil
@@ -438,28 +448,143 @@ func TestApplyPendingUpdates(t *testing.T) {
 	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Pair: pair, Asset: asset.Spot}},
 	}})
-	require.ErrorIs(t, err, orderbook.ErrOrderbookInvalid, "must error due to orderbook invalid when update application fails")
+	require.ErrorIs(t, err, orderbook.ErrOrderbookInvalid, "applyPendingUpdates must error when update application invalidates the orderbook")
 
 	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now()})
-	require.NoError(t, err)
+	require.NoError(t, err, "LoadSnapshot must not error after orderbook invalidation")
 
 	cache := &updateCache{updates: []pendingUpdate{
 		{update: &orderbook.Update{Pair: pair, Asset: asset.Spot, AllowEmpty: true, UpdateTime: time.Now()}},
 	}}
 	err = m.applyPendingUpdates(cache)
-	require.NoError(t, err, "must not error when update application succeeds")
-	assert.Equal(t, cacheStateSynced, cache.state, "state should be synced after successful application of pending updates")
+	require.NoError(t, err, "applyPendingUpdates must not error when update application succeeds")
+	assert.Equal(t, cacheStateSynced, cache.state, "applyPendingUpdates should set the cache state to synced")
 
 	pair, err = currency.NewPairFromStrings("PENDSEQ", "USDT")
-	require.NoError(t, err)
+	require.NoError(t, err, "NewPairFromStrings must not error")
 	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 1336})
-	require.NoError(t, err)
+	require.NoError(t, err, "LoadSnapshot must not error for the pending-sequence orderbook")
 
 	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
 		{firstUpdateID: 1337, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 1337, AllowEmpty: true, UpdateTime: time.Now()}},
 		{firstUpdateID: 1339, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 1339, AllowEmpty: true, UpdateTime: time.Now()}},
 	}})
-	require.ErrorIs(t, err, ErrOrderbookSnapshotOutdated, "must error when a later pending update is out of sequence")
+	require.ErrorIs(t, err, ErrOrderbookSnapshotOutdated, "applyPendingUpdates must error when a later pending update is out of sequence")
+
+	firstPair, err := currency.NewPairFromStrings("PENDMIXONE", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error for the first mixed pair")
+	secondPair, err := currency.NewPairFromStrings("PENDMIXTWO", "BTC")
+	require.NoError(t, err, "NewPairFromStrings must not error for the second mixed pair")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: firstPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now()})
+	require.NoError(t, err, "LoadSnapshot must not error for the first mixed-pair snapshot")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: secondPair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+	require.NoError(t, err, "LoadSnapshot must not error for the second mixed-pair snapshot")
+
+	cache = &updateCache{updates: []pendingUpdate{
+		{firstUpdateID: 1, update: &orderbook.Update{Pair: firstPair, Asset: asset.Spot, UpdateID: 1, AllowEmpty: true, UpdateTime: time.Now()}},
+		{firstUpdateID: 11, update: &orderbook.Update{Pair: secondPair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+	}}
+	err = m.applyPendingUpdates(cache)
+	require.NoError(t, err, "applyPendingUpdates must not error when pending updates use different orderbooks")
+	assert.Equal(t, cacheStateSynced, cache.state, "applyPendingUpdates should sync mixed-orderbook pending updates")
+	firstUpdateID, err := m.ob.LastUpdateID(firstPair, asset.Spot)
+	require.NoError(t, err, "LastUpdateID must not error for the first mixed-pair orderbook")
+	assert.Equal(t, int64(1), firstUpdateID, "LastUpdateID should return the correct first mixed-pair update ID")
+	secondUpdateID, err := m.ob.LastUpdateID(secondPair, asset.Spot)
+	require.NoError(t, err, "LastUpdateID must not error for the second mixed-pair orderbook")
+	assert.Equal(t, int64(11), secondUpdateID, "LastUpdateID should return the correct second mixed-pair update ID")
+}
+
+func TestApplyPendingUpdatesCachedHolderAfterSkip(t *testing.T) {
+	t.Parallel()
+
+	tp := newTestParams()
+	m := NewUpdateManager(&tp)
+	pair, err := currency.NewPairFromStrings("PENDSKIP", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+	require.NoError(t, err, "LoadSnapshot must not error for the skipped-update orderbook")
+	m.checkPendingUpdate = func(_, _ int64, update *orderbook.Update) (bool, error) {
+		return update.UpdateID == 10, nil
+	}
+
+	cache := &updateCache{updates: []pendingUpdate{
+		{firstUpdateID: 10, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 10, AllowEmpty: true, UpdateTime: time.Now()}},
+		{firstUpdateID: 11, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+	}}
+	err = m.applyPendingUpdates(cache)
+	require.NoError(t, err, "applyPendingUpdates must not error after skipping an outdated pending update")
+	assert.Equal(t, cacheStateSynced, cache.state, "applyPendingUpdates should sync after skipping an outdated pending update")
+	lastUpdateID, err := m.ob.LastUpdateID(pair, asset.Spot)
+	require.NoError(t, err, "LastUpdateID must not error for the skipped-update orderbook")
+	assert.Equal(t, int64(11), lastUpdateID, "LastUpdateID should return the applied update ID after a skip")
+}
+
+func TestApplyPendingUpdatesCachedHolderAdvances(t *testing.T) {
+	t.Parallel()
+
+	tp := newTestParams()
+	m := NewUpdateManager(&tp)
+	pair, err := currency.NewPairFromStrings("PENDADVANCE", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+	require.NoError(t, err, "LoadSnapshot must not error for the advancing orderbook")
+
+	cache := &updateCache{updates: []pendingUpdate{
+		{firstUpdateID: 11, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+		{firstUpdateID: 12, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 12, AllowEmpty: true, UpdateTime: time.Now()}},
+	}}
+	err = m.applyPendingUpdates(cache)
+	require.NoError(t, err, "applyPendingUpdates must not error for consecutive in-sequence updates")
+	assert.Equal(t, cacheStateSynced, cache.state, "applyPendingUpdates should sync consecutive in-sequence updates")
+	lastUpdateID, err := m.ob.LastUpdateID(pair, asset.Spot)
+	require.NoError(t, err, "LastUpdateID must not error for the advancing orderbook")
+	assert.Equal(t, int64(12), lastUpdateID, "LastUpdateID should advance to the final applied update ID")
+}
+
+func TestApplyPendingUpdatesCachedHolderWithBuffer(t *testing.T) {
+	t.Parallel()
+
+	tp := newTestParams()
+	tp.BufferInstance.bufferEnabled = true
+	tp.BufferInstance.obBufferLimit = 3
+	m := NewUpdateManager(&tp)
+	pair, err := currency.NewPairFromStrings("PENDBUFFER", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+	require.NoError(t, err, "LoadSnapshot must not error for the buffered orderbook")
+
+	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
+		{firstUpdateID: 11, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+		{firstUpdateID: 12, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 12, AllowEmpty: true, UpdateTime: time.Now()}},
+	}})
+	require.ErrorIs(t, err, ErrOrderbookSnapshotOutdated, "applyPendingUpdates must error when buffering leaves the live update ID unchanged")
+	lastUpdateID, err := m.ob.LastUpdateID(pair, asset.Spot)
+	require.NoError(t, err, "LastUpdateID must not error for the buffered orderbook")
+	assert.Equal(t, int64(10), lastUpdateID, "LastUpdateID should remain unchanged while the first update is buffered")
+}
+
+func TestApplyPendingUpdatesCachedHolderInvalidated(t *testing.T) {
+	t.Parallel()
+
+	tp := newTestParams()
+	m := NewUpdateManager(&tp)
+	pair, err := currency.NewPairFromStrings("PENDINVALID", "USDT")
+	require.NoError(t, err, "NewPairFromStrings must not error")
+	err = m.ob.LoadSnapshot(&orderbook.Book{Pair: pair, Asset: asset.Spot, Exchange: m.ob.exchangeName, LastUpdated: time.Now(), LastUpdateID: 10})
+	require.NoError(t, err, "LoadSnapshot must not error for the invalidation orderbook")
+
+	var invalidationErr error
+	m.checkPendingUpdate = func(_, _ int64, _ *orderbook.Update) (bool, error) {
+		invalidationErr = m.ob.InvalidateOrderbook(pair, asset.Spot)
+		return true, nil
+	}
+	err = m.applyPendingUpdates(&updateCache{updates: []pendingUpdate{
+		{firstUpdateID: 10, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 10, AllowEmpty: true, UpdateTime: time.Now()}},
+		{firstUpdateID: 11, update: &orderbook.Update{Pair: pair, Asset: asset.Spot, UpdateID: 11, AllowEmpty: true, UpdateTime: time.Now()}},
+	}})
+	assert.NoError(t, invalidationErr, "InvalidateOrderbook should not error")
+	require.ErrorIs(t, err, orderbook.ErrOrderbookInvalid, "applyPendingUpdates must return the cached holder invalidation error")
 }
 
 func TestWaitForUpdate(t *testing.T) {


### PR DESCRIPTION
## Summary

- reuse the stable orderbook holder for consecutive pending updates to the same pair and asset while reading its live update ID on every iteration
- install a newly loaded snapshot holder in one exclusive map critical section so concurrent first snapshots cannot replace a cached holder
- add deterministic backlog benchmarks and direct coverage for sequencing, errors, buffering, invalidation, mixed orderbooks, and concurrent holder creation

## Performance

The deterministic offline benchmark used Go 1.26.5 on Linux/amd64 WSL2 with an Intel Core i7-6700K, `GOMAXPROCS=1`, one pinned benchmark CPU, one-second samples, and 20 counterbalanced fresh-process observations per revision. The byte-identical fixture measures `LoadSnapshot`, `applyPendingUpdates`, and relay draining.

| Pending updates | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1 | 528.8 ns/op | 535.4 ns/op | +1.25% (p=0.007) |
| 2 | 822.2 ns/op | 797.9 ns/op | -2.97% (p=0.000) |
| 8 | 2.551 µs/op | 2.327 µs/op | -8.80% (p=0.000) |
| 64 | 18.58 µs/op | 16.66 µs/op | -10.30% (p=0.000) |
| 256 | 74.13 µs/op | 65.87 µs/op | -11.14% (p=0.000) |

Bytes and allocations were unchanged in every case. The 64-update workload remained at 3120 B/op and 65 allocs/op; the 256-update workload remained at 12336 B/op and 257 allocs/op.

The statistically detected 1.25% single-update slowdown is disclosed as a small guard regression. The primary 64- and 256-update backlogs retain double-digit latency improvements without allocation movement. The baseline CPU profile attributed 16.96% cumulative time to the repeated `Orderbook.LastUpdateID` wrapper lookup; that wrapper no longer appeared in the candidate profile's top entries.

## Validation

- direct tests cover both changed functions at 100% statement coverage, including concurrent first snapshots and all reachable error paths
- focused tests passed 100 repetitions and 10 race-detector repetitions
- package and affected caller tests passed repeated and race-detector runs
- the complete repository race-detector suite passed
- the ordinary repository suite had one GateIO live request return HTTP 504; that exact test passed immediately on focused retry
- formatting, lint, spelling, and miscellaneous repository policy checks passed

## Limitations

- this microbenchmark measures a deterministic orderbook resynchronisation backlog, not end-to-end websocket throughput or network latency
- CPU governor, external power state, and thermal sensors were unavailable in the WSL2 environment
- the one-update workload is 1.25% slower even though the declared primary backlog workloads improve materially