### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security Policy
+
+GoCryptoTrader handles exchange API credentials and can place live orders with real funds. We take
+security reports seriously and appreciate the effort involved in finding and disclosing them
+responsibly.
+
+## Supported Versions
+
+GoCryptoTrader is developed as a rolling release. Only the latest commit on `master` is supported;
+fixes are not backported to older commits, tags or forks. Please confirm an issue still reproduces
+against current `master` before reporting it.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, pull requests or
+Slack.**
+
+Report privately using either of the following:
+
+- **GitHub Security Advisories** (preferred) — go to the
+  [Security tab](https://github.com/thrasher-corp/gocryptotrader/security/advisories/new), click
+  **Report a vulnerability**, and include as much of the detail below as you can.
+- **Email** — <contact@thrasher.io>.
+
+### What to include
+
+- The type of issue and the component affected (exchange wrapper, engine, RPC server, config, etc.).
+- The commit hash you tested against.
+- Step-by-step reproduction instructions, ideally as a failing Go test or minimal program.
+- Impact: what an attacker gains, and what access they need to get it.
+- Any proof-of-concept code, logs or configuration needed to reproduce, with credentials redacted.
+
+### What to expect
+
+- **Acknowledgement:** within 5 business days.
+- **Assessment:** we will confirm the issue, determine severity and let you know our intended fix
+  and timeline.
+- **Disclosure:** we aim to release a fix within 90 days of confirmation. We will coordinate public
+  disclosure with you and credit you in the advisory unless you prefer to remain anonymous.
+
+Please give us reasonable time to release a fix before disclosing publicly.
+
+## Scope
+
+Vulnerabilities in this repository's code are in scope. Areas of particular interest:
+
+- Leakage of API keys, secrets or client IDs — including via logs, error messages, RPC responses or
+  crash output.
+- Weaknesses in configuration encryption or credential storage (see [config](/config/README.md)).
+- Flaws in exchange request signing or authentication.
+- Authentication, authorisation or input handling flaws in the gRPC/REST server (see
+  [gctrpc](/gctrpc/README.md)) or the websocket server.
+- Sandbox escapes or unintended host access from [gctscript](/gctscript/README.md).
+- Parsing or state-handling flaws that let untrusted exchange responses cause memory corruption,
+  unbounded resource use or incorrect order placement.
+- Dependency vulnerabilities that are actually reachable from GoCryptoTrader code.
+
+### Out of scope
+
+- Financial loss from trading strategies, market conditions or user configuration.
+- Vulnerabilities in exchange APIs themselves — report those to the exchange.
+- Issues that require an already-compromised host, or physical or root access to the machine running
+  the bot.
+- Running the RPC server with authentication disabled, weak credentials or bound to a public
+  interface where the documentation advises otherwise.
+- Missing hardening that has no demonstrated impact, or automated scanner output without a working
+  proof of concept.
+- Denial of service caused solely by exhausting exchange rate limits.
+
+## Operational Guidance
+
+GoCryptoTrader is a framework, not a hosted service, and its security depends heavily on how it is
+deployed. When running it:
+
+- Never commit `config.json` — it may contain API credentials. Use the built-in configuration
+  encryption.
+- Scope exchange API keys to the minimum permissions needed and disable withdrawal permissions
+  unless you require them.
+- Restrict the RPC server to a trusted network and change the default credentials.
+- Treat logs as sensitive; enable debug logging only when needed and review output before sharing it
+  in issues.

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -8,6 +8,14 @@ This document outlines the coding, formatting, and testing standards for impleme
 - Code must adhere to these [Effective Go](https://go.dev/doc/effective_go) guidelines.
 - Code must also follow these [Go Style](https://google.github.io/styleguide/go/) guidelines.
 
+## Security
+
+See [SECURITY.md](/SECURITY.md) for the project's security policy, supported versions and reporting process.
+
+- Never commit API keys, secrets, client IDs or a populated `config.json`. Use placeholder values in tests and examples.
+- Never log or return credentials in error messages, RPC responses or test output.
+- If you discover a vulnerability while working on the codebase, report it privately as described in [SECURITY.md](/SECURITY.md). Do not describe it in a public issue, pull request or commit message.
+
 ## Exchange Implementation Guidelines
 
 Refer to the [ADD_NEW_EXCHANGE.md](/docs/ADD_NEW_EXCHANGE.md) document for comprehensive steps on integrating a new exchange.


### PR DESCRIPTION
# PR Description

Adds a `SECURITY.md` at the repository root. GoCryptoTrader handles exchange API credentials and can place live orders with real funds, but until now there was no documented way to report a vulnerability privately — the only options a reporter could infer were a public issue or public Slack.

The policy covers:

- **Reporting** — GitHub Security Advisories (private vulnerability reporting is already enabled on this repo) as the preferred channel, with <contact@thrasher.io> as an alternative. Explicitly directs reporters away from public issues, PRs and Slack.
- **Supported versions** — states that only the latest `master` is supported and that fixes are not backported. GoCryptoTrader is effectively a rolling release, so a version support table would be misleading.
- **What to include / what to expect** — reproduction details and a commit hash from reporters; acknowledgement within 5 business days, and a 90 day target for a coordinated fix and disclosure from us. These timelines are a starting proposal — happy to adjust to whatever maintainers can realistically commit to.
- **Scope** — targeted at what this codebase actually exposes: credential leakage via logs/errors/RPC responses, config encryption, exchange request signing, gRPC/websocket server auth, gctscript sandbox escapes, and untrusted exchange response parsing. Out of scope covers trading losses, exchange-side API bugs, already-compromised hosts, and deliberately disabled RPC auth.
- **Operational guidance** — a short deployment hygiene section (don't commit `config.json`, scope API keys, restrict the RPC server, treat logs as sensitive).

Documentation only — no code changes.

Fixes # (issue)

## Type of change

- [x] This change requires a documentation update

## How has this been tested

Documentation-only change; there is no Go code in this PR for `go test` or `golangci-lint` to exercise.

- [x] `make misc_checks` — all checks pass
- [x] Verified every relative link in `SECURITY.md` resolves: `/config/README.md`, `/gctrpc/README.md`, `/gctscript/README.md`
- [x] Confirmed private vulnerability reporting is enabled on `thrasher-corp/gocryptotrader`, so the advisory link is live

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Github Actions with my changes
