### PR TITLE
backtester: clarify RunLive data processing comment

### DIFF
--- a/backtester/engine/backtest.go
+++ b/backtester/engine/backtest.go
@@ -75,7 +75,7 @@ func (bt *BackTest) Reset() error {
 }
 
 // RunLive is a proof of concept function that does not yet support multi currency usage
-// It tasks by constantly checking for new live datas and running through the list of events
+// It works by constantly checking for new live data and running through the list of events
 // once new data is processed. It will run until application close event has been received
 func (bt *BackTest) RunLive() error {
 	if bt.LiveDataHandler == nil {


### PR DESCRIPTION
# PR Description

Clarify the `RunLive` GoDoc so it accurately describes the loop as checking for new live data and processing events. This also replaces the incorrect plural “datas” with the standard uncountable form “data”. There are no runtime changes or new dependencies.

Fixes # N/A

## Type of change

- [x] This change requires a documentation update

## How has this been tested

- [ ] go test ./... -race
- [ ] golangci-lint run
- [x] `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — not applicable; comment-only change
- [ ] New and existing unit tests pass locally and on Github Actions with my changes — full suite not run locally