### PR TITLE
exchanges/kraken: fix futures trade range cursors

### DIFF
--- a/exchanges/kraken/kraken_futures.go
+++ b/exchanges/kraken/kraken_futures.go
@@ -57,21 +57,21 @@ func (e *Exchange) GetFuturesCharts(ctx context.Context, resolution, tickType st
 	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, reqStr, &resp)
 }
 
-// GetFuturesTrades returns public trade data for kraken futures
-func (e *Exchange) GetFuturesTrades(ctx context.Context, symbol currency.Pair, to, from time.Time) (*FuturesPublicTrades, error) {
+// GetFuturesTrades returns public trade data for Kraken Futures, bounded by optional millisecond since and before cursors
+func (e *Exchange) GetFuturesTrades(ctx context.Context, symbol currency.Pair, since, before time.Time) (*FuturesPublicTrades, error) {
 	symbolValue, err := e.FormatSymbol(symbol, asset.Futures)
 	if err != nil {
 		return nil, err
 	}
 	params := url.Values{}
-	if !to.IsZero() {
-		params.Set("since", strconv.FormatInt(to.Unix(), 10))
+	if !since.IsZero() {
+		params.Set("since", strconv.FormatInt(since.UnixMilli(), 10))
 	}
-	if !from.IsZero() {
-		params.Set("before", strconv.FormatInt(from.Unix(), 10))
+	if !before.IsZero() {
+		params.Set("before", strconv.FormatInt(before.UnixMilli(), 10))
 	}
 	var resp FuturesPublicTrades
-	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, futuresPublicTrades+"/"+symbolValue+"/executions?"+params.Encode(), &resp)
+	return &resp, e.SendHTTPRequest(ctx, exchange.RestFuturesSupplementary, common.EncodeURLValues(futuresPublicTrades+symbolValue+"/executions", params), &resp)
 }
 
 // GetInstruments gets a list of futures markets and their data

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1652,6 +1652,15 @@ func TestGetFuturesTrades(t *testing.T) {
 		_, err := ex.GetFuturesTrades(ctx, futuresTestPair, time.Time{}, time.Time{})
 		assert.ErrorIs(t, err, context.Canceled, "GetFuturesTrades should error correctly for a cancelled request")
 	})
+
+	t.Run("live request", func(t *testing.T) {
+		t.Parallel()
+		_, err := e.GetFuturesTrades(t.Context(), futuresTestPair, time.Time{}, time.Time{})
+		assert.NoError(t, err, "GetFuturesTrades should not error")
+
+		_, err = e.GetFuturesTrades(t.Context(), futuresTestPair, time.Now().Add(-time.Hour), time.Now())
+		assert.NoError(t, err, "GetFuturesTrades should not error")
+	})
 }
 
 var websocketXDGUSDOrderbookUpdates = []string{

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,9 +1,11 @@
 package kraken
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -1479,11 +1481,177 @@ func TestGetCharts(t *testing.T) {
 
 func TestGetFuturesTrades(t *testing.T) {
 	t.Parallel()
-	_, err := e.GetFuturesTrades(t.Context(), futuresTestPair, time.Time{}, time.Time{})
-	assert.NoError(t, err, "GetFuturesTrades should not error")
+	require.True(t, strings.HasSuffix(krakenFuturesSupplementaryURL, "/"), "krakenFuturesSupplementaryURL must end with a slash")
 
-	_, err = e.GetFuturesTrades(t.Context(), futuresTestPair, time.Now().Add(-time.Hour), time.Now())
-	assert.NoError(t, err, "GetFuturesTrades should not error")
+	type requestData struct {
+		path       string
+		rawQuery   string
+		requestURI string
+	}
+
+	since := time.UnixMilli(1700000000123)
+	before := time.UnixMilli(1700003600456)
+	for _, tc := range []struct {
+		name              string
+		since             time.Time
+		before            time.Time
+		response          string
+		expectedQuery     string
+		expectedLen       int64
+		expectedToken     string
+		expectedUID       string
+		expectedTime      time.Time
+		expectedJSONError string
+		errorContains     string
+	}{
+		{
+			name:     "no range",
+			response: `{"elements":[],"len":0}`,
+		},
+		{
+			name:          "since only",
+			since:         since,
+			response:      `{"elements":[],"len":0}`,
+			expectedQuery: "since=1700000000123",
+		},
+		{
+			name:          "before only",
+			before:        before,
+			response:      `{"elements":[],"len":0}`,
+			expectedQuery: "before=1700003600456",
+		},
+		{
+			name:          "complete range",
+			since:         since,
+			before:        before,
+			response:      `{"elements":[],"len":0}`,
+			expectedQuery: "before=1700003600456&since=1700000000123",
+		},
+		{
+			name:          "populated response",
+			response:      `{"continuationToken":"next-page","elements":[{"event":{"Execution":{"execution":{"makerOrder":{"direction":"Sell","limitPrice":"123.40","quantity":"1.00","timestamp":1699999999123},"price":"123.45","quantity":"0.25","timestamp":1700000000223,"uid":"execution-id"},"takerReducedQuantity":""}},"timestamp":1700000000123,"uid":"trade-id"}],"len":1}`,
+			expectedLen:   1,
+			expectedToken: "next-page",
+			expectedUID:   "trade-id",
+			expectedTime:  time.UnixMilli(1700000000123),
+		},
+		{
+			name:              "invalid response",
+			response:          `{"elements":`,
+			expectedJSONError: "syntax",
+		},
+		{
+			name:              "invalid trade data",
+			response:          `{"elements":"invalid"}`,
+			expectedJSONError: "type",
+		},
+		{
+			name:          "futures error response",
+			response:      `{"result":"error","error":"invalid range"}`,
+			errorContains: "invalid range",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			requestC := make(chan requestData, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case requestC <- requestData{path: r.URL.Path, rawQuery: r.URL.RawQuery, requestURI: r.RequestURI}:
+				default:
+					assert.Fail(t, "GetFuturesTrades should send one request")
+				}
+				_, err := w.Write([]byte(tc.response))
+				assert.NoError(t, err, "ResponseWriter.Write should not error")
+			}))
+			t.Cleanup(server.Close)
+
+			ex := new(Exchange)
+			require.NoError(t, testexch.Setup(ex), "Setup must not error")
+			require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestFuturesSupplementary.String(), server.URL+"/"), "SetRunningURL must not error")
+
+			resp, err := ex.GetFuturesTrades(t.Context(), futuresTestPair, tc.since, tc.before)
+			if tc.expectedJSONError != "" || tc.errorContains != "" {
+				switch tc.expectedJSONError {
+				case "syntax":
+					if json.Implementation == "bytedance/sonic" {
+						assert.ErrorContains(t, err, "Syntax error at index", "GetFuturesTrades should return the correct JSON syntax error")
+					} else {
+						var target *json.SyntaxError
+						assert.ErrorAs(t, err, &target, "GetFuturesTrades should return the correct JSON syntax error type")
+					}
+				case "type":
+					if json.Implementation == "bytedance/sonic" {
+						assert.ErrorContains(t, err, "Mismatch type", "GetFuturesTrades should return the correct JSON type error")
+					} else {
+						var target *json.UnmarshalTypeError
+						assert.ErrorAs(t, err, &target, "GetFuturesTrades should return the correct JSON type error type")
+					}
+				}
+				if tc.errorContains != "" {
+					assert.ErrorContains(t, err, tc.errorContains, "GetFuturesTrades should return the correct error")
+				}
+			} else {
+				require.NoError(t, err, "GetFuturesTrades must not error")
+				require.NotNil(t, resp, "GetFuturesTrades response must not be nil")
+				assert.Equal(t, tc.expectedLen, resp.Len, "GetFuturesTrades should return the correct response length")
+				assert.Equal(t, tc.expectedToken, resp.ContinuationToken, "GetFuturesTrades should return the correct continuation token")
+				require.Len(t, resp.Elements, int(tc.expectedLen), "GetFuturesTrades response elements must contain the correct number of entries")
+				if tc.expectedUID != "" {
+					element := resp.Elements[0]
+					execution := element.ExecutionEvent.OuterExecutionHolder.Execution
+					assert.Equal(t, tc.expectedUID, element.UID, "GetFuturesTrades should return the correct trade UID")
+					assert.Equal(t, tc.expectedTime, element.Timestamp.Time(), "GetFuturesTrades should return the correct trade timestamp")
+					assert.Equal(t, "execution-id", execution.UID, "GetFuturesTrades should return the correct execution UID")
+					assert.Equal(t, 123.45, execution.Price, "GetFuturesTrades should return the correct execution price")
+					assert.Equal(t, 0.25, execution.Quantity, "GetFuturesTrades should return the correct execution quantity")
+					assert.Equal(t, time.UnixMilli(1700000000223), execution.Timestamp.Time(), "GetFuturesTrades should return the correct execution timestamp")
+					assert.Equal(t, "Sell", execution.MakerOrder.Direction, "GetFuturesTrades should return the correct maker order direction")
+					assert.Equal(t, 123.4, execution.MakerOrder.LimitPrice, "GetFuturesTrades should return the correct maker order price")
+					assert.Equal(t, 1.0, execution.MakerOrder.Quantity, "GetFuturesTrades should return the correct maker order quantity")
+					assert.Equal(t, time.UnixMilli(1699999999123), execution.MakerOrder.Timestamp.Time(), "GetFuturesTrades should return the correct maker order timestamp")
+					assert.Empty(t, element.ExecutionEvent.OuterExecutionHolder.TakerReducedQuantity, "GetFuturesTrades should return the correct reduced quantity")
+				}
+			}
+			require.Len(t, requestC, 1, "GetFuturesTrades must send one request")
+			request := <-requestC
+			const expectedPath = "/history/v2/market/PF_XBTUSD/executions"
+			assert.Equal(t, expectedPath, request.path, "GetFuturesTrades should request the correct path")
+			assert.Equal(t, tc.expectedQuery, request.rawQuery, "GetFuturesTrades request query should match correctly")
+			expectedRequestURI := expectedPath
+			if tc.expectedQuery != "" {
+				expectedRequestURI += "?" + tc.expectedQuery
+			}
+			assert.Equal(t, expectedRequestURI, request.requestURI, "GetFuturesTrades should request the correct URI")
+		})
+	}
+
+	t.Run("pair format error", func(t *testing.T) {
+		t.Parallel()
+		ex := new(Exchange)
+		ex.CurrencyPairs.UseGlobalFormat = true
+		_, err := ex.GetFuturesTrades(t.Context(), futuresTestPair, time.Time{}, time.Time{})
+		assert.ErrorIs(t, err, currency.ErrPairFormatIsNil, "GetFuturesTrades should error correctly when pair format is missing")
+	})
+
+	t.Run("endpoint error", func(t *testing.T) {
+		t.Parallel()
+		ex := new(Exchange)
+		require.NoError(t, testexch.Setup(ex), "Setup must not error")
+		ex.API.Endpoints = ex.NewEndpoints()
+		_, err := ex.GetFuturesTrades(t.Context(), futuresTestPair, time.Time{}, time.Time{})
+		assert.ErrorIs(t, err, exchange.ErrEndpointPathNotFound, "GetFuturesTrades should error correctly when the futures endpoint is missing")
+	})
+
+	t.Run("request error", func(t *testing.T) {
+		t.Parallel()
+		ex := new(Exchange)
+		require.NoError(t, testexch.Setup(ex), "Setup must not error")
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := ex.GetFuturesTrades(ctx, futuresTestPair, time.Time{}, time.Time{})
+		assert.ErrorIs(t, err, context.Canceled, "GetFuturesTrades should error correctly for a cancelled request")
+	})
 }
 
 var websocketXDGUSDOrderbookUpdates = []string{


### PR DESCRIPTION
# PR Description

Kraken Futures public execution-history requests encoded the optional `since` and `before` cursors in Unix seconds even though the API expects millisecond timestamps. This shifted requested ranges by a factor of 1,000 and could return the wrong trade window.

This change encodes both cursors in Unix milliseconds and constructs the request URL without a duplicate path separator or an empty trailing query marker. It adds deterministic local HTTP coverage for omitted, single, and combined cursors, response decoding, and error paths, while retaining live endpoint coverage for unbounded and one-hour trade windows.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] go test ./exchanges/kraken -race -count=1
- [x] go test ./exchanges/kraken -run '^TestGetFuturesTrades$' -race -count=20
- [x] go test ./exchanges/kraken -run '^TestGetFuturesTrades$' -tags sonic_on -race -count=1
- [x] make misc_checks
- [x] codespell

The focused cursor regression and complete Kraken package race suite pass locally under the default JSON implementation, and the focused test passes with the Sonic build tag. The full repository race suite was not run locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Documentation regeneration is not required for this request-parameter correction. Local focused and package tests pass, but the full repository suite was not run locally. There are no dependent downstream changes.
