### PR TITLE
kline: Support exchange interval suffixes and add ParseInterval

### DIFF
--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -226,32 +226,100 @@ func (i Interval) Short() string {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Intervals
-// It does not validate the duration is aligned, only that it is a parsable duration
+// It is retained alongside UnmarshalText because encoding/json rejects bare numbers for
+// types implementing encoding.TextUnmarshaler, and stored configs record intervals as a
+// nanosecond count
 func (i *Interval) UnmarshalJSON(text []byte) error {
-	text = bytes.Trim(text, `"`)
-	if string(text) == "raw" {
+	return i.UnmarshalText(text)
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for Intervals
+// It does not validate the duration is aligned, only that it is a parsable duration
+// A bare integer is interpreted as a nanosecond count, matching Interval's underlying type
+func (i *Interval) UnmarshalText(text []byte) error {
+	s := string(bytes.Trim(text, `"`))
+	if s == "raw" {
 		*i = Raw
 		return nil
 	}
-	if len(bytes.TrimLeft(text, `0123456789`)) > 0 { // contains non-numerics, ParseDuration can handle errors
-		d, err := time.ParseDuration(string(text))
+	if s == "" {
+		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
+	}
+	if strings.TrimLeft(s, `0123456789`) == "" { // Bare nanosecond count
+		n, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return err
-		}
-		*i = Interval(d)
-	} else {
-		n, err := strconv.ParseInt(string(text), 10, 64)
-		if err != nil {
-			return err
+			return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
 		}
 		*i = Interval(n)
+		return nil
 	}
+	return i.parseDuration(s)
+}
+
+// parseDuration parses an interval with a unit suffix, extending time.ParseDuration
+// with the day, week and month units that exchanges commonly use
+// Units are case-insensitive apart from a bare "M", which exchanges use for month to
+// distinguish it from "m" for minute
+func (i *Interval) parseDuration(s string) error {
+	if d, err := time.ParseDuration(s); err == nil {
+		*i = Interval(d)
+		return nil
+	}
+
+	split := strings.IndexFunc(s, func(r rune) bool { return r < '0' || r > '9' })
+	if split <= 0 { // No leading count, so there is nothing to scale the unit by
+		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
+	}
+
+	n, err := strconv.ParseInt(s[:split], 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
+	}
+
+	unit := s[split:]
+	if unit == "M" { // Resolve month before folding case would make it ambiguous with minute
+		unit = "month"
+	}
+
+	var scale Interval
+	switch strings.ToLower(unit) {
+	case "s", "sec", "secs", "second", "seconds":
+		scale = Interval(time.Second)
+	case "m", "min", "mins", "minute", "minutes":
+		scale = OneMin
+	case "h", "hr", "hrs", "hour", "hours":
+		scale = OneHour
+	case "d", "day", "days":
+		scale = OneDay
+	case "w", "wk", "wks", "week", "weeks":
+		scale = OneWeek
+	case "mo", "month", "months":
+		scale = OneMonth
+	default:
+		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
+	}
+
+	*i = Interval(n) * scale
+
 	return nil
 }
 
 // MarshalText implements the TextMarshaler interface for Intervals
 func (i Interval) MarshalText() ([]byte, error) {
 	return []byte(i.Short()), nil
+}
+
+// ParseInterval converts an exchange interval string into an Interval
+// Raw is rejected because callers requesting candles require a positive interval
+func ParseInterval(text string) (Interval, error) {
+	var i Interval
+	if err := i.UnmarshalText([]byte(text)); err != nil {
+		return 0, err
+	}
+	if i <= 0 {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidInterval, text)
+	}
+	return i, nil
 }
 
 // addPadding inserts padding time aligned when exchanges do not supply all data

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -226,31 +227,25 @@ func (i Interval) Short() string {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Intervals
-// It is retained alongside UnmarshalText because encoding/json rejects bare numbers for
-// types implementing encoding.TextUnmarshaler, and stored configs record intervals as a
-// nanosecond count
+// A bare number is a nanosecond count, which stored strategy configs record and which
+// encoding/json would otherwise reject for a type implementing encoding.TextUnmarshaler
+// A nanosecond count is not a valid exchange interval, so UnmarshalText deliberately does
+// not accept one: exchanges use bare numbers for their own interval codes, such as
+// Bybit's "60" for one hour
 func (i *Interval) UnmarshalJSON(text []byte) error {
+	if n, err := strconv.ParseInt(string(bytes.Trim(text, `"`)), 10, 64); err == nil {
+		*i = Interval(n)
+		return nil
+	}
 	return i.UnmarshalText(text)
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface for Intervals
 // It does not validate the duration is aligned, only that it is a parsable duration
-// A bare integer is interpreted as a nanosecond count, matching Interval's underlying type
 func (i *Interval) UnmarshalText(text []byte) error {
 	s := string(bytes.Trim(text, `"`))
 	if s == "raw" {
 		*i = Raw
-		return nil
-	}
-	if s == "" {
-		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
-	}
-	if strings.TrimLeft(s, `0123456789`) == "" { // Bare nanosecond count
-		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
-		}
-		*i = Interval(n)
 		return nil
 	}
 	return i.parseDuration(s)
@@ -297,6 +292,10 @@ func (i *Interval) parseDuration(s string) error {
 		scale = OneMonth
 	default:
 		return fmt.Errorf("%w: %q", ErrInvalidInterval, s)
+	}
+
+	if n > int64(math.MaxInt64)/int64(scale) { // Interval is int64 nanoseconds, so scaling must not wrap
+		return fmt.Errorf("%w: %q overflows", ErrInvalidInterval, s)
 	}
 
 	*i = Interval(n) * scale

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -230,9 +230,9 @@ func (i Interval) Short() string {
 // An unquoted JSON number is a nanosecond count, which stored strategy configs record and
 // which encoding/json would otherwise reject for a type implementing
 // encoding.TextUnmarshaler
-// A quoted value is interval text and is never read as a nanosecond count, because
-// exchanges quote their own numeric interval codes: Bybit sends "60" for one hour and "5"
-// for five minutes, which as nanoseconds would be silently wrong
+// A quoted value is treated as duration text. Bare numeric exchange codes,
+// such as Bybit's "60" for one hour, are rejected rather than interpreted as nanoseconds 
+// and must be mapped by the exchange implementation.
 func (i *Interval) UnmarshalJSON(text []byte) error {
 	if n, err := strconv.ParseInt(string(text), 10, 64); err == nil {
 		*i = Interval(n)

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -227,13 +227,14 @@ func (i Interval) Short() string {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Intervals
-// A bare number is a nanosecond count, which stored strategy configs record and which
-// encoding/json would otherwise reject for a type implementing encoding.TextUnmarshaler
-// A nanosecond count is not a valid exchange interval, so UnmarshalText deliberately does
-// not accept one: exchanges use bare numbers for their own interval codes, such as
-// Bybit's "60" for one hour
+// An unquoted JSON number is a nanosecond count, which stored strategy configs record and
+// which encoding/json would otherwise reject for a type implementing
+// encoding.TextUnmarshaler
+// A quoted value is interval text and is never read as a nanosecond count, because
+// exchanges quote their own numeric interval codes: Bybit sends "60" for one hour and "5"
+// for five minutes, which as nanoseconds would be silently wrong
 func (i *Interval) UnmarshalJSON(text []byte) error {
-	if n, err := strconv.ParseInt(string(bytes.Trim(text, `"`)), 10, 64); err == nil {
+	if n, err := strconv.ParseInt(string(text), 10, 64); err == nil {
 		*i = Interval(n)
 		return nil
 	}

--- a/exchanges/kline/kline.go
+++ b/exchanges/kline/kline.go
@@ -231,7 +231,7 @@ func (i Interval) Short() string {
 // which encoding/json would otherwise reject for a type implementing
 // encoding.TextUnmarshaler
 // A quoted value is treated as duration text. Bare numeric exchange codes,
-// such as Bybit's "60" for one hour, are rejected rather than interpreted as nanoseconds 
+// such as Bybit's "60" for one hour, are rejected rather than interpreted as nanoseconds
 // and must be mapped by the exchange implementation.
 func (i *Interval) UnmarshalJSON(text []byte) error {
 	if n, err := strconv.ParseInt(string(text), 10, 64); err == nil {

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1534,6 +1534,12 @@ func TestIntervalJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`{"interval":720000000000}`), &s), "Unmarshal must not error on a bare nanosecond count")
 	assert.Equal(t, OneMin*12, s.Interval, "Unmarshal should parse a bare nanosecond count")
 
+	// Quoted values are interval text, never a nanosecond count; exchanges quote their own
+	// numeric interval codes, such as Bybit's "60" for one hour
+	for _, in := range []string{`{"interval":"60"}`, `{"interval":"5"}`, `{"interval":"720000000000"}`} {
+		assert.ErrorIsf(t, json.Unmarshal([]byte(in), &s), ErrInvalidInterval, "Unmarshal should error on the quoted numeric code in %s", in)
+	}
+
 	s.Interval = FourHour
 	b, err := json.Marshal(&s)
 	require.NoError(t, err, "Marshal must not error")

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1437,6 +1437,8 @@ func TestUnmarshalText(t *testing.T) {
 	}{
 		{`"3m"`, ThreeMin},
 		{`"15s"`, FifteenSecond},
+		{`"30sec"`, ThirtySecond},
+		{`"10seconds"`, TenSecond},
 		{`"-1ns"`, Raw},
 		{`"raw"`, Raw},
 		{`"1h"`, OneHour},
@@ -1487,7 +1489,8 @@ func TestParseIntervalRejectsExchangeCodes(t *testing.T) {
 // and so would pass the non-positive check
 func TestParseIntervalOverflow(t *testing.T) {
 	t.Parallel()
-	for _, in := range []string{"106752d", "2147483647d", "15251w", "3559mo", "9223372036854775807mo"} {
+	// The last count exceeds int64 itself, failing before it reaches the scaling guard
+	for _, in := range []string{"106752d", "2147483647d", "15251w", "3559mo", "9223372036854775807mo", "99999999999999999999d"} {
 		_, err := ParseInterval(in)
 		assert.ErrorIsf(t, err, ErrInvalidInterval, "ParseInterval should error on overflowing input %q", in)
 	}

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -1437,7 +1437,6 @@ func TestUnmarshalText(t *testing.T) {
 	}{
 		{`"3m"`, ThreeMin},
 		{`"15s"`, FifteenSecond},
-		{`720000000000`, OneMin * 12},
 		{`"-1ns"`, Raw},
 		{`"raw"`, Raw},
 		{`"1h"`, OneHour},
@@ -1459,11 +1458,44 @@ func TestUnmarshalText(t *testing.T) {
 
 func TestUnmarshalTextError(t *testing.T) {
 	t.Parallel()
-	for _, in := range []string{``, `""`, `"m"`, `"hedgehogs"`, `"6hedgehogs"`, `"1x"`, `"99999999999999999999"`} {
+	for _, in := range []string{
+		``, `""`, `"m"`, `"hedgehogs"`, `"6hedgehogs"`, `"1x"`, `"99999999999999999999"`,
+		// Bare counts are exchange interval codes, not nanoseconds; only UnmarshalJSON accepts them
+		`"60"`, `"720000000000"`,
+		// Scaling these would wrap int64 nanoseconds
+		`"106752d"`, `"2147483647d"`, `"15251w"`, `"9223372036854775807mo"`,
+	} {
 		var i Interval
 		err := i.UnmarshalText([]byte(in))
 		assert.ErrorIsf(t, err, ErrInvalidInterval, "UnmarshalText should error on %q", in)
 	}
+}
+
+// TestParseIntervalRejectsExchangeCodes covers bare exchange interval codes, which must not
+// be mistaken for a nanosecond count; Bybit uses "60" for one hour and "D"/"W"/"M" for the
+// longer intervals
+func TestParseIntervalRejectsExchangeCodes(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"60", "120", "240", "D", "W"} {
+		_, err := ParseInterval(in)
+		assert.ErrorIsf(t, err, ErrInvalidInterval, "ParseInterval should error on the bare exchange code %q", in)
+	}
+}
+
+// TestParseIntervalOverflow ensures unit scaling that would wrap int64 nanoseconds is
+// rejected rather than yielding a wrapped interval, which for some inputs stays positive
+// and so would pass the non-positive check
+func TestParseIntervalOverflow(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"106752d", "2147483647d", "15251w", "3559mo", "9223372036854775807mo"} {
+		_, err := ParseInterval(in)
+		assert.ErrorIsf(t, err, ErrInvalidInterval, "ParseInterval should error on overflowing input %q", in)
+	}
+
+	// The largest day count that still fits is accepted
+	i, err := ParseInterval("106751d")
+	require.NoError(t, err, "ParseInterval must not error on the largest representable day count")
+	assert.Equal(t, 106751*OneDay, i, "ParseInterval should parse the largest representable day count")
 }
 
 func TestParseInterval(t *testing.T) {

--- a/exchanges/kline/kline_test.go
+++ b/exchanges/kline/kline_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/database/repository/candle"
 	"github.com/thrasher-corp/gocryptotrader/database/repository/exchange"
 	"github.com/thrasher-corp/gocryptotrader/database/testhelpers"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/order"
 )
@@ -1428,16 +1429,81 @@ func TestGetIntervalResultLimit(t *testing.T) {
 	}
 }
 
-func TestUnmarshalJSON(t *testing.T) {
+func TestUnmarshalText(t *testing.T) {
 	t.Parallel()
-	var i Interval
 	for _, tt := range []struct {
 		in  string
 		exp Interval
-	}{{`"3m"`, ThreeMin}, {`"15s"`, FifteenSecond}, {`720000000000`, OneMin * 12}, {`"-1ns"`, Raw}, {`"raw"`, Raw}} {
-		err := i.UnmarshalJSON([]byte(tt.in))
-		assert.NoErrorf(t, err, "UnmarshalJSON should not error on %q", tt.in)
+	}{
+		{`"3m"`, ThreeMin},
+		{`"15s"`, FifteenSecond},
+		{`720000000000`, OneMin * 12},
+		{`"-1ns"`, Raw},
+		{`"raw"`, Raw},
+		{`"1h"`, OneHour},
+		{`"1h30m"`, OneHour + ThirtyMin},
+		{`"1d"`, OneDay},
+		{`"1w"`, OneWeek},
+		{`"7days"`, OneWeek},
+		{`"1M"`, OneMonth},
+		{`"2mo"`, 2 * OneMonth},
+		{`"1m"`, OneMin},
+		{`"5MIN"`, 5 * OneMin},
+		{`"12Hours"`, TwelveHour},
+	} {
+		var i Interval
+		require.NoErrorf(t, i.UnmarshalText([]byte(tt.in)), "UnmarshalText must not error on %q", tt.in)
+		assert.Equalf(t, tt.exp, i, "UnmarshalText should parse %q correctly", tt.in)
 	}
-	err := i.UnmarshalJSON([]byte(`"6hedgehogs"`))
-	assert.ErrorContains(t, err, "unknown unit", "UnmarshalJSON should error")
+}
+
+func TestUnmarshalTextError(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{``, `""`, `"m"`, `"hedgehogs"`, `"6hedgehogs"`, `"1x"`, `"99999999999999999999"`} {
+		var i Interval
+		err := i.UnmarshalText([]byte(in))
+		assert.ErrorIsf(t, err, ErrInvalidInterval, "UnmarshalText should error on %q", in)
+	}
+}
+
+func TestParseInterval(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		in  string
+		exp Interval
+	}{{"1m", OneMin}, {"1M", OneMonth}, {"4h", FourHour}, {"1d", OneDay}} {
+		i, err := ParseInterval(tt.in)
+		require.NoErrorf(t, err, "ParseInterval must not error on %q", tt.in)
+		assert.Equalf(t, tt.exp, i, "ParseInterval should parse %q correctly", tt.in)
+	}
+
+	// Raw and other non-positive intervals are not valid candle intervals
+	for _, in := range []string{"raw", "-1ns", "0", "hedgehogs"} {
+		_, err := ParseInterval(in)
+		assert.ErrorIsf(t, err, ErrInvalidInterval, "ParseInterval should error on %q", in)
+	}
+}
+
+// TestIntervalJSON ensures Interval still round-trips through encoding/json now that it
+// also implements TextUnmarshaler, in particular the bare nanosecond counts that stored
+// strategy configs record
+func TestIntervalJSON(t *testing.T) {
+	t.Parallel()
+	var s struct {
+		Interval Interval `json:"interval"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(`{"interval":"1M"}`), &s), "Unmarshal must not error on a quoted interval")
+	assert.Equal(t, OneMonth, s.Interval, "Unmarshal should parse a quoted interval")
+
+	require.NoError(t, json.Unmarshal([]byte(`{"interval":720000000000}`), &s), "Unmarshal must not error on a bare nanosecond count")
+	assert.Equal(t, OneMin*12, s.Interval, "Unmarshal should parse a bare nanosecond count")
+
+	s.Interval = FourHour
+	b, err := json.Marshal(&s)
+	require.NoError(t, err, "Marshal must not error")
+	assert.JSONEq(t, `{"interval":"4h"}`, string(b), "Marshal should emit the short form")
+
+	require.NoError(t, json.Unmarshal(b, &s), "Unmarshal must not error on marshalled output")
+	assert.Equal(t, FourHour, s.Interval, "Interval should round-trip through JSON")
 }


### PR DESCRIPTION
## Summary

Exchanges express candle intervals with unit suffixes that time.ParseDuration does not understand: days, weeks and months. Every exchange wrapper therefore carries its own string-to-Interval mapping, typically a long switch listing each supported interval individually.

This adds that parsing to the kline package itself:

- Interval now implements encoding.TextUnmarshaler, so intervals parse from any text-based decoder rather than JSON alone, and pairs with the existing MarshalText.
- parseDuration extends time.ParseDuration with day, week and month units, accepting the common long and short spellings (d/day/days, w/wk/week/weeks, mo/month/months). Months use the package's existing OneMonth definition of 30 days.
- Units are case-insensitive, except that a bare "M" resolves to month before case folding, preserving the exchange convention that distinguishes it from "m" for minute.
- ParseInterval exports the same parsing for callers holding an exchange interval string. It rejects Raw and other non-positive values, since a caller requesting candles requires a positive interval.

Parse failures now return ErrInvalidInterval wrapped with the offending input, rather than propagating time.ParseDuration's error verbatim, giving callers a stable sentinel to match on.

UnmarshalJSON is retained and delegates to UnmarshalText. It cannot simply be removed: once a type implements encoding.TextUnmarshaler, encoding/json routes values through it and rejects bare JSON numbers, and every shipped .strat strategy config records its interval as a nanosecond count ("interval": 86400000000000). Dropping it would fail to load all of them.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Validation

The previous TestUnmarshalJSON iterated a table of expected values but only asserted that no error occurred, so it would not have caught a wrong result. Its replacements assert the parsed value, and cover the new units, the M/m month-minute distinction, case folding, and the ErrInvalidInterval paths.

TestIntervalJSON covers the round trip through encoding/json in both forms, guarding the bare nanosecond counts the strategy configs depend on.