### PR TITLE
orderbook: Reduce level sorting overhead

### DIFF
--- a/exchanges/orderbook/orderbook.go
+++ b/exchanges/orderbook/orderbook.go
@@ -2,6 +2,8 @@ package orderbook
 
 import (
 	"fmt"
+	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -198,12 +200,62 @@ func (l *Levels) Reverse() {
 // scattered. If order from exchange is descending consider using the Reverse
 // function.
 func (l Levels) SortAsks() {
-	sort.Slice(l, func(i, j int) bool { return l[i].Price < l[j].Price })
+	for i := range l {
+		// NaN masks inversions on either side, so preserve the legacy sort path.
+		if math.IsNaN(l[i].Price) {
+			sort.Slice(l, func(x, y int) bool { return l[x].Price < l[y].Price })
+			return
+		}
+		if i > 0 && l[i].Price < l[i-1].Price {
+			for j := i + 1; j < len(l); j++ {
+				if math.IsNaN(l[j].Price) {
+					sort.Slice(l, func(x, y int) bool { return l[x].Price < l[y].Price })
+					return
+				}
+			}
+			slices.SortFunc(l, func(x, y Level) int {
+				switch {
+				case x.Price < y.Price:
+					return -1
+				case x.Price > y.Price:
+					return 1
+				default:
+					return 0
+				}
+			})
+			return
+		}
+	}
 }
 
 // SortBids sorts bid items to the correct descending order if pricing values
 // are scattered. If order from exchange is ascending consider using the Reverse
 // function.
 func (l Levels) SortBids() {
-	sort.Slice(l, func(i, j int) bool { return l[i].Price > l[j].Price })
+	for i := range l {
+		// NaN masks inversions on either side, so preserve the legacy sort path.
+		if math.IsNaN(l[i].Price) {
+			sort.Slice(l, func(x, y int) bool { return l[x].Price > l[y].Price })
+			return
+		}
+		if i > 0 && l[i].Price > l[i-1].Price {
+			for j := i + 1; j < len(l); j++ {
+				if math.IsNaN(l[j].Price) {
+					sort.Slice(l, func(x, y int) bool { return l[x].Price > l[y].Price })
+					return
+				}
+			}
+			slices.SortFunc(l, func(x, y Level) int {
+				switch {
+				case x.Price > y.Price:
+					return -1
+				case x.Price < y.Price:
+					return 1
+				default:
+					return 0
+				}
+			})
+			return
+		}
+	}
 }

--- a/exchanges/orderbook/orderbook_bench_test.go
+++ b/exchanges/orderbook/orderbook_bench_test.go
@@ -1,6 +1,7 @@
 package orderbook
 
 import (
+	"math"
 	"testing"
 
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -19,10 +20,10 @@ func BenchmarkReverse(b *testing.B) {
 	}
 }
 
-// 361266	      3556 ns/op	      24 B/op	       1 allocs/op (old)
-// 385783	      3000 ns/op	     152 B/op	       3 allocs/op (new)
+// BenchmarkSortAsksDecending measures the full-sort path for asks.
 func BenchmarkSortAsksDecending(b *testing.B) {
 	lvls := levelsFixture()
+	lvls.Reverse()
 	bucket := make(Levels, len(lvls))
 	for b.Loop() {
 		copy(bucket, lvls)
@@ -30,11 +31,9 @@ func BenchmarkSortAsksDecending(b *testing.B) {
 	}
 }
 
-// 266998	      4292 ns/op	      40 B/op	       2 allocs/op (old)
-// 372396	      3001 ns/op	     152 B/op	       3 allocs/op (new)
+// BenchmarkSortBidsAscending measures the full-sort path for bids.
 func BenchmarkSortBidsAscending(b *testing.B) {
 	lvls := levelsFixture()
-	lvls.Reverse()
 	bucket := make(Levels, len(lvls))
 	for b.Loop() {
 		copy(bucket, lvls)
@@ -42,8 +41,88 @@ func BenchmarkSortBidsAscending(b *testing.B) {
 	}
 }
 
-// 22119	     46532 ns/op	      35 B/op	       1 allocs/op (old)
-// 16233	     76951 ns/op	     167 B/op	       3 allocs/op (new)
+// BenchmarkSortAsksLateInversion measures the fallback after a full ordered-prefix scan.
+func BenchmarkSortAsksLateInversion(b *testing.B) {
+	lvls := levelsFixture()
+	lvls[len(lvls)-1].Price = 0.5
+	bucket := make(Levels, len(lvls))
+	for b.Loop() {
+		copy(bucket, lvls)
+		bucket.SortAsks()
+	}
+}
+
+// BenchmarkSortBidsLateInversion measures the fallback after a full ordered-prefix scan.
+func BenchmarkSortBidsLateInversion(b *testing.B) {
+	lvls := levelsFixture()
+	lvls.Reverse()
+	lvls[len(lvls)-1].Price = float64(len(lvls)) + 0.5
+	bucket := make(Levels, len(lvls))
+	for b.Loop() {
+		copy(bucket, lvls)
+		bucket.SortBids()
+	}
+}
+
+// BenchmarkSortAsksNaN measures each legacy NaN fallback entry point for asks.
+func BenchmarkSortAsksNaN(b *testing.B) {
+	early := levelsFixture()
+	early[0].Price = math.NaN()
+	late := levelsFixture()
+	late[len(late)-1].Price = math.NaN()
+	afterInversion := levelsFixture()
+	afterInversion[0], afterInversion[1] = afterInversion[1], afterInversion[0]
+	afterInversion[len(afterInversion)-1].Price = math.NaN()
+
+	for _, tc := range []struct {
+		name   string
+		levels Levels
+	}{
+		{name: "early", levels: early},
+		{name: "late", levels: late},
+		{name: "after-inversion", levels: afterInversion},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			bucket := make(Levels, len(tc.levels))
+			for b.Loop() {
+				copy(bucket, tc.levels)
+				bucket.SortAsks()
+			}
+		})
+	}
+}
+
+// BenchmarkSortBidsNaN measures each legacy NaN fallback entry point for bids.
+func BenchmarkSortBidsNaN(b *testing.B) {
+	early := levelsFixture()
+	early.Reverse()
+	early[0].Price = math.NaN()
+	late := levelsFixture()
+	late.Reverse()
+	late[len(late)-1].Price = math.NaN()
+	afterInversion := levelsFixture()
+	afterInversion.Reverse()
+	afterInversion[0], afterInversion[1] = afterInversion[1], afterInversion[0]
+	afterInversion[len(afterInversion)-1].Price = math.NaN()
+
+	for _, tc := range []struct {
+		name   string
+		levels Levels
+	}{
+		{name: "early", levels: early},
+		{name: "late", levels: late},
+		{name: "after-inversion", levels: afterInversion},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			bucket := make(Levels, len(tc.levels))
+			for b.Loop() {
+				copy(bucket, tc.levels)
+				bucket.SortBids()
+			}
+		})
+	}
+}
+
 func BenchmarkSortAsksStandard(b *testing.B) {
 	lvls := levelsFixtureRandom()
 	bucket := make(Levels, len(lvls))
@@ -53,8 +132,6 @@ func BenchmarkSortAsksStandard(b *testing.B) {
 	}
 }
 
-// 19504	     62518 ns/op	      53 B/op	       2 allocs/op (old)
-// 15698	     72859 ns/op	     168 B/op	       3 allocs/op (new)
 func BenchmarkSortBidsStandard(b *testing.B) {
 	lvls := levelsFixtureRandom()
 	bucket := make(Levels, len(lvls))
@@ -64,8 +141,6 @@ func BenchmarkSortBidsStandard(b *testing.B) {
 	}
 }
 
-// 376708	      3559 ns/op	      24 B/op 		   1 allocs/op (old)
-// 377113	      3020 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortAsksAscending(b *testing.B) {
 	lvls := levelsFixture()
 	bucket := make(Levels, len(lvls))
@@ -75,8 +150,6 @@ func BenchmarkSortAsksAscending(b *testing.B) {
 	}
 }
 
-// 262874	      4364 ns/op	      40 B/op	       2 allocs/op (old)
-// 401788	      3348 ns/op	     152 B/op	       3 allocs/op (new)
 func BenchmarkSortBidsDescending(b *testing.B) {
 	lvls := levelsFixture()
 	lvls.Reverse()

--- a/exchanges/orderbook/orderbook_bench_test.go
+++ b/exchanges/orderbook/orderbook_bench_test.go
@@ -20,8 +20,8 @@ func BenchmarkReverse(b *testing.B) {
 	}
 }
 
-// BenchmarkSortAsksDecending measures the full-sort path for asks.
-func BenchmarkSortAsksDecending(b *testing.B) {
+// BenchmarkSortAsksDescending measures the full-sort path for asks.
+func BenchmarkSortAsksDescending(b *testing.B) {
 	lvls := levelsFixture()
 	lvls.Reverse()
 	bucket := make(Levels, len(lvls))

--- a/exchanges/orderbook/orderbook_test.go
+++ b/exchanges/orderbook/orderbook_test.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"os"
 	"slices"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -413,6 +415,160 @@ func TestSorting(t *testing.T) {
 	b.Bids.SortBids()
 	err = b.Validate()
 	require.NoError(t, err)
+}
+
+func TestSortAsks(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		levels Levels
+	}{
+		{name: "nil"},
+		{name: "empty", levels: Levels{}},
+		{name: "singleton", levels: Levels{{Price: 1, Amount: 2, ID: 1}}},
+		{name: "ordered duplicates", levels: Levels{{Price: 1, ID: 1}, {Price: 2, ID: 2}, {Price: 2, ID: 3}, {Price: 3, ID: 4}}},
+		{name: "long ordered duplicates", levels: Levels{{Price: 1, ID: 1}, {Price: 1, ID: 2}, {Price: 2, ID: 3}, {Price: 2, ID: 4}, {Price: 3, ID: 5}, {Price: 3, ID: 6}, {Price: 4, ID: 7}, {Price: 4, ID: 8}, {Price: 5, ID: 9}, {Price: 5, ID: 10}, {Price: 6, ID: 11}, {Price: 6, ID: 12}, {Price: 7, ID: 13}, {Price: 7, ID: 14}, {Price: 8, ID: 15}, {Price: 8, ID: 16}, {Price: 9, ID: 17}, {Price: 9, ID: 18}, {Price: 10, ID: 19}, {Price: 10, ID: 20}}},
+		{
+			name: "long scattered duplicates",
+			levels: func() Levels {
+				rng := rand.New(rand.NewSource(1)) //nolint:gosec // Deterministic test fixture.
+				levels := make(Levels, 100)
+				for i := range levels {
+					levels[i] = Level{Price: float64(rng.Intn(16) + 1), ID: int64(i + 1)}
+				}
+				return levels
+			}(),
+		},
+		{name: "final inversion", levels: Levels{{Price: 1, ID: 1}, {Price: 2, ID: 2}, {Price: 2, ID: 3}, {Price: 0.5, ID: 4}}},
+		{name: "reverse ordered", levels: Levels{{Price: 3, ID: 1}, {Price: 2, ID: 2}, {Price: 1, ID: 3}}},
+		{name: "infinities", levels: Levels{{Price: math.Inf(1), ID: 1}, {Price: 0, ID: 2}, {Price: math.Inf(-1), ID: 3}}},
+		{name: "signed zero ordered", levels: Levels{{Price: -1, ID: 1}, {Price: math.Copysign(0, -1), ID: 2}, {Price: 0, ID: 3}, {Price: 1, ID: 4}}},
+		{name: "signed zero after inversion", levels: Levels{{Price: 1, ID: 1}, {Price: math.Copysign(0, -1), ID: 2}, {Price: 0, ID: 3}, {Price: -1, ID: 4}}},
+		{name: "NaN first", levels: Levels{{Price: math.NaN(), ID: 1}, {Price: 1, ID: 2}, {Price: 2, ID: 3}}},
+		{name: "NaN final", levels: Levels{{Price: 1, ID: 1}, {Price: 2, ID: 2}, {Price: math.NaN(), ID: 3}}},
+		{name: "NaN after inversion", levels: Levels{{Price: 2, ID: 1}, {Price: 1, ID: 2}, {Price: math.NaN(), ID: 3}}},
+		{name: "multiple NaNs", levels: Levels{{Price: 3, ID: 1}, {Price: math.NaN(), ID: 2}, {Price: 1, ID: 3}, {Price: math.NaN(), ID: 4}, {Price: 2, ID: 5}}},
+		{
+			name: "NaN masks non-adjacent inversion",
+			levels: Levels{
+				{Price: 1, ID: 1},
+				{Price: 2, ID: 2},
+				{Price: 3, ID: 3},
+				{Price: 4, ID: 4},
+				{Price: 10, ID: 5},
+				{Price: math.NaN(), ID: 6},
+				{Price: math.NaN(), ID: 7},
+				{Price: math.NaN(), ID: 8},
+				{Price: 5, ID: 9},
+				{Price: 6, ID: 10},
+				{Price: 7, ID: 11},
+				{Price: math.NaN(), ID: 12},
+				{Price: 1, ID: 13},
+				{Price: 2, ID: 14},
+				{Price: 3, ID: 15},
+				{Price: 4, ID: 16},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expected := slices.Clone(tc.levels)
+			sort.Slice(expected, func(i, j int) bool { return expected[i].Price < expected[j].Price })
+			actual := slices.Clone(tc.levels)
+			actual.SortAsks()
+			if !slices.ContainsFunc(tc.levels, func(level Level) bool { return math.IsNaN(level.Price) }) {
+				assert.Equal(t, expected, actual, "SortAsks should preserve legacy ordering")
+				return
+			}
+
+			expectedIDs := make([]int64, len(expected))
+			actualIDs := make([]int64, len(actual))
+			for i := range expected {
+				expectedIDs[i] = expected[i].ID
+				actualIDs[i] = actual[i].ID
+			}
+			assert.Equal(t, expectedIDs, actualIDs, "SortAsks should preserve legacy NaN ordering")
+		})
+	}
+}
+
+func TestSortBids(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		levels Levels
+	}{
+		{name: "nil"},
+		{name: "empty", levels: Levels{}},
+		{name: "singleton", levels: Levels{{Price: 1, Amount: 2, ID: 1}}},
+		{name: "ordered duplicates", levels: Levels{{Price: 3, ID: 1}, {Price: 2, ID: 2}, {Price: 2, ID: 3}, {Price: 1, ID: 4}}},
+		{name: "long ordered duplicates", levels: Levels{{Price: 10, ID: 1}, {Price: 10, ID: 2}, {Price: 9, ID: 3}, {Price: 9, ID: 4}, {Price: 8, ID: 5}, {Price: 8, ID: 6}, {Price: 7, ID: 7}, {Price: 7, ID: 8}, {Price: 6, ID: 9}, {Price: 6, ID: 10}, {Price: 5, ID: 11}, {Price: 5, ID: 12}, {Price: 4, ID: 13}, {Price: 4, ID: 14}, {Price: 3, ID: 15}, {Price: 3, ID: 16}, {Price: 2, ID: 17}, {Price: 2, ID: 18}, {Price: 1, ID: 19}, {Price: 1, ID: 20}}},
+		{
+			name: "long scattered duplicates",
+			levels: func() Levels {
+				rng := rand.New(rand.NewSource(2)) //nolint:gosec // Deterministic test fixture.
+				levels := make(Levels, 100)
+				for i := range levels {
+					levels[i] = Level{Price: float64(rng.Intn(16) + 1), ID: int64(i + 1)}
+				}
+				return levels
+			}(),
+		},
+		{name: "final inversion", levels: Levels{{Price: 3, ID: 1}, {Price: 2, ID: 2}, {Price: 2, ID: 3}, {Price: 4, ID: 4}}},
+		{name: "reverse ordered", levels: Levels{{Price: 1, ID: 1}, {Price: 2, ID: 2}, {Price: 3, ID: 3}}},
+		{name: "infinities", levels: Levels{{Price: math.Inf(-1), ID: 1}, {Price: 0, ID: 2}, {Price: math.Inf(1), ID: 3}}},
+		{name: "signed zero ordered", levels: Levels{{Price: 1, ID: 1}, {Price: 0, ID: 2}, {Price: math.Copysign(0, -1), ID: 3}, {Price: -1, ID: 4}}},
+		{name: "signed zero after inversion", levels: Levels{{Price: -1, ID: 1}, {Price: 0, ID: 2}, {Price: math.Copysign(0, -1), ID: 3}, {Price: 1, ID: 4}}},
+		{name: "NaN first", levels: Levels{{Price: math.NaN(), ID: 1}, {Price: 2, ID: 2}, {Price: 1, ID: 3}}},
+		{name: "NaN final", levels: Levels{{Price: 2, ID: 1}, {Price: 1, ID: 2}, {Price: math.NaN(), ID: 3}}},
+		{name: "NaN after inversion", levels: Levels{{Price: 1, ID: 1}, {Price: 2, ID: 2}, {Price: math.NaN(), ID: 3}}},
+		{name: "multiple NaNs", levels: Levels{{Price: 1, ID: 1}, {Price: math.NaN(), ID: 2}, {Price: 3, ID: 3}, {Price: math.NaN(), ID: 4}, {Price: 2, ID: 5}}},
+		{
+			name: "NaN masks non-adjacent inversion",
+			levels: Levels{
+				{Price: 10, ID: 1},
+				{Price: 9, ID: 2},
+				{Price: 8, ID: 3},
+				{Price: 7, ID: 4},
+				{Price: 1, ID: 5},
+				{Price: math.NaN(), ID: 6},
+				{Price: math.NaN(), ID: 7},
+				{Price: math.NaN(), ID: 8},
+				{Price: 6, ID: 9},
+				{Price: 5, ID: 10},
+				{Price: 4, ID: 11},
+				{Price: math.NaN(), ID: 12},
+				{Price: 10, ID: 13},
+				{Price: 9, ID: 14},
+				{Price: 8, ID: 15},
+				{Price: 7, ID: 16},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expected := slices.Clone(tc.levels)
+			sort.Slice(expected, func(i, j int) bool { return expected[i].Price > expected[j].Price })
+			actual := slices.Clone(tc.levels)
+			actual.SortBids()
+			if !slices.ContainsFunc(tc.levels, func(level Level) bool { return math.IsNaN(level.Price) }) {
+				assert.Equal(t, expected, actual, "SortBids should preserve legacy ordering")
+				return
+			}
+
+			expectedIDs := make([]int64, len(expected))
+			actualIDs := make([]int64, len(actual))
+			for i := range expected {
+				expectedIDs[i] = expected[i].ID
+				actualIDs[i] = actual[i].ID
+			}
+			assert.Equal(t, expectedIDs, actualIDs, "SortBids should preserve legacy NaN ordering")
+		})
+	}
 }
 
 func levelsFixture() Levels {


### PR DESCRIPTION
## Summary

- Return immediately when ask or bid levels are already in the required order.
- Use the typed sorting fallback for finite out-of-order prices, removing reflection-backed sort allocations.
- Preserve the exact legacy sorting path for NaN-bearing levels and add direct compatibility and benchmark coverage for edge cases.

## Performance

Measured on Go 1.26.5, linux/amd64, Intel i7-6700K, with `GOMAXPROCS=1`, `-benchtime=500ms`, and 15 samples per side. Each workload uses the same deterministic 1,000-level fixture and includes the same destination copy on both sides.

| Workload | Before | After | Change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: |
| asks, ordered | 4.531 us/op | 2.960 us/op | -34.67% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |
| bids, ordered | 4.564 us/op | 2.964 us/op | -35.06% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |
| asks, reverse ordered | 13.28 us/op | 12.17 us/op | -8.34% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |
| bids, reverse ordered | 13.32 us/op | 12.67 us/op | -4.86% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |
| asks, late inversion | 22.67 us/op | 23.02 us/op | +1.57% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |
| bids, late inversion | 22.59 us/op | 21.45 us/op | -5.04% | 152 B/op, 3 allocs/op | 0 B/op, 0 allocs/op |

The six-workload time geomean improved by 15.78%. All finite-price workloads eliminated the prior 152 B/op and three allocations per operation.

## Compatibility and limitations

- Exact element permutations remain compatible with the former `sort.Slice` behaviour across duplicates, infinities, signed zero, and NaN placement.
- NaN at the first level was unchanged. Late NaN regressed by 27.88% for asks and 27.65% for bids; NaN after an earlier inversion regressed by 23.01% and 18.96%, respectively. NaN is outside standard JSON numeric syntax and is not representative of normal exchange price payloads, but the compatibility path is retained and benchmarked.
- The late-inversion ask case regressed by 1.57% while eliminating all per-operation allocations.
- These results are scoped to deterministic level sorting and do not claim system-level order-book throughput or tail-latency improvements.

## Validation

- Direct tests cover nil, empty, singleton, ordered and reverse-ordered data, duplicates above the insertion-sort threshold, scattered duplicates, early and late inversions, infinities, signed zero, and permutation-sensitive NaN arrangements.
- Exact legacy permutations were checked over deterministic generated inputs for lengths 0 through 127 in both directions.
- Order-book package tests, repeated focused tests, race tests, and the Kraken and BTSE caller-package tests pass.
- `SortAsks` and `SortBids` each have 100% statement coverage; package coverage is 98.9%.
- Formatting, lint, spelling, miscellaneous, generated-code, and direct-test checks pass.