### PR TITLE
gctscript/vm: migrate tests to testify

### DIFF
--- a/gctscript/vm/autoload_test.go
+++ b/gctscript/vm/autoload_test.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGctScriptManagerAutoLoadNonExisting(t *testing.T) {
@@ -14,7 +16,5 @@ func TestGctScriptManagerAutoLoadNonExisting(t *testing.T) {
 		MaxVirtualMachines: &vms,
 	}
 	g.autoLoad()
-	if VMSCount != 0 {
-		t.Errorf("Expected no VMs, got %v", VMSCount)
-	}
+	assert.Zero(t, VMSCount.Len(), "autoLoad should not register virtual machines for missing scripts")
 }

--- a/gctscript/vm/manager_test.go
+++ b/gctscript/vm/manager_test.go
@@ -1,22 +1,22 @@
 package vm
 
 import (
-	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/common"
 )
 
 func TestNewManager(t *testing.T) {
 	t.Parallel()
-	type args struct {
-		config *Config
-	}
 	sharedConf := &Config{
 		AllowImports: true,
 	}
-	tests := []struct {
+	for _, tc := range []struct {
 		name    string
-		args    args
+		config  *Config
 		want    *GctScriptManager
 		wantErr bool
 	}{
@@ -25,26 +25,23 @@ func TestNewManager(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "config is applied",
-			args: args{
-				config: sharedConf,
-			},
+			name:   "config is applied",
+			config: sharedConf,
 			want: &GctScriptManager{
 				config: sharedConf,
 			},
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := NewManager(tt.args.config)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewManager() error = %v, wantErr %v", err, tt.wantErr)
+			got, err := NewManager(tc.config)
+			if tc.wantErr {
+				require.Error(t, err, "NewManager must return an error for invalid configuration")
+				assert.Equal(t, tc.want, got, "NewManager should return the expected manager for invalid configuration")
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewManager() = %v, want %v", got, tt.want)
-			}
+			require.NoError(t, err, "NewManager must accept valid configuration")
+			assert.Equal(t, tc.want, got, "NewManager should return the configured manager")
 		})
 	}
 }
@@ -52,71 +49,67 @@ func TestNewManager(t *testing.T) {
 func TestGctScriptManagerStartStopNominal(t *testing.T) {
 	t.Parallel()
 	mgr, err := NewManager(&Config{AllowImports: true})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "NewManager must create the manager")
 	var wg sync.WaitGroup
 	err = mgr.Start(&wg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mgr.started != 1 {
-		t.Errorf("Manager should be started (%v)", mgr.started)
-	}
+	require.NoError(t, err, "Start must start the manager")
+	assert.Equal(t, int32(1), mgr.started, "Start should mark the manager as started")
 	err = mgr.Stop()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Stop must stop the manager")
 	wg.Wait()
-	if mgr.started != 0 {
-		t.Errorf("Manager should be stopped, expected=%v, got %v", 0, mgr.started)
-	}
+	assert.Zero(t, mgr.started, "Stop should mark the manager as stopped")
+}
+
+func TestGctScriptManagerStartStopErrors(t *testing.T) {
+	mgr, err := NewManager(&Config{AllowImports: true})
+	require.NoError(t, err, "NewManager must create the manager")
+	require.ErrorIs(t, mgr.Start(nil), common.ErrNilPointer, "Start must reject a nil wait group")
+	require.EqualError(t, mgr.Stop(), "GCTScript not running", "Stop must reject a manager that is not running")
+
+	var wg sync.WaitGroup
+	require.NoError(t, mgr.Start(&wg), "Start must start the manager")
+	require.EqualError(t, mgr.Start(&wg), "GCTScript validation failed", "Start must reject an already running manager")
+	require.NoError(t, mgr.Stop(), "Stop must stop the manager")
+	wg.Wait()
+
+	var nilManager *GctScriptManager
+	require.ErrorIs(t, nilManager.Stop(), ErrNilSubsystem, "Stop must reject a nil manager")
 }
 
 func TestGctScriptManagerGetMaxVirtualMachines(t *testing.T) {
-	type fields struct {
+	var value uint64 = 6
+	for _, tc := range []struct {
+		name               string
 		config             *Config
 		started            int32
 		shutdown           chan struct{}
-		MaxVirtualMachines *uint64
-	}
-	var value uint64 = 6
-	tests := []struct {
-		name   string
-		fields fields
-		want   uint64
+		maxVirtualMachines *uint64
+		want               uint64
 	}{
 		{
 			name: "get from config",
-			fields: fields{
-				config: &Config{
-					MaxVirtualMachines: 7,
-				},
+			config: &Config{
+				MaxVirtualMachines: 7,
 			},
 			want: 7,
 		},
 		{
 			name: "get from manager",
-			fields: fields{
-				config: &Config{
-					MaxVirtualMachines: 7,
-				},
-				MaxVirtualMachines: &value,
+			config: &Config{
+				MaxVirtualMachines: 7,
 			},
-			want: 6,
+			maxVirtualMachines: &value,
+			want:               6,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			g := &GctScriptManager{
-				config:             tt.fields.config,
-				started:            tt.fields.started,
-				shutdown:           tt.fields.shutdown,
-				MaxVirtualMachines: tt.fields.MaxVirtualMachines,
+				config:             tc.config,
+				started:            tc.started,
+				shutdown:           tc.shutdown,
+				MaxVirtualMachines: tc.maxVirtualMachines,
 			}
-			if got := g.GetMaxVirtualMachines(); got != tt.want {
-				t.Errorf("GctScriptManager.GetMaxVirtualMachines() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tc.want, g.GetMaxVirtualMachines(), "GetMaxVirtualMachines should return the configured limit")
 		})
 	}
 }

--- a/gctscript/vm/manager_test.go
+++ b/gctscript/vm/manager_test.go
@@ -36,11 +36,11 @@ func TestNewManager(t *testing.T) {
 			t.Parallel()
 			got, err := NewManager(tc.config)
 			if tc.wantErr {
-				require.Error(t, err, "NewManager must return an error for invalid configuration")
+				assert.Error(t, err, "NewManager should return an error for invalid configuration")
 				assert.Equal(t, tc.want, got, "NewManager should return the expected manager for invalid configuration")
 				return
 			}
-			require.NoError(t, err, "NewManager must accept valid configuration")
+			assert.NoError(t, err, "NewManager should accept valid configuration")
 			assert.Equal(t, tc.want, got, "NewManager should return the configured manager")
 		})
 	}
@@ -63,17 +63,17 @@ func TestGctScriptManagerStartStopNominal(t *testing.T) {
 func TestGctScriptManagerStartStopErrors(t *testing.T) {
 	mgr, err := NewManager(&Config{AllowImports: true})
 	require.NoError(t, err, "NewManager must create the manager")
-	require.ErrorIs(t, mgr.Start(nil), common.ErrNilPointer, "Start must reject a nil wait group")
-	require.EqualError(t, mgr.Stop(), "GCTScript not running", "Stop must reject a manager that is not running")
+	assert.ErrorIs(t, mgr.Start(nil), common.ErrNilPointer, "Start should reject a nil wait group")
+	assert.EqualError(t, mgr.Stop(), "GCTScript not running", "Stop should reject a manager that is not running")
 
 	var wg sync.WaitGroup
 	require.NoError(t, mgr.Start(&wg), "Start must start the manager")
-	require.EqualError(t, mgr.Start(&wg), "GCTScript validation failed", "Start must reject an already running manager")
+	assert.EqualError(t, mgr.Start(&wg), "GCTScript validation failed", "Start should reject an already running manager")
 	require.NoError(t, mgr.Stop(), "Stop must stop the manager")
 	wg.Wait()
 
 	var nilManager *GctScriptManager
-	require.ErrorIs(t, nilManager.Stop(), ErrNilSubsystem, "Stop must reject a nil manager")
+	assert.ErrorIs(t, nilManager.Stop(), ErrNilSubsystem, "Stop should reject a nil manager")
 }
 
 func TestGctScriptManagerGetMaxVirtualMachines(t *testing.T) {

--- a/gctscript/vm/vm_test.go
+++ b/gctscript/vm/vm_test.go
@@ -43,14 +43,14 @@ func TestVMLoad(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
 
 	testScript = testScript[0 : len(testScript)-4]
 	testVM = manager.New()
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must accept the script without an extension")
 
 	manager.config = configHelper(false, false, maxTestVirtualMachines)
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must accept the script when imports are disabled")
 }
 
 func TestVMLoad1s(t *testing.T) {
@@ -59,10 +59,10 @@ func TestVMLoad1s(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScriptRunner1s))
+	require.NoError(t, testVM.Load(testScriptRunner1s), "Load must accept the one-second timer script")
 
 	testVM.CompileAndRun()
-	require.NoError(t, testVM.Shutdown())
+	require.NoError(t, testVM.Shutdown(), "Shutdown must stop the one-second timer script")
 }
 
 func TestVMLoadNegativeTimer(t *testing.T) {
@@ -71,10 +71,10 @@ func TestVMLoadNegativeTimer(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScriptRunnerNegative))
+	require.NoError(t, testVM.Load(testScriptRunnerNegative), "Load must accept the negative-timer script")
 
 	testVM.CompileAndRun()
-	require.Error(t, testVM.Shutdown())
+	require.Error(t, testVM.Shutdown(), "Shutdown must report the negative timer")
 }
 
 func TestVMLoadNilVM(t *testing.T) {
@@ -83,10 +83,10 @@ func TestVMLoadNilVM(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
 
 	testVM = nil
-	require.ErrorIs(t, testVM.Load(testScript), ErrNoVMLoaded)
+	require.ErrorIs(t, testVM.Load(testScript), ErrNoVMLoaded, "Load must reject a nil virtual machine")
 }
 
 func TestCompileAndRunNilVM(t *testing.T) {
@@ -96,14 +96,14 @@ func TestCompileAndRunNilVM(t *testing.T) {
 	}
 	vmcount := VMSCount.Len()
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
 
-	require.NoError(t, testVM.Load(testScript))
+	require.NoError(t, testVM.Load(testScript), "Load must remain idempotent for the valid script")
 
 	testVM = nil
 	testVM.CompileAndRun()
-	require.ErrorIs(t, testVM.Shutdown(), ErrNoVMLoaded)
-	assert.NotEqual(t, vmcount-1, VMSCount.Len(), "Expected vmcount to decrease")
+	require.ErrorIs(t, testVM.Shutdown(), ErrNoVMLoaded, "Shutdown must reject a nil virtual machine")
+	assert.NotEqual(t, vmcount-1, VMSCount.Len(), "CompileAndRun should not decrement the virtual-machine count after nil reassignment")
 }
 
 func TestVMLoadNoFile(t *testing.T) {
@@ -112,7 +112,7 @@ func TestVMLoadNoFile(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	assert.ErrorIs(t, testVM.Load("missing file"), os.ErrNotExist)
+	assert.ErrorIs(t, testVM.Load("missing file"), os.ErrNotExist, "Load should return the missing-file error")
 }
 
 func TestVMCompile(t *testing.T) {
@@ -122,14 +122,10 @@ func TestVMCompile(t *testing.T) {
 	}
 	testVM := manager.New()
 	err := testVM.Load(testScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the valid script")
 
 	err = testVM.Compile()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Compile must compile the valid script")
 }
 
 func TestVMRun(t *testing.T) {
@@ -139,19 +135,13 @@ func TestVMRun(t *testing.T) {
 	}
 	testVM := manager.NewVM()
 	err := testVM.Load(testScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the valid script")
 
 	err = testVM.Compile()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Compile must compile the valid script")
 
 	err = testVM.RunCtx()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "RunCtx must run the compiled script")
 }
 
 func TestVMRunTX(t *testing.T) {
@@ -161,19 +151,13 @@ func TestVMRunTX(t *testing.T) {
 	}
 	testVM := manager.NewVM()
 	err := testVM.Load(testScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the valid script")
 
 	err = testVM.Compile()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Compile must compile the valid script")
 
 	err = testVM.RunCtx()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "RunCtx must run the compiled transaction script")
 }
 
 func TestVMWithRunner(t *testing.T) {
@@ -183,24 +167,14 @@ func TestVMWithRunner(t *testing.T) {
 	}
 	vmCount := VMSCount.Len()
 	VM := manager.New()
-	if VM == nil {
-		t.Fatal("Failed to allocate new VM exiting")
-	}
+	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunner)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if VMSCount.Len() == vmCount {
-		t.Fatal("expected VM count to increase")
-	}
+	require.NoError(t, err, "Load must accept the timer script")
+	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if VMSCount.Len() == vmCount-1 {
-		t.Fatal("expected VM count to decrease")
-	}
+	require.NoError(t, err, "Shutdown must stop the timer script")
+	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
 }
 
 func TestVMWithRunnerOnce(t *testing.T) {
@@ -210,21 +184,13 @@ func TestVMWithRunnerOnce(t *testing.T) {
 	}
 	vmCount := VMSCount.Len()
 	VM := manager.New()
-	if VM == nil {
-		t.Fatal("Failed to allocate new VM exiting")
-	}
+	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScript)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if VMSCount.Len() == vmCount {
-		t.Fatal("expected VM count to increase")
-	}
+	require.NoError(t, err, "Load must accept the run-once script")
+	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	if err == nil {
-		t.Fatal("VM should not be running with invalid timer")
-	}
+	require.Error(t, err, "Shutdown must report the completed run-once script")
 }
 
 func TestVMWithRunnerNegativeTimer(t *testing.T) {
@@ -234,24 +200,14 @@ func TestVMWithRunnerNegativeTimer(t *testing.T) {
 	}
 	vmCount := VMSCount.Len()
 	VM := manager.New()
-	if VM == nil {
-		t.Fatal("Failed to allocate new VM exiting")
-	}
+	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunnerNegative)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if VMSCount.Len() == vmCount {
-		t.Fatal("expected VM count to increase")
-	}
+	require.NoError(t, err, "Load must accept the negative-timer script")
+	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	if err == nil {
-		t.Fatal("VM should not be running with invalid timer")
-	}
-	if VMSCount.Len() == vmCount-1 {
-		t.Fatal("expected VM count to decrease")
-	}
+	require.Error(t, err, "Shutdown must report the negative timer")
+	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
 }
 
 func TestVMWithRunnerInvalidTimer(t *testing.T) {
@@ -261,25 +217,14 @@ func TestVMWithRunnerInvalidTimer(t *testing.T) {
 	}
 	vmCount := VMSCount.Len()
 	VM := manager.New()
-	if VM == nil {
-		t.Fatal("Failed to allocate new VM exiting")
-	}
+	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunnerInvalid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if VMSCount.Len() == vmCount {
-		t.Fatal("expected VM count to increase")
-	}
+	require.NoError(t, err, "Load must accept the invalid-timer script")
+	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	if err == nil {
-		t.Fatal("VM should not be running with invalid timer")
-	}
-
-	if VMSCount.Len() == vmCount-1 {
-		t.Fatal("expected VM count to decrease")
-	}
+	require.Error(t, err, "Shutdown must report the invalid timer")
+	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
 }
 
 func TestShutdownAll(t *testing.T) {
@@ -290,23 +235,15 @@ func TestShutdownAll(t *testing.T) {
 	vmCount := VMSCount.Len()
 	VM := manager.New()
 	err := VM.Load(testScriptRunner)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the timer script")
 
 	VM.CompileAndRun()
 
-	if VMSCount.Len() == vmCount {
-		t.Fatal("expected VM count to increase")
-	}
+	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
 	err = manager.ShutdownAll()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "ShutdownAll must stop every virtual machine")
 
-	if VMSCount.Len() == vmCount-1 {
-		t.Fatal("expected VM count to decrease")
-	}
+	require.NotEqual(t, vmCount-1, VMSCount.Len(), "ShutdownAll must update the virtual-machine count")
 }
 
 func TestRead(t *testing.T) {
@@ -316,18 +253,12 @@ func TestRead(t *testing.T) {
 	}
 	VM := manager.NewVM()
 	err := VM.Load(testScriptRunner)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the timer script")
 
 	ScriptPath = filepath.Join("..", "..", "testdata", "gctscript")
 	data, err := VM.Read()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data) < 1 {
-		t.Fatal("expected data to be returned")
-	}
+	require.NoError(t, err, "Read must read the loaded script")
+	require.NotEmpty(t, data, "Read must return script data")
 	_ = VM.Shutdown()
 }
 
@@ -338,11 +269,7 @@ func TestRemoveVM(t *testing.T) {
 	}
 	id, _ := uuid.FromString("6f20c907-64a0-48f2-848a-7837dee61672")
 	err := manager.RemoveVM(id)
-	if err != nil {
-		if err.Error() != "VM 6f20c907-64a0-48f2-848a-7837dee61672 not found" {
-			t.Fatal(err)
-		}
-	}
+	require.EqualError(t, err, "VM 6f20c907-64a0-48f2-848a-7837dee61672 not found", "RemoveVM must reject an unknown virtual machine")
 }
 
 func TestError_Error(t *testing.T) {
@@ -352,9 +279,7 @@ func TestError_Error(t *testing.T) {
 		Cause:  errors.New("HELLO ERROR"),
 	}
 
-	if x.Error() != "GCT Script: (ACTION) test (SCRIPT) noscript.gct HELLO ERROR" {
-		t.Fatal(x.Error())
-	}
+	require.Equal(t, "GCT Script: (ACTION) test (SCRIPT) noscript.gct HELLO ERROR", x.Error(), "Error must format the script failure")
 }
 
 func TestVM_CompileInvalid(t *testing.T) {
@@ -364,46 +289,30 @@ func TestVM_CompileInvalid(t *testing.T) {
 	}
 	testVM := manager.New()
 	err := testVM.Load(testInvalidScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the invalid-runtime script")
 
 	err = testVM.Compile()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Compile must compile the invalid-runtime script")
 	err = testVM.RunCtx()
-	if err == nil {
-		t.Fatal("unexpected result broken script compiled successfully ")
-	}
+	require.Error(t, err, "RunCtx must reject the invalid-runtime script")
 
 	testVM = manager.New()
 	err = testVM.Load(testInvalidScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the invalid-runtime script on repeat")
 
 	err = testVM.Compile()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Compile must compile the invalid-runtime script on repeat")
 
 	err = testVM.RunCtx()
-	if err == nil {
-		t.Fatal("unexpected result broken script compiled successfully ")
-	}
+	require.Error(t, err, "RunCtx must reject the invalid-runtime script on repeat")
 
 	testVM = manager.New()
 	err = testVM.Load(testInvalidScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the invalid-runtime script for asynchronous execution")
 
 	testVM.CompileAndRun()
 	err = testVM.Shutdown()
-	if err == nil {
-		t.Fatal("Shutdown() passed successfully but expected to fail with invalid script")
-	}
+	require.Error(t, err, "Shutdown must report the invalid-runtime script")
 }
 
 func TestVM_CompileBroken(t *testing.T) {
@@ -413,14 +322,10 @@ func TestVM_CompileBroken(t *testing.T) {
 	}
 	testVM := manager.New()
 	err := testVM.Load(testBrokenScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the syntactically broken script")
 
 	err = testVM.Compile()
-	if err == nil {
-		t.Fatal("unexpected result broken script compiled successfully ")
-	}
+	require.Error(t, err, "Compile must reject the syntactically broken script")
 }
 
 func TestVM_CompileAndRunBroken(t *testing.T) {
@@ -430,15 +335,11 @@ func TestVM_CompileAndRunBroken(t *testing.T) {
 	}
 	testVM := manager.New()
 	err := testVM.Load(testBrokenScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Load must accept the syntactically broken script")
 
 	testVM.CompileAndRun()
 	err = testVM.Shutdown()
-	if err == nil {
-		t.Fatal("expect error on shutdown due to invalid VM")
-	}
+	require.Error(t, err, "Shutdown must report the broken virtual machine")
 }
 
 func TestValidate(t *testing.T) {
@@ -447,13 +348,9 @@ func TestValidate(t *testing.T) {
 		started: 1,
 	}
 	err := manager.Validate(testBrokenScript)
-	if err == nil {
-		t.Fatal(err)
-	}
+	require.Error(t, err, "Validate must reject the broken script")
 	err = manager.Validate(testScript)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Validate must accept the valid script")
 }
 
 func TestVMLimit(t *testing.T) {
@@ -461,9 +358,7 @@ func TestVMLimit(t *testing.T) {
 		config:  configHelper(true, false, 0),
 		started: 1,
 	}
-	if testVM := manager.New(); testVM != nil {
-		t.Fatal("expected nil but received pointer to VM")
-	}
+	require.Nil(t, manager.New(), "New must enforce the virtual-machine limit")
 }
 
 func TestAutoload(t *testing.T) {
@@ -479,33 +374,21 @@ func TestAutoload(t *testing.T) {
 
 	ScriptPath = filepath.Join("..", "..", "testdata", "gctscript")
 	err := manager.Autoload(scriptName, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Autoload must load the named script")
 	err = manager.Autoload(scriptName, true)
-	if err == nil {
-		t.Fatal("expected err to be script not found received nil")
-	}
+	require.Error(t, err, "Autoload must reject a duplicate named script")
 	err = manager.Autoload("once", false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "Autoload must load the extensionless script")
 	err = manager.Autoload(scriptName, false)
-	if err == nil {
-		t.Fatal("expected err to be script not found received nil")
-	}
+	require.Error(t, err, "Autoload must reject the missing extensionless script")
 }
 
 func TestVMCount(t *testing.T) {
 	var c vmscount
 	c.add()
-	if c.Len() != 1 {
-		t.Fatalf("expect c len to be 1 instead received %v", c.Len())
-	}
+	require.Equal(t, uint64(1), c.Len(), "add must increment the virtual-machine count")
 	c.remove()
-	if c.Len() != 0 {
-		t.Fatalf("expect c len to be 0 instead received %v", c.Len())
-	}
+	require.Zero(t, c.Len(), "remove must decrement the virtual-machine count")
 }
 
 func configHelper(enabled, imports bool, maxVMs uint64) *Config {

--- a/gctscript/vm/vm_test.go
+++ b/gctscript/vm/vm_test.go
@@ -32,9 +32,9 @@ func TestNewVM(t *testing.T) {
 	manager := GctScriptManager{
 		config: configHelper(true, true, maxTestVirtualMachines),
 	}
-	require.Nil(t, manager.New(), "New must not create a VM when manager not started")
+	assert.Nil(t, manager.New(), "New should not create a VM when manager not started")
 	manager.started = 1
-	require.NotNil(t, manager.New(), "New must create a VM when manager is started")
+	assert.NotNil(t, manager.New(), "New should create a VM when manager is started")
 }
 
 func TestVMLoad(t *testing.T) {
@@ -43,14 +43,14 @@ func TestVMLoad(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
+	assert.NoError(t, testVM.Load(testScript), "Load should accept the valid script")
 
 	testScript = testScript[0 : len(testScript)-4]
 	testVM = manager.New()
-	require.NoError(t, testVM.Load(testScript), "Load must accept the script without an extension")
+	assert.NoError(t, testVM.Load(testScript), "Load should accept the script without an extension")
 
 	manager.config = configHelper(false, false, maxTestVirtualMachines)
-	require.NoError(t, testVM.Load(testScript), "Load must accept the script when imports are disabled")
+	assert.NoError(t, testVM.Load(testScript), "Load should accept the extensionless script on repeat")
 }
 
 func TestVMLoad1s(t *testing.T) {
@@ -62,7 +62,7 @@ func TestVMLoad1s(t *testing.T) {
 	require.NoError(t, testVM.Load(testScriptRunner1s), "Load must accept the one-second timer script")
 
 	testVM.CompileAndRun()
-	require.NoError(t, testVM.Shutdown(), "Shutdown must stop the one-second timer script")
+	assert.NoError(t, testVM.Shutdown(), "Shutdown should stop the one-second timer script")
 }
 
 func TestVMLoadNegativeTimer(t *testing.T) {
@@ -74,7 +74,7 @@ func TestVMLoadNegativeTimer(t *testing.T) {
 	require.NoError(t, testVM.Load(testScriptRunnerNegative), "Load must accept the negative-timer script")
 
 	testVM.CompileAndRun()
-	require.Error(t, testVM.Shutdown(), "Shutdown must report the negative timer")
+	assert.Error(t, testVM.Shutdown(), "Shutdown should report the negative timer")
 }
 
 func TestVMLoadNilVM(t *testing.T) {
@@ -83,10 +83,10 @@ func TestVMLoadNilVM(t *testing.T) {
 		started: 1,
 	}
 	testVM := manager.New()
-	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
+	assert.NoError(t, testVM.Load(testScript), "Load should accept the valid script")
 
 	testVM = nil
-	require.ErrorIs(t, testVM.Load(testScript), ErrNoVMLoaded, "Load must reject a nil virtual machine")
+	assert.ErrorIs(t, testVM.Load(testScript), ErrNoVMLoaded, "Load should reject a nil virtual machine")
 }
 
 func TestCompileAndRunNilVM(t *testing.T) {
@@ -98,12 +98,12 @@ func TestCompileAndRunNilVM(t *testing.T) {
 	testVM := manager.New()
 	require.NoError(t, testVM.Load(testScript), "Load must accept the valid script")
 
-	require.NoError(t, testVM.Load(testScript), "Load must remain idempotent for the valid script")
+	assert.NoError(t, testVM.Load(testScript), "Load should remain idempotent for the valid script")
 
 	testVM = nil
 	testVM.CompileAndRun()
-	require.ErrorIs(t, testVM.Shutdown(), ErrNoVMLoaded, "Shutdown must reject a nil virtual machine")
-	assert.NotEqual(t, vmcount-1, VMSCount.Len(), "CompileAndRun should not decrement the virtual-machine count after nil reassignment")
+	assert.ErrorIs(t, testVM.Shutdown(), ErrNoVMLoaded, "Shutdown should reject a nil virtual machine")
+	assert.Equal(t, vmcount+1, VMSCount.Len(), "CompileAndRun should preserve the registered virtual-machine count after nil reassignment")
 }
 
 func TestVMLoadNoFile(t *testing.T) {
@@ -125,7 +125,7 @@ func TestVMCompile(t *testing.T) {
 	require.NoError(t, err, "Load must accept the valid script")
 
 	err = testVM.Compile()
-	require.NoError(t, err, "Compile must compile the valid script")
+	assert.NoError(t, err, "Compile should compile the valid script")
 }
 
 func TestVMRun(t *testing.T) {
@@ -141,7 +141,7 @@ func TestVMRun(t *testing.T) {
 	require.NoError(t, err, "Compile must compile the valid script")
 
 	err = testVM.RunCtx()
-	require.NoError(t, err, "RunCtx must run the compiled script")
+	assert.NoError(t, err, "RunCtx should run the compiled script")
 }
 
 func TestVMRunTX(t *testing.T) {
@@ -157,7 +157,7 @@ func TestVMRunTX(t *testing.T) {
 	require.NoError(t, err, "Compile must compile the valid script")
 
 	err = testVM.RunCtx()
-	require.NoError(t, err, "RunCtx must run the compiled transaction script")
+	assert.NoError(t, err, "RunCtx should run the compiled transaction script")
 }
 
 func TestVMWithRunner(t *testing.T) {
@@ -170,11 +170,11 @@ func TestVMWithRunner(t *testing.T) {
 	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunner)
 	require.NoError(t, err, "Load must accept the timer script")
-	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
+	assert.Equal(t, vmCount+1, VMSCount.Len(), "New should increment the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	require.NoError(t, err, "Shutdown must stop the timer script")
-	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
+	assert.NoError(t, err, "Shutdown should stop the timer script")
+	assert.Equal(t, vmCount, VMSCount.Len(), "Shutdown should restore the virtual-machine count")
 }
 
 func TestVMWithRunnerOnce(t *testing.T) {
@@ -187,10 +187,11 @@ func TestVMWithRunnerOnce(t *testing.T) {
 	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScript)
 	require.NoError(t, err, "Load must accept the run-once script")
-	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
+	assert.Equal(t, vmCount+1, VMSCount.Len(), "New should increment the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	require.Error(t, err, "Shutdown must report the completed run-once script")
+	assert.Error(t, err, "Shutdown should report the completed run-once script")
+	assert.Equal(t, vmCount, VMSCount.Len(), "CompileAndRun should restore the virtual-machine count after a run-once script")
 }
 
 func TestVMWithRunnerNegativeTimer(t *testing.T) {
@@ -203,11 +204,11 @@ func TestVMWithRunnerNegativeTimer(t *testing.T) {
 	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunnerNegative)
 	require.NoError(t, err, "Load must accept the negative-timer script")
-	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
+	assert.Equal(t, vmCount+1, VMSCount.Len(), "New should increment the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	require.Error(t, err, "Shutdown must report the negative timer")
-	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
+	assert.Error(t, err, "Shutdown should report the negative timer")
+	assert.Equal(t, vmCount, VMSCount.Len(), "Shutdown should restore the virtual-machine count")
 }
 
 func TestVMWithRunnerInvalidTimer(t *testing.T) {
@@ -220,11 +221,11 @@ func TestVMWithRunnerInvalidTimer(t *testing.T) {
 	require.NotNil(t, VM, "New must allocate a virtual machine")
 	err := VM.Load(testScriptRunnerInvalid)
 	require.NoError(t, err, "Load must accept the invalid-timer script")
-	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
+	assert.Equal(t, vmCount+1, VMSCount.Len(), "New should increment the virtual-machine count")
 	VM.CompileAndRun()
 	err = VM.Shutdown()
-	require.Error(t, err, "Shutdown must report the invalid timer")
-	require.NotEqual(t, vmCount-1, VMSCount.Len(), "Shutdown must update the virtual-machine count")
+	assert.Error(t, err, "Shutdown should report the invalid timer")
+	assert.Equal(t, vmCount, VMSCount.Len(), "Shutdown should restore the virtual-machine count")
 }
 
 func TestShutdownAll(t *testing.T) {
@@ -239,11 +240,11 @@ func TestShutdownAll(t *testing.T) {
 
 	VM.CompileAndRun()
 
-	require.NotEqual(t, vmCount, VMSCount.Len(), "New must increase the virtual-machine count")
+	assert.Equal(t, vmCount+1, VMSCount.Len(), "New should increment the virtual-machine count")
 	err = manager.ShutdownAll()
-	require.NoError(t, err, "ShutdownAll must stop every virtual machine")
+	assert.NoError(t, err, "ShutdownAll should stop every virtual machine")
 
-	require.NotEqual(t, vmCount-1, VMSCount.Len(), "ShutdownAll must update the virtual-machine count")
+	assert.Zero(t, VMSCount.Len(), "ShutdownAll should clear the virtual-machine count")
 }
 
 func TestRead(t *testing.T) {
@@ -258,7 +259,7 @@ func TestRead(t *testing.T) {
 	ScriptPath = filepath.Join("..", "..", "testdata", "gctscript")
 	data, err := VM.Read()
 	require.NoError(t, err, "Read must read the loaded script")
-	require.NotEmpty(t, data, "Read must return script data")
+	assert.NotEmpty(t, data, "Read should return script data")
 	_ = VM.Shutdown()
 }
 
@@ -269,7 +270,7 @@ func TestRemoveVM(t *testing.T) {
 	}
 	id, _ := uuid.FromString("6f20c907-64a0-48f2-848a-7837dee61672")
 	err := manager.RemoveVM(id)
-	require.EqualError(t, err, "VM 6f20c907-64a0-48f2-848a-7837dee61672 not found", "RemoveVM must reject an unknown virtual machine")
+	assert.EqualError(t, err, "VM 6f20c907-64a0-48f2-848a-7837dee61672 not found", "RemoveVM should reject an unknown virtual machine")
 }
 
 func TestError_Error(t *testing.T) {
@@ -279,7 +280,7 @@ func TestError_Error(t *testing.T) {
 		Cause:  errors.New("HELLO ERROR"),
 	}
 
-	require.Equal(t, "GCT Script: (ACTION) test (SCRIPT) noscript.gct HELLO ERROR", x.Error(), "Error must format the script failure")
+	assert.Equal(t, "GCT Script: (ACTION) test (SCRIPT) noscript.gct HELLO ERROR", x.Error(), "Error should format the script failure")
 }
 
 func TestVM_CompileInvalid(t *testing.T) {
@@ -294,7 +295,7 @@ func TestVM_CompileInvalid(t *testing.T) {
 	err = testVM.Compile()
 	require.NoError(t, err, "Compile must compile the invalid-runtime script")
 	err = testVM.RunCtx()
-	require.Error(t, err, "RunCtx must reject the invalid-runtime script")
+	assert.Error(t, err, "RunCtx should reject the invalid-runtime script")
 
 	testVM = manager.New()
 	err = testVM.Load(testInvalidScript)
@@ -304,7 +305,7 @@ func TestVM_CompileInvalid(t *testing.T) {
 	require.NoError(t, err, "Compile must compile the invalid-runtime script on repeat")
 
 	err = testVM.RunCtx()
-	require.Error(t, err, "RunCtx must reject the invalid-runtime script on repeat")
+	assert.Error(t, err, "RunCtx should reject the invalid-runtime script on repeat")
 
 	testVM = manager.New()
 	err = testVM.Load(testInvalidScript)
@@ -312,7 +313,7 @@ func TestVM_CompileInvalid(t *testing.T) {
 
 	testVM.CompileAndRun()
 	err = testVM.Shutdown()
-	require.Error(t, err, "Shutdown must report the invalid-runtime script")
+	assert.Error(t, err, "Shutdown should report the invalid-runtime script")
 }
 
 func TestVM_CompileBroken(t *testing.T) {
@@ -325,7 +326,7 @@ func TestVM_CompileBroken(t *testing.T) {
 	require.NoError(t, err, "Load must accept the syntactically broken script")
 
 	err = testVM.Compile()
-	require.Error(t, err, "Compile must reject the syntactically broken script")
+	assert.Error(t, err, "Compile should reject the syntactically broken script")
 }
 
 func TestVM_CompileAndRunBroken(t *testing.T) {
@@ -339,7 +340,7 @@ func TestVM_CompileAndRunBroken(t *testing.T) {
 
 	testVM.CompileAndRun()
 	err = testVM.Shutdown()
-	require.Error(t, err, "Shutdown must report the broken virtual machine")
+	assert.Error(t, err, "Shutdown should report the broken virtual machine")
 }
 
 func TestValidate(t *testing.T) {
@@ -348,9 +349,9 @@ func TestValidate(t *testing.T) {
 		started: 1,
 	}
 	err := manager.Validate(testBrokenScript)
-	require.Error(t, err, "Validate must reject the broken script")
+	assert.Error(t, err, "Validate should reject the broken script")
 	err = manager.Validate(testScript)
-	require.NoError(t, err, "Validate must accept the valid script")
+	assert.NoError(t, err, "Validate should accept the valid script")
 }
 
 func TestVMLimit(t *testing.T) {
@@ -358,7 +359,7 @@ func TestVMLimit(t *testing.T) {
 		config:  configHelper(true, false, 0),
 		started: 1,
 	}
-	require.Nil(t, manager.New(), "New must enforce the virtual-machine limit")
+	assert.Nil(t, manager.New(), "New should enforce the virtual-machine limit")
 }
 
 func TestAutoload(t *testing.T) {
@@ -374,21 +375,21 @@ func TestAutoload(t *testing.T) {
 
 	ScriptPath = filepath.Join("..", "..", "testdata", "gctscript")
 	err := manager.Autoload(scriptName, true)
-	require.NoError(t, err, "Autoload must load the named script")
+	require.NoError(t, err, "Autoload must remove the configured script")
 	err = manager.Autoload(scriptName, true)
-	require.Error(t, err, "Autoload must reject a duplicate named script")
+	assert.Error(t, err, "Autoload should reject removing an unlisted script")
 	err = manager.Autoload("once", false)
-	require.NoError(t, err, "Autoload must load the extensionless script")
+	assert.NoError(t, err, "Autoload should add the extensionless script")
 	err = manager.Autoload(scriptName, false)
-	require.Error(t, err, "Autoload must reject the missing extensionless script")
+	assert.Error(t, err, "Autoload should reject adding a missing script")
 }
 
 func TestVMCount(t *testing.T) {
 	var c vmscount
 	c.add()
-	require.Equal(t, uint64(1), c.Len(), "add must increment the virtual-machine count")
+	assert.Equal(t, uint64(1), c.Len(), "add should increment the virtual-machine count")
 	c.remove()
-	require.Zero(t, c.Len(), "remove must decrement the virtual-machine count")
+	assert.Zero(t, c.Len(), "remove should decrement the virtual-machine count")
 }
 
 func configHelper(enabled, imports bool, maxVMs uint64) *Config {


### PR DESCRIPTION
# PR Description

The `gctscript/vm` tests mixed raw `testing` failures with Testify assertions. This migrates all 66 remaining legacy assertion sites across the package's three test files, preserving fatal and non-fatal control flow while adding operation-specific diagnostics.

The change also adds direct coverage for manager start and stop validation: nil wait groups, duplicate starts, stops before startup, and nil manager receivers. No production code, fixtures, dependencies, or existing test names changed.

No linked issue.

## Type of change

- [x] Test refactor (no production behaviour change)

## How has this been tested

- [ ] go test ./... -race
- [x] golangci-lint run
- [x] go test ./gctscript/vm -race -count=1
- [x] go test ./gctscript/vm -run '^TestGctScriptManager' -count=50
- [x] go test ./gctscript/vm -run '^TestGctScriptManager' -race -count=20
- [x] make misc_checks
- [x] codespell

All 29 existing test names remain, with one direct manager error-path test added. `Start` statement coverage rises from 75.0% to 100.0%, `Stop` rises from 66.7% to 88.9%, and the matched package statement profile rises from 87.9% to 88.3%. Fifty process-isolated normal package runs and 20 process-isolated race-enabled package runs passed on the exact commit. The full repository race suite and GitHub Actions have not run.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Comments and documentation changes are not applicable to this test-only refactor. Focused, package, repeated, and race-enabled tests pass locally, but the complete repository suite and GitHub Actions have not run. There are no dependent downstream changes.