### PR TITLE
exchanges/currencystate: reduce snapshot allocations

### DIFF
--- a/exchanges/currencystate/currency_state.go
+++ b/exchanges/currencystate/currency_state.go
@@ -46,17 +46,43 @@ func (s *States) GetCurrencyStateSnapshot() ([]Snapshot, error) {
 
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	var sh []Snapshot
+	snapshotCount := 0
+	for _, states := range s.m {
+		snapshotCount += len(states)
+	}
+	var snapshots []Snapshot
+	// Snapshots own their option pointers, so a contiguous backing store avoids
+	// one heap allocation per boolean without exposing Currency fields.
+	type stateValue struct {
+		withdrawals bool
+		deposits    bool
+		trading     bool
+	}
+	var stateValues []stateValue
+	if snapshotCount != 0 {
+		snapshots = make([]Snapshot, 0, snapshotCount)
+		stateValues = make([]stateValue, snapshotCount)
+	}
 	for a, m1 := range s.m {
 		for c, val := range m1 {
-			sh = append(sh, Snapshot{
-				Code:    currency.Code{Item: c},
-				Asset:   a,
-				Options: val.GetState(),
+			state := &stateValues[len(snapshots)]
+			val.mtx.RLock()
+			state.withdrawals = val.withdrawals
+			state.deposits = val.deposits
+			state.trading = val.trading
+			val.mtx.RUnlock()
+			snapshots = append(snapshots, Snapshot{
+				Code:  currency.Code{Item: c},
+				Asset: a,
+				Options: Options{
+					Withdraw: &state.withdrawals,
+					Deposit:  &state.deposits,
+					Trade:    &state.trading,
+				},
 			})
 		}
 	}
-	return sh, nil
+	return snapshots, nil
 }
 
 // CanTradePair returns if the currency pair is currently tradeable for this

--- a/exchanges/currencystate/currency_state_bench_test.go
+++ b/exchanges/currencystate/currency_state_bench_test.go
@@ -1,0 +1,45 @@
+package currencystate
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+)
+
+func BenchmarkGetCurrencyStateSnapshot(b *testing.B) {
+	for _, currencyCount := range []int{1, 32, 512} {
+		b.Run(strconv.Itoa(currencyCount), func(b *testing.B) {
+			states := &States{m: map[asset.Item]map[*currency.Item]*Currency{
+				asset.Spot: make(map[*currency.Item]*Currency, currencyCount),
+			}}
+			if currencyCount > 1 {
+				states.m[asset.Futures] = make(map[*currency.Item]*Currency, currencyCount/2)
+			}
+			for i := range currencyCount {
+				code := currency.NewCode("BENCH" + strconv.Itoa(i))
+				assetType := asset.Spot
+				if i%2 != 0 {
+					assetType = asset.Futures
+				}
+				states.m[assetType][code.Item] = &Currency{
+					withdrawals: true,
+					deposits:    i%2 == 0,
+					trading:     i%3 == 0,
+				}
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				snapshots, err := states.GetCurrencyStateSnapshot()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(snapshots) != currencyCount {
+					b.Fatalf("snapshot length %d, want %d", len(snapshots), currencyCount)
+				}
+			}
+		})
+	}
+}

--- a/exchanges/currencystate/currency_state_test.go
+++ b/exchanges/currencystate/currency_state_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/currency"
@@ -16,25 +17,59 @@ func TestNewCurrencyStates(t *testing.T) {
 	}
 }
 
-func TestGetSnapshot(t *testing.T) {
+func TestGetCurrencyStateSnapshot(t *testing.T) {
 	t.Parallel()
-	_, err := (*States)(nil).GetCurrencyStateSnapshot()
-	require.ErrorIs(t, err, errNilStates)
+	snapshots, err := (*States)(nil).GetCurrencyStateSnapshot()
+	require.ErrorIs(t, err, errNilStates, "GetCurrencyStateSnapshot must error correctly for nil states")
+	assert.Nil(t, snapshots, "GetCurrencyStateSnapshot should return nil snapshots for nil states")
 
-	o, err := (&States{
+	snapshots, err = NewCurrencyStates().GetCurrencyStateSnapshot()
+	require.NoError(t, err, "GetCurrencyStateSnapshot must not error for empty states")
+	assert.Nil(t, snapshots, "GetCurrencyStateSnapshot should preserve a nil snapshot for empty states")
+
+	states := &States{
 		m: map[asset.Item]map[*currency.Item]*Currency{
-			asset.Spot: {currency.BTC.Item: {
+			asset.Spot: {currency.BTC.Item: &Currency{
 				withdrawals: true,
 				deposits:    true,
+				trading:     false,
+			}},
+			asset.Futures: {currency.BTC.Item: &Currency{
+				withdrawals: true,
+				deposits:    false,
 				trading:     true,
 			}},
 		},
-	}).GetCurrencyStateSnapshot()
-	require.NoError(t, err)
-
-	if o == nil {
-		t.Fatal("unexpected value")
 	}
+	snapshots, err = states.GetCurrencyStateSnapshot()
+	require.NoError(t, err, "GetCurrencyStateSnapshot must not error for populated states")
+	require.Len(t, snapshots, 2, "GetCurrencyStateSnapshot must return every state")
+
+	type snapshotKey struct {
+		asset asset.Item
+		code  *currency.Item
+	}
+	snapshotByKey := make(map[snapshotKey]Snapshot, len(snapshots))
+	for i := range snapshots {
+		snapshotByKey[snapshotKey{asset: snapshots[i].Asset, code: snapshots[i].Code.Item}] = snapshots[i]
+	}
+	spotBTC, ok := snapshotByKey[snapshotKey{asset: asset.Spot, code: currency.BTC.Item}]
+	require.True(t, ok, "GetCurrencyStateSnapshot must include spot BTC")
+	assert.True(t, *spotBTC.Withdraw, "GetCurrencyStateSnapshot should preserve spot BTC withdrawals")
+	assert.True(t, *spotBTC.Deposit, "GetCurrencyStateSnapshot should preserve spot BTC deposits")
+	assert.False(t, *spotBTC.Trade, "GetCurrencyStateSnapshot should preserve spot BTC trading")
+	futuresBTC, ok := snapshotByKey[snapshotKey{asset: asset.Futures, code: currency.BTC.Item}]
+	require.True(t, ok, "GetCurrencyStateSnapshot must include futures BTC")
+	assert.True(t, *futuresBTC.Withdraw, "GetCurrencyStateSnapshot should preserve futures BTC withdrawals")
+	assert.False(t, *futuresBTC.Deposit, "GetCurrencyStateSnapshot should preserve futures BTC deposits")
+	assert.True(t, *futuresBTC.Trade, "GetCurrencyStateSnapshot should preserve futures BTC trading")
+
+	*spotBTC.Withdraw = false
+	assert.True(t, *spotBTC.Deposit, "GetCurrencyStateSnapshot should return independent option fields")
+	assert.False(t, *spotBTC.Trade, "GetCurrencyStateSnapshot should return independent option fields")
+	assert.True(t, *futuresBTC.Withdraw, "GetCurrencyStateSnapshot should return independent snapshots")
+	btcState := states.m[asset.Spot][currency.BTC.Item].GetState()
+	assert.True(t, *btcState.Withdraw, "GetCurrencyStateSnapshot should not expose internal state pointers")
 }
 
 func TestCanTradePair(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preallocate currency-state snapshot output and compact Boolean backing storage.
- Preserve independent mutable option pointers without exposing lock-protected internal state.
- Add direct nil, empty, multi-asset value-fidelity, and pointer-independence coverage plus a deterministic benchmark.

## Benchmarks

```console
GOMAXPROCS=8 go test ./exchanges/currencystate -run '^$' -bench '^BenchmarkGetCurrencyStateSnapshot$' -benchmem -benchtime=500ms -count=12
```

| States | Latency | Bytes/op | Allocs/op |
| ---: | ---: | ---: | ---: |
| 1 | 198.4 ns → 193.4 ns (no significant change, p=0.104) | 51 B → 51 B | 4 → 2 (-50.00%) |
| 32 | 3.447 µs → 1.686 µs (-51.10%, p<0.001) | 3.422 KiB → 1.844 KiB (-46.12%) | 102 → 2 (-98.04%) |
| 512 | 62.90 µs → 25.36 µs (-59.68%, p<0.001) | 64.83 KiB → 28.12 KiB (-56.62%) | 1546 → 2 (-99.87%) |

Measurements used Go 1.26.5 on Linux/amd64 with an Intel Core i7-6700K and `GOMAXPROCS=8`. The 32- and 512-state workloads split entries across spot and futures maps.

## Validation

- `go test ./exchanges/currencystate -count=20`
- `go test -race ./exchanges/currencystate -count=1`
- `make lint`
- `codespell`
- `make misc_checks`

## Limitations

- This is a deterministic snapshot-construction microbenchmark, not end-to-end RPC latency.
- Map iteration order remains intentionally unspecified, matching existing behaviour.
- Each returned option pointer remains independent, but retaining one snapshot retains the compact per-call Boolean backing store, approximately three bytes per snapshot entry.