### PR TITLE
gateio: swap orderbook subscription from spot incremental updates to v2 orderbook updates

### DIFF
--- a/cmd/documentation/exchanges_templates/gateio.tmpl
+++ b/cmd/documentation/exchanges_templates/gateio.tmpl
@@ -6,6 +6,10 @@
 
 + REST functions
 
+### Spot Orderbook Depth
+
+The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. V2 supports 50 or 400 levels, not 100. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
+
 ### How to enable
 
 + [Enable via configuration](https://github.com/thrasher-corp/gocryptotrader/tree/master/config#enable-exchange-via-config-example)

--- a/cmd/documentation/exchanges_templates/gateio.tmpl
+++ b/cmd/documentation/exchanges_templates/gateio.tmpl
@@ -8,7 +8,7 @@
 
 ### Spot Orderbook Depth
 
-The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. V2 supports 50 or 400 levels, not 100. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
+The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. Gate documents 50 and 400 levels for V2, which are the levels GoCryptoTrader accepts. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
 
 ### How to enable
 

--- a/config/versions/register.go
+++ b/config/versions/register.go
@@ -7,6 +7,7 @@ import (
 	v11 "github.com/thrasher-corp/gocryptotrader/config/versions/v11"
 	v12 "github.com/thrasher-corp/gocryptotrader/config/versions/v12"
 	v13 "github.com/thrasher-corp/gocryptotrader/config/versions/v13"
+	v14 "github.com/thrasher-corp/gocryptotrader/config/versions/v14"
 	v2 "github.com/thrasher-corp/gocryptotrader/config/versions/v2"
 	v3 "github.com/thrasher-corp/gocryptotrader/config/versions/v3"
 	v4 "github.com/thrasher-corp/gocryptotrader/config/versions/v4"
@@ -33,5 +34,6 @@ func newManager() *manager {
 	m.registerVersion(11, &v11.Version{})
 	m.registerVersion(12, &v12.Version{})
 	m.registerVersion(13, &v13.Version{})
+	m.registerVersion(14, &v14.Version{})
 	return m
 }

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -62,8 +62,9 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 
 	legacyIndex, v2Index := -1, -1
 	for i := range subscriptions {
-		if subscriptions[i].Channel == legacyOrderbookAliasChannel &&
-			(subscriptions[i].Asset == spotAsset || subscriptions[i].Asset == allAsset) &&
+		if ((subscriptions[i].Channel == legacyOrderbookAliasChannel && subscriptions[i].Asset == spotAsset) ||
+			((subscriptions[i].Channel == legacyOrderbookAliasChannel || subscriptions[i].Channel == legacyOrderbookChannel) &&
+				subscriptions[i].Asset == allAsset)) &&
 			(subscriptions[i].Enabled == nil || *subscriptions[i].Enabled) {
 			return exchange, nil
 		}

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -15,6 +15,7 @@ const (
 	legacyOrderbookChannel      = "orderbook"
 	legacyOrderbookAliasChannel = "spot.order_book_update"
 	spotAsset                   = "spot"
+	allAsset                    = "all"
 	spotOrderbookV2Channel      = "spot.obu"
 )
 
@@ -61,6 +62,11 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 
 	legacyIndex, v2Index := -1, -1
 	for i := range subscriptions {
+		if subscriptions[i].Channel == legacyOrderbookAliasChannel &&
+			(subscriptions[i].Asset == spotAsset || subscriptions[i].Asset == allAsset) &&
+			(subscriptions[i].Enabled == nil || *subscriptions[i].Enabled) {
+			return exchange, nil
+		}
 		if subscriptions[i].Asset != spotAsset {
 			continue
 		}
@@ -70,10 +76,6 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 				return exchange, nil
 			}
 			legacyIndex = i
-		case legacyOrderbookAliasChannel:
-			if subscriptions[i].Enabled == nil || *subscriptions[i].Enabled {
-				return exchange, nil
-			}
 		case spotOrderbookV2Channel:
 			if v2Index != -1 {
 				return exchange, nil

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -52,10 +52,14 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	if err := json.Unmarshal(raw, &subscriptions); err != nil {
 		return exchange, fmt.Errorf("error decoding GateIO subscriptions: %w", err)
 	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return exchange, fmt.Errorf("error decoding GateIO subscription entries: %w", err)
+	}
 
 	legacyIndex, v2Index := -1, -1
 	for i := range subscriptions {
-		if subscriptions[i].Asset != spotAsset || subscriptions[i].Enabled == nil {
+		if subscriptions[i].Asset != spotAsset {
 			continue
 		}
 		switch subscriptions[i].Channel {
@@ -73,16 +77,13 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	}
 	if legacyIndex == -1 ||
 		string(subscriptions[legacyIndex].Interval) != `"100ms"` || subscriptions[legacyIndex].Pairs != "" ||
+		subscriptions[legacyIndex].Enabled == nil ||
 		*subscriptions[legacyIndex].Enabled != upgrade {
 		return exchange, nil
 	}
 	if v2Index == -1 {
 		if !upgrade {
 			return exchange, nil
-		}
-		entries := make([]json.RawMessage, 0, len(subscriptions)+1)
-		if err := json.Unmarshal(raw, &entries); err != nil {
-			return exchange, fmt.Errorf("error decoding GateIO subscription entries: %w", err)
 		}
 		v2Index = len(entries)
 		entries = append(entries, json.RawMessage(`{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}`))
@@ -94,8 +95,15 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 		if err != nil {
 			return exchange, fmt.Errorf("error adding GateIO V2 spot orderbook subscription: %w", err)
 		}
-	} else if subscriptions[v2Index].Levels != 50 || subscriptions[v2Index].Pairs != "" || *subscriptions[v2Index].Enabled == upgrade {
-		return exchange, nil
+	} else {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(entries[v2Index], &fields); err != nil {
+			return exchange, fmt.Errorf("error decoding GateIO V2 subscription: %w", err)
+		}
+		if len(fields) != 4 || subscriptions[v2Index].Levels != 50 ||
+			subscriptions[v2Index].Enabled == nil || *subscriptions[v2Index].Enabled == upgrade {
+			return exchange, nil
+		}
 	}
 
 	exchange, err = jsonparser.Set(exchange, []byte(strconv.FormatBool(!upgrade)), "features", "subscriptions", "["+strconv.Itoa(legacyIndex)+"]", "enabled")

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -71,7 +71,9 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 			}
 			legacyIndex = i
 		case legacyOrderbookAliasChannel:
-			return exchange, nil
+			if subscriptions[i].Enabled == nil || *subscriptions[i].Enabled {
+				return exchange, nil
+			}
 		case spotOrderbookV2Channel:
 			if v2Index != -1 {
 				return exchange, nil

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -4,6 +4,7 @@ package v14
 import (
 	"context"
 	"encoding/json" //nolint:depguard // Used instead of gct encoding/json so that we can ensure consistent library functionality between versions
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -11,9 +12,10 @@ import (
 )
 
 const (
-	legacyOrderbookChannel = "orderbook"
-	spotAsset              = "spot"
-	spotOrderbookV2Channel = "spot.obu"
+	legacyOrderbookChannel      = "orderbook"
+	legacyOrderbookAliasChannel = "spot.order_book_update"
+	spotAsset                   = "spot"
+	spotOrderbookV2Channel      = "spot.obu"
 )
 
 // Version implements ExchangeVersion for GateIO's spot orderbook subscription migration.
@@ -35,7 +37,7 @@ func (*Version) DowngradeExchange(_ context.Context, exchange []byte) ([]byte, e
 func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	raw, _, _, err := jsonparser.Get(exchange, "features", "subscriptions")
 	if err != nil {
-		if err == jsonparser.KeyPathNotFoundError {
+		if errors.Is(err, jsonparser.KeyPathNotFoundError) {
 			return exchange, nil
 		}
 		return exchange, fmt.Errorf("error getting GateIO subscriptions: %w", err)
@@ -68,6 +70,8 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 				return exchange, nil
 			}
 			legacyIndex = i
+		case legacyOrderbookAliasChannel:
+			return exchange, nil
 		case spotOrderbookV2Channel:
 			if v2Index != -1 {
 				return exchange, nil

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/buger/jsonparser"
 )
@@ -63,13 +64,16 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 
 	legacyIndex, v2Index := -1, -1
 	for i := range subscriptions {
-		if ((subscriptions[i].Channel == legacyOrderbookAliasChannel && subscriptions[i].Asset == spotAsset) ||
-			((subscriptions[i].Channel == legacyOrderbookAliasChannel || subscriptions[i].Channel == legacyOrderbookChannel) &&
-				subscriptions[i].Asset == allAsset)) &&
+		isSpot := strings.EqualFold(subscriptions[i].Asset, spotAsset)
+		isAll := strings.EqualFold(subscriptions[i].Asset, allAsset)
+		if ((subscriptions[i].Channel == legacyOrderbookAliasChannel && isSpot) ||
+			((subscriptions[i].Channel == legacyOrderbookAliasChannel ||
+				subscriptions[i].Channel == legacyOrderbookChannel ||
+				subscriptions[i].Channel == spotOrderbookV2Channel) && isAll)) &&
 			subscriptions[i].Enabled != nil && *subscriptions[i].Enabled {
 			return exchange, nil
 		}
-		if subscriptions[i].Asset != spotAsset {
+		if !isSpot {
 			continue
 		}
 		switch subscriptions[i].Channel {

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -42,11 +42,12 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	}
 
 	var subscriptions []struct {
-		Enabled  *bool  `json:"enabled"`
-		Channel  string `json:"channel"`
-		Asset    string `json:"asset"`
-		Interval string `json:"interval"`
-		Levels   int    `json:"levels"`
+		Enabled  *bool           `json:"enabled"`
+		Channel  string          `json:"channel"`
+		Asset    string          `json:"asset"`
+		Interval json.RawMessage `json:"interval"`
+		Levels   int             `json:"levels"`
+		Pairs    string          `json:"pairs"`
 	}
 	if err := json.Unmarshal(raw, &subscriptions); err != nil {
 		return exchange, fmt.Errorf("error decoding GateIO subscriptions: %w", err)
@@ -70,9 +71,30 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 			v2Index = i
 		}
 	}
-	if legacyIndex == -1 || v2Index == -1 ||
-		subscriptions[legacyIndex].Interval != "100ms" || subscriptions[v2Index].Levels != 50 ||
-		*subscriptions[legacyIndex].Enabled != upgrade || *subscriptions[v2Index].Enabled == upgrade {
+	if legacyIndex == -1 ||
+		string(subscriptions[legacyIndex].Interval) != `"100ms"` || subscriptions[legacyIndex].Pairs != "" ||
+		*subscriptions[legacyIndex].Enabled != upgrade {
+		return exchange, nil
+	}
+	if v2Index == -1 {
+		if !upgrade {
+			return exchange, nil
+		}
+		entries := make([]json.RawMessage, 0, len(subscriptions)+1)
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return exchange, fmt.Errorf("error decoding GateIO subscription entries: %w", err)
+		}
+		v2Index = len(entries)
+		entries = append(entries, json.RawMessage(`{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}`))
+		updated, err := json.Marshal(entries)
+		if err != nil {
+			return exchange, fmt.Errorf("error encoding GateIO subscription entries: %w", err)
+		}
+		exchange, err = jsonparser.Set(exchange, updated, "features", "subscriptions")
+		if err != nil {
+			return exchange, fmt.Errorf("error adding GateIO V2 spot orderbook subscription: %w", err)
+		}
+	} else if subscriptions[v2Index].Levels != 50 || subscriptions[v2Index].Pairs != "" || *subscriptions[v2Index].Enabled == upgrade {
 		return exchange, nil
 	}
 

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -1,0 +1,88 @@
+// Package v14 migrates GateIO's default spot orderbook websocket subscription to V2.
+package v14
+
+import (
+	"context"
+	"encoding/json" //nolint:depguard // Used instead of gct encoding/json so that we can ensure consistent library functionality between versions
+	"fmt"
+	"strconv"
+
+	"github.com/buger/jsonparser"
+)
+
+const (
+	legacyOrderbookChannel = "orderbook"
+	spotAsset              = "spot"
+	spotOrderbookV2Channel = "spot.obu"
+)
+
+// Version implements ExchangeVersion for GateIO's spot orderbook subscription migration.
+type Version struct{}
+
+// Exchanges returns just GateIO.
+func (*Version) Exchanges() []string { return []string{"GateIO"} }
+
+// UpgradeExchange replaces the previous default spot orderbook subscription with V2.
+func (*Version) UpgradeExchange(_ context.Context, exchange []byte) ([]byte, error) {
+	return migrateSubscriptions(exchange, true)
+}
+
+// DowngradeExchange restores the previous default spot orderbook subscription.
+func (*Version) DowngradeExchange(_ context.Context, exchange []byte) ([]byte, error) {
+	return migrateSubscriptions(exchange, false)
+}
+
+func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
+	raw, _, _, err := jsonparser.Get(exchange, "features", "subscriptions")
+	if err != nil {
+		if err == jsonparser.KeyPathNotFoundError {
+			return exchange, nil
+		}
+		return exchange, fmt.Errorf("error getting GateIO subscriptions: %w", err)
+	}
+
+	var subscriptions []struct {
+		Enabled  *bool  `json:"enabled"`
+		Channel  string `json:"channel"`
+		Asset    string `json:"asset"`
+		Interval string `json:"interval"`
+		Levels   int    `json:"levels"`
+	}
+	if err := json.Unmarshal(raw, &subscriptions); err != nil {
+		return exchange, fmt.Errorf("error decoding GateIO subscriptions: %w", err)
+	}
+
+	legacyIndex, v2Index := -1, -1
+	for i := range subscriptions {
+		if subscriptions[i].Asset != spotAsset || subscriptions[i].Enabled == nil {
+			continue
+		}
+		switch subscriptions[i].Channel {
+		case legacyOrderbookChannel:
+			if legacyIndex != -1 {
+				return exchange, nil
+			}
+			legacyIndex = i
+		case spotOrderbookV2Channel:
+			if v2Index != -1 {
+				return exchange, nil
+			}
+			v2Index = i
+		}
+	}
+	if legacyIndex == -1 || v2Index == -1 ||
+		subscriptions[legacyIndex].Interval != "100ms" || subscriptions[v2Index].Levels != 50 ||
+		*subscriptions[legacyIndex].Enabled != upgrade || *subscriptions[v2Index].Enabled == upgrade {
+		return exchange, nil
+	}
+
+	exchange, err = jsonparser.Set(exchange, []byte(strconv.FormatBool(!upgrade)), "features", "subscriptions", "["+strconv.Itoa(legacyIndex)+"]", "enabled")
+	if err != nil {
+		return exchange, fmt.Errorf("error setting GateIO legacy spot orderbook subscription: %w", err)
+	}
+	exchange, err = jsonparser.Set(exchange, []byte(strconv.FormatBool(upgrade)), "features", "subscriptions", "["+strconv.Itoa(v2Index)+"]", "enabled")
+	if err != nil {
+		return exchange, fmt.Errorf("error setting GateIO V2 spot orderbook subscription: %w", err)
+	}
+	return exchange, nil
+}

--- a/config/versions/v14/v14.go
+++ b/config/versions/v14/v14.go
@@ -45,12 +45,13 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	}
 
 	var subscriptions []struct {
-		Enabled  *bool           `json:"enabled"`
-		Channel  string          `json:"channel"`
-		Asset    string          `json:"asset"`
-		Interval json.RawMessage `json:"interval"`
-		Levels   int             `json:"levels"`
-		Pairs    string          `json:"pairs"`
+		Enabled       *bool           `json:"enabled"`
+		Channel       string          `json:"channel"`
+		Asset         string          `json:"asset"`
+		Interval      json.RawMessage `json:"interval"`
+		Levels        int             `json:"levels"`
+		Pairs         string          `json:"pairs"`
+		Authenticated bool            `json:"authenticated"`
 	}
 	if err := json.Unmarshal(raw, &subscriptions); err != nil {
 		return exchange, fmt.Errorf("error decoding GateIO subscriptions: %w", err)
@@ -65,7 +66,7 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 		if ((subscriptions[i].Channel == legacyOrderbookAliasChannel && subscriptions[i].Asset == spotAsset) ||
 			((subscriptions[i].Channel == legacyOrderbookAliasChannel || subscriptions[i].Channel == legacyOrderbookChannel) &&
 				subscriptions[i].Asset == allAsset)) &&
-			(subscriptions[i].Enabled == nil || *subscriptions[i].Enabled) {
+			subscriptions[i].Enabled != nil && *subscriptions[i].Enabled {
 			return exchange, nil
 		}
 		if subscriptions[i].Asset != spotAsset {
@@ -86,6 +87,7 @@ func migrateSubscriptions(exchange []byte, upgrade bool) ([]byte, error) {
 	}
 	if legacyIndex == -1 ||
 		string(subscriptions[legacyIndex].Interval) != `"100ms"` || subscriptions[legacyIndex].Pairs != "" ||
+		subscriptions[legacyIndex].Authenticated ||
 		subscriptions[legacyIndex].Enabled == nil ||
 		*subscriptions[legacyIndex].Enabled != upgrade {
 		return exchange, nil

--- a/config/versions/v14/v14_internal_test.go
+++ b/config/versions/v14/v14_internal_test.go
@@ -1,0 +1,89 @@
+package v14
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateSubscriptions(t *testing.T) {
+	t.Parallel()
+	for _, upgrade := range []bool{true, false} {
+		legacy := fmt.Sprintf(`{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"}`, upgrade)
+		v2 := fmt.Sprintf(`{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}`, !upgrade)
+		migratedLegacy := fmt.Sprintf(`{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"}`, !upgrade)
+		migratedV2 := fmt.Sprintf(`{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}`, upgrade)
+		otherAssets := `{"enabled":true,"channel":"orderbook","asset":"usdtmarginedfutures","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"margin","levels":50},{"enabled":true,"channel":"spot.order_book_update","asset":"coinmarginedfutures"}`
+		missingV2Expected := ""
+		if upgrade {
+			missingV2Expected = `{"features":{"subscriptions":[` + migratedLegacy + `,` + migratedV2 + `]}}`
+		}
+		for _, test := range []struct {
+			name        string
+			input       string
+			expected    string
+			errContains string
+		}{
+			{
+				name:     "defaults",
+				input:    `{"features":{"subscriptions":[` + legacy + `,` + v2 + `]}}`,
+				expected: `{"features":{"subscriptions":[` + migratedLegacy + `,` + migratedV2 + `]}}`,
+			},
+			{
+				name:  "duplicate legacy entries",
+				input: `{"features":{"subscriptions":[` + legacy + `,` + legacy + `,` + v2 + `]}}`,
+			},
+			{
+				name:  "non-spot entries only",
+				input: `{"features":{"subscriptions":[` + otherAssets + `]}}`,
+			},
+			{
+				name:     "non-spot entries alongside spot defaults",
+				input:    `{"features":{"subscriptions":[` + otherAssets + `,` + legacy + `,` + v2 + `]}}`,
+				expected: `{"features":{"subscriptions":[` + otherAssets + `,` + migratedLegacy + `,` + migratedV2 + `]}}`,
+			},
+			{
+				name:     "missing V2 entry",
+				input:    `{"features":{"subscriptions":[` + legacy + `]}}`,
+				expected: missingV2Expected,
+			},
+			{
+				name:  "missing subscriptions",
+				input: `{"features":{}}`,
+			},
+			{
+				name:        "malformed subscription array",
+				input:       `{"features":{"subscriptions":[}`,
+				errContains: "error getting GateIO subscriptions",
+			},
+			{
+				name:        "subscriptions object",
+				input:       `{"features":{"subscriptions":{}}}`,
+				errContains: "error decoding GateIO subscriptions",
+			},
+			{
+				name:        "invalid enabled type",
+				input:       `{"features":{"subscriptions":[{"enabled":"true","channel":"orderbook","asset":"spot"}]}}`,
+				errContains: "error decoding GateIO subscriptions",
+			},
+		} {
+			t.Run(fmt.Sprintf("%s/upgrade=%t", test.name, upgrade), func(t *testing.T) {
+				t.Parallel()
+				got, err := migrateSubscriptions([]byte(test.input), upgrade)
+				if test.errContains != "" {
+					require.ErrorContains(t, err, test.errContains, "migration must report the failing operation")
+					assert.Equal(t, test.input, string(got), "failed migration should preserve the input")
+					return
+				}
+				require.NoError(t, err, "migration must accept valid subscriptions")
+				if test.expected == "" {
+					assert.Equal(t, test.input, string(got), "ineligible migration should preserve the input byte-for-byte")
+				} else {
+					assert.JSONEq(t, test.expected, string(got), "migration should change only eligible spot defaults")
+				}
+			})
+		}
+	}
+}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -212,7 +212,11 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 		} {
 			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()
-				raw := `{` + test.enabledField + `"channel":"` + test.channel + `","asset":"` + test.asset + `","interval":"100ms","pairs":"ETH_USDT"}`
+				settings := `"interval":"100ms","pairs":"ETH_USDT"`
+				if test.channel == "spot.obu" {
+					settings = `"levels":50,"pairs":"ETH_USDT"`
+				}
+				raw := `{` + test.enabledField + `"channel":"` + test.channel + `","asset":"` + test.asset + `",` + settings + `}`
 				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, raw, !upgrade)
 				version := new(v14.Version)
 				migrate := version.UpgradeExchange

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -132,25 +132,34 @@ func TestMigrationRequiresDefaultV2Entry(t *testing.T) {
 
 func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 	t.Parallel()
+	const (
+		rawLegacyChannel = "spot.order_book_update"
+		allAssets        = "all"
+	)
 	for _, upgrade := range []bool{true, false} {
 		for _, test := range []struct {
 			name          string
+			channel       string
 			asset         string
 			enabledField  string
 			wantMigration bool
 		}{
-			{name: "enabled", asset: "spot", enabledField: `"enabled":true,`},
-			{name: "disabled", asset: "spot", enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "missing enabled", asset: "spot"},
-			{name: "null enabled", asset: "spot", enabledField: `"enabled":null,`},
-			{name: "all assets enabled", asset: "all", enabledField: `"enabled":true,`},
-			{name: "all assets disabled", asset: "all", enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "all assets missing enabled", asset: "all"},
-			{name: "all assets null enabled", asset: "all", enabledField: `"enabled":null,`},
+			{name: "enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":true,`},
+			{name: "disabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "missing enabled", channel: rawLegacyChannel, asset: "spot"},
+			{name: "null enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":null,`},
+			{name: "all assets enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":true,`},
+			{name: "all assets disabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "all assets missing enabled", channel: rawLegacyChannel, asset: allAssets},
+			{name: "all assets null enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":null,`},
+			{name: "generic all assets enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":true,`},
+			{name: "generic all assets disabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "generic all assets missing enabled", channel: "orderbook", asset: allAssets},
+			{name: "generic all assets null enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":null,`},
 		} {
 			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()
-				raw := `{` + test.enabledField + `"channel":"spot.order_book_update","asset":"` + test.asset + `","interval":"100ms","pairs":"ETH_USDT"}`
+				raw := `{` + test.enabledField + `"channel":"` + test.channel + `","asset":"` + test.asset + `","interval":"100ms","pairs":"ETH_USDT"}`
 				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, raw, !upgrade)
 				version := new(v14.Version)
 				migrate := version.UpgradeExchange

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -1,6 +1,9 @@
 package v14_test
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,6 +85,8 @@ func TestMigrationPreservesCustomSubscriptions(t *testing.T) {
 		"disabled legacy without V2":  `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"}]}}`,
 		"downgrade restricted legacy": `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms","pairs":"BTC_USDT"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
 		"downgrade restricted V2":     `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50,"pairs":"ETH_USDT"}]}}`,
+		"duplicate missing enabled":   `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"channel":"spot.obu","asset":"spot","levels":50},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		"legacy missing enabled":      `{"features":{"subscriptions":[{"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -93,6 +98,35 @@ func TestMigrationPreservesCustomSubscriptions(t *testing.T) {
 			require.NoError(t, err, "DowngradeExchange must accept custom subscriptions")
 			assert.Equal(t, input, string(got), "DowngradeExchange should preserve custom subscriptions byte-for-byte")
 		})
+	}
+}
+
+func TestMigrationRequiresDefaultV2Entry(t *testing.T) {
+	t.Parallel()
+	for name, entry := range map[string]string{
+		"authenticated":   `{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50,"authenticated":true}`,
+		"explicit false":  `{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50,"authenticated":false}`,
+		"custom interval": `{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50,"interval":"20ms"}`,
+		"unknown field":   `{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50,"custom":"retained"}`,
+		"empty pairs":     `{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50,"pairs":""}`,
+		"null enabled":    `{"enabled":null,"channel":"spot.obu","asset":"spot","levels":50}`,
+		"missing enabled": `{"channel":"spot.obu","asset":"spot","levels":50}`,
+	} {
+		for _, upgrade := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/upgrade=%t", name, upgrade), func(t *testing.T) {
+				t.Parallel()
+				v2 := strings.ReplaceAll(entry, "%t", strconv.FormatBool(!upgrade))
+				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s]}}`, upgrade, v2)
+				version := new(v14.Version)
+				migrate := version.UpgradeExchange
+				if !upgrade {
+					migrate = version.DowngradeExchange
+				}
+				got, err := migrate(t.Context(), []byte(input))
+				require.NoError(t, err, "migration must accept customized V2 entries")
+				assert.Equal(t, input, string(got), "migration should preserve customized V2 entries byte-for-byte")
+			})
+		}
 	}
 }
 

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -33,6 +33,21 @@ func TestUpgradeExchange(t *testing.T) {
 			exp:  `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
 		},
 		{
+			name: "numeric candle interval",
+			in:   `{"features":{"subscriptions":[{"enabled":true,"channel":"candles","asset":"spot","interval":300000000000},{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+			exp:  `{"features":{"subscriptions":[{"enabled":true,"channel":"candles","asset":"spot","interval":300000000000},{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		},
+		{
+			name: "numeric orderbook interval",
+			in:   `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":100000000},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+			exp:  `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":100000000},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		},
+		{
+			name: "missing V2 entry preserves unrelated fields",
+			in:   `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms","custom":"retained"},{"enabled":true,"channel":"candles","asset":"spot","interval":300000000000}]}}`,
+			exp:  `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms","custom":"retained"},{"enabled":true,"channel":"candles","asset":"spot","interval":300000000000},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		},
+		{
 			name: "custom settings",
 			in:   `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"10ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":20}]}}`,
 			exp:  `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"10ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":20}]}}`,
@@ -49,8 +64,50 @@ func TestUpgradeExchange(t *testing.T) {
 			got, err := version.UpgradeExchange(t.Context(), []byte(tc.in))
 			require.NoError(t, err, "UpgradeExchange must not error")
 			assert.JSONEq(t, tc.exp, string(got), "UpgradeExchange should migrate only previous defaults")
+			again, err := version.UpgradeExchange(t.Context(), got)
+			require.NoError(t, err, "repeated UpgradeExchange must not error")
+			assert.Equal(t, got, again, "UpgradeExchange should be idempotent")
 		})
 	}
+}
+
+func TestMigrationPreservesCustomSubscriptions(t *testing.T) {
+	t.Parallel()
+	for name, input := range map[string]string{
+		"legacy pairs":                `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms","pairs":"BTC_USDT"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		"V2 pairs":                    `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50,"pairs":"ETH_USDT"}]}}`,
+		"different pairs":             `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms","pairs":"BTC_USDT"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50,"pairs":"ETH_USDT"}]}}`,
+		"legacy pairs without V2":     `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms","pairs":"BTC_USDT"}]}}`,
+		"numeric interval without V2": `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":100000000}]}}`,
+		"disabled legacy without V2":  `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"}]}}`,
+		"downgrade restricted legacy": `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms","pairs":"BTC_USDT"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		"downgrade restricted V2":     `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50,"pairs":"ETH_USDT"}]}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			version := new(v14.Version)
+			got, err := version.UpgradeExchange(t.Context(), []byte(input))
+			require.NoError(t, err, "UpgradeExchange must accept custom subscriptions")
+			assert.Equal(t, input, string(got), "UpgradeExchange should preserve custom subscriptions byte-for-byte")
+			got, err = version.DowngradeExchange(t.Context(), []byte(input))
+			require.NoError(t, err, "DowngradeExchange must accept custom subscriptions")
+			assert.Equal(t, input, string(got), "DowngradeExchange should preserve custom subscriptions byte-for-byte")
+		})
+	}
+}
+
+func TestMissingV2RoundTrip(t *testing.T) {
+	t.Parallel()
+	version := new(v14.Version)
+	in := []byte(`{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"}]}}`)
+	upgraded, err := version.UpgradeExchange(t.Context(), in)
+	require.NoError(t, err, "UpgradeExchange must add the missing V2 entry")
+	down, err := version.DowngradeExchange(t.Context(), upgraded)
+	require.NoError(t, err, "DowngradeExchange must restore the legacy feed")
+	assert.JSONEq(t, `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`, string(down), "DowngradeExchange should retain the new V2 entry disabled")
+	again, err := version.UpgradeExchange(t.Context(), down)
+	require.NoError(t, err, "UpgradeExchange must support a downgraded config")
+	assert.JSONEq(t, string(upgraded), string(again), "re-upgrade should restore the V2 feed")
 }
 
 func TestDowngradeExchange(t *testing.T) {

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -133,10 +133,20 @@ func TestMigrationRequiresDefaultV2Entry(t *testing.T) {
 func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 	t.Parallel()
 	for _, upgrade := range []bool{true, false} {
-		for _, rawEnabled := range []bool{true, false} {
-			t.Run(fmt.Sprintf("upgrade=%t/rawEnabled=%t", upgrade, rawEnabled), func(t *testing.T) {
+		for _, test := range []struct {
+			name          string
+			enabledField  string
+			wantMigration bool
+		}{
+			{name: "enabled", enabledField: `"enabled":true,`},
+			{name: "disabled", enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "missing enabled"},
+			{name: "null enabled", enabledField: `"enabled":null,`},
+		} {
+			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()
-				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":%t,"channel":"spot.order_book_update","asset":"spot","interval":"100ms","pairs":"ETH_USDT"},{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, rawEnabled, !upgrade)
+				raw := `{` + test.enabledField + `"channel":"spot.order_book_update","asset":"spot","interval":"100ms","pairs":"ETH_USDT"}`
+				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, raw, !upgrade)
 				version := new(v14.Version)
 				migrate := version.UpgradeExchange
 				if !upgrade {
@@ -144,7 +154,15 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 				}
 				got, err := migrate(t.Context(), []byte(input))
 				require.NoError(t, err, "migration must accept raw legacy channels")
-				assert.Equal(t, input, string(got), "migration should preserve the raw legacy feed and its generic snapshot dependency byte-for-byte")
+				if test.wantMigration {
+					expected := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, !upgrade, raw, upgrade)
+					assert.JSONEq(t, expected, string(got), "disabled raw legacy entries should allow migration without being changed")
+				} else {
+					assert.Equal(t, input, string(got), "migration should preserve the raw legacy feed and its generic snapshot dependency byte-for-byte")
+				}
+				again, err := migrate(t.Context(), got)
+				require.NoError(t, err, "repeated migration must not error")
+				assert.Equal(t, got, again, "migration should be idempotent")
 			})
 		}
 	}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -123,8 +123,28 @@ func TestMigrationRequiresDefaultV2Entry(t *testing.T) {
 					migrate = version.DowngradeExchange
 				}
 				got, err := migrate(t.Context(), []byte(input))
-				require.NoError(t, err, "migration must accept customized V2 entries")
-				assert.Equal(t, input, string(got), "migration should preserve customized V2 entries byte-for-byte")
+				require.NoError(t, err, "migration must accept customised V2 entries")
+				assert.Equal(t, input, string(got), "migration should preserve customised V2 entries byte-for-byte")
+			})
+		}
+	}
+}
+
+func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
+	t.Parallel()
+	for _, upgrade := range []bool{true, false} {
+		for _, rawEnabled := range []bool{true, false} {
+			t.Run(fmt.Sprintf("upgrade=%t/rawEnabled=%t", upgrade, rawEnabled), func(t *testing.T) {
+				t.Parallel()
+				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":%t,"channel":"spot.order_book_update","asset":"spot","interval":"100ms","pairs":"ETH_USDT"},{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, rawEnabled, !upgrade)
+				version := new(v14.Version)
+				migrate := version.UpgradeExchange
+				if !upgrade {
+					migrate = version.DowngradeExchange
+				}
+				got, err := migrate(t.Context(), []byte(input))
+				require.NoError(t, err, "migration must accept raw legacy channels")
+				assert.Equal(t, input, string(got), "migration should preserve the raw legacy feed and its generic snapshot dependency byte-for-byte")
 			})
 		}
 	}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -1,0 +1,69 @@
+package v14_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v14 "github.com/thrasher-corp/gocryptotrader/config/versions/v14"
+)
+
+func TestExchanges(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"GateIO"}, new(v14.Version).Exchanges())
+}
+
+func TestUpgradeExchange(t *testing.T) {
+	t.Parallel()
+	version := new(v14.Version)
+
+	tests := []struct {
+		name string
+		in   string
+		exp  string
+	}{
+		{
+			name: "previous defaults",
+			in:   `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+			exp:  `{"name":"GateIO","features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		},
+		{
+			name: "custom selection",
+			in:   `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+			exp:  `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`,
+		},
+		{
+			name: "custom settings",
+			in:   `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"10ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":20}]}}`,
+			exp:  `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"10ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":20}]}}`,
+		},
+		{
+			name: "missing subscriptions",
+			in:   `{"name":"GateIO"}`,
+			exp:  `{"name":"GateIO"}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := version.UpgradeExchange(t.Context(), []byte(tc.in))
+			require.NoError(t, err, "UpgradeExchange must not error")
+			assert.JSONEq(t, tc.exp, string(got), "UpgradeExchange should migrate only previous defaults")
+		})
+	}
+}
+
+func TestDowngradeExchange(t *testing.T) {
+	t.Parallel()
+	in := []byte(`{"name":"GateIO","features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50}]}}`)
+	exp := `{"name":"GateIO","features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"spot","levels":50}]}}`
+	got, err := new(v14.Version).DowngradeExchange(t.Context(), in)
+	require.NoError(t, err, "DowngradeExchange must not error")
+	assert.JSONEq(t, exp, string(got), "DowngradeExchange should restore previous defaults")
+}
+
+func TestUpgradeExchangeRejectsMalformedSubscriptions(t *testing.T) {
+	t.Parallel()
+	_, err := new(v14.Version).UpgradeExchange(t.Context(), []byte(`{"features":{"subscriptions":{}}}`))
+	require.Error(t, err, "UpgradeExchange must reject malformed subscriptions")
+}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -130,7 +130,7 @@ func TestMigrationPreservesLegacyAuthentication(t *testing.T) {
 					got, err := migrate(t.Context(), []byte(input))
 					require.NoError(t, err, "migration must accept legacy authentication settings")
 					if test.authenticated || (!upgrade && !hasV2) {
-						assert.Equal(t, input, string(got), "migration should preserve authenticated legacy entries byte-for-byte")
+						assert.Equal(t, input, string(got), "ineligible migrations should preserve the input byte-for-byte")
 					} else {
 						legacy := fmt.Sprintf(`{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"%s}`, !upgrade, test.field)
 						v2 = fmt.Sprintf(`{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}`, upgrade)
@@ -184,6 +184,7 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 	const (
 		rawLegacyChannel = "spot.order_book_update"
 		allAssets        = "all"
+		enabledTrue      = `"enabled":true,`
 	)
 	for _, upgrade := range []bool{true, false} {
 		for _, test := range []struct {
@@ -193,18 +194,21 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 			enabledField  string
 			wantMigration bool
 		}{
-			{name: "enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":true,`},
+			{name: "enabled", channel: rawLegacyChannel, asset: "spot", enabledField: enabledTrue},
 			{name: "disabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":false,`, wantMigration: true},
 			{name: "missing enabled", channel: rawLegacyChannel, asset: "spot", wantMigration: true},
 			{name: "null enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":null,`, wantMigration: true},
-			{name: "all assets enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":true,`},
+			{name: "all assets enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: enabledTrue},
 			{name: "all assets disabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
 			{name: "all assets missing enabled", channel: rawLegacyChannel, asset: allAssets, wantMigration: true},
 			{name: "all assets null enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":null,`, wantMigration: true},
-			{name: "generic all assets enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":true,`},
+			{name: "generic all assets enabled", channel: "orderbook", asset: allAssets, enabledField: enabledTrue},
 			{name: "generic all assets disabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
 			{name: "generic all assets missing enabled", channel: "orderbook", asset: allAssets, wantMigration: true},
 			{name: "generic all assets null enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":null,`, wantMigration: true},
+			{name: "uppercase spot enabled", channel: rawLegacyChannel, asset: "SPOT", enabledField: enabledTrue},
+			{name: "uppercase all assets enabled", channel: "orderbook", asset: "ALL", enabledField: enabledTrue},
+			{name: "all assets V2 enabled", channel: "spot.obu", asset: allAssets, enabledField: enabledTrue},
 		} {
 			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()
@@ -219,13 +223,34 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 				require.NoError(t, err, "migration must accept raw legacy channels")
 				if test.wantMigration {
 					expected := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, !upgrade, raw, upgrade)
-					assert.JSONEq(t, expected, string(got), "disabled raw legacy entries should allow migration without being changed")
+					assert.JSONEq(t, expected, string(got), "inactive raw legacy entries should allow migration without being changed")
 				} else {
 					assert.Equal(t, input, string(got), "migration should preserve the raw legacy feed and its generic snapshot dependency byte-for-byte")
 				}
 				again, err := migrate(t.Context(), got)
 				require.NoError(t, err, "repeated migration must not error")
 				assert.Equal(t, got, again, "migration should be idempotent")
+			})
+		}
+	}
+}
+
+func TestMigrationMatchesSpotAssetCaseInsensitively(t *testing.T) {
+	t.Parallel()
+	for _, assetName := range []string{"SPOT", "Spot"} {
+		for _, upgrade := range []bool{true, false} {
+			t.Run(fmt.Sprintf("asset=%s/upgrade=%t", assetName, upgrade), func(t *testing.T) {
+				t.Parallel()
+				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":%q,"interval":"100ms"},{"enabled":%t,"channel":"spot.obu","asset":%q,"levels":50}]}}`, upgrade, assetName, !upgrade, assetName)
+				expected := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":%q,"interval":"100ms"},{"enabled":%t,"channel":"spot.obu","asset":%q,"levels":50}]}}`, !upgrade, assetName, upgrade, assetName)
+				version := new(v14.Version)
+				migrate := version.UpgradeExchange
+				if !upgrade {
+					migrate = version.DowngradeExchange
+				}
+				got, err := migrate(t.Context(), []byte(input))
+				require.NoError(t, err, "migration must accept case-insensitive spot assets")
+				assert.JSONEq(t, expected, string(got), "migration should update case-insensitive spot assets")
 			})
 		}
 	}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -135,17 +135,22 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 	for _, upgrade := range []bool{true, false} {
 		for _, test := range []struct {
 			name          string
+			asset         string
 			enabledField  string
 			wantMigration bool
 		}{
-			{name: "enabled", enabledField: `"enabled":true,`},
-			{name: "disabled", enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "missing enabled"},
-			{name: "null enabled", enabledField: `"enabled":null,`},
+			{name: "enabled", asset: "spot", enabledField: `"enabled":true,`},
+			{name: "disabled", asset: "spot", enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "missing enabled", asset: "spot"},
+			{name: "null enabled", asset: "spot", enabledField: `"enabled":null,`},
+			{name: "all assets enabled", asset: "all", enabledField: `"enabled":true,`},
+			{name: "all assets disabled", asset: "all", enabledField: `"enabled":false,`, wantMigration: true},
+			{name: "all assets missing enabled", asset: "all"},
+			{name: "all assets null enabled", asset: "all", enabledField: `"enabled":null,`},
 		} {
 			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()
-				raw := `{` + test.enabledField + `"channel":"spot.order_book_update","asset":"spot","interval":"100ms","pairs":"ETH_USDT"}`
+				raw := `{` + test.enabledField + `"channel":"spot.order_book_update","asset":"` + test.asset + `","interval":"100ms","pairs":"ETH_USDT"}`
 				input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"},%s,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}]}}`, upgrade, raw, !upgrade)
 				version := new(v14.Version)
 				migrate := version.UpgradeExchange

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -288,3 +288,9 @@ func TestUpgradeExchangeRejectsMalformedSubscriptions(t *testing.T) {
 	_, err := new(v14.Version).UpgradeExchange(t.Context(), []byte(`{"features":{"subscriptions":{}}}`))
 	require.Error(t, err, "UpgradeExchange must reject malformed subscriptions")
 }
+
+func TestDowngradeExchangeRejectsMalformedSubscriptions(t *testing.T) {
+	t.Parallel()
+	_, err := new(v14.Version).DowngradeExchange(t.Context(), []byte(`{"features":{"subscriptions":{}}}`))
+	require.Error(t, err, "DowngradeExchange must reject malformed subscriptions")
+}

--- a/config/versions/v14/v14_test.go
+++ b/config/versions/v14/v14_test.go
@@ -101,6 +101,55 @@ func TestMigrationPreservesCustomSubscriptions(t *testing.T) {
 	}
 }
 
+func TestMigrationPreservesLegacyAuthentication(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name          string
+		field         string
+		authenticated bool
+	}{
+		{name: "authenticated", field: `,"authenticated":true`, authenticated: true},
+		{name: "unauthenticated", field: `,"authenticated":false`},
+		{name: "omitted"},
+		{name: "null", field: `,"authenticated":null`},
+	} {
+		for _, upgrade := range []bool{true, false} {
+			for _, hasV2 := range []bool{true, false} {
+				t.Run(fmt.Sprintf("%s/upgrade=%t/V2=%t", test.name, upgrade, hasV2), func(t *testing.T) {
+					t.Parallel()
+					v2 := ""
+					if hasV2 {
+						v2 = fmt.Sprintf(`,{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}`, !upgrade)
+					}
+					input := fmt.Sprintf(`{"features":{"subscriptions":[{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"%s}%s,{"enabled":true,"channel":"spot.order_book","asset":"spot"}]}}`, upgrade, test.field, v2)
+					version := new(v14.Version)
+					migrate := version.UpgradeExchange
+					if !upgrade {
+						migrate = version.DowngradeExchange
+					}
+					got, err := migrate(t.Context(), []byte(input))
+					require.NoError(t, err, "migration must accept legacy authentication settings")
+					if test.authenticated || (!upgrade && !hasV2) {
+						assert.Equal(t, input, string(got), "migration should preserve authenticated legacy entries byte-for-byte")
+					} else {
+						legacy := fmt.Sprintf(`{"enabled":%t,"channel":"orderbook","asset":"spot","interval":"100ms"%s}`, !upgrade, test.field)
+						v2 = fmt.Sprintf(`{"enabled":%t,"channel":"spot.obu","asset":"spot","levels":50}`, upgrade)
+						snapshot := `{"enabled":true,"channel":"spot.order_book","asset":"spot"}`
+						entries := legacy + "," + v2 + "," + snapshot
+						if !hasV2 {
+							entries = legacy + "," + snapshot + "," + v2
+						}
+						assert.JSONEq(t, `{"features":{"subscriptions":[`+entries+`]}}`, string(got), "unauthenticated legacy entries should allow migration without changing other fields")
+					}
+					again, err := migrate(t.Context(), got)
+					require.NoError(t, err, "repeated migration must not error")
+					assert.Equal(t, got, again, "migration should be idempotent")
+				})
+			}
+		}
+	}
+}
+
 func TestMigrationRequiresDefaultV2Entry(t *testing.T) {
 	t.Parallel()
 	for name, entry := range map[string]string{
@@ -146,16 +195,16 @@ func TestMigrationPreservesRawLegacyChannel(t *testing.T) {
 		}{
 			{name: "enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":true,`},
 			{name: "disabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "missing enabled", channel: rawLegacyChannel, asset: "spot"},
-			{name: "null enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":null,`},
+			{name: "missing enabled", channel: rawLegacyChannel, asset: "spot", wantMigration: true},
+			{name: "null enabled", channel: rawLegacyChannel, asset: "spot", enabledField: `"enabled":null,`, wantMigration: true},
 			{name: "all assets enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":true,`},
 			{name: "all assets disabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "all assets missing enabled", channel: rawLegacyChannel, asset: allAssets},
-			{name: "all assets null enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":null,`},
+			{name: "all assets missing enabled", channel: rawLegacyChannel, asset: allAssets, wantMigration: true},
+			{name: "all assets null enabled", channel: rawLegacyChannel, asset: allAssets, enabledField: `"enabled":null,`, wantMigration: true},
 			{name: "generic all assets enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":true,`},
 			{name: "generic all assets disabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":false,`, wantMigration: true},
-			{name: "generic all assets missing enabled", channel: "orderbook", asset: allAssets},
-			{name: "generic all assets null enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":null,`},
+			{name: "generic all assets missing enabled", channel: "orderbook", asset: allAssets, wantMigration: true},
+			{name: "generic all assets null enabled", channel: "orderbook", asset: allAssets, enabledField: `"enabled":null,`, wantMigration: true},
 		} {
 			t.Run(fmt.Sprintf("upgrade=%t/%s", upgrade, test.name), func(t *testing.T) {
 				t.Parallel()

--- a/config/versions/versions_test.go
+++ b/config/versions/versions_test.go
@@ -12,14 +12,16 @@ import (
 	v0 "github.com/thrasher-corp/gocryptotrader/config/versions/v0"
 	v1 "github.com/thrasher-corp/gocryptotrader/config/versions/v1"
 	v13 "github.com/thrasher-corp/gocryptotrader/config/versions/v13"
+	v14 "github.com/thrasher-corp/gocryptotrader/config/versions/v14"
 	v2 "github.com/thrasher-corp/gocryptotrader/config/versions/v2"
 )
 
 func TestNewManager(t *testing.T) {
 	t.Parallel()
 	m := newManager()
-	require.Len(t, m.versions, 14, "newManager must register every config version through v13")
+	require.Len(t, m.versions, 15, "newManager must register every config version through v14")
 	assert.IsType(t, &v13.Version{}, m.Version(13), "newManager should register v13 at index 13")
+	assert.IsType(t, &v14.Version{}, m.Version(14), "newManager should register v14 at index 14")
 }
 
 func TestDeploy(t *testing.T) {

--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,6 @@
 {
  "name": "Skynet",
- "version": 13,
+ "version": 14,
  "dataDirectory": "",
  "encryptConfig": 0,
  "globalHTTPTimeout": 15000000000,
@@ -2041,7 +2041,7 @@
       "interval": "5m"
      },
      {
-      "enabled": true,
+      "enabled": false,
       "channel": "orderbook",
       "asset": "spot",
       "interval": "100ms"
@@ -2061,7 +2061,7 @@
       "levels": 100
      },
      {
-      "enabled": false,
+      "enabled": true,
       "channel": "spot.obu",
       "asset": "spot",
       "levels": 50

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -124,6 +124,7 @@ Migration code lives in [config/versions](../config/versions), with each version
 ### Migration Guards
 
 - Before adding a guard that skips migration, identify the downstream dependency it protects and whether the affected entry can reach that code path. A disabled entry must not block migration solely because its channel exists.
+- Evaluate effective scope before filtering literal values. Wildcards such as `asset:"all"` can overlap a specific asset after expansion; test both wildcard and explicitly scoped entries.
 - Distinguish explicit `false`, explicit `true`, omitted and `null` values where their meanings differ. Use presence-aware decoding when necessary, and document any conservative treatment of unspecified values.
 - Test both sides of each guard: a configuration that must remain unchanged and a minimally different configuration that must migrate. Exercise upgrade and downgrade when the guard is shared, and verify unrelated entries remain unchanged.
 - Account for version advancement when a migration makes no changes. Do not assume a skipped transformation will be retried after the user changes their configuration.
@@ -177,6 +178,7 @@ Use `require` and `assert` appropriately:
 
 - Maintain original test inputs unless they are incorrect.
 - Derive expected outcomes from intended behaviour and downstream requirements, not solely from the current implementation. Passing tests can preserve an incorrect policy.
+- Integration tests must reproduce the registration order, ownership and lookup paths relevant to the bug. For isolation tests, make the competing entry reachable first so lookup order cannot conceal a missing discriminator. Where practical, verify the test fails with the targeted fix removed, then restore the fix and verify it passes.
 - Full test coverage is preferable; mock external calls as needed.
 - All unit tests must pass before finalising changes.
 

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -111,6 +111,23 @@ Refer to the [ADD_NEW_EXCHANGE.md](/docs/ADD_NEW_EXCHANGE.md) document for compr
 - Always include enough context in errors to aid in debugging and traceability.
 - Do not use panic; always return and propagate errors cleanly.
 
+## Configuration Migrations
+
+Migration code lives in [config/versions](../config/versions), with each version in its own `vN` package. Start with the package instructions and the `ExchangeVersion` and `ConfigVersion` interfaces in [config/versions/versions.go](../config/versions/versions.go). Register new versions in [config/versions/register.go](../config/versions/register.go). For an exchange-specific example, see [config/versions/v14/v14.go](../config/versions/v14/v14.go) and its tests in [config/versions/v14/v14_test.go](../config/versions/v14/v14_test.go).
+
+- Add a new version for subsequent configuration changes rather than rewriting historical migrations to match new types. Keep migration-specific types local to the version package instead of depending on evolving types in the config package.
+- For every configuration change, assess how existing saved configurations behave after upgrade. Implement a versioned migration when existing values would otherwise lose functionality, change meaning, or prevent adoption of an intended replacement.
+- Updating defaults or example configurations does not migrate existing installations. Test a representative configuration from the previous version through the real configuration loader.
+- When no migration is needed, explain why existing configurations remain compatible and whether retaining their previous behaviour is intentional.
+- Preserve explicit user choices. Apply default-changing migrations only to configurations that can be reliably identified as using the previous defaults.
+
+### Migration Guards
+
+- Before adding a guard that skips migration, identify the downstream dependency it protects and whether the affected entry can reach that code path. A disabled entry must not block migration solely because its channel exists.
+- Distinguish explicit `false`, explicit `true`, omitted and `null` values where their meanings differ. Use presence-aware decoding when necessary, and document any conservative treatment of unspecified values.
+- Test both sides of each guard: a configuration that must remain unchanged and a minimally different configuration that must migrate. Exercise upgrade and downgrade when the guard is shared, and verify unrelated entries remain unchanged.
+- Account for version advancement when a migration makes no changes. Do not assume a skipped transformation will be retried after the user changes their configuration.
+
 ## Testing Guidelines
 
 ### General testing
@@ -159,6 +176,7 @@ Use `require` and `assert` appropriately:
 ### Test Coverage
 
 - Maintain original test inputs unless they are incorrect.
+- Derive expected outcomes from intended behaviour and downstream requirements, not solely from the current implementation. Passing tests can preserve an incorrect policy.
 - Full test coverage is preferable; mock external calls as needed.
 - All unit tests must pass before finalising changes.
 

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -113,7 +113,7 @@ Refer to the [ADD_NEW_EXCHANGE.md](/docs/ADD_NEW_EXCHANGE.md) document for compr
 
 ## Configuration Migrations
 
-Migration code lives in [config/versions](../config/versions), with each version in its own `vN` package. Start with the package instructions and the `ExchangeVersion` and `ConfigVersion` interfaces in [config/versions/versions.go](../config/versions/versions.go). Register new versions in [config/versions/register.go](../config/versions/register.go). For an exchange-specific example, see [config/versions/v14/v14.go](../config/versions/v14/v14.go) and its tests in [config/versions/v14/v14_test.go](../config/versions/v14/v14_test.go).
+Migration code lives in [config/versions](/config/versions), with each version in its own `vN` package. Start with the package instructions and the `ExchangeVersion` and `ConfigVersion` interfaces in [config/versions/versions.go](/config/versions/versions.go). Register new versions in [config/versions/register.go](/config/versions/register.go). For an exchange-specific example, see [config/versions/v14/v14.go](/config/versions/v14/v14.go) and its tests in [config/versions/v14/v14_test.go](/config/versions/v14/v14_test.go).
 
 - Add a new version for subsequent configuration changes rather than rewriting historical migrations to match new types. Keep migration-specific types local to the version package instead of depending on evolving types in the config package.
 - For every configuration change, assess how existing saved configurations behave after upgrade. Implement a versioned migration when existing values would otherwise lose functionality, change meaning, or prevent adoption of an intended replacement.

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -124,10 +124,12 @@ Migration code lives in [config/versions](../config/versions), with each version
 ### Migration Guards
 
 - Before adding a guard that skips migration, identify the downstream dependency it protects and whether the affected entry can reach that code path. A disabled entry must not block migration solely because its channel exists.
+- Match configuration values using the same normalisation rules as the runtime. If runtime parsing is case-insensitive or canonicalises identifiers, test every accepted representation relevant to the migration, such as `spot`, `Spot` and `SPOT`.
 - Evaluate effective scope before filtering literal values. Wildcards such as `asset:"all"` can overlap a specific asset after expansion; test both wildcard and explicitly scoped entries.
 - Evaluate equivalent channel names together. Generic names and exchange-specific aliases may resolve to the same downstream subscription; guards must cover both spellings across explicit and wildcard scopes.
 - Distinguish explicit `false`, explicit `true`, omitted and `null` values where their meanings differ. Use presence-aware decoding when necessary, and document any conservative treatment of unspecified values.
 - Test both sides of each guard: a configuration that must remain unchanged and a minimally different configuration that must migrate. Exercise upgrade and downgrade when the guard is shared, and verify unrelated entries remain unchanged.
+- Validate migrated configurations through the real downstream loading, expansion and validation paths. Assert that the result remains usable, preserves the intended coverage and introduces no conflicting or exclusive entries.
 - Account for version advancement when a migration makes no changes. Do not assume a skipped transformation will be retried after the user changes their configuration.
 
 ## Testing Guidelines
@@ -179,7 +181,7 @@ Use `require` and `assert` appropriately:
 
 - Maintain original test inputs unless they are incorrect.
 - Derive expected outcomes from intended behaviour and downstream requirements, not solely from the current implementation. Passing tests can preserve an incorrect policy.
-- When fixing one accepted representation, extend the regression matrix to its equivalent forms, such as generic names and aliases. Cross these with enabled, disabled, omitted and null states where relevant.
+- When fixing behaviour for one accepted representation, extend the regression matrix to its equivalent forms. Cross relevant input dimensions, such as aliases, wildcards, accepted capitalisation, authentication or authorisation states, explicit, omitted or `null` values, and forward or reverse lifecycle transitions, where they can affect runtime behaviour.
 - Integration tests must reproduce the registration order, ownership and lookup paths relevant to the bug. For isolation tests, make the competing entry reachable first so lookup order cannot conceal a missing discriminator. Where practical, verify the test fails with the targeted fix removed, then restore the fix and verify it passes.
 - Full test coverage is preferable; mock external calls as needed.
 - All unit tests must pass before finalising changes.

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -125,6 +125,7 @@ Migration code lives in [config/versions](../config/versions), with each version
 
 - Before adding a guard that skips migration, identify the downstream dependency it protects and whether the affected entry can reach that code path. A disabled entry must not block migration solely because its channel exists.
 - Evaluate effective scope before filtering literal values. Wildcards such as `asset:"all"` can overlap a specific asset after expansion; test both wildcard and explicitly scoped entries.
+- Evaluate equivalent channel names together. Generic names and exchange-specific aliases may resolve to the same downstream subscription; guards must cover both spellings across explicit and wildcard scopes.
 - Distinguish explicit `false`, explicit `true`, omitted and `null` values where their meanings differ. Use presence-aware decoding when necessary, and document any conservative treatment of unspecified values.
 - Test both sides of each guard: a configuration that must remain unchanged and a minimally different configuration that must migrate. Exercise upgrade and downgrade when the guard is shared, and verify unrelated entries remain unchanged.
 - Account for version advancement when a migration makes no changes. Do not assume a skipped transformation will be retried after the user changes their configuration.
@@ -178,6 +179,7 @@ Use `require` and `assert` appropriately:
 
 - Maintain original test inputs unless they are incorrect.
 - Derive expected outcomes from intended behaviour and downstream requirements, not solely from the current implementation. Passing tests can preserve an incorrect policy.
+- When fixing one accepted representation, extend the regression matrix to its equivalent forms, such as generic names and aliases. Cross these with enabled, disabled, omitted and null states where relevant.
 - Integration tests must reproduce the registration order, ownership and lookup paths relevant to the bug. For isolation tests, make the competing entry reachable first so lookup order cannot conceal a missing discriminator. Where practical, verify the test fails with the targeted fix removed, then restore the fix and verify it passes.
 - Full test coverage is preferable; mock external calls as needed.
 - All unit tests must pass before finalising changes.

--- a/exchanges/gateio/README.md
+++ b/exchanges/gateio/README.md
@@ -23,6 +23,10 @@ Join our slack to discuss all things related to GoCryptoTrader! [GoCryptoTrader 
 
 + REST functions
 
+### Spot Orderbook Depth
+
+The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. V2 supports 50 or 400 levels, not 100. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
+
 ### How to enable
 
 + [Enable via configuration](https://github.com/thrasher-corp/gocryptotrader/tree/master/config#enable-exchange-via-config-example)

--- a/exchanges/gateio/README.md
+++ b/exchanges/gateio/README.md
@@ -25,7 +25,7 @@ Join our slack to discuss all things related to GoCryptoTrader! [GoCryptoTrader 
 
 ### Spot Orderbook Depth
 
-The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. V2 supports 50 or 400 levels, not 100. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
+The default spot orderbook subscription uses `spot.obu` with `levels: 50`, retaining the existing V2 entry's depth. The previous `orderbook` subscription at `100ms` seeded a 100-level snapshot, so migration to the V2 default reduces the initial book depth. Gate documents 50 and 400 levels for V2, which are the levels GoCryptoTrader accepts. Set `levels: 400` on the spot `spot.obu` subscription when more depth is required.
 
 ### How to enable
 

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -2777,6 +2777,19 @@ func TestGenerateSubscriptionsSpot(t *testing.T) {
 	e.Websocket.SetCanUseAuthenticatedEndpoints(true)
 	subs, err := e.generateSubscriptionsSpot()
 	require.NoError(t, err, "generateSubscriptions must not error")
+	var spotV2Count int
+	for _, sub := range subs {
+		if sub.Asset == asset.Spot && sub.Channel == subscription.OrderbookChannel {
+			assert.Fail(t, "legacy spot orderbook subscription should be disabled")
+		}
+		if sub.Asset == asset.Spot && sub.Channel == spotOrderbookV2 {
+			spotV2Count++
+			assert.Equal(t, 50, sub.Levels, "V2 spot orderbook subscription should request 50 levels")
+		}
+	}
+	spotPairs, err := e.GetEnabledPairs(asset.Spot)
+	require.NoError(t, err, "GetEnabledPairs must not error")
+	assert.Equal(t, len(spotPairs), spotV2Count, "each enabled spot pair should generate one V2 orderbook subscription")
 	exp := subscription.List{}
 	assets := slices.DeleteFunc(e.GetAssetTypes(true), func(a asset.Item) bool { return !e.IsAssetWebsocketSupported(a) })
 	for _, s := range e.Features.Subscriptions {

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -2851,6 +2851,21 @@ func TestGenerateFuturesDefaultSubscriptions(t *testing.T) {
 	subs, err := e.GenerateFuturesDefaultSubscriptions(asset.USDTMarginedFutures)
 	require.NoError(t, err)
 	require.NotEmpty(t, subs)
+	var orderbooks int
+	for _, sub := range subs {
+		if sub.Channel != futuresOrderbookV2 {
+			continue
+		}
+		orderbooks++
+		assert.Equal(t, "ob."+sub.Pairs[0].String()+".50", sub.QualifiedChannel, "V2 recovery key should identify the pair and depth")
+		for _, event := range []string{subscribeEvent, unsubscribeEvent} {
+			payload, err := e.generateFuturesPayload(t.Context(), event, subscription.List{sub})
+			require.NoError(t, err, "V2 payload generation must succeed")
+			require.Len(t, payload, 1, "V2 subscription must generate one request")
+			assert.Equal(t, []string{sub.QualifiedChannel}, payload[0].Payload, "V2 payload should match the recovery key")
+		}
+	}
+	require.Positive(t, orderbooks, "futures defaults must include V2 orderbooks")
 	subs, err = e.GenerateFuturesDefaultSubscriptions(asset.CoinMarginedFutures)
 	require.NoError(t, err)
 	require.NotEmpty(t, subs)

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -62,10 +62,10 @@ const (
 var defaultSubscriptions = subscription.List{
 	{Enabled: true, Channel: subscription.TickerChannel, Asset: asset.Spot},
 	{Enabled: true, Channel: subscription.CandlesChannel, Asset: asset.Spot, Interval: kline.FiveMin},
-	{Enabled: true, Channel: subscription.OrderbookChannel, Asset: asset.Spot, Interval: kline.HundredMilliseconds},
+	{Enabled: false, Channel: subscription.OrderbookChannel, Asset: asset.Spot, Interval: kline.HundredMilliseconds},
 	{Enabled: false, Channel: spotOrderbookTickerChannel, Asset: asset.Spot, Interval: kline.TenMilliseconds, Levels: 1},
 	{Enabled: false, Channel: spotOrderbookChannel, Asset: asset.Spot, Interval: kline.HundredMilliseconds, Levels: 100},
-	{Enabled: false, Channel: spotOrderbookV2, Asset: asset.Spot, Levels: 50},
+	{Enabled: true, Channel: spotOrderbookV2, Asset: asset.Spot, Levels: 50},
 	{Enabled: true, Channel: spotBalancesChannel, Asset: asset.Spot, Authenticated: true},
 	{Enabled: true, Channel: crossMarginBalanceChannel, Asset: asset.CrossMargin, Authenticated: true},
 	{Enabled: true, Channel: marginBalancesChannel, Asset: asset.Margin, Authenticated: true},

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -434,14 +434,15 @@ func (e *Exchange) processOrderbookUpdateWithSnapshot(ctx context.Context, conn 
 
 	if data.Full {
 		if err := e.Websocket.Orderbook.LoadSnapshot(&orderbook.Book{
-			Exchange:     e.Name,
-			Pair:         pair,
-			Asset:        a,
-			LastUpdated:  data.UpdateTime.Time(),
-			LastPushed:   lastPushed,
-			LastUpdateID: data.LastUpdateID,
-			Bids:         data.Bids.Levels(),
-			Asks:         data.Asks.Levels(),
+			Exchange:          e.Name,
+			Pair:              pair,
+			Asset:             a,
+			LastUpdated:       data.UpdateTime.Time(),
+			LastPushed:        lastPushed,
+			LastUpdateID:      data.LastUpdateID,
+			Bids:              data.Bids.Levels(),
+			Asks:              data.Asks.Levels(),
+			ValidateOrderbook: e.ValidateOrderbook,
 		}); err != nil {
 			return err
 		}

--- a/exchanges/gateio/gateio_websocket_futures.go
+++ b/exchanges/gateio/gateio_websocket_futures.go
@@ -130,12 +130,16 @@ func (e *Exchange) GenerateFuturesDefaultSubscriptions(a asset.Item) (subscripti
 			if err != nil {
 				return nil, err
 			}
-			subscriptions = append(subscriptions, &subscription.Subscription{
+			sub := &subscription.Subscription{
 				Channel: channelsToSubscribe[i],
 				Pairs:   currency.Pairs{fPair.Upper()},
 				Params:  params,
 				Asset:   a,
-			})
+			}
+			if sub.Channel == futuresOrderbookV2 {
+				sub.QualifiedChannel = fmt.Sprintf("ob.%s.%d", sub.Pairs[0], params["level"])
+			}
+			subscriptions = append(subscriptions, sub)
 		}
 	}
 	return subscriptions, nil

--- a/exchanges/gateio/gateio_websocket_futures.go
+++ b/exchanges/gateio/gateio_websocket_futures.go
@@ -51,6 +51,7 @@ const (
 	futuresAutoOrdersChannel        = "futures.autoorders"
 
 	futuresOrderbookUpdateLimit uint64 = 20
+	futuresOrderbookV2Limit     uint64 = 50
 )
 
 var defaultFuturesSubscriptions = []string{
@@ -124,7 +125,7 @@ func (e *Exchange) GenerateFuturesDefaultSubscriptions(a asset.Item) (subscripti
 				params["level"] = strconv.FormatUint(futuresOrderbookUpdateLimit, 10)
 			case futuresOrderbookV2:
 				// Fastest frequency available. 50 levels which defaults to 20ms frequency
-				params["level"] = uint64(50)
+				params["level"] = futuresOrderbookV2Limit
 			}
 			fPair, err := e.FormatExchangeCurrency(pairs[j], a)
 			if err != nil {
@@ -137,7 +138,7 @@ func (e *Exchange) GenerateFuturesDefaultSubscriptions(a asset.Item) (subscripti
 				Asset:   a,
 			}
 			if sub.Channel == futuresOrderbookV2 {
-				sub.QualifiedChannel = fmt.Sprintf("ob.%s.%d", sub.Pairs[0], params["level"])
+				sub.QualifiedChannel = "ob." + sub.Pairs[0].String() + "." + strconv.FormatUint(futuresOrderbookV2Limit, 10)
 			}
 			subscriptions = append(subscriptions, sub)
 		}

--- a/exchanges/gateio/gateio_websocket_test.go
+++ b/exchanges/gateio/gateio_websocket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/key"
 	"github.com/thrasher-corp/gocryptotrader/config"
+	v14 "github.com/thrasher-corp/gocryptotrader/config/versions/v14"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
@@ -288,7 +289,7 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "ob.BTC_USDT.50"}})
+		sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "ob.BTC_USDT.50", Asset: asset.Spot}})
 		return sub != nil && sub.State() == subscription.SubscribedState
 	}, time.Second, 10*time.Millisecond, "out-of-order update must successfully resubscribe in the background")
 }
@@ -335,4 +336,49 @@ func TestDefaultSpotOrderbookSubscription(t *testing.T) {
 	require.NotNil(t, v2, "V2 spot orderbook subscription must be defined")
 	assert.True(t, v2.Enabled, "V2 spot orderbook subscription should be enabled")
 	assert.Equal(t, 50, v2.Levels, "V2 spot orderbook subscription should request 50 levels")
+}
+
+func TestV14MigrationGeneratesValidSpotSubscriptions(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		upgrade bool
+		input   string
+	}{
+		{
+			name:    "uppercase upgrade",
+			upgrade: true,
+			input:   `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"SPOT","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"Spot","levels":50}]}}`,
+		},
+		{
+			name:  "mixed-case downgrade",
+			input: `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"Spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"SPOT","levels":50}]}}`,
+		},
+		{
+			name:  "wildcard V2 downgrade",
+			input: `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50},{"enabled":true,"channel":"spot.obu","asset":"all","levels":50,"pairs":"BTC_USDT"}]}}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			version := new(v14.Version)
+			migrate := version.DowngradeExchange
+			if test.upgrade {
+				migrate = version.UpgradeExchange
+			}
+			migrated, err := migrate(t.Context(), []byte(test.input))
+			require.NoError(t, err, "migration must not error")
+			var migratedConfig config.Exchange
+			require.NoError(t, json.Unmarshal(migrated, &migratedConfig), "migrated configuration must unmarshal")
+			require.NotNil(t, migratedConfig.Features, "migrated configuration features must not be nil")
+
+			e := new(Exchange)
+			require.NoError(t, testexch.Setup(e), "test instance setup must not error")
+			e.Config.Features.Subscriptions = migratedConfig.Features.Subscriptions
+			e.SetSubscriptionsFromConfig()
+			subs, err := e.generateSubscriptionsSpot()
+			require.NoError(t, err, "migrated subscriptions must expand and validate")
+			assert.NotEmpty(t, subs, "migrated configuration should generate subscriptions")
+		})
+	}
 }

--- a/exchanges/gateio/gateio_websocket_test.go
+++ b/exchanges/gateio/gateio_websocket_test.go
@@ -3,6 +3,8 @@ package gateio
 import (
 	"context"
 	"maps"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"testing"
@@ -13,13 +15,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/common/key"
+	"github.com/thrasher-corp/gocryptotrader/config"
 	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/encoding/json"
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
 	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
+	testutils "github.com/thrasher-corp/gocryptotrader/internal/testing/utils"
 	"github.com/thrasher-corp/gocryptotrader/types"
 )
 
@@ -277,6 +282,29 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 			require.NotEmpty(t, book.Bids, "updated book must contain bids")
 			assert.Equal(t, 0.146841, book.Bids[0].Amount, "incremental update should replace the matching bid amount")
 		}
+	}
+}
+
+func TestShippedConfigsMatchDefaultSubscriptions(t *testing.T) {
+	t.Parallel()
+	root, err := testutils.RootPathFromCWD()
+	require.NoError(t, err, "repository root must be found")
+	expected, err := json.Marshal(defaultSubscriptions)
+	require.NoError(t, err, "default subscriptions must marshal")
+	for _, name := range []string{"config_example.json", filepath.Join("testdata", "configtest.json")} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(filepath.Join(root, name))
+			require.NoError(t, err, "shipped config must be readable")
+			var cfg config.Config
+			require.NoError(t, json.Unmarshal(data, &cfg), "shipped config must unmarshal")
+			exchangeConfig, err := cfg.GetExchangeConfig("GateIO")
+			require.NoError(t, err, "shipped config must contain GateIO")
+			require.NotNil(t, exchangeConfig.Features, "GateIO features must be configured")
+			got, err := json.Marshal(exchangeConfig.Features.Subscriptions)
+			require.NoError(t, err, "shipped subscriptions must marshal")
+			assert.JSONEq(t, string(expected), string(got), "shipped subscriptions should match defaultSubscriptions")
+		})
 	}
 }
 

--- a/exchanges/gateio/gateio_websocket_test.go
+++ b/exchanges/gateio/gateio_websocket_test.go
@@ -222,6 +222,7 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 	e := new(Exchange)
 	require.NoError(t, testexch.Setup(e))
 	e.Name = "ProcessOrderbookUpdateWithSnapshot"
+	e.ValidateOrderbook = true
 	e.Features.Subscriptions = subscription.List{
 		{Enabled: true, Channel: spotOrderbookV2, Asset: asset.Spot, Levels: 50},
 	}
@@ -235,8 +236,9 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 	e.wsOBResubMgr.lookup[key.PairAsset{Base: currency.BTC.Item, Quote: currency.USDT.Item, Asset: asset.Spot}] = true
 
 	for _, tc := range []struct {
-		payload []byte
-		err     error
+		payload      []byte
+		err          error
+		assertUpdate bool
 	}{
 		{payload: []byte(`{"t":"bingbong"}`), err: types.ErrInvalidTimestampFormat},
 		{payload: []byte(`{"s":"ob.50"}`), err: common.ErrMalformedData},
@@ -252,7 +254,8 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 		},
 		{
 			// Incremental update will apply correctly
-			payload: []byte(`{"t":1757377580073,"s":"ob.BTC_USDT.50","u":27053258987,"U":27053258982,"b":[["111666","0.146841"]],"a":[["111666.1","0.791633"],["111676.8","0.014"]]}`),
+			payload:      []byte(`{"t":1757377580073,"s":"ob.BTC_USDT.50","u":27053258987,"U":27053258982,"b":[["111666","0.146841"]],"a":[["111666.1","0.791633"],["111676.8","0.014"]]}`),
+			assertUpdate: true,
 		},
 		{
 			// Incremental update out of order will force resubscription
@@ -266,5 +269,34 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 			continue
 		}
 		require.NoError(t, err)
+		if tc.assertUpdate {
+			book, err := e.Websocket.Orderbook.GetOrderbook(currency.NewBTCUSDT(), asset.Spot)
+			require.NoError(t, err, "GetOrderbook must not error")
+			assert.True(t, book.ValidateOrderbook, "V2 snapshot should retain configured validation")
+			assert.Equal(t, int64(27053258987), book.LastUpdateID, "incremental update should advance the update ID")
+			require.NotEmpty(t, book.Bids, "updated book must contain bids")
+			assert.Equal(t, 0.146841, book.Bids[0].Amount, "incremental update should replace the matching bid amount")
+		}
 	}
+}
+
+func TestDefaultSpotOrderbookSubscription(t *testing.T) {
+	t.Parallel()
+	var legacy, v2 *subscription.Subscription
+	for _, sub := range defaultSubscriptions {
+		if sub.Asset != asset.Spot {
+			continue
+		}
+		switch sub.Channel {
+		case subscription.OrderbookChannel:
+			legacy = sub
+		case spotOrderbookV2:
+			v2 = sub
+		}
+	}
+	require.NotNil(t, legacy, "legacy spot orderbook subscription must be defined")
+	assert.False(t, legacy.Enabled, "legacy spot orderbook subscription should be disabled")
+	require.NotNil(t, v2, "V2 spot orderbook subscription must be defined")
+	assert.True(t, v2.Enabled, "V2 spot orderbook subscription should be enabled")
+	assert.Equal(t, 50, v2.Levels, "V2 spot orderbook subscription should request 50 levels")
 }

--- a/exchanges/gateio/gateio_websocket_test.go
+++ b/exchanges/gateio/gateio_websocket_test.go
@@ -344,19 +344,23 @@ func TestV14MigrationGeneratesValidSpotSubscriptions(t *testing.T) {
 		name    string
 		upgrade bool
 		input   string
+		channel string
 	}{
 		{
 			name:    "uppercase upgrade",
 			upgrade: true,
 			input:   `{"features":{"subscriptions":[{"enabled":true,"channel":"orderbook","asset":"SPOT","interval":"100ms"},{"enabled":false,"channel":"spot.obu","asset":"Spot","levels":50}]}}`,
+			channel: spotOrderbookV2,
 		},
 		{
-			name:  "mixed-case downgrade",
-			input: `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"Spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"SPOT","levels":50}]}}`,
+			name:    "mixed-case downgrade",
+			input:   `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"Spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"SPOT","levels":50}]}}`,
+			channel: spotOrderbookUpdateChannel,
 		},
 		{
-			name:  "wildcard V2 downgrade",
-			input: `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50},{"enabled":true,"channel":"spot.obu","asset":"all","levels":50,"pairs":"BTC_USDT"}]}}`,
+			name:    "wildcard V2 downgrade",
+			input:   `{"features":{"subscriptions":[{"enabled":false,"channel":"orderbook","asset":"spot","interval":"100ms"},{"enabled":true,"channel":"spot.obu","asset":"spot","levels":50},{"enabled":true,"channel":"spot.obu","asset":"all","levels":50,"pairs":"BTC_USDT"}]}}`,
+			channel: spotOrderbookV2,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -379,6 +383,9 @@ func TestV14MigrationGeneratesValidSpotSubscriptions(t *testing.T) {
 			subs, err := e.generateSubscriptionsSpot()
 			require.NoError(t, err, "migrated subscriptions must expand and validate")
 			assert.NotEmpty(t, subs, "migrated configuration should generate subscriptions")
+			for _, s := range subs {
+				assert.Equal(t, test.channel, channelName(s), "migrated subscriptions should use the expected orderbook feed")
+			}
 		})
 	}
 }

--- a/exchanges/gateio/ws_ob_resub_manager.go
+++ b/exchanges/gateio/ws_ob_resub_manager.go
@@ -35,7 +35,7 @@ func (m *wsOBResubManager) Resubscribe(ctx context.Context, e *Exchange, conn we
 		return err
 	}
 
-	sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: qualifiedChannel}})
+	sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: qualifiedChannel, Asset: a}})
 	if sub == nil {
 		return fmt.Errorf("%w: %q", subscription.ErrNotFound, qualifiedChannel)
 	}
@@ -67,7 +67,8 @@ type qualifiedChannelKey struct {
 }
 
 func (k qualifiedChannelKey) Match(eachKey subscription.MatchableKey) bool {
-	return k.Subscription.QualifiedChannel == eachKey.GetSubscription().QualifiedChannel
+	s := eachKey.GetSubscription()
+	return k.Subscription.QualifiedChannel == s.QualifiedChannel && k.Subscription.Asset == s.Asset
 }
 
 func (k qualifiedChannelKey) GetSubscription() *subscription.Subscription {

--- a/exchanges/gateio/ws_ob_resub_manager_test.go
+++ b/exchanges/gateio/ws_ob_resub_manager_test.go
@@ -87,7 +87,7 @@ func TestResubscribe(t *testing.T) {
 	assert.True(t, m.IsResubscribing(currency.NewBTCUSDT(), asset.Spot), "manager should mark the pair as resubscribing immediately")
 	assert.Eventually(t,
 		func() bool {
-			sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: qualifiedChannel}})
+			sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: qualifiedChannel, Asset: asset.Spot}})
 			return sub != nil && sub.State() == subscription.SubscribedState
 		},
 		time.Second,
@@ -123,8 +123,9 @@ func TestQualifiedChannelKey_Match(t *testing.T) {
 
 	require.Implements(t, (*subscription.MatchableKey)(nil), new(qualifiedChannelKey))
 
-	k := qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "test.channel"}}
+	k := qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "test.channel", Asset: asset.Spot}}
 	require.True(t, k.Match(k))
-	require.False(t, k.Match(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "TEST.channel"}}))
+	require.False(t, k.Match(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "TEST.channel", Asset: asset.Spot}}))
+	require.False(t, k.Match(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "test.channel", Asset: asset.Futures}}))
 	assert.NotNil(t, k.GetSubscription())
 }

--- a/exchanges/gateio/ws_ob_resub_manager_test.go
+++ b/exchanges/gateio/ws_ob_resub_manager_test.go
@@ -124,15 +124,16 @@ func TestFuturesV2GapRecovery(t *testing.T) {
 	require.NotNil(t, futures, "defaults must include a futures V2 subscription")
 	pair := futures.Pairs[0]
 	qualifiedChannel := "ob." + pair.String() + ".50"
-	baseConn, err := exchange.Websocket.CreateTestConnection(asset.USDTMarginedFutures)
-	require.NoError(t, err, "futures connection must be created")
-	conn := &FixtureConnection{Connection: baseConn}
-	require.NoError(t, exchange.Websocket.TrackTestConnection(asset.USDTMarginedFutures, conn), "futures connection must be tracked")
 	spot := &subscription.Subscription{Channel: spotOrderbookV2, Asset: asset.Spot, Pairs: currency.Pairs{pair}, Levels: 50, QualifiedChannel: qualifiedChannel}
 	spotBase, err := exchange.Websocket.CreateTestConnection(asset.Spot)
 	require.NoError(t, err, "spot connection must be created")
 	spotConn := &FixtureConnection{Connection: spotBase}
+	require.NoError(t, exchange.Websocket.TrackTestConnection(asset.Spot, spotConn), "spot connection must be tracked")
 	require.NoError(t, exchange.Websocket.AddSuccessfulSubscriptions(spotConn, spot), "spot subscription must register")
+	baseConn, err := exchange.Websocket.CreateTestConnection(asset.USDTMarginedFutures)
+	require.NoError(t, err, "futures connection must be created")
+	conn := &FixtureConnection{Connection: baseConn}
+	require.NoError(t, exchange.Websocket.TrackTestConnection(asset.USDTMarginedFutures, conn), "futures connection must be tracked")
 	require.NoError(t, exchange.Websocket.AddSubscriptions(conn, futures), "generated futures subscription must register")
 	for _, assetType := range []asset.Item{asset.Spot, asset.USDTMarginedFutures} {
 		snapshot := fmt.Appendf(nil, `{"t":1757377580046,"full":true,"s":%q,"u":100,"b":[["100","1"]],"a":[["101","1"]]}`, qualifiedChannel)

--- a/exchanges/gateio/ws_ob_resub_manager_test.go
+++ b/exchanges/gateio/ws_ob_resub_manager_test.go
@@ -1,6 +1,7 @@
 package gateio
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -104,6 +105,62 @@ func TestResubscribe(t *testing.T) {
 		10*time.Millisecond,
 		"resubscription state should clear after completion is signalled",
 	)
+}
+
+func TestFuturesV2GapRecovery(t *testing.T) {
+	t.Parallel()
+	exchange := new(Exchange)
+	require.NoError(t, testexch.Setup(exchange), "test exchange setup must succeed")
+	exchange.Name = t.Name()
+	subs, err := exchange.GenerateFuturesDefaultSubscriptions(asset.USDTMarginedFutures)
+	require.NoError(t, err, "futures subscriptions must generate")
+	var futures *subscription.Subscription
+	for _, sub := range subs {
+		if sub.Channel == futuresOrderbookV2 {
+			futures = sub
+			break
+		}
+	}
+	require.NotNil(t, futures, "defaults must include a futures V2 subscription")
+	pair := futures.Pairs[0]
+	qualifiedChannel := "ob." + pair.String() + ".50"
+	baseConn, err := exchange.Websocket.CreateTestConnection(asset.USDTMarginedFutures)
+	require.NoError(t, err, "futures connection must be created")
+	conn := &FixtureConnection{Connection: baseConn}
+	require.NoError(t, exchange.Websocket.TrackTestConnection(asset.USDTMarginedFutures, conn), "futures connection must be tracked")
+	spot := &subscription.Subscription{Channel: spotOrderbookV2, Asset: asset.Spot, Pairs: currency.Pairs{pair}, Levels: 50, QualifiedChannel: qualifiedChannel}
+	spotBase, err := exchange.Websocket.CreateTestConnection(asset.Spot)
+	require.NoError(t, err, "spot connection must be created")
+	spotConn := &FixtureConnection{Connection: spotBase}
+	require.NoError(t, exchange.Websocket.AddSuccessfulSubscriptions(spotConn, spot), "spot subscription must register")
+	require.NoError(t, exchange.Websocket.AddSubscriptions(conn, futures), "generated futures subscription must register")
+	for _, assetType := range []asset.Item{asset.Spot, asset.USDTMarginedFutures} {
+		snapshot := fmt.Appendf(nil, `{"t":1757377580046,"full":true,"s":%q,"u":100,"b":[["100","1"]],"a":[["101","1"]]}`, qualifiedChannel)
+		require.NoError(t, exchange.processOrderbookUpdateWithSnapshot(t.Context(), conn, snapshot, time.Now(), assetType), "initial snapshot must load")
+	}
+	gap := fmt.Appendf(nil, `{"time":1757377580,"channel":"futures.obu","event":"update","result":{"t":1757377580073,"s":%q,"U":102,"u":103}}`, qualifiedChannel)
+	require.NoError(t, exchange.WsHandleFuturesData(t.Context(), conn, gap, asset.USDTMarginedFutures), "futures gap must find its generated subscription")
+	assert.True(t, exchange.wsOBResubMgr.IsResubscribing(pair, asset.USDTMarginedFutures), "futures should await a replacement snapshot")
+	assert.False(t, exchange.wsOBResubMgr.IsResubscribing(pair, asset.Spot), "spot should not enter recovery")
+	assert.Equal(t, subscription.SubscribedState, spot.State(), "spot subscription should remain subscribed")
+	_, err = exchange.Websocket.Orderbook.GetOrderbook(pair, asset.USDTMarginedFutures)
+	require.Error(t, err, "gapped futures book must be unavailable")
+	spotBook, err := exchange.Websocket.Orderbook.GetOrderbook(pair, asset.Spot)
+	require.NoError(t, err, "spot book must remain available")
+	assert.Equal(t, int64(100), spotBook.LastUpdateID, "spot sequence should remain unchanged")
+	require.Eventually(t, func() bool {
+		return futures.State() == subscription.SubscribedState
+	}, time.Second, time.Millisecond, "futures subscription must complete unsubscribe and resubscribe")
+	fresh := fmt.Appendf(nil, `{"t":1757377580080,"full":true,"s":%q,"u":200,"b":[["100","2"]],"a":[["101","2"]]}`, qualifiedChannel)
+	require.NoError(t, exchange.processOrderbookUpdateWithSnapshot(t.Context(), conn, fresh, time.Now(), asset.USDTMarginedFutures), "replacement snapshot must load")
+	assert.False(t, exchange.wsOBResubMgr.IsResubscribing(pair, asset.USDTMarginedFutures), "replacement snapshot should clear recovery")
+	update := fmt.Appendf(nil, `{"t":1757377580090,"s":%q,"U":201,"u":201,"b":[["100","3"]]}`, qualifiedChannel)
+	require.NoError(t, exchange.processOrderbookUpdateWithSnapshot(t.Context(), conn, update, time.Now(), asset.USDTMarginedFutures), "incremental processing must resume")
+	book, err := exchange.Websocket.Orderbook.GetOrderbook(pair, asset.USDTMarginedFutures)
+	require.NoError(t, err, "recovered futures book must be available")
+	assert.Equal(t, int64(201), book.LastUpdateID, "recovered book should advance its sequence")
+	require.NotEmpty(t, book.Bids, "recovered book must contain bids")
+	assert.Equal(t, float64(3), book.Bids[0].Amount, "recovered book should apply incremental quantities")
 }
 
 func TestCompletedResubscribe(t *testing.T) {

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -1,6 +1,6 @@
 {
  "name": "Skynet",
- "version": 13,
+ "version": 14,
  "dataDirectory": "",
  "encryptConfig": -1,
  "globalHTTPTimeout": 15000000000,
@@ -2037,7 +2037,7 @@
       "interval": "5m"
      },
      {
-      "enabled": true,
+      "enabled": false,
       "channel": "orderbook",
       "asset": "spot",
       "interval": "100ms"
@@ -2057,7 +2057,7 @@
       "levels": 100
      },
      {
-      "enabled": false,
+      "enabled": true,
       "channel": "spot.obu",
       "asset": "spot",
       "levels": 50


### PR DESCRIPTION
## Summary

Switches GateIO's default spot websocket orderbook feed from `spot.order_book_update` to V2 `spot.obu`, requesting 50 levels.

Updates shipped configs, migrates existing default subscriptions, and fixes V2 orderbook recovery for both spot and USDT-margined futures.

## Changes

- Enables `spot.obu` and disables the legacy generic spot orderbook subscription in defaults and shipped configs.
- Adds config version 14 to migrate previous default subscriptions, including older configs without a V2 entry.
- Preserves customized subscriptions. Existing V2 entries must match the shipped default before migration changes them.
- Accepts numeric subscription intervals without failing config load.
- Prevents duplicate V2 entries when an existing entry omits `enabled`.
- Supports idempotent upgrades and downgrades.
- Makes V2 recovery lookups asset-aware so a futures gap cannot select a spot subscription.
- Populates futures V2 subscription keys so `futures.obu` gaps can unsubscribe, resubscribe, and recover from a fresh snapshot.
- Preserves configured orderbook validation when loading V2 snapshots.

## Regression Coverage

- Default spot feed selection and incremental V2 updates.
- Migration eligibility, custom-field preservation, incomplete entries, numeric intervals, and upgrade/downgrade behavior.
- Futures subscription keys matching subscribe and unsubscribe payloads.
- Futures gap recovery, replacement snapshots, resumed incremental updates, and isolation from same-key spot subscriptions.

## Validation

- GateIO and all config package tests pass with the race detector.
- Focused recovery and migration regressions pass with `-race -count=2`.
- Scoped `golangci-lint --new-from-rev=upstream/master` reports zero issues.
- Repository miscellaneous checks pass.
- Full repository race testing was attempted; failures were limited to unrelated Bitstamp ticker-response decoding tests.