### PR TITLE
request: context rate-limit coordination barrier

### DIFF
--- a/exchange/websocket/connection.go
+++ b/exchange/websocket/connection.go
@@ -215,6 +215,8 @@ func (c *connection) writeToConn(ctx context.Context, epl request.EndpointLimit,
 		if err := rl.RateLimit(ctx); err != nil {
 			return fmt.Errorf("%s websocket connection: rate limit error: %w", c.ExchangeName, err)
 		}
+	} else if err := request.WaitForRateLimitBarrier(ctx); err != nil {
+		return fmt.Errorf("%s websocket connection: rate limit barrier error: %w", c.ExchangeName, err)
 	}
 	// This lock acts as a rolling gate to prevent WriteMessage panics. Acquire after rate limit check.
 	c.writeControl.Lock()
@@ -391,6 +393,7 @@ func (c *connection) SendMessageReturnResponsesWithInspector(ctx context.Context
 	start := time.Now()
 	err = c.SendRawMessage(ctx, epl, gws.TextMessage, outbound)
 	if err != nil {
+		c.Match.RemoveSignature(signature)
 		return nil, err
 	}
 

--- a/exchange/websocket/manager_test.go
+++ b/exchange/websocket/manager_test.go
@@ -1647,6 +1647,45 @@ func TestWriteToConn(t *testing.T) {
 	require.ErrorIs(t, wc.writeToConn(ctx, request.Unset, func() error { return nil }), errRateLimitNotFound)
 }
 
+func TestWriteToConnRateLimitBarrierWithoutLimiter(t *testing.T) {
+	t.Parallel()
+	wc := connection{}
+	wc.setConnectedStatus(true)
+	contexts, err := request.NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errs := make(chan error, 2)
+	writes := make(chan struct{}, 2)
+	go func() {
+		errs <- wc.writeToConn(contexts[0], request.Unset, func() error {
+			writes <- struct{}{}
+			return nil
+		})
+	}()
+	require.Never(t, func() bool { return len(writes) != 0 }, 10*time.Millisecond, time.Millisecond, "first participant must not write before its peer arrives")
+	go func() {
+		errs <- wc.writeToConn(contexts[1], request.Unset, func() error {
+			writes <- struct{}{}
+			return nil
+		})
+	}()
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.Len(t, writes, 2)
+}
+
+func TestSendMessageBarrierRejectionRemovesSignature(t *testing.T) {
+	t.Parallel()
+	wc := connection{Match: NewMatch()}
+	wc.setConnectedStatus(true)
+	contexts, err := request.NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	request.AbortRateLimitBarrier(contexts[1])
+	_, err = wc.SendMessageReturnResponse(contexts[0], request.Unset, "signature", struct{}{})
+	require.ErrorIs(t, err, request.ErrDelayNotAllowed)
+	_, err = wc.Match.Set("signature", 1)
+	require.NoError(t, err)
+}
+
 func TestDrain(t *testing.T) {
 	t.Parallel()
 	drain(nil)

--- a/exchange/websocket/manager_test.go
+++ b/exchange/websocket/manager_test.go
@@ -1681,7 +1681,7 @@ func TestSendMessageBarrierRejectionRemovesSignature(t *testing.T) {
 	require.NoError(t, err)
 	request.AbortRateLimitBarrier(contexts[1])
 	_, err = wc.SendMessageReturnResponse(contexts[0], request.Unset, "signature", struct{}{})
-	require.ErrorIs(t, err, request.ErrDelayNotAllowed)
+	require.ErrorIs(t, err, request.ErrRateLimitBarrierRejected)
 	_, err = wc.Match.Set("signature", 1)
 	require.NoError(t, err)
 }

--- a/exchanges/request/context_helpers.go
+++ b/exchanges/request/context_helpers.go
@@ -2,9 +2,19 @@ package request
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"sync"
+	"sync/atomic"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
+)
+
+var (
+	// ErrInvalidRateLimitBarrierParticipants is returned when a barrier cannot coordinate at least two requests.
+	ErrInvalidRateLimitBarrierParticipants = errors.New("rate limit barrier requires at least two participants")
+	// ErrRateLimitBarrierParticipantUsed is returned when a one-use participant context reaches a limiter more than once.
+	ErrRateLimitBarrierParticipantUsed = errors.New("rate limit barrier participant already used")
 )
 
 const contextVerboseFlag verbosity = "verbose"
@@ -56,6 +66,116 @@ func WithDelayNotAllowed(ctx context.Context) context.Context {
 func hasDelayNotAllowed(ctx context.Context) bool {
 	_, ok := ctx.Value(delayNotAllowedKey{}).(struct{})
 	return ok
+}
+
+type rateLimitBarrierKey struct{}
+
+type rateLimitBarrier struct {
+	done      chan struct{}
+	remaining uint
+	rejected  bool
+	closed    bool
+	mu        sync.Mutex
+}
+
+type rateLimitBarrierParticipant struct {
+	barrier *rateLimitBarrier
+	used    atomic.Bool
+}
+
+// NewRateLimitBarrierContexts returns distinct one-use contexts whose rate-limit calls proceed only when every participant can proceed immediately.
+// Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants.
+func NewRateLimitBarrierContexts(ctx context.Context, participants uint) ([]context.Context, error) {
+	if participants < 2 {
+		return nil, ErrInvalidRateLimitBarrierParticipants
+	}
+	barrier := &rateLimitBarrier{done: make(chan struct{}), remaining: participants}
+	contexts := make([]context.Context, participants)
+	for i := range contexts {
+		contexts[i] = context.WithValue(ctx, rateLimitBarrierKey{}, &rateLimitBarrierParticipant{barrier: barrier}) //nolint:fatcontext // Participants are independent siblings of the same parent.
+	}
+	return contexts, nil
+}
+
+// AbortRateLimitBarrier rejects a participant that failed before reaching RateLimit. It is a no-op after the participant is consumed.
+func AbortRateLimitBarrier(ctx context.Context) {
+	participant, _ := ctx.Value(rateLimitBarrierKey{}).(*rateLimitBarrierParticipant)
+	if participant == nil || !participant.used.CompareAndSwap(false, true) {
+		return
+	}
+	participant.barrier.reject()
+}
+
+// WaitForRateLimitBarrier marks a request without an active limiter as immediately available and waits for its peers.
+func WaitForRateLimitBarrier(ctx context.Context) error {
+	participant := rateLimitBarrierParticipantFromContext(ctx)
+	if participant == nil {
+		return nil
+	}
+	return participant.wait(ctx, true)
+}
+
+func rateLimitBarrierParticipantFromContext(ctx context.Context) *rateLimitBarrierParticipant {
+	participant, _ := ctx.Value(rateLimitBarrierKey{}).(*rateLimitBarrierParticipant)
+	return participant
+}
+
+func (p *rateLimitBarrierParticipant) wait(ctx context.Context, immediate bool) error {
+	if !p.used.CompareAndSwap(false, true) {
+		return ErrRateLimitBarrierParticipantUsed
+	}
+	if !immediate {
+		p.barrier.reject()
+		return ErrDelayNotAllowed
+	}
+	if p.barrier.arrive() {
+		return nil
+	}
+	select {
+	case <-p.barrier.done:
+		return p.barrier.result()
+	case <-ctx.Done():
+		if p.barrier.reject() {
+			return ctx.Err()
+		}
+		return p.barrier.result()
+	}
+}
+
+func (b *rateLimitBarrier) arrive() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return !b.rejected
+	}
+	b.remaining--
+	if b.remaining == 0 {
+		b.closed = true
+		close(b.done)
+		return true
+	}
+	return false
+}
+
+func (b *rateLimitBarrier) reject() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return false
+	}
+	b.rejected = true
+	b.closed = true
+	close(b.done)
+	return true
+}
+
+func (b *rateLimitBarrier) result() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.rejected {
+		return ErrDelayNotAllowed
+	}
+	return nil
 }
 
 type retryNotAllowedKey struct{}

--- a/exchanges/request/context_helpers.go
+++ b/exchanges/request/context_helpers.go
@@ -15,6 +15,8 @@ var (
 	ErrInvalidRateLimitBarrierParticipants = errors.New("rate limit barrier requires at least two participants")
 	// ErrRateLimitBarrierParticipantUsed is returned when a participant context reaches a limiter again before its barrier resolves.
 	ErrRateLimitBarrierParticipantUsed = errors.New("rate limit barrier participant already used")
+	// ErrRateLimitBarrierRejected is returned when a peer aborts or is cancelled before group admission.
+	ErrRateLimitBarrierRejected = errors.New("rate limit barrier rejected")
 )
 
 const contextVerboseFlag verbosity = "verbose"
@@ -74,7 +76,7 @@ type rateLimitBarrier struct {
 	done         chan struct{}
 	participants []*rateLimitBarrierParticipant
 	remaining    uint
-	rejected     bool
+	rejection    error
 	closed       bool
 	mu           sync.Mutex
 }
@@ -90,6 +92,10 @@ type rateLimitBarrierParticipant struct {
 // Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants. The final arrival
 // atomically reserves capacity for the group; shared limiters must have enough burst capacity for all participants, and each weight must fit its
 // limiter's burst. After acceptance, subsequent rate-limit calls using a participant context proceed normally, including retries.
+// Coordination covers only the first gate, not request execution: additional rate-limited calls under the same participant context can fail
+// independently and lose the group's all-or-nothing admission guarantee. Cancellation or transport errors after admission can also split execution.
+// NewRateLimit uses burst 1, so participants using its finite limiters must use distinct limiter instances and weight 1. Larger groups sharing
+// a limiter or larger weights require sufficient burst capacity, for example via GetRateLimiterWithWeight with a custom limiter.
 func NewRateLimitBarrierContexts(ctx context.Context, participants uint) ([]context.Context, error) {
 	if participants < 2 {
 		return nil, ErrInvalidRateLimitBarrierParticipants
@@ -167,7 +173,7 @@ func (b *rateLimitBarrier) arrive(ctx context.Context, participant *rateLimitBar
 	participant.limiter = limiter
 	b.remaining--
 	if b.remaining == 0 {
-		b.rejected = !b.admitLocked()
+		b.rejection = b.admitLocked()
 		b.closed = true
 		close(b.done)
 		return true
@@ -181,7 +187,7 @@ func (b *rateLimitBarrier) reject() bool {
 	if b.closed {
 		return false
 	}
-	b.rejected = true
+	b.rejection = ErrRateLimitBarrierRejected
 	b.closed = true
 	close(b.done)
 	return true
@@ -190,10 +196,7 @@ func (b *rateLimitBarrier) reject() bool {
 func (b *rateLimitBarrier) result() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.rejected {
-		return ErrDelayNotAllowed
-	}
-	return nil
+	return b.rejection
 }
 
 func (b *rateLimitBarrier) resultFor(ctx context.Context) error {
@@ -210,10 +213,7 @@ func (b *rateLimitBarrier) closedResult() (bool, error) {
 	if !b.closed {
 		return false, nil
 	}
-	if b.rejected {
-		return true, ErrDelayNotAllowed
-	}
-	return true, nil
+	return true, b.rejection
 }
 
 func (b *rateLimitBarrier) reuseResult() error {

--- a/exchanges/request/context_helpers.go
+++ b/exchanges/request/context_helpers.go
@@ -71,30 +71,39 @@ func hasDelayNotAllowed(ctx context.Context) bool {
 type rateLimitBarrierKey struct{}
 
 type rateLimitBarrier struct {
-	done      chan struct{}
-	remaining uint
-	rejected  bool
-	closed    bool
-	mu        sync.Mutex
+	done         chan struct{}
+	participants []*rateLimitBarrierParticipant
+	remaining    uint
+	rejected     bool
+	closed       bool
+	mu           sync.Mutex
 }
 
 type rateLimitBarrierParticipant struct {
 	barrier *rateLimitBarrier
+	done    <-chan struct{}
+	limiter *RateLimiterWithWeight
 	used    atomic.Bool
 }
 
 // NewRateLimitBarrierContexts returns distinct contexts whose first rate-limit calls proceed only when every participant can proceed immediately.
-// Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants. After acceptance,
-// subsequent rate-limit calls using a participant context proceed normally, including retries. Participants sharing a limiter are paced normally
-// after the barrier accepts them and therefore might not execute simultaneously.
+// Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants. The final arrival
+// atomically reserves capacity for the group; shared limiters must have enough burst capacity for all participants, and each weight must fit its
+// limiter's burst. After acceptance, subsequent rate-limit calls using a participant context proceed normally, including retries.
 func NewRateLimitBarrierContexts(ctx context.Context, participants uint) ([]context.Context, error) {
 	if participants < 2 {
 		return nil, ErrInvalidRateLimitBarrierParticipants
 	}
-	barrier := &rateLimitBarrier{done: make(chan struct{}), remaining: participants}
+	barrier := &rateLimitBarrier{
+		done:         make(chan struct{}),
+		participants: make([]*rateLimitBarrierParticipant, participants),
+		remaining:    participants,
+	}
 	contexts := make([]context.Context, participants)
 	for i := range contexts {
-		contexts[i] = context.WithValue(ctx, rateLimitBarrierKey{}, &rateLimitBarrierParticipant{barrier: barrier}) //nolint:fatcontext // Participants are independent siblings of the same parent.
+		participant := &rateLimitBarrierParticipant{barrier: barrier}
+		barrier.participants[i] = participant
+		contexts[i] = context.WithValue(ctx, rateLimitBarrierKey{}, participant) //nolint:fatcontext // Participants are independent siblings of the same parent.
 	}
 	return contexts, nil
 }
@@ -114,7 +123,8 @@ func WaitForRateLimitBarrier(ctx context.Context) error {
 	if participant == nil {
 		return nil
 	}
-	return participant.wait(ctx, true)
+	_, err := participant.wait(ctx, nil)
+	return err
 }
 
 func rateLimitBarrierParticipantFromContext(ctx context.Context) *rateLimitBarrierParticipant {
@@ -122,43 +132,42 @@ func rateLimitBarrierParticipantFromContext(ctx context.Context) *rateLimitBarri
 	return participant
 }
 
-func (p *rateLimitBarrierParticipant) wait(ctx context.Context, immediate bool) error {
+func (p *rateLimitBarrierParticipant) wait(ctx context.Context, limiter *RateLimiterWithWeight) (bool, error) {
 	if !p.used.CompareAndSwap(false, true) {
-		return p.barrier.reuseResult()
+		return false, p.barrier.reuseResult()
 	}
 	if closed, err := p.barrier.closedResult(); closed {
-		return err
-	}
-	if !immediate {
-		p.barrier.reject()
-		return ErrDelayNotAllowed
+		return true, err
 	}
 	if err := ctx.Err(); err != nil {
 		p.barrier.reject()
-		return err
+		return true, err
 	}
-	if p.barrier.arrive() {
-		return nil
+	if p.barrier.arrive(ctx, p, limiter) {
+		return true, p.barrier.resultFor(ctx)
 	}
 	select {
 	case <-p.barrier.done:
-		return p.barrier.result()
+		return true, p.barrier.resultFor(ctx)
 	case <-ctx.Done():
 		if p.barrier.reject() {
-			return ctx.Err()
+			return true, ctx.Err()
 		}
-		return p.barrier.result()
+		return true, p.barrier.resultFor(ctx)
 	}
 }
 
-func (b *rateLimitBarrier) arrive() bool {
+func (b *rateLimitBarrier) arrive(ctx context.Context, participant *rateLimitBarrierParticipant, limiter *RateLimiterWithWeight) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {
-		return !b.rejected
+		return true
 	}
+	participant.done = ctx.Done()
+	participant.limiter = limiter
 	b.remaining--
 	if b.remaining == 0 {
+		b.rejected = !b.admitLocked()
 		b.closed = true
 		close(b.done)
 		return true
@@ -185,6 +194,14 @@ func (b *rateLimitBarrier) result() error {
 		return ErrDelayNotAllowed
 	}
 	return nil
+}
+
+func (b *rateLimitBarrier) resultFor(ctx context.Context) error {
+	err := b.result()
+	if err != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func (b *rateLimitBarrier) closedResult() (bool, error) {

--- a/exchanges/request/context_helpers.go
+++ b/exchanges/request/context_helpers.go
@@ -13,7 +13,7 @@ import (
 var (
 	// ErrInvalidRateLimitBarrierParticipants is returned when a barrier cannot coordinate at least two requests.
 	ErrInvalidRateLimitBarrierParticipants = errors.New("rate limit barrier requires at least two participants")
-	// ErrRateLimitBarrierParticipantUsed is returned when a one-use participant context reaches a limiter more than once.
+	// ErrRateLimitBarrierParticipantUsed is returned when a participant context reaches a limiter again before its barrier resolves.
 	ErrRateLimitBarrierParticipantUsed = errors.New("rate limit barrier participant already used")
 )
 
@@ -83,8 +83,10 @@ type rateLimitBarrierParticipant struct {
 	used    atomic.Bool
 }
 
-// NewRateLimitBarrierContexts returns distinct one-use contexts whose rate-limit calls proceed only when every participant can proceed immediately.
-// Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants.
+// NewRateLimitBarrierContexts returns distinct contexts whose first rate-limit calls proceed only when every participant can proceed immediately.
+// Each request owner must defer AbortRateLimitBarrier so a failure before reaching the limiter releases the other participants. After acceptance,
+// subsequent rate-limit calls using a participant context proceed normally, including retries. Participants sharing a limiter are paced normally
+// after the barrier accepts them and therefore might not execute simultaneously.
 func NewRateLimitBarrierContexts(ctx context.Context, participants uint) ([]context.Context, error) {
 	if participants < 2 {
 		return nil, ErrInvalidRateLimitBarrierParticipants
@@ -122,11 +124,18 @@ func rateLimitBarrierParticipantFromContext(ctx context.Context) *rateLimitBarri
 
 func (p *rateLimitBarrierParticipant) wait(ctx context.Context, immediate bool) error {
 	if !p.used.CompareAndSwap(false, true) {
-		return ErrRateLimitBarrierParticipantUsed
+		return p.barrier.reuseResult()
+	}
+	if closed, err := p.barrier.closedResult(); closed {
+		return err
 	}
 	if !immediate {
 		p.barrier.reject()
 		return ErrDelayNotAllowed
+	}
+	if err := ctx.Err(); err != nil {
+		p.barrier.reject()
+		return err
 	}
 	if p.barrier.arrive() {
 		return nil
@@ -176,6 +185,26 @@ func (b *rateLimitBarrier) result() error {
 		return ErrDelayNotAllowed
 	}
 	return nil
+}
+
+func (b *rateLimitBarrier) closedResult() (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.closed {
+		return false, nil
+	}
+	if b.rejected {
+		return true, ErrDelayNotAllowed
+	}
+	return true, nil
+}
+
+func (b *rateLimitBarrier) reuseResult() error {
+	closed, err := b.closedResult()
+	if !closed {
+		return ErrRateLimitBarrierParticipantUsed
+	}
+	return err
 }
 
 type retryNotAllowedKey struct{}

--- a/exchanges/request/context_helpers_test.go
+++ b/exchanges/request/context_helpers_test.go
@@ -27,6 +27,43 @@ func TestWithDelayNotAllowed(t *testing.T) {
 	assert.False(t, hasDelayNotAllowed(WithRetryNotAllowed(WithVerbose(t.Context()))))
 }
 
+func TestNewRateLimitBarrierContexts(t *testing.T) {
+	t.Parallel()
+
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 1)
+	require.ErrorIs(t, err, ErrInvalidRateLimitBarrierParticipants)
+	require.Nil(t, contexts)
+
+	contexts, err = NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	require.Len(t, contexts, 2)
+	require.NotSame(t, rateLimitBarrierParticipantFromContext(contexts[0]), rateLimitBarrierParticipantFromContext(contexts[1]))
+}
+
+func TestWaitForRateLimitBarrier(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, WaitForRateLimitBarrier(t.Context()))
+
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errs := make(chan error, 2)
+	go func() { errs <- WaitForRateLimitBarrier(contexts[0]) }()
+	go func() { errs <- WaitForRateLimitBarrier(contexts[1]) }()
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+}
+
+func TestAbortRateLimitBarrier(t *testing.T) {
+	t.Parallel()
+
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	AbortRateLimitBarrier(contexts[0])
+	require.ErrorIs(t, rateLimitBarrierParticipantFromContext(contexts[1]).wait(t.Context(), true), ErrDelayNotAllowed)
+	AbortRateLimitBarrier(contexts[0])
+	AbortRateLimitBarrier(t.Context())
+}
+
 func TestWithHeaders(t *testing.T) {
 	t.Parallel()
 	headers := http.Header{"User-Agent": {"custom"}, "X-Values": {"one", "two"}}

--- a/exchanges/request/context_helpers_test.go
+++ b/exchanges/request/context_helpers_test.go
@@ -66,7 +66,7 @@ func TestWaitForRateLimitBarrierRejectsCancelledFinalParticipant(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(contexts[1])
 	cancel()
 	require.ErrorIs(t, WaitForRateLimitBarrier(cancelledContext), context.Canceled)
-	require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
+	require.ErrorIs(t, <-errCh, ErrRateLimitBarrierRejected)
 }
 
 func TestWaitForRateLimitBarrierRejectsParticipantCancelledWhileParked(t *testing.T) {
@@ -80,7 +80,7 @@ func TestWaitForRateLimitBarrierRejectsParticipantCancelledWhileParked(t *testin
 		time.Second, time.Millisecond, "first participant must reach the barrier")
 
 	cancel()
-	require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrDelayNotAllowed)
+	require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrRateLimitBarrierRejected)
 	require.ErrorIs(t, <-errCh, context.Canceled)
 }
 
@@ -95,7 +95,7 @@ func TestWaitForRateLimitBarrierRejectsReuseBeforeResolution(t *testing.T) {
 
 	require.ErrorIs(t, WaitForRateLimitBarrier(contexts[0]), ErrRateLimitBarrierParticipantUsed)
 	AbortRateLimitBarrier(contexts[1])
-	require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
+	require.ErrorIs(t, <-errCh, ErrRateLimitBarrierRejected)
 }
 
 func TestAbortRateLimitBarrier(t *testing.T) {
@@ -105,7 +105,7 @@ func TestAbortRateLimitBarrier(t *testing.T) {
 	require.NoError(t, err)
 	AbortRateLimitBarrier(contexts[0])
 	_, err = rateLimitBarrierParticipantFromContext(contexts[1]).wait(t.Context(), nil)
-	require.ErrorIs(t, err, ErrDelayNotAllowed)
+	require.ErrorIs(t, err, ErrRateLimitBarrierRejected)
 	AbortRateLimitBarrier(contexts[0])
 	AbortRateLimitBarrier(t.Context())
 }
@@ -125,9 +125,9 @@ func TestRateLimitBarrierTerminalResults(t *testing.T) {
 	assert.NoError(t, err, "accepted barrier should not have an error")
 	assert.NoError(t, barrier.reuseResult(), "accepted barrier should allow reuse")
 
-	barrier.rejected = true
-	assert.ErrorIs(t, barrier.result(), ErrDelayNotAllowed)
-	assert.ErrorIs(t, barrier.reuseResult(), ErrDelayNotAllowed)
+	barrier.rejection = ErrRateLimitBarrierRejected
+	assert.ErrorIs(t, barrier.result(), ErrRateLimitBarrierRejected)
+	assert.ErrorIs(t, barrier.reuseResult(), ErrRateLimitBarrierRejected)
 }
 
 func TestWithHeaders(t *testing.T) {

--- a/exchanges/request/context_helpers_test.go
+++ b/exchanges/request/context_helpers_test.go
@@ -69,6 +69,21 @@ func TestWaitForRateLimitBarrierRejectsCancelledFinalParticipant(t *testing.T) {
 	require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
 }
 
+func TestWaitForRateLimitBarrierRejectsParticipantCancelledWhileParked(t *testing.T) {
+	t.Parallel()
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	parkedContext, cancel := context.WithCancel(contexts[0])
+	errCh := make(chan error, 1)
+	go func() { errCh <- WaitForRateLimitBarrier(parkedContext) }()
+	require.Eventually(t, rateLimitBarrierParticipantFromContext(contexts[0]).used.Load,
+		time.Second, time.Millisecond, "first participant must reach the barrier")
+
+	cancel()
+	require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrDelayNotAllowed)
+	require.ErrorIs(t, <-errCh, context.Canceled)
+}
+
 func TestWaitForRateLimitBarrierRejectsReuseBeforeResolution(t *testing.T) {
 	t.Parallel()
 	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
@@ -89,9 +104,30 @@ func TestAbortRateLimitBarrier(t *testing.T) {
 	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
 	require.NoError(t, err)
 	AbortRateLimitBarrier(contexts[0])
-	require.ErrorIs(t, rateLimitBarrierParticipantFromContext(contexts[1]).wait(t.Context(), true), ErrDelayNotAllowed)
+	_, err = rateLimitBarrierParticipantFromContext(contexts[1]).wait(t.Context(), nil)
+	require.ErrorIs(t, err, ErrDelayNotAllowed)
 	AbortRateLimitBarrier(contexts[0])
 	AbortRateLimitBarrier(t.Context())
+}
+
+func TestRateLimitBarrierTerminalResults(t *testing.T) {
+	t.Parallel()
+
+	barrier := &rateLimitBarrier{done: make(chan struct{})}
+	closed, err := barrier.closedResult()
+	assert.False(t, closed, "open barrier should not report closed")
+	assert.NoError(t, err, "open barrier should not have a result")
+	assert.ErrorIs(t, barrier.reuseResult(), ErrRateLimitBarrierParticipantUsed)
+
+	barrier.closed = true
+	closed, err = barrier.closedResult()
+	assert.True(t, closed, "accepted barrier should report closed")
+	assert.NoError(t, err, "accepted barrier should not have an error")
+	assert.NoError(t, barrier.reuseResult(), "accepted barrier should allow reuse")
+
+	barrier.rejected = true
+	assert.ErrorIs(t, barrier.result(), ErrDelayNotAllowed)
+	assert.ErrorIs(t, barrier.reuseResult(), ErrDelayNotAllowed)
 }
 
 func TestWithHeaders(t *testing.T) {

--- a/exchanges/request/context_helpers_test.go
+++ b/exchanges/request/context_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,35 @@ func TestWaitForRateLimitBarrier(t *testing.T) {
 	go func() { errs <- WaitForRateLimitBarrier(contexts[1]) }()
 	require.NoError(t, <-errs)
 	require.NoError(t, <-errs)
+}
+
+func TestWaitForRateLimitBarrierRejectsCancelledFinalParticipant(t *testing.T) {
+	t.Parallel()
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() { errCh <- WaitForRateLimitBarrier(contexts[0]) }()
+	require.Eventually(t, rateLimitBarrierParticipantFromContext(contexts[0]).used.Load,
+		time.Second, time.Millisecond, "first participant must reach the barrier")
+
+	cancelledContext, cancel := context.WithCancel(contexts[1])
+	cancel()
+	require.ErrorIs(t, WaitForRateLimitBarrier(cancelledContext), context.Canceled)
+	require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
+}
+
+func TestWaitForRateLimitBarrierRejectsReuseBeforeResolution(t *testing.T) {
+	t.Parallel()
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() { errCh <- WaitForRateLimitBarrier(contexts[0]) }()
+	require.Eventually(t, rateLimitBarrierParticipantFromContext(contexts[0]).used.Load,
+		time.Second, time.Millisecond, "first participant must reach the barrier")
+
+	require.ErrorIs(t, WaitForRateLimitBarrier(contexts[0]), ErrRateLimitBarrierParticipantUsed)
+	AbortRateLimitBarrier(contexts[1])
+	require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
 }
 
 func TestAbortRateLimitBarrier(t *testing.T) {

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -102,7 +102,7 @@ func (r *Requester) InitiateRateLimit(ctx context.Context, e EndpointLimit) erro
 		return ErrRequestSystemIsNil
 	}
 	if atomic.LoadInt32(&r.disableRateLimiter) == 1 {
-		return nil
+		return WaitForRateLimitBarrier(ctx)
 	}
 	if err := common.NilGuard(r.limiter); err != nil {
 		return err
@@ -141,6 +141,17 @@ func (r *RateLimiterWithWeight) RateLimit(ctx context.Context) error {
 		reserved = append(reserved, r.limiter.ReserveN(tn, 1))
 	}
 	finalDelay := reserved[len(reserved)-1].DelayFrom(tn)
+	barrierParticipant := rateLimitBarrierParticipantFromContext(ctx)
+	if barrierParticipant != nil {
+		r.m.Unlock()
+		if err := barrierParticipant.wait(ctx, finalDelay == 0); err != nil {
+			r.m.Lock()
+			cancelAll(reserved, tn)
+			r.m.Unlock()
+			return err
+		}
+		return nil
+	}
 
 	if finalDelay == 0 {
 		r.m.Unlock()

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -48,7 +48,10 @@ type RateLimitDefinitions map[any]*RateLimiterWithWeight
 type RateLimiterWithWeight struct {
 	limiter *rate.Limiter
 	weight  Weight
-	m       sync.Mutex
+	// Redundant under rateLimitReservationMu in production, but retained so
+	// TestRateLimitReservationLock and TestRateLimitBarrierCancellationDuringAdmission
+	// can pause admission deterministically to verify locking and cancellation safeguards.
+	m sync.Mutex
 }
 
 // NewRateLimit creates a new RateLimit based of time interval and how many actions allowed and breaks it down to an

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -125,27 +125,19 @@ func (r *Requester) GetRateLimiterDefinitions() RateLimitDefinitions {
 // RateLimit throttles a request based on weight, delaying the request.
 // Errors if no delay is permitted via the context and a delay is required.
 func (r *RateLimiterWithWeight) RateLimit(ctx context.Context) error {
-	return r.rateLimit(ctx, true)
-}
-
-func (r *RateLimiterWithWeight) rateLimit(ctx context.Context, coordinate bool) error {
 	if err := common.NilGuard(r); err != nil {
 		return err
 	}
 
 	if r.weight == 0 {
-		if coordinate {
-			AbortRateLimitBarrier(ctx)
-		}
+		AbortRateLimitBarrier(ctx)
 		return errInvalidWeight
 	}
 
-	if coordinate {
-		if participant := rateLimitBarrierParticipantFromContext(ctx); participant != nil {
-			admitted, err := participant.wait(ctx, r)
-			if err != nil || admitted {
-				return err
-			}
+	if participant := rateLimitBarrierParticipantFromContext(ctx); participant != nil {
+		admitted, err := participant.wait(ctx, r)
+		if err != nil || admitted {
+			return err
 		}
 	}
 
@@ -194,16 +186,16 @@ func (r *RateLimiterWithWeight) reserveLocked(at time.Time) ([]*rate.Reservation
 }
 
 // admitLocked reserves every participant's capacity as one transaction. The barrier lock must be held by the caller.
-func (b *rateLimitBarrier) admitLocked() bool {
+func (b *rateLimitBarrier) admitLocked() error {
 	rateLimitReservationMu.Lock()
 	defer rateLimitReservationMu.Unlock()
 
 	at := time.Now()
 	reservations := make([]*rate.Reservation, 0, len(b.participants))
 	for _, participant := range b.participants {
-		if participant.done == nil && !participant.used.Load() || contextDone(participant.done) {
+		if contextDone(participant.done) {
 			cancelAll(reservations, at)
-			return false
+			return ErrRateLimitBarrierRejected
 		}
 		if participant.limiter == nil {
 			continue
@@ -214,16 +206,16 @@ func (b *rateLimitBarrier) admitLocked() bool {
 		reservations = append(reservations, reserved...)
 		if delay != 0 {
 			cancelAll(reservations, at)
-			return false
+			return ErrDelayNotAllowed
 		}
 	}
 	for _, participant := range b.participants {
 		if contextDone(participant.done) {
 			cancelAll(reservations, at)
-			return false
+			return ErrRateLimitBarrierRejected
 		}
 	}
-	return true
+	return nil
 }
 
 func contextDone(done <-chan struct{}) bool {

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -124,6 +124,10 @@ func (r *Requester) GetRateLimiterDefinitions() RateLimitDefinitions {
 // RateLimit throttles a request based on weight, delaying the request.
 // Errors if no delay is permitted via the context and a delay is required.
 func (r *RateLimiterWithWeight) RateLimit(ctx context.Context) error {
+	return r.rateLimit(ctx, true)
+}
+
+func (r *RateLimiterWithWeight) rateLimit(ctx context.Context, coordinate bool) error {
 	if err := common.NilGuard(r); err != nil {
 		return err
 	}
@@ -141,16 +145,20 @@ func (r *RateLimiterWithWeight) RateLimit(ctx context.Context) error {
 		reserved = append(reserved, r.limiter.ReserveN(tn, 1))
 	}
 	finalDelay := reserved[len(reserved)-1].DelayFrom(tn)
-	barrierParticipant := rateLimitBarrierParticipantFromContext(ctx)
+	var barrierParticipant *rateLimitBarrierParticipant
+	if coordinate {
+		barrierParticipant = rateLimitBarrierParticipantFromContext(ctx)
+	}
 	if barrierParticipant != nil {
+		// Reservations only probe immediate availability. Restore them before
+		// parking so rejection cannot consume capacity and acceptance is charged
+		// when the request is ready to proceed.
+		cancelAll(reserved, tn)
 		r.m.Unlock()
 		if err := barrierParticipant.wait(ctx, finalDelay == 0); err != nil {
-			r.m.Lock()
-			cancelAll(reserved, tn)
-			r.m.Unlock()
 			return err
 		}
-		return nil
+		return r.rateLimit(ctx, false)
 	}
 
 	if finalDelay == 0 {

--- a/exchanges/request/limit.go
+++ b/exchanges/request/limit.go
@@ -19,7 +19,8 @@ var (
 	ErrRateLimiterAlreadyEnabled  = errors.New("rate limiter already enabled")
 	ErrDelayNotAllowed            = errors.New("delay not allowed")
 
-	errInvalidWeight = errors.New("weight must be equal-or-greater than 1")
+	errInvalidWeight       = errors.New("weight must be equal-or-greater than 1")
+	rateLimitReservationMu sync.Mutex
 )
 
 // RateLimitNotRequired is a no-op rate limiter.
@@ -132,58 +133,105 @@ func (r *RateLimiterWithWeight) rateLimit(ctx context.Context, coordinate bool) 
 		return err
 	}
 
-	r.m.Lock()
 	if r.weight == 0 {
-		r.m.Unlock()
+		if coordinate {
+			AbortRateLimitBarrier(ctx)
+		}
 		return errInvalidWeight
 	}
 
-	tn := time.Now()
-	reserved := make([]*rate.Reservation, 0, r.weight)
-	for range r.weight {
-		// This avoids needing burst capacity in the limiter, which would otherwise allow the rate limit to be exceeded over short periods
-		reserved = append(reserved, r.limiter.ReserveN(tn, 1))
-	}
-	finalDelay := reserved[len(reserved)-1].DelayFrom(tn)
-	var barrierParticipant *rateLimitBarrierParticipant
 	if coordinate {
-		barrierParticipant = rateLimitBarrierParticipantFromContext(ctx)
-	}
-	if barrierParticipant != nil {
-		// Reservations only probe immediate availability. Restore them before
-		// parking so rejection cannot consume capacity and acceptance is charged
-		// when the request is ready to proceed.
-		cancelAll(reserved, tn)
-		r.m.Unlock()
-		if err := barrierParticipant.wait(ctx, finalDelay == 0); err != nil {
-			return err
+		if participant := rateLimitBarrierParticipantFromContext(ctx); participant != nil {
+			admitted, err := participant.wait(ctx, r)
+			if err != nil || admitted {
+				return err
+			}
 		}
-		return r.rateLimit(ctx, false)
 	}
+
+	rateLimitReservationMu.Lock()
+	r.m.Lock()
+	tn := time.Now()
+	reserved, finalDelay := r.reserveLocked(tn)
 
 	if finalDelay == 0 {
 		r.m.Unlock()
+		rateLimitReservationMu.Unlock()
 		return nil
 	}
 
 	if hasDelayNotAllowed(ctx) {
 		cancelAll(reserved, tn)
 		r.m.Unlock()
+		rateLimitReservationMu.Unlock()
 		return ErrDelayNotAllowed
 	}
 
 	if dl, ok := ctx.Deadline(); ok && dl.Before(tn.Add(finalDelay)) {
 		cancelAll(reserved, tn)
 		r.m.Unlock()
+		rateLimitReservationMu.Unlock()
 		return fmt.Errorf("rate limit delay of %s will exceed deadline: %w", finalDelay, context.DeadlineExceeded)
 	}
 	r.m.Unlock()
+	rateLimitReservationMu.Unlock()
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(finalDelay):
 		return nil
+	}
+}
+
+func (r *RateLimiterWithWeight) reserveLocked(at time.Time) ([]*rate.Reservation, time.Duration) {
+	reserved := make([]*rate.Reservation, 0, r.weight)
+	for range r.weight {
+		// This avoids needing burst capacity in the limiter, which would otherwise allow the rate limit to be exceeded over short periods
+		reserved = append(reserved, r.limiter.ReserveN(at, 1))
+	}
+	return reserved, reserved[len(reserved)-1].DelayFrom(at)
+}
+
+// admitLocked reserves every participant's capacity as one transaction. The barrier lock must be held by the caller.
+func (b *rateLimitBarrier) admitLocked() bool {
+	rateLimitReservationMu.Lock()
+	defer rateLimitReservationMu.Unlock()
+
+	at := time.Now()
+	reservations := make([]*rate.Reservation, 0, len(b.participants))
+	for _, participant := range b.participants {
+		if participant.done == nil && !participant.used.Load() || contextDone(participant.done) {
+			cancelAll(reservations, at)
+			return false
+		}
+		if participant.limiter == nil {
+			continue
+		}
+		participant.limiter.m.Lock()
+		reserved, delay := participant.limiter.reserveLocked(at)
+		participant.limiter.m.Unlock()
+		reservations = append(reservations, reserved...)
+		if delay != 0 {
+			cancelAll(reservations, at)
+			return false
+		}
+	}
+	for _, participant := range b.participants {
+		if contextDone(participant.done) {
+			cancelAll(reservations, at)
+			return false
+		}
+	}
+	return true
+}
+
+func contextDone(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/exchanges/request/limit_test.go
+++ b/exchanges/request/limit_test.go
@@ -103,6 +103,66 @@ func TestRateLimit_Concurrent(t *testing.T) {
 	})
 }
 
+func TestRateLimitBarrier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both immediate", func(t *testing.T) {
+		t.Parallel()
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+		require.NoError(t, err)
+		left := NewRateLimitWithWeight(time.Second, 1, 1)
+		right := NewRateLimitWithWeight(time.Second, 1, 1)
+		errs := make(chan error, 2)
+		go func() { errs <- left.RateLimit(contexts[0]) }()
+		go func() { errs <- right.RateLimit(contexts[1]) }()
+		require.NoError(t, <-errs)
+		require.NoError(t, <-errs)
+	})
+
+	t.Run("one delayed rejects both and restores reservations", func(t *testing.T) {
+		t.Parallel()
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+		require.NoError(t, err)
+		left := NewRateLimitWithWeight(time.Hour, 1, 1)
+		right := NewRateLimitWithWeight(time.Hour, 1, 1)
+		require.NoError(t, right.RateLimit(t.Context()))
+		errs := make(chan error, 2)
+		go func() { errs <- left.RateLimit(contexts[0]) }()
+		go func() { errs <- right.RateLimit(contexts[1]) }()
+		require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+		require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
+	})
+
+	t.Run("participant is one use", func(t *testing.T) {
+		t.Parallel()
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+		require.NoError(t, err)
+		left := NewRateLimitWithWeight(time.Second, 1, 1)
+		right := NewRateLimitWithWeight(time.Second, 1, 1)
+		errs := make(chan error, 2)
+		go func() { errs <- left.RateLimit(contexts[0]) }()
+		go func() { errs <- right.RateLimit(contexts[1]) }()
+		require.NoError(t, <-errs)
+		require.NoError(t, <-errs)
+		require.ErrorIs(t, left.RateLimit(contexts[0]), ErrRateLimitBarrierParticipantUsed)
+	})
+
+	t.Run("cancellation rejects peer and restores reservation", func(t *testing.T) {
+		t.Parallel()
+		parent, cancel := context.WithCancel(t.Context())
+		contexts, err := NewRateLimitBarrierContexts(parent, 2)
+		require.NoError(t, err)
+		left := NewRateLimitWithWeight(time.Hour, 1, 1)
+		errCh := make(chan error, 1)
+		go func() { errCh <- left.RateLimit(contexts[0]) }()
+		cancel()
+		require.ErrorIs(t, <-errCh, context.Canceled)
+		require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrDelayNotAllowed)
+		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
+	})
+}
+
 func TestRateLimit_Linear_WithFailure(t *testing.T) {
 	t.Parallel()
 
@@ -235,6 +295,13 @@ func TestInitiateRateLimit(t *testing.T) {
 	atomic.StoreInt32(&r.disableRateLimiter, 1)
 	err = r.InitiateRateLimit(t.Context(), Unset)
 	assert.NoError(t, err, "should not error when rate limiter is disabled")
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errs := make(chan error, 2)
+	go func() { errs <- r.InitiateRateLimit(contexts[0], Unset) }()
+	go func() { errs <- r.InitiateRateLimit(contexts[1], Unset) }()
+	require.NoError(t, <-errs, "disabled limiter barrier participant must not error")
+	require.NoError(t, <-errs, "disabled limiter barrier participant must not error")
 
 	atomic.StoreInt32(&r.disableRateLimiter, 0)
 	err = r.InitiateRateLimit(t.Context(), Unset)

--- a/exchanges/request/limit_test.go
+++ b/exchanges/request/limit_test.go
@@ -130,9 +130,9 @@ func TestRateLimitBarrier(t *testing.T) {
 		go func() { errs <- right.RateLimit(contexts[1]) }()
 		require.NoError(t, <-errs)
 		require.NoError(t, <-errs)
-		require.ErrorIs(t, left.rateLimit(WithDelayNotAllowed(t.Context()), false), ErrDelayNotAllowed,
+		require.ErrorIs(t, left.RateLimit(WithDelayNotAllowed(t.Context())), ErrDelayNotAllowed,
 			"accepted participant must retain its reservation")
-		require.ErrorIs(t, right.rateLimit(WithDelayNotAllowed(t.Context()), false), ErrDelayNotAllowed,
+		require.ErrorIs(t, right.RateLimit(WithDelayNotAllowed(t.Context())), ErrDelayNotAllowed,
 			"accepted participant must retain its reservation")
 	})
 
@@ -165,7 +165,7 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.NoError(t, left.RateLimit(contexts[0]), "post-acceptance calls must use ordinary rate limiting")
 	})
 
-	t.Run("cancellation rejects peer and restores reservation", func(t *testing.T) {
+	t.Run("cancellation rejects peer without consuming capacity", func(t *testing.T) {
 		t.Parallel()
 		parent, cancel := context.WithCancel(t.Context())
 		contexts, err := NewRateLimitBarrierContexts(parent, 2)
@@ -175,7 +175,7 @@ func TestRateLimitBarrier(t *testing.T) {
 		go func() { errCh <- left.RateLimit(contexts[0]) }()
 		cancel()
 		require.ErrorIs(t, <-errCh, context.Canceled)
-		require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrDelayNotAllowed)
+		require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrRateLimitBarrierRejected)
 		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
 	})
 
@@ -205,7 +205,7 @@ func TestRateLimitBarrier(t *testing.T) {
 			errs := make(chan error, 2)
 			go func() { errs <- left.RateLimit(contexts[0]) }()
 			synctest.Wait()
-			require.NoError(t, left.rateLimit(t.Context(), false), "competitor must consume left capacity")
+			require.NoError(t, left.RateLimit(t.Context()), "competitor must consume left capacity")
 			go func() { errs <- right.RateLimit(contexts[1]) }()
 
 			require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
@@ -228,7 +228,7 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
 	})
 
-	t.Run("rejected probe restores capacity before competitor", func(t *testing.T) {
+	t.Run("parked participant holds no capacity", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
 			contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
 			require.NoError(t, err)
@@ -238,13 +238,116 @@ func TestRateLimitBarrier(t *testing.T) {
 			synctest.Wait()
 
 			require.NoError(t, limiter.RateLimit(WithDelayNotAllowed(t.Context())),
-				"competitor must receive capacity restored before the participant parks")
+				"competitor must receive capacity unused by the parked participant")
 			AbortRateLimitBarrier(contexts[1])
-			require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
+			require.ErrorIs(t, <-errCh, ErrRateLimitBarrierRejected)
 			assert.InDelta(t, 0, limiter.limiter.Tokens(), 0.001,
-				"rejected barrier probe should not consume capacity")
+				"rejected barrier should not consume capacity")
 		})
 	})
+}
+
+func TestRateLimitBarrierZeroWeightReleasesParkedPeer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 3)
+		require.NoError(t, err, "barrier contexts must be created")
+		defer AbortRateLimitBarrier(contexts[2])
+		peer := NewRateLimitWithWeight(time.Hour, 1, 1)
+		errors := make(chan error, 1)
+		go func() { errors <- peer.RateLimit(contexts[0]) }()
+		synctest.Wait()
+		invalid := NewRateLimitWithWeight(time.Hour, 1, 0)
+		require.ErrorIs(t, invalid.RateLimit(contexts[1]), errInvalidWeight, "zero weight must be rejected")
+		synctest.Wait()
+		select {
+		case err := <-errors:
+			assert.ErrorIs(t, err, ErrRateLimitBarrierRejected, "parked peer should observe rejection before the last arrival")
+			assert.NotErrorIs(t, err, ErrDelayNotAllowed, "invalid peer should not report a capacity delay")
+		default:
+			t.Error("zero weight should release the parked peer without a final arrival")
+		}
+		assert.Equal(t, float64(1), peer.limiter.Tokens(), "rejected group should leave capacity untouched")
+	})
+}
+
+func TestRateLimitBarrierCancellationWithoutFinalArrival(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+		require.NoError(t, err, "barrier contexts must be created")
+		defer AbortRateLimitBarrier(contexts[1])
+		parked, cancel := context.WithCancel(contexts[0])
+		defer cancel()
+		errors := make(chan error, 1)
+		go func() { errors <- WaitForRateLimitBarrier(parked) }()
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-errors:
+			assert.ErrorIs(t, err, context.Canceled, "parked participant should observe cancellation without a final arrival")
+		default:
+			t.Error("cancelled participant should return without a final arrival")
+		}
+		assert.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrRateLimitBarrierRejected, "late peer should observe group rejection")
+	})
+}
+
+func TestRateLimitReservationLock(t *testing.T) {
+	for _, coordinated := range []bool{false, true} {
+		name := "ordinary reservation"
+		if coordinated {
+			name = "group admission"
+		}
+		t.Run(name, func(t *testing.T) {
+			limiter := NewRateLimitWithWeight(time.Hour, 1, 1)
+			limiter.m.Lock()
+			ctx := t.Context()
+			if coordinated {
+				contexts, err := NewRateLimitBarrierContexts(ctx, 2)
+				if !assert.NoError(t, err, "barrier contexts should be created") {
+					limiter.m.Unlock()
+					return
+				}
+				ctx = contexts[0]
+				peerErrors := make(chan error, 1)
+				go func() { peerErrors <- WaitForRateLimitBarrier(contexts[1]) }()
+				defer func() { assert.NoError(t, <-peerErrors, "unlimited peer should be admitted") }()
+			}
+			errors := make(chan error, 1)
+			go func() { errors <- limiter.RateLimit(ctx) }()
+			assert.Eventually(t, func() bool {
+				if !rateLimitReservationMu.TryLock() {
+					return true
+				}
+				rateLimitReservationMu.Unlock()
+				return false
+			}, time.Second, time.Millisecond, "reservation should hold the accounting lock while waiting for the limiter")
+			limiter.m.Unlock()
+			assert.NoError(t, <-errors, "reservation should complete after the limiter unlocks")
+		})
+	}
+}
+
+func TestRateLimitBarrierCancellationDuringAdmission(t *testing.T) {
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err, "barrier contexts must be created")
+	first, cancel := context.WithCancel(contexts[0])
+	defer cancel()
+	left := NewRateLimitWithWeight(time.Hour, 1, 1)
+	right := NewRateLimitWithWeight(time.Hour, 1, 1)
+	right.m.Lock()
+	leftErrors, rightErrors := make(chan error, 1), make(chan error, 1)
+	go func() { leftErrors <- left.RateLimit(first) }()
+	go func() { rightErrors <- right.RateLimit(contexts[1]) }()
+	assert.Eventually(t, func() bool {
+		return left.limiter.Tokens() < 0.5
+	}, time.Second, time.Millisecond, "admission should reserve the first participant before blocking on the second")
+	cancel()
+	right.m.Unlock()
+	assert.ErrorIs(t, <-leftErrors, context.Canceled, "first participant should observe cancellation during admission")
+	assert.ErrorIs(t, <-rightErrors, ErrRateLimitBarrierRejected, "peer should observe post-reservation rejection")
+	assert.InDelta(t, 1, left.limiter.Tokens(), 0.001, "cancelled admission should restore the first reservation")
+	assert.InDelta(t, 1, right.limiter.Tokens(), 0.001, "cancelled admission should restore the second reservation")
 }
 
 func TestRateLimit_Linear_WithFailure(t *testing.T) {

--- a/exchanges/request/limit_test.go
+++ b/exchanges/request/limit_test.go
@@ -119,6 +119,23 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.NoError(t, <-errs)
 	})
 
+	t.Run("acceptance retains final reservations", func(t *testing.T) {
+		t.Parallel()
+		contexts, err := NewRateLimitBarrierContexts(WithDelayNotAllowed(t.Context()), 2)
+		require.NoError(t, err)
+		left := NewRateLimitWithWeight(time.Hour, 1, 1)
+		right := NewRateLimitWithWeight(time.Hour, 1, 1)
+		errs := make(chan error, 2)
+		go func() { errs <- left.RateLimit(contexts[0]) }()
+		go func() { errs <- right.RateLimit(contexts[1]) }()
+		require.NoError(t, <-errs)
+		require.NoError(t, <-errs)
+		require.ErrorIs(t, left.rateLimit(WithDelayNotAllowed(t.Context()), false), ErrDelayNotAllowed,
+			"accepted participant must retain its reservation")
+		require.ErrorIs(t, right.rateLimit(WithDelayNotAllowed(t.Context()), false), ErrDelayNotAllowed,
+			"accepted participant must retain its reservation")
+	})
+
 	t.Run("one delayed rejects both and restores reservations", func(t *testing.T) {
 		t.Parallel()
 		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
@@ -162,31 +179,53 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
 	})
 
-	t.Run("accepted shared limiter participants remain paced", func(t *testing.T) {
+	t.Run("shared limiter without group burst rejects all participants", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
 			contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
 			require.NoError(t, err)
 			limiter := NewRateLimitWithWeight(100*time.Millisecond, 1, 1)
-			completed := make(chan time.Time, 2)
 			errs := make(chan error, 2)
-			go func() {
-				errs <- limiter.RateLimit(contexts[0])
-				completed <- time.Now()
-			}()
+			go func() { errs <- limiter.RateLimit(contexts[0]) }()
 			synctest.Wait()
-			time.Sleep(120 * time.Millisecond)
-			go func() {
-				errs <- limiter.RateLimit(contexts[1])
-				completed <- time.Now()
-			}()
+			go func() { errs <- limiter.RateLimit(contexts[1]) }()
 
-			require.NoError(t, <-errs)
-			require.NoError(t, <-errs)
-			first := <-completed
-			second := <-completed
-			assert.GreaterOrEqual(t, second.Sub(first).Abs(), 100*time.Millisecond,
-				"shared limiter participants should retain ordinary pacing")
+			require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+			require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+			assert.InDelta(t, 1, limiter.limiter.Tokens(), 0.001,
+				"rejected group should restore shared limiter capacity")
 		})
+	})
+
+	t.Run("contention before final arrival rejects group atomically", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
+			contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+			require.NoError(t, err)
+			left := NewRateLimitWithWeight(200*time.Millisecond, 1, 1)
+			right := NewRateLimitWithWeight(200*time.Millisecond, 1, 1)
+			errs := make(chan error, 2)
+			go func() { errs <- left.RateLimit(contexts[0]) }()
+			synctest.Wait()
+			require.NoError(t, left.rateLimit(t.Context(), false), "competitor must consume left capacity")
+			go func() { errs <- right.RateLimit(contexts[1]) }()
+
+			require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+			require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+			assert.InDelta(t, 1, right.limiter.Tokens(), 0.001,
+				"atomic rejection should restore the other participant's capacity")
+		})
+	})
+
+	t.Run("weight exceeding burst rejects group", func(t *testing.T) {
+		t.Parallel()
+		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+		require.NoError(t, err)
+		weighted := NewRateLimitWithWeight(time.Second, 1, 2)
+		peer := NewRateLimitWithWeight(time.Second, 1, 1)
+		errs := make(chan error, 2)
+		go func() { errs <- weighted.RateLimit(contexts[0]) }()
+		go func() { errs <- peer.RateLimit(contexts[1]) }()
+		require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
+		require.ErrorIs(t, <-errs, ErrDelayNotAllowed)
 	})
 
 	t.Run("rejected probe restores capacity before competitor", func(t *testing.T) {

--- a/exchanges/request/limit_test.go
+++ b/exchanges/request/limit_test.go
@@ -134,7 +134,7 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
 	})
 
-	t.Run("participant is one use", func(t *testing.T) {
+	t.Run("participant reuse", func(t *testing.T) {
 		t.Parallel()
 		contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
 		require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestRateLimitBarrier(t *testing.T) {
 		go func() { errs <- right.RateLimit(contexts[1]) }()
 		require.NoError(t, <-errs)
 		require.NoError(t, <-errs)
-		require.ErrorIs(t, left.RateLimit(contexts[0]), ErrRateLimitBarrierParticipantUsed)
+		require.NoError(t, left.RateLimit(contexts[0]), "post-acceptance calls must use ordinary rate limiting")
 	})
 
 	t.Run("cancellation rejects peer and restores reservation", func(t *testing.T) {
@@ -160,6 +160,51 @@ func TestRateLimitBarrier(t *testing.T) {
 		require.ErrorIs(t, <-errCh, context.Canceled)
 		require.ErrorIs(t, WaitForRateLimitBarrier(contexts[1]), ErrDelayNotAllowed)
 		require.NoError(t, left.RateLimit(WithDelayNotAllowed(t.Context())))
+	})
+
+	t.Run("accepted shared limiter participants remain paced", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
+			contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+			require.NoError(t, err)
+			limiter := NewRateLimitWithWeight(100*time.Millisecond, 1, 1)
+			completed := make(chan time.Time, 2)
+			errs := make(chan error, 2)
+			go func() {
+				errs <- limiter.RateLimit(contexts[0])
+				completed <- time.Now()
+			}()
+			synctest.Wait()
+			time.Sleep(120 * time.Millisecond)
+			go func() {
+				errs <- limiter.RateLimit(contexts[1])
+				completed <- time.Now()
+			}()
+
+			require.NoError(t, <-errs)
+			require.NoError(t, <-errs)
+			first := <-completed
+			second := <-completed
+			assert.GreaterOrEqual(t, second.Sub(first).Abs(), 100*time.Millisecond,
+				"shared limiter participants should retain ordinary pacing")
+		})
+	})
+
+	t.Run("rejected probe restores capacity before competitor", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) { //nolint:thelper,nolintlint // false positive
+			contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+			require.NoError(t, err)
+			limiter := NewRateLimitWithWeight(200*time.Millisecond, 1, 1)
+			errCh := make(chan error, 1)
+			go func() { errCh <- limiter.RateLimit(contexts[0]) }()
+			synctest.Wait()
+
+			require.NoError(t, limiter.RateLimit(WithDelayNotAllowed(t.Context())),
+				"competitor must receive capacity restored before the participant parks")
+			AbortRateLimitBarrier(contexts[1])
+			require.ErrorIs(t, <-errCh, ErrDelayNotAllowed)
+			assert.InDelta(t, 0, limiter.limiter.Tokens(), 0.001,
+				"rejected barrier probe should not consume capacity")
+		})
 	})
 }
 
@@ -299,6 +344,8 @@ func TestInitiateRateLimit(t *testing.T) {
 	require.NoError(t, err)
 	errs := make(chan error, 2)
 	go func() { errs <- r.InitiateRateLimit(contexts[0], Unset) }()
+	require.Never(t, func() bool { return len(errs) != 0 }, 10*time.Millisecond, time.Millisecond,
+		"disabled limiter participant must wait for its peer")
 	go func() { errs <- r.InitiateRateLimit(contexts[1], Unset) }()
 	require.NoError(t, <-errs, "disabled limiter barrier participant must not error")
 	require.NoError(t, <-errs, "disabled limiter barrier participant must not error")

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -160,6 +160,8 @@ func (r *Requester) doRequest(ctx context.Context, endpoint EndpointLimit, newRe
 			if err != nil {
 				return fmt.Errorf("failed to rate limit HTTP request: %w", err)
 			}
+		} else if err := WaitForRateLimitBarrier(ctx); err != nil {
+			return fmt.Errorf("failed to coordinate HTTP request: %w", err)
 		}
 
 		p, err := newRequest()

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -1381,6 +1381,79 @@ func TestBasicLimiter(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+func TestSendPayloadRateLimitBarrierWithoutLimiter(t *testing.T) {
+	t.Parallel()
+	writes := make(chan struct{}, 2)
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		writes <- struct{}{}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+		}, nil
+	})}
+	r, err := New("barrier", client)
+	require.NoError(t, err, "New requester must not error")
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errs := make(chan error, 2)
+	send := func(ctx context.Context) {
+		errs <- r.SendPayload(ctx, Unset, func() (*Item, error) {
+			return &Item{Method: http.MethodGet, Path: "https://example.com", Result: new(any)}, nil
+		}, UnauthenticatedRequest)
+	}
+
+	go send(contexts[0])
+	require.Never(t, func() bool { return len(writes) != 0 }, 10*time.Millisecond, time.Millisecond,
+		"limiter-less request must wait for its peer")
+	go send(contexts[1])
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.Len(t, writes, 2)
+}
+
+func TestSendPayloadRateLimitBarrierAllowsRetryAfterAcceptance(t *testing.T) {
+	t.Parallel()
+	newRequester := func(retryFirst bool) (*Requester, *int) {
+		calls := 0
+		client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			status := http.StatusOK
+			if retryFirst && calls == 1 {
+				status = http.StatusTooManyRequests
+			}
+			return &http.Response{
+				StatusCode: status,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		})}
+		r, err := New("barrier-retry", client,
+			WithLimiter(NewBasicRateLimit(time.Millisecond, 100, 1)),
+			WithBackoff(func(int) time.Duration { return 0 }))
+		require.NoError(t, err, "New requester must not error")
+		return r, &calls
+	}
+
+	left, leftCalls := newRequester(false)
+	right, rightCalls := newRequester(true)
+	contexts, err := NewRateLimitBarrierContexts(t.Context(), 2)
+	require.NoError(t, err)
+	errs := make(chan error, 2)
+	send := func(ctx context.Context, r *Requester) {
+		errs <- r.SendPayload(ctx, Unset, func() (*Item, error) {
+			return &Item{Method: http.MethodGet, Path: "https://example.com", Result: new(any)}, nil
+		}, UnauthenticatedRequest)
+	}
+
+	go send(contexts[0], left)
+	go send(contexts[1], right)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	assert.Equal(t, 1, *leftCalls, "accepted request should execute once")
+	assert.Equal(t, 2, *rightCalls, "accepted request should pass its retry rate-limit gate")
+}
+
 func TestEnableDisableRateLimit(t *testing.T) {
 	r, err := New("TestRequest", new(http.Client), WithLimiter(NewBasicRateLimit(50*time.Millisecond, 1, 1)))
 	require.NoError(t, err, "New requester must not error")


### PR DESCRIPTION
## Summary

Adds context-based rate-limit barriers for coordinating the first rate-limit admission of concurrent HTTP and websocket requests.

Participants wait without reserving capacity. The final arrival checks participant cancellation and reserves capacity for the group under a shared accounting lock. The group is admitted only when every participant can proceed without a rate-limit delay; otherwise, admission is rejected and acquired reservations are cancelled.

## Usage

Create participant contexts with `NewRateLimitBarrierContexts(parent, count)` and run each participant concurrently.

Each request owner must defer `AbortRateLimitBarrier(participantCtx)` so a failure before reaching the first gate releases waiting peers.

Concurrent reuse of a participant before the barrier resolves is rejected. After acceptance, subsequent calls and retries use ordinary rate limiting without re-entering the barrier.

## Behavior

- Coordinates HTTP and websocket rate-limit admission.
- Supports participants without active rate limiters.
- Rejects the group when a participant aborts or cancellation is observed before acceptance.
- Distinguishes peer rejection (`ErrRateLimitBarrierRejected`) from insufficient immediate capacity (`ErrDelayNotAllowed`).
- Removes pending websocket response signatures when coordination fails.

## Scope and Limitations

- Coordinates the first rate-limit gate only, not atomic request execution or order fills.
- Additional gates, cancellation after admission, transport errors, and exchange rejection can still produce partial execution.
- Finite limiters created by `NewRateLimit` have burst 1: participating requests must use distinct limiter instances and weight 1.
- Shared limiters or larger weights require sufficient custom burst capacity. Infinite-rate limiters are exempt.
- Reservation cancellation uses existing accounting. Its pre-existing rounding-related rollback defect is outside this PR; exact capacity restoration is not guaranteed.

## Validation

- Request and websocket suites pass with `-race -count=2`.
- Regression tests detect removal of reservation locking, post-reservation cancellation checks, zero-weight peer release, and parked cancellation handling.
- Scoped lint and repository miscellaneous checks pass.
- Full repository race testing was attempted; failures occurred in unrelated Bitstamp and Huobi response-decoding tests.
