### PR TITLE
engine: fix NTP check counting network delay as clock error

### DIFF
--- a/cmd/documentation/config_templates/config_readme.tmpl
+++ b/cmd/documentation/config_templates/config_readme.tmpl
@@ -227,21 +227,43 @@ See the section `exchange.features.enabled.subscriptions` for configuring subscr
 ```
 
 
-## Configure Network Time Server 
+## Configure Network Time Server
 
-+ To configure and enable a NTP server you need to set the "enabled" field to one of 3 values -1 is disabled 0 is enabled and alert at start up 1 is enabled and warn at start up
-servers are configured by the pool array and attempted first to last allowedDifference and allowedNegativeDifference are how far ahead and behind is acceptable for the time to be out in nanoseconds
+The `enabled` field controls when NTP clock checks run:
+
+These settings take effect only when the engine's NTP client feature is enabled; the command-line
+application enables that feature by default.
+
+- `-1` disables checks.
+- `0` checks during engine startup. The alert/warn/disable prompt is shown only when the complete
+  measured uncertainty interval proves that the local clock is ahead or behind the configured
+  tolerance window.
+- `1` checks every 30 minutes after the `ntp_timekeeper` subsystem is explicitly started. Normal
+  engine startup constructs this subsystem but does not start it.
+
+Pools are attempted in configured order, and the first valid response is used. The result is one of
+four states: in sync, ahead, behind, or inconclusive. An inconclusive result warns without prompting;
+configure a closer or lower-latency NTP server to reduce measurement uncertainty.
+The interval is a diagnostic bound based on the server's reported NTP metadata, not authenticated
+proof of UTC.
+
+`allowedDifference` is the permitted local-clock-behind magnitude and
+`allowedNegativeDifference` is the permitted local-clock-ahead magnitude, both expressed as Go
+`time.Duration` nanoseconds. Missing, zero, or negative values default to 50 milliseconds. An empty
+pool list defaults to `pool.ntp.org:123`.
 
 ```js
- "ntpclient": {
-  "enabled": 0,
-  "pool": [
-   "pool.ntp.org:123"
-  ],
-  "allowedDifference": 0,
-  "allowedNegativeDifference": 0
- },
- ```
+{
+  "ntpclient": {
+    "enabled": 0,
+    "pool": [
+      "pool.ntp.org:123"
+    ],
+    "allowedDifference": 0,
+    "allowedNegativeDifference": 0
+  }
+}
+```
 
 {{template "donations" .}}
 {{end}}

--- a/cmd/documentation/engine_templates/ntp_manager.tmpl
+++ b/cmd/documentation/engine_templates/ntp_manager.tmpl
@@ -1,19 +1,39 @@
 {{define "engine ntp_manager" -}}
 {{template "header" .}}
-## Current Features for {{.CapitalName}}
-+ The NTP manager subsystem is used highlight discrepancies between your system time and specified NTP server times
-+ It is useful for debugging and understanding why a request to an exchange may be rejected
-+ The NTP manager cannot update your system clock, so when it does alert you of issues, you must take it upon yourself to change your system time in the event your requests are being rejected for being too far out of sync
-+ In order to modify the behaviour of the NTP manager subsystem, you can edit the following inside your config file under `ntpclient`:
+## Current Features for NTP Manager
+
+The NTP manager compares the local clock with configured NTP servers. It is a diagnostic feature
+for investigating timestamp-sensitive request failures; it does not adjust the system clock.
+These settings take effect only when the engine's NTP client feature is enabled; the command-line
+application enables that feature by default.
+
+Servers are tried in configured order and the first valid response is used. The clock correction is
+evaluated together with its complete root-distance interval, producing one of four results:
+
+- `in-sync`: the complete interval is within the configured tolerances;
+- `ahead`: the complete interval proves the local clock is ahead;
+- `behind`: the complete interval proves the local clock is behind;
+- `inconclusive`: the interval crosses a tolerance boundary, so no clock verdict is made.
+
+At startup, the alert/warn/disable prompt is shown only for a conclusive `ahead` or `behind` result.
+An inconclusive result warns without prompting and recommends a closer or lower-latency NTP server.
+The interval is a diagnostic bound based on the server's reported NTP metadata, not authenticated
+proof of UTC.
+
+Periodic checks run every 30 minutes only after the `ntp_timekeeper` subsystem is explicitly
+started. Normal engine startup constructs the subsystem but does not start it, including when the
+startup prompt changes the setting to periodic mode.
+
+The following settings are available under `ntpclient`:
 
 ### ntpclient
 
 | Config | Description | Example |
 | ------ | ----------- | ------- |
-| enabled | An integer value representing whether the NTP manager is enabled. It will warn you of time sync discrepancies on startup with a value of 0 and will alert you periodically with a value of 1. A value of -1 will disable the manager  |  `1` |
-| pool | A string array of the NTP servers to check for time discrepancies |  `["0.pool.ntp.org:123","pool.ntp.org:123"]` |
-| allowedDifference | A Golang time.Duration representation of the allowable time discrepancy between NTP server and your system time. Any discrepancy greater than this allowance will display an alert to your logging output |  `50000000` |
-| allowedNegativeDifference | A Golang time.Duration representation of the allowable negative time discrepancy between NTP server and your system time. Any discrepancy greater than this allowance will display an alert to your logging output |  `50000000` |
+| enabled | `-1` disables checks, `0` checks at startup, and `1` permits periodic checks when the subsystem is explicitly started | `1` |
+| pool | NTP servers attempted in configured order until the first valid response | `["0.pool.ntp.org:123","pool.ntp.org:123"]` |
+| allowedDifference | Maximum permitted local-clock-behind duration, expressed as Go `time.Duration` nanoseconds | `50000000` |
+| allowedNegativeDifference | Maximum permitted local-clock-ahead duration, expressed as Go `time.Duration` nanoseconds | `50000000` |
 
 {{template "donations" .}}
 {{end}}

--- a/config/README.md
+++ b/config/README.md
@@ -244,21 +244,43 @@ See the section `exchange.features.enabled.subscriptions` for configuring subscr
 ```
 
 
-## Configure Network Time Server 
+## Configure Network Time Server
 
-+ To configure and enable a NTP server you need to set the "enabled" field to one of 3 values -1 is disabled 0 is enabled and alert at start up 1 is enabled and warn at start up
-servers are configured by the pool array and attempted first to last allowedDifference and allowedNegativeDifference are how far ahead and behind is acceptable for the time to be out in nanoseconds
+The `enabled` field controls when NTP clock checks run:
+
+These settings take effect only when the engine's NTP client feature is enabled; the command-line
+application enables that feature by default.
+
+- `-1` disables checks.
+- `0` checks during engine startup. The alert/warn/disable prompt is shown only when the complete
+  measured uncertainty interval proves that the local clock is ahead or behind the configured
+  tolerance window.
+- `1` checks every 30 minutes after the `ntp_timekeeper` subsystem is explicitly started. Normal
+  engine startup constructs this subsystem but does not start it.
+
+Pools are attempted in configured order, and the first valid response is used. The result is one of
+four states: in sync, ahead, behind, or inconclusive. An inconclusive result warns without prompting;
+configure a closer or lower-latency NTP server to reduce measurement uncertainty.
+The interval is a diagnostic bound based on the server's reported NTP metadata, not authenticated
+proof of UTC.
+
+`allowedDifference` is the permitted local-clock-behind magnitude and
+`allowedNegativeDifference` is the permitted local-clock-ahead magnitude, both expressed as Go
+`time.Duration` nanoseconds. Missing, zero, or negative values default to 50 milliseconds. An empty
+pool list defaults to `pool.ntp.org:123`.
 
 ```js
- "ntpclient": {
-  "enabled": 0,
-  "pool": [
-   "pool.ntp.org:123"
-  ],
-  "allowedDifference": 0,
-  "allowedNegativeDifference": 0
- },
- ```
+{
+  "ntpclient": {
+    "enabled": 0,
+    "pool": [
+      "pool.ntp.org:123"
+    ],
+    "allowedDifference": 0,
+    "allowedNegativeDifference": 0
+  }
+}
+```
 
 ## Donations
 

--- a/config/config.go
+++ b/config/config.go
@@ -1250,7 +1250,7 @@ func (c *Config) CheckNTPConfig() {
 	m.Lock()
 	defer m.Unlock()
 
-	if c.NTPClient.AllowedDifference == nil || *c.NTPClient.AllowedDifference == 0 {
+	if c.NTPClient.AllowedDifference == nil || *c.NTPClient.AllowedDifference <= 0 {
 		c.NTPClient.AllowedDifference = new(time.Duration)
 		*c.NTPClient.AllowedDifference = defaultNTPAllowedDifference
 	}
@@ -1261,7 +1261,7 @@ func (c *Config) CheckNTPConfig() {
 	}
 
 	if len(c.NTPClient.Pool) < 1 {
-		log.Warnln(log.ConfigMgr, "NTPClient enabled with no servers configured, enabling default pool.")
+		log.Warnln(log.ConfigMgr, "NTPClient has no servers configured, enabling default pool.")
 		c.NTPClient.Pool = []string{"pool.ntp.org:123"}
 	}
 }
@@ -1286,15 +1286,15 @@ func (c *Config) SetNTPCheck(input io.Reader) (string, error) {
 		answer = strings.TrimRight(answer, "\r\n")
 		switch answer {
 		case "a":
-			c.NTPClient.Level = 0
+			c.NTPClient.Level = NTPClientStartup
 			resp = "Time sync has been set to alert"
 			answered = true
 		case "w":
-			c.NTPClient.Level = 1
+			c.NTPClient.Level = NTPClientPeriodic
 			resp = "Time sync has been set to warn only"
 			answered = true
 		case "d":
-			c.NTPClient.Level = -1
+			c.NTPClient.Level = NTPClientDisabled
 			resp = "Future notifications for out of time sync has been disabled"
 			answered = true
 		default:
@@ -1658,9 +1658,7 @@ func (c *Config) CheckConfig() error {
 		c.GlobalHTTPTimeout = defaultHTTPTimeout
 	}
 
-	if c.NTPClient.Level != 0 {
-		c.CheckNTPConfig()
-	}
+	c.CheckNTPConfig()
 
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -1879,11 +1880,10 @@ func TestCheckRemoteControlConfig(t *testing.T) {
 	assert.True(t, c.RemoteControl.GRPC.GRPCProxyEnabled, "gRPCProxyEnabled should be true when gRPC is enabled")
 }
 
-func TestCheckConfig(t *testing.T) {
-	t.Parallel()
+func newConfigForCheckConfig() *Config {
 	cp1 := currency.NewPair(currency.DOGE, currency.XRP)
 	cp2 := currency.NewPair(currency.DOGE, currency.USD)
-	cfg := &Config{
+	return &Config{
 		Exchanges: []Exchange{
 			{
 				Name:    testFakeExchangeName,
@@ -1909,8 +1909,34 @@ func TestCheckConfig(t *testing.T) {
 			},
 		},
 	}
-	if err := cfg.CheckConfig(); err != nil {
-		t.Fatal(err)
+}
+
+func TestCheckConfigNTP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		level int
+	}{
+		{name: "disabled", level: NTPClientDisabled},
+		{name: "startup", level: NTPClientStartup},
+		{name: "periodic", level: NTPClientPeriodic},
+		{name: "unknown", level: 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newConfigForCheckConfig()
+			cfg.NTPClient.Level = tt.level
+
+			require.NoError(t, cfg.CheckConfig(), "CheckConfig must not error")
+			assert.Equal(t, tt.level, cfg.NTPClient.Level, "NTP Level should remain unchanged")
+			require.NotNil(t, cfg.NTPClient.AllowedDifference, "AllowedDifference must be normalized")
+			require.NotNil(t, cfg.NTPClient.AllowedNegativeDifference, "AllowedNegativeDifference must be normalized")
+			assert.Equal(t, 50*time.Millisecond, *cfg.NTPClient.AllowedDifference, "AllowedDifference should use the default")
+			assert.Equal(t, 50*time.Millisecond, *cfg.NTPClient.AllowedNegativeDifference, "AllowedNegativeDifference should use the default")
+			assert.Equal(t, []string{"pool.ntp.org:123"}, cfg.NTPClient.Pool, "NTP pools should use the exact default")
+		})
 	}
 }
 
@@ -1976,33 +2002,48 @@ func TestCheckLoggerConfig(t *testing.T) {
 	}
 }
 
-func TestDisableNTPCheck(t *testing.T) {
-	t.Parallel()
+func TestSetNTPCheck(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedLevel int
+		expectedText  string
+	}{
+		{
+			name:          "alert at startup",
+			input:         "a\n",
+			expectedLevel: 0,
+			expectedText:  "Time sync has been set to alert",
+		},
+		{
+			name:          "disable",
+			input:         "d\n",
+			expectedLevel: -1,
+			expectedText:  "Future notifications for out of time sync has been disabled",
+		},
+		{
+			name:          "invalid then warn periodically",
+			input:         "invalid\nw\n",
+			expectedLevel: 1,
+			expectedText:  "Time sync has been set to warn only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{NTPClient: NTPClientConfig{Level: 42}}
+			input := strings.NewReader(tt.input)
+			response, err := c.SetNTPCheck(iotest.OneByteReader(input))
+			require.NoError(t, err, "SetNTPCheck must not error")
+			assert.Equal(t, tt.expectedText, response, "SetNTPCheck response should remain unchanged")
+			assert.Equal(t, tt.expectedLevel, c.NTPClient.Level, "SetNTPCheck should set the expected Level")
+			assert.Zero(t, input.Len(), "SetNTPCheck should consume the complete input")
+		})
+	}
 
 	var c Config
-
-	warn, err := c.SetNTPCheck(strings.NewReader("w\n"))
-	if err != nil {
-		t.Fatalf("to create ntpclient failed reason: %v", err)
-	}
-
-	if warn != "Time sync has been set to warn only" {
-		t.Errorf("failed expected %v got %v", "Time sync has been set to warn only", warn)
-	}
-	alert, _ := c.SetNTPCheck(strings.NewReader("a\n"))
-	if alert != "Time sync has been set to alert" {
-		t.Errorf("failed expected %v got %v", "Time sync has been set to alert", alert)
-	}
-
-	disable, _ := c.SetNTPCheck(strings.NewReader("d\n"))
-	if disable != "Future notifications for out of time sync has been disabled" {
-		t.Errorf("failed expected %v got %v", "Future notifications for out of time sync has been disabled", disable)
-	}
-
-	_, err = c.SetNTPCheck(strings.NewReader(" "))
-	if err.Error() != "EOF" {
-		t.Errorf("failed expected EOF got: %v", err)
-	}
+	_, err := c.SetNTPCheck(strings.NewReader(" "))
+	require.ErrorIs(t, err, io.EOF, "SetNTPCheck must propagate EOF")
 }
 
 func TestCheckGCTScriptConfig(t *testing.T) {
@@ -2051,23 +2092,76 @@ func TestCheckDatabaseConfig(t *testing.T) {
 
 func TestCheckNTPConfig(t *testing.T) {
 	t.Parallel()
-	cfg := &Config{
-		NTPClient: NTPClientConfig{},
+	durationPointer := func(value time.Duration) *time.Duration {
+		return &value
+	}
+	validConfig := func() NTPClientConfig {
+		return NTPClientConfig{
+			AllowedDifference:         durationPointer(75 * time.Millisecond),
+			AllowedNegativeDifference: durationPointer(25 * time.Millisecond),
+			Pool:                      []string{"configured.example:123"},
+		}
+	}
+	check := func(t *testing.T, input NTPClientConfig, wantAllowed, wantNegative time.Duration, wantPools []string) {
+		t.Helper()
+		cfg := &Config{NTPClient: input}
+		cfg.CheckNTPConfig()
+		require.NotNil(t, cfg.NTPClient.AllowedDifference, "AllowedDifference must be populated")
+		require.NotNil(t, cfg.NTPClient.AllowedNegativeDifference, "AllowedNegativeDifference must be populated")
+		assert.Equal(t, wantAllowed, *cfg.NTPClient.AllowedDifference, "AllowedDifference should be normalized independently")
+		assert.Equal(t, wantNegative, *cfg.NTPClient.AllowedNegativeDifference, "AllowedNegativeDifference should be normalized independently")
+		assert.Equal(t, wantPools, cfg.NTPClient.Pool, "NTP pool order should be preserved")
+	}
+	invalidValues := []struct {
+		name  string
+		value *time.Duration
+	}{
+		{name: "nil"},
+		{name: "zero", value: durationPointer(0)},
+		{name: "negative", value: durationPointer(-time.Millisecond)},
+	}
+	fields := []struct {
+		name         string
+		setInvalid   func(*NTPClientConfig, *time.Duration)
+		wantAllowed  time.Duration
+		wantNegative time.Duration
+	}{
+		{
+			name:         "allowed difference",
+			setInvalid:   func(c *NTPClientConfig, value *time.Duration) { c.AllowedDifference = value },
+			wantAllowed:  50 * time.Millisecond,
+			wantNegative: 25 * time.Millisecond,
+		},
+		{
+			name:         "allowed negative difference",
+			setInvalid:   func(c *NTPClientConfig, value *time.Duration) { c.AllowedNegativeDifference = value },
+			wantAllowed:  75 * time.Millisecond,
+			wantNegative: 50 * time.Millisecond,
+		},
+	}
+	for _, field := range fields {
+		for _, invalid := range invalidValues {
+			t.Run(invalid.name+" "+field.name, func(t *testing.T) {
+				t.Parallel()
+				input := validConfig()
+				field.setInvalid(&input, invalid.value)
+				check(t, input, field.wantAllowed, field.wantNegative, input.Pool)
+			})
+		}
 	}
 
-	cfg.CheckNTPConfig()
-
-	if cfg.NTPClient.Pool[0] != "pool.ntp.org:123" {
-		t.Error("ntpclient with no valid pool should default to pool.ntp.org")
-	}
-
-	if cfg.NTPClient.AllowedDifference == nil {
-		t.Error("ntpclient with nil alloweddifference should default to sane value")
-	}
-
-	if cfg.NTPClient.AllowedNegativeDifference == nil {
-		t.Error("ntpclient with nil allowednegativedifference should default to sane value")
-	}
+	t.Run("default pool", func(t *testing.T) {
+		t.Parallel()
+		input := validConfig()
+		input.Pool = nil
+		check(t, input, 75*time.Millisecond, 25*time.Millisecond, []string{"pool.ntp.org:123"})
+	})
+	t.Run("valid asymmetric values and ordered pools", func(t *testing.T) {
+		t.Parallel()
+		input := validConfig()
+		input.Pool = []string{"first.example:123", "second.example:123"}
+		check(t, input, 75*time.Millisecond, 25*time.Millisecond, input.Pool)
+	})
 }
 
 func TestCheckCurrencyConfigValues(t *testing.T) {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -31,8 +31,8 @@ const (
 	defaultWebsocketOrderbookBufferLimit = 5
 	DefaultConnectionMonitorDelay        = time.Second * 2
 	maxAuthFailures                      = 3
-	defaultNTPAllowedDifference          = 50000000
-	defaultNTPAllowedNegativeDifference  = 50000000
+	defaultNTPAllowedDifference          = 50 * time.Millisecond
+	defaultNTPAllowedNegativeDifference  = 50 * time.Millisecond
 	DefaultAPIKey                        = "Key"
 	DefaultAPISecret                     = "Secret"
 	DefaultAPIClientID                   = "ClientID"
@@ -224,6 +224,18 @@ type Profiler struct {
 	ListenAddress        string `json:"listen_address"`
 	BlockProfileRate     int    `json:"block_profile_rate"`
 }
+
+const (
+	// NTPClientDisabled disables NTP checks. SetNTPCheck selects it for input "d"
+	// and returns "Future notifications for out of time sync has been disabled".
+	NTPClientDisabled = -1
+	// NTPClientStartup checks at startup. SetNTPCheck selects it for input "a"
+	// and returns "Time sync has been set to alert".
+	NTPClientStartup = 0
+	// NTPClientPeriodic checks periodically once started. SetNTPCheck selects it
+	// for input "w" and returns "Time sync has been set to warn only".
+	NTPClientPeriodic = 1
+)
 
 // NTPClientConfig defines a network time protocol configuration to allow for
 // positive and negative differences

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -349,19 +349,8 @@ func (bot *Engine) Start() error {
 		}
 	}
 
-	if bot.Settings.EnableNTPClient {
-		if bot.Config.NTPClient.Level == 0 {
-			responseMessage, err := bot.Config.SetNTPCheck(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("unable to set NTP check: %w", err)
-			}
-			gctlog.Infoln(gctlog.TimeMgr, responseMessage)
-		}
-		if n, err := setupNTPManager(&bot.Config.NTPClient, *bot.Config.Logging.Enabled); err != nil {
-			gctlog.Errorf(gctlog.Global, "NTP manager unable to start: %s", err)
-		} else {
-			bot.ntpManager = n
-		}
+	if err := bot.setupNTPClient(runtimeCtx, os.Stdin); err != nil {
+		return err
 	}
 
 	bot.uptime = time.Now()

--- a/engine/helpers.go
+++ b/engine/helpers.go
@@ -184,9 +184,7 @@ func (bot *Engine) SetSubsystem(subSystemName string, enable bool) error {
 	case NTPManagerName:
 		if enable {
 			if bot.ntpManager == nil {
-				bot.ntpManager, err = setupNTPManager(
-					&bot.Config.NTPClient,
-					*bot.Config.Logging.Enabled)
+				bot.ntpManager, err = setupNTPManager(&bot.Config.NTPClient)
 				if err != nil {
 					return err
 				}

--- a/engine/helpers_test.go
+++ b/engine/helpers_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thrasher-corp/gocryptotrader/common/convert"
 	"github.com/thrasher-corp/gocryptotrader/common/file"
 	"github.com/thrasher-corp/gocryptotrader/communications"
 	"github.com/thrasher-corp/gocryptotrader/config"
@@ -35,7 +34,6 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/protocol"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/stats"
 	"github.com/thrasher-corp/gocryptotrader/gctscript/vm"
-	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
 var testExchange = "Bitstamp"
@@ -148,7 +146,7 @@ func TestSetSubsystem(t *testing.T) { //nolint // TO-DO: Fix race t.Parallel() u
 		},
 		{
 			Subsystem:    NTPManagerName,
-			Engine:       &Engine{Config: &config.Config{Logging: log.Config{Enabled: convert.BoolPtr(false)}}},
+			Engine:       &Engine{Config: &config.Config{}},
 			EnableError:  errNilNTPConfigValues,
 			DisableError: ErrNilSubsystem,
 		},
@@ -206,6 +204,33 @@ func TestSetSubsystem(t *testing.T) { //nolint // TO-DO: Fix race t.Parallel() u
 			require.ErrorIs(t, err, tt.DisableError)
 		})
 	}
+}
+
+func TestSetSubsystemNTPManagerRoundTrip(t *testing.T) {
+	cfg := &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientPeriodic}}
+	cfg.CheckNTPConfig()
+	bot := &Engine{Config: cfg}
+
+	status, ok := bot.GetSubsystemsStatus()["ntp_timekeeper"]
+	require.True(t, ok, "subsystem status must retain the ntp_timekeeper key")
+	assert.False(t, status, "NTP manager should initially be stopped")
+
+	require.NoError(t, bot.SetSubsystem(NTPManagerName, true), "NTP manager subsystem must start")
+	registerNTPManagerCleanup(t, bot.ntpManager)
+	assert.True(t, bot.GetSubsystemsStatus()["ntp_timekeeper"], "ntp_timekeeper status should report running")
+
+	require.NoError(t, bot.SetSubsystem(NTPManagerName, false), "NTP manager subsystem must stop")
+	assert.False(t, bot.GetSubsystemsStatus()["ntp_timekeeper"], "ntp_timekeeper status should report stopped")
+}
+
+func TestSetSubsystemNTPManagerRejectsNonPeriodicLevel(t *testing.T) {
+	cfg := &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}
+	cfg.CheckNTPConfig()
+	bot := &Engine{Config: cfg}
+
+	err := bot.SetSubsystem("ntp_timekeeper", true)
+	assert.ErrorIs(t, err, errNTPManagerDisabled, "non-periodic subsystem enable should return errNTPManagerDisabled")
+	assert.False(t, bot.GetSubsystemsStatus()["ntp_timekeeper"], "non-periodic NTP manager should remain stopped")
 }
 
 func TestSetSubsystemEnableDeniedAfterShutdownRequest(t *testing.T) {

--- a/engine/ntp_clock.go
+++ b/engine/ntp_clock.go
@@ -1,0 +1,167 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/beevik/ntp"
+)
+
+const (
+	ntpDialTimeout  = 5 * time.Second
+	ntpIOTimeout    = 5 * time.Second
+	maximumDuration = time.Duration(1<<63 - 1)
+	minimumDuration = -maximumDuration - 1
+)
+
+var (
+	errNoNTPPoolsConfigured    = errors.New("no NTP pools configured")
+	errNoValidNTPServer        = errors.New("no valid NTP server")
+	errNegativeNTPRoundTrip    = errors.New("negative NTP round-trip time")
+	errNegativeNTPRootDistance = errors.New("negative NTP root distance")
+	errNTPRootDistanceBelowRTT = errors.New("NTP root distance below half round-trip time")
+)
+
+// clockCorrection is server time minus local time: a positive value means the local clock is behind.
+// uncertainty is the NTP root distance. It bounds how far clockCorrection can be from the true offset.
+type clockObservation struct {
+	source          string
+	clockCorrection time.Duration
+	uncertainty     time.Duration
+	roundTrip       time.Duration
+}
+
+type queryClockFunc func(context.Context, string) (clockObservation, error)
+
+type clockMeasurer struct {
+	queryOne queryClockFunc
+}
+
+// Servers are asked in order and the first valid reply wins.
+// Selection never depends on the answer: a server is not skipped because its result is inconvenient.
+func (m clockMeasurer) measure(ctx context.Context, pools []string) (clockObservation, error) {
+	if len(pools) == 0 {
+		return clockObservation{}, errNoNTPPoolsConfigured
+	}
+
+	failures := make([]error, 0, len(pools))
+	for i := range pools {
+		if err := ctx.Err(); err != nil {
+			return clockObservation{}, err
+		}
+
+		observation, err := m.queryOne(ctx, pools[i])
+		// Drop even a successful observation after cancellation so shutdown
+		// cannot reach the startup prompt.
+		if contextErr := ctx.Err(); contextErr != nil {
+			return clockObservation{}, contextErr
+		}
+		if err == nil {
+			return observation, nil
+		}
+		failures = append(failures, fmt.Errorf("NTP server %q: %w", pools[i], err))
+	}
+
+	return clockObservation{}, fmt.Errorf("%w: %w", errNoValidNTPServer, errors.Join(failures...))
+}
+
+func queryClock(ctx context.Context, source string) (clockObservation, error) {
+	if err := ctx.Err(); err != nil {
+		return clockObservation{}, err
+	}
+
+	dialer := &net.Dialer{Timeout: ntpDialTimeout}
+	response, err := ntp.QueryWithOptions(source, ntp.QueryOptions{
+		Timeout: ntpIOTimeout,
+		Dialer: func(_, remoteAddress string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "udp", remoteAddress)
+		},
+	})
+	if err != nil {
+		return clockObservation{}, fmt.Errorf("query: %w", err)
+	}
+	if err := response.Validate(); err != nil {
+		return clockObservation{}, fmt.Errorf("validate response: %w", err)
+	}
+	return observationFromResponse(source, response)
+}
+
+func observationFromResponse(source string, response *ntp.Response) (clockObservation, error) {
+	if response.RTT < 0 {
+		return clockObservation{}, errNegativeNTPRoundTrip
+	}
+	if response.RootDistance < 0 {
+		return clockObservation{}, errNegativeNTPRootDistance
+	}
+	// Path asymmetry can put all of the delay in one direction, so half the round-trip
+	// time is the smallest honest uncertainty. A smaller value means the reply contradicts itself.
+	if response.RootDistance < response.RTT/2 {
+		return clockObservation{}, errNTPRootDistanceBelowRTT
+	}
+
+	return clockObservation{
+		source:          source,
+		clockCorrection: response.ClockOffset,
+		uncertainty:     response.RootDistance,
+		roundTrip:       response.RTT,
+	}, nil
+}
+
+type clockSyncState uint8
+
+const (
+	clockSyncInconclusive clockSyncState = iota
+	clockSyncInSync
+	clockSyncAhead
+	clockSyncBehind
+)
+
+// evaluateClock compares the complete uncertainty interval with the tolerance window.
+// A single value would report network delay as clock error, so a result is conclusive
+// only when the whole interval falls outside the window.
+func evaluateClock(
+	observation clockObservation,
+	allowedDifference,
+	allowedNegativeDifference time.Duration,
+) clockSyncState {
+	low := saturatingSubtract(observation.clockCorrection, observation.uncertainty)
+	high := saturatingAdd(observation.clockCorrection, observation.uncertainty)
+	// A positive correction means the local clock is behind, so allowedDifference is the upper bound.
+	behindBound := allowedDifference
+	aheadBound := -allowedNegativeDifference
+
+	switch {
+	case low > behindBound:
+		return clockSyncBehind
+	case high < aheadBound:
+		return clockSyncAhead
+	case low >= aheadBound && high <= behindBound:
+		return clockSyncInSync
+	default:
+		return clockSyncInconclusive
+	}
+}
+
+// Clamping keeps evaluateClock total: a very large correction cannot wrap and give the opposite result.
+func saturatingAdd(a, b time.Duration) time.Duration {
+	if b > 0 && a > maximumDuration-b {
+		return maximumDuration
+	}
+	if b < 0 && a < minimumDuration-b {
+		return minimumDuration
+	}
+	return a + b
+}
+
+func saturatingSubtract(a, b time.Duration) time.Duration {
+	if b > 0 && a < minimumDuration+b {
+		return minimumDuration
+	}
+	if b < 0 && a > maximumDuration+b {
+		return maximumDuration
+	}
+	return a - b
+}

--- a/engine/ntp_clock_test.go
+++ b/engine/ntp_clock_test.go
@@ -1,0 +1,391 @@
+package engine
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/beevik/ntp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClockMeasurerEmptyPools(t *testing.T) {
+	calls := 0
+	measurer := clockMeasurer{
+		queryOne: func(context.Context, string) (clockObservation, error) {
+			calls++
+			return clockObservation{}, errors.New("unexpected query")
+		},
+	}
+
+	_, err := measurer.measure(t.Context(), nil)
+	require.ErrorIs(t, err, errNoNTPPoolsConfigured, "an empty pool list must return the dedicated sentinel")
+	assert.NotErrorIs(t, err, errNoValidNTPServer, "an empty pool list should not report attempted servers")
+	assert.Zero(t, calls, "an empty pool list should not query a source")
+}
+
+func TestClockMeasurerOrderedFallback(t *testing.T) {
+	errFirst := errors.New("first source failed")
+	want := clockObservation{
+		source:          "second.test",
+		clockCorrection: 12 * time.Millisecond,
+		uncertainty:     4 * time.Millisecond,
+		roundTrip:       3 * time.Millisecond,
+	}
+	var calls []string
+	measurer := clockMeasurer{
+		queryOne: func(_ context.Context, source string) (clockObservation, error) {
+			calls = append(calls, source)
+			if source == "first.test" {
+				return clockObservation{}, errFirst
+			}
+			if source == "second.test" {
+				return want, nil
+			}
+			return clockObservation{}, errors.New("later source must not be queried")
+		},
+	}
+
+	got, err := measurer.measure(t.Context(), []string{"first.test", "second.test", "third.test"})
+	require.NoError(t, err, "a valid fallback source must produce a measurement")
+	assert.Equal(t, want, got, "measurement should return the first valid observation")
+	assert.Equal(t, []string{"first.test", "second.test"}, calls, "measurement should visit sources in order and stop after success")
+}
+
+func TestClockMeasurerJoinsAllFailures(t *testing.T) {
+	errFirst := errors.New("first failure")
+	errSecond := errors.New("second failure")
+	measurer := clockMeasurer{
+		queryOne: func(_ context.Context, source string) (clockObservation, error) {
+			switch source {
+			case "first.test":
+				return clockObservation{}, errFirst
+			case "second.test":
+				return clockObservation{}, errSecond
+			default:
+				return clockObservation{}, errors.New("unexpected source")
+			}
+		},
+	}
+
+	_, err := measurer.measure(t.Context(), []string{"first.test", "second.test"})
+	require.ErrorIs(t, err, errNoValidNTPServer, "the aggregate must retain the no-valid-server sentinel")
+	assert.ErrorIs(t, err, errFirst, "the aggregate should retain the first source failure")
+	assert.ErrorIs(t, err, errSecond, "the aggregate should retain the second source failure")
+	assert.Contains(t, err.Error(), "first.test", "the aggregate should identify the first source")
+	assert.Contains(t, err.Error(), "second.test", "the aggregate should identify the second source")
+}
+
+func TestClockMeasurerContextStopsFailover(t *testing.T) {
+	t.Run("canceled before first attempt", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		calls := 0
+		measurer := clockMeasurer{
+			queryOne: func(context.Context, string) (clockObservation, error) {
+				calls++
+				return clockObservation{}, errors.New("unexpected query")
+			},
+		}
+
+		_, err := measurer.measure(ctx, []string{"first.test"})
+		require.ErrorIs(t, err, context.Canceled, "measurement must preserve context cancellation")
+		assert.NotErrorIs(t, err, errNoValidNTPServer, "cancellation should not collapse into a server aggregate")
+		assert.Zero(t, calls, "a pre-canceled context should prevent the first query")
+	})
+
+	t.Run("canceled during an attempt", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		var calls []string
+		measurer := clockMeasurer{
+			queryOne: func(_ context.Context, source string) (clockObservation, error) {
+				calls = append(calls, source)
+				cancel()
+				return clockObservation{}, errors.New("query interrupted")
+			},
+		}
+
+		_, err := measurer.measure(ctx, []string{"first.test", "second.test"})
+		require.ErrorIs(t, err, context.Canceled, "measurement must preserve cancellation after an attempt")
+		assert.NotErrorIs(t, err, errNoValidNTPServer, "cancellation should not collapse into a server aggregate")
+		assert.Equal(t, []string{"first.test"}, calls, "cancellation should prevent further attempts")
+	})
+
+	t.Run("successful result after cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		measurer := clockMeasurer{
+			queryOne: func(context.Context, string) (clockObservation, error) {
+				cancel()
+				return clockObservation{
+					clockCorrection: time.Second,
+					uncertainty:     time.Millisecond,
+				}, nil
+			},
+		}
+
+		observation, err := measurer.measure(ctx, []string{"clock.test:123"})
+		require.ErrorIs(t, err, context.Canceled, "measurement must discard a successful observation returned after cancellation")
+		assert.Zero(t, observation, "measurement should not return the discarded observation")
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+		defer cancel()
+		calls := 0
+		measurer := clockMeasurer{
+			queryOne: func(context.Context, string) (clockObservation, error) {
+				calls++
+				return clockObservation{}, errors.New("unexpected query")
+			},
+		}
+
+		_, err := measurer.measure(ctx, []string{"first.test"})
+		require.ErrorIs(t, err, context.DeadlineExceeded, "measurement must preserve the deadline error")
+		assert.NotErrorIs(t, err, errNoValidNTPServer, "a deadline should not collapse into a server aggregate")
+		assert.Zero(t, calls, "an expired deadline should prevent the first query")
+	})
+}
+
+func TestNTPTimeoutConstants(t *testing.T) {
+	// Pin the user-visible bounds; these assertions do not prove transport wiring.
+	assert.Equal(t, 5*time.Second, ntpDialTimeout, "the dial timeout should preserve the five-second bound")
+	assert.Equal(t, 5*time.Second, ntpIOTimeout, "the connected I/O timeout should preserve the five-second bound")
+}
+
+func TestObservationFromResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		correction time.Duration
+	}{
+		{name: "positive correction", correction: 23 * time.Millisecond},
+		{name: "zero correction", correction: 0},
+		{name: "negative correction", correction: -17 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &ntp.Response{
+				ClockOffset:  tt.correction,
+				RootDistance: 11 * time.Millisecond,
+				RTT:          20 * time.Millisecond,
+			}
+
+			observation, err := observationFromResponse("clock.test:321", response)
+			require.NoError(t, err, "a consistent response must produce an observation")
+			assert.Equal(t, "clock.test:321", observation.source, "the observation should retain the configured source")
+			assert.Equal(t, tt.correction, observation.clockCorrection, "clock correction should map without a sign change")
+			assert.Equal(t, response.RootDistance, observation.uncertainty, "uncertainty should map root distance exactly once")
+			assert.Equal(t, response.RTT, observation.roundTrip, "round trip should map without modification")
+		})
+	}
+}
+
+func TestObservationFromResponseRejectsInvalidMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *ntp.Response
+		wantErr  error
+	}{
+		{
+			name:     "negative round trip",
+			response: &ntp.Response{RTT: -time.Nanosecond},
+			wantErr:  errNegativeNTPRoundTrip,
+		},
+		{
+			name:     "negative root distance",
+			response: &ntp.Response{RootDistance: -time.Nanosecond},
+			wantErr:  errNegativeNTPRootDistance,
+		},
+		{
+			name:     "root distance below half round trip",
+			response: &ntp.Response{RTT: 10 * time.Millisecond, RootDistance: 5*time.Millisecond - time.Nanosecond},
+			wantErr:  errNTPRootDistanceBelowRTT,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := observationFromResponse("clock.test", tt.response)
+			require.ErrorIs(t, err, tt.wantErr, "invalid response metadata must return its dedicated sentinel")
+		})
+	}
+}
+
+func TestObservationFromResponseAcceptsBoundaryAndLargeDistance(t *testing.T) {
+	tests := []struct {
+		name         string
+		roundTrip    time.Duration
+		rootDistance time.Duration
+	}{
+		{
+			name:         "half round trip boundary",
+			roundTrip:    10 * time.Millisecond,
+			rootDistance: 5 * time.Millisecond,
+		},
+		{
+			name:         "large root distance",
+			roundTrip:    10 * time.Millisecond,
+			rootDistance: time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observation, err := observationFromResponse("clock.test", &ntp.Response{
+				RTT:          tt.roundTrip,
+				RootDistance: tt.rootDistance,
+			})
+			require.NoError(t, err, "consistent response metadata must be accepted")
+			assert.Equal(t, tt.rootDistance, observation.uncertainty, "the accepted observation should retain root distance")
+		})
+	}
+}
+
+func TestEvaluateClock(t *testing.T) {
+	const (
+		aheadTolerance  = 20 * time.Millisecond
+		behindTolerance = 50 * time.Millisecond
+	)
+	tests := []struct {
+		name       string
+		correction time.Duration
+		radius     time.Duration
+		want       clockSyncState
+	}{
+		{name: "zero point", want: clockSyncInSync},
+		{name: "whole interval on both bounds", correction: 15 * time.Millisecond, radius: 35 * time.Millisecond, want: clockSyncInSync},
+		{name: "interval crosses both bounds", correction: 15 * time.Millisecond, radius: 45 * time.Millisecond, want: clockSyncInconclusive},
+		{name: "interval crosses behind bound", correction: 45 * time.Millisecond, radius: 10 * time.Millisecond, want: clockSyncInconclusive},
+		{name: "interval touches behind bound from outside", correction: 60 * time.Millisecond, radius: 10 * time.Millisecond, want: clockSyncInconclusive},
+		{name: "interval entirely behind", correction: 61 * time.Millisecond, radius: 10 * time.Millisecond, want: clockSyncBehind},
+		{name: "interval touches ahead bound from outside", correction: -30 * time.Millisecond, radius: 10 * time.Millisecond, want: clockSyncInconclusive},
+		{name: "interval entirely ahead", correction: -31 * time.Millisecond, radius: 10 * time.Millisecond, want: clockSyncAhead},
+		{name: "large correction remains behind", correction: 500 * time.Millisecond, radius: 100 * time.Millisecond, want: clockSyncBehind},
+		{name: "large radius overlaps both bounds", radius: 100 * time.Millisecond, want: clockSyncInconclusive},
+		{name: "exact behind point boundary", correction: behindTolerance, want: clockSyncInSync},
+		{name: "one nanosecond beyond behind point boundary", correction: behindTolerance + time.Nanosecond, want: clockSyncBehind},
+		{name: "exact ahead point boundary", correction: -aheadTolerance, want: clockSyncInSync},
+		{name: "one nanosecond beyond ahead point boundary", correction: -aheadTolerance - time.Nanosecond, want: clockSyncAhead},
+		{name: "positive endpoint does not wrap high", correction: time.Duration(math.MaxInt64), radius: time.Duration(math.MaxInt64), want: clockSyncInconclusive},
+		{name: "negative endpoint does not wrap low", correction: time.Duration(math.MinInt64), radius: time.Duration(math.MaxInt64), want: clockSyncInconclusive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateClock(clockObservation{
+				clockCorrection: tt.correction,
+				uncertainty:     tt.radius,
+			}, behindTolerance, aheadTolerance)
+			assert.Equal(t, tt.want, got, "the interval classifier should return the expected state")
+		})
+	}
+}
+
+func TestQueryClockLoopbackNegativeCorrectionSign(t *testing.T) {
+	endpoint, serverResult := startNTPTestServer(t, func(request []byte) ([]byte, error) {
+		return makeNTPTestResponse(request, -2*time.Second, 1)
+	})
+
+	observation, err := queryClock(t.Context(), endpoint)
+	require.NoError(t, err, "the real loopback query must accept a valid NTP response")
+	require.NoError(t, <-serverResult, "the loopback NTP server must complete its exchange")
+	assert.Equal(t, endpoint, observation.source, "the real query should retain the allocated endpoint")
+	assert.Less(t, observation.clockCorrection, time.Duration(0), "a server behind local time should produce a negative correction")
+}
+
+func TestQueryClockRejectsMalformedLoopbackResponse(t *testing.T) {
+	endpoint, serverResult := startNTPTestServer(t, func([]byte) ([]byte, error) {
+		return []byte{1, 2, 3}, nil
+	})
+
+	_, err := queryClock(t.Context(), endpoint)
+	require.Error(t, err, "a malformed NTP response must fail the real query boundary")
+	require.NoError(t, <-serverResult, "the malformed-response server must complete its exchange")
+}
+
+func TestClockMeasurerRejectsValidationFailure(t *testing.T) {
+	endpoint, serverResult := startNTPTestServer(t, func(request []byte) ([]byte, error) {
+		return makeNTPTestResponse(request, 0, 0)
+	})
+
+	_, err := (clockMeasurer{queryOne: queryClock}).measure(t.Context(), []string{endpoint})
+	require.Error(t, err, "a response rejected by Validate must make the source invalid")
+	require.NoError(t, <-serverResult, "the invalid-response server must complete its exchange")
+	assert.ErrorIs(t, err, errNoValidNTPServer, "a rejected response should contribute to the no-valid-server aggregate")
+	assert.ErrorIs(t, err, ntp.ErrKissOfDeath, "the aggregate should retain the validation failure")
+}
+
+type ntpTestResponder func([]byte) ([]byte, error)
+
+func startNTPTestServer(t *testing.T, responder ntpTestResponder) (endpoint string, serverResult <-chan error) {
+	t.Helper()
+
+	var listener net.ListenConfig
+	connection, err := listener.ListenPacket(t.Context(), "udp4", "127.0.0.1:0")
+	require.NoError(t, err, "the loopback UDP listener must start")
+	t.Cleanup(func() {
+		_ = connection.Close()
+	})
+
+	result := make(chan error, 1)
+	go func() {
+		if err := connection.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			result <- fmt.Errorf("set loopback server deadline: %w", err)
+			return
+		}
+
+		request := make([]byte, 512)
+		n, client, err := connection.ReadFrom(request)
+		if err != nil {
+			result <- fmt.Errorf("read loopback NTP request: %w", err)
+			return
+		}
+		response, err := responder(request[:n])
+		if err != nil {
+			result <- err
+			return
+		}
+		if _, err := connection.WriteTo(response, client); err != nil {
+			result <- fmt.Errorf("write loopback NTP response: %w", err)
+			return
+		}
+		result <- nil
+	}()
+
+	return connection.LocalAddr().String(), result
+}
+
+func makeNTPTestResponse(request []byte, serverOffset time.Duration, stratum uint8) ([]byte, error) {
+	const ntpPacketLength = 48
+	if len(request) < ntpPacketLength {
+		return nil, fmt.Errorf("NTP request too short: %d", len(request))
+	}
+
+	serverTime := time.Now().Add(serverOffset)
+	response := make([]byte, ntpPacketLength)
+	response[0] = request[0]&0x38 | 4
+	response[1] = stratum
+	response[2] = request[2]
+	response[3] = 0xec
+	binary.BigEndian.PutUint32(response[4:8], 1311) // 20 ms in NTP short format, rounded.
+	binary.BigEndian.PutUint32(response[8:12], 655) // 10 ms in NTP short format, rounded.
+	copy(response[12:16], "LOCL")
+	putNTPTime(response[16:24], serverTime.Add(-time.Second))
+	copy(response[24:32], request[40:48])
+	putNTPTime(response[32:40], serverTime)
+	putNTPTime(response[40:48], serverTime)
+	return response, nil
+}
+
+func putNTPTime(destination []byte, value time.Time) {
+	const ntpEpochOffsetSeconds = 2_208_988_800
+	seconds := uint64(value.Unix() + ntpEpochOffsetSeconds)      //nolint:gosec // Test timestamps are after the NTP epoch.
+	fraction := uint64(value.Nanosecond()) << 32 / 1_000_000_000 //nolint:gosec // Nanosecond is non-negative and below one second.
+	binary.BigEndian.PutUint64(destination, seconds<<32|fraction)
+}

--- a/engine/ntp_manager.go
+++ b/engine/ntp_manager.go
@@ -1,37 +1,35 @@
 package engine
 
 import (
-	"encoding/binary"
+	"context"
 	"fmt"
-	"net"
+	"io"
 	"time"
 
 	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/log"
 )
 
-// setupNTPManager creates a new NTP manager
-func setupNTPManager(cfg *config.NTPClientConfig, loggingEnabled bool) (*ntpManager, error) {
+// setupNTPManager creates a new NTP manager.
+func setupNTPManager(cfg *config.NTPClientConfig) (*ntpManager, error) {
 	if cfg == nil {
 		return nil, errNilConfig
 	}
-	if cfg.AllowedNegativeDifference == nil ||
-		cfg.AllowedDifference == nil {
+	if cfg.AllowedNegativeDifference == nil || cfg.AllowedDifference == nil {
 		return nil, errNilNTPConfigValues
 	}
 	return &ntpManager{
 		shutdown:                  make(chan struct{}),
-		level:                     int64(cfg.Level),
+		level:                     cfg.Level,
 		allowedDifference:         *cfg.AllowedDifference,
 		allowedNegativeDifference: *cfg.AllowedNegativeDifference,
 		pools:                     cfg.Pool,
 		checkInterval:             defaultNTPCheckInterval,
-		retryLimit:                defaultRetryLimit,
-		loggingEnabled:            loggingEnabled,
+		measure:                   clockMeasurer{queryOne: queryClock}.measure,
 	}, nil
 }
 
-// IsRunning safely checks whether the subsystem is running
+// IsRunning safely checks whether the subsystem is running.
 func (m *ntpManager) IsRunning() bool {
 	if m == nil {
 		return false
@@ -39,7 +37,7 @@ func (m *ntpManager) IsRunning() bool {
 	return m.started.Load()
 }
 
-// Start runs the subsystem
+// Start runs the subsystem.
 func (m *ntpManager) Start() error {
 	if m == nil {
 		return fmt.Errorf("ntp manager %w", ErrNilSubsystem)
@@ -47,27 +45,7 @@ func (m *ntpManager) Start() error {
 	if !m.started.CompareAndSwap(false, true) {
 		return fmt.Errorf("NTP manager %w", ErrSubSystemAlreadyStarted)
 	}
-	if m.level == 0 && m.loggingEnabled {
-		// Sometimes the NTP client can have transient issues due to UDP, try
-		// the default retry limits before giving up
-	check:
-		for i := range m.retryLimit {
-			err := m.processTime()
-			switch err {
-			case nil:
-				break check
-			case ErrSubSystemNotStarted:
-				log.Debugln(log.TimeMgr, "NTP manager: User disabled NTP prompts. Exiting.")
-				m.started.CompareAndSwap(true, false)
-				return nil
-			default:
-				if i == m.retryLimit-1 {
-					return err
-				}
-			}
-		}
-	}
-	if m.level != 1 {
+	if m.level != config.NTPClientPeriodic {
 		m.started.CompareAndSwap(true, false)
 		return errNTPManagerDisabled
 	}
@@ -77,7 +55,7 @@ func (m *ntpManager) Start() error {
 	return nil
 }
 
-// Stop attempts to shutdown the subsystem
+// Stop attempts to shutdown the subsystem.
 func (m *ntpManager) Stop() error {
 	if m == nil {
 		return fmt.Errorf("ntp manager %w", ErrNilSubsystem)
@@ -94,111 +72,130 @@ func (m *ntpManager) Stop() error {
 	return nil
 }
 
-// run continuously checks the internet connection at intervals
+// run periodically checks the configured time sources.
 func (m *ntpManager) run() {
-	t := time.NewTicker(m.checkInterval)
-	defer func() {
-		t.Stop()
-	}()
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-m.shutdown:
 			return
-		case <-t.C:
-			err := m.processTime()
-			if err != nil {
+		case <-ticker.C:
+			if err := m.processTime(context.Background()); err != nil {
 				log.Errorln(log.TimeMgr, err)
 			}
 		}
 	}
 }
 
-// FetchNTPTime returns the time from defined NTP pools
-func (m *ntpManager) FetchNTPTime() (time.Time, error) {
-	if m == nil {
-		return time.Time{}, fmt.Errorf("ntp manager %w", ErrNilSubsystem)
+func (m *ntpManager) checkClock(ctx context.Context) (clockObservation, clockSyncState, error) {
+	observation, err := m.measure(ctx, m.pools)
+	if err != nil {
+		return clockObservation{}, clockSyncInconclusive, fmt.Errorf("NTP clock measurement failed: %w", err)
 	}
-	if !m.started.Load() {
-		return time.Time{}, fmt.Errorf("NTP manager %w", ErrSubSystemNotStarted)
-	}
-	return m.checkTimeInPools(), nil
+	return observation,
+		evaluateClock(observation, m.allowedDifference, m.allowedNegativeDifference),
+		nil
 }
 
-// processTime determines the difference between system time and NTP time
-// to discover discrepancies
-func (m *ntpManager) processTime() error {
+// processTime checks and reports the current clock state for a running manager.
+func (m *ntpManager) processTime(ctx context.Context) error {
 	if !m.started.Load() {
 		return fmt.Errorf("NTP manager %w", ErrSubSystemNotStarted)
 	}
-	NTPTime, err := m.FetchNTPTime()
+	observation, state, err := m.checkClock(ctx)
 	if err != nil {
 		return err
 	}
-	currentTime := time.Now()
-	diff := NTPTime.Sub(currentTime)
-	configNTPTime := m.allowedDifference
-	negDiff := m.allowedNegativeDifference
-	configNTPNegativeTime := -negDiff
-	if diff > configNTPTime || diff < configNTPNegativeTime {
-		log.Warnf(log.TimeMgr, "NTP manager: Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v\n",
-			NTPTime,
-			currentTime,
-			diff,
-			configNTPTime,
-			configNTPNegativeTime)
-	}
+	m.logClockObservation(observation, state)
 	return nil
 }
 
-// checkTimeInPools returns local based on ntp servers provided timestamp
-// if no server can be reached will return local time in UTC()
-func (m *ntpManager) checkTimeInPools() time.Time {
-	for i := range m.pools {
-		con, err := net.DialTimeout("udp", m.pools[i], 5*time.Second) //nolint:noctx // TODO: #2006 Use (*net.Dialer).DialContext with (*net.Dialer).Timeout
-		if err != nil {
-			log.Warnf(log.TimeMgr, "Unable to connect to hosts %v attempting next", m.pools[i])
-			continue
-		}
-
-		if err = con.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to SetDeadline. Error: %s\n", err)
-			err = con.Close()
-			if err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		req := &ntpPacket{Settings: 0x1B}
-		if err = binary.Write(con, binary.BigEndian, req); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to write. Error: %s\n", err)
-			err = con.Close()
-			if err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		rsp := &ntpPacket{}
-		if err = binary.Read(con, binary.BigEndian, rsp); err != nil {
-			log.Warnf(log.TimeMgr, "Unable to read. Error: %s\n", err)
-			err = con.Close()
-			if err != nil {
-				log.Errorln(log.TimeMgr, err)
-			}
-			continue
-		}
-
-		secs := float64(rsp.TxTimeSec) - 2208988800
-		nanos := (int64(rsp.TxTimeFrac) * 1e9) >> 32
-
-		err = con.Close()
-		if err != nil {
-			log.Errorln(log.TimeMgr, err)
-		}
-		return time.Unix(int64(secs), nanos)
+func (bot *Engine) setupNTPClient(parent context.Context, input io.Reader) error {
+	if !bot.Settings.EnableNTPClient {
+		return nil
 	}
-	log.Warnln(log.TimeMgr, "No valid NTP servers found, using current system time")
-	return time.Now().UTC()
+
+	manager, err := setupNTPManager(&bot.Config.NTPClient)
+	bot.ntpManager = manager
+	if err != nil {
+		log.Errorf(log.Global, "NTP manager unable to start: %s", err)
+		return nil
+	}
+	return bot.handleStartupNTPPolicy(parent, input, ntpStartupBudget)
+}
+
+func (bot *Engine) handleStartupNTPPolicy(parent context.Context, input io.Reader, budget time.Duration) error {
+	if bot.Config.NTPClient.Level != config.NTPClientStartup {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(parent, budget)
+	defer cancel()
+
+	observation, state, err := bot.ntpManager.checkClock(ctx)
+	if err != nil {
+		if parentErr := parent.Err(); parentErr != nil {
+			return fmt.Errorf("NTP startup check aborted: %w", parentErr)
+		}
+		log.Warnf(log.TimeMgr, "NTP manager startup check failed: %v", err)
+		return nil
+	}
+
+	bot.ntpManager.logClockObservation(observation, state)
+	if state != clockSyncAhead && state != clockSyncBehind {
+		return nil
+	}
+
+	responseMessage, err := bot.Config.SetNTPCheck(input)
+	if err != nil {
+		return fmt.Errorf("unable to set NTP check: %w", err)
+	}
+	log.Infoln(log.TimeMgr, responseMessage)
+	bot.ntpManager.level = bot.Config.NTPClient.Level
+	return nil
+}
+
+func (m *ntpManager) logClockObservation(observation clockObservation, state clockSyncState) {
+	message, warning := m.clockObservationReport(observation, state)
+	if warning {
+		log.Warnln(log.TimeMgr, message)
+		return
+	}
+	log.Debugln(log.TimeMgr, message)
+}
+
+func (m *ntpManager) clockObservationReport(observation clockObservation, state clockSyncState) (string, bool) {
+	correction := observation.clockCorrection.String()
+	if observation.clockCorrection > 0 {
+		correction = "+" + correction
+	}
+	message := fmt.Sprintf(
+		"NTP manager: state=%s correction=%s (server-local; positive means local behind) root-distance=±%s RTT=%s source=%q allowed=[-%s ahead,+%s behind]",
+		state,
+		correction,
+		observation.uncertainty,
+		observation.roundTrip,
+		observation.source,
+		m.allowedNegativeDifference,
+		m.allowedDifference,
+	)
+	if state == clockSyncInconclusive {
+		message += "; no conclusion was possible; configure a closer or lower-latency NTP server"
+	}
+	return message, state != clockSyncInSync
+}
+
+func (s clockSyncState) String() string {
+	switch s {
+	case clockSyncInSync:
+		return "in-sync"
+	case clockSyncAhead:
+		return "ahead"
+	case clockSyncBehind:
+		return "behind"
+	default:
+		return "inconclusive"
+	}
 }

--- a/engine/ntp_manager.md
+++ b/engine/ntp_manager.md
@@ -17,20 +17,40 @@ You can track ideas, planned features and what's in progress on our [GoCryptoTra
 
 Join our slack to discuss all things related to GoCryptoTrader! [GoCryptoTrader Slack](https://join.slack.com/t/gocryptotrader/shared_invite/zt-38z8abs3l-gH8AAOk8XND6DP5NfCiG_g)
 
-## Current Features for Ntp Manager
-+ The NTP manager subsystem is used highlight discrepancies between your system time and specified NTP server times
-+ It is useful for debugging and understanding why a request to an exchange may be rejected
-+ The NTP manager cannot update your system clock, so when it does alert you of issues, you must take it upon yourself to change your system time in the event your requests are being rejected for being too far out of sync
-+ In order to modify the behaviour of the NTP manager subsystem, you can edit the following inside your config file under `ntpclient`:
+## Current Features for NTP Manager
+
+The NTP manager compares the local clock with configured NTP servers. It is a diagnostic feature
+for investigating timestamp-sensitive request failures; it does not adjust the system clock.
+These settings take effect only when the engine's NTP client feature is enabled; the command-line
+application enables that feature by default.
+
+Servers are tried in configured order and the first valid response is used. The clock correction is
+evaluated together with its complete root-distance interval, producing one of four results:
+
+- `in-sync`: the complete interval is within the configured tolerances;
+- `ahead`: the complete interval proves the local clock is ahead;
+- `behind`: the complete interval proves the local clock is behind;
+- `inconclusive`: the interval crosses a tolerance boundary, so no clock verdict is made.
+
+At startup, the alert/warn/disable prompt is shown only for a conclusive `ahead` or `behind` result.
+An inconclusive result warns without prompting and recommends a closer or lower-latency NTP server.
+The interval is a diagnostic bound based on the server's reported NTP metadata, not authenticated
+proof of UTC.
+
+Periodic checks run every 30 minutes only after the `ntp_timekeeper` subsystem is explicitly
+started. Normal engine startup constructs the subsystem but does not start it, including when the
+startup prompt changes the setting to periodic mode.
+
+The following settings are available under `ntpclient`:
 
 ### ntpclient
 
 | Config | Description | Example |
 | ------ | ----------- | ------- |
-| enabled | An integer value representing whether the NTP manager is enabled. It will warn you of time sync discrepancies on startup with a value of 0 and will alert you periodically with a value of 1. A value of -1 will disable the manager  |  `1` |
-| pool | A string array of the NTP servers to check for time discrepancies |  `["0.pool.ntp.org:123","pool.ntp.org:123"]` |
-| allowedDifference | A Golang time.Duration representation of the allowable time discrepancy between NTP server and your system time. Any discrepancy greater than this allowance will display an alert to your logging output |  `50000000` |
-| allowedNegativeDifference | A Golang time.Duration representation of the allowable negative time discrepancy between NTP server and your system time. Any discrepancy greater than this allowance will display an alert to your logging output |  `50000000` |
+| enabled | `-1` disables checks, `0` checks at startup, and `1` permits periodic checks when the subsystem is explicitly started | `1` |
+| pool | NTP servers attempted in configured order until the first valid response | `["0.pool.ntp.org:123","pool.ntp.org:123"]` |
+| allowedDifference | Maximum permitted local-clock-behind duration, expressed as Go `time.Duration` nanoseconds | `50000000` |
+| allowedNegativeDifference | Maximum permitted local-clock-ahead duration, expressed as Go `time.Duration` nanoseconds | `50000000` |
 
 ## Donations
 

--- a/engine/ntp_manager_test.go
+++ b/engine/ntp_manager_test.go
@@ -1,167 +1,431 @@
 package engine
 
 import (
+	"context"
+	"errors"
+	"io"
+	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/config"
 )
 
+func testNTPManager(t *testing.T, level int) *ntpManager {
+	t.Helper()
+	ahead := 20 * time.Millisecond
+	behind := 50 * time.Millisecond
+	m, err := setupNTPManager(&config.NTPClientConfig{
+		Level:                     level,
+		Pool:                      []string{"first.test:123", "second.test:123"},
+		AllowedDifference:         &behind,
+		AllowedNegativeDifference: &ahead,
+	})
+	require.NoError(t, err, "NTP manager setup must not error")
+	return m
+}
+
+func registerNTPManagerCleanup(t *testing.T, m *ntpManager) {
+	t.Helper()
+	t.Cleanup(func() {
+		if m.IsRunning() {
+			require.NoError(t, m.Stop(), "started manager cleanup must stop")
+		}
+	})
+}
+
 func TestSetupNTPManager(t *testing.T) {
-	_, err := setupNTPManager(nil, false)
-	assert.ErrorIs(t, err, errNilConfig)
+	_, err := setupNTPManager(nil)
+	require.ErrorIs(t, err, errNilConfig, "nil config must return errNilConfig")
 
-	_, err = setupNTPManager(&config.NTPClientConfig{}, false)
-	assert.ErrorIs(t, err, errNilNTPConfigValues)
+	_, err = setupNTPManager(&config.NTPClientConfig{})
+	require.ErrorIs(t, err, errNilNTPConfigValues, "nil tolerances must return errNilNTPConfigValues")
 
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
+	m := testNTPManager(t, config.NTPClientPeriodic)
+	_, err = m.measure(t.Context(), nil)
+	require.ErrorIs(t, err, errNoNTPPoolsConfigured, "setup measurement must retain the empty-pool sentinel")
+
+	endpoint, serverResult := startNTPTestServer(t, func(request []byte) ([]byte, error) {
+		return makeNTPTestResponse(request, time.Second, 1)
+	})
+	observation, err := m.measure(t.Context(), []string{endpoint})
+	require.NoError(t, err, "setup measurement must use the production NTP query path")
+	require.NoError(t, <-serverResult, "the setup measurement server must complete its exchange")
+	assert.Greater(t, observation.clockCorrection, time.Duration(0), "setup measurement should retain the signed correction")
+	assert.Equal(t, endpoint, observation.source, "setup measurement should retain the queried source")
+	assert.Equal(t, 30*time.Minute, m.checkInterval, "manager cadence should be thirty minutes")
+}
+
+func TestSetupNTPClient(t *testing.T) {
+	existing := &ntpManager{}
+	disabled := &Engine{ntpManager: existing}
+	disabledInput := &readTrackingReader{}
+	require.NoError(
+		t,
+		disabled.setupNTPClient(t.Context(), disabledInput),
+		"disabled NTP client setup must not error",
+	)
+	assert.Same(t, existing, disabled.ntpManager, "disabled NTP client should not replace the manager")
+	assert.Zero(t, disabledInput.reads, "disabled NTP client should not prompt")
+
+	setupFailure := &Engine{
+		Config:     &config.Config{},
+		Settings:   Settings{CoreSettings: CoreSettings{EnableNTPClient: true}},
+		ntpManager: existing,
 	}
-	m, err := setupNTPManager(cfg, false)
-	assert.NoError(t, err)
+	setupFailureInput := &readTrackingReader{}
+	require.NoError(
+		t,
+		setupFailure.setupNTPClient(t.Context(), setupFailureInput),
+		"NTP manager setup failure must not abort startup",
+	)
+	assert.Nil(t, setupFailure.ntpManager, "NTP manager setup failure should clear a stale manager")
+	assert.Zero(t, setupFailureInput.reads, "NTP manager setup failure should not prompt")
 
-	if m == nil {
-		t.Error("expected manager")
+	for _, level := range []int{config.NTPClientDisabled, config.NTPClientPeriodic} {
+		ahead := 20 * time.Millisecond
+		behind := 50 * time.Millisecond
+		bot := &Engine{
+			Config: &config.Config{NTPClient: config.NTPClientConfig{
+				Level:                     level,
+				Pool:                      []string{"first.test:123"},
+				AllowedDifference:         &behind,
+				AllowedNegativeDifference: &ahead,
+			}},
+			Settings: Settings{CoreSettings: CoreSettings{EnableNTPClient: true}},
+		}
+		input := &readTrackingReader{}
+		require.NoError(
+			t,
+			bot.setupNTPClient(t.Context(), input),
+			"non-startup NTP client setup must not error",
+		)
+		require.NotNil(t, bot.ntpManager, "enabled NTP client setup must construct the manager")
+		assert.False(t, bot.ntpManager.IsRunning(), "normal engine setup should leave the manager stopped")
+		assert.Zero(t, input.reads, "non-startup NTP client setup should not prompt")
 	}
 }
 
-func TestNTPManagerIsRunning(t *testing.T) {
-	var m *ntpManager
-	if m.IsRunning() {
-		t.Error("expected false")
+func TestNTPManagerLifecycle(t *testing.T) {
+	var nilManager *ntpManager
+	assert.False(t, nilManager.IsRunning(), "nil manager should not be running")
+	require.ErrorIs(t, nilManager.Start(), ErrNilSubsystem, "nil manager Start must return ErrNilSubsystem")
+	require.ErrorIs(t, nilManager.Stop(), ErrNilSubsystem, "nil manager Stop must return ErrNilSubsystem")
+
+	for _, level := range []int{
+		config.NTPClientStartup,
+		config.NTPClientDisabled,
+		42,
+	} {
+		m := testNTPManager(t, level)
+		measurements := 0
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			measurements++
+			return clockObservation{}, nil
+		}
+		err := m.Start()
+		assert.ErrorIs(t, err, errNTPManagerDisabled, "non-periodic level should return errNTPManagerDisabled")
+		assert.False(t, m.IsRunning(), "disabled manager should roll back its running state")
+		assert.Zero(t, measurements, "Start should not perform a synchronous measurement")
 	}
 
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
-		Level:                     1,
+	m := testNTPManager(t, config.NTPClientPeriodic)
+	measurements := 0
+	m.measure = func(context.Context, []string) (clockObservation, error) {
+		measurements++
+		return clockObservation{}, nil
 	}
-	m, err := setupNTPManager(cfg, false)
-	assert.NoError(t, err)
-
-	if m.IsRunning() {
-		t.Error("expected false")
-	}
-
-	err = m.Start()
-	if err != nil {
-		t.Error(err)
-	}
-	if !m.IsRunning() {
-		t.Error("expected true")
-	}
-}
-
-func TestNTPManagerStart(t *testing.T) {
-	var m *ntpManager
-	err := m.Start()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
-
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
-	}
-	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
-
-	err = m.Start()
-	assert.ErrorIs(t, err, errNTPManagerDisabled)
-
-	m.level = 1
-	err = m.Start()
-	assert.NoError(t, err)
-
-	err = m.Start()
-	assert.ErrorIs(t, err, ErrSubSystemAlreadyStarted)
-}
-
-func TestNTPManagerStop(t *testing.T) {
-	var m *ntpManager
+	assert.False(t, m.IsRunning(), "new manager should not be running")
 	err := m.Stop()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
-
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
-		Level:                     1,
-	}
-	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
-
-	err = m.Stop()
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
-
+	assert.ErrorIs(t, err, ErrSubSystemNotStarted, "manager stopped before Start should return ErrSubSystemNotStarted")
+	require.NoError(t, m.Start(), "periodic manager must start")
+	registerNTPManagerCleanup(t, m)
+	assert.True(t, m.IsRunning(), "started manager should be running")
+	assert.Zero(t, measurements, "Start should defer measurement until the first ticker event")
 	err = m.Start()
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, ErrSubSystemAlreadyStarted, "second start should return ErrSubSystemAlreadyStarted")
 
+	require.NoError(t, m.Stop(), "running manager must stop")
+	assert.False(t, m.IsRunning(), "stopped manager should not be running")
 	err = m.Stop()
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, ErrSubSystemNotStarted, "second stop should return ErrSubSystemNotStarted")
 }
 
-func TestFetchNTPTime(t *testing.T) {
-	var m *ntpManager
-	_, err := m.FetchNTPTime()
-	assert.ErrorIs(t, err, ErrNilSubsystem)
+func TestNTPProcessTime(t *testing.T) {
+	stopped := testNTPManager(t, config.NTPClientPeriodic)
+	err := stopped.processTime(t.Context())
+	require.ErrorIs(t, err, ErrSubSystemNotStarted, "stopped processTime must return ErrSubSystemNotStarted")
 
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
-		Level:                     1,
+	t.Run("success", func(t *testing.T) {
+		m := testNTPManager(t, config.NTPClientPeriodic)
+		measurements := 0
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			measurements++
+			return clockObservation{
+				source:          "first.test:123",
+				clockCorrection: 5 * time.Millisecond,
+				uncertainty:     10 * time.Millisecond,
+				roundTrip:       12 * time.Millisecond,
+			}, nil
+		}
+		require.NoError(t, m.Start(), "periodic manager must start before processing time")
+		registerNTPManagerCleanup(t, m)
+		require.NoError(t, m.processTime(t.Context()), "successful processTime must not error")
+		assert.Equal(t, 1, measurements, "successful processTime should measure exactly once")
+	})
+
+	t.Run("measurement failure", func(t *testing.T) {
+		errMeasurement := errors.New("measurement failed")
+		m := testNTPManager(t, config.NTPClientPeriodic)
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			return clockObservation{}, errMeasurement
+		}
+		require.NoError(t, m.Start(), "periodic manager must start before processing time")
+		registerNTPManagerCleanup(t, m)
+		err := m.processTime(t.Context())
+		require.ErrorIs(t, err, errMeasurement, "measurement error must retain its identity")
+	})
+}
+
+func TestClockObservationReport(t *testing.T) {
+	m := testNTPManager(t, config.NTPClientStartup)
+	observation := clockObservation{
+		source:          "first.test:123",
+		clockCorrection: 45 * time.Millisecond,
+		uncertainty:     10 * time.Millisecond,
+		roundTrip:       12 * time.Millisecond,
 	}
-	m, err = setupNTPManager(cfg, true)
-	assert.NoError(t, err)
-
-	_, err = m.FetchNTPTime()
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
-
-	err = m.Start()
-	assert.NoError(t, err)
-
-	tt, err := m.FetchNTPTime()
-	assert.NoError(t, err)
-
-	if tt.IsZero() {
-		t.Error("expected time")
+	message, warning := m.clockObservationReport(observation, clockSyncInconclusive)
+	assert.True(t, warning, "Inconclusive should use warning severity")
+	for _, expected := range []string{
+		"state=inconclusive",
+		"correction=+45ms",
+		"positive means local behind",
+		"root-distance=±10ms",
+		"RTT=12ms",
+		`source="first.test:123"`,
+		"-20ms ahead",
+		"+50ms behind",
+		"no conclusion was possible",
+		"closer or lower-latency NTP server",
+	} {
+		assert.Contains(t, message, expected, "Inconclusive report should contain required diagnostics")
 	}
 
-	m.pools = []string{"0.pool.ntp.org:123"}
-	tt, err = m.FetchNTPTime()
-	assert.NoError(t, err)
+	_, warning = m.clockObservationReport(clockObservation{}, clockSyncInSync)
+	assert.False(t, warning, "InSync should use debug severity")
 
-	if tt.IsZero() {
-		t.Error("expected time")
+	for _, tc := range []struct {
+		state clockSyncState
+		label string
+	}{
+		{state: clockSyncAhead, label: "state=ahead"},
+		{state: clockSyncBehind, label: "state=behind"},
+	} {
+		message, warning = m.clockObservationReport(clockObservation{}, tc.state)
+		assert.True(t, warning, "conclusive out-of-sync state should use warning severity")
+		assert.Contains(t, message, tc.label, "conclusive report should identify the clock state")
 	}
 }
 
-func TestProcessTime(t *testing.T) {
-	sec := time.Second
-	cfg := &config.NTPClientConfig{
-		AllowedDifference:         &sec,
-		AllowedNegativeDifference: &sec,
-		Level:                     1,
-		Pool:                      []string{"0.pool.ntp.org:123"},
+func TestHandleStartupNTPPolicyStates(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		observation clockObservation
+		input       string
+		wantLevel   int
+	}{
+		{
+			name: "in sync",
+			observation: clockObservation{
+				clockCorrection: 0,
+				uncertainty:     time.Millisecond,
+			},
+			wantLevel: config.NTPClientStartup,
+		},
+		{
+			name: "inconclusive",
+			observation: clockObservation{
+				clockCorrection: 45 * time.Millisecond,
+				uncertainty:     10 * time.Millisecond,
+			},
+			wantLevel: config.NTPClientStartup,
+		},
+		{
+			name: "behind choose alert",
+			observation: clockObservation{
+				clockCorrection: 100 * time.Millisecond,
+				uncertainty:     time.Millisecond,
+			},
+			input:     "a\n",
+			wantLevel: config.NTPClientStartup,
+		},
+		{
+			name: "behind choose periodic",
+			observation: clockObservation{
+				clockCorrection: 100 * time.Millisecond,
+				uncertainty:     time.Millisecond,
+			},
+			input:     "w\n",
+			wantLevel: config.NTPClientPeriodic,
+		},
+		{
+			name: "ahead choose disabled",
+			observation: clockObservation{
+				clockCorrection: -100 * time.Millisecond,
+				uncertainty:     time.Millisecond,
+			},
+			input:     "d\n",
+			wantLevel: config.NTPClientDisabled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testNTPManager(t, config.NTPClientStartup)
+			measurements := 0
+			m.measure = func(context.Context, []string) (clockObservation, error) {
+				measurements++
+				observation := tc.observation
+				observation.source = "first.test:123"
+				observation.roundTrip = time.Millisecond
+				return observation, nil
+			}
+			bot := &Engine{
+				Config:     &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}},
+				ntpManager: m,
+			}
+			input := strings.NewReader(tc.input)
+			err := bot.handleStartupNTPPolicy(t.Context(), iotest.OneByteReader(input), ntpStartupBudget)
+			require.NoError(t, err, "startup NTP policy must not error")
+			assert.Equal(t, 1, measurements, "startup policy should perform one aggregate measurement")
+			assert.Equal(t, tc.wantLevel, bot.Config.NTPClient.Level, "config Level should match the selected policy")
+			assert.Equal(t, tc.wantLevel, m.level, "manager Level should match the selected policy")
+			if tc.input != "" {
+				assert.Zero(t, input.Len(), "prompting startup policy should consume the selected response")
+			}
+		})
 	}
-	m, err := setupNTPManager(cfg, true)
-	assert.NoError(t, err)
+}
 
-	err = m.processTime()
-	assert.ErrorIs(t, err, ErrSubSystemNotStarted)
+func TestHandleStartupNTPPolicySkipsOtherLevels(t *testing.T) {
+	for _, level := range []int{config.NTPClientDisabled, config.NTPClientPeriodic, 42} {
+		m := testNTPManager(t, level)
+		measurements := 0
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			measurements++
+			return clockObservation{}, nil
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: level}}, ntpManager: m}
+		err := bot.handleStartupNTPPolicy(t.Context(), strings.NewReader(""), ntpStartupBudget)
+		require.NoError(t, err, "non-startup NTP policy must not error")
+		assert.Zero(t, measurements, "non-startup Level should not measure")
+	}
+}
 
-	err = m.Start()
-	assert.NoError(t, err)
+func TestHandleStartupNTPPolicyFailures(t *testing.T) {
+	errMeasurement := errors.New("measurement failed")
 
-	err = m.processTime()
-	assert.NoError(t, err)
+	t.Run("measurement failure", func(t *testing.T) {
+		m := testNTPManager(t, config.NTPClientStartup)
+		measurements := 0
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			measurements++
+			return clockObservation{}, errMeasurement
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+		input := &readTrackingReader{}
+		err := bot.handleStartupNTPPolicy(t.Context(), input, ntpStartupBudget)
+		require.NoError(t, err, "measurement failure must not abort startup")
+		assert.Equal(t, 1, measurements, "measurement failure should not trigger an outer retry")
+		assert.Zero(t, input.reads, "measurement failure should not prompt")
+		assert.Equal(t, config.NTPClientStartup, bot.Config.NTPClient.Level, "measurement failure should preserve Level")
+	})
 
-	m.allowedDifference = time.Duration(1)
-	m.allowedNegativeDifference = time.Duration(1)
-	err = m.processTime()
-	assert.NoError(t, err)
+	t.Run("parent canceled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(t.Context())
+		cancel()
+		m := testNTPManager(t, config.NTPClientStartup)
+		m.measure = func(ctx context.Context, _ []string) (clockObservation, error) {
+			return clockObservation{}, ctx.Err()
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+		input := &readTrackingReader{}
+		err := bot.handleStartupNTPPolicy(parent, input, ntpStartupBudget)
+		require.ErrorIs(t, err, context.Canceled, "parent cancellation must abort startup")
+		assert.Zero(t, input.reads, "parent cancellation should not prompt")
+	})
+
+	t.Run("parent deadline", func(t *testing.T) {
+		parent, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+		defer cancel()
+		m := testNTPManager(t, config.NTPClientStartup)
+		m.measure = func(ctx context.Context, _ []string) (clockObservation, error) {
+			return clockObservation{}, ctx.Err()
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+		input := &readTrackingReader{}
+		err := bot.handleStartupNTPPolicy(parent, input, ntpStartupBudget)
+		require.ErrorIs(t, err, context.DeadlineExceeded, "parent deadline must abort startup")
+		assert.Zero(t, input.reads, "parent deadline should not prompt")
+	})
+
+	t.Run("child budget", func(t *testing.T) {
+		m := testNTPManager(t, config.NTPClientStartup)
+		m.measure = func(ctx context.Context, pools []string) (clockObservation, error) {
+			assert.Len(t, pools, 2, "configured pool list should reach the aggregate measurement")
+			<-ctx.Done()
+			return clockObservation{}, ctx.Err()
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+		input := &readTrackingReader{}
+		err := bot.handleStartupNTPPolicy(t.Context(), input, 0)
+		require.NoError(t, err, "child budget expiry must not abort startup")
+		assert.Zero(t, input.reads, "child budget expiry should not prompt")
+	})
+
+	t.Run("prompt EOF", func(t *testing.T) {
+		m := testNTPManager(t, config.NTPClientStartup)
+		m.measure = func(context.Context, []string) (clockObservation, error) {
+			return clockObservation{
+				clockCorrection: 100 * time.Millisecond,
+				uncertainty:     time.Millisecond,
+			}, nil
+		}
+		bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+		err := bot.handleStartupNTPPolicy(t.Context(), strings.NewReader(""), ntpStartupBudget)
+		require.ErrorIs(t, err, io.EOF, "prompt EOF must abort startup and retain io.EOF")
+	})
+}
+
+func TestHandleStartupNTPPolicyBudget(t *testing.T) {
+	m := testNTPManager(t, config.NTPClientStartup)
+	var observedDeadline time.Time
+	var hasDeadline bool
+	m.measure = func(ctx context.Context, _ []string) (clockObservation, error) {
+		observedDeadline, hasDeadline = ctx.Deadline()
+		return clockObservation{uncertainty: time.Millisecond}, nil
+	}
+	bot := &Engine{Config: &config.Config{NTPClient: config.NTPClientConfig{Level: config.NTPClientStartup}}, ntpManager: m}
+	before := time.Now()
+	require.NoError(
+		t,
+		bot.handleStartupNTPPolicy(t.Context(), strings.NewReader(""), ntpStartupBudget),
+		"startup policy must use the bounded context",
+	)
+	after := time.Now()
+	require.True(t, hasDeadline, "startup measurement context must have a deadline")
+	assert.False(t, observedDeadline.Before(before.Add(ntpStartupBudget)), "startup deadline should not precede the requested budget")
+	assert.False(t, observedDeadline.After(after.Add(ntpStartupBudget)), "startup deadline should not exceed the requested budget")
+	assert.Equal(t, 10*time.Second, ntpStartupBudget, "startup budget should remain ten seconds")
+}
+
+type readTrackingReader struct {
+	reads int
+}
+
+func (r *readTrackingReader) Read([]byte) (int, error) {
+	r.reads++
+	return 0, io.EOF
 }

--- a/engine/ntp_manager_types.go
+++ b/engine/ntp_manager_types.go
@@ -1,14 +1,15 @@
 package engine
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"time"
 )
 
 const (
-	defaultNTPCheckInterval = time.Second * 30
-	defaultRetryLimit       = 3
+	defaultNTPCheckInterval = 30 * time.Minute
+	ntpStartupBudget        = 10 * time.Second
 	// NTPManagerName is an exported subsystem name
 	NTPManagerName = "ntp_timekeeper"
 )
@@ -22,29 +23,10 @@ var (
 type ntpManager struct {
 	started                   atomic.Bool
 	shutdown                  chan struct{}
-	level                     int64
+	level                     int
 	allowedDifference         time.Duration
 	allowedNegativeDifference time.Duration
 	pools                     []string
 	checkInterval             time.Duration
-	retryLimit                int
-	loggingEnabled            bool
-}
-
-type ntpPacket struct {
-	Settings       uint8  // leap yr indicator, ver number, and mode
-	Stratum        uint8  // stratum of local clock
-	Poll           int8   // poll exponent
-	Precision      int8   // precision exponent
-	RootDelay      uint32 // root delay
-	RootDispersion uint32 // root dispersion
-	ReferenceID    uint32 // reference id
-	RefTimeSec     uint32 // reference timestamp sec
-	RefTimeFrac    uint32 // reference timestamp fractional
-	OrigTimeSec    uint32 // origin time secs
-	OrigTimeFrac   uint32 // origin time fractional
-	RxTimeSec      uint32 // receive time secs
-	RxTimeFrac     uint32 // receive time frac
-	TxTimeSec      uint32 // transmit time secs
-	TxTimeFrac     uint32 // transmit time frac
+	measure                   func(context.Context, []string) (clockObservation, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/beevik/ntp v1.5.0
 	github.com/buger/jsonparser v1.6.1
 	github.com/bytedance/sonic v1.15.2
 	github.com/d5/tengo/v2 v2.17.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apmckinlay/gsuneido v0.0.0-20180907175622-1f10244968e3/go.mod h1:hJnaqxrCRgMCTWtpNz9XUFkBCREiQdlcyK6YNmOfroM=
 github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f/go.mod h1:JU2DOj5Fc6rol0yaT79Csr47QR0vONGwJtBNGRD7jmc=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
+github.com/beevik/ntp v1.5.0/go.mod h1:mJEhBrwT76w9D+IfOEGvuzyuudiW9E52U2BaTrMOYow=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
## Summary

GoCryptoTrader told me my system clock was wrong. It was correct.

The cause is a measurement error in the NTP client on `master`. The code compares two timestamps
that are not comparable, so it reads network delay as clock error. On a normal internet connection,
the network delay alone can use the complete default tolerance.

This pull request replaces the hand-written SNTP code with a validated measurement. It uses the
standard offset formula from RFC 5905, it reports how accurate each measurement is, and it warns
only when the measurement supports a conclusion.

You do not need to read any other pull request to review this one. Everything is explained below.

---

## Background: what the NTP client does in GoCryptoTrader

Exchange APIs reject signed requests when the timestamp in the request is outside a receive window.
The window is often a few seconds. If the local clock drifts, orders fail. The failure message from
the exchange is usually not clear about the cause.

GoCryptoTrader therefore checks the local clock against public NTP servers. The subsystem is called
`ntp_timekeeper`. It is advisory only: **it never changes the system clock.** It writes a log
message, and at one setting it asks the user how to be told in future.

The configuration is small:

```json
"ntpclient": {
  "enabled": 0,
  "pool": ["pool.ntp.org:123"],
  "allowedDifference": 50000000,
  "allowedNegativeDifference": 50000000
}
```

| Field | Meaning |
|---|---|
| `enabled` | `-1` off, `0` check at startup and prompt, `1` warn periodically |
| `pool` | NTP servers, tried in order |
| `allowedDifference` | How far the clock may be **behind**, in nanoseconds (50 ms) |
| `allowedNegativeDifference` | How far the clock may be **ahead**, in nanoseconds (50 ms) |

---

## The problem I hit

At startup, GoCryptoTrader showed me this:

```
Your system time is out of sync, this may cause issues with trading
How would you like to show future notifications? (a)lert at startup / (w)arn periodically / (d)isable
```

My clock was fine. `systemd-timesyncd` reported an error of **−383 microseconds**:

```
       Server: 162.159.200.1 (time.cloudflare.com)
Root distance: 2.852ms (max: 5s)
       Offset: -383us
        Delay: 10.140ms
```

So I looked at the code on `master`.

### Why the code on `master` is wrong

To compare your clock with a server clock, you need the time at the server **now**. The reply from
the server is always late, because the packet needs time to travel.

An NTP exchange produces four timestamps:

| Name | Event | Clock that records it |
|---|---|---|
| **T1** | The client sends the request | Client |
| **T2** | The server receives the request | Server |
| **T3** | The server sends the reply | Server |
| **T4** | The client receives the reply | Client |

`master` uses two of the four. It reads the server transmit time (T3) and compares it with the local
time at reception (T4):

```go
// engine/ntp_manager.go on master
NTPTime, err := m.FetchNTPTime()   // T3: time at the server when it sent the reply
currentTime := time.Now()          // T4: time at the client when the reply arrived
diff := NTPTime.Sub(currentTime)   // T3 − T4
```

`T3 − T4` is not the clock error. It is:

```
T3 − T4  =  clock offset  −  one-way delay (server → client)
```

The network delay is always inside the result. A correct clock therefore looks slow, by the size of
the delay.

### The numbers show why this fires so easily

The default tolerance is 50 ms in each direction. I measured `pool.ntp.org` from a home connection:
the round-trip time is 35 ms to 55 ms, so the one-way delay is roughly 18 ms to 28 ms. Slower paths
give more.

| True clock error | One-way delay | Result on `master` | Warning shown? |
|---:|---:|---:|---|
| 0 ms | 20 ms | −20 ms | No |
| 0 ms | 50 ms | −50 ms | **Yes, but the clock is perfect** |
| 0 ms | 60 ms | −60 ms | **Yes, but the clock is perfect** |

The distance to the server alone can use the whole tolerance.

### Two more problems in the same code

**It asks before it measures.** At `enabled: 0`, `master` shows the prompt every time. The prompt
does not depend on the clock:

```go
// engine/engine.go on master
if bot.Config.NTPClient.Level == 0 {
    responseMessage, err := bot.Config.SetNTPCheck(os.Stdin)   // no measurement first
```

**A total failure looks like success.** When no server answers, `master` returns the local time:

```go
log.Warnln(log.TimeMgr, "No valid NTP servers found, using current system time")
return time.Now().UTC()
```

The caller then compares local time with local time. The difference is always zero. So a complete
network failure and a perfect clock produce the same result.

That last point explains why the bug survived so long. The check reported success no matter what
happened.

---

## The approach

The three problems above share one cause: the code measures the clock, judges the clock, talks to
the network, and prompts the user, all in the same functions. Nothing can be tested without a
network, so nothing was.

This change splits that into four stages with one direction of flow:

```
  configured pools (in order)
            │
            ▼
  queryClock ──────► github.com/beevik/ntp ──────► reply validation
            │
            ▼
  clockObservation { correction, uncertainty, round-trip, source }
            │
            ▼
  evaluateClock   ← pure function: no network, no logging, no config
            │
            ▼
  In sync | Ahead | Behind | Inconclusive
            │
            ├────────────► startup policy   (measure, then maybe prompt)
            └────────────► periodic loop    (measure, then log)
```

Four decisions define the design:

**1. The protocol is not ours to implement.** `queryClock` is the only function that speaks NTP, and
it delegates to a maintained library. Library types stop at the adapter; nothing else in the engine
knows the dependency exists.

**2. The measurement is a value, not a time.** The adapter returns one local type:

```go
type clockObservation struct {
    source          string
    clockCorrection time.Duration   // server − local; positive means the local clock is behind
    uncertainty     time.Duration   // root distance
    roundTrip       time.Duration
}
```

`master` returned a `time.Time`, which throws away everything except the answer. Carrying the
uncertainty is what makes the fourth result possible.

**3. The decision is a pure function.** `evaluateClock` takes an observation and two limits and
returns one of four states. It performs no I/O, writes no logs, and reads no configuration. Every
boundary case is therefore testable in microseconds, with no network and no clock.

**4. Startup and the periodic loop share one check.** Both call the same
measure-then-evaluate helper, so the sign convention and the threshold comparison exist in exactly
one place. On `master` the comparison was written twice, in two different forms.

### How each stage now handles failure

| Stage | On failure |
|---|---|
| One server | Try the next configured server |
| All servers | Return an error. Never substitute local time. |
| Startup measurement | Write one warning, continue starting, do not prompt |
| Engine shutdown during a check | Stop, and report the cancellation, not a clock verdict |

---

## What this changes in behaviour

### 1. It uses all four timestamps

RFC 5905 defines the clock offset as:

```
offset = ((T2 − T1) + (T3 − T4)) / 2
```

The two delays cancel each other when the path is symmetric. What remains is the clock difference.

### 2. It reports how accurate each measurement is

You cannot know the offset exactly. You can only know it within a limit. The limit has two parts:

- **Path asymmetry.** If the two directions have different delays, the error can be as large as half
  the round-trip time.
- **Server error.** The server has its own error against its reference clock.

NTP calls the total the **root distance**. This change keeps that value and uses it as the radius of
an interval:

```
low  = offset − root distance
high = offset + root distance
```

### 3. It decides from the interval, not from one number

The code compares the complete interval with the tolerance window:

| Result | Condition | Action |
|---|---|---|
| **In sync** | The interval is completely inside the window | Log at debug level |
| **Behind** | The interval is completely above the window | Warn, and prompt at `enabled: 0` |
| **Ahead** | The interval is completely below the window | Warn, and prompt at `enabled: 0` |
| **Inconclusive** | The interval crosses a limit of the window | Warn, but **never** prompt |

`Inconclusive` is the important addition. The code on `master` has no way to say *"I cannot tell"*.
It always produces an answer, even when the measurement does not support one. An `Inconclusive`
result also tells the user what to do: configure a nearer NTP server, or one with a lower delay.

### 4. It measures before it prompts

The prompt appears only after a conclusive `Ahead` or `Behind` result. A failed measurement writes
one warning, and startup continues.

---

## `master` compared with this pull request

| Item | `master` today | This pull request |
|---|---|---|
| Timestamps used | 2 of 4 (T3, T4) | 4 of 4 |
| Network delay | Counted as clock error | Removed by the formula |
| Accuracy of result | Not known | Root distance, reported with every result |
| Possible results | Warn, or nothing | In sync, Ahead, Behind, Inconclusive |
| Prompt at `enabled: 0` | Always, before measuring | Only after a conclusive result |
| If every server fails | Returns local time as if it worked | Returns an error, warns once, continues |
| Packet handling | Hand-written struct and bit arithmetic | `github.com/beevik/ntp` v1.5.0 |
| Reply validation | None | Mode, stratum, leap indicator, originate echo, kiss-o'-death |
| Wire version | NTPv3 (`0x1B`) | NTPv4 (library default) |
| Server selection | First that answers | First that answers **and** passes validation |

---

## Why a library

The code on `master` contains a partial SNTP client: a packet struct, epoch conversion, and
fixed-point arithmetic. It performs no validation of the reply.

`github.com/beevik/ntp` v1.5.0 is the standard Go client. It supplies the offset formula, the
round-trip time, the root distance, and the reply checks. The version is pinned exactly.

Library types do not leave the adapter. Only two functions name them. The rest of the engine uses one
local type:

```go
type clockObservation struct {
    source          string
    clockCorrection time.Duration   // server − local; positive means the local clock is behind
    uncertainty     time.Duration   // root distance
    roundTrip       time.Duration
}
```

The adapter also rejects a reply when its own values disagree:

| Check | Reason |
|---|---|
| `RTT < 0` | Impossible; the reply is not trustworthy |
| `RootDistance < 0` | Impossible |
| `RootDistance < RTT/2` | The stated accuracy is better than physics allows |

A rejected reply causes a move to the next configured server.

---

## What is deleted

- `ntpPacket`, and the hand-written epoch and fixed-point conversion
- `checkTimeInPools`, including the fallback to local time
- `FetchNTPTime`, which has no caller in the code base
- The retry loop in `ntpManager.Start` and its `retryLimit` field
- The `loggingEnabled` field and parameter
- Per-server log messages that repeat the error the caller already reports

Production code is **`+304/−158`** against `master`: a net increase of 146 lines that removes a
protocol implementation and adds validation, uncertainty, and four distinct results.

---

## Compatibility

Nothing in the public surface changes:

| Surface | Status |
|---|---|
| `ntp_timekeeper` subsystem name | Unchanged |
| `SetSubsystem`, gRPC `EnableSubsystem`, `gctcli` | Unchanged |
| Config JSON shape and field names | Unchanged |
| `enabled` values `-1`, `0`, `1` | Unchanged |
| `config.SetNTPCheck` and its prompt text | Unchanged |
| Default pool `pool.ntp.org:123` | Unchanged |
| Default tolerance ±50 ms | Unchanged |
| Error values such as `errNTPManagerDisabled` | Unchanged |

The `enabled` numbers now have names in code (`NTPClientDisabled`, `NTPClientStartup`,
`NTPClientPeriodic`). The numbers themselves do not change, because they are written to the
configuration file.

---

## Existing behaviour you should know about

These items are **not** new, and this pull request does not change them. They are written down here
because they are easy to miss.

1. **Periodic mode does not start by itself.** `Engine.Start` builds the manager but never starts it.
   Only `gctcli enablesubsystem ntp_timekeeper` starts it, so `enabled: 1` is inactive in a normal
   run. This also explains how the wrong formula stayed in the code: almost nothing ran it. This
   needs a separate issue.

2. **If you answer `w` at the prompt, you get no periodic warnings.** The answer updates the
   configuration and the manager, but it does not start the manager, for the reason above.

3. **`Stop` does not wait for the periodic goroutine.** A fast `Stop` then `Start` can race. This is
   an existing defect and needs a separate issue.

4. **The default pool name stays `pool.ntp.org`.** The NTP Pool project asks software vendors to use
   a vendor zone. Requesting one is a project decision, not part of this change.

5. **The check interval changes from 30 seconds to 30 minutes.** 30 seconds is 120 requests per hour
   to the public pool. `systemd-timesyncd` uses about 34 minutes for comparison. Because of item 1,
   this affects only a manager that a user starts. This is one line; remove it if you prefer.

6. **One server at a time, in order.** The code asks the configured servers in order and uses the
   first valid reply. It does not query servers at the same time and does not compare their answers.
   It makes no claim of consensus.

---

## Tests

All tests are hermetic. No test contacts a public NTP server.

| Area | What it protects |
|---|---|
| Classifier table | The interval logic, using **different** ahead and behind limits, so a swap of signs or limits fails |
| Boundary rows | Exact limits, and one nanosecond outside each limit |
| Saturation | A very large offset cannot overflow into the opposite result |
| Startup policy | In sync and Inconclusive do not prompt; Ahead and Behind do; a failed measurement does not prompt |
| Context handling | A cancelled parent stops startup; an expired measurement budget does not |
| Ordered fallback | The first valid server wins; later servers are not asked |
| Adapter rejects | Each invalid-metadata rejection returns its own error value |
| **Production path** | `setupNTPManager` builds the real measurement chain, proved through a local UDP server |
| Subsystem | `ntp_timekeeper` enable and disable still work |

The production-path test is worth a note. Tests that replace a component prove the parts, not the
assembly. An earlier version of that test only checked that a function was present. A stub that
always reported "in sync" would have passed the complete suite, and the original failure would have
returned in silence. The test now runs a real exchange against a local UDP server and checks the
sign of the result.

---

## Timing

Each attempt against one server is bounded twice: 5 seconds to connect, then 5 seconds to read.
These are the same limits as `master`.

| Path | Bound | What the bound covers |
|---|---|---|
| Startup | 10 second budget | Stops further servers and any work before the next query |
| Periodic | servers × 10 seconds | The same per-server limits, applied in turn |

**The startup budget is not a hard stop on an exchange already in progress.** The library sets its
own read deadline after the connection opens, so one reply that is already being awaited can finish
up to 5 seconds after the budget ends. The budget stops the *next* server from being tried; it does
not interrupt the current read.

This is a known limit of the library, which has no context-aware query method. The alternative is a
wrapper around the connection. For a feature that only writes a log line, that cost is not
justified, so the behaviour is documented instead of worked around.

---

## Verification

```console
go test ./config -race -shuffle=on -count=20 -run '^(TestCheckNTPConfig|TestSetNTPCheck|TestCheckConfig.*NTP)'
go test ./engine -race -shuffle=on -count=50 -run '^(Test.*NTP|Test.*Clock)'
go test ./... -race -count 1
make check
go mod tidy -diff
```

All pass.

---

## Review guidance

The change is 17 files. Most lines are tests and generated documentation.

**Read the production code first. It is `+304/−158` of the `+1376/−372` total:**

| File | Content |
|---|---|
| `engine/ntp_clock.go` | New. Adapter, ordered fallback, and the pure classifier |
| `engine/ntp_manager.go` | Setup, lifecycle, the shared check, startup policy, reporting |
| `engine/ntp_manager_types.go` | Fields removed, measurement seam added |
| `engine/engine.go` | One call replaces the old block |
| `config/config.go` | Normalisation is now unconditional; both tolerances treat `<= 0` the same |

One configuration defect is fixed at the same time. `CheckNTPConfig` normalised `allowedDifference`
only when it was `0`, but normalised `allowedNegativeDifference` when it was `<= 0`. A negative
`allowedDifference` therefore survived and inverted the valid window. `CheckConfig` also skipped
normalisation completely at `enabled: 0`, which is the setting that needs it most.

---

## Housekeeping

This supersedes #2137, an earlier attempt of mine that applied the correct formula but kept the
hand-written protocol code and extended it. Nothing from that pull request is needed to review this
one. Please close it in favour of this change.
