### PR TITLE
common/timeperiods: speed up data range matching

### DIFF
--- a/common/timeperiods/timeperiods.go
+++ b/common/timeperiods/timeperiods.go
@@ -33,7 +33,6 @@ func FindTimeRangesContainingData(start, end time.Time, period time.Duration, co
 	t.comparisonTimes = comparisonTimes
 
 	t.setTimePeriodExists()
-	t.Sort(false)
 	t.calculateRanges()
 
 	return t.TimeRanges, nil

--- a/common/timeperiods/timeperiods.go
+++ b/common/timeperiods/timeperiods.go
@@ -130,6 +130,8 @@ func (t *TimePeriodCalculator) setTimePeriodExists() {
 		return
 	}
 	newPeriods := t.TimePeriods[periodOffset:]
+	// Check every period retained from earlier calls because the same
+	// timestamp may appear in more than one previously appended range.
 	for i := range t.comparisonTimes {
 		comparisonTime := t.comparisonTimes[i].Truncate(t.periodDuration)
 		for j := range periodOffset {
@@ -137,7 +139,9 @@ func (t *TimePeriodCalculator) setTimePeriodExists() {
 				t.TimePeriods[j].dataInRange = true
 			}
 		}
-		// calculatePeriods appends in ascending order; binary search also avoids duration overflow across long ranges.
+		// The range appended by calculatePeriods contains one entry per
+		// interval in ascending time order. Find the first period at or after
+		// comparisonTime, then mark it only when the timestamps match exactly.
 		periodIndex := sort.Search(len(newPeriods), func(j int) bool {
 			return !newPeriods[j].Time.Before(comparisonTime)
 		})

--- a/common/timeperiods/timeperiods.go
+++ b/common/timeperiods/timeperiods.go
@@ -125,13 +125,25 @@ func (t *TimePeriodCalculator) calculatePeriods() {
 // against calculated TimePeriods to determine whether
 // there is existing data within the time period
 func (t *TimePeriodCalculator) setTimePeriodExists() {
+	periodOffset := len(t.TimePeriods)
 	t.calculatePeriods()
-	for i := range t.TimePeriods {
-		for j := range t.comparisonTimes {
-			if t.comparisonTimes[j].Truncate(t.periodDuration).Equal(t.TimePeriods[i].Time) {
-				t.TimePeriods[i].dataInRange = true
-				break
+	if len(t.TimePeriods) == 0 {
+		return
+	}
+	newPeriods := t.TimePeriods[periodOffset:]
+	for i := range t.comparisonTimes {
+		comparisonTime := t.comparisonTimes[i].Truncate(t.periodDuration)
+		for j := range periodOffset {
+			if t.TimePeriods[j].Time.Equal(comparisonTime) {
+				t.TimePeriods[j].dataInRange = true
 			}
+		}
+		// calculatePeriods appends in ascending order; binary search also avoids duration overflow across long ranges.
+		periodIndex := sort.Search(len(newPeriods), func(j int) bool {
+			return !newPeriods[j].Time.Before(comparisonTime)
+		})
+		if periodIndex < len(newPeriods) && newPeriods[periodIndex].Time.Equal(comparisonTime) {
+			newPeriods[periodIndex].dataInRange = true
 		}
 	}
 }

--- a/common/timeperiods/timeperiods_bench_test.go
+++ b/common/timeperiods/timeperiods_bench_test.go
@@ -1,0 +1,38 @@
+package timeperiods
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkFindTimeRangesContainingData(b *testing.B) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	sparseComparisonTimes := make([]time.Time, 0, 24*12)
+	for offset := time.Duration(0); offset < end.Sub(start); offset += 5 * time.Minute {
+		sparseComparisonTimes = append(sparseComparisonTimes, start.Add(offset+30*time.Second))
+	}
+	denseComparisonTimes := make([]time.Time, 0, 24*60)
+	for offset := time.Duration(0); offset < end.Sub(start); offset += time.Minute {
+		denseComparisonTimes = append(denseComparisonTimes, start.Add(offset+30*time.Second))
+	}
+	outOfRangeComparisonTimes := make([]time.Time, len(sparseComparisonTimes))
+	for i := range sparseComparisonTimes {
+		outOfRangeComparisonTimes[i] = sparseComparisonTimes[i].Add(-24 * time.Hour)
+	}
+	run := func(b *testing.B, comparisonTimes []time.Time) {
+		b.Helper()
+		b.ReportAllocs()
+		for b.Loop() {
+			_, err := FindTimeRangesContainingData(start, end, time.Minute, comparisonTimes)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("empty", func(b *testing.B) { run(b, nil) })
+	b.Run("sparse", func(b *testing.B) { run(b, sparseComparisonTimes) })
+	b.Run("dense", func(b *testing.B) { run(b, denseComparisonTimes) })
+	b.Run("out-of-range", func(b *testing.B) { run(b, outOfRangeComparisonTimes) })
+}

--- a/common/timeperiods/timeperiods_test.go
+++ b/common/timeperiods/timeperiods_test.go
@@ -82,6 +82,27 @@ func TestFindTimeRangesContainingData(t *testing.T) {
 	assert.Len(t, ranges, 6, "ranges should have 6 time ranges")
 }
 
+func TestFindTimeRangesContainingDataOrderedRanges(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	ranges, err := FindTimeRangesContainingData(
+		start,
+		start.Add(5*time.Minute),
+		time.Minute,
+		[]time.Time{
+			start.Add(3*time.Minute + 30*time.Second),
+			start.Add(30 * time.Second),
+		},
+	)
+	require.NoError(t, err, "FindTimeRangesContainingData must not error")
+	expected := []TimeRange{
+		{StartOfRange: start, EndOfRange: start.Add(time.Minute), HasDataInRange: true},
+		{StartOfRange: start.Add(time.Minute), EndOfRange: start.Add(3 * time.Minute)},
+		{StartOfRange: start.Add(3 * time.Minute), EndOfRange: start.Add(4 * time.Minute), HasDataInRange: true},
+		{StartOfRange: start.Add(4 * time.Minute), EndOfRange: start.Add(5 * time.Minute)},
+	}
+	assert.Equal(t, expected, ranges, "FindTimeRangesContainingData should return correctly ordered ranges")
+}
+
 func TestCalculateTimePeriodsInRange(t *testing.T) {
 	// validation issues
 	_, err := CalculateTimePeriodsInRange(time.Time{}, time.Time{}, 0)
@@ -262,6 +283,24 @@ func TestSetTimePeriodExistsReuse(t *testing.T) {
 		{Time: start},
 		{Time: start.Add(time.Minute), dataInRange: true},
 	}, calculator.TimePeriods, "setTimePeriodExists should preserve matches when reused")
+}
+
+func TestSetTimePeriodExistsReuseWithoutNewPeriods(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	calculator := TimePeriodCalculator{
+		start:          start,
+		end:            start.Add(2 * time.Minute),
+		periodDuration: time.Minute,
+	}
+	calculator.setTimePeriodExists()
+	calculator.start = calculator.end
+	calculator.comparisonTimes = []time.Time{start.Add(time.Minute)}
+	calculator.setTimePeriodExists()
+	expected := []TimePeriod{
+		{Time: start},
+		{Time: start.Add(time.Minute), dataInRange: true},
+	}
+	assert.Equal(t, expected, calculator.TimePeriods, "setTimePeriodExists should match existing periods without calculating new periods")
 }
 
 func TestSort(t *testing.T) {

--- a/common/timeperiods/timeperiods_test.go
+++ b/common/timeperiods/timeperiods_test.go
@@ -141,6 +141,129 @@ func TestValidateCalculatePeriods(t *testing.T) {
 	}
 }
 
+func TestSetTimePeriodExists(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	testCalculator := TimePeriodCalculator{
+		start:          start,
+		end:            start.Add(4 * time.Minute),
+		periodDuration: time.Minute,
+		comparisonTimes: []time.Time{
+			start.Add(-time.Minute),
+			start.Add(30 * time.Second),
+			start.Add(45 * time.Second),
+			start.Add(2*time.Minute + 30*time.Second).In(time.FixedZone("comparison", 10*60*60)),
+			start.Add(4 * time.Minute),
+			start.Add(5 * time.Minute),
+		},
+	}
+	testCalculator.setTimePeriodExists()
+	assert.Equal(t, []TimePeriod{
+		{Time: start, dataInRange: true},
+		{Time: start.Add(time.Minute)},
+		{Time: start.Add(2 * time.Minute), dataInRange: true},
+		{Time: start.Add(3 * time.Minute)},
+	}, testCalculator.TimePeriods, "setTimePeriodExists should match comparison times to the correct periods")
+
+	emptyCalculator := TimePeriodCalculator{
+		start:          start,
+		end:            start.Add(2 * time.Minute),
+		periodDuration: time.Minute,
+	}
+	emptyCalculator.setTimePeriodExists()
+	assert.Equal(t, []TimePeriod{{Time: start}, {Time: start.Add(time.Minute)}}, emptyCalculator.TimePeriods, "setTimePeriodExists should leave periods unmatched without comparison times")
+
+	zeroRangeCalculator := TimePeriodCalculator{
+		start:           start,
+		end:             start,
+		periodDuration:  time.Minute,
+		comparisonTimes: []time.Time{start},
+	}
+	zeroRangeCalculator.setTimePeriodExists()
+	assert.Empty(t, zeroRangeCalculator.TimePeriods, "setTimePeriodExists should leave a zero-length range empty")
+
+	reversedRangeCalculator := TimePeriodCalculator{
+		start:           start.Add(time.Minute),
+		end:             start,
+		periodDuration:  time.Minute,
+		comparisonTimes: []time.Time{start},
+	}
+	reversedRangeCalculator.setTimePeriodExists()
+	assert.Empty(t, reversedRangeCalculator.TimePeriods, "setTimePeriodExists should leave a reversed range empty")
+
+	longRangeStart := time.Date(1700, time.January, 1, 0, 0, 0, 0, time.UTC)
+	longRangeEnd := longRangeStart.AddDate(400, 0, 0)
+	longRangeCalculator := TimePeriodCalculator{
+		start:           longRangeStart,
+		end:             longRangeEnd,
+		periodDuration:  24 * time.Hour,
+		comparisonTimes: []time.Time{longRangeEnd.Add(-time.Hour)},
+	}
+	longRangeCalculator.setTimePeriodExists()
+	matchedPeriods := 0
+	for i := range longRangeCalculator.TimePeriods {
+		if longRangeCalculator.TimePeriods[i].dataInRange {
+			matchedPeriods++
+		}
+	}
+	assert.Equal(t, 1, matchedPeriods, "setTimePeriodExists should match one period across a multi-century range")
+	require.NotEmpty(t, longRangeCalculator.TimePeriods, "setTimePeriodExists must calculate periods across a multi-century range")
+	assert.True(t, longRangeCalculator.TimePeriods[len(longRangeCalculator.TimePeriods)-1].dataInRange, "setTimePeriodExists should match the final period across a multi-century range")
+
+	zeroStartCalculator := TimePeriodCalculator{
+		start:           time.Time{},
+		end:             time.Time{}.Add(time.Minute),
+		periodDuration:  time.Minute,
+		comparisonTimes: []time.Time{time.Time{}.Add(30 * time.Second)},
+	}
+	zeroStartCalculator.setTimePeriodExists()
+	assert.Empty(t, zeroStartCalculator.TimePeriods, "setTimePeriodExists should leave a zero-start range empty")
+
+	truncatedZeroStart := time.Time{}.Add(30 * time.Second)
+	ranges, err := FindTimeRangesContainingData(truncatedZeroStart, truncatedZeroStart.Add(time.Minute), time.Minute, []time.Time{truncatedZeroStart})
+	require.NoError(t, err, "FindTimeRangesContainingData must not error when start truncates to zero")
+	assert.Empty(t, ranges, "FindTimeRangesContainingData should leave a range empty when start truncates to zero")
+}
+
+func TestSetTimePeriodExistsSupportedPeriods(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	secondCalculator := TimePeriodCalculator{
+		start:           start,
+		end:             start.Add(2 * time.Second),
+		periodDuration:  time.Second,
+		comparisonTimes: []time.Time{start},
+	}
+	secondCalculator.setTimePeriodExists()
+	assert.Equal(t, []TimePeriod{{Time: start, dataInRange: true}, {Time: start.Add(time.Second)}}, secondCalculator.TimePeriods, "setTimePeriodExists should match an exact start with a second period")
+
+	hourCalculator := TimePeriodCalculator{
+		start:           start,
+		end:             start.Add(3 * time.Hour),
+		periodDuration:  time.Hour,
+		comparisonTimes: []time.Time{start.Add(90 * time.Minute)},
+	}
+	hourCalculator.setTimePeriodExists()
+	assert.Equal(t, []TimePeriod{{Time: start}, {Time: start.Add(time.Hour), dataInRange: true}, {Time: start.Add(2 * time.Hour)}}, hourCalculator.TimePeriods, "setTimePeriodExists should match the correct hour period")
+}
+
+func TestSetTimePeriodExistsReuse(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	calculator := TimePeriodCalculator{
+		start:           start,
+		end:             start.Add(2 * time.Minute),
+		periodDuration:  time.Minute,
+		comparisonTimes: []time.Time{start},
+	}
+	calculator.setTimePeriodExists()
+	calculator.comparisonTimes = []time.Time{start.Add(time.Minute)}
+	calculator.setTimePeriodExists()
+	assert.Equal(t, []TimePeriod{
+		{Time: start, dataInRange: true},
+		{Time: start.Add(time.Minute), dataInRange: true},
+		{Time: start},
+		{Time: start.Add(time.Minute), dataInRange: true},
+	}, calculator.TimePeriods, "setTimePeriodExists should preserve matches when reused")
+}
+
 func TestSort(t *testing.T) {
 	var tpc TimePeriodCalculator
 	date1 := time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)


### PR DESCRIPTION
## Summary

- replace the nested period/comparison scan in `FindTimeRangesContainingData` with one truncation per comparison and a binary search over generated periods
- remove the redundant post-match sort because generated periods remain in ascending order
- preserve range boundaries, duplicate comparison handling, location-equivalent timestamps, long ranges, and calculator reuse behaviour
- add deterministic benchmarks and direct tests for the matching paths and boundaries

## Benchmarks

Primary range-matching comparison:

`GOMAXPROCS=1 go test ./common/timeperiods -run '^$' -bench '^BenchmarkFindTimeRangesContainingData$' -benchmem -count=15 -benchtime=300ms`

Go 1.26.5, Linux/amd64, Intel Core i7-6700K:

| Case | Baseline | Initial PR head | Change |
| --- | ---: | ---: | ---: |
| empty | 50.27 us/op | 49.11 us/op | -2.31% |
| sparse | 7,772.49 us/op | 94.63 us/op | -98.78% |
| dense | 21,578.6 us/op | 169.3 us/op | -99.22% |
| out-of-range | 8,606.91 us/op | 64.50 us/op | -99.25% |

Each comparison used 15 samples with p <= 0.007. Bytes/op and allocs/op were unchanged in this initial comparison.

Redundant-sort follow-up:

The initial PR head and the same code without `Sort(false)` were compiled and run in alternating order with `GOMAXPROCS=1`, CPU affinity fixed to one core, `-test.benchtime=500ms`, and 10 samples per state.

| Case | Initial PR head | Final PR head | Timing | Allocs/op |
| --- | ---: | ---: | ---: | ---: |
| empty | 105.31 us/op | 96.00 us/op | -8.84% (p=0.035) | 16 -> 13 |
| sparse | 204.5 us/op | 196.8 us/op | ~ (p=0.739) | 25 -> 22 |
| dense | 346.8 us/op | 303.7 us/op | ~ (p=0.280) | 16 -> 13 |
| out-of-range | 141.8 us/op | 131.0 us/op | ~ (p=0.579) | 16 -> 13 |

The timing geomean improved by 8.23%. Every workload saved exactly 3 allocs/op and 104 B/op; the allocation and byte reductions were stable across all samples (p < 0.001).

## Test plan

- `go test ./common/timeperiods -count=20`
- `go test -race ./common/timeperiods -count=1`
- `go test ./common/timeperiods -count=1 -coverprofile=coverage.out`
- `go vet ./common/timeperiods`
- `golangci-lint run ./...`
- `codespell`
- `make misc_checks`

## Limitations

These results are from a deterministic package microbenchmark using a 24-hour range divided into one-minute periods. They do not measure end-to-end RPC, database, or exchange latency. WSL2 timing variance was high in the redundant-sort comparison, so only the empty timing case reached individual significance; the allocation and byte reductions were stable across every sample.
