### PR TITLE
backtester: validate stream events before sorting

### DIFF
--- a/backtester/data/data.go
+++ b/backtester/data/data.go
@@ -134,9 +134,6 @@ func (b *Base) SetStream(s []Event) error {
 	b.m.Lock()
 	defer b.m.Unlock()
 
-	sort.Slice(s, func(i, j int) bool {
-		return s[i].GetTime().Before(s[j].GetTime())
-	})
 	for x := range s {
 		if s[x] == nil {
 			return fmt.Errorf("%w Event", gctcommon.ErrNilPointer)
@@ -151,6 +148,12 @@ func (b *Base) SetStream(s []Event) error {
 				return fmt.Errorf("%w cannot set base stream from %v %v %v to %v %v %v", errMismatchedEvent, s[x].GetExchange(), s[x].GetAssetType(), s[x].Pair(), b.stream[0].GetExchange(), b.stream[0].GetAssetType(), b.stream[0].Pair())
 			}
 		}
+	}
+
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].GetTime().Before(s[j].GetTime())
+	})
+	for x := range s {
 		// due to the Next() function, we cannot take
 		// stream offsets as is, and we re-set them
 		s[x].SetOffset(int64(x) + 1)

--- a/backtester/data/data_test.go
+++ b/backtester/data/data_test.go
@@ -210,6 +210,17 @@ func TestSetStream(t *testing.T) {
 	err = b.SetStream([]Event{nil})
 	require.ErrorIs(t, err, gctcommon.ErrNilPointer)
 
+	err = b.SetStream([]Event{
+		&fakeEvent{Base: &event.Base{
+			Time:         time.Now(),
+			Exchange:     "test",
+			AssetType:    asset.Spot,
+			CurrencyPair: cp,
+		}},
+		nil,
+	})
+	require.ErrorIs(t, err, gctcommon.ErrNilPointer)
+
 	b = nil
 	err = b.SetStream(nil)
 	assert.ErrorIs(t, err, gctcommon.ErrNilPointer)


### PR DESCRIPTION
Validate every event before sorting and assigning offsets; mixed valid/nil input now returns ErrNilPointer instead of panicking.

# PR Description

SetStream sorted events before validating them, so a slice containing a valid event and nil could panic in the sort comparator. Validate the complete slice first, then sort and reset offsets. A regression case covers mixed valid/nil input.



Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested

- [x] go test ./backtester/data -run TestSetStream -count=1
- [x] go test ./... -race
- [x] golangci-lint run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
