### PR TITLE
KuCoin: harden private state, tickers, and order submission

### DIFF
--- a/exchanges/kucoin/kucoin.go
+++ b/exchanges/kucoin/kucoin.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -31,7 +32,9 @@ import (
 // Exchange implements exchange.IBotExchange and contains additional specific api methods for interacting with Kucoin
 type Exchange struct {
 	exchange.Base
-	wsOBUpdateMgr *buffer.UpdateManager
+	wsOBUpdateMgr            *buffer.UpdateManager
+	futuresPositionModeMtx   sync.Mutex
+	futuresPositionModeCache map[string]cachedFuturesPositionMode
 }
 
 const (
@@ -1421,8 +1424,11 @@ func (e *Exchange) SendPlaceMarginHFOrder(ctx context.Context, arg *PlaceMarginH
 			return nil, limits.ErrAmountBelowMin
 		}
 	case arg.OrderType == order.Market.Lower():
-		if arg.Size <= 0 && arg.Funds == "" {
-			return nil, errSizeOrFundIsRequired
+		switch {
+		case arg.Size < 0:
+			return nil, limits.ErrAmountBelowMin
+		case arg.Size == 0 && arg.Funds == "", arg.Size > 0 && arg.Funds != "":
+			return nil, fmt.Errorf("%w: either size or funds must be set, but not both", errSizeOrFundIsRequired)
 		}
 	default:
 		return nil, fmt.Errorf("%w: %s", order.ErrTypeIsInvalid, arg.OrderType)

--- a/exchanges/kucoin/kucoin.go
+++ b/exchanges/kucoin/kucoin.go
@@ -1399,24 +1399,33 @@ func (e *Exchange) PlaceMarginHFOrderTest(ctx context.Context, arg *PlaceMarginH
 
 // SendPlaceMarginHFOrder applies a high-frequency margin order placement or tests the order placement process.
 func (e *Exchange) SendPlaceMarginHFOrder(ctx context.Context, arg *PlaceMarginHFOrderParam, path string) (*MarginHFOrderResponse, error) {
-	if *arg == (PlaceMarginHFOrderParam{}) {
+	if arg == nil || *arg == (PlaceMarginHFOrderParam{}) {
 		return nil, common.ErrNilPointer
 	}
 	if arg.ClientOrderID == "" {
-		return nil, order.ErrClientOrderIDNotSupported
-	}
-	if arg.Side == "" {
-		return nil, order.ErrSideIsInvalid
+		return nil, order.ErrClientOrderIDMustBeSet
 	}
 	arg.Side = strings.ToLower(arg.Side)
+	if arg.Side != order.Buy.Lower() && arg.Side != order.Sell.Lower() {
+		return nil, order.ErrSideIsInvalid
+	}
 	if arg.Symbol.IsEmpty() {
 		return nil, currency.ErrCurrencyPairEmpty
 	}
-	if arg.Price <= 0 {
-		return nil, limits.ErrPriceBelowMin
-	}
-	if arg.Size <= 0 {
-		return nil, limits.ErrAmountBelowMin
+	switch {
+	case arg.OrderType == order.Limit.Lower():
+		if arg.Price <= 0 {
+			return nil, limits.ErrPriceBelowMin
+		}
+		if arg.Size <= 0 {
+			return nil, limits.ErrAmountBelowMin
+		}
+	case arg.OrderType == order.Market.Lower():
+		if arg.Size <= 0 && arg.Funds == "" {
+			return nil, errSizeOrFundIsRequired
+		}
+	default:
+		return nil, fmt.Errorf("%w: %s", order.ErrTypeIsInvalid, arg.OrderType)
 	}
 	var resp *MarginHFOrderResponse
 	return resp, e.SendAuthHTTPRequest(ctx, exchange.RestSpot, placeMarginOrderEPL, http.MethodPost, path, arg, &resp)
@@ -2587,7 +2596,7 @@ func (e *Exchange) AccountToTradeTypeString(a asset.Item, marginMode string) str
 	case asset.Spot:
 		return SpotTradeType
 	case asset.Margin:
-		if strings.EqualFold(marginMode, "isolated") {
+		if strings.EqualFold(marginMode, kucoinIsolated) {
 			return IsolatedMarginTradeType
 		}
 		return CrossMarginTradeType

--- a/exchanges/kucoin/kucoin_futures.go
+++ b/exchanges/kucoin/kucoin_futures.go
@@ -31,11 +31,17 @@ const (
 
 	kucoinOneWayPositionMode = 0
 	kucoinHedgePositionMode  = 1
+
+	futuresPositionModeCacheDuration = 30 * time.Second
 )
 
+type cachedFuturesPositionMode struct {
+	mode      FuturesPositionMode
+	expiresAt time.Time
+}
+
 // GetFuturesPositionMode returns the account-level KuCoin futures position
-// mode. It deliberately avoids caching because credentials and account mode can
-// change independently of an Exchange instance.
+// mode directly from KuCoin.
 func (e *Exchange) GetFuturesPositionMode(ctx context.Context) (FuturesPositionMode, error) {
 	var resp *FuturesPositionModeResponse
 	if err := e.SendAuthHTTPRequest(
@@ -60,6 +66,34 @@ func (e *Exchange) GetFuturesPositionMode(ctx context.Context) (FuturesPositionM
 	default:
 		return FuturesPositionModeUnknown, fmt.Errorf("%w: %s", errInvalidFuturesPositionMode, resp.PositionMode)
 	}
+}
+
+// getCachedFuturesPositionMode bounds order-submission latency while keeping
+// mode changes and context-carried credentials isolated to a short cache window.
+func (e *Exchange) getCachedFuturesPositionMode(ctx context.Context) (FuturesPositionMode, error) {
+	creds, err := e.GetCredentials(ctx)
+	if err != nil {
+		return FuturesPositionModeUnknown, err
+	}
+
+	e.futuresPositionModeMtx.Lock()
+	defer e.futuresPositionModeMtx.Unlock()
+	if cached, ok := e.futuresPositionModeCache[creds.Key]; ok && time.Now().Before(cached.expiresAt) {
+		return cached.mode, nil
+	}
+
+	mode, err := e.GetFuturesPositionMode(ctx)
+	if err != nil {
+		return FuturesPositionModeUnknown, err
+	}
+	if e.futuresPositionModeCache == nil {
+		e.futuresPositionModeCache = make(map[string]cachedFuturesPositionMode)
+	}
+	e.futuresPositionModeCache[creds.Key] = cachedFuturesPositionMode{
+		mode:      mode,
+		expiresAt: time.Now().Add(futuresPositionModeCacheDuration),
+	}
+	return mode, nil
 }
 
 // GetFuturesOpenContracts gets all open futures contract with its details

--- a/exchanges/kucoin/kucoin_futures.go
+++ b/exchanges/kucoin/kucoin_futures.go
@@ -28,7 +28,39 @@ const (
 
 	kucoinFuturesOrder     = "/v1/orders"
 	kucoinFuturesStopOrder = "/v1/stopOrders"
+
+	kucoinOneWayPositionMode = 0
+	kucoinHedgePositionMode  = 1
 )
+
+// GetFuturesPositionMode returns the account-level KuCoin futures position
+// mode. It deliberately avoids caching because credentials and account mode can
+// change independently of an Exchange instance.
+func (e *Exchange) GetFuturesPositionMode(ctx context.Context) (FuturesPositionMode, error) {
+	var resp *FuturesPositionModeResponse
+	if err := e.SendAuthHTTPRequest(
+		ctx,
+		exchange.RestFutures,
+		futuresPositionModeEPL,
+		http.MethodGet,
+		"/v2/position/getPositionMode",
+		nil,
+		&resp,
+	); err != nil {
+		return FuturesPositionModeUnknown, err
+	}
+	if resp == nil {
+		return FuturesPositionModeUnknown, common.ErrNoResponse
+	}
+	switch resp.PositionMode.Int64() {
+	case kucoinOneWayPositionMode:
+		return FuturesPositionModeOneWay, nil
+	case kucoinHedgePositionMode:
+		return FuturesPositionModeHedge, nil
+	default:
+		return FuturesPositionModeUnknown, fmt.Errorf("%w: %s", errInvalidFuturesPositionMode, resp.PositionMode)
+	}
+}
 
 // GetFuturesOpenContracts gets all open futures contract with its details
 func (e *Exchange) GetFuturesOpenContracts(ctx context.Context) ([]Contract, error) {
@@ -390,6 +422,16 @@ func (e *Exchange) FillFuturesPostOrderArgumentFilter(arg *FuturesOrderParam) er
 		}
 	default:
 		return fmt.Errorf("%w, order type= %s", order.ErrTypeIsInvalid, arg.OrderType)
+	}
+	switch arg.MarginMode {
+	case kucoinIsolatedMarginMode, kucoinCrossMarginMode:
+	default:
+		return fmt.Errorf("%w: %s", errInvalidFuturesMarginMode, arg.MarginMode)
+	}
+	switch arg.PositionSide {
+	case kucoinBothPositionSide, kucoinLongPositionSide, kucoinShortPositionSide:
+	default:
+		return fmt.Errorf("%w: %s", errInvalidFuturesPositionSide, arg.PositionSide)
 	}
 	return nil
 }

--- a/exchanges/kucoin/kucoin_futures.go
+++ b/exchanges/kucoin/kucoin_futures.go
@@ -52,7 +52,7 @@ func (e *Exchange) GetFuturesPositionMode(ctx context.Context) (FuturesPositionM
 	if resp == nil {
 		return FuturesPositionModeUnknown, common.ErrNoResponse
 	}
-	switch resp.PositionMode.Int64() {
+	switch resp.PositionMode {
 	case kucoinOneWayPositionMode:
 		return FuturesPositionModeOneWay, nil
 	case kucoinHedgePositionMode:

--- a/exchanges/kucoin/kucoin_futures.go
+++ b/exchanges/kucoin/kucoin_futures.go
@@ -382,7 +382,7 @@ func (e *Exchange) PostFuturesOrderTest(ctx context.Context, arg *FuturesOrderPa
 
 // FillFuturesPostOrderArgumentFilter verifies futures order request parameters
 func (e *Exchange) FillFuturesPostOrderArgumentFilter(arg *FuturesOrderParam) error {
-	if *arg == (FuturesOrderParam{}) {
+	if arg == nil || *arg == (FuturesOrderParam{}) {
 		return common.ErrNilPointer
 	}
 	if arg.Leverage <= 0 {

--- a/exchanges/kucoin/kucoin_ratelimit.go
+++ b/exchanges/kucoin/kucoin_ratelimit.go
@@ -172,6 +172,7 @@ const (
 	futuresOpenOrderStatsEPL
 	futuresPositionEPL
 	futuresPositionListEPL
+	futuresPositionModeEPL
 	setAutoDepositMarginEPL
 	maxWithdrawMarginEPL
 	removeMarginManuallyEPL
@@ -383,6 +384,7 @@ func GetRateLimit() request.RateLimitDefinitions {
 		futuresOpenOrderStatsEPL:                      request.GetRateLimiterWithWeight(futuresRate, 10),
 		futuresPositionEPL:                            request.GetRateLimiterWithWeight(futuresRate, 2),
 		futuresPositionListEPL:                        request.GetRateLimiterWithWeight(futuresRate, 2),
+		futuresPositionModeEPL:                        request.GetRateLimiterWithWeight(futuresRate, 2),
 		setAutoDepositMarginEPL:                       request.GetRateLimiterWithWeight(futuresRate, 4),
 		maxWithdrawMarginEPL:                          request.GetRateLimiterWithWeight(futuresRate, 10),
 		removeMarginManuallyEPL:                       request.GetRateLimiterWithWeight(futuresRate, 10),

--- a/exchanges/kucoin/kucoin_ratelimit_test.go
+++ b/exchanges/kucoin/kucoin_ratelimit_test.go
@@ -164,6 +164,7 @@ func TestRateLimit_LimitStatic(t *testing.T) {
 		"futures Open Order Stats":                         futuresOpenOrderStatsEPL,
 		"futures Position":                                 futuresPositionEPL,
 		"futures Position List":                            futuresPositionListEPL,
+		"futures Position Mode":                            futuresPositionModeEPL,
 		"set Auto Deposit Margin":                          setAutoDepositMarginEPL,
 		"max Withdraw Margin":                              maxWithdrawMarginEPL,
 		"remove Margin Manually":                           removeMarginManuallyEPL,

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -1686,7 +1686,9 @@ func TestPostFuturesOrder(t *testing.T) {
 
 func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 	t.Parallel()
-	err := e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy"})
+	err := e.FillFuturesPostOrderArgumentFilter(nil)
+	require.ErrorIs(t, err, common.ErrNilPointer)
+	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy"})
 	require.ErrorIs(t, err, errInvalidLeverage)
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{Side: "buy", Leverage: 1})
 	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
@@ -1728,6 +1730,16 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 		Size: 1, Price: 1000, Leverage: 1,
 	})
 	require.ErrorIs(t, err, errInvalidFuturesMarginMode)
+	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit",
+		Size: 1, Price: 1000, Leverage: 1, VisibleSize: -1,
+	})
+	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
+	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "unsupported",
+		Size: 1, Price: 1000, Leverage: 1,
+	})
+	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
 
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit",
@@ -2847,6 +2859,26 @@ func TestSubmitMarginOrder(t *testing.T) {
 	require.Equal(t, order.GoodTillCancel.String(), payload["timeInForce"], "timeInForce must be a plain API string")
 	require.Equal(t, "1", payload["price"], "price must be encoded as a decimal string")
 	require.Equal(t, "1", payload["size"], "size must be encoded as a decimal string")
+
+	payload = nil
+	result, err = ku.SubmitOrder(t.Context(), &order.Submit{
+		Side:          order.Sell,
+		AssetType:     asset.Margin,
+		Pair:          marginTradablePair,
+		Type:          order.Market,
+		Amount:        2,
+		MarginType:    margin.Multi,
+		ClientOrderID: "market-order-id",
+		AutoBorrow:    true,
+	})
+	require.NoError(t, err, "SubmitOrder must support margin market orders")
+	require.NotNil(t, result, "SubmitOrder must return a market order response")
+	assert.Equal(t, true, payload["autoBorrow"], "market order should auto-borrow when requested")
+	assert.NotContains(t, payload, "autoRepay", "market order should omit disabled auto-repay")
+	assert.NotContains(t, payload, "isIsolated", "cross-margin order should omit isolated mode")
+	assert.NotContains(t, payload, "price", "market order should omit price")
+	assert.NotContains(t, payload, "timeInForce", "market order should omit time in force")
+	assert.Equal(t, "2", payload["size"], "market order size should be encoded as a decimal string")
 }
 
 func TestCancelOrder(t *testing.T) {

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -3,11 +3,13 @@ package kucoin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2716,6 +2718,43 @@ func TestGetFuturesPositionMode(t *testing.T) {
 	}
 }
 
+func TestGetCachedFuturesPositionMode(t *testing.T) {
+	t.Parallel()
+
+	ku := testInstance(t)
+	ku.SkipAuthCheck = true
+	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, err := w.Write([]byte(`{"code":"200000","data":{"positionMode":0}}`))
+		assert.NoError(t, err, "writing position mode response should not error")
+	}))
+	t.Cleanup(server.Close)
+	require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+	require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+	for range 2 {
+		mode, err := ku.getCachedFuturesPositionMode(t.Context())
+		require.NoError(t, err, "getCachedFuturesPositionMode must not error")
+		require.Equal(t, FuturesPositionModeOneWay, mode, "getCachedFuturesPositionMode must return the API position mode")
+	}
+	require.Equal(t, int32(1), requestCount.Load(), "a valid cached mode must prevent a duplicate API request")
+
+	ku.futuresPositionModeCache[mockAPIKey] = cachedFuturesPositionMode{
+		mode:      FuturesPositionModeOneWay,
+		expiresAt: time.Now().Add(-time.Second),
+	}
+	_, err := ku.getCachedFuturesPositionMode(t.Context())
+	require.NoError(t, err, "an expired position mode must be refreshed without error")
+	require.Equal(t, int32(2), requestCount.Load(), "an expired position mode must trigger a new API request")
+
+	ku.SetCredentials(&accounts.Credentials{Key: "another-key", Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+	_, err = ku.getCachedFuturesPositionMode(t.Context())
+	require.NoError(t, err, "a different credential must retrieve its own position mode")
+	require.Equal(t, int32(3), requestCount.Load(), "position modes must be cached per API key")
+}
+
 func TestFuturesPositionModeString(t *testing.T) {
 	t.Parallel()
 
@@ -2774,48 +2813,97 @@ func TestFuturesPositionSide(t *testing.T) {
 func TestSubmitFuturesOrder(t *testing.T) {
 	t.Parallel()
 
-	ku := testInstance(t)
-	ku.SkipAuthCheck = true
-	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+	testCases := []struct {
+		name                 string
+		positionMode         int
+		reduceOnly           bool
+		expectedPositionSide string
+		expectedReduceOnly   bool
+	}{
+		{name: "one-way reduction", positionMode: kucoinOneWayPositionMode, reduceOnly: true, expectedPositionSide: kucoinBothPositionSide, expectedReduceOnly: true},
+		{name: "hedge reduction", positionMode: kucoinHedgePositionMode, reduceOnly: true, expectedPositionSide: kucoinLongPositionSide},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	var payload map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var response string
-		switch r.URL.Path {
-		case "/api/v2/position/getPositionMode":
-			assert.Equal(t, http.MethodGet, r.Method, "position mode request method should be correct")
-			response = `{"code":"200000","data":{"positionMode":0}}`
-		case "/api/v1/orders":
-			assert.Equal(t, http.MethodPost, r.Method, "futures order request method should be correct")
-			body, err := io.ReadAll(r.Body)
-			assert.NoError(t, err, "ReadAll should not error")
-			assert.NoError(t, json.Unmarshal(body, &payload), "Unmarshal should not error")
-			response = `{"code":"200000","data":{"orderId":"order-id"}}`
-		default:
-			assert.Fail(t, "unexpected request path", r.URL.Path)
-		}
-		_, err := w.Write([]byte(response))
-		assert.NoError(t, err, "writing futures order response should not error")
-	}))
-	t.Cleanup(server.Close)
-	require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
-	require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
+			ku := testInstance(t)
+			ku.SkipAuthCheck = true
+			ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+			var payload map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var response string
+				switch r.URL.Path {
+				case "/api/v2/position/getPositionMode":
+					assert.Equal(t, http.MethodGet, r.Method, "position mode request method should be correct")
+					response = fmt.Sprintf(`{"code":"200000","data":{"positionMode":%d}}`, tc.positionMode)
+				case "/api/v1/orders":
+					assert.Equal(t, http.MethodPost, r.Method, "futures order request method should be correct")
+					body, err := io.ReadAll(r.Body)
+					assert.NoError(t, err, "ReadAll should not error")
+					assert.NoError(t, json.Unmarshal(body, &payload), "Unmarshal should not error")
+					response = `{"code":"200000","data":{"orderId":"order-id"}}`
+				default:
+					assert.Fail(t, "unexpected request path", r.URL.Path)
+				}
+				_, err := w.Write([]byte(response))
+				assert.NoError(t, err, "writing futures order response should not error")
+			}))
+			t.Cleanup(server.Close)
+			require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+			require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
 
-	result, err := ku.SubmitOrder(t.Context(), &order.Submit{
-		Side:          order.Short,
-		AssetType:     asset.Futures,
-		Pair:          futuresTradablePair,
-		Type:          order.Market,
-		Amount:        3,
-		Leverage:      1,
-		MarginType:    margin.Isolated,
-		ClientOrderID: "client-order-id",
+			result, err := ku.SubmitOrder(t.Context(), &order.Submit{
+				Side:          order.Short,
+				AssetType:     asset.Futures,
+				Pair:          futuresTradablePair,
+				Type:          order.Market,
+				Amount:        3,
+				Leverage:      1,
+				MarginType:    margin.Isolated,
+				ClientOrderID: "client-order-id",
+				ReduceOnly:    tc.reduceOnly,
+			})
+			require.NoError(t, err, "SubmitOrder must not error")
+			require.NotNil(t, result, "SubmitOrder must return a response")
+			require.Equal(t, "order-id", result.OrderID, "OrderID must be correct")
+			require.Equal(t, kucoinIsolatedMarginMode, payload["marginMode"], "payload must select isolated margin")
+			require.Equal(t, tc.expectedPositionSide, payload["positionSide"], "payload must select the expected position side")
+			if tc.expectedReduceOnly {
+				require.Equal(t, true, payload["reduceOnly"], "payload must retain reduceOnly in one-way mode")
+			} else {
+				require.NotContains(t, payload, "reduceOnly", "payload must omit reduceOnly in hedge mode")
+			}
+		})
+	}
+
+	t.Run("invalid order avoids position mode request", func(t *testing.T) {
+		t.Parallel()
+
+		ku := testInstance(t)
+		ku.SkipAuthCheck = true
+		ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+		var requestCount atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			requestCount.Add(1)
+		}))
+		t.Cleanup(server.Close)
+		require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+		require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+		_, err := ku.SubmitOrder(t.Context(), &order.Submit{
+			Side:          order.Short,
+			AssetType:     asset.Futures,
+			Pair:          futuresTradablePair,
+			Type:          order.ConditionalStop,
+			Amount:        3,
+			Leverage:      1,
+			MarginType:    margin.Isolated,
+			ClientOrderID: "client-order-id",
+		})
+		require.ErrorIs(t, err, order.ErrUnsupportedOrderType, "SubmitOrder must reject the unsupported order type")
+		require.Zero(t, requestCount.Load(), "invalid orders must not request the account position mode")
 	})
-	require.NoError(t, err, "SubmitOrder must not error")
-	require.NotNil(t, result, "SubmitOrder must return a response")
-	require.Equal(t, "order-id", result.OrderID, "OrderID must be correct")
-	require.Equal(t, kucoinIsolatedMarginMode, payload["marginMode"], "payload must select isolated margin")
-	require.Equal(t, kucoinBothPositionSide, payload["positionSide"], "payload must select one-way position mode")
 }
 
 func TestSubmitMarginOrder(t *testing.T) {
@@ -3890,6 +3978,15 @@ func TestSendPlaceMarginHFOrder(t *testing.T) {
 
 	arg.OrderType = order.Market.Lower()
 	arg.Price = 0
+	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
+	require.ErrorIs(t, err, errSizeOrFundIsRequired)
+
+	arg.Size = -1
+	arg.Funds = "1"
+	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
+	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
+
+	arg.Size = 1
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, errSizeOrFundIsRequired)
 }

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -3,7 +3,10 @@ package kucoin
 import (
 	"context"
 	"errors"
+	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -35,7 +38,12 @@ import (
 )
 
 // Please supply your own keys here to do authenticated endpoint testing
-const canManipulateRealOrders = false
+const (
+	canManipulateRealOrders = false
+	mockAPIKey              = "key"
+	mockAPISecret           = "secret"
+	mockAPIPassphrase       = "passphrase"
+)
 
 // Please supply your own credentials here to do authenticated endpoint testing
 var apiCredentials = &accounts.Credentials{
@@ -1623,7 +1631,8 @@ func TestPostFuturesOrder(t *testing.T) {
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	result, err := e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1,
+		MarginMode: kucoinIsolatedMarginMode, PositionSide: kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -1638,7 +1647,7 @@ func TestPostFuturesOrder(t *testing.T) {
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	result, err = e.PostFuturesOrder(t.Context(), &FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+		Size: 1, Price: 1000, Leverage: 1, MarginMode: kucoinIsolatedMarginMode, PositionSide: kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -1668,7 +1677,8 @@ func TestPostFuturesOrder(t *testing.T) {
 		Price:         1000,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0,
+		MarginMode:    kucoinIsolatedMarginMode,
+		PositionSide:  kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -1700,7 +1710,8 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+		Stop: "up", StopPriceType: "TP", StopPrice: 123456, TimeInForce: "", Size: 1, Price: 1000, Leverage: 1,
+		MarginMode: kucoinIsolatedMarginMode, PositionSide: kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 
@@ -1714,9 +1725,15 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
 		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit", Remark: "10",
-		Size: 1, Price: 1000, Leverage: 1, VisibleSize: 0,
+		Size: 1, Price: 1000, Leverage: 1,
 	})
-	assert.NoError(t, err)
+	require.ErrorIs(t, err, errInvalidFuturesMarginMode)
+
+	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
+		ClientOrderID: "5bd6e9286d99522a52e458de", Side: "buy", Symbol: futuresTradablePair, OrderType: "limit",
+		Size: 1, Price: 1000, Leverage: 1, MarginMode: kucoinIsolatedMarginMode,
+	})
+	require.ErrorIs(t, err, errInvalidFuturesPositionSide)
 
 	// Market Orders
 	err = e.FillFuturesPostOrderArgumentFilter(&FuturesOrderParam{
@@ -1743,7 +1760,8 @@ func TestFillFuturesPostOrderArgumentFilter(t *testing.T) {
 		Price:         1000,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0,
+		MarginMode:    kucoinIsolatedMarginMode,
+		PositionSide:  kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 }
@@ -1763,7 +1781,8 @@ func TestPostFuturesOrderTest(t *testing.T) {
 		Size:          1,
 		StopPrice:     0,
 		Leverage:      1,
-		VisibleSize:   0,
+		MarginMode:    kucoinIsolatedMarginMode,
+		PositionSide:  kucoinBothPositionSide,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
@@ -1784,6 +1803,8 @@ func TestPlaceMultipleFuturesOrders(t *testing.T) {
 			Price:         2150,
 			Size:          2,
 			Leverage:      1,
+			MarginMode:    kucoinIsolatedMarginMode,
+			PositionSide:  kucoinBothPositionSide,
 		},
 		{
 			ClientOrderID: "5c52e11203aa677f33e492",
@@ -1793,6 +1814,8 @@ func TestPlaceMultipleFuturesOrders(t *testing.T) {
 			Price:         32150,
 			Size:          2,
 			Leverage:      1,
+			MarginMode:    kucoinIsolatedMarginMode,
+			PositionSide:  kucoinBothPositionSide,
 		},
 	})
 	assert.NoError(t, err)
@@ -2518,9 +2541,13 @@ func TestSubmitOrder(t *testing.T) {
 	_, err := e.SubmitOrder(t.Context(), orderSubmission)
 	require.ErrorIs(t, err, asset.ErrNotSupported)
 
-	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
 	orderSubmission.AssetType = asset.Futures
 	orderSubmission.Pair = futuresTradablePair
+	_, err = e.SubmitOrder(t.Context(), orderSubmission)
+	require.ErrorIs(t, err, margin.ErrInvalidMarginType)
+
+	sharedtestvalues.SkipTestIfCredentialsUnset(t, e, canManipulateRealOrders)
+	orderSubmission.MarginType = margin.Isolated
 	result, err := e.SubmitOrder(t.Context(), orderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -2590,6 +2617,198 @@ func TestSubmitOrder(t *testing.T) {
 	result, err = e.SubmitOrder(t.Context(), marginOrderSubmission)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
+}
+
+func TestGetFuturesPositionMode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		response    string
+		expected    FuturesPositionMode
+		expectedErr error
+		anyError    bool
+	}{
+		{name: "one-way", response: `{"code":"200000","data":{"positionMode":0}}`, expected: FuturesPositionModeOneWay},
+		{name: "hedge", response: `{"code":"200000","data":{"positionMode":1}}`, expected: FuturesPositionModeHedge},
+		{name: "invalid", response: `{"code":"200000","data":{"positionMode":2}}`, expectedErr: errInvalidFuturesPositionMode},
+		{name: "no response", response: `{"code":"200000","data":null}`, expectedErr: common.ErrNoResponse},
+		{name: "malformed response", response: `{`, anyError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ku := testInstance(t)
+			ku.SkipAuthCheck = true
+			ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method, "position mode request method should be correct")
+				assert.Equal(t, "/api/v2/position/getPositionMode", r.URL.Path, "position mode request path should be correct")
+				_, err := w.Write([]byte(tc.response))
+				assert.NoError(t, err, "writing position mode response should not error")
+			}))
+			t.Cleanup(server.Close)
+			require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+			require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+			mode, err := ku.GetFuturesPositionMode(t.Context())
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr, "GetFuturesPositionMode must return the expected error")
+				require.Equal(t, FuturesPositionModeUnknown, mode, "invalid responses must not return a position mode")
+				return
+			}
+			if tc.anyError {
+				require.Error(t, err, "GetFuturesPositionMode must return an error")
+				require.Equal(t, FuturesPositionModeUnknown, mode, "invalid responses must not return a position mode")
+				return
+			}
+			require.NoError(t, err, "GetFuturesPositionMode must not error")
+			require.Equal(t, tc.expected, mode, "GetFuturesPositionMode must return the API position mode")
+		})
+	}
+}
+
+func TestFuturesPositionModeString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		mode     FuturesPositionMode
+		expected string
+	}{
+		{name: "unknown", mode: FuturesPositionModeUnknown, expected: "unknown"},
+		{name: "one-way", mode: FuturesPositionModeOneWay, expected: "one-way"},
+		{name: "hedge", mode: FuturesPositionModeHedge, expected: "hedge"},
+		{name: "invalid", mode: FuturesPositionMode(99), expected: "unknown"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.mode.String(), "String must return the expected position mode")
+		})
+	}
+}
+
+func TestFuturesPositionSide(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		mode        FuturesPositionMode
+		side        order.Side
+		reduceOnly  bool
+		expected    string
+		expectedErr error
+	}{
+		{name: "one-way short", mode: FuturesPositionModeOneWay, side: order.Short, expected: kucoinBothPositionSide},
+		{name: "hedge increase short", mode: FuturesPositionModeHedge, side: order.Short, expected: kucoinShortPositionSide},
+		{name: "hedge increase long", mode: FuturesPositionModeHedge, side: order.Long, expected: kucoinLongPositionSide},
+		{name: "hedge reduce short", mode: FuturesPositionModeHedge, side: order.Long, reduceOnly: true, expected: kucoinShortPositionSide},
+		{name: "hedge reduce long", mode: FuturesPositionModeHedge, side: order.Short, reduceOnly: true, expected: kucoinLongPositionSide},
+		{name: "unknown mode", mode: FuturesPositionModeUnknown, side: order.Short, expectedErr: errInvalidFuturesPositionMode},
+		{name: "invalid side", mode: FuturesPositionModeHedge, side: order.AnySide, expectedErr: order.ErrSideIsInvalid},
+		{name: "one-way invalid side", mode: FuturesPositionModeOneWay, side: order.AnySide, expectedErr: order.ErrSideIsInvalid},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := futuresPositionSide(tc.mode, tc.side, tc.reduceOnly)
+			require.ErrorIs(t, err, tc.expectedErr, "futuresPositionSide must return the expected error")
+			require.Equal(t, tc.expected, actual, "futuresPositionSide must return the expected side")
+		})
+	}
+}
+
+func TestSubmitFuturesOrder(t *testing.T) {
+	t.Parallel()
+
+	ku := testInstance(t)
+	ku.SkipAuthCheck = true
+	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response string
+		switch r.URL.Path {
+		case "/api/v2/position/getPositionMode":
+			assert.Equal(t, http.MethodGet, r.Method, "position mode request method should be correct")
+			response = `{"code":"200000","data":{"positionMode":0}}`
+		case "/api/v1/orders":
+			assert.Equal(t, http.MethodPost, r.Method, "futures order request method should be correct")
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err, "ReadAll should not error")
+			assert.NoError(t, json.Unmarshal(body, &payload), "Unmarshal should not error")
+			response = `{"code":"200000","data":{"orderId":"order-id"}}`
+		default:
+			assert.Fail(t, "unexpected request path", r.URL.Path)
+		}
+		_, err := w.Write([]byte(response))
+		assert.NoError(t, err, "writing futures order response should not error")
+	}))
+	t.Cleanup(server.Close)
+	require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+	require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestFutures.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+	result, err := ku.SubmitOrder(t.Context(), &order.Submit{
+		Side:          order.Short,
+		AssetType:     asset.Futures,
+		Pair:          futuresTradablePair,
+		Type:          order.Market,
+		Amount:        3,
+		Leverage:      1,
+		MarginType:    margin.Isolated,
+		ClientOrderID: "client-order-id",
+	})
+	require.NoError(t, err, "SubmitOrder must not error")
+	require.NotNil(t, result, "SubmitOrder must return a response")
+	require.Equal(t, "order-id", result.OrderID, "OrderID must be correct")
+	require.Equal(t, kucoinIsolatedMarginMode, payload["marginMode"], "payload must select isolated margin")
+	require.Equal(t, kucoinBothPositionSide, payload["positionSide"], "payload must select one-way position mode")
+}
+
+func TestSubmitMarginOrder(t *testing.T) {
+	t.Parallel()
+
+	ku := testInstance(t)
+	ku.SkipAuthCheck = true
+	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "margin order request method should be correct")
+		assert.Equal(t, "/api/v3/hf/margin/order", r.URL.Path, "margin order request path should use the supported HF endpoint")
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err, "ReadAll should not error")
+		assert.NoError(t, json.Unmarshal(body, &payload), "Unmarshal should not error")
+		_, err = w.Write([]byte(`{"code":"200000","data":{"orderId":"order-id","borrowSize":0,"loanApplyId":"loan-id"}}`))
+		assert.NoError(t, err, "writing margin order response should not error")
+	}))
+	t.Cleanup(server.Close)
+	require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+	require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+	result, err := ku.SubmitOrder(t.Context(), &order.Submit{
+		Side:          order.Buy,
+		AssetType:     asset.Margin,
+		Pair:          marginTradablePair,
+		Type:          order.Limit,
+		Price:         1,
+		Amount:        1,
+		MarginType:    margin.Isolated,
+		ClientOrderID: "client-order-id",
+		AutoRepay:     true,
+	})
+	require.NoError(t, err, "SubmitOrder must not error")
+	require.NotNil(t, result, "SubmitOrder must return a response")
+	require.Equal(t, "order-id", result.OrderID, "OrderID must be correct")
+	require.Equal(t, true, payload["autoRepay"], "payload must auto-repay when AutoRepay is true")
+	require.NotContains(t, payload, "autoBorrow", "payload must not auto-borrow when AutoBorrow is false")
+	require.Equal(t, true, payload["isIsolated"], "payload must select isolated margin")
+	require.Equal(t, order.GoodTillCancel.String(), payload["timeInForce"], "timeInForce must be a plain API string")
+	require.Equal(t, "1", payload["price"], "price must be encoded as a decimal string")
+	require.Equal(t, "1", payload["size"], "size must be encoded as a decimal string")
 }
 
 func TestCancelOrder(t *testing.T) {
@@ -2854,6 +3073,50 @@ func getFirstTradablePairOfAssets(ctx context.Context) {
 
 func TestUpdateAccountBalances(t *testing.T) {
 	t.Parallel()
+	testCases := []struct {
+		name          string
+		assetType     asset.Item
+		expectedFree  float64
+		expectedHold  float64
+		expectedTotal float64
+	}{
+		{name: "spot", assetType: asset.Spot, expectedFree: 11, expectedHold: 2, expectedTotal: 13},
+		{name: "margin", assetType: asset.Margin, expectedFree: 12.5, expectedHold: 2.5, expectedTotal: 15},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name+" account families", func(t *testing.T) {
+			t.Parallel()
+
+			ku := testInstance(t)
+			ku.SkipAuthCheck = true
+			ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/v1/accounts", r.URL.Path, "account request path should be correct")
+				_, err := w.Write([]byte(`{"code":"200000","data":[` +
+					`{"currency":"USDT","type":"main","balance":"100","available":"100","holds":"0"},` +
+					`{"currency":"USDT","type":"trade","balance":"10","available":"8","holds":"2"},` +
+					`{"currency":"USDT","type":"trade_hf","balance":"3","available":"3","holds":"0"},` +
+					`{"currency":"USDT","type":"margin","balance":"5","available":"4","holds":"1"},` +
+					`{"currency":"USDT","type":"margin_v2","balance":"7","available":"6","holds":"1"},` +
+					`{"currency":"USDT","type":"isolated","balance":"2","available":"1.5","holds":"0.5"},` +
+					`{"currency":"USDT","type":"isolated_v2","balance":"1","available":"1","holds":"0"}]}`))
+				assert.NoError(t, err, "writing account response should not error")
+			}))
+			t.Cleanup(server.Close)
+			require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+			require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+			result, err := ku.UpdateAccountBalances(t.Context(), tc.assetType)
+			require.NoError(t, err, "UpdateAccountBalances must not error")
+			require.Len(t, result, 1, "UpdateAccountBalances must return one sub-account")
+			balance, ok := result[0].Balances[currency.USDT]
+			require.True(t, ok, "UpdateAccountBalances must return the USDT balance")
+			require.InDelta(t, tc.expectedTotal, balance.Total, 1e-12, "total must aggregate matching account families")
+			require.InDelta(t, tc.expectedFree, balance.Free, 1e-12, "free must aggregate matching account families")
+			require.InDelta(t, tc.expectedHold, balance.Hold, 1e-12, "hold must aggregate matching account families")
+		})
+	}
+
 	sharedtestvalues.SkipTestIfCredentialsUnset(t, e)
 	assetTypes := e.GetAssetTypes(true)
 	for _, assetType := range assetTypes {
@@ -3525,12 +3788,15 @@ func TestGetOCOOrderList(t *testing.T) {
 
 func TestSendPlaceMarginHFOrder(t *testing.T) {
 	t.Parallel()
-	_, err := e.SendPlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{}, "")
+	_, err := e.SendPlaceMarginHFOrder(t.Context(), nil, "")
+	require.ErrorIs(t, err, common.ErrNilPointer)
+
+	_, err = e.SendPlaceMarginHFOrder(t.Context(), &PlaceMarginHFOrderParam{}, "")
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	arg := &PlaceMarginHFOrderParam{PostOnly: true}
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
-	require.ErrorIs(t, err, order.ErrClientOrderIDNotSupported)
+	require.ErrorIs(t, err, order.ErrClientOrderIDMustBeSet)
 
 	arg.ClientOrderID = "first-order"
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
@@ -3542,11 +3808,20 @@ func TestSendPlaceMarginHFOrder(t *testing.T) {
 
 	arg.Symbol = marginTradablePair
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
+	require.ErrorIs(t, err, order.ErrTypeIsInvalid)
+
+	arg.OrderType = order.Limit.Lower()
+	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, limits.ErrPriceBelowMin)
 
 	arg.Price = 1000
 	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
 	require.ErrorIs(t, err, limits.ErrAmountBelowMin)
+
+	arg.OrderType = order.Market.Lower()
+	arg.Price = 0
+	_, err = e.SendPlaceMarginHFOrder(t.Context(), arg, "")
+	require.ErrorIs(t, err, errSizeOrFundIsRequired)
 }
 
 func TestPlaceMarginHFOrder(t *testing.T) {
@@ -4039,7 +4314,7 @@ func TestMarginModeToString(t *testing.T) {
 		MarginMode margin.Type
 		Result     string
 	}{
-		{MarginMode: margin.Isolated, Result: "isolated"},
+		{MarginMode: margin.Isolated, Result: kucoinIsolated},
 		{MarginMode: margin.Multi, Result: "cross"},
 		{MarginMode: margin.Unknown, Result: ""},
 	}
@@ -4057,11 +4332,11 @@ func TestAccountToTradeTypeString(t *testing.T) {
 		Result      string
 	}{
 		{AccountType: asset.Margin, MarginMode: "cross", Result: "MARGIN_TRADE"},
-		{AccountType: asset.Margin, MarginMode: "isolated", Result: "MARGIN_ISOLATED_TRADE"},
+		{AccountType: asset.Margin, MarginMode: kucoinIsolated, Result: "MARGIN_ISOLATED_TRADE"},
 		{AccountType: asset.Spot, MarginMode: "cross", Result: SpotTradeType},
-		{AccountType: asset.Spot, MarginMode: "isolated", Result: SpotTradeType},
-		{AccountType: asset.Futures, MarginMode: "isolated", Result: ""},
-		{AccountType: asset.Futures, MarginMode: "isolated", Result: ""},
+		{AccountType: asset.Spot, MarginMode: kucoinIsolated, Result: SpotTradeType},
+		{AccountType: asset.Futures, MarginMode: kucoinIsolated, Result: ""},
+		{AccountType: asset.Futures, MarginMode: kucoinIsolated, Result: ""},
 	}
 	for a := range accountToTradeTypeResults {
 		result := e.AccountToTradeTypeString(accountToTradeTypeResults[a].AccountType, accountToTradeTypeResults[a].MarginMode)

--- a/exchanges/kucoin/kucoin_test.go
+++ b/exchanges/kucoin/kucoin_test.go
@@ -2196,25 +2196,58 @@ func TestMergeRoundedOrderbookLevels(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	for _, a := range e.GetAssetTypes(true) {
-		err := e.UpdateTickers(t.Context(), a)
-		assert.NoError(t, err)
 
-		pairs, err := e.GetEnabledPairs(a)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, pairs)
+	t.Run("enabled pairs", func(t *testing.T) {
+		t.Parallel()
+		for _, a := range e.GetAssetTypes(true) {
+			err := e.UpdateTickers(t.Context(), a)
+			assert.NoError(t, err)
 
-		for _, p := range pairs {
-			tick, err := ticker.GetTicker(e.Name, p, a)
-			if assert.NoError(t, err) {
-				assert.Positivef(t, tick.Last, "%s %s Tick Last should be positive", a, p)
-				assert.NotEmptyf(t, tick.Pair, "%s %s Tick Pair should not be empty", a, p)
-				assert.Equalf(t, e.Name, tick.ExchangeName, "ExchangeName should be correct")
-				assert.Equalf(t, a, tick.AssetType, "AssetType should be correct")
-				assert.NotEmptyf(t, tick.LastUpdated, "%s %s Tick LastUpdated should not be empty", a, p)
+			pairs, err := e.GetEnabledPairs(a)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, pairs)
+
+			for _, p := range pairs {
+				tick, err := ticker.GetTicker(e.Name, p, a)
+				if assert.NoError(t, err) {
+					assert.Positivef(t, tick.Last, "%s %s Tick Last should be positive", a, p)
+					assert.NotEmptyf(t, tick.Pair, "%s %s Tick Pair should not be empty", a, p)
+					assert.Equalf(t, e.Name, tick.ExchangeName, "ExchangeName should be correct")
+					assert.Equalf(t, a, tick.AssetType, "AssetType should be correct")
+					assert.NotEmptyf(t, tick.LastUpdated, "%s %s Tick LastUpdated should not be empty", a, p)
+				}
 			}
 		}
-	}
+	})
+
+	t.Run("available pairs", func(t *testing.T) {
+		t.Parallel()
+
+		ku := testInstance(t)
+		ku.Name += "-AvailableTickers"
+		availablePair := currency.NewBTCUSDT()
+		enabledPair := currency.NewPair(currency.ETH, currency.USDT)
+		require.NoError(t, ku.UpdatePairs(currency.Pairs{availablePair, enabledPair}, asset.Spot, false), "UpdatePairs must set available pairs")
+		require.NoError(t, ku.UpdatePairs(currency.Pairs{enabledPair}, asset.Spot, true), "UpdatePairs must set enabled pairs")
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v1/market/allTickers", r.URL.Path, "ticker request path should be correct")
+			_, err := w.Write([]byte(`{"code":"200000","data":{"time":1784868353683,"ticker":[` +
+				`{"symbol":"BTC-USDT","symbolName":"BTC-USDT","buy":"99","sell":"101","high":"110","low":"90","vol":"12","last":"100"},` +
+				`{"symbol":"DOGE-USDT","symbolName":"DOGE-USDT","buy":"0.1","sell":"0.2","high":"0.3","low":"0.05","vol":"20","last":"0.15"}]}}`))
+			assert.NoError(t, err, "writing ticker response should not error")
+		}))
+		t.Cleanup(server.Close)
+		require.NoError(t, ku.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+		require.NoError(t, ku.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api"), "SetRunningURL must not error")
+
+		require.NoError(t, ku.UpdateTickers(t.Context(), asset.Spot), "UpdateTickers must process all available pairs")
+		price, err := ticker.GetTicker(ku.Name, availablePair, asset.Spot)
+		require.NoError(t, err, "GetTicker must return a disabled but available pair")
+		assert.Equal(t, float64(100), price.Last, "available pair ticker price should match")
+		_, err = ticker.GetTicker(ku.Name, currency.NewPair(currency.DOGE, currency.USDT), asset.Spot)
+		assert.Error(t, err, "unavailable pair should not be cached")
+	})
 }
 
 func TestUpdateTicker(t *testing.T) {
@@ -2632,6 +2665,7 @@ func TestGetFuturesPositionMode(t *testing.T) {
 		{name: "one-way", response: `{"code":"200000","data":{"positionMode":0}}`, expected: FuturesPositionModeOneWay},
 		{name: "hedge", response: `{"code":"200000","data":{"positionMode":1}}`, expected: FuturesPositionModeHedge},
 		{name: "invalid", response: `{"code":"200000","data":{"positionMode":2}}`, expectedErr: errInvalidFuturesPositionMode},
+		{name: "fractional", response: `{"code":"200000","data":{"positionMode":0.5}}`, expectedErr: errInvalidFuturesPositionMode},
 		{name: "no response", response: `{"code":"200000","data":null}`, expectedErr: common.ErrNoResponse},
 		{name: "malformed response", response: `{`, anyError: true},
 	}
@@ -2715,7 +2749,11 @@ func TestFuturesPositionSide(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			actual, err := futuresPositionSide(tc.mode, tc.side, tc.reduceOnly)
-			require.ErrorIs(t, err, tc.expectedErr, "futuresPositionSide must return the expected error")
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr, "futuresPositionSide must return the expected error")
+			} else {
+				require.NoError(t, err, "futuresPositionSide must not error")
+			}
 			require.Equal(t, tc.expected, actual, "futuresPositionSide must return the expected side")
 		})
 	}

--- a/exchanges/kucoin/kucoin_types.go
+++ b/exchanges/kucoin/kucoin_types.go
@@ -56,7 +56,42 @@ var (
 	errPageSizeRequired           = errors.New("pageSize is required")
 	errCurrentPageRequired        = errors.New("current page value is required")
 	errTimeoutRequired            = errors.New("timeout value required")
+	errInvalidFuturesPositionMode = errors.New("invalid futures position mode")
+	errInvalidFuturesMarginMode   = errors.New("invalid futures margin mode")
+	errInvalidFuturesPositionSide = errors.New("invalid futures position side")
 )
+
+// FuturesPositionMode identifies how a KuCoin futures account represents
+// directional positions.
+type FuturesPositionMode uint8
+
+const (
+	// FuturesPositionModeUnknown indicates that the position mode is unavailable.
+	FuturesPositionModeUnknown FuturesPositionMode = iota
+	// FuturesPositionModeOneWay uses a single net position and positionSide BOTH.
+	FuturesPositionModeOneWay
+	// FuturesPositionModeHedge keeps independent LONG and SHORT positions.
+	FuturesPositionModeHedge
+
+	kucoinIsolatedMarginMode = "ISOLATED"
+	kucoinCrossMarginMode    = "CROSS"
+	kucoinBothPositionSide   = "BOTH"
+	kucoinLongPositionSide   = "LONG"
+	kucoinShortPositionSide  = "SHORT"
+	kucoinIsolated           = "isolated"
+)
+
+// String returns a human-readable futures position mode.
+func (m FuturesPositionMode) String() string {
+	switch m {
+	case FuturesPositionModeOneWay:
+		return "one-way"
+	case FuturesPositionModeHedge:
+		return "hedge"
+	default:
+		return "unknown"
+	}
+}
 
 // UnmarshalTo acts as interface to exchange API response
 type UnmarshalTo interface {
@@ -775,7 +810,7 @@ type StopOrder struct {
 type AccountInfo struct {
 	ID          string        `json:"id"`
 	Currency    currency.Code `json:"currency"`
-	AccountType string        `json:"type"` // Account type: main, trade, trade_hf, margin
+	AccountType string        `json:"type"` // Account type: main, trade, trade_hf, margin, margin_v2, isolated, isolated_v2
 	Balance     types.Number  `json:"balance"`
 	Available   types.Number  `json:"available"`
 	Holds       types.Number  `json:"holds"`
@@ -1867,12 +1902,19 @@ type FuturesFundingHistoryResponse struct {
 	HasMore  bool                    `json:"hasMore"`
 }
 
-// FuturesOrderParam represents a query parameter for placing future oorder
+// FuturesPositionModeResponse represents the account-level futures position mode.
+type FuturesPositionModeResponse struct {
+	PositionMode types.Number `json:"positionMode"`
+}
+
+// FuturesOrderParam represents a query parameter for placing a futures order
 type FuturesOrderParam struct {
 	ClientOrderID string        `json:"clientOid"`
 	Side          string        `json:"side"`
 	Symbol        currency.Pair `json:"symbol"`
 	Leverage      float64       `json:"leverage,string"`
+	MarginMode    string        `json:"marginMode"`
+	PositionSide  string        `json:"positionSide"`
 
 	Size  float64 `json:"size,omitempty,string"`
 	Price float64 `json:"price,string,omitempty"`
@@ -2026,13 +2068,13 @@ type PlaceMarginHFOrderParam struct {
 	IsIsolated          bool          `json:"isIsolated,omitempty"`
 	AutoBorrow          bool          `json:"autoBorrow,omitempty"`
 	AutoRepay           bool          `json:"autoRepay,omitempty"`
-	Price               float64       `json:"price,string"`
-	Size                float64       `json:"size,string"`
-	TimeInForce         string        `json:"timeInForce,omitempty,string"`
-	CancelAfter         int64         `json:"cancelAfter,omitempty,string"`
-	PostOnly            bool          `json:"postOnly,omitempty,string"`
-	Hidden              bool          `json:"hidden,omitempty,string"`
-	Iceberg             bool          `json:"iceberg,omitempty,string"`
+	Price               float64       `json:"price,omitempty,string"`
+	Size                float64       `json:"size,omitempty,string"`
+	TimeInForce         string        `json:"timeInForce,omitempty"`
+	CancelAfter         int64         `json:"cancelAfter,omitempty"`
+	PostOnly            bool          `json:"postOnly,omitempty"`
+	Hidden              bool          `json:"hidden,omitempty"`
+	Iceberg             bool          `json:"iceberg,omitempty"`
 	VisibleSize         float64       `json:"visibleSize,omitempty,string"`
 	Funds               string        `json:"funds,omitempty"`
 }

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -634,13 +634,26 @@ func (e *Exchange) processAccountBalanceChange(ctx context.Context, respData []b
 	if accountAsset == asset.Empty {
 		return e.Websocket.DataHandler.Send(ctx, &resp)
 	}
-	subAccts := accounts.SubAccounts{accounts.NewSubAccount(accountAsset, "")}
-	subAccts[0].Balances.Set(resp.Currency, accounts.Balance{
+	balance := accounts.Balance{
 		Total:     resp.Total,
 		Hold:      resp.Hold,
 		Free:      resp.Available,
 		UpdatedAt: resp.Time.Time(),
-	})
+	}
+	creds, err := e.GetCredentials(ctx)
+	if err != nil {
+		return err
+	}
+	current, err := e.Accounts.GetBalance("", creds, accountAsset, resp.Currency)
+	if err == nil {
+		balance.Total = current.Total + resp.AvailableChange + resp.HoldChange
+		balance.Hold = current.Hold + resp.HoldChange
+		balance.Free = current.Free + resp.AvailableChange
+	} else if !errors.Is(err, accounts.ErrNoBalances) && !errors.Is(err, common.ErrNilPointer) {
+		return err
+	}
+	subAccts := accounts.SubAccounts{accounts.NewSubAccount(accountAsset, "")}
+	subAccts[0].Balances.Set(resp.Currency, balance)
 	if err := e.Accounts.Save(ctx, subAccts, false); err != nil {
 		return err
 	}

--- a/exchanges/kucoin/kucoin_websocket.go
+++ b/exchanges/kucoin/kucoin_websocket.go
@@ -186,7 +186,7 @@ func (e *Exchange) wsHandleData(ctx context.Context, conn websocket.Connection, 
 	if resp.Type == "pong" || resp.Type == "welcome" {
 		return nil
 	}
-	if resp.ID != "" {
+	if resp.ID != "" && resp.Topic == "" {
 		return conn.RequireMatchWithData(resp.ID, respData)
 	}
 
@@ -630,7 +630,11 @@ func (e *Exchange) processAccountBalanceChange(ctx context.Context, respData []b
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return err
 	}
-	subAccts := accounts.SubAccounts{accounts.NewSubAccount(asset.Futures, "")}
+	accountAsset := accountBalanceAsset(resp.RelationEvent)
+	if accountAsset == asset.Empty {
+		return e.Websocket.DataHandler.Send(ctx, &resp)
+	}
+	subAccts := accounts.SubAccounts{accounts.NewSubAccount(accountAsset, "")}
 	subAccts[0].Balances.Set(resp.Currency, accounts.Balance{
 		Total:     resp.Total,
 		Hold:      resp.Hold,
@@ -641,6 +645,22 @@ func (e *Exchange) processAccountBalanceChange(ctx context.Context, respData []b
 		return err
 	}
 	return e.Websocket.DataHandler.Send(ctx, subAccts)
+}
+
+// accountBalanceAsset maps KuCoin account families to GCT assets while leaving
+// funding and unknown accounts unclassified so their raw events remain visible.
+func accountBalanceAsset(accountTypeOrEvent string) asset.Item {
+	accountType, _, _ := strings.Cut(accountTypeOrEvent, ".")
+	switch {
+	case accountType == "trade", accountType == "trade_hf":
+		return asset.Spot
+	case accountType == "margin", accountType == "marginV2", accountType == "margin_v2",
+		accountType == kucoinIsolated, accountType == "isolated_v2",
+		strings.HasPrefix(accountType, "isolated_"), strings.HasPrefix(accountType, "isolatedV2_"):
+		return asset.Margin
+	default:
+		return asset.Empty
+	}
 }
 
 // processOrderChangeEvent processes order update events.

--- a/exchanges/kucoin/kucoin_websocket_test.go
+++ b/exchanges/kucoin/kucoin_websocket_test.go
@@ -159,26 +159,64 @@ func TestWsHandleData(t *testing.T) {
 func TestProcessAccountBalanceChange(t *testing.T) {
 	t.Parallel()
 
-	ku := testInstance(t)
-	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
-	ku.API.AuthenticatedSupport = true
-	payload := []byte(`{"available":"50.17067692","currency":"USDT","hold":"0","relationEvent":"trade.setted","time":"1784868353688","total":"50.17067692"}`)
+	for _, tc := range []struct {
+		name          string
+		relationEvent string
+		expectedAsset asset.Item
+		expectedRaw   bool
+	}{
+		{name: "spot", relationEvent: "trade.setted", expectedAsset: asset.Spot},
+		{name: "margin", relationEvent: "marginV2.setted", expectedAsset: asset.Margin},
+		{name: "unclassified funding account", relationEvent: "main.transfer", expectedRaw: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ku := testInstance(t)
+			ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+			ku.API.AuthenticatedSupport = true
+			payload := fmt.Appendf(nil,
+				`{"available":"50.17067692","currency":"USDT","hold":"0","relationEvent":%q,"time":"1784868353688","total":"50.17067692"}`,
+				tc.relationEvent)
 
-	require.NoError(t, ku.processAccountBalanceChange(t.Context(), payload), "processAccountBalanceChange must not error")
-	require.Len(t, ku.Websocket.DataHandler.C, 1, "DataHandler must receive the account balance change")
-	item := <-ku.Websocket.DataHandler.C
-	subAccounts, ok := item.Data.(accounts.SubAccounts)
-	require.True(t, ok, "DataHandler item must contain sub-accounts")
-	require.Len(t, subAccounts, 1, "account balance change must contain one sub-account")
-	require.Equal(t, asset.Spot, subAccounts[0].AssetType, "account balance change must update the spot account")
+			require.NoError(t, ku.processAccountBalanceChange(t.Context(), payload), "processAccountBalanceChange must not error")
+			require.Len(t, ku.Websocket.DataHandler.C, 1, "DataHandler must receive the account balance change")
+			item := <-ku.Websocket.DataHandler.C
+			if tc.expectedRaw {
+				raw, ok := item.Data.(*WsAccountBalance)
+				require.True(t, ok, "unclassified account changes must remain raw websocket events")
+				assert.Equal(t, tc.relationEvent, raw.RelationEvent, "raw relation event should be preserved")
+				return
+			}
 
-	creds, err := ku.GetCredentials(t.Context())
-	require.NoError(t, err, "GetCredentials must not error")
-	balance, err := ku.Accounts.GetBalance("", creds, asset.Spot, currency.USDT)
-	require.NoError(t, err, "GetBalance must find the stored spot balance")
-	require.InDelta(t, 50.17067692, balance.Total, 1e-12, "stored spot total must match the update")
-	require.InDelta(t, 50.17067692, balance.Free, 1e-12, "stored spot free balance must match the update")
-	require.Zero(t, balance.Hold, "stored spot hold balance must match the update")
+			subAccounts, ok := item.Data.(accounts.SubAccounts)
+			require.True(t, ok, "classified account changes must contain sub-accounts")
+			require.Len(t, subAccounts, 1, "account balance change must contain one sub-account")
+			require.Equal(t, tc.expectedAsset, subAccounts[0].AssetType, "account balance change must update the expected account")
+
+			creds, err := ku.GetCredentials(t.Context())
+			require.NoError(t, err, "GetCredentials must not error")
+			balance, err := ku.Accounts.GetBalance("", creds, tc.expectedAsset, currency.USDT)
+			require.NoError(t, err, "GetBalance must find the stored balance")
+			assert.InDelta(t, 50.17067692, balance.Total, 1e-12, "stored total should match the update")
+			assert.InDelta(t, 50.17067692, balance.Free, 1e-12, "stored free balance should match the update")
+			assert.Zero(t, balance.Hold, "stored hold balance should match the update")
+		})
+	}
+
+	t.Run("malformed payload", func(t *testing.T) {
+		t.Parallel()
+		ku := testInstance(t)
+		require.Error(t, ku.processAccountBalanceChange(t.Context(), []byte(`{"total":`)), "processAccountBalanceChange must reject malformed JSON")
+	})
+
+	t.Run("account store unavailable", func(t *testing.T) {
+		t.Parallel()
+		ku := testInstance(t)
+		ku.Accounts = nil
+		err := ku.processAccountBalanceChange(t.Context(), []byte(
+			`{"available":"1","currency":"USDT","hold":"0","relationEvent":"trade.setted","time":"1784868353688","total":"1"}`))
+		require.Error(t, err, "processAccountBalanceChange must return account storage errors")
+	})
 }
 
 func TestAccountBalanceAsset(t *testing.T) {

--- a/exchanges/kucoin/kucoin_websocket_test.go
+++ b/exchanges/kucoin/kucoin_websocket_test.go
@@ -165,8 +165,8 @@ func TestProcessAccountBalanceChange(t *testing.T) {
 		expectedAsset asset.Item
 		expectedRaw   bool
 	}{
-		{name: "spot", relationEvent: "trade.setted", expectedAsset: asset.Spot},
-		{name: "margin", relationEvent: "marginV2.setted", expectedAsset: asset.Margin},
+		{name: "spot", relationEvent: "trade.balance", expectedAsset: asset.Spot},
+		{name: "margin", relationEvent: "marginV2.balance", expectedAsset: asset.Margin},
 		{name: "unclassified funding account", relationEvent: "main.transfer", expectedRaw: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -209,12 +209,38 @@ func TestProcessAccountBalanceChange(t *testing.T) {
 		require.Error(t, ku.processAccountBalanceChange(t.Context(), []byte(`{"total":`)), "processAccountBalanceChange must reject malformed JSON")
 	})
 
+	t.Run("component delta preserves aggregate", func(t *testing.T) {
+		t.Parallel()
+		ku := testInstance(t)
+		ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+		ku.API.AuthenticatedSupport = true
+		initial := accounts.SubAccounts{accounts.NewSubAccount(asset.Spot, "")}
+		initial[0].Balances.Set(currency.USDT, accounts.Balance{
+			Total:     13,
+			Hold:      2,
+			Free:      11,
+			UpdatedAt: time.UnixMilli(1),
+		})
+		require.NoError(t, ku.Accounts.Save(t.Context(), initial, true), "initial aggregate balance must be stored")
+
+		payload := []byte(`{"available":"4","availableChange":"1","currency":"USDT","hold":"0","holdChange":"0","relationEvent":"trade_hf.balance","time":"4102444800000","total":"4"}`)
+		require.NoError(t, ku.processAccountBalanceChange(t.Context(), payload), "processAccountBalanceChange must not error")
+
+		creds, err := ku.GetCredentials(t.Context())
+		require.NoError(t, err, "GetCredentials must not error")
+		balance, err := ku.Accounts.GetBalance("", creds, asset.Spot, currency.USDT)
+		require.NoError(t, err, "GetBalance must find the stored aggregate")
+		assert.InDelta(t, 14.0, balance.Total, 1e-12, "component total change should update the aggregate total")
+		assert.InDelta(t, 12.0, balance.Free, 1e-12, "component available change should update aggregate free funds")
+		assert.InDelta(t, 2.0, balance.Hold, 1e-12, "an unchanged component hold should preserve aggregate held funds")
+	})
+
 	t.Run("account store unavailable", func(t *testing.T) {
 		t.Parallel()
 		ku := testInstance(t)
 		ku.Accounts = nil
 		err := ku.processAccountBalanceChange(t.Context(), []byte(
-			`{"available":"1","currency":"USDT","hold":"0","relationEvent":"trade.setted","time":"1784868353688","total":"1"}`))
+			`{"available":"1","currency":"USDT","hold":"0","relationEvent":"trade.balance","time":"1784868353688","total":"1"}`))
 		require.Error(t, err, "processAccountBalanceChange must return account storage errors")
 	})
 }
@@ -227,14 +253,14 @@ func TestAccountBalanceAsset(t *testing.T) {
 		relationEvent string
 		expected      asset.Item
 	}{
-		{name: "classic spot", relationEvent: "trade.setted", expected: asset.Spot},
+		{name: "classic spot", relationEvent: "trade.balance", expected: asset.Spot},
 		{name: "high frequency spot", relationEvent: "trade_hf.hold", expected: asset.Spot},
 		{name: "classic margin", relationEvent: "margin.transfer", expected: asset.Margin},
 		{name: "high frequency margin", relationEvent: "marginV2.other", expected: asset.Margin},
 		{name: "REST high frequency margin", relationEvent: "margin_v2", expected: asset.Margin},
 		{name: "REST isolated margin", relationEvent: kucoinIsolated, expected: asset.Margin},
 		{name: "REST isolated high frequency margin", relationEvent: "isolated_v2", expected: asset.Margin},
-		{name: "isolated margin", relationEvent: "isolated_BTC-USDT.setted", expected: asset.Margin},
+		{name: "isolated margin", relationEvent: "isolated_BTC-USDT.balance", expected: asset.Margin},
 		{name: "isolated high frequency margin", relationEvent: "isolatedV2_BTC-USDT.hold", expected: asset.Margin},
 		{name: "funding account", relationEvent: "main.transfer", expected: asset.Empty},
 		{name: "unknown", relationEvent: "other", expected: asset.Empty},

--- a/exchanges/kucoin/kucoin_websocket_test.go
+++ b/exchanges/kucoin/kucoin_websocket_test.go
@@ -144,6 +144,73 @@ func TestPushData(t *testing.T) {
 	assert.ErrorContains(t, fErrs[0].Err, "cannot save holdings: nil pointer: *accounts.Accounts")
 }
 
+func TestWsHandleData(t *testing.T) {
+	t.Parallel()
+
+	ku := testInstance(t)
+	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+	ku.API.AuthenticatedSupport = true
+	payload := []byte(`{"topic":"/account/balance","type":"message","subject":"account.balance","id":"2806792994029696","channelType":"private","data":{"available":"0","currency":"KITE","hold":"30","relationEvent":"trade.hold","time":"1784868353683","total":"30"}}`)
+
+	require.NoError(t, ku.wsHandleData(t.Context(), nil, payload), "wsHandleData must route identified push messages by topic")
+	require.Len(t, ku.Websocket.DataHandler.C, 1, "DataHandler must receive the account balance change")
+}
+
+func TestProcessAccountBalanceChange(t *testing.T) {
+	t.Parallel()
+
+	ku := testInstance(t)
+	ku.SetCredentials(&accounts.Credentials{Key: mockAPIKey, Secret: mockAPISecret, ClientID: mockAPIPassphrase})
+	ku.API.AuthenticatedSupport = true
+	payload := []byte(`{"available":"50.17067692","currency":"USDT","hold":"0","relationEvent":"trade.setted","time":"1784868353688","total":"50.17067692"}`)
+
+	require.NoError(t, ku.processAccountBalanceChange(t.Context(), payload), "processAccountBalanceChange must not error")
+	require.Len(t, ku.Websocket.DataHandler.C, 1, "DataHandler must receive the account balance change")
+	item := <-ku.Websocket.DataHandler.C
+	subAccounts, ok := item.Data.(accounts.SubAccounts)
+	require.True(t, ok, "DataHandler item must contain sub-accounts")
+	require.Len(t, subAccounts, 1, "account balance change must contain one sub-account")
+	require.Equal(t, asset.Spot, subAccounts[0].AssetType, "account balance change must update the spot account")
+
+	creds, err := ku.GetCredentials(t.Context())
+	require.NoError(t, err, "GetCredentials must not error")
+	balance, err := ku.Accounts.GetBalance("", creds, asset.Spot, currency.USDT)
+	require.NoError(t, err, "GetBalance must find the stored spot balance")
+	require.InDelta(t, 50.17067692, balance.Total, 1e-12, "stored spot total must match the update")
+	require.InDelta(t, 50.17067692, balance.Free, 1e-12, "stored spot free balance must match the update")
+	require.Zero(t, balance.Hold, "stored spot hold balance must match the update")
+}
+
+func TestAccountBalanceAsset(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		relationEvent string
+		expected      asset.Item
+	}{
+		{name: "classic spot", relationEvent: "trade.setted", expected: asset.Spot},
+		{name: "high frequency spot", relationEvent: "trade_hf.hold", expected: asset.Spot},
+		{name: "classic margin", relationEvent: "margin.transfer", expected: asset.Margin},
+		{name: "high frequency margin", relationEvent: "marginV2.other", expected: asset.Margin},
+		{name: "REST high frequency margin", relationEvent: "margin_v2", expected: asset.Margin},
+		{name: "REST isolated margin", relationEvent: kucoinIsolated, expected: asset.Margin},
+		{name: "REST isolated high frequency margin", relationEvent: "isolated_v2", expected: asset.Margin},
+		{name: "isolated margin", relationEvent: "isolated_BTC-USDT.setted", expected: asset.Margin},
+		{name: "isolated high frequency margin", relationEvent: "isolatedV2_BTC-USDT.hold", expected: asset.Margin},
+		{name: "funding account", relationEvent: "main.transfer", expected: asset.Empty},
+		{name: "unknown", relationEvent: "other", expected: asset.Empty},
+		{name: "similar isolated prefix", relationEvent: "isolatedOther.hold", expected: asset.Empty},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, accountBalanceAsset(tc.relationEvent), "accountBalanceAsset must classify the account family")
+		})
+	}
+}
+
 func TestGenerateSubscriptions(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -445,16 +445,16 @@ func (e *Exchange) UpdateAccountBalances(ctx context.Context, assetType asset.It
 			return nil, err
 		}
 		for i := range resp {
-			if resp[i].AccountType == "margin" && assetType == asset.Spot {
-				continue
-			} else if resp[i].AccountType == "trade" && assetType == asset.Margin {
+			if accountBalanceAsset(resp[i].AccountType) != assetType {
 				continue
 			}
-			subAccts[0].Balances.Set(resp[i].Currency, accounts.Balance{
+			if err := subAccts[0].Balances.Add(resp[i].Currency, accounts.Balance{
 				Total: resp[i].Balance.Float64(),
 				Hold:  resp[i].Holds.Float64(),
 				Free:  resp[i].Available.Float64(),
-			})
+			}); err != nil {
+				return nil, err
+			}
 		}
 	default:
 		return nil, fmt.Errorf("%w %v", asset.ErrNotSupported, assetType)
@@ -615,6 +615,18 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		if s.Leverage == 0 {
 			s.Leverage = 1
 		}
+		marginMode := strings.ToUpper(MarginModeToString(s.MarginType))
+		if marginMode == "" {
+			return nil, fmt.Errorf("%w: KuCoin futures orders require isolated or cross margin", margin.ErrInvalidMarginType)
+		}
+		positionMode, err := e.GetFuturesPositionMode(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting KuCoin futures position mode: %w", err)
+		}
+		positionSide, err := futuresPositionSide(positionMode, s.Side, s.ReduceOnly)
+		if err != nil {
+			return nil, err
+		}
 		var orderType, stopOrderType, stopOrderBoundary string
 		switch s.Type {
 		case order.Stop, order.StopLimit, order.TrailingStop:
@@ -661,6 +673,8 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 			Size:          s.Amount,
 			Price:         s.Price,
 			Leverage:      s.Leverage,
+			MarginMode:    marginMode,
+			PositionSide:  positionSide,
 			VisibleSize:   0,
 			ReduceOnly:    s.ReduceOnly,
 			PostOnly:      s.TimeInForce.Is(order.PostOnly),
@@ -776,22 +790,33 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 			return nil, order.ErrUnsupportedOrderType
 		}
 	case asset.Margin:
-		o, err := e.PostMarginOrder(ctx,
-			&MarginOrderParam{
-				ClientOrderID: s.ClientOrderID,
-				Side:          sideString,
-				Symbol:        s.Pair,
-				OrderType:     s.Type.Lower(),
-				MarginModel:   MarginModeToString(s.MarginType),
-				Price:         s.Price,
-				Size:          s.Amount,
-				VisibleSize:   s.Amount,
-				PostOnly:      s.TimeInForce.Is(order.PostOnly),
-				Hidden:        s.Hidden,
-				AutoBorrow:    s.AutoBorrow,
-				AutoRepay:     s.AutoBorrow,
-				Iceberg:       s.Iceberg,
-			})
+		if !s.Type.Is(order.Limit) && !s.Type.Is(order.Market) {
+			return nil, order.ErrUnsupportedOrderType
+		}
+		var timeInForce string
+		if s.Type.Is(order.Limit) {
+			switch {
+			case s.TimeInForce.Is(order.FillOrKill), s.TimeInForce.Is(order.ImmediateOrCancel):
+				timeInForce = s.TimeInForce.String()
+			default:
+				timeInForce = order.GoodTillCancel.String()
+			}
+		}
+		o, err := e.PlaceMarginHFOrder(ctx, &PlaceMarginHFOrderParam{
+			ClientOrderID: s.ClientOrderID,
+			Side:          sideString,
+			Symbol:        s.Pair,
+			OrderType:     s.Type.Lower(),
+			IsIsolated:    s.MarginType == margin.Isolated,
+			AutoBorrow:    s.AutoBorrow,
+			AutoRepay:     s.AutoRepay,
+			Price:         s.Price,
+			Size:          s.Amount,
+			TimeInForce:   timeInForce,
+			PostOnly:      s.TimeInForce.Is(order.PostOnly),
+			Hidden:        s.Hidden,
+			Iceberg:       s.Iceberg,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -807,11 +832,33 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 	}
 }
 
+// futuresPositionSide derives the position affected by a futures order. Hedge
+// reductions act on the opposite directional position to the order side.
+func futuresPositionSide(mode FuturesPositionMode, side order.Side, reduceOnly bool) (string, error) {
+	if !side.IsLong() && !side.IsShort() {
+		return "", fmt.Errorf("%w: %s", order.ErrSideIsInvalid, side)
+	}
+	if mode == FuturesPositionModeOneWay {
+		return kucoinBothPositionSide, nil
+	}
+	if mode != FuturesPositionModeHedge {
+		return "", fmt.Errorf("%w: %s", errInvalidFuturesPositionMode, mode)
+	}
+	isLong := side.IsLong()
+	if reduceOnly {
+		isLong = !isLong
+	}
+	if isLong {
+		return kucoinLongPositionSide, nil
+	}
+	return kucoinShortPositionSide, nil
+}
+
 // MarginModeToString returns a string representation of a MarginMode
 func MarginModeToString(mType margin.Type) string {
 	switch mType {
 	case margin.Isolated:
-		return mType.String()
+		return kucoinIsolated
 	case margin.Multi:
 		return "cross"
 	default:

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -609,14 +609,6 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		if marginMode == "" {
 			return nil, fmt.Errorf("%w: KuCoin futures orders require isolated or cross margin", margin.ErrInvalidMarginType)
 		}
-		positionMode, err := e.GetFuturesPositionMode(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("getting KuCoin futures position mode: %w", err)
-		}
-		positionSide, err := futuresPositionSide(positionMode, s.Side, s.ReduceOnly)
-		if err != nil {
-			return nil, err
-		}
 		var orderType, stopOrderType, stopOrderBoundary string
 		switch s.Type {
 		case order.Stop, order.StopLimit, order.TrailingStop:
@@ -655,7 +647,7 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		default:
 			return nil, order.ErrUnsupportedOrderType
 		}
-		o, err = e.PostFuturesOrder(ctx, &FuturesOrderParam{
+		orderParams := &FuturesOrderParam{
 			ClientOrderID: s.ClientOrderID,
 			Side:          sideString,
 			Symbol:        s.Pair,
@@ -664,7 +656,7 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 			Price:         s.Price,
 			Leverage:      s.Leverage,
 			MarginMode:    marginMode,
-			PositionSide:  positionSide,
+			PositionSide:  kucoinBothPositionSide,
 			VisibleSize:   0,
 			ReduceOnly:    s.ReduceOnly,
 			PostOnly:      s.TimeInForce.Is(order.PostOnly),
@@ -673,7 +665,20 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 			StopPrice:     s.TriggerPrice,
 			StopPriceType: stopOrderType,
 			Iceberg:       s.Iceberg,
-		})
+		}
+		if err := e.FillFuturesPostOrderArgumentFilter(orderParams); err != nil {
+			return nil, err
+		}
+		positionMode, err := e.getCachedFuturesPositionMode(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting KuCoin futures position mode: %w", err)
+		}
+		orderParams.PositionSide, err = futuresPositionSide(positionMode, s.Side, s.ReduceOnly)
+		if err != nil {
+			return nil, err
+		}
+		orderParams.ReduceOnly = s.ReduceOnly && positionMode == FuturesPositionModeOneWay
+		o, err = e.PostFuturesOrder(ctx, orderParams)
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -292,24 +292,15 @@ func (e *Exchange) UpdateTicker(ctx context.Context, p currency.Pair, assetType 
 
 // UpdateTickers updates all currency pairs of a given asset type
 func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) error {
-	var errs error
 	switch assetType {
 	case asset.Futures:
 		ticks, err := e.GetFuturesOpenContracts(ctx)
 		if err != nil {
 			return err
 		}
-		pairs, err := e.GetEnabledPairs(asset.Futures)
-		if err != nil {
-			return err
-		}
 		for x := range ticks {
-			pair := currency.NewPair(ticks[x].BaseCurrency,
-				currency.NewCode(ticks[x].Symbol[len(ticks[x].BaseCurrency.String()):]))
-			if !pairs.Contains(pair, true) {
-				continue
-			}
-			err = ticker.ProcessTicker(&ticker.Price{
+			pair := currency.NewPair(ticks[x].BaseCurrency, currency.NewCode(ticks[x].Symbol[len(ticks[x].BaseCurrency.String()):]))
+			if err := ticker.ProcessTicker(&ticker.Price{
 				Last:         ticks[x].LastTradePrice,
 				High:         ticks[x].HighPrice,
 				Low:          ticks[x].LowPrice,
@@ -318,9 +309,8 @@ func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) erro
 				Pair:         pair,
 				ExchangeName: e.Name,
 				AssetType:    assetType,
-			})
-			if err != nil {
-				errs = common.AppendError(errs, err)
+			}); err != nil {
+				return err
 			}
 		}
 	case asset.Spot, asset.Margin:
@@ -329,15 +319,15 @@ func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) erro
 			return err
 		}
 		for t := range ticks.Tickers {
-			pair, enabled, err := e.MatchSymbolCheckEnabled(ticks.Tickers[t].Symbol, assetType, true)
-			if err != nil && !errors.Is(err, currency.ErrPairNotFound) {
+			pair, err := e.MatchSymbolWithAvailablePairs(ticks.Tickers[t].Symbol, assetType, true)
+			if err != nil {
+				if errors.Is(err, currency.ErrPairNotFound) {
+					continue
+				}
 				return err
 			}
-			if !enabled {
-				continue
-			}
 
-			err = ticker.ProcessTicker(&ticker.Price{
+			if err := ticker.ProcessTicker(&ticker.Price{
 				Last:         ticks.Tickers[t].Last,
 				High:         ticks.Tickers[t].High,
 				Low:          ticks.Tickers[t].Low,
@@ -348,15 +338,14 @@ func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) erro
 				ExchangeName: e.Name,
 				AssetType:    assetType,
 				LastUpdated:  ticks.Time.Time(),
-			})
-			if err != nil {
-				errs = common.AppendError(errs, err)
+			}); err != nil {
+				return err
 			}
 		}
 	default:
 		return fmt.Errorf("%w %v", asset.ErrNotSupported, assetType)
 	}
-	return errs
+	return nil
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair

--- a/exchanges/kucoin/kucoin_wrapper.go
+++ b/exchanges/kucoin/kucoin_wrapper.go
@@ -292,6 +292,7 @@ func (e *Exchange) UpdateTicker(ctx context.Context, p currency.Pair, assetType 
 
 // UpdateTickers updates all currency pairs of a given asset type
 func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) error {
+	var errs error
 	switch assetType {
 	case asset.Futures:
 		ticks, err := e.GetFuturesOpenContracts(ctx)
@@ -310,7 +311,7 @@ func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) erro
 				ExchangeName: e.Name,
 				AssetType:    assetType,
 			}); err != nil {
-				return err
+				errs = common.AppendError(errs, err)
 			}
 		}
 	case asset.Spot, asset.Margin:
@@ -339,13 +340,13 @@ func (e *Exchange) UpdateTickers(ctx context.Context, assetType asset.Item) erro
 				AssetType:    assetType,
 				LastUpdated:  ticks.Time.Time(),
 			}); err != nil {
-				return err
+				errs = common.AppendError(errs, err)
 			}
 		}
 	default:
-		return fmt.Errorf("%w %v", asset.ErrNotSupported, assetType)
+		return fmt.Errorf("%w: %s", asset.ErrNotSupported, assetType)
 	}
-	return nil
+	return errs
 }
 
 // UpdateOrderbook updates and returns the orderbook for a currency pair
@@ -446,7 +447,7 @@ func (e *Exchange) UpdateAccountBalances(ctx context.Context, assetType asset.It
 			}
 		}
 	default:
-		return nil, fmt.Errorf("%w %v", asset.ErrNotSupported, assetType)
+		return nil, fmt.Errorf("%w: %s", asset.ErrNotSupported, assetType)
 	}
 	return subAccts, e.Accounts.Save(ctx, subAccts, true)
 }
@@ -817,7 +818,7 @@ func (e *Exchange) SubmitOrder(ctx context.Context, s *order.Submit) (*order.Sub
 		ret.LoanApplyID = o.LoanApplyID
 		return ret, nil
 	default:
-		return nil, fmt.Errorf("%w %v", asset.ErrNotSupported, s.AssetType)
+		return nil, fmt.Errorf("%w: %s", asset.ErrNotSupported, s.AssetType)
 	}
 }
 


### PR DESCRIPTION
## Summary

- update ticker caches from all available KuCoin markets, including disabled but available pairs, while retaining per-ticker error aggregation
- classify current spot and margin account families consistently across REST and WebSocket updates, aggregate split balances, and preserve unclassified funding events as raw data
- submit margin orders through the supported high-frequency endpoint with corrected JSON encoding and independent auto-borrow and auto-repay handling
- query the futures account position mode and populate the required marginMode and positionSide fields for one-way and hedge-mode orders
- validate nil and invalid order inputs with stable wrapped errors

## Testing

- go test ./exchanges/kucoin -race -count 1
- make gofumpt
- make lint
- make misc_checks