### PR TITLE
exchanges/GateIO: Add mark and index prices for derivatives

### DIFF
--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -346,8 +346,17 @@ func TestUpdateTicker(t *testing.T) {
 	t.Run("all supported assets", func(t *testing.T) {
 		t.Parallel()
 		for _, a := range e.GetAssetTypes(false) {
-			_, err := e.UpdateTicker(t.Context(), getPair(t, a), a)
-			assert.NoErrorf(t, err, "UpdateTicker should not error for %s", a)
+			t.Run(a.String(), func(t *testing.T) {
+				t.Parallel()
+				got, err := e.UpdateTicker(t.Context(), getPair(t, a), a)
+				require.NoError(t, err, "UpdateTicker must not error")
+				switch a {
+				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures:
+					require.NotNil(t, got, "live ticker must not be nil")
+					assert.Positive(t, got.MarkPrice, "live ticker mark price should be positive")
+					assert.Positive(t, got.IndexPrice, "live ticker index price should be positive")
+				}
+			})
 		}
 	})
 
@@ -358,19 +367,19 @@ func TestUpdateTicker(t *testing.T) {
 		expectedPath string
 	}{
 		{
-			name:         "USDT margined futures mark and index prices",
+			name:         "mocked USDT margined futures mark and index prices",
 			asset:        asset.USDTMarginedFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/futures/usdt/tickers",
 		},
 		{
-			name:         "coin margined futures mark and index prices",
+			name:         "mocked coin margined futures mark and index prices",
 			asset:        asset.CoinMarginedFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USD", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/futures/btc/tickers",
 		},
 		{
-			name:         "delivery futures mark and index prices",
+			name:         "mocked delivery futures mark and index prices",
 			asset:        asset.DeliveryFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/delivery/usdt/tickers",
@@ -2163,8 +2172,25 @@ func TestUpdateTickers(t *testing.T) {
 	t.Run("all supported assets", func(t *testing.T) {
 		t.Parallel()
 		for _, a := range e.GetAssetTypes(false) {
-			err := e.UpdateTickers(t.Context(), a)
-			assert.NoErrorf(t, err, "UpdateTickers should not error for %s", a)
+			t.Run(a.String(), func(t *testing.T) {
+				t.Parallel()
+				switch a {
+				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures:
+					pair := getPair(t, a)
+					ex := new(Exchange)
+					require.NoError(t, testexch.Setup(ex), "Setup must not error")
+					// Isolate the cache so another test cannot supply the ticker being checked.
+					ex.Name = t.Name()
+					require.NoError(t, ex.UpdateTickers(t.Context(), a), "live UpdateTickers must not error")
+					got, err := ticker.GetTicker(ex.Name, pair, a)
+					require.NoError(t, err, "live UpdateTickers must cache the requested ticker")
+					require.NotNil(t, got, "live ticker must not be nil")
+					assert.Positive(t, got.MarkPrice, "live ticker mark price should be positive")
+					assert.Positive(t, got.IndexPrice, "live ticker index price should be positive")
+				default:
+					assert.NoError(t, e.UpdateTickers(t.Context(), a), "UpdateTickers should not error")
+				}
+			})
 		}
 	})
 
@@ -2175,19 +2201,19 @@ func TestUpdateTickers(t *testing.T) {
 		expectedPath string
 	}{
 		{
-			name:         "USDT margined futures mark and index prices",
+			name:         "mocked USDT margined futures mark and index prices",
 			asset:        asset.USDTMarginedFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/futures/usdt/tickers",
 		},
 		{
-			name:         "coin margined futures mark and index prices",
+			name:         "mocked coin margined futures mark and index prices",
 			asset:        asset.CoinMarginedFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USD", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/futures/btc/tickers",
 		},
 		{
-			name:         "delivery futures mark and index prices",
+			name:         "mocked delivery futures mark and index prices",
 			asset:        asset.DeliveryFutures,
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/delivery/usdt/tickers",

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -351,7 +351,7 @@ func TestUpdateTicker(t *testing.T) {
 				got, err := e.UpdateTicker(t.Context(), getPair(t, a), a)
 				require.NoError(t, err, "UpdateTicker must not error")
 				switch a {
-				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures:
+				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures, asset.Options:
 					require.NotNil(t, got, "live ticker must not be nil")
 					assert.Positive(t, got.MarkPrice, "live ticker mark price should be positive")
 					assert.Positive(t, got.IndexPrice, "live ticker index price should be positive")
@@ -384,6 +384,12 @@ func TestUpdateTicker(t *testing.T) {
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/delivery/usdt/tickers",
 		},
+		{
+			name:         "mocked options mark and index prices",
+			asset:        asset.Options,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT-20261225-100000-C", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/options/tickers",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -391,10 +397,19 @@ func TestUpdateTicker(t *testing.T) {
 			ex := new(Exchange)
 			require.NoError(t, testexch.Setup(ex), "Setup must not error")
 			ex.Name = t.Name()
+			if tc.asset == asset.Options {
+				require.NoError(t, ex.UpdatePairs(currency.Pairs{tc.pair}, tc.asset, true), "mocked options pair must be enabled")
+			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
 				assert.Equal(t, tc.expectedPath, r.URL.Path)
+				if tc.asset == asset.Options {
+					assert.Equal(t, "BTC_USDT", r.URL.Query().Get("underlying"), "options underlying should match")
+					_, err := fmt.Fprintf(w, `[{"name":%q,"last_price":"118.4","mark_price":"118.35","index_price":"100000.25"}]`, tc.pair.String())
+					assert.NoError(t, err, "mocked response should be written")
+					return
+				}
 				assert.Equal(t, tc.pair.String(), r.URL.Query().Get("contract"))
 				_, err := fmt.Fprintf(w, `[{"contract":%q,"last":"118.4","low_24h":"99.2","high_24h":"132.5","volume_24h_base":"5526","volume_24h_quote":"1665006","mark_price":"118.35","index_price":"118.36"}]`, tc.pair.String())
 				assert.NoError(t, err)
@@ -407,7 +422,11 @@ func TestUpdateTicker(t *testing.T) {
 			got, err := ex.UpdateTicker(t.Context(), tc.pair, tc.asset)
 			require.NoError(t, err)
 			assert.Equal(t, 118.35, got.MarkPrice)
-			assert.Equal(t, 118.36, got.IndexPrice)
+			if tc.asset == asset.Options {
+				assert.Equal(t, 100000.25, got.IndexPrice, "options index price should match")
+			} else {
+				assert.Equal(t, 118.36, got.IndexPrice)
+			}
 		})
 	}
 }
@@ -2175,10 +2194,13 @@ func TestUpdateTickers(t *testing.T) {
 			t.Run(a.String(), func(t *testing.T) {
 				t.Parallel()
 				switch a {
-				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures:
+				case asset.USDTMarginedFutures, asset.CoinMarginedFutures, asset.DeliveryFutures, asset.Options:
 					pair := getPair(t, a)
 					ex := new(Exchange)
 					require.NoError(t, testexch.Setup(ex), "Setup must not error")
+					if a == asset.Options {
+						testexch.UpdatePairsOnce(t, ex)
+					}
 					// Isolate the cache so another test cannot supply the ticker being checked.
 					ex.Name = t.Name()
 					require.NoError(t, ex.UpdateTickers(t.Context(), a), "live UpdateTickers must not error")
@@ -2218,6 +2240,12 @@ func TestUpdateTickers(t *testing.T) {
 			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
 			expectedPath: "/api/v4/delivery/usdt/tickers",
 		},
+		{
+			name:         "mocked options mark and index prices",
+			asset:        asset.Options,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT-20261225-100000-C", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/options/tickers",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -2225,10 +2253,19 @@ func TestUpdateTickers(t *testing.T) {
 			ex := new(Exchange)
 			require.NoError(t, testexch.Setup(ex), "Setup must not error")
 			ex.Name = t.Name()
+			if tc.asset == asset.Options {
+				require.NoError(t, ex.UpdatePairs(currency.Pairs{tc.pair}, tc.asset, true), "mocked options pair must be enabled")
+			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
 				assert.Equal(t, tc.expectedPath, r.URL.Path)
+				if tc.asset == asset.Options {
+					assert.Equal(t, "BTC_USDT", r.URL.Query().Get("underlying"), "options underlying should match")
+					_, err := fmt.Fprintf(w, `[{"name":%q,"last_price":"118.4","mark_price":"118.35","index_price":"100000.25"}]`, tc.pair.String())
+					assert.NoError(t, err, "mocked response should be written")
+					return
+				}
 				assert.Empty(t, r.URL.Query().Get("contract"))
 				_, err := fmt.Fprintf(w, `[{"contract":%q,"last":"118.4","low_24h":"99.2","high_24h":"132.5","volume_24h":"745487577","volume_24h_quote":"1665006","mark_price":"118.35","index_price":"118.36"}]`, tc.pair.String())
 				assert.NoError(t, err)
@@ -2242,7 +2279,11 @@ func TestUpdateTickers(t *testing.T) {
 			got, err := ticker.GetTicker(ex.Name, tc.pair, tc.asset)
 			require.NoError(t, err)
 			assert.Equal(t, 118.35, got.MarkPrice)
-			assert.Equal(t, 118.36, got.IndexPrice)
+			if tc.asset == asset.Options {
+				assert.Equal(t, 100000.25, got.IndexPrice, "options index price should match")
+			} else {
+				assert.Equal(t, 118.36, got.IndexPrice)
+			}
 		})
 	}
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"slices"
@@ -24,6 +26,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
 	"github.com/thrasher-corp/gocryptotrader/exchange/order/limits"
 	"github.com/thrasher-corp/gocryptotrader/exchange/websocket"
+	exchange "github.com/thrasher-corp/gocryptotrader/exchanges"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/fundingrate"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/futures"
@@ -33,6 +36,7 @@ import (
 	"github.com/thrasher-corp/gocryptotrader/exchanges/request"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/sharedtestvalues"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
 	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 	testsubs "github.com/thrasher-corp/gocryptotrader/internal/testing/subscriptions"
 	"github.com/thrasher-corp/gocryptotrader/portfolio/withdraw"
@@ -338,9 +342,64 @@ func TestGetOrderInfo(t *testing.T) {
 
 func TestUpdateTicker(t *testing.T) {
 	t.Parallel()
-	for _, a := range e.GetAssetTypes(false) {
-		_, err := e.UpdateTicker(t.Context(), getPair(t, a), a)
-		assert.NoErrorf(t, err, "UpdateTicker should not error for %s", a)
+
+	t.Run("all supported assets", func(t *testing.T) {
+		t.Parallel()
+		for _, a := range e.GetAssetTypes(false) {
+			_, err := e.UpdateTicker(t.Context(), getPair(t, a), a)
+			assert.NoErrorf(t, err, "UpdateTicker should not error for %s", a)
+		}
+	})
+
+	for _, tc := range []struct {
+		name         string
+		asset        asset.Item
+		pair         currency.Pair
+		expectedPath string
+	}{
+		{
+			name:         "USDT margined futures mark and index prices",
+			asset:        asset.USDTMarginedFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/futures/usdt/tickers",
+		},
+		{
+			name:         "coin margined futures mark and index prices",
+			asset:        asset.CoinMarginedFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USD", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/futures/btc/tickers",
+		},
+		{
+			name:         "delivery futures mark and index prices",
+			asset:        asset.DeliveryFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/delivery/usdt/tickers",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ex := new(Exchange)
+			require.NoError(t, testexch.Setup(ex), "Setup must not error")
+			ex.Name = t.Name()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, tc.expectedPath, r.URL.Path)
+				assert.Equal(t, tc.pair.String(), r.URL.Query().Get("contract"))
+				_, err := fmt.Fprintf(w, `[{"contract":%q,"last":"118.4","low_24h":"99.2","high_24h":"132.5","volume_24h_base":"5526","volume_24h_quote":"1665006","mark_price":"118.35","index_price":"118.36"}]`, tc.pair.String())
+				assert.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			require.NoError(t, ex.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+			require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api/v4/"), "SetRunningURL must not error")
+
+			got, err := ex.UpdateTicker(t.Context(), tc.pair, tc.asset)
+			require.NoError(t, err)
+			assert.Equal(t, 118.35, got.MarkPrice)
+			assert.Equal(t, 118.36, got.IndexPrice)
+		})
 	}
 }
 
@@ -2100,9 +2159,65 @@ func TestFetchTradablePairs(t *testing.T) {
 
 func TestUpdateTickers(t *testing.T) {
 	t.Parallel()
-	for _, a := range e.GetAssetTypes(false) {
-		err := e.UpdateTickers(t.Context(), a)
-		assert.NoErrorf(t, err, "UpdateTickers should not error for %s", a)
+
+	t.Run("all supported assets", func(t *testing.T) {
+		t.Parallel()
+		for _, a := range e.GetAssetTypes(false) {
+			err := e.UpdateTickers(t.Context(), a)
+			assert.NoErrorf(t, err, "UpdateTickers should not error for %s", a)
+		}
+	})
+
+	for _, tc := range []struct {
+		name         string
+		asset        asset.Item
+		pair         currency.Pair
+		expectedPath string
+	}{
+		{
+			name:         "USDT margined futures mark and index prices",
+			asset:        asset.USDTMarginedFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/futures/usdt/tickers",
+		},
+		{
+			name:         "coin margined futures mark and index prices",
+			asset:        asset.CoinMarginedFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USD", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/futures/btc/tickers",
+		},
+		{
+			name:         "delivery futures mark and index prices",
+			asset:        asset.DeliveryFutures,
+			pair:         currency.NewPairWithDelimiter("BTC", "USDT_20261225", currency.UnderscoreDelimiter),
+			expectedPath: "/api/v4/delivery/usdt/tickers",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ex := new(Exchange)
+			require.NoError(t, testexch.Setup(ex), "Setup must not error")
+			ex.Name = t.Name()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, tc.expectedPath, r.URL.Path)
+				assert.Empty(t, r.URL.Query().Get("contract"))
+				_, err := fmt.Fprintf(w, `[{"contract":%q,"last":"118.4","low_24h":"99.2","high_24h":"132.5","volume_24h":"745487577","volume_24h_quote":"1665006","mark_price":"118.35","index_price":"118.36"}]`, tc.pair.String())
+				assert.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			require.NoError(t, ex.SetHTTPClient(server.Client()), "SetHTTPClient must not error")
+			require.NoError(t, ex.API.Endpoints.SetRunningURL(exchange.RestSpot.String(), server.URL+"/api/v4/"), "SetRunningURL must not error")
+
+			require.NoError(t, ex.UpdateTickers(t.Context(), tc.asset))
+			got, err := ticker.GetTicker(ex.Name, tc.pair, tc.asset)
+			require.NoError(t, err)
+			assert.Equal(t, 118.35, got.MarkPrice)
+			assert.Equal(t, 118.36, got.IndexPrice)
+		})
 	}
 }
 

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -771,7 +771,7 @@ type ContractStat struct {
 	ShortLiquidationAmount types.Number `json:"short_liq_amount"`
 	LongLiquidationAmount  types.Number `json:"long_liq_amount"`
 	LastFundingRate        types.Number `json:"last_funding_rate"`
-	OpenInterestUsd        types.Number `json:"open_interest_usd"`
+	OpenInterestUSD        types.Number `json:"open_interest_usd"`
 	TopLongShortAccount    types.Number `json:"top_lsr_account"`
 	LongLiquidationUSD     types.Number `json:"long_liq_usd"`
 	TopLongSize            types.Number `json:"top_long_size"`

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -931,6 +931,7 @@ type OptionsTicker struct {
 	Name                  currency.Pair `json:"name"`
 	LastPrice             types.Number  `json:"last_price"`
 	MarkPrice             types.Number  `json:"mark_price"`
+	IndexPrice            types.Number  `json:"index_price"`
 	PositionSize          types.Number  `json:"position_size"`
 	Ask1Size              types.Number  `json:"ask1_size"`
 	Ask1Price             types.Number  `json:"ask1_price"`
@@ -945,9 +946,6 @@ type OptionsTicker struct {
 	BidImpliedVolatility  types.Number  `json:"bid_iv"`
 	AskImpliedVolatility  types.Number  `json:"ask_iv"`
 	Leverage              types.Number  `json:"leverage"`
-
-	// Added fields for the websocket
-	IndexPrice types.Number `json:"index_price"`
 }
 
 // OptionsUnderlyingTicker represents underlying ticker

--- a/exchanges/gateio/gateio_websocket_futures.go
+++ b/exchanges/gateio/gateio_websocket_futures.go
@@ -343,6 +343,8 @@ func (e *Exchange) processFuturesTickers(ctx context.Context, data []byte, asset
 			High:         resp.Result[x].High24H.Float64(),
 			Low:          resp.Result[x].Low24H.Float64(),
 			Last:         resp.Result[x].Last.Float64(),
+			MarkPrice:    resp.Result[x].MarkPrice.Float64(),
+			IndexPrice:   resp.Result[x].IndexPrice.Float64(),
 			AssetType:    assetType,
 			Pair:         resp.Result[x].Contract,
 			LastUpdated:  resp.Time.Time(),

--- a/exchanges/gateio/gateio_websocket_futures_test.go
+++ b/exchanges/gateio/gateio_websocket_futures_test.go
@@ -5,13 +5,41 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchange/accounts"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/kline"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
+	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
 )
+
+func TestProcessFuturesTickers(t *testing.T) {
+	t.Parallel()
+
+	ex := new(Exchange)
+	require.NoError(t, testexch.Setup(ex), "Setup must not error")
+
+	payload := []byte(`{"time":1541659086,"channel":"futures.tickers","event":"update","result":[{"contract":"BTC_USDT","last":"118.4","mark_price":"118.35","index_price":"118.36","volume_24h_quote":"1665006","volume_24h_base":"5526","low_24h":"99.2","high_24h":"132.5"}]}`)
+	require.NoError(t, ex.processFuturesTickers(t.Context(), payload, asset.USDTMarginedFutures))
+
+	select {
+	case msg := <-ex.Websocket.DataHandler.C:
+		got, ok := msg.Data.([]ticker.Price)
+		require.True(t, ok, "expected []ticker.Price")
+		require.Len(t, got, 1)
+		assert.Equal(t, 118.35, got[0].MarkPrice)
+		assert.Equal(t, 118.36, got[0].IndexPrice)
+		assert.Equal(t, asset.USDTMarginedFutures, got[0].AssetType)
+		assert.Equal(t, currency.NewPairWithDelimiter("BTC", "USDT", currency.UnderscoreDelimiter), got[0].Pair)
+		assert.Equal(t, time.Unix(1541659086, 0), got[0].LastUpdated)
+	default:
+		require.Fail(t, "expected websocket futures ticker payload")
+	}
+}
 
 func TestGenerateFuturesPayload(t *testing.T) {
 	t.Parallel()

--- a/exchanges/gateio/gateio_websocket_option.go
+++ b/exchanges/gateio/gateio_websocket_option.go
@@ -350,6 +350,8 @@ func (e *Exchange) processOptionsContractTickers(ctx context.Context, incoming [
 	return e.Websocket.DataHandler.Send(ctx, &ticker.Price{
 		Pair:         data.Name,
 		Last:         data.LastPrice.Float64(),
+		MarkPrice:    data.MarkPrice.Float64(),
+		IndexPrice:   data.IndexPrice.Float64(),
 		Bid:          data.Bid1Price.Float64(),
 		Ask:          data.Ask1Price.Float64(),
 		AskSize:      data.Ask1Size.Float64(),

--- a/exchanges/gateio/gateio_websocket_option_test.go
+++ b/exchanges/gateio/gateio_websocket_option_test.go
@@ -1,0 +1,55 @@
+package gateio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thrasher-corp/gocryptotrader/currency"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/asset"
+	"github.com/thrasher-corp/gocryptotrader/exchanges/ticker"
+	testexch "github.com/thrasher-corp/gocryptotrader/internal/testing/exchange"
+)
+
+func TestProcessOptionsContractTickers(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+		wantErr bool
+	}{
+		{
+			name:    "mocked mark and index prices",
+			payload: `{"name":"BTC_USDT-20261225-100000-C","last_price":"118.4","mark_price":"118.35","index_price":"100000.25"}`,
+		},
+		{
+			name:    "mocked malformed response",
+			payload: `{`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ex := new(Exchange)
+			require.NoError(t, testexch.Setup(ex), "Setup must not error")
+			err := ex.processOptionsContractTickers(t.Context(), []byte(tc.payload))
+			if tc.wantErr {
+				require.Error(t, err, "malformed response must fail")
+				return
+			}
+			require.NoError(t, err, "options ticker processing must succeed")
+			select {
+			case msg := <-ex.Websocket.DataHandler.C:
+				got, ok := msg.Data.(*ticker.Price)
+				require.True(t, ok, "message must contain a ticker price")
+				assert.Equal(t, 118.35, got.MarkPrice, "mark price should match")
+				assert.Equal(t, 100000.25, got.IndexPrice, "index price should match")
+				assert.Equal(t, asset.Options, got.AssetType, "asset should be options")
+				assert.Equal(t, currency.NewPairWithDelimiter("BTC", "USDT-20261225-100000-C", currency.UnderscoreDelimiter), got.Pair, "contract should match")
+			default:
+				require.Fail(t, "options ticker must be emitted")
+			}
+		})
+	}
+}

--- a/exchanges/gateio/gateio_websocket_test.go
+++ b/exchanges/gateio/gateio_websocket_test.go
@@ -228,7 +228,10 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 	subs, err := e.Features.Subscriptions.ExpandTemplates(e)
 	require.NoError(t, err)
 
-	conn := &FixtureConnection{}
+	baseConn, err := e.Websocket.CreateTestConnection(asset.Spot)
+	require.NoError(t, err, "test connection creation must succeed")
+	conn := &FixtureConnection{Connection: baseConn}
+	require.NoError(t, e.Websocket.TrackTestConnection(asset.Spot, conn), "fixture connection registration must succeed")
 	err = e.Websocket.AddSubscriptions(conn, subs...)
 	require.NoError(t, err)
 
@@ -267,4 +270,9 @@ func TestProcessOrderbookUpdateWithSnapshot(t *testing.T) {
 		}
 		require.NoError(t, err)
 	}
+
+	require.Eventually(t, func() bool {
+		sub := e.Websocket.GetSubscription(qualifiedChannelKey{&subscription.Subscription{QualifiedChannel: "ob.BTC_USDT.50"}})
+		return sub != nil && sub.State() == subscription.SubscribedState
+	}, time.Second, 10*time.Millisecond, "out-of-order update must successfully resubscribe in the background")
 }

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -396,6 +396,8 @@ func (e *Exchange) UpdateTicker(ctx context.Context, p currency.Pair, a asset.It
 			tickerData = &ticker.Price{
 				Pair:         tickers[x].Name,
 				Last:         tickers[x].LastPrice.Float64(),
+				MarkPrice:    tickers[x].MarkPrice.Float64(),
+				IndexPrice:   tickers[x].IndexPrice.Float64(),
 				Bid:          tickers[x].Bid1Price.Float64(),
 				Ask:          tickers[x].Ask1Price.Float64(),
 				AskSize:      tickers[x].Ask1Size.Float64(),
@@ -646,6 +648,8 @@ func (e *Exchange) UpdateTickers(ctx context.Context, a asset.Item) error {
 			for x := range tickers {
 				err = ticker.ProcessTicker(&ticker.Price{
 					Last:         tickers[x].LastPrice.Float64(),
+					MarkPrice:    tickers[x].MarkPrice.Float64(),
+					IndexPrice:   tickers[x].IndexPrice.Float64(),
 					Ask:          tickers[x].Ask1Price.Float64(),
 					AskSize:      tickers[x].Ask1Size.Float64(),
 					Bid:          tickers[x].Bid1Price.Float64(),

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -2563,7 +2563,7 @@ func openInterestFromStats(stats []ContractStat) (float64, error) {
 			latest = stats[i]
 		}
 	}
-	return latest.OpenInterestUsd.Float64(), nil
+	return latest.OpenInterestUSD.Float64(), nil
 }
 
 func useOpenInterestStats(keys []key.PairAsset, a asset.Item) bool {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -371,6 +371,8 @@ func (e *Exchange) UpdateTicker(ctx context.Context, p currency.Pair, a asset.It
 			Last:         tickers[0].Last.Float64(),
 			Volume:       tickers[0].Volume24HBase.Float64(),
 			QuoteVolume:  tickers[0].Volume24HQuote.Float64(),
+			MarkPrice:    tickers[0].MarkPrice.Float64(),
+			IndexPrice:   tickers[0].IndexPrice.Float64(),
 			ExchangeName: e.Name,
 			AssetType:    a,
 		}
@@ -617,6 +619,8 @@ func (e *Exchange) UpdateTickers(ctx context.Context, a asset.Item) error {
 				Low:          tickers[i].Low24H.Float64(),
 				Volume:       tickers[i].Volume24H.Float64(),
 				QuoteVolume:  tickers[i].Volume24HQuote.Float64(),
+				MarkPrice:    tickers[i].MarkPrice.Float64(),
+				IndexPrice:   tickers[i].IndexPrice.Float64(),
 				ExchangeName: e.Name,
 				Pair:         currencyPair,
 				AssetType:    a,
@@ -2559,7 +2563,7 @@ func openInterestFromStats(stats []ContractStat) (float64, error) {
 			latest = stats[i]
 		}
 	}
-	return latest.OpenInterest.Float64(), nil
+	return latest.OpenInterestUsd.Float64(), nil
 }
 
 func useOpenInterestStats(keys []key.PairAsset, a asset.Item) bool {

--- a/exchanges/gateio/gateio_wrapper_test.go
+++ b/exchanges/gateio/gateio_wrapper_test.go
@@ -86,16 +86,44 @@ func TestCancelAllOrders(t *testing.T) {
 func TestOpenInterestFromStats(t *testing.T) {
 	t.Parallel()
 
-	_, err := openInterestFromStats(nil)
-	require.ErrorIs(t, err, errNoValidResponseFromServer)
+	for _, tc := range []struct {
+		name   string
+		stats  []ContractStat
+		expect float64
+		errIs  error
+	}{
+		{name: "missing statistics", errIs: errNoValidResponseFromServer},
+		{
+			name: "quote notional instead of contract count",
+			stats: []ContractStat{{
+				Time:            types.Time(time.Unix(100, 0)),
+				OpenInterest:    types.Number(9_999_999),
+				OpenInterestUsd: types.Number(123_456.78),
+			}},
+			expect: 123_456.78,
+		},
+		{
+			name: "latest statistic from unordered response",
+			stats: []ContractStat{
+				{Time: types.Time(time.Unix(100, 0)), OpenInterest: types.Number(2), OpenInterestUsd: types.Number(20)},
+				{Time: types.Time(time.Unix(300, 0)), OpenInterest: types.Number(4), OpenInterestUsd: types.Number(40)},
+				{Time: types.Time(time.Unix(200, 0)), OpenInterest: types.Number(3), OpenInterestUsd: types.Number(30)},
+			},
+			expect: 40,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	openInterest, err := openInterestFromStats([]ContractStat{
-		{Time: types.Time(time.Unix(100, 0)), OpenInterest: types.Number(2)},
-		{Time: types.Time(time.Unix(300, 0)), OpenInterest: types.Number(4)},
-		{Time: types.Time(time.Unix(200, 0)), OpenInterest: types.Number(3)},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 4.0, openInterest)
+			openInterest, err := openInterestFromStats(tc.stats)
+			if tc.errIs != nil {
+				require.ErrorIs(t, err, tc.errIs)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expect, openInterest)
+		})
+	}
 }
 
 func TestUseOpenInterestStats(t *testing.T) {
@@ -122,7 +150,7 @@ func TestGetOpenInterestFromStatsUsesTwoRows(t *testing.T) {
 		limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
 		assert.NoError(t, err, "request limit should be an integer")
 		assert.GreaterOrEqual(t, limit, 2, "request should leave room for a fallback statistics row")
-		_, err = fmt.Fprint(w, `[{"time":1720000000,"open_interest":4},{"time":1710000000,"open_interest":3}]`)
+		_, err = fmt.Fprint(w, `[{"time":1720000000,"open_interest":9999999,"open_interest_usd":123456.78},{"time":1710000000,"open_interest":8888888,"open_interest_usd":100000}]`)
 		assert.NoError(t, err, "writing contract stats should not error")
 	}))
 	t.Cleanup(server.Close)
@@ -133,7 +161,7 @@ func TestGetOpenInterestFromStatsUsesTwoRows(t *testing.T) {
 	pair := currency.Pair{Base: currency.BTC, Quote: currency.USDT, Delimiter: currency.UnderscoreDelimiter}
 	openInterest, err := ex.getOpenInterestFromStats(t.Context(), asset.USDTMarginedFutures, pair)
 	require.NoError(t, err, "getOpenInterestFromStats must not error")
-	assert.Equal(t, 4.0, openInterest, "getOpenInterestFromStats should return the latest open interest")
+	assert.Equal(t, 123_456.78, openInterest, "getOpenInterestFromStats should return the latest quote notional, not contract count")
 }
 
 func TestContractStatUnmarshalLastFundingRate(t *testing.T) {

--- a/exchanges/gateio/gateio_wrapper_test.go
+++ b/exchanges/gateio/gateio_wrapper_test.go
@@ -98,16 +98,16 @@ func TestOpenInterestFromStats(t *testing.T) {
 			stats: []ContractStat{{
 				Time:            types.Time(time.Unix(100, 0)),
 				OpenInterest:    types.Number(9_999_999),
-				OpenInterestUsd: types.Number(123_456.78),
+				OpenInterestUSD: types.Number(123_456.78),
 			}},
 			expect: 123_456.78,
 		},
 		{
 			name: "latest statistic from unordered response",
 			stats: []ContractStat{
-				{Time: types.Time(time.Unix(100, 0)), OpenInterest: types.Number(2), OpenInterestUsd: types.Number(20)},
-				{Time: types.Time(time.Unix(300, 0)), OpenInterest: types.Number(4), OpenInterestUsd: types.Number(40)},
-				{Time: types.Time(time.Unix(200, 0)), OpenInterest: types.Number(3), OpenInterestUsd: types.Number(30)},
+				{Time: types.Time(time.Unix(100, 0)), OpenInterest: types.Number(2), OpenInterestUSD: types.Number(20)},
+				{Time: types.Time(time.Unix(300, 0)), OpenInterest: types.Number(4), OpenInterestUSD: types.Number(40)},
+				{Time: types.Time(time.Unix(200, 0)), OpenInterest: types.Number(3), OpenInterestUSD: types.Number(30)},
 			},
 			expect: 40,
 		},


### PR DESCRIPTION
Adds mark and index prices to Gate.io futures, delivery futures and options tickers over REST and WebSocket, with mocked mapping tests and live API assertions.

Corrects the contract-statistics path in `GetOpenInterest` to return `open_interest_usd` rather than the raw contract count. A regression test checks that the latest statistics entry supplies the USD notional. This does not address the separate existing differences between statistics and contract endpoint calculations.

Fixes the orderbook snapshot test's unregistered WebSocket connection and waits for background resubscription to succeed, so a connection-not-found error can no longer pass silently.