### PR TITLE
common/timeperiods: Refactor TimePeriodCalculator.Sort with slices.SortFunc

### DIFF
--- a/common/timeperiods/timeperiods.go
+++ b/common/timeperiods/timeperiods.go
@@ -2,6 +2,7 @@ package timeperiods
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"time"
 
@@ -153,10 +154,10 @@ func (t *TimePeriodCalculator) setTimePeriodExists() {
 
 // Sort will sort the time period asc or desc
 func (t *TimePeriodCalculator) Sort(desc bool) {
-	sort.Slice(t.TimePeriods, func(i, j int) bool {
+	slices.SortFunc(t.TimePeriods, func(a, b TimePeriod) int {
 		if desc {
-			return t.TimePeriods[i].Time.After(t.TimePeriods[j].Time)
+			return b.Time.Compare(a.Time)
 		}
-		return t.TimePeriods[i].Time.Before(t.TimePeriods[j].Time)
+		return a.Time.Compare(b.Time)
 	})
 }


### PR DESCRIPTION
# PR Description

Replace the manual period comparator with `slices.SortFunc`, preserving ascending and descending results. 

Fixes # (issue)  N/A

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested


- [x] go test ./... -race
- [x] golangci-lint run
- [x] Test X
- [x] `go test ./common/timeperiods`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
