### PR TITLE
exchanges/order: fix UpdateOrderFromDetail re-deriving RemainingAmount from trades

### DIFF
--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -297,9 +297,8 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) error {
 			updated = true
 		}
 	}
-	// RemainingAmount is an authoritative value reported by the exchange
-	// (Amount - ExecutedAmount); it must be used as-is and never re-derived by
-	// subtracting trade amounts, which would double-count fills.
+	// Do not derive RemainingAmount from Trades: trade lists may be cumulative
+	// or from a different snapshot. A supplied non-zero value is preserved.
 	if m.RemainingAmount > 0 && m.RemainingAmount != d.RemainingAmount {
 		d.RemainingAmount = m.RemainingAmount
 		updated = true

--- a/exchanges/order/orders.go
+++ b/exchanges/order/orders.go
@@ -296,8 +296,10 @@ func (d *Detail) UpdateOrderFromDetail(m *Detail) error {
 			d.Trades = append(d.Trades, m.Trades[x])
 			updated = true
 		}
-		m.RemainingAmount -= m.Trades[x].Amount
 	}
+	// RemainingAmount is an authoritative value reported by the exchange
+	// (Amount - ExecutedAmount); it must be used as-is and never re-derived by
+	// subtracting trade amounts, which would double-count fills.
 	if m.RemainingAmount > 0 && m.RemainingAmount != d.RemainingAmount {
 		d.RemainingAmount = m.RemainingAmount
 		updated = true

--- a/exchanges/order/orders_test.go
+++ b/exchanges/order/orders_test.go
@@ -1156,13 +1156,13 @@ func TestUpdateOrderFromDetailRemainingAmountInvariant(t *testing.T) {
 	}
 
 	od := &Detail{OrderID: "abc", Amount: 10}
-	require.NoError(t, od.UpdateOrderFromDetail(om))
+	require.NoError(t, od.UpdateOrderFromDetail(om), "UpdateOrderFromDetail must not error")
 
-	assert.Equal(t, 10.0, od.Amount)
-	assert.Equal(t, 4.0, od.ExecutedAmount)
-	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount is the authoritative remaining, not reduced by trade amounts")
-	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount equals Amount")
-	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail is not mutated")
+	assert.Equal(t, 10.0, od.Amount, "Amount should be unchanged")
+	assert.Equal(t, 4.0, od.ExecutedAmount, "ExecutedAmount should come from the incoming detail")
+	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount should be the authoritative remaining, not reduced by trade amounts")
+	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount should equal Amount")
+	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail should not be mutated")
 }
 
 func TestClassificationError_Error(t *testing.T) {

--- a/exchanges/order/orders_test.go
+++ b/exchanges/order/orders_test.go
@@ -1139,11 +1139,10 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 }
 
 // TestUpdateOrderFromDetailRemainingAmountInvariant ensures that when an
-// incoming detail carries an authoritative RemainingAmount (Amount -
-// ExecutedAmount, as every exchange populates it) alongside the fill(s) that
-// produced it, the stored RemainingAmount is trusted rather than re-derived by
-// subtracting trade amounts. Re-deriving double-counts fills and violates the
-// invariant ExecutedAmount + RemainingAmount == Amount.
+// incoming detail carries a RemainingAmount alongside the fill(s) that
+// produced it, the stored RemainingAmount is trusted rather than re-derived
+// by subtracting trade amounts. Re-deriving double-counts fills and violates
+// the invariant ExecutedAmount + RemainingAmount == Amount.
 func TestUpdateOrderFromDetailRemainingAmountInvariant(t *testing.T) {
 	t.Parallel()
 
@@ -1163,6 +1162,44 @@ func TestUpdateOrderFromDetailRemainingAmountInvariant(t *testing.T) {
 	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount should be the authoritative remaining, not reduced by trade amounts")
 	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount should equal Amount")
 	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail should not be mutated")
+
+	// A fill at least as large as the reported remainder drove the old
+	// subtraction negative, which failed the guard in UpdateOrderFromDetail and
+	// dropped the update entirely, leaving the stored value stale rather than
+	// merely wrong.
+	od = &Detail{OrderID: "def", Amount: 10, RemainingAmount: 10}
+	om = &Detail{
+		OrderID:         "def",
+		Amount:          10,
+		ExecutedAmount:  8,
+		RemainingAmount: 2,
+		Trades:          []TradeHistory{{TID: "2", Price: 100, Amount: 8}},
+	}
+	require.NoError(t, od.UpdateOrderFromDetail(om), "UpdateOrderFromDetail must not error")
+	assert.Equal(t, 2.0, od.RemainingAmount, "RemainingAmount should be updated when the fill is larger than the reported remainder")
+}
+
+// TestUpdateOrderFromDetailTradesOnly pins the behaviour for feeds that report
+// fills without a remainder (bitmex execution, kraken ownTrades, huobi
+// trade.clearing). The engine merges such a detail into a copy of the stored
+// order first, so this method sees the stored remainder alongside the new
+// trade; that remainder is now left alone rather than reduced by the trade
+// amount. Those exchanges get their remainder from a companion order feed or
+// the REST poll instead.
+func TestUpdateOrderFromDetailTradesOnly(t *testing.T) {
+	t.Parallel()
+
+	od := &Detail{OrderID: "ghi", Amount: 10, RemainingAmount: 10}
+	om := &Detail{
+		OrderID:         "ghi",
+		Amount:          10,
+		RemainingAmount: 10,
+		Trades:          []TradeHistory{{TID: "1", Price: 100, Amount: 4}},
+	}
+	require.NoError(t, od.UpdateOrderFromDetail(om), "UpdateOrderFromDetail must not error")
+
+	require.Len(t, od.Trades, 1, "trade must be merged")
+	assert.Equal(t, 10.0, od.RemainingAmount, "RemainingAmount should be left as reported, not reduced by the merged trade")
 }
 
 func TestClassificationError_Error(t *testing.T) {

--- a/exchanges/order/orders_test.go
+++ b/exchanges/order/orders_test.go
@@ -1138,6 +1138,33 @@ func TestUpdateOrderFromDetail(t *testing.T) {
 	assert.NotEqual(t, id, od.InternalOrderID, "Should not be able to update the internal order ID after initialisation")
 }
 
+// TestUpdateOrderFromDetailRemainingAmountInvariant ensures that when an
+// incoming detail carries an authoritative RemainingAmount (Amount -
+// ExecutedAmount, as every exchange populates it) alongside the fill(s) that
+// produced it, the stored RemainingAmount is trusted rather than re-derived by
+// subtracting trade amounts. Re-deriving double-counts fills and violates the
+// invariant ExecutedAmount + RemainingAmount == Amount.
+func TestUpdateOrderFromDetailRemainingAmountInvariant(t *testing.T) {
+	t.Parallel()
+
+	om := &Detail{
+		OrderID:         "abc",
+		Amount:          10,
+		ExecutedAmount:  4,
+		RemainingAmount: 6, // authoritative: 10 - 4
+		Trades:          []TradeHistory{{TID: "1", Price: 100, Amount: 4}},
+	}
+
+	od := &Detail{OrderID: "abc", Amount: 10}
+	require.NoError(t, od.UpdateOrderFromDetail(om))
+
+	assert.Equal(t, 10.0, od.Amount)
+	assert.Equal(t, 4.0, od.ExecutedAmount)
+	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount must equal the authoritative remaining, not be reduced by trade amounts")
+	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount must equal Amount")
+	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail must not be mutated")
+}
+
 func TestClassificationError_Error(t *testing.T) {
 	class := ClassificationError{OrderID: "1337", Exchange: "test", Err: errors.New("test error")}
 	require.Equal(t, "Exchange test: OrderID: 1337 classification error: test error", class.Error())

--- a/exchanges/order/orders_test.go
+++ b/exchanges/order/orders_test.go
@@ -1160,9 +1160,9 @@ func TestUpdateOrderFromDetailRemainingAmountInvariant(t *testing.T) {
 
 	assert.Equal(t, 10.0, od.Amount)
 	assert.Equal(t, 4.0, od.ExecutedAmount)
-	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount must equal the authoritative remaining, not be reduced by trade amounts")
-	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount must equal Amount")
-	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail must not be mutated")
+	assert.Equal(t, 6.0, od.RemainingAmount, "RemainingAmount is the authoritative remaining, not reduced by trade amounts")
+	assert.Equal(t, od.Amount, od.ExecutedAmount+od.RemainingAmount, "ExecutedAmount + RemainingAmount equals Amount")
+	assert.Equal(t, 6.0, om.RemainingAmount, "incoming detail is not mutated")
 }
 
 func TestClassificationError_Error(t *testing.T) {


### PR DESCRIPTION
## Problem

`Detail.UpdateOrderFromDetail` re-derived `RemainingAmount` by subtracting each merged trade's `Amount` inside the trade-merge loop:

```go
for ... {
    d.Trades = append(d.Trades, m.Trades[x])
    updated = true
    m.RemainingAmount -= m.Trades[x].Amount   // <-- double-counts fills
}
```

`RemainingAmount` is an authoritative value reported by the exchange (`Amount - ExecutedAmount`). Subtracting trade amounts from it again double-counts fills already reflected in the exchange's own figure, producing a too-low (potentially negative) remaining amount and incorrect order state.

## Fix

Use the exchange-reported `RemainingAmount` as-is; never re-derive it from trades.

## Test

`TestUpdateOrderFromDetailRemainingAmountInvariant` covers the invariant that merging trades must not double-subtract from `RemainingAmount`.

`go test ./exchanges/order/ -run TestUpdateOrderFromDetailRemainingAmountInvariant -count=1 -v`
