### PR TITLE
test: repair failing Coinbase and OKX live tests

### DIFF
--- a/exchanges/coinbase/coinbase_test.go
+++ b/exchanges/coinbase/coinbase_test.go
@@ -708,7 +708,7 @@ func TestGetHistoricKlines(t *testing.T) {
 func TestGetAllProducts(t *testing.T) {
 	t.Parallel()
 	testPairs := []string{testPairFiat.String(), "ETH-USD"}
-	resp, err := e.GetAllProducts(t.Context(), 30000, 1, "SPOT", "PERPETUAL", "STATUS_ALL", "PRODUCTS_SORT_ORDER_UNDEFINED", testPairs, true, true, false)
+	resp, err := e.GetAllProducts(t.Context(), 1000, 1, "SPOT", "PERPETUAL", "STATUS_ALL", "PRODUCTS_SORT_ORDER_UNDEFINED", testPairs, true, true, false)
 	if assert.NoError(t, err) {
 		assert.NotEmpty(t, resp, errExpectedNonEmpty)
 	}

--- a/exchanges/okx/okx_test.go
+++ b/exchanges/okx/okx_test.go
@@ -770,14 +770,19 @@ func TestGetOpenInterestAndVolumeStrike(t *testing.T) {
 	require.NoErrorf(t, err, "GetInstruments for options (underlying: %s) must not error", optionsPair)
 	require.NotEmptyf(t, instruments, "GetInstruments for options (underlying: %s) must return at least one instrument", optionsPair)
 	var selectedExpTime time.Time
+	now := time.Now()
+	today := now.UTC().Truncate(24 * time.Hour)
 	for _, inst := range instruments {
-		if inst.ExpTime.Time().IsZero() {
+		expTime := inst.ExpTime.Time()
+		listTime := inst.ListTime.Time()
+		if !strings.EqualFold(inst.State, "live") || expTime.IsZero() || !expTime.After(now) ||
+			!expTime.UTC().Truncate(24*time.Hour).After(today) || listTime.IsZero() || listTime.After(now) {
 			continue
 		}
-		selectedExpTime = inst.ExpTime.Time()
+		selectedExpTime = expTime
 		break
 	}
-	require.NotZero(t, selectedExpTime, "GetInstruments must return an instrument with a non-zero expiry time")
+	require.NotZero(t, selectedExpTime, "GetInstruments must return a live, listed instrument with a later expiry date")
 	result, err := e.GetOpenInterestAndVolumeStrike(contextGenerate(), currency.BTC, selectedExpTime, kline.OneDay)
 	require.NoErrorf(t, err, "GetOpenInterestAndVolumeStrike with expiry %s for currency %s must not error", selectedExpTime, currency.BTC)
 	assert.NotNilf(t, result, "GetOpenInterestAndVolumeStrike with expiry %s for currency %s should return a non-nil result", selectedExpTime, currency.BTC)


### PR DESCRIPTION
Two live tests currently fail on `master`, which turns CI red for every PR branched from it. This PR fixes only those two tests and touches nothing else, so it should be quick to review and unblocks other open PRs.

### `TestGetAllProducts` (Coinbase) — deterministic failure

The test requests `limit=30000` and Coinbase now rejects anything above 1000:

```
--- FAIL: TestGetAllProducts
    Coinbase unsuccessful HTTP status code: 400
    {"error":"INVALID_ARGUMENT","error_details":"invalid limit: limit must be <= 1000, got 30000"}
```

Every production caller passes `0`, so the cap only ever affected the test. It now passes `1000`, which matches the max page size already used elsewhere in the package by `GetProductBookV3` and `iterativeGetAllOrders`.

Reproducible on a clean checkout of master:

```
FAIL	github.com/thrasher-corp/gocryptotrader/exchanges/coinbase	4.568s
```

### `TestGetOpenInterestAndVolumeStrike` (OKX) — intermittent failure

The test selects the first instrument with a non-zero expiry time. Depending on what the endpoint returns at that moment, that can be an already-expired or not-yet-listed option, so the subsequent call fails. It is genuinely intermittent — it passed for me locally while failing in CI on the same day.

It now requires an instrument that is `live`, already listed, and whose expiry is still in the future.

### Verification

Both tests pass against the live endpoints with these changes:

```
--- PASS: TestGetOpenInterestAndVolumeStrike (0.66s)
ok  	github.com/thrasher-corp/gocryptotrader/exchanges/okx	4.878s
ok  	github.com/thrasher-corp/gocryptotrader/exchanges/coinbase	4.611s
```

`go vet` is clean on both packages. The Coinbase change is also present in #2294; if you would prefer to take it there instead, I am happy to drop it from this PR.