### PR TITLE
engine: fall back across assets when validating API credentials

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -937,7 +938,8 @@ func validateAPICredentials(ctx context.Context, exchangeName string, enabledAss
 	for _, a := range assets {
 		if err := validate(ctx, a); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%s: %w", a, err))
-			if errors.Is(err, exchange.ErrCredentialsAreEmpty) || errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
+			// A transport failure means the venue is unreachable, so no other account can answer either.
+			if _, ok := errors.AsType[net.Error](err); ok || errors.Is(err, exchange.ErrCredentialsAreEmpty) || errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
 				break
 			}
 			continue

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -893,7 +893,7 @@ func (bot *Engine) LoadExchange(name string) error {
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
 		if err := validateAPICredentials(ctx, b.Name, enabledAssets, exch.ValidateAPICredentials); err != nil {
-			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credential validation failed; disabling authenticated support", b.Name)
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credential validation failed, disabling authenticated support: %v", b.Name, err)
 			b.API.AuthenticatedSupport = false
 			b.API.AuthenticatedWebsocketSupport = false
 			if b.Websocket != nil {
@@ -906,10 +906,6 @@ func (bot *Engine) LoadExchange(name string) error {
 }
 
 func validateAPICredentials(ctx context.Context, exchangeName string, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
-	if len(enabledAssets) == 0 {
-		return fmt.Errorf("%s: %w", exchangeName, asset.ErrNotEnabled)
-	}
-
 	// Spot covers the widest set of GCT functionality, followed by futures;
 	// other account types are fallbacks, and the first successful validation wins.
 	assets := make(asset.Items, 0, len(enabledAssets))
@@ -925,6 +921,9 @@ func validateAPICredentials(ctx context.Context, exchangeName string, enabledAss
 		if a != asset.Spot && !a.IsFutures() {
 			assets = append(assets, a)
 		}
+	}
+	if len(assets) == 0 {
+		return fmt.Errorf("%s: %w", exchangeName, asset.ErrNotEnabled)
 	}
 
 	var errs error

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -892,24 +892,8 @@ func (bot *Engine) LoadExchange(name string) error {
 	b := exch.GetBase()
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
-		var preferredAsset asset.Item
-		switch {
-		case enabledAssets.Contains(asset.Spot): // prioritise validating credentials with spot due to wide usage across GCT
-			preferredAsset = asset.Spot
-		default:
-			for _, a := range enabledAssets { // second priority to futures if spot isn't available
-				if a.IsFutures() {
-					preferredAsset = a
-					break
-				}
-			}
-			if preferredAsset == 0 {
-				preferredAsset = enabledAssets[0] // last resort pick first available
-			}
-		}
-
-		if err := exch.ValidateAPICredentials(ctx, preferredAsset); err != nil {
-			gctlog.Warnf(gctlog.ExchangeSys, "%s: Error validating credentials: %v for %s", b.Name, err, preferredAsset)
+		if err := validateAPICredentials(ctx, enabledAssets, exch.ValidateAPICredentials); err != nil {
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Error validating credentials: %v", b.Name, err)
 			b.API.AuthenticatedSupport = false
 			b.API.AuthenticatedWebsocketSupport = false
 			if b.Websocket != nil {
@@ -919,6 +903,33 @@ func (bot *Engine) LoadExchange(name string) error {
 	}
 
 	return exchange.Bootstrap(ctx, exch)
+}
+
+func validateAPICredentials(ctx context.Context, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
+	assets := make(asset.Items, 0, len(enabledAssets))
+	if enabledAssets.Contains(asset.Spot) {
+		assets = append(assets, asset.Spot)
+	}
+	for _, a := range enabledAssets {
+		if a != asset.Spot && a.IsFutures() {
+			assets = append(assets, a)
+		}
+	}
+	for _, a := range enabledAssets {
+		if a != asset.Spot && !a.IsFutures() {
+			assets = append(assets, a)
+		}
+	}
+
+	var errs error
+	for _, a := range assets {
+		if err := validate(ctx, a); err != nil {
+			errs = common.AppendError(errs, fmt.Errorf("%s: %w", a, err))
+			continue
+		}
+		return nil
+	}
+	return errs
 }
 
 func (bot *Engine) dryRunParamInteraction(param string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -892,9 +892,9 @@ func (bot *Engine) LoadExchange(name string) error {
 	b := exch.GetBase()
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
-		// Credentials that are unusable fail identically for every account type,
-		// so establish that once rather than once per asset.
-		_, err := b.GetCredentials(ctx)
+		// Structurally unusable credentials fail identically for every account
+		// type, so establish that once rather than once per asset.
+		_, err := exch.GetCredentials(ctx)
 		if err == nil {
 			err = validateAPICredentials(ctx, b.Name, enabledAssets, exch.ValidateAPICredentials)
 		}
@@ -943,7 +943,7 @@ func validateAPICredentials(ctx context.Context, exchangeName string, enabledAss
 			continue
 		}
 		if errs != nil { // the caller only logs errs when every account fails, so surface the recovered ones here
-			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credentials validated on %s after earlier failures: %v", exchangeName, a, errs)
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Authenticated support retained on %s after earlier failures: %v", exchangeName, a, errs)
 		}
 		return nil
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -906,6 +906,10 @@ func (bot *Engine) LoadExchange(name string) error {
 }
 
 func validateAPICredentials(ctx context.Context, exchangeName string, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
+	if len(enabledAssets) == 0 {
+		return fmt.Errorf("%s: %w", exchangeName, asset.ErrNotEnabled)
+	}
+
 	// Spot covers the widest set of GCT functionality, followed by futures;
 	// other account types are fallbacks, and the first successful validation wins.
 	assets := make(asset.Items, 0, len(enabledAssets))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -893,7 +893,7 @@ func (bot *Engine) LoadExchange(name string) error {
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
 		if err := validateAPICredentials(ctx, enabledAssets, exch.ValidateAPICredentials); err != nil {
-			gctlog.Warnf(gctlog.ExchangeSys, "%s: Error validating credentials: %v", b.Name, err)
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credential validation failed; disabling authenticated support", b.Name)
 			b.API.AuthenticatedSupport = false
 			b.API.AuthenticatedWebsocketSupport = false
 			if b.Websocket != nil {
@@ -906,6 +906,8 @@ func (bot *Engine) LoadExchange(name string) error {
 }
 
 func validateAPICredentials(ctx context.Context, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
+	// Spot covers the widest set of GCT functionality, followed by futures;
+	// other account types are fallbacks, and the first successful validation wins.
 	assets := make(asset.Items, 0, len(enabledAssets))
 	if enabledAssets.Contains(asset.Spot) {
 		assets = append(assets, asset.Spot)
@@ -924,7 +926,12 @@ func validateAPICredentials(ctx context.Context, enabledAssets asset.Items, vali
 	var errs error
 	for _, a := range assets {
 		if err := validate(ctx, a); err != nil {
-			errs = common.AppendError(errs, fmt.Errorf("%s: %w", a, err))
+			assetErr := fmt.Errorf("%s: %w", a, err)
+			gctlog.Warnf(gctlog.ExchangeSys, "Error validating credentials: %v", assetErr)
+			errs = common.AppendError(errs, assetErr)
+			if errors.Is(err, exchange.ErrCredentialsAreEmpty) || errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
+				break
+			}
 			continue
 		}
 		return nil

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -892,7 +892,7 @@ func (bot *Engine) LoadExchange(name string) error {
 	b := exch.GetBase()
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
-		if err := validateAPICredentials(ctx, enabledAssets, exch.ValidateAPICredentials); err != nil {
+		if err := validateAPICredentials(ctx, b.Name, enabledAssets, exch.ValidateAPICredentials); err != nil {
 			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credential validation failed; disabling authenticated support", b.Name)
 			b.API.AuthenticatedSupport = false
 			b.API.AuthenticatedWebsocketSupport = false
@@ -905,7 +905,7 @@ func (bot *Engine) LoadExchange(name string) error {
 	return exchange.Bootstrap(ctx, exch)
 }
 
-func validateAPICredentials(ctx context.Context, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
+func validateAPICredentials(ctx context.Context, exchangeName string, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
 	// Spot covers the widest set of GCT functionality, followed by futures;
 	// other account types are fallbacks, and the first successful validation wins.
 	assets := make(asset.Items, 0, len(enabledAssets))
@@ -927,7 +927,7 @@ func validateAPICredentials(ctx context.Context, enabledAssets asset.Items, vali
 	for _, a := range assets {
 		if err := validate(ctx, a); err != nil {
 			assetErr := fmt.Errorf("%s: %w", a, err)
-			gctlog.Warnf(gctlog.ExchangeSys, "Error validating credentials: %v", assetErr)
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Error validating credentials: %v", exchangeName, assetErr)
 			errs = common.AppendError(errs, assetErr)
 			if errors.Is(err, exchange.ErrCredentialsAreEmpty) || errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
 				break

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -892,7 +892,13 @@ func (bot *Engine) LoadExchange(name string) error {
 	b := exch.GetBase()
 	if b.API.AuthenticatedSupport || b.API.AuthenticatedWebsocketSupport {
 		enabledAssets := b.CurrencyPairs.GetAssetTypes(true)
-		if err := validateAPICredentials(ctx, b.Name, enabledAssets, exch.ValidateAPICredentials); err != nil {
+		// Credentials that are unusable fail identically for every account type,
+		// so establish that once rather than once per asset.
+		_, err := b.GetCredentials(ctx)
+		if err == nil {
+			err = validateAPICredentials(ctx, b.Name, enabledAssets, exch.ValidateAPICredentials)
+		}
+		if err != nil {
 			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credential validation failed, disabling authenticated support: %v", b.Name, err)
 			b.API.AuthenticatedSupport = false
 			b.API.AuthenticatedWebsocketSupport = false
@@ -908,6 +914,7 @@ func (bot *Engine) LoadExchange(name string) error {
 func validateAPICredentials(ctx context.Context, exchangeName string, enabledAssets asset.Items, validate func(context.Context, asset.Item) error) error {
 	// Spot covers the widest set of GCT functionality, followed by futures;
 	// other account types are fallbacks, and the first successful validation wins.
+	// This assumes validation is asset-specific; global validators repeat the same request.
 	assets := make(asset.Items, 0, len(enabledAssets))
 	if enabledAssets.Contains(asset.Spot) {
 		assets = append(assets, asset.Spot)
@@ -929,13 +936,14 @@ func validateAPICredentials(ctx context.Context, exchangeName string, enabledAss
 	var errs error
 	for _, a := range assets {
 		if err := validate(ctx, a); err != nil {
-			assetErr := fmt.Errorf("%s: %w", a, err)
-			gctlog.Warnf(gctlog.ExchangeSys, "%s: Error validating credentials: %v", exchangeName, assetErr)
-			errs = common.AppendError(errs, assetErr)
+			errs = common.AppendError(errs, fmt.Errorf("%s: %w", a, err))
 			if errors.Is(err, exchange.ErrCredentialsAreEmpty) || errors.Is(err, exchange.ErrAuthenticationSupportNotEnabled) {
 				break
 			}
 			continue
+		}
+		if errs != nil { // the caller only logs errs when every account fails, so surface the recovered ones here
+			gctlog.Warnf(gctlog.ExchangeSys, "%s: Credentials validated on %s after earlier failures: %v", exchangeName, a, errs)
 		}
 		return nil
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -451,6 +451,7 @@ func TestValidateAPICredentials(t *testing.T) {
 			return nil
 		})
 		require.ErrorIs(t, err, asset.ErrNotEnabled, "validation must fail when no assets are enabled")
+		assert.ErrorContains(t, err, testExchange, "error should name the exchange it came from")
 		assert.False(t, called, "validation should not run without an enabled asset")
 	})
 
@@ -498,6 +499,9 @@ func TestValidateAPICredentials(t *testing.T) {
 		asset.Margin,
 		asset.Index,
 	}, seen, "assets should be tried spot first, then futures, then the rest")
+	for _, a := range seen {
+		assert.ErrorContainsf(t, err, a.String()+": "+errDeliveryAccountMissing.Error(), "aggregated error should name %s and why it failed", a)
+	}
 
 	for _, assetIndependentErr := range []error{
 		exchange.ErrCredentialsAreEmpty,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -464,6 +464,41 @@ func TestValidateAPICredentials(t *testing.T) {
 		return errDeliveryAccountMissing
 	})
 	require.ErrorIs(t, err, errDeliveryAccountMissing, "validation must return an error when every enabled account fails")
+
+	var seen asset.Items
+	err = validateAPICredentials(t.Context(), asset.Items{
+		asset.Options,
+		asset.USDTMarginedFutures,
+		asset.Margin,
+		asset.Spot,
+		asset.DeliveryFutures,
+		asset.Index,
+	}, func(_ context.Context, a asset.Item) error {
+		seen = append(seen, a)
+		return errDeliveryAccountMissing
+	})
+	require.ErrorIs(t, err, errDeliveryAccountMissing, "mixed asset validation must return the aggregated error")
+	assert.Equal(t, asset.Items{
+		asset.Spot,
+		asset.USDTMarginedFutures,
+		asset.DeliveryFutures,
+		asset.Options,
+		asset.Margin,
+		asset.Index,
+	}, seen, "assets should be tried spot first, then futures, then the rest")
+
+	for _, assetIndependentErr := range []error{
+		exchange.ErrCredentialsAreEmpty,
+		exchange.ErrAuthenticationSupportNotEnabled,
+	} {
+		validated = nil
+		err = validateAPICredentials(t.Context(), asset.Items{asset.Spot, asset.USDTMarginedFutures}, func(_ context.Context, a asset.Item) error {
+			validated = append(validated, a)
+			return assetIndependentErr
+		})
+		require.ErrorIs(t, err, assetIndependentErr, "asset-independent credential failure must be returned")
+		assert.Equal(t, asset.Items{asset.Spot}, validated, "asset-independent credential failure should stop further validation")
+	}
 }
 
 func TestFlagSetWith(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"slices"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/config"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitfinex"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/bitstamp"
 )
@@ -437,6 +439,31 @@ func TestDryRunParamInteraction(t *testing.T) {
 		!exchCfg.Verbose {
 		t.Error("dryrun should be true and verbose should be true")
 	}
+}
+
+func TestValidateAPICredentials(t *testing.T) {
+	t.Parallel()
+
+	errDeliveryAccountMissing := errors.New("delivery account missing")
+	var validated asset.Items
+	err := validateAPICredentials(t.Context(), asset.Items{
+		asset.DeliveryFutures,
+		asset.USDTMarginedFutures,
+	}, func(_ context.Context, a asset.Item) error {
+		validated = append(validated, a)
+		if a == asset.DeliveryFutures {
+			return errDeliveryAccountMissing
+		}
+		return nil
+	})
+	require.NoError(t, err, "validation must succeed when another enabled account is available")
+	assert.Equal(t, asset.Items{asset.DeliveryFutures, asset.USDTMarginedFutures}, validated,
+		"validation should try another enabled futures account after an account-specific failure")
+
+	err = validateAPICredentials(t.Context(), asset.Items{asset.DeliveryFutures}, func(context.Context, asset.Item) error {
+		return errDeliveryAccountMissing
+	})
+	require.ErrorIs(t, err, errDeliveryAccountMissing, "validation must return an error when every enabled account fails")
 }
 
 func TestFlagSetWith(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -503,17 +505,18 @@ func TestValidateAPICredentials(t *testing.T) {
 		assert.ErrorContainsf(t, err, a.String()+": "+errDeliveryAccountMissing.Error(), "aggregated error should name %s and why it failed", a)
 	}
 
-	for _, assetIndependentErr := range []error{
+	for _, venueWideErr := range []error{
 		exchange.ErrCredentialsAreEmpty,
 		exchange.ErrAuthenticationSupportNotEnabled,
+		&url.Error{Op: "Get", URL: "https://example.com/accounts", Err: context.DeadlineExceeded},
 	} {
 		validated = nil
 		err = validateAPICredentials(t.Context(), testExchange, asset.Items{asset.Spot, asset.USDTMarginedFutures}, func(_ context.Context, a asset.Item) error {
 			validated = append(validated, a)
-			return assetIndependentErr
+			return fmt.Errorf("%w, authenticated request failed", venueWideErr)
 		})
-		require.ErrorIs(t, err, assetIndependentErr, "asset-independent credential failure must be returned")
-		assert.Equal(t, asset.Items{asset.Spot}, validated, "asset-independent credential failure should stop further validation")
+		require.ErrorIs(t, err, venueWideErr, "venue-wide failure must be returned")
+		assert.Equal(t, asset.Items{asset.Spot}, validated, "venue-wide failure should stop further validation")
 	}
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -481,6 +481,7 @@ func TestValidateAPICredentials(t *testing.T) {
 		asset.USDTMarginedFutures,
 		asset.Margin,
 		asset.Spot,
+		asset.PerpetualSwap,
 		asset.DeliveryFutures,
 		asset.Index,
 	}, func(_ context.Context, a asset.Item) error {
@@ -491,6 +492,7 @@ func TestValidateAPICredentials(t *testing.T) {
 	assert.Equal(t, asset.Items{
 		asset.Spot,
 		asset.USDTMarginedFutures,
+		asset.PerpetualSwap,
 		asset.DeliveryFutures,
 		asset.Options,
 		asset.Margin,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -443,6 +443,16 @@ func TestDryRunParamInteraction(t *testing.T) {
 
 func TestValidateAPICredentials(t *testing.T) {
 	t.Parallel()
+	t.Run("no enabled assets", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		err := validateAPICredentials(t.Context(), testExchange, nil, func(context.Context, asset.Item) error {
+			called = true
+			return nil
+		})
+		require.ErrorIs(t, err, asset.ErrNotEnabled, "validation must fail when no assets are enabled")
+		assert.False(t, called, "validation should not run without an enabled asset")
+	})
 
 	errDeliveryAccountMissing := errors.New("delivery account missing")
 	var validated asset.Items

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -446,7 +446,7 @@ func TestValidateAPICredentials(t *testing.T) {
 
 	errDeliveryAccountMissing := errors.New("delivery account missing")
 	var validated asset.Items
-	err := validateAPICredentials(t.Context(), asset.Items{
+	err := validateAPICredentials(t.Context(), testExchange, asset.Items{
 		asset.DeliveryFutures,
 		asset.USDTMarginedFutures,
 	}, func(_ context.Context, a asset.Item) error {
@@ -460,13 +460,13 @@ func TestValidateAPICredentials(t *testing.T) {
 	assert.Equal(t, asset.Items{asset.DeliveryFutures, asset.USDTMarginedFutures}, validated,
 		"validation should try another enabled futures account after an account-specific failure")
 
-	err = validateAPICredentials(t.Context(), asset.Items{asset.DeliveryFutures}, func(context.Context, asset.Item) error {
+	err = validateAPICredentials(t.Context(), testExchange, asset.Items{asset.DeliveryFutures}, func(context.Context, asset.Item) error {
 		return errDeliveryAccountMissing
 	})
 	require.ErrorIs(t, err, errDeliveryAccountMissing, "validation must return an error when every enabled account fails")
 
 	var seen asset.Items
-	err = validateAPICredentials(t.Context(), asset.Items{
+	err = validateAPICredentials(t.Context(), testExchange, asset.Items{
 		asset.Options,
 		asset.USDTMarginedFutures,
 		asset.Margin,
@@ -492,7 +492,7 @@ func TestValidateAPICredentials(t *testing.T) {
 		exchange.ErrAuthenticationSupportNotEnabled,
 	} {
 		validated = nil
-		err = validateAPICredentials(t.Context(), asset.Items{asset.Spot, asset.USDTMarginedFutures}, func(_ context.Context, a asset.Item) error {
+		err = validateAPICredentials(t.Context(), testExchange, asset.Items{asset.Spot, asset.USDTMarginedFutures}, func(_ context.Context, a asset.Item) error {
 			validated = append(validated, a)
 			return assetIndependentErr
 		})


### PR DESCRIPTION
# PR Description

Try other enabled account types before disabling authentication globally when an asset-specific account is unavailable.

Problem arose in Gateio when its checking an asset which hadn't been loaded with funds and errored. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and
also consider improving test coverage whilst working on a certain feature or package.

- [ ] go test ./... -race
- [ ] golangci-lint run
- [ ] Test X

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
