### PR TITLE
fix(websocket): make resubscription recovery retryable

### DIFF
--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -25,217 +25,129 @@ import (
 
 // Public websocket errors
 var (
-	ErrWebsocketNotEnabled = errors.New("websocket not enabled")
-
-	ErrAlreadyDisabled = errors.New("websocket already disabled")
-
+	ErrWebsocketNotEnabled     = errors.New("websocket not enabled")
+	ErrAlreadyDisabled         = errors.New("websocket already disabled")
 	ErrWebsocketAlreadyEnabled = errors.New("websocket already enabled")
-
-	ErrNotConnected = errors.New("websocket is not connected")
-
-	ErrSignatureTimeout = errors.New("websocket timeout waiting for response with signature")
-
-	ErrRequestRouteNotFound = errors.New("request route not found")
-
-	ErrSignatureNotSet = errors.New("signature not set")
+	ErrNotConnected            = errors.New("websocket is not connected")
+	ErrSignatureTimeout        = errors.New("websocket timeout waiting for response with signature")
+	ErrRequestRouteNotFound    = errors.New("request route not found")
+	ErrSignatureNotSet         = errors.New("signature not set")
 )
 
 // Private websocket errors
 var (
-	errWebsocketAlreadyInitialised = errors.New("websocket already initialised")
-
-	errDefaultURLIsEmpty = errors.New("default url is empty")
-
-	errRunningURLIsEmpty = errors.New("running url cannot be empty")
-
-	errInvalidWebsocketURL = errors.New("invalid websocket url")
-
-	errExchangeConfigNameEmpty = errors.New("exchange config name empty")
-
-	errInvalidTrafficTimeout = errors.New("invalid traffic timeout")
-
-	errTrafficAlertNil = errors.New("traffic alert is nil")
-
-	errWebsocketSubscriberUnset = errors.New("websocket subscriber function needs to be set")
-
-	errWebsocketUnsubscriberUnset = errors.New("websocket unsubscriber functionality allowed but unsubscriber function not set")
-
-	errWebsocketConnectorUnset = errors.New("websocket connector function not set")
-
-	errWebsocketDataHandlerUnset = errors.New("websocket data handler not set")
-
-	errReadMessageErrorsNil = errors.New("read message errors is nil")
-
+	errWebsocketAlreadyInitialised          = errors.New("websocket already initialised")
+	errDefaultURLIsEmpty                    = errors.New("default url is empty")
+	errRunningURLIsEmpty                    = errors.New("running url cannot be empty")
+	errInvalidWebsocketURL                  = errors.New("invalid websocket url")
+	errExchangeConfigNameEmpty              = errors.New("exchange config name empty")
+	errInvalidTrafficTimeout                = errors.New("invalid traffic timeout")
+	errTrafficAlertNil                      = errors.New("traffic alert is nil")
+	errWebsocketSubscriberUnset             = errors.New("websocket subscriber function needs to be set")
+	errWebsocketUnsubscriberUnset           = errors.New("websocket unsubscriber functionality allowed but unsubscriber function not set")
+	errWebsocketConnectorUnset              = errors.New("websocket connector function not set")
+	errWebsocketDataHandlerUnset            = errors.New("websocket data handler not set")
+	errReadMessageErrorsNil                 = errors.New("read message errors is nil")
 	errWebsocketSubscriptionsGeneratorUnset = errors.New("websocket subscriptions generator function needs to be set")
-
-	errInvalidMaxSubscriptions = errors.New("max subscriptions cannot be less than 0")
-
-	errSameProxyAddress = errors.New("cannot set proxy address to the same address")
-
-	errNoConnectFunc = errors.New("websocket connect func not set")
-
-	errAlreadyConnected = errors.New("websocket already connected")
-
-	errCannotShutdown = errors.New("websocket cannot shutdown")
-
-	errAlreadyReconnecting = errors.New("websocket in the process of reconnection")
-
-	errConnSetup = errors.New("error in connection setup")
-
-	errNoPendingConnections = errors.New("no pending connections, call SetupNewConnection first")
-
-	errDuplicateConnectionSetup = errors.New("duplicate connection setup")
-
-	errCannotChangeConnectionURL = errors.New("cannot change connection URL when using multi connection management")
-
-	errExchangeConfigEmpty = errors.New("exchange config is empty")
-
-	errCannotObtainOutboundConnection = errors.New("cannot obtain outbound connection")
-
-	errMessageFilterNotComparable = errors.New("message filter is not comparable")
-
-	errFailedToAuthenticate = errors.New("failed to authenticate")
+	errInvalidMaxSubscriptions              = errors.New("max subscriptions cannot be less than 0")
+	errSameProxyAddress                     = errors.New("cannot set proxy address to the same address")
+	errNoConnectFunc                        = errors.New("websocket connect func not set")
+	errAlreadyConnected                     = errors.New("websocket already connected")
+	errCannotShutdown                       = errors.New("websocket cannot shutdown")
+	errAlreadyReconnecting                  = errors.New("websocket in the process of reconnection")
+	errConnSetup                            = errors.New("error in connection setup")
+	errNoPendingConnections                 = errors.New("no pending connections, call SetupNewConnection first")
+	errDuplicateConnectionSetup             = errors.New("duplicate connection setup")
+	errCannotChangeConnectionURL            = errors.New("cannot change connection URL when using multi connection management")
+	errExchangeConfigEmpty                  = errors.New("exchange config is empty")
+	errCannotObtainOutboundConnection       = errors.New("cannot obtain outbound connection")
+	errMessageFilterNotComparable           = errors.New("message filter is not comparable")
+	errFailedToAuthenticate                 = errors.New("failed to authenticate")
 )
 
 // Websocket functionality list and state consts
 const (
 	UnhandledMessage = " - Unhandled websocket message: "
-
-	jobBuffer = 5000
+	jobBuffer        = 5000
 )
 
 const (
 	uninitialisedState uint32 = iota
-
 	disconnectedState
-
 	connectingState
-
 	connectedState
 )
 
 // Manager provides connection and subscription management and routing
 type Manager struct {
-	enabled atomic.Bool
-
-	state atomic.Uint32
-
-	verbose bool
-
-	canUseAuthenticatedEndpoints atomic.Bool
-
-	connectionMonitorRunning atomic.Bool
-
-	trafficTimeout time.Duration
-
-	connectionMonitorDelay time.Duration
-
-	proxyAddr string
-
-	defaultURL string
-
-	defaultURLAuth string
-
-	runningURL string
-
-	runningURLAuth string
-
-	exchangeName string
-
-	features *protocol.Features
-
-	m sync.Mutex
-
-	connectionManagerMu sync.RWMutex
-
-	connections map[Connection]*websocket
-
-	subscriptions *subscription.Store
-
-	resubscriptionsMu sync.Mutex
-
-	resubscriptions map[*subscription.Subscription]*resubscribeTracker
-
-	resubscribePreLockHook func(*subscription.Subscription)
-
-	resubscribeWaiterHook func(*subscription.Subscription)
-
-	connector func() error
-
-	rateLimitDefinitions request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
-
-	Subscriber func(subscription.List) error
-
-	Unsubscriber func(subscription.List) error
-
-	GenerateSubs func() (subscription.List, error)
-
-	useMultiConnectionManagement bool
-
-	DataHandler *stream.Relay
-
-	Match *Match
-
-	ShutdownC chan struct{}
-
-	Wg sync.WaitGroup
-
-	Orderbook buffer.Orderbook
-
-	Trade trade.Trade // Trade is a notifier for trades
-
-	Fills fill.Fills // Fills is a notifier for fills
-
-	TrafficAlert chan struct{}
-
-	ReadMessageErrors chan error
-
-	Conn Connection // Public connection
-
-	AuthConn Connection // Authenticated Private connection
-
-	ExchangeLevelReporter Reporter // Latency reporter
-
+	enabled                       atomic.Bool
+	state                         atomic.Uint32
+	verbose                       bool
+	canUseAuthenticatedEndpoints  atomic.Bool
+	connectionMonitorRunning      atomic.Bool
+	trafficTimeout                time.Duration
+	connectionMonitorDelay        time.Duration
+	proxyAddr                     string
+	defaultURL                    string
+	defaultURLAuth                string
+	runningURL                    string
+	runningURLAuth                string
+	exchangeName                  string
+	features                      *protocol.Features
+	m                             sync.Mutex
+	connectionManagerMu           sync.RWMutex
+	connections                   map[Connection]*websocket
+	subscriptions                 *subscription.Store
+	resubscriptionsMu             sync.Mutex
+	resubscriptions               map[*subscription.Subscription]*resubscribeTracker
+	resubscribePreLockHook        func(*subscription.Subscription)
+	resubscribeWaiterHook         func(*subscription.Subscription)
+	connector                     func() error
+	rateLimitDefinitions          request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
+	Subscriber                    func(subscription.List) error
+	Unsubscriber                  func(subscription.List) error
+	GenerateSubs                  func() (subscription.List, error)
+	useMultiConnectionManagement  bool
+	DataHandler                   *stream.Relay
+	Match                         *Match
+	ShutdownC                     chan struct{}
+	Wg                            sync.WaitGroup
+	Orderbook                     buffer.Orderbook
+	Trade                         trade.Trade // Trade is a notifier for trades
+	Fills                         fill.Fills  // Fills is a notifier for fills
+	TrafficAlert                  chan struct{}
+	ReadMessageErrors             chan error
+	Conn                          Connection // Public connection
+	AuthConn                      Connection // Authenticated Private connection
+	ExchangeLevelReporter         Reporter   // Latency reporter
 	MaxSubscriptionsPerConnection int
 
 	// connectionManager stores all *potential* connections for the exchange, organised within websocket structs.
 	// For example, separate connections can be used for Spot, Margin, and Futures trading. This structure is especially useful
 	// for exchanges that differentiate between trading pairs by using different connection endpoints or protocols for various asset classes.
 	// If an exchange does not require such differentiation, all connections may be managed under a single websocket.
-
 	connectionManager []*websocket
 }
 
 // ManagerSetup defines variables for setting up a websocket manager
 type ManagerSetup struct {
-	ExchangeConfig *config.Exchange
-
-	DefaultURL string
-
-	RunningURL string
-
-	RunningURLAuth string
-
-	Connector func() error
-
-	Subscriber func(subscription.List) error
-
-	Unsubscriber func(subscription.List) error
-
+	ExchangeConfig        *config.Exchange
+	DefaultURL            string
+	RunningURL            string
+	RunningURLAuth        string
+	Connector             func() error
+	Subscriber            func(subscription.List) error
+	Unsubscriber          func(subscription.List) error
 	GenerateSubscriptions func() (subscription.List, error)
-
-	Features *protocol.Features
-
+	Features              *protocol.Features
 	OrderbookBufferConfig buffer.Config
 
 	// UseMultiConnectionManagement allows the connections to be managed by the
 	// connection manager. If false, this will default to the global fields
 	// provided in this struct.
-
 	UseMultiConnectionManagement bool
 
 	TradeFeed bool
-
 	FillsFeed bool
 
 	MaxWebsocketSubscriptionsPerConnection int
@@ -245,7 +157,6 @@ type ManagerSetup struct {
 	// If no connection-specific rate limit is provided and the endpoint does not match any of these definitions,
 	// an error will be returned. However, if a connection configuration includes its own rate limit,
 	// it will fall back to that configuration’s rate limit without raising an error.
-
 	RateLimitDefinitions request.RateLimitDefinitions
 }
 
@@ -253,11 +164,9 @@ type ManagerSetup struct {
 // knows of all subscriptions for each connection. Each connection will have its own subscription
 // store to track subscriptions made on that specific connection.
 type websocket struct {
-	setup *ConnectionSetup
-
+	setup         *ConnectionSetup
 	subscriptions *subscription.Store
-
-	connections []Connection
+	connections   []Connection
 }
 
 var globalReporter Reporter
@@ -271,30 +180,20 @@ func SetupGlobalReporter(r Reporter) {
 // NewManager initialises the websocket struct
 func NewManager() *Manager {
 	return &Manager{
-		DataHandler: stream.NewRelay(jobBuffer),
-
-		ShutdownC: make(chan struct{}),
-
+		DataHandler:  stream.NewRelay(jobBuffer),
+		ShutdownC:    make(chan struct{}),
 		TrafficAlert: make(chan struct{}, 1),
-
 		// ReadMessageErrors is buffered for an edge case when `Connect` fails
 		// after subscriptions are made but before the connectionMonitor has
 		// started. This allows the error to be read and handled in the
 		// connectionMonitor and start a connection cycle again.
-
 		ReadMessageErrors: make(chan error, 1),
-
-		Match: NewMatch(),
-
-		subscriptions: subscription.NewStore(),
-
-		features: &protocol.Features{},
-
-		Orderbook: buffer.Orderbook{},
-
-		connections: make(map[Connection]*websocket),
-
-		resubscriptions: make(map[*subscription.Subscription]*resubscribeTracker),
+		Match:             NewMatch(),
+		subscriptions:     subscription.NewStore(),
+		features:          &protocol.Features{},
+		Orderbook:         buffer.Orderbook{},
+		connections:       make(map[Connection]*websocket),
+		resubscriptions:   make(map[*subscription.Subscription]*resubscribeTracker),
 	}
 }
 
@@ -303,21 +202,17 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	if err := common.NilGuard(m, s); err != nil {
 		return err
 	}
-
 	if s.ExchangeConfig == nil {
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig", common.ErrNilPointer)
 	}
-
 	if s.ExchangeConfig.Features == nil {
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig.Features", common.ErrNilPointer)
 	}
-
 	if s.Features == nil {
 		return fmt.Errorf("%w: ManagerSetup.Features", common.ErrNilPointer)
 	}
 
 	m.m.Lock()
-
 	defer m.m.Unlock()
 
 	if m.IsInitialised() {
@@ -327,9 +222,7 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	if s.ExchangeConfig.Name == "" {
 		return errExchangeConfigNameEmpty
 	}
-
 	m.exchangeName = s.ExchangeConfig.Name
-
 	m.verbose = s.ExchangeConfig.Verbose
 
 	m.features = s.Features
@@ -341,39 +234,29 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	if !m.useMultiConnectionManagement {
 		// TODO: Remove this block when all exchanges are updated and backwards
 		// compatibility is no longer required.
-
 		if s.Connector == nil {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
 		}
-
 		if s.Subscriber == nil {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
 		}
-
 		if s.Unsubscriber == nil && m.features.Unsubscribe {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
 		}
-
 		if s.GenerateSubscriptions == nil {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
 		}
-
 		if s.DefaultURL == "" {
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errDefaultURLIsEmpty)
 		}
-
 		m.defaultURL = s.DefaultURL
-
 		if s.RunningURL == "" {
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errRunningURLIsEmpty)
 		}
 
 		m.connector = s.Connector
-
 		m.Subscriber = s.Subscriber
-
 		m.Unsubscriber = s.Unsubscriber
-
 		m.GenerateSubs = s.GenerateSubscriptions
 
 		err := m.SetWebsocketURL(s.RunningURL, false, false)
@@ -390,21 +273,16 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	}
 
 	m.connectionMonitorDelay = s.ExchangeConfig.ConnectionMonitorDelay
-
 	if m.connectionMonitorDelay <= 0 {
 		m.connectionMonitorDelay = config.DefaultConnectionMonitorDelay
 	}
 
 	if s.ExchangeConfig.WebsocketTrafficTimeout < time.Second {
 		return fmt.Errorf("%s %w cannot be less than %s",
-
 			m.exchangeName,
-
 			errInvalidTrafficTimeout,
-
 			time.Second)
 	}
-
 	m.trafficTimeout = s.ExchangeConfig.WebsocketTrafficTimeout
 
 	m.SetCanUseAuthenticatedEndpoints(s.ExchangeConfig.API.AuthenticatedWebsocketSupport)
@@ -414,19 +292,15 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	}
 
 	m.Trade.Setup(s.TradeFeed, m.DataHandler)
-
 	m.Fills.Setup(s.FillsFeed, m.DataHandler)
 
 	if s.MaxWebsocketSubscriptionsPerConnection < 0 {
 		return fmt.Errorf("%s %w", m.exchangeName, errInvalidMaxSubscriptions)
 	}
-
 	m.MaxSubscriptionsPerConnection = s.MaxWebsocketSubscriptionsPerConnection
-
 	m.setState(disconnectedState)
 
 	m.rateLimitDefinitions = s.RateLimitDefinitions
-
 	return nil
 }
 
@@ -437,7 +311,6 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 	}
 
 	m.m.Lock()
-
 	defer m.m.Unlock()
 
 	if c.ResponseCheckTimeout == 0 && c.ResponseMaxLimit == 0 && c.RateLimit == nil && c.URL == "" && c.ConnectionLevelReporter == nil {
@@ -447,19 +320,15 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 	if m.exchangeName == "" {
 		return fmt.Errorf("%w: %w", errConnSetup, errExchangeConfigNameEmpty)
 	}
-
 	if m.TrafficAlert == nil {
 		return fmt.Errorf("%w: %w", errConnSetup, errTrafficAlertNil)
 	}
-
 	if m.ReadMessageErrors == nil {
 		return fmt.Errorf("%w: %w", errConnSetup, errReadMessageErrorsNil)
 	}
-
 	if c.ConnectionLevelReporter == nil {
 		c.ConnectionLevelReporter = m.ExchangeLevelReporter
 	}
-
 	if c.ConnectionLevelReporter == nil {
 		c.ConnectionLevelReporter = globalReporter
 	}
@@ -467,27 +336,21 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 	if m.useMultiConnectionManagement {
 		// The connection and supporting functions are defined per connection and the connection websocket is stored in
 		// the connection manager.
-
 		if c.URL == "" {
 			return fmt.Errorf("%w: %w", errConnSetup, errDefaultURLIsEmpty)
 		}
-
 		if c.Connector == nil {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
 		}
-
 		if c.GenerateSubscriptions == nil && !c.SubscriptionsNotRequired {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
 		}
-
 		if c.Subscriber == nil && !c.SubscriptionsNotRequired {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
 		}
-
 		if c.Unsubscriber == nil && m.features.Unsubscribe && !c.SubscriptionsNotRequired {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
 		}
-
 		if c.Handler == nil {
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketDataHandlerUnset)
 		}
@@ -497,21 +360,16 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 		}
 
 		m.connectionManagerMu.Lock()
-
 		defer m.connectionManagerMu.Unlock()
-
 		for x := range m.connectionManager {
 			// Below allows for multiple connections to the same URL with different outbound request signatures. This
 			// allows for easier determination of inbound and outbound messages. e.g. Gateio cross_margin, margin on
 			// a spot connection.
-
 			if m.connectionManager[x].setup.URL == c.URL && c.MessageFilter == m.connectionManager[x].setup.MessageFilter {
 				return fmt.Errorf("%w: %w", errConnSetup, errDuplicateConnectionSetup)
 			}
 		}
-
 		m.connectionManager = append(m.connectionManager, &websocket{setup: c, subscriptions: subscription.NewStore()})
-
 		return nil
 	}
 
@@ -528,62 +386,40 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 // configuration. This is used for setting up new connections on the fly.
 func (m *Manager) createConnectionFromSetup(c *ConnectionSetup) *connection {
 	connectionURL := m.GetWebsocketURL()
-
 	if c.URL != "" {
 		connectionURL = c.URL
 	}
-
 	match := m.Match
-
 	if m.useMultiConnectionManagement {
 		// If we are using multi connection management, we can decouple
 		// the match from the global match and have a match per connection.
-
 		match = NewMatch()
 	}
-
 	rateLimit := c.RateLimit
-
 	if c.ConnectionRateLimiter != nil {
 		rateLimit = c.ConnectionRateLimiter()
 	}
-
 	return &connection{
-		ExchangeName: m.exchangeName,
-
-		URL: connectionURL,
-
-		ProxyURL: m.GetProxyAddress(),
-
-		Verbose: m.verbose,
-
-		ResponseMaxLimit: c.ResponseMaxLimit,
-
-		Traffic: m.TrafficAlert,
-
-		readMessageErrors: m.ReadMessageErrors,
-
-		shutdown: m.ShutdownC,
-
-		Wg: &m.Wg,
-
-		Match: match,
-
-		RateLimit: rateLimit,
-
-		Reporter: c.ConnectionLevelReporter,
-
+		ExchangeName:         m.exchangeName,
+		URL:                  connectionURL,
+		ProxyURL:             m.GetProxyAddress(),
+		Verbose:              m.verbose,
+		ResponseMaxLimit:     c.ResponseMaxLimit,
+		Traffic:              m.TrafficAlert,
+		readMessageErrors:    m.ReadMessageErrors,
+		shutdown:             m.ShutdownC,
+		Wg:                   &m.Wg,
+		Match:                match,
+		RateLimit:            rateLimit,
+		Reporter:             c.ConnectionLevelReporter,
 		RateLimitDefinitions: m.rateLimitDefinitions,
-
-		subscriptions: subscription.NewStore(),
+		subscriptions:        subscription.NewStore(),
 	}
 }
 
 func (m *Manager) snapshotConnectionManager() []*websocket {
 	m.connectionManagerMu.RLock()
-
 	defer m.connectionManagerMu.RUnlock()
-
 	return slices.Clone(m.connectionManager)
 }
 
@@ -593,31 +429,23 @@ func (m *Manager) snapshotManagedConnections(ws *websocket) []Connection {
 	}
 
 	m.connectionManagerMu.RLock()
-
 	defer m.connectionManagerMu.RUnlock()
-
 	return slices.Clone(ws.connections)
 }
 
 func (m *Manager) trackConnection(conn Connection, ws *websocket) {
 	m.connectionManagerMu.Lock()
-
 	defer m.connectionManagerMu.Unlock()
-
 	if m.connections == nil {
 		m.connections = make(map[Connection]*websocket)
 	}
-
 	if existing, ok := m.connections[conn]; ok {
 		if existing == ws {
 			return
 		}
-
 		panic("trackConnection called with connection already associated with a different websocket")
 	}
-
 	m.connections[conn] = ws
-
 	if !slices.Contains(ws.connections, conn) {
 		ws.connections = append(ws.connections, conn)
 	}
@@ -627,9 +455,7 @@ func (m *Manager) trackConnection(conn Connection, ws *websocket) {
 // function
 func (m *Manager) Connect(ctx context.Context) error {
 	m.m.Lock()
-
 	defer m.m.Unlock()
-
 	return m.connect(ctx)
 }
 
@@ -637,11 +463,9 @@ func (m *Manager) connect(ctx context.Context) error {
 	if !m.IsEnabled() {
 		return ErrWebsocketNotEnabled
 	}
-
 	if m.IsConnecting() {
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyReconnecting)
 	}
-
 	if m.IsConnected() {
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyConnected)
 	}
@@ -649,32 +473,26 @@ func (m *Manager) connect(ctx context.Context) error {
 	if m.subscriptions == nil {
 		return fmt.Errorf("%w: subscriptions", common.ErrNilPointer)
 	}
-
 	m.subscriptions.Clear()
 
 	m.setState(connectingState)
 
 	m.Wg.Add(1)
-
 	go m.monitorFrame(ctx, &m.Wg, m.monitorTraffic)
 
 	if !m.useMultiConnectionManagement {
 		if m.connector == nil {
 			return fmt.Errorf("%v %w", m.exchangeName, errNoConnectFunc)
 		}
-
 		err := m.connector()
 		if err != nil {
 			m.setState(disconnectedState)
-
 			return fmt.Errorf("%v Error connecting %w", m.exchangeName, err)
 		}
-
 		m.setState(connectedState)
 
 		if m.connectionMonitorRunning.CompareAndSwap(false, true) {
 			// This oversees all connections and does not need to be part of wait group management.
-
 			go m.monitorFrame(ctx, nil, m.monitorConnection)
 		}
 
@@ -682,7 +500,6 @@ func (m *Manager) connect(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
 		}
-
 		if len(subs) != 0 {
 			if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
 				return err
@@ -692,15 +509,12 @@ func (m *Manager) connect(ctx context.Context) error {
 				return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
 			}
 		}
-
 		return nil
 	}
 
 	connectionManager := m.snapshotConnectionManager()
-
 	if len(connectionManager) == 0 {
 		m.setState(disconnectedState)
-
 		return fmt.Errorf("cannot connect: %w", errNoPendingConnections)
 	}
 
@@ -712,83 +526,64 @@ func (m *Manager) connect(ctx context.Context) error {
 	var subscriptionError error
 
 	// TODO: Implement concurrency below.
-
 	for i, ws := range connectionManager {
 		var subs subscription.List
-
 		if !ws.setup.SubscriptionsNotRequired {
 			if ws.setup.GenerateSubscriptions == nil {
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriptionsGeneratorUnset)
-
 				break
 			}
 
 			var err error
-
 			subs, err = ws.setup.GenerateSubscriptions() // regenerate state on new connection
 			if err != nil {
 				multiConnectFatalError = fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
-
 				break
 			}
 
 			if len(subs) == 0 {
 				// If no subscriptions are generated, we skip this connection.
-
 				if m.verbose {
 					log.Debugf(log.WebsocketMgr, "%s websocket: no subscriptions generated for [conn:%d] [URL:%s], skipping", m.exchangeName, i+1, ws.setup.URL)
 				}
-
 				continue
 			}
 		}
 
 		if ws.setup.Connector == nil {
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errNoConnectFunc)
-
 			break
 		}
-
 		if ws.setup.Handler == nil {
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketDataHandlerUnset)
-
 			break
 		}
-
 		if ws.setup.Subscriber == nil && !ws.setup.SubscriptionsNotRequired {
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriberUnset)
-
 			break
 		}
 
 		if ws.setup.SubscriptionsNotRequired && len(subs) == 0 {
 			if err := m.createConnectAndSubscribe(ctx, ws, nil); err != nil {
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
-
 				break
 			}
-
 			if m.verbose {
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected", m.exchangeName, ws.setup.URL)
 			}
-
 			continue
 		}
 
 		// Pre-pass: absorb trackable logical subscriptions onto already-managed connections before batching/capacity routing to avoid misplacement.
-
 		remainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
 		if err != nil {
 			subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
-
 			continue
 		}
-
 		if len(remainingSubs) == 0 {
 			if m.verbose {
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(subs))
 			}
-
 			continue
 		}
 
@@ -796,30 +591,22 @@ func (m *Manager) connect(ctx context.Context) error {
 			batchRemainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batchCandidates)
 			if err != nil {
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
-
 				continue
 			}
-
 			if len(batchRemainingSubs) == 0 {
 				if m.verbose {
 					log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchCandidates))
 				}
-
 				continue
 			}
-
 			if err := m.createConnectAndSubscribe(ctx, ws, batchRemainingSubs); err != nil {
 				if errors.Is(err, common.ErrFatal) {
 					multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
-
 					break
 				}
-
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
-
 				continue
 			}
-
 			if m.verbose {
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected. [Total Subs: %d] [Subscribed: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchRemainingSubs))
 			}
@@ -832,35 +619,25 @@ func (m *Manager) connect(ctx context.Context) error {
 
 	if multiConnectFatalError != nil {
 		// Roll back any successful connections and flush subscriptions
-
 		connectionManager = m.snapshotConnectionManager()
-
 		m.connectionManagerMu.Lock()
-
 		for _, ws := range connectionManager {
 			for _, conn := range ws.connections {
 				if err := conn.Shutdown(); err != nil {
 					log.Errorln(log.WebsocketMgr, err)
 				}
-
 				conn.Subscriptions().Clear()
 			}
-
 			ws.connections = nil
-
 			ws.subscriptions.Clear()
 		}
-
 		clear(m.connections)
-
 		m.connectionManagerMu.Unlock()
-
 		m.setState(disconnectedState) // Flip from connecting to disconnected.
 
 		// Drain residual error in the single buffered channel, this mitigates
 		// the cycle when `Connect` is called again and the connectionMonitor
 		// starts but there is an old error in the channel.
-
 		drain(m.ReadMessageErrors)
 
 		return multiConnectFatalError
@@ -869,12 +646,10 @@ func (m *Manager) connect(ctx context.Context) error {
 	// Assume connected state here. All connections have been established.
 	// All subscriptions have been sent and stored. All data received is being
 	// handled by the appropriate data handler.
-
 	m.setState(connectedState)
 
 	if m.connectionMonitorRunning.CompareAndSwap(false, true) {
 		// This oversees all connections and does not need to be part of wait group management.
-
 		go m.monitorFrame(ctx, nil, m.monitorConnection)
 	}
 
@@ -899,7 +674,6 @@ func (m *Manager) createConnectAndSubscribe(ctx context.Context, ws *websocket, 
 	m.trackConnection(conn, ws)
 
 	m.Wg.Add(1)
-
 	go m.Reader(ctx, conn, ws.setup.Handler)
 
 	if ws.setup.Authenticate != nil && m.CanUseAuthenticatedEndpoints() {
@@ -912,23 +686,19 @@ func (m *Manager) createConnectAndSubscribe(ctx context.Context, ws *websocket, 
 		if len(subs) != 0 {
 			return fmt.Errorf("%w %w: subscriptions were provided but not required", common.ErrFatal, ErrSubscriptionFailure)
 		}
-
 		return nil
 	}
 
 	if err := ws.setup.Subscriber(ctx, conn, subs); err != nil {
 		return fmt.Errorf("%w: %w", ErrSubscriptionFailure, err)
 	}
-
 	if missing := ws.subscriptions.Missing(subs); len(missing) > 0 {
 		return fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
 	}
 
 	connSubsStore := conn.Subscriptions()
-
 	for _, sub := range ws.subscriptions.Contained(subs) {
 		// Store subscription against this specific connection for tracking
-
 		if err := connSubsStore.Add(sub); err != nil {
 			return fmt.Errorf("%w: adding subscriptions to the specific connection subscription store: %w", ErrSubscriptionFailure, err)
 		}
@@ -945,7 +715,6 @@ func (m *Manager) Disable() error {
 	}
 
 	m.setEnabled(false)
-
 	return nil
 }
 
@@ -956,7 +725,6 @@ func (m *Manager) Enable(ctx context.Context) error {
 	}
 
 	m.setEnabled(true)
-
 	return m.Connect(ctx)
 }
 
@@ -964,9 +732,7 @@ func (m *Manager) Enable(ctx context.Context) error {
 // by using a package defined shutdown function
 func (m *Manager) Shutdown() error {
 	m.m.Lock()
-
 	defer m.m.Unlock()
-
 	return m.shutdown()
 }
 
@@ -993,29 +759,20 @@ func (m *Manager) shutdown() error {
 	var nonFatalCloseConnectionErrors error
 
 	// Shutdown managed connections
-
 	m.connectionManagerMu.Lock()
-
 	for _, ws := range m.connectionManager {
 		for _, conn := range ws.connections {
 			if err := conn.Shutdown(); err != nil {
 				nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
 			}
-
 			conn.Subscriptions().Clear()
 		}
-
 		ws.connections = nil
-
 		// Flush any subscriptions from last connection across any managed connections
-
 		ws.subscriptions.Clear()
 	}
-
 	// Clean map of old connections
-
 	clear(m.connections)
-
 	m.connectionManagerMu.Unlock()
 
 	if m.Conn != nil {
@@ -1023,36 +780,27 @@ func (m *Manager) shutdown() error {
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
 		}
 	}
-
 	if m.AuthConn != nil {
 		if err := m.AuthConn.Shutdown(); err != nil {
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
 		}
 	}
-
 	// flush any subscriptions from last connection if needed
-
 	m.subscriptions.Clear()
 
 	close(m.ShutdownC)
-
 	m.setState(disconnectedState)
-
 	m.Wg.Wait()
-
 	m.ShutdownC = make(chan struct{})
 
 	for _, conn := range []Connection{m.Conn, m.AuthConn} {
 		if conn == nil {
 			continue
 		}
-
 		conn, ok := conn.(*connection)
-
 		if !ok {
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.GetTypeAssertError("*connection", conn))
 		}
-
 		conn.shutdown = m.ShutdownC
 	}
 
@@ -1063,7 +811,6 @@ func (m *Manager) shutdown() error {
 	// Drain residual error in the single buffered channel, this mitigates
 	// the cycle when `Connect` is called again and the connectionMonitor
 	// starts but there is an old error in the channel.
-
 	drain(m.ReadMessageErrors)
 
 	if nonFatalCloseConnectionErrors != nil {
@@ -1108,10 +855,8 @@ func (m *Manager) CanUseAuthenticatedWebsocketForWrapper() bool {
 		if m.CanUseAuthenticatedEndpoints() {
 			return true
 		}
-
 		log.Infof(log.WebsocketMgr, "%v - Websocket not authenticated, using REST\n", m.exchangeName)
 	}
-
 	return false
 }
 
@@ -1119,12 +864,9 @@ func (m *Manager) CanUseAuthenticatedWebsocketForWrapper() bool {
 func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
 	if m.useMultiConnectionManagement {
 		// TODO: Add functionality for multi-connection management to change URL
-
 		return fmt.Errorf("%s: %w", m.exchangeName, errCannotChangeConnectionURL)
 	}
-
 	defaultVals := u == "" || u == config.WebsocketURLNonDefaultMessage
-
 	if auth {
 		if defaultVals {
 			u = m.defaultURLAuth
@@ -1134,7 +876,6 @@ func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
 		if err != nil {
 			return err
 		}
-
 		m.runningURLAuth = u
 
 		if m.verbose {
@@ -1153,7 +894,6 @@ func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
 		if err != nil {
 			return err
 		}
-
 		m.runningURL = u
 
 		if m.verbose {
@@ -1167,7 +907,6 @@ func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
 
 	if m.IsConnected() && reconnect {
 		log.Debugf(log.WebsocketMgr, "%s websocket: flushing websocket connection to %s\n", m.exchangeName, u)
-
 		return m.Shutdown()
 	}
 
@@ -1186,52 +925,39 @@ func (m *Manager) GetConfiguredWebsocketURLs() ([]string, error) {
 	}
 
 	m.m.Lock()
-
 	defer m.m.Unlock()
 
 	if m.useMultiConnectionManagement {
 		m.connectionManagerMu.RLock()
-
 		defer m.connectionManagerMu.RUnlock()
-
 		urls := make([]string, 0, len(m.connectionManager))
-
 		seen := make(map[string]struct{}, len(m.connectionManager))
-
 		for _, ws := range m.connectionManager {
 			if ws == nil || ws.setup.URL == "" {
 				continue
 			}
-
 			if _, ok := seen[ws.setup.URL]; ok {
 				continue
 			}
-
 			seen[ws.setup.URL] = struct{}{}
-
 			urls = append(urls, ws.setup.URL)
 		}
-
 		return urls, nil
 	}
 
 	if m.runningURL != "" {
 		return []string{m.runningURL}, nil
 	}
-
 	if m.defaultURL != "" {
 		return []string{m.defaultURL}, nil
 	}
-
 	return nil, nil
 }
 
 // SetProxyAddress sets websocket proxy address
 func (m *Manager) SetProxyAddress(ctx context.Context, proxyAddr string) error {
 	m.m.Lock()
-
 	defer m.m.Unlock()
-
 	if proxyAddr != "" {
 		if _, err := url.ParseRequestURI(proxyAddr); err != nil {
 			return fmt.Errorf("%v websocket: cannot set proxy address: %w", m.exchangeName, err)
@@ -1247,19 +973,15 @@ func (m *Manager) SetProxyAddress(ctx context.Context, proxyAddr string) error {
 	}
 
 	m.connectionManagerMu.RLock()
-
 	for _, ws := range m.connectionManager {
 		for _, conn := range ws.connections {
 			conn.SetProxy(proxyAddr)
 		}
 	}
-
 	m.connectionManagerMu.RUnlock()
-
 	if m.Conn != nil {
 		m.Conn.SetProxy(proxyAddr)
 	}
-
 	if m.AuthConn != nil {
 		m.AuthConn.SetProxy(proxyAddr)
 	}
@@ -1269,11 +991,9 @@ func (m *Manager) SetProxyAddress(ctx context.Context, proxyAddr string) error {
 	if !m.IsConnected() {
 		return nil
 	}
-
 	if err := m.shutdown(); err != nil {
 		return err
 	}
-
 	return m.connect(ctx)
 }
 
@@ -1303,7 +1023,6 @@ func checkWebsocketURL(s string) error {
 	if err != nil {
 		return err
 	}
-
 	if u.Scheme != "ws" && u.Scheme != "wss" {
 		return fmt.Errorf("cannot set %w %s", errInvalidWebsocketURL, s)
 	}
@@ -1314,17 +1033,13 @@ func checkWebsocketURL(s string) error {
 // Reader reads and handles data from a specific connection
 func (m *Manager) Reader(ctx context.Context, conn Connection, handler func(ctx context.Context, conn Connection, message []byte) error) {
 	defer m.Wg.Done()
-
 	for {
 		resp := conn.ReadMessage()
-
 		if resp.Raw == nil {
 			return // Connection has been closed
 		}
-
 		if err := handler(ctx, conn, resp.Raw); err != nil {
 			err = fmt.Errorf("connection URL:[%v] error: %w", conn.GetURL(), err)
-
 			if errSend := m.DataHandler.Send(ctx, err); errSend != nil {
 				log.Errorf(log.WebsocketMgr, "%s: %s %s", m.exchangeName, errSend, err)
 			}
@@ -1336,9 +1051,7 @@ func drain(ch <-chan error) {
 	for {
 		select {
 		case <-ch:
-
 		default:
-
 			return
 		}
 	}
@@ -1354,9 +1067,7 @@ func (m *Manager) monitorFrame(ctx context.Context, wg *sync.WaitGroup, fn Closu
 	if wg != nil {
 		defer wg.Done()
 	}
-
 	observe := fn(ctx)
-
 	for {
 		if observe() {
 			return
@@ -1367,7 +1078,6 @@ func (m *Manager) monitorFrame(ctx context.Context, wg *sync.WaitGroup, fn Closu
 // monitorConnection monitors the connection and attempts to reconnect if the connection is lost
 func (m *Manager) monitorConnection(ctx context.Context) func() bool {
 	timer := time.NewTimer(m.connectionMonitorDelay)
-
 	return func() bool { return m.observeConnection(ctx, timer) }
 }
 
@@ -1375,10 +1085,8 @@ func (m *Manager) monitorConnection(ctx context.Context) func() bool {
 func (m *Manager) observeConnection(ctx context.Context, t *time.Timer) (exit bool) {
 	select {
 	case err := <-m.ReadMessageErrors:
-
 		if errors.Is(err, errConnectionFault) {
 			log.Warnf(log.WebsocketMgr, "%v websocket has been disconnected. Reason: %v", m.exchangeName, err)
-
 			if m.IsConnected() {
 				if shutdownErr := m.Shutdown(); shutdownErr != nil {
 					log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor shutdown err: %s", m.exchangeName, shutdownErr)
@@ -1387,57 +1095,43 @@ func (m *Manager) observeConnection(ctx context.Context, t *time.Timer) (exit bo
 				m.state.CompareAndSwap(connectingState, disconnectedState)
 			}
 		}
-
 		// Speedier reconnection, instead of waiting for the next cycle.
-
 		if m.IsEnabled() && (!m.IsConnected() && !m.IsConnecting()) {
 			if connectErr := m.Connect(ctx); connectErr != nil {
 				log.Errorln(log.WebsocketMgr, connectErr)
 			}
 		}
-
 		if err := m.DataHandler.Send(ctx, err); err != nil {
 			log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor data handler err: %s", m.exchangeName, err)
 		}
-
 	case <-t.C:
-
 		if m.verbose {
 			log.Debugf(log.WebsocketMgr, "%v websocket: running connection monitor cycle", m.exchangeName)
 		}
-
 		if !m.IsEnabled() {
 			if m.verbose {
 				log.Debugf(log.WebsocketMgr, "%v websocket: connectionMonitor - websocket disabled, shutting down", m.exchangeName)
 			}
-
 			if m.IsConnected() {
 				if err := m.Shutdown(); err != nil {
 					log.Errorln(log.WebsocketMgr, err)
 				}
 			}
-
 			if m.verbose {
 				log.Debugf(log.WebsocketMgr, "%v websocket: connection monitor exiting", m.exchangeName)
 			}
-
 			t.Stop()
-
 			m.connectionMonitorRunning.Store(false)
-
 			return true
 		}
-
 		if !m.IsConnecting() && !m.IsConnected() {
 			err := m.Connect(ctx)
 			if err != nil {
 				log.Errorln(log.WebsocketMgr, err)
 			}
 		}
-
 		t.Reset(m.connectionMonitorDelay)
 	}
-
 	return false
 }
 
@@ -1458,26 +1152,20 @@ func (m *Manager) monitorTraffic(context.Context) func() bool {
 func (m *Manager) observeTraffic(timeout <-chan time.Time, onTimeout func()) bool {
 	select {
 	case <-m.ShutdownC:
-
 		if m.verbose {
 			log.Debugf(log.WebsocketMgr, "%v websocket: trafficMonitor shutdown message received", m.exchangeName)
 		}
-
 	case <-timeout:
-
 		if m.IsConnecting() || signalReceived(m.TrafficAlert) {
 			return false
 		}
-
 		if m.verbose {
 			log.Warnf(log.WebsocketMgr, "%v websocket: has not received a traffic alert in %v. Reconnecting", m.exchangeName, m.trafficTimeout)
 		}
-
 		if m.IsConnected() && onTimeout != nil {
 			onTimeout()
 		}
 	}
-
 	return true
 }
 
@@ -1485,11 +1173,8 @@ func (m *Manager) observeTraffic(timeout <-chan time.Time, onTimeout func()) boo
 func signalReceived(ch chan struct{}) bool {
 	select {
 	case <-ch:
-
 		return true
-
 	default:
-
 		return false
 	}
 }
@@ -1500,13 +1185,11 @@ func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
 	if err := common.NilGuard(m); err != nil {
 		return nil, err
 	}
-
 	if messageFilter == nil {
 		return nil, fmt.Errorf("%w: messageFilter", common.ErrNilPointer)
 	}
 
 	m.m.Lock()
-
 	defer m.m.Unlock()
 
 	if !m.useMultiConnectionManagement {
@@ -1518,18 +1201,14 @@ func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
 	}
 
 	m.connectionManagerMu.RLock()
-
 	defer m.connectionManagerMu.RUnlock()
-
 	for _, ws := range m.connectionManager {
 		if ws.setup.MessageFilter != messageFilter {
 			continue
 		}
-
 		if len(ws.connections) == 0 {
 			return nil, fmt.Errorf("%s: %s %w associated with message filter: '%v'", m.exchangeName, ws.setup.URL, ErrNotConnected, messageFilter)
 		}
-
 		return ws.connections[0], nil
 	}
 

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -24,204 +24,352 @@ import (
 )
 
 // Public websocket errors
+
 var (
-	ErrWebsocketNotEnabled     = errors.New("websocket not enabled")
-	ErrAlreadyDisabled         = errors.New("websocket already disabled")
+	ErrWebsocketNotEnabled = errors.New("websocket not enabled")
+
+	ErrAlreadyDisabled = errors.New("websocket already disabled")
+
 	ErrWebsocketAlreadyEnabled = errors.New("websocket already enabled")
-	ErrNotConnected            = errors.New("websocket is not connected")
-	ErrSignatureTimeout        = errors.New("websocket timeout waiting for response with signature")
-	ErrRequestRouteNotFound    = errors.New("request route not found")
-	ErrSignatureNotSet         = errors.New("signature not set")
+
+	ErrNotConnected = errors.New("websocket is not connected")
+
+	ErrSignatureTimeout = errors.New("websocket timeout waiting for response with signature")
+
+	ErrRequestRouteNotFound = errors.New("request route not found")
+
+	ErrSignatureNotSet = errors.New("signature not set")
 )
 
 // Private websocket errors
+
 var (
-	errWebsocketAlreadyInitialised          = errors.New("websocket already initialised")
-	errDefaultURLIsEmpty                    = errors.New("default url is empty")
-	errRunningURLIsEmpty                    = errors.New("running url cannot be empty")
-	errInvalidWebsocketURL                  = errors.New("invalid websocket url")
-	errExchangeConfigNameEmpty              = errors.New("exchange config name empty")
-	errInvalidTrafficTimeout                = errors.New("invalid traffic timeout")
-	errTrafficAlertNil                      = errors.New("traffic alert is nil")
-	errWebsocketSubscriberUnset             = errors.New("websocket subscriber function needs to be set")
-	errWebsocketUnsubscriberUnset           = errors.New("websocket unsubscriber functionality allowed but unsubscriber function not set")
-	errWebsocketConnectorUnset              = errors.New("websocket connector function not set")
-	errWebsocketDataHandlerUnset            = errors.New("websocket data handler not set")
-	errReadMessageErrorsNil                 = errors.New("read message errors is nil")
+	errWebsocketAlreadyInitialised = errors.New("websocket already initialised")
+
+	errDefaultURLIsEmpty = errors.New("default url is empty")
+
+	errRunningURLIsEmpty = errors.New("running url cannot be empty")
+
+	errInvalidWebsocketURL = errors.New("invalid websocket url")
+
+	errExchangeConfigNameEmpty = errors.New("exchange config name empty")
+
+	errInvalidTrafficTimeout = errors.New("invalid traffic timeout")
+
+	errTrafficAlertNil = errors.New("traffic alert is nil")
+
+	errWebsocketSubscriberUnset = errors.New("websocket subscriber function needs to be set")
+
+	errWebsocketUnsubscriberUnset = errors.New("websocket unsubscriber functionality allowed but unsubscriber function not set")
+
+	errWebsocketConnectorUnset = errors.New("websocket connector function not set")
+
+	errWebsocketDataHandlerUnset = errors.New("websocket data handler not set")
+
+	errReadMessageErrorsNil = errors.New("read message errors is nil")
+
 	errWebsocketSubscriptionsGeneratorUnset = errors.New("websocket subscriptions generator function needs to be set")
-	errInvalidMaxSubscriptions              = errors.New("max subscriptions cannot be less than 0")
-	errSameProxyAddress                     = errors.New("cannot set proxy address to the same address")
-	errNoConnectFunc                        = errors.New("websocket connect func not set")
-	errAlreadyConnected                     = errors.New("websocket already connected")
-	errCannotShutdown                       = errors.New("websocket cannot shutdown")
-	errAlreadyReconnecting                  = errors.New("websocket in the process of reconnection")
-	errConnSetup                            = errors.New("error in connection setup")
-	errNoPendingConnections                 = errors.New("no pending connections, call SetupNewConnection first")
-	errDuplicateConnectionSetup             = errors.New("duplicate connection setup")
-	errCannotChangeConnectionURL            = errors.New("cannot change connection URL when using multi connection management")
-	errExchangeConfigEmpty                  = errors.New("exchange config is empty")
-	errCannotObtainOutboundConnection       = errors.New("cannot obtain outbound connection")
-	errMessageFilterNotComparable           = errors.New("message filter is not comparable")
-	errFailedToAuthenticate                 = errors.New("failed to authenticate")
+
+	errInvalidMaxSubscriptions = errors.New("max subscriptions cannot be less than 0")
+
+	errSameProxyAddress = errors.New("cannot set proxy address to the same address")
+
+	errNoConnectFunc = errors.New("websocket connect func not set")
+
+	errAlreadyConnected = errors.New("websocket already connected")
+
+	errCannotShutdown = errors.New("websocket cannot shutdown")
+
+	errAlreadyReconnecting = errors.New("websocket in the process of reconnection")
+
+	errConnSetup = errors.New("error in connection setup")
+
+	errNoPendingConnections = errors.New("no pending connections, call SetupNewConnection first")
+
+	errDuplicateConnectionSetup = errors.New("duplicate connection setup")
+
+	errCannotChangeConnectionURL = errors.New("cannot change connection URL when using multi connection management")
+
+	errExchangeConfigEmpty = errors.New("exchange config is empty")
+
+	errCannotObtainOutboundConnection = errors.New("cannot obtain outbound connection")
+
+	errMessageFilterNotComparable = errors.New("message filter is not comparable")
+
+	errFailedToAuthenticate = errors.New("failed to authenticate")
 )
 
 // Websocket functionality list and state consts
+
 const (
 	UnhandledMessage = " - Unhandled websocket message: "
-	jobBuffer        = 5000
+
+	jobBuffer = 5000
 )
 
 const (
 	uninitialisedState uint32 = iota
+
 	disconnectedState
+
 	connectingState
+
 	connectedState
 )
 
 // Manager provides connection and subscription management and routing
+
 type Manager struct {
-	enabled                       atomic.Bool
-	state                         atomic.Uint32
-	verbose                       bool
-	canUseAuthenticatedEndpoints  atomic.Bool
-	connectionMonitorRunning      atomic.Bool
-	trafficTimeout                time.Duration
-	connectionMonitorDelay        time.Duration
-	proxyAddr                     string
-	defaultURL                    string
-	defaultURLAuth                string
-	runningURL                    string
-	runningURLAuth                string
-	exchangeName                  string
-	features                      *protocol.Features
-	m                             sync.Mutex
-	connectionManagerMu           sync.RWMutex
-	connections                   map[Connection]*websocket
-	subscriptions                 *subscription.Store
-	resubscriptionsMu             sync.Mutex
-	resubscriptions               map[*subscription.Subscription]struct{}
-	resubscribePreLockHook        func(*subscription.Subscription)
-	connector                     func() error
-	rateLimitDefinitions          request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
-	Subscriber                    func(subscription.List) error
-	Unsubscriber                  func(subscription.List) error
-	GenerateSubs                  func() (subscription.List, error)
-	useMultiConnectionManagement  bool
-	DataHandler                   *stream.Relay
-	Match                         *Match
-	ShutdownC                     chan struct{}
-	Wg                            sync.WaitGroup
-	Orderbook                     buffer.Orderbook
-	Trade                         trade.Trade // Trade is a notifier for trades
-	Fills                         fill.Fills  // Fills is a notifier for fills
-	TrafficAlert                  chan struct{}
-	ReadMessageErrors             chan error
-	Conn                          Connection // Public connection
-	AuthConn                      Connection // Authenticated Private connection
-	ExchangeLevelReporter         Reporter   // Latency reporter
+	enabled atomic.Bool
+
+	state atomic.Uint32
+
+	verbose bool
+
+	canUseAuthenticatedEndpoints atomic.Bool
+
+	connectionMonitorRunning atomic.Bool
+
+	trafficTimeout time.Duration
+
+	connectionMonitorDelay time.Duration
+
+	proxyAddr string
+
+	defaultURL string
+
+	defaultURLAuth string
+
+	runningURL string
+
+	runningURLAuth string
+
+	exchangeName string
+
+	features *protocol.Features
+
+	m sync.Mutex
+
+	connectionManagerMu sync.RWMutex
+
+	connections map[Connection]*websocket
+
+	subscriptions *subscription.Store
+
+	resubscriptionsMu sync.Mutex
+
+	resubscriptions map[*subscription.Subscription]struct{}
+
+	resubscribePreLockHook func(*subscription.Subscription)
+
+	connector func() error
+
+	rateLimitDefinitions request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
+
+	Subscriber func(subscription.List) error
+
+	Unsubscriber func(subscription.List) error
+
+	GenerateSubs func() (subscription.List, error)
+
+	useMultiConnectionManagement bool
+
+	DataHandler *stream.Relay
+
+	Match *Match
+
+	ShutdownC chan struct{}
+
+	Wg sync.WaitGroup
+
+	Orderbook buffer.Orderbook
+
+	Trade trade.Trade // Trade is a notifier for trades
+
+	Fills fill.Fills // Fills is a notifier for fills
+
+	TrafficAlert chan struct{}
+
+	ReadMessageErrors chan error
+
+	Conn Connection // Public connection
+
+	AuthConn Connection // Authenticated Private connection
+
+	ExchangeLevelReporter Reporter // Latency reporter
+
 	MaxSubscriptionsPerConnection int
 
 	// connectionManager stores all *potential* connections for the exchange, organised within websocket structs.
+
 	// For example, separate connections can be used for Spot, Margin, and Futures trading. This structure is especially useful
+
 	// for exchanges that differentiate between trading pairs by using different connection endpoints or protocols for various asset classes.
+
 	// If an exchange does not require such differentiation, all connections may be managed under a single websocket.
+
 	connectionManager []*websocket
 }
 
 // ManagerSetup defines variables for setting up a websocket manager
+
 type ManagerSetup struct {
-	ExchangeConfig        *config.Exchange
-	DefaultURL            string
-	RunningURL            string
-	RunningURLAuth        string
-	Connector             func() error
-	Subscriber            func(subscription.List) error
-	Unsubscriber          func(subscription.List) error
+	ExchangeConfig *config.Exchange
+
+	DefaultURL string
+
+	RunningURL string
+
+	RunningURLAuth string
+
+	Connector func() error
+
+	Subscriber func(subscription.List) error
+
+	Unsubscriber func(subscription.List) error
+
 	GenerateSubscriptions func() (subscription.List, error)
-	Features              *protocol.Features
+
+	Features *protocol.Features
+
 	OrderbookBufferConfig buffer.Config
 
 	// UseMultiConnectionManagement allows the connections to be managed by the
+
 	// connection manager. If false, this will default to the global fields
+
 	// provided in this struct.
+
 	UseMultiConnectionManagement bool
 
 	TradeFeed bool
+
 	FillsFeed bool
 
 	MaxWebsocketSubscriptionsPerConnection int
 
 	// RateLimitDefinitions contains the rate limiters shared between WebSocket and REST connections for all endpoints.
+
 	// These rate limits take precedence over any rate limits specified in individual connection configurations.
+
 	// If no connection-specific rate limit is provided and the endpoint does not match any of these definitions,
+
 	// an error will be returned. However, if a connection configuration includes its own rate limit,
+
 	// it will fall back to that configuration’s rate limit without raising an error.
+
 	RateLimitDefinitions request.RateLimitDefinitions
 }
 
 // websocket contains the connection setup details to be used when attempting a new connection. Its subscription store
+
 // knows of all subscriptions for each connection. Each connection will have its own subscription
+
 // store to track subscriptions made on that specific connection.
+
 type websocket struct {
-	setup         *ConnectionSetup
+	setup *ConnectionSetup
+
 	subscriptions *subscription.Store
-	connections   []Connection
+
+	connections []Connection
 }
 
 var globalReporter Reporter
 
 // SetupGlobalReporter sets a reporter interface to be used
+
 // for all exchange requests
+
 func SetupGlobalReporter(r Reporter) {
+
 	globalReporter = r
+
 }
 
 // NewManager initialises the websocket struct
+
 func NewManager() *Manager {
+
 	return &Manager{
-		DataHandler:  stream.NewRelay(jobBuffer),
-		ShutdownC:    make(chan struct{}),
+
+		DataHandler: stream.NewRelay(jobBuffer),
+
+		ShutdownC: make(chan struct{}),
+
 		TrafficAlert: make(chan struct{}, 1),
+
 		// ReadMessageErrors is buffered for an edge case when `Connect` fails
+
 		// after subscriptions are made but before the connectionMonitor has
+
 		// started. This allows the error to be read and handled in the
+
 		// connectionMonitor and start a connection cycle again.
+
 		ReadMessageErrors: make(chan error, 1),
-		Match:             NewMatch(),
-		subscriptions:     subscription.NewStore(),
-		features:          &protocol.Features{},
-		Orderbook:         buffer.Orderbook{},
-		connections:       make(map[Connection]*websocket),
-		resubscriptions:   make(map[*subscription.Subscription]struct{}),
+
+		Match: NewMatch(),
+
+		subscriptions: subscription.NewStore(),
+
+		features: &protocol.Features{},
+
+		Orderbook: buffer.Orderbook{},
+
+		connections: make(map[Connection]*websocket),
+
+		resubscriptions: make(map[*subscription.Subscription]struct{}),
 	}
+
 }
 
 // Setup sets main variables for websocket connection
+
 func (m *Manager) Setup(s *ManagerSetup) error {
+
 	if err := common.NilGuard(m, s); err != nil {
+
 		return err
+
 	}
+
 	if s.ExchangeConfig == nil {
+
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig", common.ErrNilPointer)
+
 	}
+
 	if s.ExchangeConfig.Features == nil {
+
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig.Features", common.ErrNilPointer)
+
 	}
+
 	if s.Features == nil {
+
 		return fmt.Errorf("%w: ManagerSetup.Features", common.ErrNilPointer)
+
 	}
 
 	m.m.Lock()
+
 	defer m.m.Unlock()
 
 	if m.IsInitialised() {
+
 		return fmt.Errorf("%s %w", m.exchangeName, errWebsocketAlreadyInitialised)
+
 	}
 
 	if s.ExchangeConfig.Name == "" {
+
 		return errExchangeConfigNameEmpty
+
 	}
+
 	m.exchangeName = s.ExchangeConfig.Name
+
 	m.verbose = s.ExchangeConfig.Verbose
 
 	m.features = s.Features
@@ -231,981 +379,1712 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	m.useMultiConnectionManagement = s.UseMultiConnectionManagement
 
 	if !m.useMultiConnectionManagement {
+
 		// TODO: Remove this block when all exchanges are updated and backwards
+
 		// compatibility is no longer required.
+
 		if s.Connector == nil {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
+
 		}
+
 		if s.Subscriber == nil {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
+
 		}
+
 		if s.Unsubscriber == nil && m.features.Unsubscribe {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
+
 		}
+
 		if s.GenerateSubscriptions == nil {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
+
 		}
+
 		if s.DefaultURL == "" {
+
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errDefaultURLIsEmpty)
+
 		}
+
 		m.defaultURL = s.DefaultURL
+
 		if s.RunningURL == "" {
+
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errRunningURLIsEmpty)
+
 		}
 
 		m.connector = s.Connector
+
 		m.Subscriber = s.Subscriber
+
 		m.Unsubscriber = s.Unsubscriber
+
 		m.GenerateSubs = s.GenerateSubscriptions
 
 		err := m.SetWebsocketURL(s.RunningURL, false, false)
+
 		if err != nil {
+
 			return fmt.Errorf("%s %w", m.exchangeName, err)
+
 		}
 
 		if s.RunningURLAuth != "" {
+
 			err = m.SetWebsocketURL(s.RunningURLAuth, true, false)
+
 			if err != nil {
+
 				return fmt.Errorf("%s %w", m.exchangeName, err)
+
 			}
+
 		}
+
 	}
 
 	m.connectionMonitorDelay = s.ExchangeConfig.ConnectionMonitorDelay
+
 	if m.connectionMonitorDelay <= 0 {
+
 		m.connectionMonitorDelay = config.DefaultConnectionMonitorDelay
+
 	}
 
 	if s.ExchangeConfig.WebsocketTrafficTimeout < time.Second {
+
 		return fmt.Errorf("%s %w cannot be less than %s",
+
 			m.exchangeName,
+
 			errInvalidTrafficTimeout,
+
 			time.Second)
+
 	}
+
 	m.trafficTimeout = s.ExchangeConfig.WebsocketTrafficTimeout
 
 	m.SetCanUseAuthenticatedEndpoints(s.ExchangeConfig.API.AuthenticatedWebsocketSupport)
 
 	if err := m.Orderbook.Setup(s.ExchangeConfig, &s.OrderbookBufferConfig, m.DataHandler); err != nil {
+
 		return err
+
 	}
 
 	m.Trade.Setup(s.TradeFeed, m.DataHandler)
+
 	m.Fills.Setup(s.FillsFeed, m.DataHandler)
 
 	if s.MaxWebsocketSubscriptionsPerConnection < 0 {
+
 		return fmt.Errorf("%s %w", m.exchangeName, errInvalidMaxSubscriptions)
+
 	}
+
 	m.MaxSubscriptionsPerConnection = s.MaxWebsocketSubscriptionsPerConnection
+
 	m.setState(disconnectedState)
 
 	m.rateLimitDefinitions = s.RateLimitDefinitions
+
 	return nil
+
 }
 
 // SetupNewConnection sets up an auth or unauth streaming connection
+
 func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
+
 	if err := common.NilGuard(m, c); err != nil {
+
 		return err
+
 	}
 
 	m.m.Lock()
+
 	defer m.m.Unlock()
 
 	if c.ResponseCheckTimeout == 0 && c.ResponseMaxLimit == 0 && c.RateLimit == nil && c.URL == "" && c.ConnectionLevelReporter == nil {
+
 		return fmt.Errorf("%w: %w", errConnSetup, errExchangeConfigEmpty)
+
 	}
 
 	if m.exchangeName == "" {
+
 		return fmt.Errorf("%w: %w", errConnSetup, errExchangeConfigNameEmpty)
+
 	}
+
 	if m.TrafficAlert == nil {
+
 		return fmt.Errorf("%w: %w", errConnSetup, errTrafficAlertNil)
+
 	}
+
 	if m.ReadMessageErrors == nil {
+
 		return fmt.Errorf("%w: %w", errConnSetup, errReadMessageErrorsNil)
+
 	}
+
 	if c.ConnectionLevelReporter == nil {
+
 		c.ConnectionLevelReporter = m.ExchangeLevelReporter
+
 	}
+
 	if c.ConnectionLevelReporter == nil {
+
 		c.ConnectionLevelReporter = globalReporter
+
 	}
 
 	if m.useMultiConnectionManagement {
+
 		// The connection and supporting functions are defined per connection and the connection websocket is stored in
+
 		// the connection manager.
+
 		if c.URL == "" {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errDefaultURLIsEmpty)
+
 		}
+
 		if c.Connector == nil {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
+
 		}
+
 		if c.GenerateSubscriptions == nil && !c.SubscriptionsNotRequired {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
+
 		}
+
 		if c.Subscriber == nil && !c.SubscriptionsNotRequired {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
+
 		}
+
 		if c.Unsubscriber == nil && m.features.Unsubscribe && !c.SubscriptionsNotRequired {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
+
 		}
+
 		if c.Handler == nil {
+
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketDataHandlerUnset)
+
 		}
 
 		if c.MessageFilter != nil && !reflect.TypeOf(c.MessageFilter).Comparable() {
+
 			return errMessageFilterNotComparable
+
 		}
 
 		m.connectionManagerMu.Lock()
+
 		defer m.connectionManagerMu.Unlock()
+
 		for x := range m.connectionManager {
+
 			// Below allows for multiple connections to the same URL with different outbound request signatures. This
+
 			// allows for easier determination of inbound and outbound messages. e.g. Gateio cross_margin, margin on
+
 			// a spot connection.
+
 			if m.connectionManager[x].setup.URL == c.URL && c.MessageFilter == m.connectionManager[x].setup.MessageFilter {
+
 				return fmt.Errorf("%w: %w", errConnSetup, errDuplicateConnectionSetup)
+
 			}
+
 		}
+
 		m.connectionManager = append(m.connectionManager, &websocket{setup: c, subscriptions: subscription.NewStore()})
+
 		return nil
+
 	}
 
 	if c.Authenticated {
+
 		m.AuthConn = m.createConnectionFromSetup(c)
+
 	} else {
+
 		m.Conn = m.createConnectionFromSetup(c)
+
 	}
 
 	return nil
+
 }
 
 // createConnectionFromSetup returns a websocket connection from a setup
+
 // configuration. This is used for setting up new connections on the fly.
+
 func (m *Manager) createConnectionFromSetup(c *ConnectionSetup) *connection {
+
 	connectionURL := m.GetWebsocketURL()
+
 	if c.URL != "" {
+
 		connectionURL = c.URL
+
 	}
+
 	match := m.Match
+
 	if m.useMultiConnectionManagement {
+
 		// If we are using multi connection management, we can decouple
+
 		// the match from the global match and have a match per connection.
+
 		match = NewMatch()
+
 	}
+
 	rateLimit := c.RateLimit
+
 	if c.ConnectionRateLimiter != nil {
+
 		rateLimit = c.ConnectionRateLimiter()
+
 	}
+
 	return &connection{
-		ExchangeName:         m.exchangeName,
-		URL:                  connectionURL,
-		ProxyURL:             m.GetProxyAddress(),
-		Verbose:              m.verbose,
-		ResponseMaxLimit:     c.ResponseMaxLimit,
-		Traffic:              m.TrafficAlert,
-		readMessageErrors:    m.ReadMessageErrors,
-		shutdown:             m.ShutdownC,
-		Wg:                   &m.Wg,
-		Match:                match,
-		RateLimit:            rateLimit,
-		Reporter:             c.ConnectionLevelReporter,
+
+		ExchangeName: m.exchangeName,
+
+		URL: connectionURL,
+
+		ProxyURL: m.GetProxyAddress(),
+
+		Verbose: m.verbose,
+
+		ResponseMaxLimit: c.ResponseMaxLimit,
+
+		Traffic: m.TrafficAlert,
+
+		readMessageErrors: m.ReadMessageErrors,
+
+		shutdown: m.ShutdownC,
+
+		Wg: &m.Wg,
+
+		Match: match,
+
+		RateLimit: rateLimit,
+
+		Reporter: c.ConnectionLevelReporter,
+
 		RateLimitDefinitions: m.rateLimitDefinitions,
-		subscriptions:        subscription.NewStore(),
+
+		subscriptions: subscription.NewStore(),
 	}
+
 }
 
 func (m *Manager) snapshotConnectionManager() []*websocket {
+
 	m.connectionManagerMu.RLock()
+
 	defer m.connectionManagerMu.RUnlock()
+
 	return slices.Clone(m.connectionManager)
+
 }
 
 func (m *Manager) snapshotManagedConnections(ws *websocket) []Connection {
+
 	if ws == nil {
+
 		return nil
+
 	}
+
 	m.connectionManagerMu.RLock()
+
 	defer m.connectionManagerMu.RUnlock()
+
 	return slices.Clone(ws.connections)
+
 }
 
 func (m *Manager) trackConnection(conn Connection, ws *websocket) {
+
 	m.connectionManagerMu.Lock()
+
 	defer m.connectionManagerMu.Unlock()
+
 	if m.connections == nil {
+
 		m.connections = make(map[Connection]*websocket)
+
 	}
+
 	if existing, ok := m.connections[conn]; ok {
+
 		if existing == ws {
+
 			return
+
 		}
+
 		panic("trackConnection called with connection already associated with a different websocket")
+
 	}
+
 	m.connections[conn] = ws
+
 	if !slices.Contains(ws.connections, conn) {
+
 		ws.connections = append(ws.connections, conn)
+
 	}
+
 }
 
 // Connect initiates a websocket connection by using a package defined connection
+
 // function
+
 func (m *Manager) Connect(ctx context.Context) error {
+
 	m.m.Lock()
+
 	defer m.m.Unlock()
+
 	return m.connect(ctx)
+
 }
 
 func (m *Manager) connect(ctx context.Context) error {
+
 	if !m.IsEnabled() {
+
 		return ErrWebsocketNotEnabled
+
 	}
+
 	if m.IsConnecting() {
+
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyReconnecting)
+
 	}
+
 	if m.IsConnected() {
+
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyConnected)
+
 	}
 
 	if m.subscriptions == nil {
+
 		return fmt.Errorf("%w: subscriptions", common.ErrNilPointer)
+
 	}
+
 	m.subscriptions.Clear()
 
 	m.setState(connectingState)
 
 	m.Wg.Add(1)
+
 	go m.monitorFrame(ctx, &m.Wg, m.monitorTraffic)
 
 	if !m.useMultiConnectionManagement {
+
 		if m.connector == nil {
+
 			return fmt.Errorf("%v %w", m.exchangeName, errNoConnectFunc)
+
 		}
+
 		err := m.connector()
+
 		if err != nil {
+
 			m.setState(disconnectedState)
+
 			return fmt.Errorf("%v Error connecting %w", m.exchangeName, err)
+
 		}
+
 		m.setState(connectedState)
 
 		if m.connectionMonitorRunning.CompareAndSwap(false, true) {
+
 			// This oversees all connections and does not need to be part of wait group management.
+
 			go m.monitorFrame(ctx, nil, m.monitorConnection)
+
 		}
 
 		subs, err := m.GenerateSubs() // regenerate state on new connection
+
 		if err != nil {
+
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
+
 		}
+
 		if len(subs) != 0 {
+
 			if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
+
 				return err
+
 			}
 
 			if missing := m.subscriptions.Missing(subs); len(missing) > 0 {
+
 				return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
+
 			}
+
 		}
+
 		return nil
+
 	}
 
 	connectionManager := m.snapshotConnectionManager()
+
 	if len(connectionManager) == 0 {
+
 		m.setState(disconnectedState)
+
 		return fmt.Errorf("cannot connect: %w", errNoPendingConnections)
+
 	}
 
 	// multiConnectFatalError is a fatal error that will cause all connections to
+
 	// be shutdown and the websocket to be disconnected.
+
 	var multiConnectFatalError error
 
 	// subscriptionError is a non-fatal error that does not shutdown connections
+
 	var subscriptionError error
 
 	// TODO: Implement concurrency below.
+
 	for i, ws := range connectionManager {
+
 		var subs subscription.List
+
 		if !ws.setup.SubscriptionsNotRequired {
+
 			if ws.setup.GenerateSubscriptions == nil {
+
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriptionsGeneratorUnset)
+
 				break
+
 			}
 
 			var err error
+
 			subs, err = ws.setup.GenerateSubscriptions() // regenerate state on new connection
+
 			if err != nil {
+
 				multiConnectFatalError = fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
+
 				break
+
 			}
 
 			if len(subs) == 0 {
+
 				// If no subscriptions are generated, we skip this connection.
+
 				if m.verbose {
+
 					log.Debugf(log.WebsocketMgr, "%s websocket: no subscriptions generated for [conn:%d] [URL:%s], skipping", m.exchangeName, i+1, ws.setup.URL)
+
 				}
+
 				continue
+
 			}
+
 		}
 
 		if ws.setup.Connector == nil {
+
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errNoConnectFunc)
+
 			break
+
 		}
+
 		if ws.setup.Handler == nil {
+
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketDataHandlerUnset)
+
 			break
+
 		}
+
 		if ws.setup.Subscriber == nil && !ws.setup.SubscriptionsNotRequired {
+
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriberUnset)
+
 			break
+
 		}
 
 		if ws.setup.SubscriptionsNotRequired && len(subs) == 0 {
+
 			if err := m.createConnectAndSubscribe(ctx, ws, nil); err != nil {
+
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
+
 				break
+
 			}
+
 			if m.verbose {
+
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected", m.exchangeName, ws.setup.URL)
+
 			}
+
 			continue
+
 		}
 
 		// Pre-pass: absorb trackable logical subscriptions onto already-managed connections before batching/capacity routing to avoid misplacement.
+
 		remainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
+
 		if err != nil {
+
 			subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
+
 			continue
+
 		}
+
 		if len(remainingSubs) == 0 {
+
 			if m.verbose {
+
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(subs))
+
 			}
+
 			continue
+
 		}
 
 		for _, batchCandidates := range common.Batch(remainingSubs, m.MaxSubscriptionsPerConnection) {
+
 			batchRemainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batchCandidates)
+
 			if err != nil {
+
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
+
 				continue
+
 			}
+
 			if len(batchRemainingSubs) == 0 {
+
 				if m.verbose {
+
 					log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchCandidates))
+
 				}
+
 				continue
+
 			}
+
 			if err := m.createConnectAndSubscribe(ctx, ws, batchRemainingSubs); err != nil {
+
 				if errors.Is(err, common.ErrFatal) {
+
 					multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
+
 					break
+
 				}
+
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
+
 				continue
+
 			}
+
 			if m.verbose {
+
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected. [Total Subs: %d] [Subscribed: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchRemainingSubs))
+
 			}
+
 		}
 
 		if multiConnectFatalError != nil {
+
 			break
+
 		}
+
 	}
 
 	if multiConnectFatalError != nil {
+
 		// Roll back any successful connections and flush subscriptions
+
 		connectionManager = m.snapshotConnectionManager()
+
 		m.connectionManagerMu.Lock()
+
 		for _, ws := range connectionManager {
+
 			for _, conn := range ws.connections {
+
 				if err := conn.Shutdown(); err != nil {
+
 					log.Errorln(log.WebsocketMgr, err)
+
 				}
+
 				conn.Subscriptions().Clear()
+
 			}
+
 			ws.connections = nil
+
 			ws.subscriptions.Clear()
+
 		}
+
 		clear(m.connections)
+
 		m.connectionManagerMu.Unlock()
+
 		m.setState(disconnectedState) // Flip from connecting to disconnected.
 
 		// Drain residual error in the single buffered channel, this mitigates
+
 		// the cycle when `Connect` is called again and the connectionMonitor
+
 		// starts but there is an old error in the channel.
+
 		drain(m.ReadMessageErrors)
 
 		return multiConnectFatalError
+
 	}
 
 	// Assume connected state here. All connections have been established.
+
 	// All subscriptions have been sent and stored. All data received is being
+
 	// handled by the appropriate data handler.
+
 	m.setState(connectedState)
 
 	if m.connectionMonitorRunning.CompareAndSwap(false, true) {
+
 		// This oversees all connections and does not need to be part of wait group management.
+
 		go m.monitorFrame(ctx, nil, m.monitorConnection)
+
 	}
 
 	return subscriptionError
+
 }
 
 func (m *Manager) createConnectAndSubscribe(ctx context.Context, ws *websocket, subs subscription.List) error {
+
 	if m.MaxSubscriptionsPerConnection > 0 && len(subs) > m.MaxSubscriptionsPerConnection {
+
 		return fmt.Errorf("%w %w: max subs allowed %d, requested %d", common.ErrFatal, errSubscriptionsExceedsLimit, m.MaxSubscriptionsPerConnection, len(subs))
+
 	}
 
 	conn := m.createConnectionFromSetup(ws.setup)
 
 	if err := ws.setup.Connector(ctx, conn); err != nil {
+
 		return fmt.Errorf("%w: %w", common.ErrFatal, err)
+
 	}
 
 	if !conn.IsConnected() {
+
 		return fmt.Errorf("%w: %w", common.ErrFatal, ErrNotConnected)
+
 	}
 
 	m.trackConnection(conn, ws)
 
 	m.Wg.Add(1)
+
 	go m.Reader(ctx, conn, ws.setup.Handler)
 
 	if ws.setup.Authenticate != nil && m.CanUseAuthenticatedEndpoints() {
+
 		if err := ws.setup.Authenticate(ctx, conn); err != nil {
+
 			return fmt.Errorf("%w %w: %w", common.ErrFatal, errFailedToAuthenticate, err)
+
 		}
+
 	}
 
 	if ws.setup.SubscriptionsNotRequired {
+
 		if len(subs) != 0 {
+
 			return fmt.Errorf("%w %w: subscriptions were provided but not required", common.ErrFatal, ErrSubscriptionFailure)
+
 		}
+
 		return nil
+
 	}
 
 	if err := ws.setup.Subscriber(ctx, conn, subs); err != nil {
+
 		return fmt.Errorf("%w: %w", ErrSubscriptionFailure, err)
+
 	}
+
 	if missing := ws.subscriptions.Missing(subs); len(missing) > 0 {
+
 		return fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
+
 	}
 
 	connSubsStore := conn.Subscriptions()
+
 	for _, sub := range ws.subscriptions.Contained(subs) {
+
 		// Store subscription against this specific connection for tracking
+
 		if err := connSubsStore.Add(sub); err != nil {
+
 			return fmt.Errorf("%w: adding subscriptions to the specific connection subscription store: %w", ErrSubscriptionFailure, err)
+
 		}
+
 	}
 
 	return nil
+
 }
 
 // Disable disables the exchange websocket protocol
+
 // Note that connectionMonitor will be responsible for shutting down the websocket after disabling
+
 func (m *Manager) Disable() error {
+
 	if !m.IsEnabled() {
+
 		return fmt.Errorf("%s %w", m.exchangeName, ErrAlreadyDisabled)
+
 	}
 
 	m.setEnabled(false)
+
 	return nil
+
 }
 
 // Enable enables the exchange websocket protocol
+
 func (m *Manager) Enable(ctx context.Context) error {
+
 	if m.IsConnected() || m.IsEnabled() {
+
 		return fmt.Errorf("%s %w", m.exchangeName, ErrWebsocketAlreadyEnabled)
+
 	}
 
 	m.setEnabled(true)
+
 	return m.Connect(ctx)
+
 }
 
 // Shutdown attempts to shut down a websocket connection and associated routines
+
 // by using a package defined shutdown function
+
 func (m *Manager) Shutdown() error {
+
 	m.m.Lock()
+
 	defer m.m.Unlock()
+
 	return m.shutdown()
+
 }
 
 func (m *Manager) shutdown() error {
+
 	if m.IsConnecting() {
+
 		return fmt.Errorf("%v %w: %w ", m.exchangeName, errCannotShutdown, errAlreadyReconnecting)
+
 	}
 
 	if !m.IsConnected() {
+
 		return fmt.Errorf("%v %w: %w", m.exchangeName, errCannotShutdown, ErrNotConnected)
+
 	}
 
 	if m.verbose {
+
 		log.Debugf(log.WebsocketMgr, "%v websocket: shutting down websocket", m.exchangeName)
+
 	}
 
 	defer m.Orderbook.FlushBuffer()
 
 	// During the shutdown process, all errors are treated as non-fatal to avoid issues when the connection has already
+
 	// been closed. In such cases, attempting to close the connection may result in a
+
 	// "failed to send closeNotify alert (but connection was closed anyway)" error. Treating these errors as non-fatal
+
 	// prevents the shutdown process from being interrupted, which could otherwise trigger a continuous traffic monitor
+
 	// cycle and potentially block the initiation of a new connection.
+
 	var nonFatalCloseConnectionErrors error
 
 	// Shutdown managed connections
+
 	m.connectionManagerMu.Lock()
+
 	for _, ws := range m.connectionManager {
+
 		for _, conn := range ws.connections {
+
 			if err := conn.Shutdown(); err != nil {
+
 				nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
+
 			}
+
 			conn.Subscriptions().Clear()
+
 		}
+
 		ws.connections = nil
+
 		// Flush any subscriptions from last connection across any managed connections
+
 		ws.subscriptions.Clear()
+
 	}
+
 	// Clean map of old connections
+
 	clear(m.connections)
+
 	m.connectionManagerMu.Unlock()
 
 	if m.Conn != nil {
+
 		if err := m.Conn.Shutdown(); err != nil {
+
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
+
 		}
+
 	}
+
 	if m.AuthConn != nil {
+
 		if err := m.AuthConn.Shutdown(); err != nil {
+
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
+
 		}
+
 	}
+
 	// flush any subscriptions from last connection if needed
+
 	m.subscriptions.Clear()
 
 	close(m.ShutdownC)
+
 	m.setState(disconnectedState)
+
 	m.Wg.Wait()
+
 	m.ShutdownC = make(chan struct{})
 
 	for _, conn := range []Connection{m.Conn, m.AuthConn} {
+
 		if conn == nil {
+
 			continue
+
 		}
+
 		conn, ok := conn.(*connection)
+
 		if !ok {
+
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.GetTypeAssertError("*connection", conn))
+
 		}
+
 		conn.shutdown = m.ShutdownC
+
 	}
 
 	if m.verbose {
+
 		log.Debugf(log.WebsocketMgr, "%v websocket: completed websocket shutdown", m.exchangeName)
+
 	}
 
 	// Drain residual error in the single buffered channel, this mitigates
+
 	// the cycle when `Connect` is called again and the connectionMonitor
+
 	// starts but there is an old error in the channel.
+
 	drain(m.ReadMessageErrors)
 
 	if nonFatalCloseConnectionErrors != nil {
+
 		log.Warnf(log.WebsocketMgr, "%v websocket: shutdown error: %v", m.exchangeName, nonFatalCloseConnectionErrors)
+
 	}
 
 	return nil
+
 }
 
 func (m *Manager) setState(s uint32) {
+
 	m.state.Store(s)
+
 }
 
 // IsInitialised returns whether the websocket has been Setup() already
+
 func (m *Manager) IsInitialised() bool {
+
 	return m.state.Load() != uninitialisedState
+
 }
 
 // IsConnected returns whether the websocket is connected
+
 func (m *Manager) IsConnected() bool {
+
 	return m.state.Load() == connectedState
+
 }
 
 // IsConnecting returns whether the websocket is connecting
+
 func (m *Manager) IsConnecting() bool {
+
 	return m.state.Load() == connectingState
+
 }
 
 func (m *Manager) setEnabled(b bool) {
+
 	m.enabled.Store(b)
+
 }
 
 // IsEnabled returns whether the websocket is enabled
+
 func (m *Manager) IsEnabled() bool {
+
 	return m.enabled.Load()
+
 }
 
 // CanUseAuthenticatedWebsocketForWrapper Handles a common check to
+
 // verify whether a wrapper can use an authenticated websocket endpoint
+
 func (m *Manager) CanUseAuthenticatedWebsocketForWrapper() bool {
+
 	if m.IsConnected() {
+
 		if m.CanUseAuthenticatedEndpoints() {
+
 			return true
+
 		}
+
 		log.Infof(log.WebsocketMgr, "%v - Websocket not authenticated, using REST\n", m.exchangeName)
+
 	}
+
 	return false
+
 }
 
 // SetWebsocketURL sets websocket URL and can refresh underlying connections
+
 func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
+
 	if m.useMultiConnectionManagement {
+
 		// TODO: Add functionality for multi-connection management to change URL
+
 		return fmt.Errorf("%s: %w", m.exchangeName, errCannotChangeConnectionURL)
+
 	}
+
 	defaultVals := u == "" || u == config.WebsocketURLNonDefaultMessage
+
 	if auth {
+
 		if defaultVals {
+
 			u = m.defaultURLAuth
+
 		}
 
 		err := checkWebsocketURL(u)
+
 		if err != nil {
+
 			return err
+
 		}
+
 		m.runningURLAuth = u
 
 		if m.verbose {
+
 			log.Debugf(log.WebsocketMgr, "%s websocket: setting authenticated websocket URL: %s\n", m.exchangeName, u)
+
 		}
 
 		if m.AuthConn != nil {
+
 			m.AuthConn.SetURL(u)
+
 		}
+
 	} else {
+
 		if defaultVals {
+
 			u = m.defaultURL
+
 		}
+
 		err := checkWebsocketURL(u)
+
 		if err != nil {
+
 			return err
+
 		}
+
 		m.runningURL = u
 
 		if m.verbose {
+
 			log.Debugf(log.WebsocketMgr, "%s websocket: setting unauthenticated websocket URL: %s\n", m.exchangeName, u)
+
 		}
 
 		if m.Conn != nil {
+
 			m.Conn.SetURL(u)
+
 		}
+
 	}
 
 	if m.IsConnected() && reconnect {
+
 		log.Debugf(log.WebsocketMgr, "%s websocket: flushing websocket connection to %s\n", m.exchangeName, u)
+
 		return m.Shutdown()
+
 	}
+
 	return nil
+
 }
 
 // GetWebsocketURL returns the running websocket URL
+
 func (m *Manager) GetWebsocketURL() string {
+
 	return m.runningURL
+
 }
 
 // GetConfiguredWebsocketURLs returns known websocket connection URLs.
+
 func (m *Manager) GetConfiguredWebsocketURLs() ([]string, error) {
+
 	if err := common.NilGuard(m); err != nil {
+
 		return nil, err
+
 	}
 
 	m.m.Lock()
+
 	defer m.m.Unlock()
 
 	if m.useMultiConnectionManagement {
+
 		m.connectionManagerMu.RLock()
+
 		defer m.connectionManagerMu.RUnlock()
+
 		urls := make([]string, 0, len(m.connectionManager))
+
 		seen := make(map[string]struct{}, len(m.connectionManager))
+
 		for _, ws := range m.connectionManager {
+
 			if ws == nil || ws.setup.URL == "" {
+
 				continue
+
 			}
+
 			if _, ok := seen[ws.setup.URL]; ok {
+
 				continue
+
 			}
+
 			seen[ws.setup.URL] = struct{}{}
+
 			urls = append(urls, ws.setup.URL)
+
 		}
+
 		return urls, nil
+
 	}
 
 	if m.runningURL != "" {
+
 		return []string{m.runningURL}, nil
+
 	}
+
 	if m.defaultURL != "" {
+
 		return []string{m.defaultURL}, nil
+
 	}
+
 	return nil, nil
+
 }
 
 // SetProxyAddress sets websocket proxy address
+
 func (m *Manager) SetProxyAddress(ctx context.Context, proxyAddr string) error {
+
 	m.m.Lock()
+
 	defer m.m.Unlock()
+
 	if proxyAddr != "" {
+
 		if _, err := url.ParseRequestURI(proxyAddr); err != nil {
+
 			return fmt.Errorf("%v websocket: cannot set proxy address: %w", m.exchangeName, err)
+
 		}
 
 		if m.proxyAddr == proxyAddr {
+
 			return fmt.Errorf("%v websocket: %w '%v'", m.exchangeName, errSameProxyAddress, m.proxyAddr)
+
 		}
 
 		log.Debugf(log.ExchangeSys, "%s websocket: setting websocket proxy: %s", m.exchangeName, proxyAddr)
+
 	} else {
+
 		log.Debugf(log.ExchangeSys, "%s websocket: removing websocket proxy", m.exchangeName)
+
 	}
 
 	m.connectionManagerMu.RLock()
+
 	for _, ws := range m.connectionManager {
+
 		for _, conn := range ws.connections {
+
 			conn.SetProxy(proxyAddr)
+
 		}
+
 	}
+
 	m.connectionManagerMu.RUnlock()
+
 	if m.Conn != nil {
+
 		m.Conn.SetProxy(proxyAddr)
+
 	}
+
 	if m.AuthConn != nil {
+
 		m.AuthConn.SetProxy(proxyAddr)
+
 	}
 
 	m.proxyAddr = proxyAddr
 
 	if !m.IsConnected() {
+
 		return nil
+
 	}
+
 	if err := m.shutdown(); err != nil {
+
 		return err
+
 	}
+
 	return m.connect(ctx)
+
 }
 
 // GetProxyAddress returns the current websocket proxy
+
 func (m *Manager) GetProxyAddress() string {
+
 	return m.proxyAddr
+
 }
 
 // GetName returns exchange name
+
 func (m *Manager) GetName() string {
+
 	return m.exchangeName
+
 }
 
 // SetCanUseAuthenticatedEndpoints sets canUseAuthenticatedEndpoints val in a thread safe manner
+
 func (m *Manager) SetCanUseAuthenticatedEndpoints(b bool) {
+
 	m.canUseAuthenticatedEndpoints.Store(b)
+
 }
 
 // CanUseAuthenticatedEndpoints gets canUseAuthenticatedEndpoints val in a thread safe manner
+
 func (m *Manager) CanUseAuthenticatedEndpoints() bool {
+
 	return m.canUseAuthenticatedEndpoints.Load()
+
 }
 
 // checkWebsocketURL checks for a valid websocket url
+
 func checkWebsocketURL(s string) error {
+
 	u, err := url.Parse(s)
+
 	if err != nil {
+
 		return err
+
 	}
+
 	if u.Scheme != "ws" && u.Scheme != "wss" {
+
 		return fmt.Errorf("cannot set %w %s", errInvalidWebsocketURL, s)
+
 	}
+
 	return nil
+
 }
 
 // Reader reads and handles data from a specific connection
+
 func (m *Manager) Reader(ctx context.Context, conn Connection, handler func(ctx context.Context, conn Connection, message []byte) error) {
+
 	defer m.Wg.Done()
+
 	for {
+
 		resp := conn.ReadMessage()
+
 		if resp.Raw == nil {
+
 			return // Connection has been closed
+
 		}
+
 		if err := handler(ctx, conn, resp.Raw); err != nil {
+
 			err = fmt.Errorf("connection URL:[%v] error: %w", conn.GetURL(), err)
+
 			if errSend := m.DataHandler.Send(ctx, err); errSend != nil {
+
 				log.Errorf(log.WebsocketMgr, "%s: %s %s", m.exchangeName, errSend, err)
+
 			}
+
 		}
+
 	}
+
 }
 
 func drain(ch <-chan error) {
+
 	for {
+
 		select {
+
 		case <-ch:
+
 		default:
+
 			return
+
 		}
+
 	}
+
 }
 
 // ClosureFrame is a closure function that wraps monitoring variables with observer, if the return is true the frame will exit
+
 type ClosureFrame func(ctx context.Context) func() bool
 
 // monitorFrame monitors a specific websocket component or critical system. It will exit if the observer returns true
+
 // This is used for monitoring data throughput, connection status and other critical websocket components. The waitgroup
+
 // is optional and is used to signal when the monitor has finished.
+
 func (m *Manager) monitorFrame(ctx context.Context, wg *sync.WaitGroup, fn ClosureFrame) {
+
 	if wg != nil {
+
 		defer wg.Done()
+
 	}
+
 	observe := fn(ctx)
+
 	for {
+
 		if observe() {
+
 			return
+
 		}
+
 	}
+
 }
 
 // monitorConnection monitors the connection and attempts to reconnect if the connection is lost
+
 func (m *Manager) monitorConnection(ctx context.Context) func() bool {
+
 	timer := time.NewTimer(m.connectionMonitorDelay)
+
 	return func() bool { return m.observeConnection(ctx, timer) }
+
 }
 
 // observeConnection observes the connection and attempts to reconnect if the connection is lost
+
 func (m *Manager) observeConnection(ctx context.Context, t *time.Timer) (exit bool) {
+
 	select {
+
 	case err := <-m.ReadMessageErrors:
+
 		if errors.Is(err, errConnectionFault) {
+
 			log.Warnf(log.WebsocketMgr, "%v websocket has been disconnected. Reason: %v", m.exchangeName, err)
+
 			if m.IsConnected() {
+
 				if shutdownErr := m.Shutdown(); shutdownErr != nil {
+
 					log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor shutdown err: %s", m.exchangeName, shutdownErr)
+
 				}
+
 			} else {
+
 				m.state.CompareAndSwap(connectingState, disconnectedState)
+
 			}
+
 		}
+
 		// Speedier reconnection, instead of waiting for the next cycle.
+
 		if m.IsEnabled() && (!m.IsConnected() && !m.IsConnecting()) {
+
 			if connectErr := m.Connect(ctx); connectErr != nil {
+
 				log.Errorln(log.WebsocketMgr, connectErr)
+
 			}
+
 		}
+
 		if err := m.DataHandler.Send(ctx, err); err != nil {
+
 			log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor data handler err: %s", m.exchangeName, err)
+
 		}
+
 	case <-t.C:
+
 		if m.verbose {
+
 			log.Debugf(log.WebsocketMgr, "%v websocket: running connection monitor cycle", m.exchangeName)
+
 		}
+
 		if !m.IsEnabled() {
+
 			if m.verbose {
+
 				log.Debugf(log.WebsocketMgr, "%v websocket: connectionMonitor - websocket disabled, shutting down", m.exchangeName)
+
 			}
+
 			if m.IsConnected() {
+
 				if err := m.Shutdown(); err != nil {
+
 					log.Errorln(log.WebsocketMgr, err)
+
 				}
+
 			}
+
 			if m.verbose {
+
 				log.Debugf(log.WebsocketMgr, "%v websocket: connection monitor exiting", m.exchangeName)
+
 			}
+
 			t.Stop()
+
 			m.connectionMonitorRunning.Store(false)
+
 			return true
+
 		}
+
 		if !m.IsConnecting() && !m.IsConnected() {
+
 			err := m.Connect(ctx)
+
 			if err != nil {
+
 				log.Errorln(log.WebsocketMgr, err)
+
 			}
+
 		}
+
 		t.Reset(m.connectionMonitorDelay)
+
 	}
+
 	return false
+
 }
 
 // monitorTraffic monitors to see if there has been traffic within the trafficTimeout time window. If there is no traffic
+
 // the connection is shutdown and will be reconnected by the connectionMonitor routine.
+
 func (m *Manager) monitorTraffic(context.Context) func() bool {
+
 	return func() bool {
+
 		return m.observeTraffic(time.After(m.trafficTimeout), func() {
+
 			go func() {
+
 				if err := m.Shutdown(); err != nil {
+
 					log.Errorf(log.WebsocketMgr, "%v websocket: trafficMonitor shutdown err: %s", m.exchangeName, err)
+
 				}
+
 			}()
+
 		})
+
 	}
+
 }
 
 func (m *Manager) observeTraffic(timeout <-chan time.Time, onTimeout func()) bool {
+
 	select {
+
 	case <-m.ShutdownC:
+
 		if m.verbose {
+
 			log.Debugf(log.WebsocketMgr, "%v websocket: trafficMonitor shutdown message received", m.exchangeName)
+
 		}
+
 	case <-timeout:
+
 		if m.IsConnecting() || signalReceived(m.TrafficAlert) {
+
 			return false
+
 		}
+
 		if m.verbose {
+
 			log.Warnf(log.WebsocketMgr, "%v websocket: has not received a traffic alert in %v. Reconnecting", m.exchangeName, m.trafficTimeout)
+
 		}
+
 		if m.IsConnected() && onTimeout != nil {
+
 			onTimeout()
+
 		}
+
 	}
+
 	return true
+
 }
 
 // signalReceived checks if a signal has been received, this also clears the signal.
+
 func signalReceived(ch chan struct{}) bool {
+
 	select {
+
 	case <-ch:
+
 		return true
+
 	default:
+
 		return false
+
 	}
+
 }
 
 // GetConnection returns the first available connection for a websocket by message filter (defined in exchange package _wrapper.go websocket connection)
+
 // for request and response handling in a multi connection context.
+
 func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
+
 	if err := common.NilGuard(m); err != nil {
+
 		return nil, err
+
 	}
+
 	if messageFilter == nil {
+
 		return nil, fmt.Errorf("%w: messageFilter", common.ErrNilPointer)
+
 	}
 
 	m.m.Lock()
+
 	defer m.m.Unlock()
 
 	if !m.useMultiConnectionManagement {
+
 		return nil, fmt.Errorf("%s: multi connection management not enabled %w please use exported Conn and AuthConn fields", m.exchangeName, errCannotObtainOutboundConnection)
+
 	}
 
 	if !m.IsConnected() {
+
 		return nil, ErrNotConnected
+
 	}
 
 	m.connectionManagerMu.RLock()
+
 	defer m.connectionManagerMu.RUnlock()
+
 	for _, ws := range m.connectionManager {
+
 		if ws.setup.MessageFilter != messageFilter {
+
 			continue
+
 		}
+
 		if len(ws.connections) == 0 {
+
 			return nil, fmt.Errorf("%s: %s %w associated with message filter: '%v'", m.exchangeName, ws.setup.URL, ErrNotConnected, messageFilter)
+
 		}
+
 		return ws.connections[0], nil
+
 	}
 
 	return nil, fmt.Errorf("%s: %w associated with message filter: '%v'", m.exchangeName, ErrRequestRouteNotFound, messageFilter)
+
 }

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -158,6 +158,8 @@ type Manager struct {
 
 	resubscribePreLockHook func(*subscription.Subscription)
 
+	resubscribeWaiterHook func(*subscription.Subscription)
+
 	connector func() error
 
 	rateLimitDefinitions request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -158,7 +158,7 @@ type Manager struct {
 
 	resubscriptionsMu sync.Mutex
 
-	resubscriptions map[*subscription.Subscription]struct{}
+	resubscriptions map[*subscription.Subscription]chan struct{}
 
 	resubscribePreLockHook func(*subscription.Subscription)
 
@@ -319,7 +319,7 @@ func NewManager() *Manager {
 
 		connections: make(map[Connection]*websocket),
 
-		resubscriptions: make(map[*subscription.Subscription]struct{}),
+		resubscriptions: make(map[*subscription.Subscription]chan struct{}),
 	}
 
 }

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -24,7 +24,6 @@ import (
 )
 
 // Public websocket errors
-
 var (
 	ErrWebsocketNotEnabled = errors.New("websocket not enabled")
 
@@ -42,7 +41,6 @@ var (
 )
 
 // Private websocket errors
-
 var (
 	errWebsocketAlreadyInitialised = errors.New("websocket already initialised")
 
@@ -100,7 +98,6 @@ var (
 )
 
 // Websocket functionality list and state consts
-
 const (
 	UnhandledMessage = " - Unhandled websocket message: "
 
@@ -118,7 +115,6 @@ const (
 )
 
 // Manager provides connection and subscription management and routing
-
 type Manager struct {
 	enabled atomic.Bool
 
@@ -201,18 +197,14 @@ type Manager struct {
 	MaxSubscriptionsPerConnection int
 
 	// connectionManager stores all *potential* connections for the exchange, organised within websocket structs.
-
 	// For example, separate connections can be used for Spot, Margin, and Futures trading. This structure is especially useful
-
 	// for exchanges that differentiate between trading pairs by using different connection endpoints or protocols for various asset classes.
-
 	// If an exchange does not require such differentiation, all connections may be managed under a single websocket.
 
 	connectionManager []*websocket
 }
 
 // ManagerSetup defines variables for setting up a websocket manager
-
 type ManagerSetup struct {
 	ExchangeConfig *config.Exchange
 
@@ -235,9 +227,7 @@ type ManagerSetup struct {
 	OrderbookBufferConfig buffer.Config
 
 	// UseMultiConnectionManagement allows the connections to be managed by the
-
 	// connection manager. If false, this will default to the global fields
-
 	// provided in this struct.
 
 	UseMultiConnectionManagement bool
@@ -249,24 +239,17 @@ type ManagerSetup struct {
 	MaxWebsocketSubscriptionsPerConnection int
 
 	// RateLimitDefinitions contains the rate limiters shared between WebSocket and REST connections for all endpoints.
-
 	// These rate limits take precedence over any rate limits specified in individual connection configurations.
-
 	// If no connection-specific rate limit is provided and the endpoint does not match any of these definitions,
-
 	// an error will be returned. However, if a connection configuration includes its own rate limit,
-
 	// it will fall back to that configuration’s rate limit without raising an error.
 
 	RateLimitDefinitions request.RateLimitDefinitions
 }
 
 // websocket contains the connection setup details to be used when attempting a new connection. Its subscription store
-
 // knows of all subscriptions for each connection. Each connection will have its own subscription
-
 // store to track subscriptions made on that specific connection.
-
 type websocket struct {
 	setup *ConnectionSetup
 
@@ -278,21 +261,14 @@ type websocket struct {
 var globalReporter Reporter
 
 // SetupGlobalReporter sets a reporter interface to be used
-
 // for all exchange requests
-
 func SetupGlobalReporter(r Reporter) {
-
 	globalReporter = r
-
 }
 
 // NewManager initialises the websocket struct
-
 func NewManager() *Manager {
-
 	return &Manager{
-
 		DataHandler: stream.NewRelay(jobBuffer),
 
 		ShutdownC: make(chan struct{}),
@@ -300,11 +276,8 @@ func NewManager() *Manager {
 		TrafficAlert: make(chan struct{}, 1),
 
 		// ReadMessageErrors is buffered for an edge case when `Connect` fails
-
 		// after subscriptions are made but before the connectionMonitor has
-
 		// started. This allows the error to be read and handled in the
-
 		// connectionMonitor and start a connection cycle again.
 
 		ReadMessageErrors: make(chan error, 1),
@@ -321,35 +294,24 @@ func NewManager() *Manager {
 
 		resubscriptions: make(map[*subscription.Subscription]chan struct{}),
 	}
-
 }
 
 // Setup sets main variables for websocket connection
-
 func (m *Manager) Setup(s *ManagerSetup) error {
-
 	if err := common.NilGuard(m, s); err != nil {
-
 		return err
-
 	}
 
 	if s.ExchangeConfig == nil {
-
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig", common.ErrNilPointer)
-
 	}
 
 	if s.ExchangeConfig.Features == nil {
-
 		return fmt.Errorf("%w: ManagerSetup.ExchangeConfig.Features", common.ErrNilPointer)
-
 	}
 
 	if s.Features == nil {
-
 		return fmt.Errorf("%w: ManagerSetup.Features", common.ErrNilPointer)
-
 	}
 
 	m.m.Lock()
@@ -357,15 +319,11 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	defer m.m.Unlock()
 
 	if m.IsInitialised() {
-
 		return fmt.Errorf("%s %w", m.exchangeName, errWebsocketAlreadyInitialised)
-
 	}
 
 	if s.ExchangeConfig.Name == "" {
-
 		return errExchangeConfigNameEmpty
-
 	}
 
 	m.exchangeName = s.ExchangeConfig.Name
@@ -379,47 +337,33 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	m.useMultiConnectionManagement = s.UseMultiConnectionManagement
 
 	if !m.useMultiConnectionManagement {
-
 		// TODO: Remove this block when all exchanges are updated and backwards
-
 		// compatibility is no longer required.
 
 		if s.Connector == nil {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
-
 		}
 
 		if s.Subscriber == nil {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
-
 		}
 
 		if s.Unsubscriber == nil && m.features.Unsubscribe {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
-
 		}
 
 		if s.GenerateSubscriptions == nil {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
-
 		}
 
 		if s.DefaultURL == "" {
-
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errDefaultURLIsEmpty)
-
 		}
 
 		m.defaultURL = s.DefaultURL
 
 		if s.RunningURL == "" {
-
 			return fmt.Errorf("%s websocket %w", m.exchangeName, errRunningURLIsEmpty)
-
 		}
 
 		m.connector = s.Connector
@@ -431,37 +375,25 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 		m.GenerateSubs = s.GenerateSubscriptions
 
 		err := m.SetWebsocketURL(s.RunningURL, false, false)
-
 		if err != nil {
-
 			return fmt.Errorf("%s %w", m.exchangeName, err)
-
 		}
 
 		if s.RunningURLAuth != "" {
-
 			err = m.SetWebsocketURL(s.RunningURLAuth, true, false)
-
 			if err != nil {
-
 				return fmt.Errorf("%s %w", m.exchangeName, err)
-
 			}
-
 		}
-
 	}
 
 	m.connectionMonitorDelay = s.ExchangeConfig.ConnectionMonitorDelay
 
 	if m.connectionMonitorDelay <= 0 {
-
 		m.connectionMonitorDelay = config.DefaultConnectionMonitorDelay
-
 	}
 
 	if s.ExchangeConfig.WebsocketTrafficTimeout < time.Second {
-
 		return fmt.Errorf("%s %w cannot be less than %s",
 
 			m.exchangeName,
@@ -469,7 +401,6 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 			errInvalidTrafficTimeout,
 
 			time.Second)
-
 	}
 
 	m.trafficTimeout = s.ExchangeConfig.WebsocketTrafficTimeout
@@ -477,9 +408,7 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	m.SetCanUseAuthenticatedEndpoints(s.ExchangeConfig.API.AuthenticatedWebsocketSupport)
 
 	if err := m.Orderbook.Setup(s.ExchangeConfig, &s.OrderbookBufferConfig, m.DataHandler); err != nil {
-
 		return err
-
 	}
 
 	m.Trade.Setup(s.TradeFeed, m.DataHandler)
@@ -487,9 +416,7 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	m.Fills.Setup(s.FillsFeed, m.DataHandler)
 
 	if s.MaxWebsocketSubscriptionsPerConnection < 0 {
-
 		return fmt.Errorf("%s %w", m.exchangeName, errInvalidMaxSubscriptions)
-
 	}
 
 	m.MaxSubscriptionsPerConnection = s.MaxWebsocketSubscriptionsPerConnection
@@ -499,17 +426,12 @@ func (m *Manager) Setup(s *ManagerSetup) error {
 	m.rateLimitDefinitions = s.RateLimitDefinitions
 
 	return nil
-
 }
 
 // SetupNewConnection sets up an auth or unauth streaming connection
-
 func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
-
 	if err := common.NilGuard(m, c); err != nil {
-
 		return err
-
 	}
 
 	m.m.Lock()
@@ -517,87 +439,59 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 	defer m.m.Unlock()
 
 	if c.ResponseCheckTimeout == 0 && c.ResponseMaxLimit == 0 && c.RateLimit == nil && c.URL == "" && c.ConnectionLevelReporter == nil {
-
 		return fmt.Errorf("%w: %w", errConnSetup, errExchangeConfigEmpty)
-
 	}
 
 	if m.exchangeName == "" {
-
 		return fmt.Errorf("%w: %w", errConnSetup, errExchangeConfigNameEmpty)
-
 	}
 
 	if m.TrafficAlert == nil {
-
 		return fmt.Errorf("%w: %w", errConnSetup, errTrafficAlertNil)
-
 	}
 
 	if m.ReadMessageErrors == nil {
-
 		return fmt.Errorf("%w: %w", errConnSetup, errReadMessageErrorsNil)
-
 	}
 
 	if c.ConnectionLevelReporter == nil {
-
 		c.ConnectionLevelReporter = m.ExchangeLevelReporter
-
 	}
 
 	if c.ConnectionLevelReporter == nil {
-
 		c.ConnectionLevelReporter = globalReporter
-
 	}
 
 	if m.useMultiConnectionManagement {
-
 		// The connection and supporting functions are defined per connection and the connection websocket is stored in
-
 		// the connection manager.
 
 		if c.URL == "" {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errDefaultURLIsEmpty)
-
 		}
 
 		if c.Connector == nil {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketConnectorUnset)
-
 		}
 
 		if c.GenerateSubscriptions == nil && !c.SubscriptionsNotRequired {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriptionsGeneratorUnset)
-
 		}
 
 		if c.Subscriber == nil && !c.SubscriptionsNotRequired {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketSubscriberUnset)
-
 		}
 
 		if c.Unsubscriber == nil && m.features.Unsubscribe && !c.SubscriptionsNotRequired {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketUnsubscriberUnset)
-
 		}
 
 		if c.Handler == nil {
-
 			return fmt.Errorf("%w: %w", errConnSetup, errWebsocketDataHandlerUnset)
-
 		}
 
 		if c.MessageFilter != nil && !reflect.TypeOf(c.MessageFilter).Comparable() {
-
 			return errMessageFilterNotComparable
-
 		}
 
 		m.connectionManagerMu.Lock()
@@ -605,77 +499,54 @@ func (m *Manager) SetupNewConnection(c *ConnectionSetup) error {
 		defer m.connectionManagerMu.Unlock()
 
 		for x := range m.connectionManager {
-
 			// Below allows for multiple connections to the same URL with different outbound request signatures. This
-
 			// allows for easier determination of inbound and outbound messages. e.g. Gateio cross_margin, margin on
-
 			// a spot connection.
 
 			if m.connectionManager[x].setup.URL == c.URL && c.MessageFilter == m.connectionManager[x].setup.MessageFilter {
-
 				return fmt.Errorf("%w: %w", errConnSetup, errDuplicateConnectionSetup)
-
 			}
-
 		}
 
 		m.connectionManager = append(m.connectionManager, &websocket{setup: c, subscriptions: subscription.NewStore()})
 
 		return nil
-
 	}
 
 	if c.Authenticated {
-
 		m.AuthConn = m.createConnectionFromSetup(c)
-
 	} else {
-
 		m.Conn = m.createConnectionFromSetup(c)
-
 	}
 
 	return nil
-
 }
 
 // createConnectionFromSetup returns a websocket connection from a setup
-
 // configuration. This is used for setting up new connections on the fly.
-
 func (m *Manager) createConnectionFromSetup(c *ConnectionSetup) *connection {
-
 	connectionURL := m.GetWebsocketURL()
 
 	if c.URL != "" {
-
 		connectionURL = c.URL
-
 	}
 
 	match := m.Match
 
 	if m.useMultiConnectionManagement {
-
 		// If we are using multi connection management, we can decouple
-
 		// the match from the global match and have a match per connection.
 
 		match = NewMatch()
-
 	}
 
 	rateLimit := c.RateLimit
 
 	if c.ConnectionRateLimiter != nil {
-
 		rateLimit = c.ConnectionRateLimiter()
-
 	}
 
 	return &connection{
-
 		ExchangeName: m.exchangeName,
 
 		URL: connectionURL,
@@ -704,25 +575,19 @@ func (m *Manager) createConnectionFromSetup(c *ConnectionSetup) *connection {
 
 		subscriptions: subscription.NewStore(),
 	}
-
 }
 
 func (m *Manager) snapshotConnectionManager() []*websocket {
-
 	m.connectionManagerMu.RLock()
 
 	defer m.connectionManagerMu.RUnlock()
 
 	return slices.Clone(m.connectionManager)
-
 }
 
 func (m *Manager) snapshotManagedConnections(ws *websocket) []Connection {
-
 	if ws == nil {
-
 		return nil
-
 	}
 
 	m.connectionManagerMu.RLock()
@@ -730,81 +595,57 @@ func (m *Manager) snapshotManagedConnections(ws *websocket) []Connection {
 	defer m.connectionManagerMu.RUnlock()
 
 	return slices.Clone(ws.connections)
-
 }
 
 func (m *Manager) trackConnection(conn Connection, ws *websocket) {
-
 	m.connectionManagerMu.Lock()
 
 	defer m.connectionManagerMu.Unlock()
 
 	if m.connections == nil {
-
 		m.connections = make(map[Connection]*websocket)
-
 	}
 
 	if existing, ok := m.connections[conn]; ok {
-
 		if existing == ws {
-
 			return
-
 		}
 
 		panic("trackConnection called with connection already associated with a different websocket")
-
 	}
 
 	m.connections[conn] = ws
 
 	if !slices.Contains(ws.connections, conn) {
-
 		ws.connections = append(ws.connections, conn)
-
 	}
-
 }
 
 // Connect initiates a websocket connection by using a package defined connection
-
 // function
-
 func (m *Manager) Connect(ctx context.Context) error {
-
 	m.m.Lock()
 
 	defer m.m.Unlock()
 
 	return m.connect(ctx)
-
 }
 
 func (m *Manager) connect(ctx context.Context) error {
-
 	if !m.IsEnabled() {
-
 		return ErrWebsocketNotEnabled
-
 	}
 
 	if m.IsConnecting() {
-
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyReconnecting)
-
 	}
 
 	if m.IsConnected() {
-
 		return fmt.Errorf("%v %w", m.exchangeName, errAlreadyConnected)
-
 	}
 
 	if m.subscriptions == nil {
-
 		return fmt.Errorf("%w: subscriptions", common.ErrNilPointer)
-
 	}
 
 	m.subscriptions.Clear()
@@ -816,251 +657,178 @@ func (m *Manager) connect(ctx context.Context) error {
 	go m.monitorFrame(ctx, &m.Wg, m.monitorTraffic)
 
 	if !m.useMultiConnectionManagement {
-
 		if m.connector == nil {
-
 			return fmt.Errorf("%v %w", m.exchangeName, errNoConnectFunc)
-
 		}
 
 		err := m.connector()
-
 		if err != nil {
-
 			m.setState(disconnectedState)
 
 			return fmt.Errorf("%v Error connecting %w", m.exchangeName, err)
-
 		}
 
 		m.setState(connectedState)
 
 		if m.connectionMonitorRunning.CompareAndSwap(false, true) {
-
 			// This oversees all connections and does not need to be part of wait group management.
 
 			go m.monitorFrame(ctx, nil, m.monitorConnection)
-
 		}
 
 		subs, err := m.GenerateSubs() // regenerate state on new connection
-
 		if err != nil {
-
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
-
 		}
 
 		if len(subs) != 0 {
-
 			if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
-
 				return err
-
 			}
 
 			if missing := m.subscriptions.Missing(subs); len(missing) > 0 {
-
 				return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
-
 			}
-
 		}
 
 		return nil
-
 	}
 
 	connectionManager := m.snapshotConnectionManager()
 
 	if len(connectionManager) == 0 {
-
 		m.setState(disconnectedState)
 
 		return fmt.Errorf("cannot connect: %w", errNoPendingConnections)
-
 	}
 
 	// multiConnectFatalError is a fatal error that will cause all connections to
-
 	// be shutdown and the websocket to be disconnected.
-
 	var multiConnectFatalError error
 
 	// subscriptionError is a non-fatal error that does not shutdown connections
-
 	var subscriptionError error
 
 	// TODO: Implement concurrency below.
 
 	for i, ws := range connectionManager {
-
 		var subs subscription.List
 
 		if !ws.setup.SubscriptionsNotRequired {
-
 			if ws.setup.GenerateSubscriptions == nil {
-
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriptionsGeneratorUnset)
 
 				break
-
 			}
 
 			var err error
 
 			subs, err = ws.setup.GenerateSubscriptions() // regenerate state on new connection
-
 			if err != nil {
-
 				multiConnectFatalError = fmt.Errorf("%s websocket: %w", m.exchangeName, common.AppendError(ErrSubscriptionFailure, err))
 
 				break
-
 			}
 
 			if len(subs) == 0 {
-
 				// If no subscriptions are generated, we skip this connection.
 
 				if m.verbose {
-
 					log.Debugf(log.WebsocketMgr, "%s websocket: no subscriptions generated for [conn:%d] [URL:%s], skipping", m.exchangeName, i+1, ws.setup.URL)
-
 				}
 
 				continue
-
 			}
-
 		}
 
 		if ws.setup.Connector == nil {
-
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errNoConnectFunc)
 
 			break
-
 		}
 
 		if ws.setup.Handler == nil {
-
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketDataHandlerUnset)
 
 			break
-
 		}
 
 		if ws.setup.Subscriber == nil && !ws.setup.SubscriptionsNotRequired {
-
 			multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, errWebsocketSubscriberUnset)
 
 			break
-
 		}
 
 		if ws.setup.SubscriptionsNotRequired && len(subs) == 0 {
-
 			if err := m.createConnectAndSubscribe(ctx, ws, nil); err != nil {
-
 				multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
 
 				break
-
 			}
 
 			if m.verbose {
-
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected", m.exchangeName, ws.setup.URL)
-
 			}
 
 			continue
-
 		}
 
 		// Pre-pass: absorb trackable logical subscriptions onto already-managed connections before batching/capacity routing to avoid misplacement.
 
 		remainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
-
 		if err != nil {
-
 			subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
 
 			continue
-
 		}
 
 		if len(remainingSubs) == 0 {
-
 			if m.verbose {
-
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(subs))
-
 			}
 
 			continue
-
 		}
 
 		for _, batchCandidates := range common.Batch(remainingSubs, m.MaxSubscriptionsPerConnection) {
-
 			batchRemainingSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batchCandidates)
-
 			if err != nil {
-
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
 
 				continue
-
 			}
 
 			if len(batchRemainingSubs) == 0 {
-
 				if m.verbose {
-
 					log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] tracked logical subscriptions on existing connection. [Total Subs: %d] [Tracked: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchCandidates))
-
 				}
 
 				continue
-
 			}
 
 			if err := m.createConnectAndSubscribe(ctx, ws, batchRemainingSubs); err != nil {
-
 				if errors.Is(err, common.ErrFatal) {
-
 					multiConnectFatalError = fmt.Errorf("cannot connect to [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err)
 
 					break
-
 				}
 
 				subscriptionError = common.AppendError(subscriptionError, fmt.Errorf("subscription error on [conn:%d] [URL:%s]: %w ", i+1, ws.setup.URL, err))
 
 				continue
-
 			}
 
 			if m.verbose {
-
 				log.Debugf(log.WebsocketMgr, "%s websocket: [URL:%s] connected. [Total Subs: %d] [Subscribed: %d]", m.exchangeName, ws.setup.URL, len(subs), len(batchRemainingSubs))
-
 			}
-
 		}
 
 		if multiConnectFatalError != nil {
-
 			break
-
 		}
-
 	}
 
 	if multiConnectFatalError != nil {
-
 		// Roll back any successful connections and flush subscriptions
 
 		connectionManager = m.snapshotConnectionManager()
@@ -1068,23 +836,17 @@ func (m *Manager) connect(ctx context.Context) error {
 		m.connectionManagerMu.Lock()
 
 		for _, ws := range connectionManager {
-
 			for _, conn := range ws.connections {
-
 				if err := conn.Shutdown(); err != nil {
-
 					log.Errorln(log.WebsocketMgr, err)
-
 				}
 
 				conn.Subscriptions().Clear()
-
 			}
 
 			ws.connections = nil
 
 			ws.subscriptions.Clear()
-
 		}
 
 		clear(m.connections)
@@ -1094,57 +856,42 @@ func (m *Manager) connect(ctx context.Context) error {
 		m.setState(disconnectedState) // Flip from connecting to disconnected.
 
 		// Drain residual error in the single buffered channel, this mitigates
-
 		// the cycle when `Connect` is called again and the connectionMonitor
-
 		// starts but there is an old error in the channel.
 
 		drain(m.ReadMessageErrors)
 
 		return multiConnectFatalError
-
 	}
 
 	// Assume connected state here. All connections have been established.
-
 	// All subscriptions have been sent and stored. All data received is being
-
 	// handled by the appropriate data handler.
 
 	m.setState(connectedState)
 
 	if m.connectionMonitorRunning.CompareAndSwap(false, true) {
-
 		// This oversees all connections and does not need to be part of wait group management.
 
 		go m.monitorFrame(ctx, nil, m.monitorConnection)
-
 	}
 
 	return subscriptionError
-
 }
 
 func (m *Manager) createConnectAndSubscribe(ctx context.Context, ws *websocket, subs subscription.List) error {
-
 	if m.MaxSubscriptionsPerConnection > 0 && len(subs) > m.MaxSubscriptionsPerConnection {
-
 		return fmt.Errorf("%w %w: max subs allowed %d, requested %d", common.ErrFatal, errSubscriptionsExceedsLimit, m.MaxSubscriptionsPerConnection, len(subs))
-
 	}
 
 	conn := m.createConnectionFromSetup(ws.setup)
 
 	if err := ws.setup.Connector(ctx, conn); err != nil {
-
 		return fmt.Errorf("%w: %w", common.ErrFatal, err)
-
 	}
 
 	if !conn.IsConnected() {
-
 		return fmt.Errorf("%w: %w", common.ErrFatal, ErrNotConnected)
-
 	}
 
 	m.trackConnection(conn, ws)
@@ -1154,137 +901,93 @@ func (m *Manager) createConnectAndSubscribe(ctx context.Context, ws *websocket, 
 	go m.Reader(ctx, conn, ws.setup.Handler)
 
 	if ws.setup.Authenticate != nil && m.CanUseAuthenticatedEndpoints() {
-
 		if err := ws.setup.Authenticate(ctx, conn); err != nil {
-
 			return fmt.Errorf("%w %w: %w", common.ErrFatal, errFailedToAuthenticate, err)
-
 		}
-
 	}
 
 	if ws.setup.SubscriptionsNotRequired {
-
 		if len(subs) != 0 {
-
 			return fmt.Errorf("%w %w: subscriptions were provided but not required", common.ErrFatal, ErrSubscriptionFailure)
-
 		}
 
 		return nil
-
 	}
 
 	if err := ws.setup.Subscriber(ctx, conn, subs); err != nil {
-
 		return fmt.Errorf("%w: %w", ErrSubscriptionFailure, err)
-
 	}
 
 	if missing := ws.subscriptions.Missing(subs); len(missing) > 0 {
-
 		return fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
-
 	}
 
 	connSubsStore := conn.Subscriptions()
 
 	for _, sub := range ws.subscriptions.Contained(subs) {
-
 		// Store subscription against this specific connection for tracking
 
 		if err := connSubsStore.Add(sub); err != nil {
-
 			return fmt.Errorf("%w: adding subscriptions to the specific connection subscription store: %w", ErrSubscriptionFailure, err)
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // Disable disables the exchange websocket protocol
-
 // Note that connectionMonitor will be responsible for shutting down the websocket after disabling
-
 func (m *Manager) Disable() error {
-
 	if !m.IsEnabled() {
-
 		return fmt.Errorf("%s %w", m.exchangeName, ErrAlreadyDisabled)
-
 	}
 
 	m.setEnabled(false)
 
 	return nil
-
 }
 
 // Enable enables the exchange websocket protocol
-
 func (m *Manager) Enable(ctx context.Context) error {
-
 	if m.IsConnected() || m.IsEnabled() {
-
 		return fmt.Errorf("%s %w", m.exchangeName, ErrWebsocketAlreadyEnabled)
-
 	}
 
 	m.setEnabled(true)
 
 	return m.Connect(ctx)
-
 }
 
 // Shutdown attempts to shut down a websocket connection and associated routines
-
 // by using a package defined shutdown function
-
 func (m *Manager) Shutdown() error {
-
 	m.m.Lock()
 
 	defer m.m.Unlock()
 
 	return m.shutdown()
-
 }
 
 func (m *Manager) shutdown() error {
-
 	if m.IsConnecting() {
-
 		return fmt.Errorf("%v %w: %w ", m.exchangeName, errCannotShutdown, errAlreadyReconnecting)
-
 	}
 
 	if !m.IsConnected() {
-
 		return fmt.Errorf("%v %w: %w", m.exchangeName, errCannotShutdown, ErrNotConnected)
-
 	}
 
 	if m.verbose {
-
 		log.Debugf(log.WebsocketMgr, "%v websocket: shutting down websocket", m.exchangeName)
-
 	}
 
 	defer m.Orderbook.FlushBuffer()
 
 	// During the shutdown process, all errors are treated as non-fatal to avoid issues when the connection has already
-
 	// been closed. In such cases, attempting to close the connection may result in a
-
 	// "failed to send closeNotify alert (but connection was closed anyway)" error. Treating these errors as non-fatal
-
 	// prevents the shutdown process from being interrupted, which could otherwise trigger a continuous traffic monitor
-
 	// cycle and potentially block the initiation of a new connection.
-
 	var nonFatalCloseConnectionErrors error
 
 	// Shutdown managed connections
@@ -1292,17 +995,12 @@ func (m *Manager) shutdown() error {
 	m.connectionManagerMu.Lock()
 
 	for _, ws := range m.connectionManager {
-
 		for _, conn := range ws.connections {
-
 			if err := conn.Shutdown(); err != nil {
-
 				nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
-
 			}
 
 			conn.Subscriptions().Clear()
-
 		}
 
 		ws.connections = nil
@@ -1310,7 +1008,6 @@ func (m *Manager) shutdown() error {
 		// Flush any subscriptions from last connection across any managed connections
 
 		ws.subscriptions.Clear()
-
 	}
 
 	// Clean map of old connections
@@ -1320,23 +1017,15 @@ func (m *Manager) shutdown() error {
 	m.connectionManagerMu.Unlock()
 
 	if m.Conn != nil {
-
 		if err := m.Conn.Shutdown(); err != nil {
-
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
-
 		}
-
 	}
 
 	if m.AuthConn != nil {
-
 		if err := m.AuthConn.Shutdown(); err != nil {
-
 			nonFatalCloseConnectionErrors = common.AppendError(nonFatalCloseConnectionErrors, err)
-
 		}
-
 	}
 
 	// flush any subscriptions from last connection if needed
@@ -1352,219 +1041,146 @@ func (m *Manager) shutdown() error {
 	m.ShutdownC = make(chan struct{})
 
 	for _, conn := range []Connection{m.Conn, m.AuthConn} {
-
 		if conn == nil {
-
 			continue
-
 		}
 
 		conn, ok := conn.(*connection)
 
 		if !ok {
-
 			return fmt.Errorf("%s websocket: %w", m.exchangeName, common.GetTypeAssertError("*connection", conn))
-
 		}
 
 		conn.shutdown = m.ShutdownC
-
 	}
 
 	if m.verbose {
-
 		log.Debugf(log.WebsocketMgr, "%v websocket: completed websocket shutdown", m.exchangeName)
-
 	}
 
 	// Drain residual error in the single buffered channel, this mitigates
-
 	// the cycle when `Connect` is called again and the connectionMonitor
-
 	// starts but there is an old error in the channel.
 
 	drain(m.ReadMessageErrors)
 
 	if nonFatalCloseConnectionErrors != nil {
-
 		log.Warnf(log.WebsocketMgr, "%v websocket: shutdown error: %v", m.exchangeName, nonFatalCloseConnectionErrors)
-
 	}
 
 	return nil
-
 }
 
 func (m *Manager) setState(s uint32) {
-
 	m.state.Store(s)
-
 }
 
 // IsInitialised returns whether the websocket has been Setup() already
-
 func (m *Manager) IsInitialised() bool {
-
 	return m.state.Load() != uninitialisedState
-
 }
 
 // IsConnected returns whether the websocket is connected
-
 func (m *Manager) IsConnected() bool {
-
 	return m.state.Load() == connectedState
-
 }
 
 // IsConnecting returns whether the websocket is connecting
-
 func (m *Manager) IsConnecting() bool {
-
 	return m.state.Load() == connectingState
-
 }
 
 func (m *Manager) setEnabled(b bool) {
-
 	m.enabled.Store(b)
-
 }
 
 // IsEnabled returns whether the websocket is enabled
-
 func (m *Manager) IsEnabled() bool {
-
 	return m.enabled.Load()
-
 }
 
 // CanUseAuthenticatedWebsocketForWrapper Handles a common check to
-
 // verify whether a wrapper can use an authenticated websocket endpoint
-
 func (m *Manager) CanUseAuthenticatedWebsocketForWrapper() bool {
-
 	if m.IsConnected() {
-
 		if m.CanUseAuthenticatedEndpoints() {
-
 			return true
-
 		}
 
 		log.Infof(log.WebsocketMgr, "%v - Websocket not authenticated, using REST\n", m.exchangeName)
-
 	}
 
 	return false
-
 }
 
 // SetWebsocketURL sets websocket URL and can refresh underlying connections
-
 func (m *Manager) SetWebsocketURL(u string, auth, reconnect bool) error {
-
 	if m.useMultiConnectionManagement {
-
 		// TODO: Add functionality for multi-connection management to change URL
 
 		return fmt.Errorf("%s: %w", m.exchangeName, errCannotChangeConnectionURL)
-
 	}
 
 	defaultVals := u == "" || u == config.WebsocketURLNonDefaultMessage
 
 	if auth {
-
 		if defaultVals {
-
 			u = m.defaultURLAuth
-
 		}
 
 		err := checkWebsocketURL(u)
-
 		if err != nil {
-
 			return err
-
 		}
 
 		m.runningURLAuth = u
 
 		if m.verbose {
-
 			log.Debugf(log.WebsocketMgr, "%s websocket: setting authenticated websocket URL: %s\n", m.exchangeName, u)
-
 		}
 
 		if m.AuthConn != nil {
-
 			m.AuthConn.SetURL(u)
-
 		}
-
 	} else {
-
 		if defaultVals {
-
 			u = m.defaultURL
-
 		}
 
 		err := checkWebsocketURL(u)
-
 		if err != nil {
-
 			return err
-
 		}
 
 		m.runningURL = u
 
 		if m.verbose {
-
 			log.Debugf(log.WebsocketMgr, "%s websocket: setting unauthenticated websocket URL: %s\n", m.exchangeName, u)
-
 		}
 
 		if m.Conn != nil {
-
 			m.Conn.SetURL(u)
-
 		}
-
 	}
 
 	if m.IsConnected() && reconnect {
-
 		log.Debugf(log.WebsocketMgr, "%s websocket: flushing websocket connection to %s\n", m.exchangeName, u)
 
 		return m.Shutdown()
-
 	}
 
 	return nil
-
 }
 
 // GetWebsocketURL returns the running websocket URL
-
 func (m *Manager) GetWebsocketURL() string {
-
 	return m.runningURL
-
 }
 
 // GetConfiguredWebsocketURLs returns known websocket connection URLs.
-
 func (m *Manager) GetConfiguredWebsocketURLs() ([]string, error) {
-
 	if err := common.NilGuard(m); err != nil {
-
 		return nil, err
-
 	}
 
 	m.m.Lock()
@@ -1572,7 +1188,6 @@ func (m *Manager) GetConfiguredWebsocketURLs() ([]string, error) {
 	defer m.m.Unlock()
 
 	if m.useMultiConnectionManagement {
-
 		m.connectionManagerMu.RLock()
 
 		defer m.connectionManagerMu.RUnlock()
@@ -1582,341 +1197,226 @@ func (m *Manager) GetConfiguredWebsocketURLs() ([]string, error) {
 		seen := make(map[string]struct{}, len(m.connectionManager))
 
 		for _, ws := range m.connectionManager {
-
 			if ws == nil || ws.setup.URL == "" {
-
 				continue
-
 			}
 
 			if _, ok := seen[ws.setup.URL]; ok {
-
 				continue
-
 			}
 
 			seen[ws.setup.URL] = struct{}{}
 
 			urls = append(urls, ws.setup.URL)
-
 		}
 
 		return urls, nil
-
 	}
 
 	if m.runningURL != "" {
-
 		return []string{m.runningURL}, nil
-
 	}
 
 	if m.defaultURL != "" {
-
 		return []string{m.defaultURL}, nil
-
 	}
 
 	return nil, nil
-
 }
 
 // SetProxyAddress sets websocket proxy address
-
 func (m *Manager) SetProxyAddress(ctx context.Context, proxyAddr string) error {
-
 	m.m.Lock()
 
 	defer m.m.Unlock()
 
 	if proxyAddr != "" {
-
 		if _, err := url.ParseRequestURI(proxyAddr); err != nil {
-
 			return fmt.Errorf("%v websocket: cannot set proxy address: %w", m.exchangeName, err)
-
 		}
 
 		if m.proxyAddr == proxyAddr {
-
 			return fmt.Errorf("%v websocket: %w '%v'", m.exchangeName, errSameProxyAddress, m.proxyAddr)
-
 		}
 
 		log.Debugf(log.ExchangeSys, "%s websocket: setting websocket proxy: %s", m.exchangeName, proxyAddr)
-
 	} else {
-
 		log.Debugf(log.ExchangeSys, "%s websocket: removing websocket proxy", m.exchangeName)
-
 	}
 
 	m.connectionManagerMu.RLock()
 
 	for _, ws := range m.connectionManager {
-
 		for _, conn := range ws.connections {
-
 			conn.SetProxy(proxyAddr)
-
 		}
-
 	}
 
 	m.connectionManagerMu.RUnlock()
 
 	if m.Conn != nil {
-
 		m.Conn.SetProxy(proxyAddr)
-
 	}
 
 	if m.AuthConn != nil {
-
 		m.AuthConn.SetProxy(proxyAddr)
-
 	}
 
 	m.proxyAddr = proxyAddr
 
 	if !m.IsConnected() {
-
 		return nil
-
 	}
 
 	if err := m.shutdown(); err != nil {
-
 		return err
-
 	}
 
 	return m.connect(ctx)
-
 }
 
 // GetProxyAddress returns the current websocket proxy
-
 func (m *Manager) GetProxyAddress() string {
-
 	return m.proxyAddr
-
 }
 
 // GetName returns exchange name
-
 func (m *Manager) GetName() string {
-
 	return m.exchangeName
-
 }
 
 // SetCanUseAuthenticatedEndpoints sets canUseAuthenticatedEndpoints val in a thread safe manner
-
 func (m *Manager) SetCanUseAuthenticatedEndpoints(b bool) {
-
 	m.canUseAuthenticatedEndpoints.Store(b)
-
 }
 
 // CanUseAuthenticatedEndpoints gets canUseAuthenticatedEndpoints val in a thread safe manner
-
 func (m *Manager) CanUseAuthenticatedEndpoints() bool {
-
 	return m.canUseAuthenticatedEndpoints.Load()
-
 }
 
 // checkWebsocketURL checks for a valid websocket url
-
 func checkWebsocketURL(s string) error {
-
 	u, err := url.Parse(s)
-
 	if err != nil {
-
 		return err
-
 	}
 
 	if u.Scheme != "ws" && u.Scheme != "wss" {
-
 		return fmt.Errorf("cannot set %w %s", errInvalidWebsocketURL, s)
-
 	}
 
 	return nil
-
 }
 
 // Reader reads and handles data from a specific connection
-
 func (m *Manager) Reader(ctx context.Context, conn Connection, handler func(ctx context.Context, conn Connection, message []byte) error) {
-
 	defer m.Wg.Done()
 
 	for {
-
 		resp := conn.ReadMessage()
 
 		if resp.Raw == nil {
-
 			return // Connection has been closed
-
 		}
 
 		if err := handler(ctx, conn, resp.Raw); err != nil {
-
 			err = fmt.Errorf("connection URL:[%v] error: %w", conn.GetURL(), err)
 
 			if errSend := m.DataHandler.Send(ctx, err); errSend != nil {
-
 				log.Errorf(log.WebsocketMgr, "%s: %s %s", m.exchangeName, errSend, err)
-
 			}
-
 		}
-
 	}
-
 }
 
 func drain(ch <-chan error) {
-
 	for {
-
 		select {
-
 		case <-ch:
 
 		default:
 
 			return
-
 		}
-
 	}
-
 }
 
 // ClosureFrame is a closure function that wraps monitoring variables with observer, if the return is true the frame will exit
-
 type ClosureFrame func(ctx context.Context) func() bool
 
 // monitorFrame monitors a specific websocket component or critical system. It will exit if the observer returns true
-
 // This is used for monitoring data throughput, connection status and other critical websocket components. The waitgroup
-
 // is optional and is used to signal when the monitor has finished.
-
 func (m *Manager) monitorFrame(ctx context.Context, wg *sync.WaitGroup, fn ClosureFrame) {
-
 	if wg != nil {
-
 		defer wg.Done()
-
 	}
 
 	observe := fn(ctx)
 
 	for {
-
 		if observe() {
-
 			return
-
 		}
-
 	}
-
 }
 
 // monitorConnection monitors the connection and attempts to reconnect if the connection is lost
-
 func (m *Manager) monitorConnection(ctx context.Context) func() bool {
-
 	timer := time.NewTimer(m.connectionMonitorDelay)
 
 	return func() bool { return m.observeConnection(ctx, timer) }
-
 }
 
 // observeConnection observes the connection and attempts to reconnect if the connection is lost
-
 func (m *Manager) observeConnection(ctx context.Context, t *time.Timer) (exit bool) {
-
 	select {
-
 	case err := <-m.ReadMessageErrors:
 
 		if errors.Is(err, errConnectionFault) {
-
 			log.Warnf(log.WebsocketMgr, "%v websocket has been disconnected. Reason: %v", m.exchangeName, err)
 
 			if m.IsConnected() {
-
 				if shutdownErr := m.Shutdown(); shutdownErr != nil {
-
 					log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor shutdown err: %s", m.exchangeName, shutdownErr)
-
 				}
-
 			} else {
-
 				m.state.CompareAndSwap(connectingState, disconnectedState)
-
 			}
-
 		}
 
 		// Speedier reconnection, instead of waiting for the next cycle.
 
 		if m.IsEnabled() && (!m.IsConnected() && !m.IsConnecting()) {
-
 			if connectErr := m.Connect(ctx); connectErr != nil {
-
 				log.Errorln(log.WebsocketMgr, connectErr)
-
 			}
-
 		}
 
 		if err := m.DataHandler.Send(ctx, err); err != nil {
-
 			log.Errorf(log.WebsocketMgr, "%v websocket: connectionMonitor data handler err: %s", m.exchangeName, err)
-
 		}
 
 	case <-t.C:
 
 		if m.verbose {
-
 			log.Debugf(log.WebsocketMgr, "%v websocket: running connection monitor cycle", m.exchangeName)
-
 		}
 
 		if !m.IsEnabled() {
-
 			if m.verbose {
-
 				log.Debugf(log.WebsocketMgr, "%v websocket: connectionMonitor - websocket disabled, shutting down", m.exchangeName)
-
 			}
 
 			if m.IsConnected() {
-
 				if err := m.Shutdown(); err != nil {
-
 					log.Errorln(log.WebsocketMgr, err)
-
 				}
-
 			}
 
 			if m.verbose {
-
 				log.Debugf(log.WebsocketMgr, "%v websocket: connection monitor exiting", m.exchangeName)
-
 			}
 
 			t.Stop()
@@ -1924,99 +1424,64 @@ func (m *Manager) observeConnection(ctx context.Context, t *time.Timer) (exit bo
 			m.connectionMonitorRunning.Store(false)
 
 			return true
-
 		}
 
 		if !m.IsConnecting() && !m.IsConnected() {
-
 			err := m.Connect(ctx)
-
 			if err != nil {
-
 				log.Errorln(log.WebsocketMgr, err)
-
 			}
-
 		}
 
 		t.Reset(m.connectionMonitorDelay)
-
 	}
 
 	return false
-
 }
 
 // monitorTraffic monitors to see if there has been traffic within the trafficTimeout time window. If there is no traffic
-
 // the connection is shutdown and will be reconnected by the connectionMonitor routine.
-
 func (m *Manager) monitorTraffic(context.Context) func() bool {
-
 	return func() bool {
-
 		return m.observeTraffic(time.After(m.trafficTimeout), func() {
-
 			go func() {
-
 				if err := m.Shutdown(); err != nil {
-
 					log.Errorf(log.WebsocketMgr, "%v websocket: trafficMonitor shutdown err: %s", m.exchangeName, err)
-
 				}
-
 			}()
-
 		})
-
 	}
-
 }
 
 func (m *Manager) observeTraffic(timeout <-chan time.Time, onTimeout func()) bool {
-
 	select {
-
 	case <-m.ShutdownC:
 
 		if m.verbose {
-
 			log.Debugf(log.WebsocketMgr, "%v websocket: trafficMonitor shutdown message received", m.exchangeName)
-
 		}
 
 	case <-timeout:
 
 		if m.IsConnecting() || signalReceived(m.TrafficAlert) {
-
 			return false
-
 		}
 
 		if m.verbose {
-
 			log.Warnf(log.WebsocketMgr, "%v websocket: has not received a traffic alert in %v. Reconnecting", m.exchangeName, m.trafficTimeout)
-
 		}
 
 		if m.IsConnected() && onTimeout != nil {
-
 			onTimeout()
-
 		}
-
 	}
 
 	return true
-
 }
 
 // signalReceived checks if a signal has been received, this also clears the signal.
-
 func signalReceived(ch chan struct{}) bool {
-
 	select {
-
 	case <-ch:
 
 		return true
@@ -2024,27 +1489,18 @@ func signalReceived(ch chan struct{}) bool {
 	default:
 
 		return false
-
 	}
-
 }
 
 // GetConnection returns the first available connection for a websocket by message filter (defined in exchange package _wrapper.go websocket connection)
-
 // for request and response handling in a multi connection context.
-
 func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
-
 	if err := common.NilGuard(m); err != nil {
-
 		return nil, err
-
 	}
 
 	if messageFilter == nil {
-
 		return nil, fmt.Errorf("%w: messageFilter", common.ErrNilPointer)
-
 	}
 
 	m.m.Lock()
@@ -2052,15 +1508,11 @@ func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
 	defer m.m.Unlock()
 
 	if !m.useMultiConnectionManagement {
-
 		return nil, fmt.Errorf("%s: multi connection management not enabled %w please use exported Conn and AuthConn fields", m.exchangeName, errCannotObtainOutboundConnection)
-
 	}
 
 	if !m.IsConnected() {
-
 		return nil, ErrNotConnected
-
 	}
 
 	m.connectionManagerMu.RLock()
@@ -2068,23 +1520,16 @@ func (m *Manager) GetConnection(messageFilter any) (Connection, error) {
 	defer m.connectionManagerMu.RUnlock()
 
 	for _, ws := range m.connectionManager {
-
 		if ws.setup.MessageFilter != messageFilter {
-
 			continue
-
 		}
 
 		if len(ws.connections) == 0 {
-
 			return nil, fmt.Errorf("%s: %s %w associated with message filter: '%v'", m.exchangeName, ws.setup.URL, ErrNotConnected, messageFilter)
-
 		}
 
 		return ws.connections[0], nil
-
 	}
 
 	return nil, fmt.Errorf("%s: %w associated with message filter: '%v'", m.exchangeName, ErrRequestRouteNotFound, messageFilter)
-
 }

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -154,7 +154,7 @@ type Manager struct {
 
 	resubscriptionsMu sync.Mutex
 
-	resubscriptions map[*subscription.Subscription]chan struct{}
+	resubscriptions map[*subscription.Subscription]*resubscribeTracker
 
 	resubscribePreLockHook func(*subscription.Subscription)
 
@@ -292,7 +292,7 @@ func NewManager() *Manager {
 
 		connections: make(map[Connection]*websocket),
 
-		resubscriptions: make(map[*subscription.Subscription]chan struct{}),
+		resubscriptions: make(map[*subscription.Subscription]*resubscribeTracker),
 	}
 }
 

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -100,8 +100,8 @@ type Manager struct {
 	subscriptions                 *subscription.Store
 	resubscriptionsMu             sync.Mutex
 	resubscriptions               map[*subscription.Subscription]*resubscribeTracker
-	resubscribePreLockHook        func(*subscription.Subscription)
-	resubscribeWaiterHook         func(*subscription.Subscription)
+	resubscribePreLockHook        func(*subscription.Subscription) // test-only, never set in production: signals a caller reached the pre-lock point
+	resubscribeWaiterHook         func(*subscription.Subscription) // test-only, never set in production: signals a caller coalesced onto an in-flight recovery
 	connector                     func() error
 	rateLimitDefinitions          request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
 	Subscriber                    func(subscription.List) error

--- a/exchange/websocket/manager.go
+++ b/exchange/websocket/manager.go
@@ -98,6 +98,9 @@ type Manager struct {
 	connectionManagerMu           sync.RWMutex
 	connections                   map[Connection]*websocket
 	subscriptions                 *subscription.Store
+	resubscriptionsMu             sync.Mutex
+	resubscriptions               map[*subscription.Subscription]struct{}
+	resubscribePreLockHook        func(*subscription.Subscription)
 	connector                     func() error
 	rateLimitDefinitions          request.RateLimitDefinitions // rate limiters shared between Websocket and REST connections
 	Subscriber                    func(subscription.List) error
@@ -189,6 +192,7 @@ func NewManager() *Manager {
 		features:          &protocol.Features{},
 		Orderbook:         buffer.Orderbook{},
 		connections:       make(map[Connection]*websocket),
+		resubscriptions:   make(map[*subscription.Subscription]struct{}),
 	}
 }
 

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -102,7 +102,13 @@ func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
 // A subscription already in ResubscribingState is retried.
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
-	m.m.Lock()
+	if !m.m.TryLock() {
+		m.m.Lock()
+		if s.State() == subscription.SubscribedState {
+			m.m.Unlock()
+			return nil
+		}
+	}
 	defer m.m.Unlock()
 
 	l := subscription.List{s}
@@ -310,7 +316,13 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		usedCapacity = subscriptionStore.Len()
 	}
 
-	if m.MaxSubscriptionsPerConnection > 0 && usedCapacity+len(subs) > m.MaxSubscriptionsPerConnection {
+	retained := 0
+	for _, s := range subs {
+		if s.State() == subscription.ResubscribingState && subscriptionStore.Get(s) != nil {
+			retained++
+		}
+	}
+	if m.MaxSubscriptionsPerConnection > 0 && usedCapacity-retained+len(subs) > m.MaxSubscriptionsPerConnection {
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
 			errSubscriptionsExceedsLimit,
 			usedCapacity,
@@ -590,7 +602,13 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
-	m.m.Lock()
+	if !m.m.TryLock() {
+		m.m.Lock()
+		if allSubscriptionsState(subs, subscription.SubscribedState) {
+			m.m.Unlock()
+			return nil
+		}
+	}
 	defer m.m.Unlock()
 
 	if err := common.NilGuard(conn, subs); err != nil {
@@ -610,6 +628,15 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		return fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
 	}
 	return nil
+}
+
+func allSubscriptionsState(subs subscription.List, state subscription.State) bool {
+	for _, sub := range subs {
+		if sub.State() != state {
+			return false
+		}
+	}
+	return true
 }
 
 // unsubscribeFromConnection unsubscribes for a connection and removes subscriptions from the connection's store

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -102,35 +102,86 @@ func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
 // A subscription already in ResubscribingState is retried.
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
-	if !m.m.TryLock() {
-		m.m.Lock()
-		if s.State() == subscription.SubscribedState {
-			m.m.Unlock()
-			return nil
-		}
+	if s == nil {
+		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
 	}
+
+	m.resubscriptionsMu.Lock()
+	if m.resubscriptions == nil {
+		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+	}
+	_, inFlight := m.resubscriptions[s]
+	if !inFlight {
+		m.resubscriptions[s] = struct{}{}
+	}
+	m.resubscriptionsMu.Unlock()
+
+	if !inFlight {
+		defer func() {
+			m.resubscriptionsMu.Lock()
+			delete(m.resubscriptions, s)
+			m.resubscriptionsMu.Unlock()
+		}()
+	}
+
+	if m.resubscribePreLockHook != nil {
+		m.resubscribePreLockHook(s)
+	}
+
+	m.m.Lock()
 	defer m.m.Unlock()
 
-	l := subscription.List{s}
-	if err := setResubscribingState(l); err != nil {
-		return fmt.Errorf("%w: %s", err, s)
+	if inFlight {
+		if s.State() == subscription.SubscribedState {
+			return nil
+		}
+		m.resubscriptionsMu.Lock()
+		m.resubscriptions[s] = struct{}{}
+		m.resubscriptionsMu.Unlock()
+		defer func() {
+			m.resubscriptionsMu.Lock()
+			delete(m.resubscriptions, s)
+			m.resubscriptionsMu.Unlock()
+		}()
 	}
+
+	l := subscription.List{s}
+	setResubscribingState(l)
+
+	store := m.subscriptionStore(conn)
+	var origSub *subscription.Subscription
+	var origKey any
+	if store != nil {
+		origSub = store.Get(s)
+		if origSub != nil {
+			origKey = origSub.Key
+		}
+	}
+
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
 		return err
 	}
-	return m.SubscribeToChannels(ctx, conn, l)
-}
-
-func setResubscribingState(subs subscription.List) error {
-	for _, sub := range subs {
-		if sub.State() == subscription.ResubscribingState {
-			continue
+	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
+		if origSub != nil && store != nil {
+			if origKey != nil {
+				origSub.Key = origKey
+			}
+			if store.Get(origSub) == nil {
+				_ = store.Add(origSub)
+			}
+			_ = origSub.SetState(subscription.ResubscribingState)
 		}
-		if err := sub.SetState(subscription.ResubscribingState); err != nil {
-			return err
-		}
+		return err
 	}
 	return nil
+}
+
+func setResubscribingState(subs subscription.List) {
+	for _, sub := range subs {
+		if sub.State() != subscription.ResubscribingState {
+			_ = sub.SetState(subscription.ResubscribingState)
+		}
+	}
 }
 
 // SubscribeToChannels subscribes to websocket channels using the exchange specific Subscriber method
@@ -213,9 +264,6 @@ func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Sub
 
 	var errs error
 	for _, s := range subs {
-		if s.State() == subscription.ResubscribingState {
-			continue
-		}
 		if err := s.SetState(subscription.UnsubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 		}
@@ -275,12 +323,11 @@ func (m *Manager) GetSubscriptions() subscription.List {
 // The subscription state is not considered when counting existing subscriptions
 func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) error {
 	var subscriptionStore *subscription.Store
-	var usedCapacity int
+	var connSubStore *subscription.Store
 	if ws, ok := m.managedWebsocket(conn); ok {
 		if ws.subscriptions == nil {
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
 		}
-		var connSubStore *subscription.Store
 		for _, c := range m.snapshotManagedConnections(ws) { // ensure connection is actually managed
 			if c == conn {
 				connSubStore = c.Subscriptions()
@@ -291,25 +338,31 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 			return fmt.Errorf("%w: connection subscription store not found", common.ErrNilPointer)
 		}
 		subscriptionStore = ws.subscriptions
-		usedCapacity = connSubStore.Len()
 	} else {
 		subscriptionStore = m.subscriptionStore(nil)
 		if subscriptionStore == nil {
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
 		}
-		usedCapacity = subscriptionStore.Len()
+		connSubStore = subscriptionStore
 	}
 
-	retained := make(map[*subscription.Subscription]struct{}, len(subs))
+	incoming := make(map[*subscription.Subscription]struct{}, len(subs))
 	for _, s := range subs {
-		if s.State() == subscription.ResubscribingState && subscriptionStore.Get(s) != nil {
-			retained[s] = struct{}{}
-		}
+		incoming[s] = struct{}{}
 	}
-	if m.MaxSubscriptionsPerConnection > 0 && usedCapacity-len(retained)+len(subs) > m.MaxSubscriptionsPerConnection {
+
+	usedCap := 0
+	for _, sub := range connSubStore.List() {
+		if _, ok := incoming[sub]; ok && sub.State() == subscription.ResubscribingState {
+			continue // Retained for this recovery, so it is not consuming a new slot
+		}
+		usedCap++
+	}
+
+	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
 			errSubscriptionsExceedsLimit,
-			usedCapacity,
+			usedCap,
 			len(subs),
 			m.MaxSubscriptionsPerConnection)
 	}
@@ -586,21 +639,67 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
-	if !m.m.TryLock() {
-		m.m.Lock()
-		if allSubscriptionsState(subs, subscription.SubscribedState) {
-			m.m.Unlock()
-			return nil
-		}
-	}
-	defer m.m.Unlock()
-
 	if err := common.NilGuard(conn, subs); err != nil {
 		return err
 	}
-	if err := setResubscribingState(subs); err != nil {
-		return err
+	if len(subs) == 0 {
+		return nil
 	}
+
+	m.resubscriptionsMu.Lock()
+	if m.resubscriptions == nil {
+		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+	}
+	allInFlight := true
+	for _, s := range subs {
+		if _, ok := m.resubscriptions[s]; !ok {
+			allInFlight = false
+			break
+		}
+	}
+	if !allInFlight {
+		for _, s := range subs {
+			m.resubscriptions[s] = struct{}{}
+		}
+	}
+	m.resubscriptionsMu.Unlock()
+
+	if !allInFlight {
+		defer func() {
+			m.resubscriptionsMu.Lock()
+			for _, s := range subs {
+				delete(m.resubscriptions, s)
+			}
+			m.resubscriptionsMu.Unlock()
+		}()
+	}
+
+	if m.resubscribePreLockHook != nil && len(subs) > 0 {
+		m.resubscribePreLockHook(subs[0])
+	}
+
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if allInFlight {
+		if allSubscriptionsState(subs, subscription.SubscribedState) {
+			return nil
+		}
+		m.resubscriptionsMu.Lock()
+		for _, s := range subs {
+			m.resubscriptions[s] = struct{}{}
+		}
+		m.resubscriptionsMu.Unlock()
+		defer func() {
+			m.resubscriptionsMu.Lock()
+			for _, s := range subs {
+				delete(m.resubscriptions, s)
+			}
+			m.resubscriptionsMu.Unlock()
+		}()
+	}
+
+	setResubscribingState(subs)
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
 	if err != nil {
 		return err
@@ -662,11 +761,17 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 		return nil, fmt.Errorf("websocket connection %w", err)
 	}
 
+	incoming := make(map[*subscription.Subscription]struct{}, len(subs))
+	for _, s := range subs {
+		incoming[s] = struct{}{}
+	}
+
 	usedCap := 0
 	for _, sub := range store.List() {
-		if sub.State() != subscription.ResubscribingState {
-			usedCap++
+		if _, ok := incoming[sub]; ok && sub.State() == subscription.ResubscribingState {
+			continue // Retained for this recovery, so it is not consuming a new slot
 		}
+		usedCap++
 	}
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
 		return subs, nil // No capacity left for this connection
@@ -693,9 +798,6 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	for _, s := range toSubscribe {
 		if tracked[s] {
 			continue
-		}
-		if store.Get(s) != nil {
-			return nil, fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
 		}
 		if err := store.Add(s); err != nil {
 			return nil, err

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -115,7 +115,7 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	if err := setResubscribingState(l); err != nil {
 		return fmt.Errorf("%w: %s", err, s)
 	}
-	if err := m.unsubscribeForResubscribe(ctx, conn, m.subscriptionStore(conn), l); err != nil {
+	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
 		return err
 	}
 	return m.SubscribeToChannels(ctx, conn, l)
@@ -131,22 +131,6 @@ func setResubscribingState(subs subscription.List) error {
 		}
 	}
 	return nil
-}
-
-func (m *Manager) unsubscribeForResubscribe(ctx context.Context, conn Connection, store *subscription.Store, subs subscription.List) error {
-	if store == nil {
-		return fmt.Errorf("%w: subscription store", common.ErrNilPointer)
-	}
-	if missing := store.Missing(subs); len(missing) > 0 {
-		return fmt.Errorf("%w: %w: %q", ErrSubscriptionsNotRemoved, subscription.ErrNotFound, missing)
-	}
-	if ws, ok := m.managedWebsocket(conn); ok {
-		return ws.setup.Unsubscriber(ctx, conn, subs)
-	}
-	if m.Unsubscriber == nil {
-		return fmt.Errorf("%w: Global Unsubscriber not set", common.ErrNilPointer)
-	}
-	return m.Unsubscriber(subs)
 }
 
 // SubscribeToChannels subscribes to websocket channels using the exchange specific Subscriber method
@@ -617,8 +601,12 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	if err := setResubscribingState(subs); err != nil {
 		return err
 	}
-	if err := m.unsubscribeForResubscribe(ctx, conn, conn.Subscriptions(), subs); err != nil {
+	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
+	if err != nil {
 		return err
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, missing)
 	}
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
 	if err != nil {
@@ -657,6 +645,9 @@ func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection
 
 	missing := store.Missing(subs)
 	for _, r := range remove {
+		if r.State() == subscription.ResubscribingState {
+			continue
+		}
 		if err := store.Remove(r); err != nil {
 			return nil, err
 		}

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -99,17 +99,48 @@ func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 }
 
 // ResubscribeToChannel resubscribes to channel
-// Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription
-// Errors if subscription is already subscribing
+// Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
+// A subscription already in ResubscribingState is retried.
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
 	l := subscription.List{s}
-	if err := s.SetState(subscription.ResubscribingState); err != nil {
+	if err := setResubscribingState(l); err != nil {
 		return fmt.Errorf("%w: %s", err, s)
 	}
-	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
+	if err := m.unsubscribeForResubscribe(ctx, conn, m.subscriptionStore(conn), l); err != nil {
 		return err
 	}
 	return m.SubscribeToChannels(ctx, conn, l)
+}
+
+func setResubscribingState(subs subscription.List) error {
+	for _, sub := range subs {
+		if sub.State() == subscription.ResubscribingState {
+			continue
+		}
+		if err := sub.SetState(subscription.ResubscribingState); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) unsubscribeForResubscribe(ctx context.Context, conn Connection, store *subscription.Store, subs subscription.List) error {
+	if store == nil {
+		return fmt.Errorf("%w: subscription store", common.ErrNilPointer)
+	}
+	if missing := store.Missing(subs); len(missing) > 0 {
+		return fmt.Errorf("%w: %w: %q", ErrSubscriptionsNotRemoved, subscription.ErrNotFound, missing)
+	}
+	if ws, ok := m.managedWebsocket(conn); ok {
+		return ws.setup.Unsubscriber(ctx, conn, subs)
+	}
+	if m.Unsubscriber == nil {
+		return fmt.Errorf("%w: Global Unsubscriber not set", common.ErrNilPointer)
+	}
+	return m.Unsubscriber(subs)
 }
 
 // SubscribeToChannels subscribes to websocket channels using the exchange specific Subscriber method
@@ -166,11 +197,14 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 
 	var errs error
 	for _, s := range subs {
+		alreadyTracked := subscriptionStore.Get(s) != nil && s.State() == subscription.ResubscribingState
 		if err := s.SetState(subscription.SubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 		}
-		if err := subscriptionStore.Add(s); err != nil {
-			errs = common.AppendError(errs, err)
+		if !alreadyTracked {
+			if err := subscriptionStore.Add(s); err != nil {
+				errs = common.AppendError(errs, err)
+			}
 		}
 	}
 	return errs
@@ -189,6 +223,9 @@ func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Sub
 
 	var errs error
 	for _, s := range subs {
+		if s.State() == subscription.ResubscribingState {
+			continue
+		}
 		if err := s.SetState(subscription.UnsubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 		}
@@ -553,18 +590,17 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
 	if err := common.NilGuard(conn, subs); err != nil {
 		return err
 	}
-	if err := subs.SetStates(subscription.ResubscribingState); err != nil {
+	if err := setResubscribingState(subs); err != nil {
 		return err
 	}
-	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
-	if err != nil {
+	if err := m.unsubscribeForResubscribe(ctx, conn, conn.Subscriptions(), subs); err != nil {
 		return err
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, missing)
 	}
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
 	if err != nil {
@@ -608,7 +644,12 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 		return nil, fmt.Errorf("websocket connection %w", err)
 	}
 
-	usedCap := store.Len()
+	usedCap := 0
+	for _, sub := range store.List() {
+		if sub.State() != subscription.ResubscribingState {
+			usedCap++
+		}
+	}
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
 		return subs, nil // No capacity left for this connection
 	}
@@ -623,11 +664,21 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	}
 
 	toSubscribe := subs[:availableCap]
+	tracked := make(map[*subscription.Subscription]bool, len(toSubscribe))
+	for _, s := range toSubscribe {
+		tracked[s] = store.Get(s) != nil && s.State() == subscription.ResubscribingState
+	}
 	if err := m.SubscribeToChannels(ctx, conn, toSubscribe); err != nil {
 		return nil, err
 	}
 
 	for _, s := range toSubscribe {
+		if tracked[s] {
+			continue
+		}
+		if store.Get(s) != nil {
+			return nil, fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
+		}
 		if err := store.Add(s); err != nil {
 			return nil, err
 		}

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -13,919 +13,1661 @@ import (
 )
 
 // Public subscription errors
+
 var (
-	ErrSubscriptionFailure     = errors.New("subscription failure")
-	ErrSubscriptionsNotAdded   = errors.New("subscriptions not added")
+	ErrSubscriptionFailure = errors.New("subscription failure")
+
+	ErrSubscriptionsNotAdded = errors.New("subscriptions not added")
+
 	ErrSubscriptionsNotRemoved = errors.New("subscriptions not removed")
 )
 
 // Public subscription errors
+
 var (
 	errSubscriptionsExceedsLimit = errors.New("subscriptions exceeds limit")
-	errConnectionNotFound        = errors.New("connection not found")
+
+	errConnectionNotFound = errors.New("connection not found")
 )
 
 // UnsubscribeChannels unsubscribes from a list of websocket channel
+
 func (m *Manager) UnsubscribeChannels(ctx context.Context, conn Connection, channels subscription.List) error {
+
 	if len(channels) == 0 {
+
 		return nil // No channels to unsubscribe from is not an error
+
 	}
 
 	if m.useMultiConnectionManagement {
+
 		if err := common.NilGuard(conn); err != nil {
+
 			return err
+
 		}
+
 		ws, ok := m.managedWebsocket(conn)
+
 		if !ok {
+
 			return fmt.Errorf("%w: %q", errConnectionNotFound, conn.GetURL())
+
 		}
+
 		return m.unsubscribe(ws.subscriptions, channels, func(channels subscription.List) error {
+
 			return ws.setup.Unsubscriber(ctx, conn, channels)
+
 		})
+
 	}
 
 	if m.Unsubscriber == nil {
+
 		return fmt.Errorf("%w: Global Unsubscriber not set", common.ErrNilPointer)
+
 	}
 
 	return m.unsubscribe(m.subscriptions, channels, func(channels subscription.List) error {
+
 		return m.Unsubscriber(channels)
+
 	})
+
 }
 
 func (m *Manager) unsubscribe(store *subscription.Store, channels subscription.List, unsub func(channels subscription.List) error) error {
+
 	if store == nil {
+
 		return nil // No channels to unsubscribe from is not an error
+
 	}
+
 	for _, s := range channels {
+
 		if store.Get(s) == nil {
+
 			return fmt.Errorf("%w: %s", subscription.ErrNotFound, s)
+
 		}
+
 	}
+
 	return unsub(channels)
+
 }
 
 func (m *Manager) managedWebsocket(conn Connection) (*websocket, bool) {
+
 	if conn == nil {
+
 		return nil, false
+
 	}
+
 	m.connectionManagerMu.RLock()
+
 	defer m.connectionManagerMu.RUnlock()
+
 	ws := m.connections[conn]
+
 	return ws, ws != nil
+
 }
 
 func (m *Manager) subscriptionStore(conn Connection) *subscription.Store {
+
 	m.connectionManagerMu.RLock()
+
 	defer m.connectionManagerMu.RUnlock()
+
 	if ws, ok := m.connections[conn]; ok && conn != nil {
+
 		return ws.subscriptions
+
 	}
+
 	return m.subscriptions
+
 }
 
 func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
+
 	m.connectionManagerMu.Lock()
+
 	defer m.connectionManagerMu.Unlock()
+
 	if ws, ok := m.connections[conn]; ok && conn != nil {
+
 		if ws.subscriptions == nil {
+
 			ws.subscriptions = subscription.NewStore()
+
 		}
+
 		return ws.subscriptions
+
 	}
+
 	if m.subscriptions == nil {
+
 		m.subscriptions = subscription.NewStore()
+
 	}
+
 	return m.subscriptions
+
 }
 
 // ResubscribeToChannel resubscribes to channel
+
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
+
 // A subscription already in ResubscribingState is retried.
+
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
+
 	if s == nil {
+
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
+
 	}
 
 	m.resubscriptionsMu.Lock()
+
 	if m.resubscriptions == nil {
+
 		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+
 	}
+
 	_, inFlight := m.resubscriptions[s]
+
 	if !inFlight {
+
 		m.resubscriptions[s] = struct{}{}
+
 	}
+
 	m.resubscriptionsMu.Unlock()
 
 	if !inFlight {
+
 		defer func() {
+
 			m.resubscriptionsMu.Lock()
+
 			delete(m.resubscriptions, s)
+
 			m.resubscriptionsMu.Unlock()
+
 		}()
+
 	}
 
 	if m.resubscribePreLockHook != nil {
+
 		m.resubscribePreLockHook(s)
+
 	}
 
 	m.m.Lock()
+
 	if inFlight {
+
 		m.m.Unlock()
+
 		m.waitForResubscriptionLeader(s)
+
 		m.m.Lock()
+
 		if s.State() == subscription.SubscribedState {
+
 			m.m.Unlock()
+
 			return nil
+
 		}
+
 		m.resubscriptionsMu.Lock()
+
 		m.resubscriptions[s] = struct{}{}
+
 		m.resubscriptionsMu.Unlock()
+
 		defer func() {
+
 			m.resubscriptionsMu.Lock()
+
 			delete(m.resubscriptions, s)
+
 			m.resubscriptionsMu.Unlock()
+
 		}()
+
 	}
 
 	l := subscription.List{s}
+
 	setResubscribingState(l)
 
 	wsStore := m.subscriptionStore(conn)
+
 	connStore := connectionSubscriptionStore(conn)
+
 	var origKey any
+
 	if wsStore != nil {
+
 		if origSub := wsStore.Get(s); origSub != nil {
+
 			origKey = origSub.Key
+
 		}
+
 	}
+
 	m.m.Unlock()
 
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
+
 		return err
+
 	}
+
 	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
+
 		m.m.Lock()
+
 		restoreFailedRecovery(wsStore, connStore, s, origKey)
+
 		m.m.Unlock()
+
 		return err
+
 	}
+
 	return nil
+
 }
 
 type recoverySnapshot struct {
-	sub     *subscription.Subscription
+	sub *subscription.Subscription
+
 	origKey any
 }
 
 func connectionSubscriptionStore(conn Connection) *subscription.Store {
+
 	if conn == nil {
+
 		return nil
+
 	}
+
 	return conn.Subscriptions()
+
 }
 
 func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscription.Subscription, origKey any) {
+
 	if sub == nil {
+
 		return
+
 	}
+
 	if connStore != nil {
+
 		restoreSubscriptionAfterFailedRecovery(connStore, sub, origKey)
+
 	}
+
 	if wsStore == nil || wsStore == connStore {
+
 		return
+
 	}
+
 	if wsStore.Get(sub) == nil {
+
 		restoreSubscriptionAfterFailedRecovery(wsStore, sub, origKey)
+
 		return
+
 	}
+
 	_ = sub.SetState(subscription.ResubscribingState)
+
 }
 
 func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
+
 	for {
+
 		m.resubscriptionsMu.Lock()
+
 		_, exists := m.resubscriptions[s]
+
 		m.resubscriptionsMu.Unlock()
+
 		if !exists {
+
 			return
+
 		}
+
 		runtime.Gosched()
+
 	}
+
 }
 
 func connectionUsedCapacity(store *subscription.Store, incoming subscription.List) int {
+
 	if store == nil {
+
 		return 0
+
 	}
+
 	usedCap := store.Len()
+
 	discounted := make(map[*subscription.Subscription]struct{}, len(incoming))
+
 	for _, s := range incoming {
+
 		if s == nil || s.State() != subscription.ResubscribingState || store.Get(s) == nil {
+
 			continue
+
 		}
+
 		if _, seen := discounted[s]; seen {
+
 			continue
+
 		}
+
 		discounted[s] = struct{}{}
+
 		usedCap--
+
 	}
+
 	return usedCap
+
 }
 
 func hasLiveRecoveryReplacement(store *subscription.Store, sub *subscription.Subscription, origKey any) bool {
+
 	if store == nil || sub == nil {
+
 		return false
+
 	}
+
 	want := subscription.ExactKey{Subscription: sub}
+
 	for _, existing := range store.List() {
+
 		if existing == sub {
+
 			continue
+
 		}
+
 		if !want.Match(subscription.ExactKey{Subscription: existing}) {
+
 			continue
+
 		}
+
 		if existing.State() != subscription.SubscribedState {
+
 			continue
+
 		}
+
 		if origKey != nil && existing.EnsureKeyed() == origKey {
+
 			continue
+
 		}
+
 		return true
+
 	}
+
 	return false
+
 }
 
 func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subscription.Subscription, origKey any) {
+
 	if store == nil || sub == nil {
+
 		return
+
 	}
+
 	if hasLiveRecoveryReplacement(store, sub, origKey) {
+
 		if store.Get(sub) != nil {
+
 			_ = sub.SetState(subscription.ResubscribingState)
+
 		}
+
 		return
+
 	}
+
 	if origKey != nil {
+
 		sub.SetKey(origKey)
+
 	}
+
 	_ = sub.SetState(subscription.ResubscribingState)
+
 	if store.Get(sub) == nil {
+
 		_ = store.Add(sub)
+
 	}
+
 }
 
 func setResubscribingState(subs subscription.List) {
+
 	for _, sub := range subs {
+
 		if sub.State() != subscription.ResubscribingState {
+
 			_ = sub.SetState(subscription.ResubscribingState)
+
 		}
+
 	}
+
 }
 
 // SubscribeToChannels subscribes to websocket channels using the exchange specific Subscriber method
+
 // Errors are returned for duplicates or exceeding max Subscriptions
+
 func (m *Manager) SubscribeToChannels(ctx context.Context, conn Connection, subs subscription.List) error {
+
 	if slices.Contains(subs, nil) {
+
 		return fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
+
 	}
+
 	if err := m.checkSubscriptions(conn, subs); err != nil {
+
 		return err
+
 	}
 
 	if ws, ok := m.managedWebsocket(conn); ok {
+
 		return ws.setup.Subscriber(ctx, conn, subs)
+
 	}
 
 	if m.Subscriber == nil {
+
 		return fmt.Errorf("%w: Global Subscriber not set", common.ErrNilPointer)
+
 	}
 
 	if err := m.Subscriber(subs); err != nil {
+
 		return fmt.Errorf("%w: %w", ErrSubscriptionFailure, err)
+
 	}
+
 	return nil
+
 }
 
 // AddSubscriptions adds subscriptions to the subscription store
+
 // Sets state to Subscribing unless the state is already set
+
 func (m *Manager) AddSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
+
 	if m == nil {
+
 		return fmt.Errorf("%w: AddSubscriptions called on nil Websocket", common.ErrNilPointer)
+
 	}
+
 	subscriptionStore := m.initSubscriptionStore(conn)
+
 	var errs error
+
 	for _, s := range subs {
+
 		if s.State() == subscription.InactiveState {
+
 			if err := s.SetState(subscription.SubscribingState); err != nil {
+
 				errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
+
 			}
+
 		}
+
 		if err := subscriptionStore.Add(s); err != nil {
+
 			errs = common.AppendError(errs, err)
+
 		}
+
 	}
+
 	return errs
+
 }
 
 // AddSuccessfulSubscriptions marks subscriptions as subscribed and adds them to the subscription store
+
 func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
+
 	if m == nil {
+
 		return fmt.Errorf("%w: AddSuccessfulSubscriptions called on nil Websocket", common.ErrNilPointer)
+
 	}
+
 	subscriptionStore := m.initSubscriptionStore(conn)
 
 	var errs error
+
 	for _, s := range subs {
+
 		alreadyTracked := subscriptionStore.Get(s) != nil && s.State() == subscription.ResubscribingState
+
 		if err := s.SetState(subscription.SubscribedState); err != nil {
+
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
+
 		}
+
 		if !alreadyTracked {
+
 			if err := subscriptionStore.Add(s); err != nil {
+
 				errs = common.AppendError(errs, err)
+
 			}
+
 		}
+
 	}
+
 	return errs
+
 }
 
 // RemoveSubscriptions removes subscriptions from the subscription list and sets the status to Unsubscribed
+
 func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
+
 	if m == nil {
+
 		return fmt.Errorf("%w: RemoveSubscriptions called on nil Websocket", common.ErrNilPointer)
+
 	}
+
 	subscriptionStore := m.subscriptionStore(conn)
 
 	if subscriptionStore == nil {
+
 		return fmt.Errorf("%w: RemoveSubscriptions called on uninitialised Websocket", common.ErrNilPointer)
+
 	}
 
 	var errs error
+
 	for _, s := range subs {
+
 		if err := s.SetState(subscription.UnsubscribedState); err != nil {
+
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
+
 		}
+
 		if err := subscriptionStore.Remove(s); err != nil {
+
 			errs = common.AppendError(errs, err)
+
 		}
+
 	}
+
 	return errs
+
 }
 
 // GetSubscription returns a subscription at the key provided
+
 // returns nil if no subscription is at that key or the key is nil
+
 // Keys can implement subscription.MatchableKey in order to provide custom matching logic
+
 func (m *Manager) GetSubscription(key any) *subscription.Subscription {
+
 	if m == nil || key == nil {
+
 		return nil
+
 	}
+
 	for _, ws := range m.snapshotConnectionManager() {
+
 		m.connectionManagerMu.RLock()
+
 		store := ws.subscriptions
+
 		var sub *subscription.Subscription
+
 		if store != nil {
+
 			sub = store.Get(key)
+
 		}
+
 		m.connectionManagerMu.RUnlock()
+
 		if sub != nil {
+
 			return sub
+
 		}
+
 	}
+
 	if store := m.subscriptionStore(nil); store != nil {
+
 		return store.Get(key)
+
 	}
+
 	return nil
+
 }
 
 // GetSubscriptions returns a new slice of the subscriptions
+
 func (m *Manager) GetSubscriptions() subscription.List {
+
 	if m == nil {
+
 		return nil
+
 	}
+
 	var subs subscription.List
+
 	for _, ws := range m.snapshotConnectionManager() {
+
 		m.connectionManagerMu.RLock()
+
 		store := ws.subscriptions
+
 		if store != nil {
+
 			subs = append(subs, store.List()...)
+
 		}
+
 		m.connectionManagerMu.RUnlock()
+
 	}
+
 	if store := m.subscriptionStore(nil); store != nil {
+
 		subs = append(subs, store.List()...)
+
 	}
+
 	return subs
+
 }
 
 // checkSubscriptions checks subscriptions against the max subscription limit and if the subscription already exists
+
 // The subscription state is not considered when counting existing subscriptions
+
 func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) error {
+
 	var subscriptionStore *subscription.Store
+
 	var connSubStore *subscription.Store
+
 	if ws, ok := m.managedWebsocket(conn); ok {
+
 		if ws.subscriptions == nil {
+
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
+
 		}
+
 		for _, c := range m.snapshotManagedConnections(ws) { // ensure connection is actually managed
+
 			if c == conn {
+
 				connSubStore = c.Subscriptions()
+
 				break
+
 			}
+
 		}
+
 		if connSubStore == nil {
+
 			return fmt.Errorf("%w: connection subscription store not found", common.ErrNilPointer)
+
 		}
+
 		subscriptionStore = ws.subscriptions
+
 	} else {
+
 		subscriptionStore = m.subscriptionStore(nil)
+
 		if subscriptionStore == nil {
+
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
+
 		}
+
 		connSubStore = subscriptionStore
+
 	}
 
 	usedCap := connectionUsedCapacity(connSubStore, subs)
 
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
+
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
+
 			errSubscriptionsExceedsLimit,
+
 			usedCap,
+
 			len(subs),
+
 			m.MaxSubscriptionsPerConnection)
+
 	}
 
 	for _, s := range subs {
+
 		if s.State() == subscription.ResubscribingState {
+
 			continue
+
 		}
+
 		if found := subscriptionStore.Get(s); found != nil {
+
 			return fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
+
 		}
+
 	}
 
 	return nil
+
 }
 
 // FlushChannels flushes channel subscriptions when there is a pair/asset change
+
 func (m *Manager) FlushChannels(ctx context.Context) error {
+
 	m.m.Lock()
+
 	defer m.m.Unlock()
+
 	return m.flushChannels(ctx)
+
 }
 
 func (m *Manager) flushChannels(ctx context.Context) error {
+
 	if !m.IsEnabled() {
+
 		return fmt.Errorf("%s %w", m.exchangeName, ErrWebsocketNotEnabled)
+
 	}
 
 	if !m.IsConnected() {
+
 		return fmt.Errorf("%s %w", m.exchangeName, ErrNotConnected)
+
 	}
 
 	// If the exchange does not support subscribing and or unsubscribing the full connection needs to be flushed to
+
 	// maintain consistency.
+
 	if !m.features.Subscribe || !m.features.Unsubscribe {
+
 		if err := m.shutdown(); err != nil {
+
 			return err
+
 		}
+
 		return m.connect(ctx)
+
 	}
 
 	if !m.useMultiConnectionManagement {
+
 		newSubs, err := m.GenerateSubs()
+
 		if err != nil {
+
 			return err
+
 		}
+
 		return m.updateChannelSubscriptions(ctx, m.subscriptions, newSubs)
+
 	}
 
 	for _, ws := range m.snapshotConnectionManager() {
+
 		if ws.setup.SubscriptionsNotRequired {
+
 			continue
+
 		}
 
 		newSubs, err := ws.setup.GenerateSubscriptions()
+
 		if err != nil {
+
 			return err
+
 		}
 
 		// Case if there is nothing to unsubscribe from and the connection is nil
+
 		if len(newSubs) == 0 && len(m.snapshotManagedConnections(ws)) == 0 {
+
 			continue
+
 		}
 
 		if err := m.scaleConnectionsToSubscriptions(ctx, ws, newSubs); err != nil {
+
 			return err
+
 		}
+
 	}
+
 	return nil
+
 }
 
 // updateChannelSubscriptions subscribes or unsubscribes from channels and checks that the correct number of channels
+
 // have been subscribed to or unsubscribed from.
+
 func (m *Manager) updateChannelSubscriptions(ctx context.Context, store *subscription.Store, incoming subscription.List) error {
+
 	subs, unsubs := store.Diff(incoming)
+
 	if len(unsubs) != 0 {
+
 		if err := m.UnsubscribeChannels(ctx, nil, unsubs); err != nil {
+
 			return err
+
 		}
 
 		if contained := store.Contained(unsubs); len(contained) > 0 {
+
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
+
 		}
+
 	}
+
 	if len(subs) != 0 {
+
 		if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
+
 			return err
+
 		}
 
 		if missing := store.Missing(subs); len(missing) > 0 {
+
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
+
 		}
+
 	}
+
 	return nil
+
 }
 
 // applyTrackedSubscriptions records tracked subscriptions in both manager-level and connection-level stores for the provided connection.
+
 func (m *Manager) applyTrackedSubscriptions(conn Connection, tracked subscription.List) error {
+
 	if len(tracked) == 0 {
+
 		return nil
+
 	}
+
 	if err := m.AddSuccessfulSubscriptions(conn, tracked...); err != nil {
+
 		return err
+
 	}
+
 	store := conn.Subscriptions()
+
 	if err := common.NilGuard(store); err != nil {
+
 		return fmt.Errorf("websocket connection %w", err)
+
 	}
+
 	for _, sub := range tracked {
+
 		if err := store.Add(sub); err != nil {
+
 			return err
+
 		}
+
 	}
+
 	return nil
+
 }
 
 // absorbTrackedSubscriptions asks each managed connection whether a subset of subs can be logically tracked on that existing connection.
+
 // It applies tracked subscriptions to manager and connection stores and returns the remaining subscriptions that still need outbound subscribe traffic/new capacity plus the list that were tracked.
+
 func (m *Manager) absorbTrackedSubscriptions(ctx context.Context, ws *websocket, subs subscription.List) (remaining, tracked subscription.List, err error) {
+
 	if len(subs) == 0 || ws == nil || ws.setup == nil || ws.setup.TrackOnExistingConnection == nil {
+
 		return subs, nil, nil
+
 	}
+
 	connections := m.snapshotManagedConnections(ws)
+
 	if len(connections) == 0 {
+
 		return subs, nil, nil
+
 	}
 
 	remaining = subs
+
 	tracked = make(subscription.List, 0, len(subs))
+
 	for _, conn := range connections {
+
 		connRemaining, connTracked, err := ws.setup.TrackOnExistingConnection(ctx, conn, remaining)
+
 		if err != nil {
+
 			return nil, nil, err
+
 		}
+
 		if err := m.applyTrackedSubscriptions(conn, connTracked); err != nil {
+
 			return nil, nil, err
+
 		}
+
 		if len(connTracked) != 0 {
+
 			tracked = append(tracked, connTracked...)
+
 		}
+
 		remaining = connRemaining
+
 		if len(remaining) == 0 {
+
 			return nil, tracked, nil
+
 		}
+
 	}
+
 	return remaining, tracked, nil
+
 }
 
 // absorbTrackableSubscriptionsAndValidate absorbs trackable subscriptions onto existing connections and verifies that tracked subscriptions were recorded in the websocket-level subscription store.
+
 func (m *Manager) absorbTrackableSubscriptionsAndValidate(ctx context.Context, ws *websocket, subs subscription.List) (subscription.List, error) {
+
 	remaining, tracked, err := m.absorbTrackedSubscriptions(ctx, ws, subs)
+
 	if err != nil {
+
 		return nil, err
+
 	}
+
 	if len(tracked) == 0 {
+
 		return remaining, nil
+
 	}
+
 	if missing := ws.subscriptions.Missing(tracked); len(missing) > 0 {
+
 		return nil, fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
+
 	}
+
 	return remaining, nil
+
 }
 
 // scaleConnectionsToSubscriptions scales connections to subscriptions based off current subscription list and subscription limit
+
 func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *websocket, incoming subscription.List) error {
+
 	if err := common.NilGuard(ws); err != nil {
+
 		return err
+
 	}
+
 	subs, unsubs := ws.subscriptions.Diff(incoming)
+
 	if len(unsubs) != 0 {
+
 		currentUnsubs := slices.Clone(unsubs)
+
 		// Unsubscribe first to free up capacity on existing connections
+
 		for _, conn := range m.snapshotManagedConnections(ws) {
+
 			leftOver, err := m.unsubscribeFromConnection(ctx, conn, currentUnsubs)
+
 			if err != nil {
+
 				return err
+
 			}
+
 			currentUnsubs = leftOver
+
 			if len(currentUnsubs) == 0 {
+
 				break
+
 			}
+
 		}
 
 		if len(currentUnsubs) != 0 {
+
 			log.Warnf(log.WebsocketMgr, "%v websocket: unable to find all subscriptions to remove on existing connections, attempting global unsubscribe for %v", m.exchangeName, currentUnsubs)
+
 			for _, s := range currentUnsubs {
+
 				if err := ws.subscriptions.Remove(s); err != nil {
+
 					return err
+
 				}
+
 			}
+
 		}
+
 		if contained := ws.subscriptions.Contained(unsubs); len(contained) > 0 {
+
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
+
 		}
+
 	}
+
 	if len(subs) != 0 {
+
 		// First, absorb subscriptions that should be tracked on existing
+
 		// connections (e.g. OKX spot/margin equivalents) before the
+
 		// generic capacity-based routing can misplace them.
+
 		currentSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
+
 		if err != nil {
+
 			return err
+
 		}
 
 		// Subscribe to existing connections to use up existing capacity
+
 		for _, conn := range m.snapshotManagedConnections(ws) {
+
 			leftOver, err := m.subscribeToConnection(ctx, conn, currentSubs)
+
 			if err != nil {
+
 				return err
+
 			}
+
 			currentSubs = leftOver
+
 			if len(currentSubs) == 0 {
+
 				break
+
 			}
+
 		}
 
 		// Spawn new connections if there are still subscriptions left to process
+
 		for _, batch := range common.Batch(currentSubs, m.MaxSubscriptionsPerConnection) {
+
 			toConnect, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batch)
+
 			if err != nil {
+
 				return err
+
 			}
+
 			if len(toConnect) == 0 {
+
 				continue
+
 			}
+
 			if err := m.createConnectAndSubscribe(ctx, ws, toConnect); err != nil {
+
 				return err
+
 			}
+
 		}
 
 		if missing := ws.subscriptions.Missing(subs); len(missing) > 0 {
+
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
+
 		}
+
 	}
 
 	// Clean up any connections that have no subscriptions left to reduce resource usage
+
 	connections := m.snapshotManagedConnections(ws)
+
 	clean := make([]Connection, 0, len(connections))
+
 	stale := make([]Connection, 0, len(connections))
+
 	for _, conn := range connections {
+
 		if conn.Subscriptions().Len() != 0 {
+
 			clean = append(clean, conn)
+
 			continue
+
 		}
+
 		stale = append(stale, conn)
+
 	}
+
 	if len(stale) == 0 {
+
 		return nil
+
 	}
+
 	staleSet := make(map[Connection]struct{}, len(stale))
+
 	for _, conn := range stale {
+
 		staleSet[conn] = struct{}{}
+
 	}
+
 	m.connectionManagerMu.Lock()
+
 	for _, conn := range stale {
+
 		delete(m.connections, conn)
+
 	}
+
 	clean = clean[:0]
+
 	for _, conn := range ws.connections {
+
 		if _, ok := staleSet[conn]; ok {
+
 			continue
+
 		}
+
 		clean = append(clean, conn)
+
 	}
+
 	ws.connections = clean
+
 	m.connectionManagerMu.Unlock()
+
 	for _, conn := range stale {
+
 		if err := conn.Shutdown(); err != nil {
+
 			log.Warnf(log.WebsocketMgr, "%v websocket: failed to shutdown connection: %v", m.exchangeName, err)
+
 		}
+
 	}
+
 	return nil
+
 }
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
+
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
+
 	if err := common.NilGuard(conn, subs); err != nil {
+
 		return err
+
 	}
+
 	if len(subs) == 0 {
+
 		return nil
+
 	}
 
 	m.resubscriptionsMu.Lock()
+
 	if m.resubscriptions == nil {
+
 		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+
 	}
+
 	allInFlight := true
+
 	for _, s := range subs {
+
 		if _, ok := m.resubscriptions[s]; !ok {
+
 			allInFlight = false
+
 			break
+
 		}
+
 	}
+
 	if !allInFlight {
+
 		for _, s := range subs {
+
 			m.resubscriptions[s] = struct{}{}
+
 		}
+
 	}
+
 	m.resubscriptionsMu.Unlock()
 
 	if !allInFlight {
+
 		defer func() {
+
 			m.resubscriptionsMu.Lock()
+
 			for _, s := range subs {
+
 				delete(m.resubscriptions, s)
+
 			}
+
 			m.resubscriptionsMu.Unlock()
+
 		}()
+
 	}
 
 	if m.resubscribePreLockHook != nil && len(subs) > 0 {
+
 		m.resubscribePreLockHook(subs[0])
+
 	}
 
 	m.m.Lock()
+
 	if allInFlight {
+
 		m.m.Unlock()
+
 		for _, s := range subs {
+
 			m.waitForResubscriptionLeader(s)
+
 		}
+
 		m.m.Lock()
+
 		if allSubscriptionsState(subs, subscription.SubscribedState) {
+
 			m.m.Unlock()
+
 			return nil
+
 		}
+
 		m.resubscriptionsMu.Lock()
+
 		for _, s := range subs {
+
 			m.resubscriptions[s] = struct{}{}
+
 		}
+
 		m.resubscriptionsMu.Unlock()
+
 		defer func() {
+
 			m.resubscriptionsMu.Lock()
+
 			for _, s := range subs {
+
 				delete(m.resubscriptions, s)
+
 			}
+
 			m.resubscriptionsMu.Unlock()
+
 		}()
+
 	}
 
 	wsStore := m.subscriptionStore(conn)
+
 	connStore := connectionSubscriptionStore(conn)
+
 	snapshots := make([]recoverySnapshot, len(subs))
+
 	for i, s := range subs {
+
 		snapshots[i] = recoverySnapshot{sub: s}
+
 		if connStore != nil {
+
 			if orig := connStore.Get(s); orig != nil {
+
 				snapshots[i].origKey = orig.Key
+
 			}
+
 		} else if wsStore != nil {
+
 			if orig := wsStore.Get(s); orig != nil {
+
 				snapshots[i].origKey = orig.Key
+
 			}
+
 		}
+
 	}
 
 	setResubscribingState(subs)
+
 	m.m.Unlock()
 
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
+
 	if err != nil {
+
 		return err
+
 	}
+
 	if len(missing) > 0 {
+
 		var notRemoved subscription.List
+
 		for _, s := range missing {
+
 			if s.State() != subscription.UnsubscribedState {
+
 				notRemoved = append(notRemoved, s)
+
 			}
+
 		}
+
 		if len(notRemoved) > 0 {
+
 			return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
+
 		}
+
 	}
+
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
+
 	if err != nil {
+
 		m.m.Lock()
+
 		for _, snap := range snapshots {
+
 			if snap.sub.State() == subscription.SubscribedState {
+
 				continue
+
 			}
+
 			restoreFailedRecovery(wsStore, connStore, snap.sub, snap.origKey)
+
 		}
+
 		m.m.Unlock()
+
 		return err
+
 	}
+
 	if len(remaining) > 0 {
+
 		return fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
+
 	}
+
 	return nil
+
 }
 
 func allSubscriptionsState(subs subscription.List, state subscription.State) bool {
+
 	for _, sub := range subs {
+
 		if sub.State() != state {
+
 			return false
+
 		}
+
 	}
+
 	return true
+
 }
 
 // unsubscribeFromConnection unsubscribes for a connection and removes subscriptions from the connection's store
+
 func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
+
 	store := conn.Subscriptions()
+
 	if err := common.NilGuard(store); err != nil {
+
 		return nil, fmt.Errorf("websocket connection %w", err)
+
 	}
 
 	remove := store.Contained(subs)
+
 	if len(remove) == 0 {
+
 		return subs, nil
+
 	}
 
 	if err := m.UnsubscribeChannels(ctx, conn, remove); err != nil {
+
 		return nil, err
+
 	}
 
 	missing := store.Missing(subs)
+
 	for _, r := range remove {
+
 		if r.State() == subscription.ResubscribingState {
+
 			continue
+
 		}
+
 		if store.Get(r) == nil {
+
 			continue
+
 		}
+
 		if err := store.Remove(r); err != nil {
+
 			return nil, err
+
 		}
+
 	}
+
 	return missing, nil
+
 }
 
 // subscribeToConnection subscribes for a connection and adds subscriptions to the connection's store
+
 func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
+
 	store := conn.Subscriptions()
+
 	if err := common.NilGuard(store); err != nil {
+
 		return nil, fmt.Errorf("websocket connection %w", err)
+
 	}
 
 	usedCap := connectionUsedCapacity(store, subs)
+
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
+
 		return subs, nil // No capacity left for this connection
+
 	}
 
 	availableCap := len(subs)
+
 	if m.MaxSubscriptionsPerConnection > 0 {
+
 		availableCap = m.MaxSubscriptionsPerConnection - usedCap
+
 	}
 
 	if availableCap > len(subs) {
+
 		availableCap = len(subs)
+
 	}
 
 	toSubscribe := subs[:availableCap]
+
 	tracked := make(map[*subscription.Subscription]bool, len(toSubscribe))
+
 	for _, s := range toSubscribe {
+
 		tracked[s] = store.Get(s) != nil && s.State() == subscription.ResubscribingState
+
 	}
+
 	if err := m.SubscribeToChannels(ctx, conn, toSubscribe); err != nil {
+
 		return nil, err
+
 	}
 
 	for _, s := range toSubscribe {
+
 		if s.State() != subscription.SubscribedState {
+
 			if err := s.SetState(subscription.SubscribedState); err != nil {
+
 				return nil, err
+
 			}
+
 		}
+
 		if tracked[s] {
+
 			continue
+
 		}
+
 		if err := store.Add(s); err != nil {
+
 			return nil, err
+
 		}
+
 	}
 
 	return subs[availableCap:], nil
+
 }

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"slices"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -180,15 +179,17 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 
 	if m.resubscriptions == nil {
 
-		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
 
 	}
 
-	_, inFlight := m.resubscriptions[s]
+	ch, inFlight := m.resubscriptions[s]
 
 	if !inFlight {
 
-		m.resubscriptions[s] = struct{}{}
+		ch = make(chan struct{})
+
+		m.resubscriptions[s] = ch
 
 	}
 
@@ -200,7 +201,13 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 
 			m.resubscriptionsMu.Lock()
 
-			delete(m.resubscriptions, s)
+			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
+
+				delete(m.resubscriptions, s)
+
+				close(ch)
+
+			}
 
 			m.resubscriptionsMu.Unlock()
 
@@ -234,7 +241,9 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 
 		m.resubscriptionsMu.Lock()
 
-		m.resubscriptions[s] = struct{}{}
+		ch = make(chan struct{})
+
+		m.resubscriptions[s] = ch
 
 		m.resubscriptionsMu.Unlock()
 
@@ -242,7 +251,13 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 
 			m.resubscriptionsMu.Lock()
 
-			delete(m.resubscriptions, s)
+			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
+
+				delete(m.resubscriptions, s)
+
+				close(ch)
+
+			}
 
 			m.resubscriptionsMu.Unlock()
 
@@ -346,23 +361,19 @@ func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscrip
 
 func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
 
-	for {
+	m.resubscriptionsMu.Lock()
 
-		m.resubscriptionsMu.Lock()
+	ch, exists := m.resubscriptions[s]
 
-		_, exists := m.resubscriptions[s]
+	m.resubscriptionsMu.Unlock()
 
-		m.resubscriptionsMu.Unlock()
+	if !exists {
 
-		if !exists {
-
-			return
-
-		}
-
-		runtime.Gosched()
+		return
 
 	}
+
+	<-ch
 
 }
 
@@ -1322,7 +1333,7 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 	if m.resubscriptions == nil {
 
-		m.resubscriptions = make(map[*subscription.Subscription]struct{})
+		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
 
 	}
 
@@ -1340,11 +1351,17 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 	}
 
+	chans := make([]chan struct{}, 0, len(subs))
+
 	if !allInFlight {
 
 		for _, s := range subs {
 
-			m.resubscriptions[s] = struct{}{}
+			ch := make(chan struct{})
+
+			m.resubscriptions[s] = ch
+
+			chans = append(chans, ch)
 
 		}
 
@@ -1358,9 +1375,15 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 			m.resubscriptionsMu.Lock()
 
-			for _, s := range subs {
+			for idx, s := range subs {
 
-				delete(m.resubscriptions, s)
+				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
+
+					delete(m.resubscriptions, s)
+
+					close(chans[idx])
+
+				}
 
 			}
 
@@ -1400,9 +1423,15 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 		m.resubscriptionsMu.Lock()
 
+		chans = make([]chan struct{}, 0, len(subs))
+
 		for _, s := range subs {
 
-			m.resubscriptions[s] = struct{}{}
+			ch := make(chan struct{})
+
+			m.resubscriptions[s] = ch
+
+			chans = append(chans, ch)
 
 		}
 
@@ -1412,9 +1441,15 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 			m.resubscriptionsMu.Lock()
 
-			for _, s := range subs {
+			for idx, s := range subs {
 
-				delete(m.resubscriptions, s)
+				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
+
+					delete(m.resubscriptions, s)
+
+					close(chans[idx])
+
+				}
 
 			}
 

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -119,6 +119,11 @@ func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 	return m.subscriptions
 }
 
+type resubscribeTracker struct {
+	done chan struct{}
+	err  error
+}
+
 // ResubscribeToChannel resubscribes to channel
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
 // A subscription already in ResubscribingState is retried.
@@ -130,72 +135,48 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	m.resubscriptionsMu.Lock()
 
 	if m.resubscriptions == nil {
-		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
+		m.resubscriptions = make(map[*subscription.Subscription]*resubscribeTracker)
 	}
 
-	ch, inFlight := m.resubscriptions[s]
+	tracker, inFlight := m.resubscriptions[s]
 
 	if !inFlight {
-		ch = make(chan struct{})
+		tracker = &resubscribeTracker{
+			done: make(chan struct{}),
+		}
 
-		m.resubscriptions[s] = ch
+		m.resubscriptions[s] = tracker
 	}
 
 	m.resubscriptionsMu.Unlock()
 
-	if !inFlight {
-		defer func() {
-			m.resubscriptionsMu.Lock()
+	if inFlight {
+		<-tracker.done
 
-			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
-				delete(m.resubscriptions, s)
-
-				close(ch)
-			}
-
-			m.resubscriptionsMu.Unlock()
-		}()
+		return tracker.err
 	}
+
+	var resErr error
+
+	defer func() {
+		m.resubscriptionsMu.Lock()
+
+		tracker.err = resErr
+
+		if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
+			delete(m.resubscriptions, s)
+
+			close(tracker.done)
+		}
+
+		m.resubscriptionsMu.Unlock()
+	}()
 
 	if m.resubscribePreLockHook != nil {
 		m.resubscribePreLockHook(s)
 	}
 
 	m.m.Lock()
-
-	if inFlight {
-		m.m.Unlock()
-
-		m.waitForResubscriptionLeader(s)
-
-		m.m.Lock()
-
-		if s.State() == subscription.SubscribedState {
-			m.m.Unlock()
-
-			return nil
-		}
-
-		m.resubscriptionsMu.Lock()
-
-		ch = make(chan struct{})
-
-		m.resubscriptions[s] = ch
-
-		m.resubscriptionsMu.Unlock()
-
-		defer func() {
-			m.resubscriptionsMu.Lock()
-
-			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
-				delete(m.resubscriptions, s)
-
-				close(ch)
-			}
-
-			m.resubscriptionsMu.Unlock()
-		}()
-	}
 
 	l := subscription.List{s}
 
@@ -216,6 +197,8 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	m.m.Unlock()
 
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
+		resErr = err
+
 		return err
 	}
 
@@ -225,6 +208,8 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 		restoreFailedRecovery(wsStore, connStore, s, origKey)
 
 		m.m.Unlock()
+
+		resErr = err
 
 		return err
 	}
@@ -243,10 +228,6 @@ func connectionSubscriptionStore(conn Connection) *subscription.Store {
 		return nil
 	}
 
-	defer func() {
-		_ = recover()
-	}()
-
 	return conn.Subscriptions()
 }
 
@@ -259,31 +240,9 @@ func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscrip
 		restoreSubscriptionAfterFailedRecovery(connStore, sub, origKey)
 	}
 
-	if wsStore == nil || wsStore == connStore {
-		return
-	}
-
-	if wsStore.Get(sub) == nil {
+	if wsStore != nil && wsStore != connStore {
 		restoreSubscriptionAfterFailedRecovery(wsStore, sub, origKey)
-
-		return
 	}
-
-	_ = sub.SetState(subscription.ResubscribingState)
-}
-
-func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
-	m.resubscriptionsMu.Lock()
-
-	ch, exists := m.resubscriptions[s]
-
-	m.resubscriptionsMu.Unlock()
-
-	if !exists {
-		return
-	}
-
-	<-ch
 }
 
 func connectionUsedCapacity(store *subscription.Store, incoming subscription.List) int {
@@ -349,7 +308,11 @@ func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subs
 
 	if hasLiveRecoveryReplacement(store, sub, origKey) {
 		if store.Get(sub) != nil {
-			_ = sub.SetState(subscription.ResubscribingState)
+			_ = store.Remove(sub)
+		}
+
+		if origKey != nil && store.Get(origKey) != nil {
+			_ = store.Remove(origKey)
 		}
 
 		return
@@ -437,10 +400,15 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 	var errs error
 
 	for _, s := range subs {
-		alreadyTracked := subscriptionStore.Get(s) != nil && s.State() == subscription.ResubscribingState
+		found := subscriptionStore.Get(s)
+		alreadyTracked := (found != nil && found.State() == subscription.ResubscribingState) || s.State() == subscription.ResubscribingState
 
 		if err := s.SetState(subscription.SubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
+		}
+
+		if found != nil && found != s {
+			_ = found.SetState(subscription.SubscribedState)
 		}
 
 		if !alreadyTracked {
@@ -595,6 +563,10 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		}
 
 		if found := subscriptionStore.Get(s); found != nil {
+			if found.State() == subscription.ResubscribingState {
+				continue
+			}
+
 			return fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
 		}
 	}
@@ -934,7 +906,7 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	m.resubscriptionsMu.Lock()
 
 	if m.resubscriptions == nil {
-		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
+		m.resubscriptions = make(map[*subscription.Subscription]*resubscribeTracker)
 	}
 
 	allInFlight := true
@@ -947,85 +919,71 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		}
 	}
 
-	chans := make([]chan struct{}, 0, len(subs))
+	trackers := make([]*resubscribeTracker, 0, len(subs))
 
-	if !allInFlight {
+	if allInFlight {
 		for _, s := range subs {
-			ch := make(chan struct{})
+			if tracker, ok := m.resubscriptions[s]; ok {
+				trackers = append(trackers, tracker)
+			}
+		}
+	} else {
+		for _, s := range subs {
+			tracker := m.resubscriptions[s]
 
-			m.resubscriptions[s] = ch
+			if tracker == nil {
+				tracker = &resubscribeTracker{
+					done: make(chan struct{}),
+				}
 
-			chans = append(chans, ch)
+				m.resubscriptions[s] = tracker
+			}
+
+			trackers = append(trackers, tracker)
 		}
 	}
 
 	m.resubscriptionsMu.Unlock()
 
-	if !allInFlight {
-		defer func() {
-			m.resubscriptionsMu.Lock()
+	if allInFlight {
+		var firstErr error
 
-			for idx, s := range subs {
-				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
-					delete(m.resubscriptions, s)
+		for _, tracker := range trackers {
+			<-tracker.done
 
-					close(chans[idx])
-				}
+			if tracker.err != nil && firstErr == nil {
+				firstErr = tracker.err
 			}
+		}
 
-			m.resubscriptionsMu.Unlock()
-		}()
+		return firstErr
 	}
+
+	var resErr error
+
+	defer func() {
+		m.resubscriptionsMu.Lock()
+
+		for idx, s := range subs {
+			tracker := trackers[idx]
+
+			tracker.err = resErr
+
+			if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
+				delete(m.resubscriptions, s)
+
+				close(tracker.done)
+			}
+		}
+
+		m.resubscriptionsMu.Unlock()
+	}()
 
 	if m.resubscribePreLockHook != nil && len(subs) > 0 {
 		m.resubscribePreLockHook(subs[0])
 	}
 
 	m.m.Lock()
-
-	if allInFlight {
-		m.m.Unlock()
-
-		for _, s := range subs {
-			m.waitForResubscriptionLeader(s)
-		}
-
-		m.m.Lock()
-
-		if allSubscriptionsState(subs, subscription.SubscribedState) {
-			m.m.Unlock()
-
-			return nil
-		}
-
-		m.resubscriptionsMu.Lock()
-
-		chans = make([]chan struct{}, 0, len(subs))
-
-		for _, s := range subs {
-			ch := make(chan struct{})
-
-			m.resubscriptions[s] = ch
-
-			chans = append(chans, ch)
-		}
-
-		m.resubscriptionsMu.Unlock()
-
-		defer func() {
-			m.resubscriptionsMu.Lock()
-
-			for idx, s := range subs {
-				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
-					delete(m.resubscriptions, s)
-
-					close(chans[idx])
-				}
-			}
-
-			m.resubscriptionsMu.Unlock()
-		}()
-	}
 
 	wsStore := m.subscriptionStore(conn)
 
@@ -1053,6 +1011,8 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
 	if err != nil {
+		resErr = err
+
 		return err
 	}
 
@@ -1066,7 +1026,9 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		}
 
 		if len(notRemoved) > 0 {
-			return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
+			resErr = fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
+
+			return resErr
 		}
 	}
 
@@ -1084,11 +1046,15 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 
 		m.m.Unlock()
 
+		resErr = err
+
 		return err
 	}
 
 	if len(remaining) > 0 {
-		return fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
+		resErr = fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
+
+		return resErr
 	}
 
 	return nil

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -14,18 +14,15 @@ import (
 
 // Public subscription errors
 var (
-	ErrSubscriptionFailure = errors.New("subscription failure")
-
-	ErrSubscriptionsNotAdded = errors.New("subscriptions not added")
-
+	ErrSubscriptionFailure     = errors.New("subscription failure")
+	ErrSubscriptionsNotAdded   = errors.New("subscriptions not added")
 	ErrSubscriptionsNotRemoved = errors.New("subscriptions not removed")
 )
 
 // Public subscription errors
 var (
 	errSubscriptionsExceedsLimit = errors.New("subscriptions exceeds limit")
-
-	errConnectionNotFound = errors.New("connection not found")
+	errConnectionNotFound        = errors.New("connection not found")
 )
 
 // UnsubscribeChannels unsubscribes from a list of websocket channel
@@ -38,13 +35,10 @@ func (m *Manager) UnsubscribeChannels(ctx context.Context, conn Connection, chan
 		if err := common.NilGuard(conn); err != nil {
 			return err
 		}
-
 		ws, ok := m.managedWebsocket(conn)
-
 		if !ok {
 			return fmt.Errorf("%w: %q", errConnectionNotFound, conn.GetURL())
 		}
-
 		return m.unsubscribe(ws.subscriptions, channels, func(channels subscription.List) error {
 			return ws.setup.Unsubscriber(ctx, conn, channels)
 		})
@@ -63,13 +57,11 @@ func (m *Manager) unsubscribe(store *subscription.Store, channels subscription.L
 	if store == nil {
 		return nil // No channels to unsubscribe from is not an error
 	}
-
 	for _, s := range channels {
 		if store.Get(s) == nil {
 			return fmt.Errorf("%w: %s", subscription.ErrNotFound, s)
 		}
 	}
-
 	return unsub(channels)
 }
 
@@ -77,45 +69,33 @@ func (m *Manager) managedWebsocket(conn Connection) (*websocket, bool) {
 	if conn == nil {
 		return nil, false
 	}
-
 	m.connectionManagerMu.RLock()
-
 	defer m.connectionManagerMu.RUnlock()
-
 	ws := m.connections[conn]
-
 	return ws, ws != nil
 }
 
 func (m *Manager) subscriptionStore(conn Connection) *subscription.Store {
 	m.connectionManagerMu.RLock()
-
 	defer m.connectionManagerMu.RUnlock()
-
 	if ws, ok := m.connections[conn]; ok && conn != nil {
 		return ws.subscriptions
 	}
-
 	return m.subscriptions
 }
 
 func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 	m.connectionManagerMu.Lock()
-
 	defer m.connectionManagerMu.Unlock()
-
 	if ws, ok := m.connections[conn]; ok && conn != nil {
 		if ws.subscriptions == nil {
 			ws.subscriptions = subscription.NewStore()
 		}
-
 		return ws.subscriptions
 	}
-
 	if m.subscriptions == nil {
 		m.subscriptions = subscription.NewStore()
 	}
-
 	return m.subscriptions
 }
 
@@ -136,88 +116,59 @@ func (m *Manager) resubscribeToChannel(ctx context.Context, conn Connection, s *
 	if s == nil {
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
 	}
-
 	m.resubscriptionsMu.Lock()
-
 	if m.resubscriptions == nil {
 		m.resubscriptions = make(map[*subscription.Subscription]*resubscribeTracker)
 	}
-
 	tracker, inFlight := m.resubscriptions[s]
-
 	if !inFlight {
 		tracker = &resubscribeTracker{
 			done: make(chan struct{}),
 		}
-
 		m.resubscriptions[s] = tracker
 	}
-
 	m.resubscriptionsMu.Unlock()
-
 	if inFlight {
 		if m.resubscribeWaiterHook != nil {
 			m.resubscribeWaiterHook(s)
 		}
-
 		<-tracker.done
-
 		if tracker.err == nil {
 			return nil
 		}
-
 		if allowRetry {
 			return m.resubscribeToChannel(ctx, conn, s, false)
 		}
-
 		return tracker.err
 	}
-
 	var resErr error
-
 	defer func() {
 		finishResubscriptionTracker(m, s, tracker, resErr)
 	}()
-
 	if m.resubscribePreLockHook != nil {
 		m.resubscribePreLockHook(s)
 	}
-
 	m.m.Lock()
-
 	l := subscription.List{s}
-
 	setResubscribingState(l)
-
 	wsStore := m.subscriptionStore(conn)
-
 	connStore := connectionSubscriptionStore(conn)
-
 	var origKey any
-
 	if wsStore != nil {
 		if origSub := wsStore.Get(s); origSub != nil {
 			origKey = origSub.Key
 		}
 	}
-
 	m.m.Unlock()
-
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
 		resErr = err
-
 		return err
 	}
-
 	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
 		m.m.Lock()
-
 		restoreFailedRecovery(wsStore, connStore, s, origKey)
-
 		m.m.Unlock()
-
 		resErr = err
-
 		return err
 	}
 
@@ -225,8 +176,7 @@ func (m *Manager) resubscribeToChannel(ctx context.Context, conn Connection, s *
 }
 
 type recoverySnapshot struct {
-	sub *subscription.Subscription
-
+	sub     *subscription.Subscription
 	origKey any
 }
 
@@ -234,7 +184,6 @@ func connectionSubscriptionStore(conn Connection) *subscription.Store {
 	if conn == nil {
 		return nil
 	}
-
 	return conn.Subscriptions()
 }
 
@@ -242,17 +191,12 @@ func finishResubscriptionTracker(m *Manager, s *subscription.Subscription, track
 	if tracker == nil {
 		return
 	}
-
 	m.resubscriptionsMu.Lock()
-
 	defer m.resubscriptionsMu.Unlock()
-
 	tracker.err = err
-
 	if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
 		delete(m.resubscriptions, s)
 	}
-
 	tracker.closeOnce.Do(func() {
 		close(tracker.done)
 	})
@@ -262,11 +206,9 @@ func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscrip
 	if sub == nil {
 		return
 	}
-
 	if connStore != nil {
 		restoreSubscriptionAfterFailedRecovery(connStore, sub, origKey)
 	}
-
 	if wsStore != nil && wsStore != connStore {
 		restoreSubscriptionAfterFailedRecovery(wsStore, sub, origKey)
 	}
@@ -278,23 +220,17 @@ func connectionUsedCapacity(store *subscription.Store, incoming subscription.Lis
 	}
 
 	usedCap := store.Len()
-
 	discounted := make(map[*subscription.Subscription]struct{}, len(incoming))
-
 	for _, s := range incoming {
 		if s == nil || s.State() != subscription.ResubscribingState || store.Get(s) == nil {
 			continue
 		}
-
 		if _, seen := discounted[s]; seen {
 			continue
 		}
-
 		discounted[s] = struct{}{}
-
 		usedCap--
 	}
-
 	return usedCap
 }
 
@@ -302,29 +238,22 @@ func hasLiveRecoveryReplacement(store *subscription.Store, sub *subscription.Sub
 	if store == nil || sub == nil {
 		return false
 	}
-
 	want := subscription.ExactKey{Subscription: sub}
-
 	for _, existing := range store.List() {
 		if existing == sub {
 			continue
 		}
-
 		if !want.Match(subscription.ExactKey{Subscription: existing}) {
 			continue
 		}
-
 		if existing.State() != subscription.SubscribedState {
 			continue
 		}
-
 		if origKey != nil && existing.EnsureKeyed() == origKey {
 			continue
 		}
-
 		return true
 	}
-
 	return false
 }
 
@@ -332,25 +261,19 @@ func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subs
 	if store == nil || sub == nil {
 		return
 	}
-
 	if hasLiveRecoveryReplacement(store, sub, origKey) {
 		if store.Get(sub) != nil {
 			_ = store.Remove(sub)
 		}
-
 		if origKey != nil && store.Get(origKey) != nil {
 			_ = store.Remove(origKey)
 		}
-
 		return
 	}
-
 	if origKey != nil {
 		sub.SetKey(origKey)
 	}
-
 	_ = sub.SetState(subscription.ResubscribingState)
-
 	if store.Get(sub) == nil {
 		_ = store.Add(sub)
 	}
@@ -370,7 +293,6 @@ func (m *Manager) SubscribeToChannels(ctx context.Context, conn Connection, subs
 	if slices.Contains(subs, nil) {
 		return fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
 	}
-
 	if err := m.checkSubscriptions(conn, subs); err != nil {
 		return err
 	}
@@ -396,23 +318,19 @@ func (m *Manager) AddSubscriptions(conn Connection, subs ...*subscription.Subscr
 	if m == nil {
 		return fmt.Errorf("%w: AddSubscriptions called on nil Websocket", common.ErrNilPointer)
 	}
-
 	subscriptionStore := m.initSubscriptionStore(conn)
 
 	var errs error
-
 	for _, s := range subs {
 		if s.State() == subscription.InactiveState {
 			if err := s.SetState(subscription.SubscribingState); err != nil {
 				errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 			}
 		}
-
 		if err := subscriptionStore.Add(s); err != nil {
 			errs = common.AppendError(errs, err)
 		}
 	}
-
 	return errs
 }
 
@@ -421,30 +339,24 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 	if m == nil {
 		return fmt.Errorf("%w: AddSuccessfulSubscriptions called on nil Websocket", common.ErrNilPointer)
 	}
-
 	subscriptionStore := m.initSubscriptionStore(conn)
 
 	var errs error
-
 	for _, s := range subs {
 		found := subscriptionStore.Get(s)
 		alreadyTracked := found != nil && (found.State() == subscription.ResubscribingState || s.State() == subscription.ResubscribingState)
-
 		if err := s.SetState(subscription.SubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 		}
-
 		if found != nil && found != s {
 			_ = found.SetState(subscription.SubscribedState)
 		}
-
 		if !alreadyTracked {
 			if err := subscriptionStore.Add(s); err != nil {
 				errs = common.AppendError(errs, err)
 			}
 		}
 	}
-
 	return errs
 }
 
@@ -453,7 +365,6 @@ func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Sub
 	if m == nil {
 		return fmt.Errorf("%w: RemoveSubscriptions called on nil Websocket", common.ErrNilPointer)
 	}
-
 	subscriptionStore := m.subscriptionStore(conn)
 
 	if subscriptionStore == nil {
@@ -461,17 +372,14 @@ func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Sub
 	}
 
 	var errs error
-
 	for _, s := range subs {
 		if err := s.SetState(subscription.UnsubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
 		}
-
 		if err := subscriptionStore.Remove(s); err != nil {
 			errs = common.AppendError(errs, err)
 		}
 	}
-
 	return errs
 }
 
@@ -485,22 +393,16 @@ func (m *Manager) GetSubscription(key any) *subscription.Subscription {
 
 	for _, ws := range m.snapshotConnectionManager() {
 		m.connectionManagerMu.RLock()
-
 		store := ws.subscriptions
-
 		var sub *subscription.Subscription
-
 		if store != nil {
 			sub = store.Get(key)
 		}
-
 		m.connectionManagerMu.RUnlock()
-
 		if sub != nil {
 			return sub
 		}
 	}
-
 	if store := m.subscriptionStore(nil); store != nil {
 		return store.Get(key)
 	}
@@ -513,25 +415,18 @@ func (m *Manager) GetSubscriptions() subscription.List {
 	if m == nil {
 		return nil
 	}
-
 	var subs subscription.List
-
 	for _, ws := range m.snapshotConnectionManager() {
 		m.connectionManagerMu.RLock()
-
 		store := ws.subscriptions
-
 		if store != nil {
 			subs = append(subs, store.List()...)
 		}
-
 		m.connectionManagerMu.RUnlock()
 	}
-
 	if store := m.subscriptionStore(nil); store != nil {
 		subs = append(subs, store.List()...)
 	}
-
 	return subs
 }
 
@@ -539,48 +434,34 @@ func (m *Manager) GetSubscriptions() subscription.List {
 // The subscription state is not considered when counting existing subscriptions
 func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) error {
 	var subscriptionStore *subscription.Store
-
 	var connSubStore *subscription.Store
-
 	if ws, ok := m.managedWebsocket(conn); ok {
 		if ws.subscriptions == nil {
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
 		}
-
 		for _, c := range m.snapshotManagedConnections(ws) { // ensure connection is actually managed
 			if c == conn {
 				connSubStore = c.Subscriptions()
-
 				break
 			}
 		}
-
 		if connSubStore == nil {
 			return fmt.Errorf("%w: connection subscription store not found", common.ErrNilPointer)
 		}
-
 		subscriptionStore = ws.subscriptions
 	} else {
 		subscriptionStore = m.subscriptionStore(nil)
-
 		if subscriptionStore == nil {
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
 		}
-
 		connSubStore = subscriptionStore
 	}
-
 	usedCap := connectionUsedCapacity(connSubStore, subs)
-
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
-
 			errSubscriptionsExceedsLimit,
-
 			usedCap,
-
 			len(subs),
-
 			m.MaxSubscriptionsPerConnection)
 	}
 
@@ -588,12 +469,10 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		if s.State() == subscription.ResubscribingState {
 			continue
 		}
-
 		if found := subscriptionStore.Get(s); found != nil {
 			if found.State() == subscription.ResubscribingState {
 				continue
 			}
-
 			return fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
 		}
 	}
@@ -604,9 +483,7 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 // FlushChannels flushes channel subscriptions when there is a pair/asset change
 func (m *Manager) FlushChannels(ctx context.Context) error {
 	m.m.Lock()
-
 	defer m.m.Unlock()
-
 	return m.flushChannels(ctx)
 }
 
@@ -621,12 +498,10 @@ func (m *Manager) flushChannels(ctx context.Context) error {
 
 	// If the exchange does not support subscribing and or unsubscribing the full connection needs to be flushed to
 	// maintain consistency.
-
 	if !m.features.Subscribe || !m.features.Unsubscribe {
 		if err := m.shutdown(); err != nil {
 			return err
 		}
-
 		return m.connect(ctx)
 	}
 
@@ -635,7 +510,6 @@ func (m *Manager) flushChannels(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
 		return m.updateChannelSubscriptions(ctx, m.subscriptions, newSubs)
 	}
 
@@ -650,7 +524,6 @@ func (m *Manager) flushChannels(ctx context.Context) error {
 		}
 
 		// Case if there is nothing to unsubscribe from and the connection is nil
-
 		if len(newSubs) == 0 && len(m.snapshotManagedConnections(ws)) == 0 {
 			continue
 		}
@@ -667,7 +540,6 @@ func (m *Manager) flushChannels(ctx context.Context) error {
 // have been subscribed to or unsubscribed from.
 func (m *Manager) updateChannelSubscriptions(ctx context.Context, store *subscription.Store, incoming subscription.List) error {
 	subs, unsubs := store.Diff(incoming)
-
 	if len(unsubs) != 0 {
 		if err := m.UnsubscribeChannels(ctx, nil, unsubs); err != nil {
 			return err
@@ -677,7 +549,6 @@ func (m *Manager) updateChannelSubscriptions(ctx context.Context, store *subscri
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
 		}
 	}
-
 	if len(subs) != 0 {
 		if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
 			return err
@@ -696,17 +567,13 @@ func (m *Manager) applyTrackedSubscriptions(conn Connection, tracked subscriptio
 	if len(tracked) == 0 {
 		return nil
 	}
-
 	if err := m.AddSuccessfulSubscriptions(conn, tracked...); err != nil {
 		return err
 	}
-
 	store := conn.Subscriptions()
-
 	if err := common.NilGuard(store); err != nil {
 		return fmt.Errorf("websocket connection %w", err)
 	}
-
 	for _, sub := range tracked {
 		if err := store.Add(sub); err != nil {
 			return err
@@ -722,38 +589,29 @@ func (m *Manager) absorbTrackedSubscriptions(ctx context.Context, ws *websocket,
 	if len(subs) == 0 || ws == nil || ws.setup == nil || ws.setup.TrackOnExistingConnection == nil {
 		return subs, nil, nil
 	}
-
 	connections := m.snapshotManagedConnections(ws)
-
 	if len(connections) == 0 {
 		return subs, nil, nil
 	}
 
 	remaining = subs
-
 	tracked = make(subscription.List, 0, len(subs))
-
 	for _, conn := range connections {
 		connRemaining, connTracked, err := ws.setup.TrackOnExistingConnection(ctx, conn, remaining)
 		if err != nil {
 			return nil, nil, err
 		}
-
 		if err := m.applyTrackedSubscriptions(conn, connTracked); err != nil {
 			return nil, nil, err
 		}
-
 		if len(connTracked) != 0 {
 			tracked = append(tracked, connTracked...)
 		}
-
 		remaining = connRemaining
-
 		if len(remaining) == 0 {
 			return nil, tracked, nil
 		}
 	}
-
 	return remaining, tracked, nil
 }
 
@@ -763,15 +621,12 @@ func (m *Manager) absorbTrackableSubscriptionsAndValidate(ctx context.Context, w
 	if err != nil {
 		return nil, err
 	}
-
 	if len(tracked) == 0 {
 		return remaining, nil
 	}
-
 	if missing := ws.subscriptions.Missing(tracked); len(missing) > 0 {
 		return nil, fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
 	}
-
 	return remaining, nil
 }
 
@@ -780,22 +635,16 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 	if err := common.NilGuard(ws); err != nil {
 		return err
 	}
-
 	subs, unsubs := ws.subscriptions.Diff(incoming)
-
 	if len(unsubs) != 0 {
 		currentUnsubs := slices.Clone(unsubs)
-
 		// Unsubscribe first to free up capacity on existing connections
-
 		for _, conn := range m.snapshotManagedConnections(ws) {
 			leftOver, err := m.unsubscribeFromConnection(ctx, conn, currentUnsubs)
 			if err != nil {
 				return err
 			}
-
 			currentUnsubs = leftOver
-
 			if len(currentUnsubs) == 0 {
 				break
 			}
@@ -803,56 +652,46 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 
 		if len(currentUnsubs) != 0 {
 			log.Warnf(log.WebsocketMgr, "%v websocket: unable to find all subscriptions to remove on existing connections, attempting global unsubscribe for %v", m.exchangeName, currentUnsubs)
-
 			for _, s := range currentUnsubs {
 				if err := ws.subscriptions.Remove(s); err != nil {
 					return err
 				}
 			}
 		}
-
 		if contained := ws.subscriptions.Contained(unsubs); len(contained) > 0 {
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
 		}
 	}
-
 	if len(subs) != 0 {
 		// First, absorb subscriptions that should be tracked on existing
 		// connections (e.g. OKX spot/margin equivalents) before the
 		// generic capacity-based routing can misplace them.
-
 		currentSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
 		if err != nil {
 			return err
 		}
 
 		// Subscribe to existing connections to use up existing capacity
-
 		for _, conn := range m.snapshotManagedConnections(ws) {
 			leftOver, err := m.subscribeToConnection(ctx, conn, currentSubs)
 			if err != nil {
 				return err
 			}
-
 			currentSubs = leftOver
-
 			if len(currentSubs) == 0 {
 				break
 			}
 		}
 
 		// Spawn new connections if there are still subscriptions left to process
-
 		for _, batch := range common.Batch(currentSubs, m.MaxSubscriptionsPerConnection) {
 			toConnect, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batch)
 			if err != nil {
 				return err
 			}
-
 			if len(toConnect) == 0 {
 				continue
 			}
-
 			if err := m.createConnectAndSubscribe(ctx, ws, toConnect); err != nil {
 				return err
 			}
@@ -864,53 +703,36 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 	}
 
 	// Clean up any connections that have no subscriptions left to reduce resource usage
-
 	connections := m.snapshotManagedConnections(ws)
-
 	clean := make([]Connection, 0, len(connections))
-
 	stale := make([]Connection, 0, len(connections))
-
 	for _, conn := range connections {
 		if conn.Subscriptions().Len() != 0 {
 			clean = append(clean, conn)
-
 			continue
 		}
-
 		stale = append(stale, conn)
 	}
-
 	if len(stale) == 0 {
 		return nil
 	}
-
 	staleSet := make(map[Connection]struct{}, len(stale))
-
 	for _, conn := range stale {
 		staleSet[conn] = struct{}{}
 	}
-
 	m.connectionManagerMu.Lock()
-
 	for _, conn := range stale {
 		delete(m.connections, conn)
 	}
-
 	clean = clean[:0]
-
 	for _, conn := range ws.connections {
 		if _, ok := staleSet[conn]; ok {
 			continue
 		}
-
 		clean = append(clean, conn)
 	}
-
 	ws.connections = clean
-
 	m.connectionManagerMu.Unlock()
-
 	for _, conn := range stale {
 		if err := conn.Shutdown(); err != nil {
 			log.Warnf(log.WebsocketMgr, "%v websocket: failed to shutdown connection: %v", m.exchangeName, err)
@@ -929,96 +751,65 @@ func (m *Manager) resubscribeFromConnection(ctx context.Context, conn Connection
 	if err := common.NilGuard(conn, subs); err != nil {
 		return err
 	}
-
 	if len(subs) == 0 {
 		return nil
 	}
-
 	m.resubscriptionsMu.Lock()
-
 	if m.resubscriptions == nil {
 		m.resubscriptions = make(map[*subscription.Subscription]*resubscribeTracker)
 	}
-
 	ownedSubs := make(subscription.List, 0, len(subs))
-
 	ownedTrackers := make([]*resubscribeTracker, 0, len(subs))
-
 	borrowed := make([]*resubscribeTracker, 0, len(subs))
-
 	for _, s := range subs {
 		tracker := m.resubscriptions[s]
-
 		if tracker != nil {
 			borrowed = append(borrowed, tracker)
-
 			continue
 		}
-
 		tracker = &resubscribeTracker{
 			done: make(chan struct{}),
 		}
-
 		m.resubscriptions[s] = tracker
-
 		ownedSubs = append(ownedSubs, s)
-
 		ownedTrackers = append(ownedTrackers, tracker)
 	}
-
 	m.resubscriptionsMu.Unlock()
-
 	if len(ownedSubs) == 0 {
 		if m.resubscribeWaiterHook != nil {
 			m.resubscribeWaiterHook(subs[0])
 		}
-
 		var firstErr error
-
 		for _, tracker := range borrowed {
 			<-tracker.done
-
 			if tracker.err != nil && firstErr == nil {
 				firstErr = tracker.err
 			}
 		}
-
 		if firstErr == nil {
 			return nil
 		}
-
 		if allowRetry {
 			return m.resubscribeFromConnection(ctx, conn, subs, false)
 		}
-
 		return firstErr
 	}
-
 	subs = ownedSubs
-
 	var resErr error
-
 	defer func() {
 		for idx, s := range ownedSubs {
 			finishResubscriptionTracker(m, s, ownedTrackers[idx], resErr)
 		}
 	}()
-
 	if m.resubscribePreLockHook != nil && len(subs) > 0 {
 		m.resubscribePreLockHook(subs[0])
 	}
-
 	m.m.Lock()
-
 	wsStore := m.subscriptionStore(conn)
-
 	connStore := connectionSubscriptionStore(conn)
-
 	snapshots := make([]recoverySnapshot, len(subs))
-
 	for i, s := range subs {
 		snapshots[i] = recoverySnapshot{sub: s}
-
 		if connStore != nil {
 			if orig := connStore.Get(s); orig != nil {
 				snapshots[i].origKey = orig.Key
@@ -1029,56 +820,40 @@ func (m *Manager) resubscribeFromConnection(ctx context.Context, conn Connection
 			}
 		}
 	}
-
 	setResubscribingState(subs)
-
 	m.m.Unlock()
-
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
 	if err != nil {
 		resErr = err
-
 		return err
 	}
-
 	if len(missing) > 0 {
 		var notRemoved subscription.List
-
 		for _, s := range missing {
 			if s.State() != subscription.UnsubscribedState {
 				notRemoved = append(notRemoved, s)
 			}
 		}
-
 		if len(notRemoved) > 0 {
 			resErr = fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
-
 			return resErr
 		}
 	}
-
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
 	if err != nil {
 		m.m.Lock()
-
 		for _, snap := range snapshots {
 			if snap.sub.State() == subscription.SubscribedState {
 				continue
 			}
-
 			restoreFailedRecovery(wsStore, connStore, snap.sub, snap.origKey)
 		}
-
 		m.m.Unlock()
-
 		resErr = err
-
 		return err
 	}
-
 	if len(remaining) > 0 {
 		resErr = fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
-
 		return resErr
 	}
 
@@ -1091,20 +866,17 @@ func allSubscriptionsState(subs subscription.List, state subscription.State) boo
 			return false
 		}
 	}
-
 	return true
 }
 
 // unsubscribeFromConnection unsubscribes for a connection and removes subscriptions from the connection's store
 func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
 	store := conn.Subscriptions()
-
 	if err := common.NilGuard(store); err != nil {
 		return nil, fmt.Errorf("websocket connection %w", err)
 	}
 
 	remove := store.Contained(subs)
-
 	if len(remove) == 0 {
 		return subs, nil
 	}
@@ -1114,40 +886,32 @@ func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection
 	}
 
 	missing := store.Missing(subs)
-
 	for _, r := range remove {
 		if r.State() == subscription.ResubscribingState {
 			continue
 		}
-
 		if store.Get(r) == nil {
 			continue
 		}
-
 		if err := store.Remove(r); err != nil {
 			return nil, err
 		}
 	}
-
 	return missing, nil
 }
 
 // subscribeToConnection subscribes for a connection and adds subscriptions to the connection's store
 func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
 	store := conn.Subscriptions()
-
 	if err := common.NilGuard(store); err != nil {
 		return nil, fmt.Errorf("websocket connection %w", err)
 	}
-
 	usedCap := connectionUsedCapacity(store, subs)
-
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
 		return subs, nil // No capacity left for this connection
 	}
 
 	availableCap := len(subs)
-
 	if m.MaxSubscriptionsPerConnection > 0 {
 		availableCap = m.MaxSubscriptionsPerConnection - usedCap
 	}
@@ -1157,13 +921,10 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	}
 
 	toSubscribe := subs[:availableCap]
-
 	tracked := make(map[*subscription.Subscription]bool, len(toSubscribe))
-
 	for _, s := range toSubscribe {
 		tracked[s] = store.Get(s) != nil && s.State() == subscription.ResubscribingState
 	}
-
 	if err := m.SubscribeToChannels(ctx, conn, toSubscribe); err != nil {
 		return nil, err
 	}
@@ -1174,11 +935,9 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 				return nil, err
 			}
 		}
-
 		if tracked[s] {
 			continue
 		}
-
 		if err := store.Add(s); err != nil {
 			return nil, err
 		}

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -12,7 +12,6 @@ import (
 )
 
 // Public subscription errors
-
 var (
 	ErrSubscriptionFailure = errors.New("subscription failure")
 
@@ -22,7 +21,6 @@ var (
 )
 
 // Public subscription errors
-
 var (
 	errSubscriptionsExceedsLimit = errors.New("subscriptions exceeds limit")
 
@@ -30,81 +28,53 @@ var (
 )
 
 // UnsubscribeChannels unsubscribes from a list of websocket channel
-
 func (m *Manager) UnsubscribeChannels(ctx context.Context, conn Connection, channels subscription.List) error {
-
 	if len(channels) == 0 {
-
 		return nil // No channels to unsubscribe from is not an error
-
 	}
 
 	if m.useMultiConnectionManagement {
-
 		if err := common.NilGuard(conn); err != nil {
-
 			return err
-
 		}
 
 		ws, ok := m.managedWebsocket(conn)
 
 		if !ok {
-
 			return fmt.Errorf("%w: %q", errConnectionNotFound, conn.GetURL())
-
 		}
 
 		return m.unsubscribe(ws.subscriptions, channels, func(channels subscription.List) error {
-
 			return ws.setup.Unsubscriber(ctx, conn, channels)
-
 		})
-
 	}
 
 	if m.Unsubscriber == nil {
-
 		return fmt.Errorf("%w: Global Unsubscriber not set", common.ErrNilPointer)
-
 	}
 
 	return m.unsubscribe(m.subscriptions, channels, func(channels subscription.List) error {
-
 		return m.Unsubscriber(channels)
-
 	})
-
 }
 
 func (m *Manager) unsubscribe(store *subscription.Store, channels subscription.List, unsub func(channels subscription.List) error) error {
-
 	if store == nil {
-
 		return nil // No channels to unsubscribe from is not an error
-
 	}
 
 	for _, s := range channels {
-
 		if store.Get(s) == nil {
-
 			return fmt.Errorf("%w: %s", subscription.ErrNotFound, s)
-
 		}
-
 	}
 
 	return unsub(channels)
-
 }
 
 func (m *Manager) managedWebsocket(conn Connection) (*websocket, bool) {
-
 	if conn == nil {
-
 		return nil, false
-
 	}
 
 	m.connectionManagerMu.RLock()
@@ -114,117 +84,85 @@ func (m *Manager) managedWebsocket(conn Connection) (*websocket, bool) {
 	ws := m.connections[conn]
 
 	return ws, ws != nil
-
 }
 
 func (m *Manager) subscriptionStore(conn Connection) *subscription.Store {
-
 	m.connectionManagerMu.RLock()
 
 	defer m.connectionManagerMu.RUnlock()
 
 	if ws, ok := m.connections[conn]; ok && conn != nil {
-
 		return ws.subscriptions
-
 	}
 
 	return m.subscriptions
-
 }
 
 func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
-
 	m.connectionManagerMu.Lock()
 
 	defer m.connectionManagerMu.Unlock()
 
 	if ws, ok := m.connections[conn]; ok && conn != nil {
-
 		if ws.subscriptions == nil {
-
 			ws.subscriptions = subscription.NewStore()
-
 		}
 
 		return ws.subscriptions
-
 	}
 
 	if m.subscriptions == nil {
-
 		m.subscriptions = subscription.NewStore()
-
 	}
 
 	return m.subscriptions
-
 }
 
 // ResubscribeToChannel resubscribes to channel
-
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
-
 // A subscription already in ResubscribingState is retried.
-
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
-
 	if s == nil {
-
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
-
 	}
 
 	m.resubscriptionsMu.Lock()
 
 	if m.resubscriptions == nil {
-
 		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
-
 	}
 
 	ch, inFlight := m.resubscriptions[s]
 
 	if !inFlight {
-
 		ch = make(chan struct{})
 
 		m.resubscriptions[s] = ch
-
 	}
 
 	m.resubscriptionsMu.Unlock()
 
 	if !inFlight {
-
 		defer func() {
-
 			m.resubscriptionsMu.Lock()
 
 			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
-
 				delete(m.resubscriptions, s)
 
 				close(ch)
-
 			}
 
 			m.resubscriptionsMu.Unlock()
-
 		}()
-
 	}
 
 	if m.resubscribePreLockHook != nil {
-
 		m.resubscribePreLockHook(s)
-
 	}
 
 	m.m.Lock()
 
 	if inFlight {
-
 		m.m.Unlock()
 
 		m.waitForResubscriptionLeader(s)
@@ -232,11 +170,9 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 		m.m.Lock()
 
 		if s.State() == subscription.SubscribedState {
-
 			m.m.Unlock()
 
 			return nil
-
 		}
 
 		m.resubscriptionsMu.Lock()
@@ -248,21 +184,16 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 		m.resubscriptionsMu.Unlock()
 
 		defer func() {
-
 			m.resubscriptionsMu.Lock()
 
 			if currentCh, ok := m.resubscriptions[s]; ok && currentCh == ch {
-
 				delete(m.resubscriptions, s)
 
 				close(ch)
-
 			}
 
 			m.resubscriptionsMu.Unlock()
-
 		}()
-
 	}
 
 	l := subscription.List{s}
@@ -276,25 +207,18 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	var origKey any
 
 	if wsStore != nil {
-
 		if origSub := wsStore.Get(s); origSub != nil {
-
 			origKey = origSub.Key
-
 		}
-
 	}
 
 	m.m.Unlock()
 
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
-
 		return err
-
 	}
 
 	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
-
 		m.m.Lock()
 
 		restoreFailedRecovery(wsStore, connStore, s, origKey)
@@ -302,11 +226,9 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 		m.m.Unlock()
 
 		return err
-
 	}
 
 	return nil
-
 }
 
 type recoverySnapshot struct {
@@ -316,51 +238,36 @@ type recoverySnapshot struct {
 }
 
 func connectionSubscriptionStore(conn Connection) *subscription.Store {
-
 	if conn == nil {
-
 		return nil
-
 	}
 
 	return conn.Subscriptions()
-
 }
 
 func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscription.Subscription, origKey any) {
-
 	if sub == nil {
-
 		return
-
 	}
 
 	if connStore != nil {
-
 		restoreSubscriptionAfterFailedRecovery(connStore, sub, origKey)
-
 	}
 
 	if wsStore == nil || wsStore == connStore {
-
 		return
-
 	}
 
 	if wsStore.Get(sub) == nil {
-
 		restoreSubscriptionAfterFailedRecovery(wsStore, sub, origKey)
 
 		return
-
 	}
 
 	_ = sub.SetState(subscription.ResubscribingState)
-
 }
 
 func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
-
 	m.resubscriptionsMu.Lock()
 
 	ch, exists := m.resubscriptions[s]
@@ -368,21 +275,15 @@ func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
 	m.resubscriptionsMu.Unlock()
 
 	if !exists {
-
 		return
-
 	}
 
 	<-ch
-
 }
 
 func connectionUsedCapacity(store *subscription.Store, incoming subscription.List) int {
-
 	if store == nil {
-
 		return 0
-
 	}
 
 	usedCap := store.Len()
@@ -390,173 +291,115 @@ func connectionUsedCapacity(store *subscription.Store, incoming subscription.Lis
 	discounted := make(map[*subscription.Subscription]struct{}, len(incoming))
 
 	for _, s := range incoming {
-
 		if s == nil || s.State() != subscription.ResubscribingState || store.Get(s) == nil {
-
 			continue
-
 		}
 
 		if _, seen := discounted[s]; seen {
-
 			continue
-
 		}
 
 		discounted[s] = struct{}{}
 
 		usedCap--
-
 	}
 
 	return usedCap
-
 }
 
 func hasLiveRecoveryReplacement(store *subscription.Store, sub *subscription.Subscription, origKey any) bool {
-
 	if store == nil || sub == nil {
-
 		return false
-
 	}
 
 	want := subscription.ExactKey{Subscription: sub}
 
 	for _, existing := range store.List() {
-
 		if existing == sub {
-
 			continue
-
 		}
 
 		if !want.Match(subscription.ExactKey{Subscription: existing}) {
-
 			continue
-
 		}
 
 		if existing.State() != subscription.SubscribedState {
-
 			continue
-
 		}
 
 		if origKey != nil && existing.EnsureKeyed() == origKey {
-
 			continue
-
 		}
 
 		return true
-
 	}
 
 	return false
-
 }
 
 func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subscription.Subscription, origKey any) {
-
 	if store == nil || sub == nil {
-
 		return
-
 	}
 
 	if hasLiveRecoveryReplacement(store, sub, origKey) {
-
 		if store.Get(sub) != nil {
-
 			_ = sub.SetState(subscription.ResubscribingState)
-
 		}
 
 		return
-
 	}
 
 	if origKey != nil {
-
 		sub.SetKey(origKey)
-
 	}
 
 	_ = sub.SetState(subscription.ResubscribingState)
 
 	if store.Get(sub) == nil {
-
 		_ = store.Add(sub)
-
 	}
-
 }
 
 func setResubscribingState(subs subscription.List) {
-
 	for _, sub := range subs {
-
 		if sub.State() != subscription.ResubscribingState {
-
 			_ = sub.SetState(subscription.ResubscribingState)
-
 		}
-
 	}
-
 }
 
 // SubscribeToChannels subscribes to websocket channels using the exchange specific Subscriber method
-
 // Errors are returned for duplicates or exceeding max Subscriptions
-
 func (m *Manager) SubscribeToChannels(ctx context.Context, conn Connection, subs subscription.List) error {
-
 	if slices.Contains(subs, nil) {
-
 		return fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
-
 	}
 
 	if err := m.checkSubscriptions(conn, subs); err != nil {
-
 		return err
-
 	}
 
 	if ws, ok := m.managedWebsocket(conn); ok {
-
 		return ws.setup.Subscriber(ctx, conn, subs)
-
 	}
 
 	if m.Subscriber == nil {
-
 		return fmt.Errorf("%w: Global Subscriber not set", common.ErrNilPointer)
-
 	}
 
 	if err := m.Subscriber(subs); err != nil {
-
 		return fmt.Errorf("%w: %w", ErrSubscriptionFailure, err)
-
 	}
 
 	return nil
-
 }
 
 // AddSubscriptions adds subscriptions to the subscription store
-
 // Sets state to Subscribing unless the state is already set
-
 func (m *Manager) AddSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
-
 	if m == nil {
-
 		return fmt.Errorf("%w: AddSubscriptions called on nil Websocket", common.ErrNilPointer)
-
 	}
 
 	subscriptionStore := m.initSubscriptionStore(conn)
@@ -564,37 +407,24 @@ func (m *Manager) AddSubscriptions(conn Connection, subs ...*subscription.Subscr
 	var errs error
 
 	for _, s := range subs {
-
 		if s.State() == subscription.InactiveState {
-
 			if err := s.SetState(subscription.SubscribingState); err != nil {
-
 				errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
-
 			}
-
 		}
 
 		if err := subscriptionStore.Add(s); err != nil {
-
 			errs = common.AppendError(errs, err)
-
 		}
-
 	}
 
 	return errs
-
 }
 
 // AddSuccessfulSubscriptions marks subscriptions as subscribed and adds them to the subscription store
-
 func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
-
 	if m == nil {
-
 		return fmt.Errorf("%w: AddSuccessfulSubscriptions called on nil Websocket", common.ErrNilPointer)
-
 	}
 
 	subscriptionStore := m.initSubscriptionStore(conn)
@@ -602,87 +432,58 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 	var errs error
 
 	for _, s := range subs {
-
 		alreadyTracked := subscriptionStore.Get(s) != nil && s.State() == subscription.ResubscribingState
 
 		if err := s.SetState(subscription.SubscribedState); err != nil {
-
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
-
 		}
 
 		if !alreadyTracked {
-
 			if err := subscriptionStore.Add(s); err != nil {
-
 				errs = common.AppendError(errs, err)
-
 			}
-
 		}
-
 	}
 
 	return errs
-
 }
 
 // RemoveSubscriptions removes subscriptions from the subscription list and sets the status to Unsubscribed
-
 func (m *Manager) RemoveSubscriptions(conn Connection, subs ...*subscription.Subscription) error {
-
 	if m == nil {
-
 		return fmt.Errorf("%w: RemoveSubscriptions called on nil Websocket", common.ErrNilPointer)
-
 	}
 
 	subscriptionStore := m.subscriptionStore(conn)
 
 	if subscriptionStore == nil {
-
 		return fmt.Errorf("%w: RemoveSubscriptions called on uninitialised Websocket", common.ErrNilPointer)
-
 	}
 
 	var errs error
 
 	for _, s := range subs {
-
 		if err := s.SetState(subscription.UnsubscribedState); err != nil {
-
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
-
 		}
 
 		if err := subscriptionStore.Remove(s); err != nil {
-
 			errs = common.AppendError(errs, err)
-
 		}
-
 	}
 
 	return errs
-
 }
 
 // GetSubscription returns a subscription at the key provided
-
 // returns nil if no subscription is at that key or the key is nil
-
 // Keys can implement subscription.MatchableKey in order to provide custom matching logic
-
 func (m *Manager) GetSubscription(key any) *subscription.Subscription {
-
 	if m == nil || key == nil {
-
 		return nil
-
 	}
 
 	for _, ws := range m.snapshotConnectionManager() {
-
 		m.connectionManagerMu.RLock()
 
 		store := ws.subscriptions
@@ -690,125 +491,88 @@ func (m *Manager) GetSubscription(key any) *subscription.Subscription {
 		var sub *subscription.Subscription
 
 		if store != nil {
-
 			sub = store.Get(key)
-
 		}
 
 		m.connectionManagerMu.RUnlock()
 
 		if sub != nil {
-
 			return sub
-
 		}
-
 	}
 
 	if store := m.subscriptionStore(nil); store != nil {
-
 		return store.Get(key)
-
 	}
 
 	return nil
-
 }
 
 // GetSubscriptions returns a new slice of the subscriptions
-
 func (m *Manager) GetSubscriptions() subscription.List {
-
 	if m == nil {
-
 		return nil
-
 	}
 
 	var subs subscription.List
 
 	for _, ws := range m.snapshotConnectionManager() {
-
 		m.connectionManagerMu.RLock()
 
 		store := ws.subscriptions
 
 		if store != nil {
-
 			subs = append(subs, store.List()...)
-
 		}
 
 		m.connectionManagerMu.RUnlock()
-
 	}
 
 	if store := m.subscriptionStore(nil); store != nil {
-
 		subs = append(subs, store.List()...)
-
 	}
 
 	return subs
-
 }
 
 // checkSubscriptions checks subscriptions against the max subscription limit and if the subscription already exists
-
 // The subscription state is not considered when counting existing subscriptions
-
 func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) error {
-
 	var subscriptionStore *subscription.Store
 
 	var connSubStore *subscription.Store
 
 	if ws, ok := m.managedWebsocket(conn); ok {
-
 		if ws.subscriptions == nil {
-
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
-
 		}
 
 		for _, c := range m.snapshotManagedConnections(ws) { // ensure connection is actually managed
-
 			if c == conn {
-
 				connSubStore = c.Subscriptions()
 
 				break
-
 			}
-
 		}
 
 		if connSubStore == nil {
-
 			return fmt.Errorf("%w: connection subscription store not found", common.ErrNilPointer)
-
 		}
 
 		subscriptionStore = ws.subscriptions
-
 	} else {
-
 		subscriptionStore = m.subscriptionStore(nil)
 
 		if subscriptionStore == nil {
-
 			return fmt.Errorf("%w: Websocket.subscriptions", common.ErrNilPointer)
-
 		}
 
 		connSubStore = subscriptionStore
-
 	}
 
 	usedCap := connectionUsedCapacity(connSubStore, subs)
 
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
-
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
 
 			errSubscriptionsExceedsLimit,
@@ -818,221 +582,147 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 			len(subs),
 
 			m.MaxSubscriptionsPerConnection)
-
 	}
 
 	for _, s := range subs {
-
 		if s.State() == subscription.ResubscribingState {
-
 			continue
-
 		}
 
 		if found := subscriptionStore.Get(s); found != nil {
-
 			return fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // FlushChannels flushes channel subscriptions when there is a pair/asset change
-
 func (m *Manager) FlushChannels(ctx context.Context) error {
-
 	m.m.Lock()
 
 	defer m.m.Unlock()
 
 	return m.flushChannels(ctx)
-
 }
 
 func (m *Manager) flushChannels(ctx context.Context) error {
-
 	if !m.IsEnabled() {
-
 		return fmt.Errorf("%s %w", m.exchangeName, ErrWebsocketNotEnabled)
-
 	}
 
 	if !m.IsConnected() {
-
 		return fmt.Errorf("%s %w", m.exchangeName, ErrNotConnected)
-
 	}
 
 	// If the exchange does not support subscribing and or unsubscribing the full connection needs to be flushed to
-
 	// maintain consistency.
 
 	if !m.features.Subscribe || !m.features.Unsubscribe {
-
 		if err := m.shutdown(); err != nil {
-
 			return err
-
 		}
 
 		return m.connect(ctx)
-
 	}
 
 	if !m.useMultiConnectionManagement {
-
 		newSubs, err := m.GenerateSubs()
-
 		if err != nil {
-
 			return err
-
 		}
 
 		return m.updateChannelSubscriptions(ctx, m.subscriptions, newSubs)
-
 	}
 
 	for _, ws := range m.snapshotConnectionManager() {
-
 		if ws.setup.SubscriptionsNotRequired {
-
 			continue
-
 		}
 
 		newSubs, err := ws.setup.GenerateSubscriptions()
-
 		if err != nil {
-
 			return err
-
 		}
 
 		// Case if there is nothing to unsubscribe from and the connection is nil
 
 		if len(newSubs) == 0 && len(m.snapshotManagedConnections(ws)) == 0 {
-
 			continue
-
 		}
 
 		if err := m.scaleConnectionsToSubscriptions(ctx, ws, newSubs); err != nil {
-
 			return err
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // updateChannelSubscriptions subscribes or unsubscribes from channels and checks that the correct number of channels
-
 // have been subscribed to or unsubscribed from.
-
 func (m *Manager) updateChannelSubscriptions(ctx context.Context, store *subscription.Store, incoming subscription.List) error {
-
 	subs, unsubs := store.Diff(incoming)
 
 	if len(unsubs) != 0 {
-
 		if err := m.UnsubscribeChannels(ctx, nil, unsubs); err != nil {
-
 			return err
-
 		}
 
 		if contained := store.Contained(unsubs); len(contained) > 0 {
-
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
-
 		}
-
 	}
 
 	if len(subs) != 0 {
-
 		if err := m.SubscribeToChannels(ctx, nil, subs); err != nil {
-
 			return err
-
 		}
 
 		if missing := store.Missing(subs); len(missing) > 0 {
-
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // applyTrackedSubscriptions records tracked subscriptions in both manager-level and connection-level stores for the provided connection.
-
 func (m *Manager) applyTrackedSubscriptions(conn Connection, tracked subscription.List) error {
-
 	if len(tracked) == 0 {
-
 		return nil
-
 	}
 
 	if err := m.AddSuccessfulSubscriptions(conn, tracked...); err != nil {
-
 		return err
-
 	}
 
 	store := conn.Subscriptions()
 
 	if err := common.NilGuard(store); err != nil {
-
 		return fmt.Errorf("websocket connection %w", err)
-
 	}
 
 	for _, sub := range tracked {
-
 		if err := store.Add(sub); err != nil {
-
 			return err
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // absorbTrackedSubscriptions asks each managed connection whether a subset of subs can be logically tracked on that existing connection.
-
 // It applies tracked subscriptions to manager and connection stores and returns the remaining subscriptions that still need outbound subscribe traffic/new capacity plus the list that were tracked.
-
 func (m *Manager) absorbTrackedSubscriptions(ctx context.Context, ws *websocket, subs subscription.List) (remaining, tracked subscription.List, err error) {
-
 	if len(subs) == 0 || ws == nil || ws.setup == nil || ws.setup.TrackOnExistingConnection == nil {
-
 		return subs, nil, nil
-
 	}
 
 	connections := m.snapshotManagedConnections(ws)
 
 	if len(connections) == 0 {
-
 		return subs, nil, nil
-
 	}
 
 	remaining = subs
@@ -1040,201 +730,133 @@ func (m *Manager) absorbTrackedSubscriptions(ctx context.Context, ws *websocket,
 	tracked = make(subscription.List, 0, len(subs))
 
 	for _, conn := range connections {
-
 		connRemaining, connTracked, err := ws.setup.TrackOnExistingConnection(ctx, conn, remaining)
-
 		if err != nil {
-
 			return nil, nil, err
-
 		}
 
 		if err := m.applyTrackedSubscriptions(conn, connTracked); err != nil {
-
 			return nil, nil, err
-
 		}
 
 		if len(connTracked) != 0 {
-
 			tracked = append(tracked, connTracked...)
-
 		}
 
 		remaining = connRemaining
 
 		if len(remaining) == 0 {
-
 			return nil, tracked, nil
-
 		}
-
 	}
 
 	return remaining, tracked, nil
-
 }
 
 // absorbTrackableSubscriptionsAndValidate absorbs trackable subscriptions onto existing connections and verifies that tracked subscriptions were recorded in the websocket-level subscription store.
-
 func (m *Manager) absorbTrackableSubscriptionsAndValidate(ctx context.Context, ws *websocket, subs subscription.List) (subscription.List, error) {
-
 	remaining, tracked, err := m.absorbTrackedSubscriptions(ctx, ws, subs)
-
 	if err != nil {
-
 		return nil, err
-
 	}
 
 	if len(tracked) == 0 {
-
 		return remaining, nil
-
 	}
 
 	if missing := ws.subscriptions.Missing(tracked); len(missing) > 0 {
-
 		return nil, fmt.Errorf("%w: %w %q", ErrSubscriptionFailure, ErrSubscriptionsNotAdded, missing)
-
 	}
 
 	return remaining, nil
-
 }
 
 // scaleConnectionsToSubscriptions scales connections to subscriptions based off current subscription list and subscription limit
-
 func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *websocket, incoming subscription.List) error {
-
 	if err := common.NilGuard(ws); err != nil {
-
 		return err
-
 	}
 
 	subs, unsubs := ws.subscriptions.Diff(incoming)
 
 	if len(unsubs) != 0 {
-
 		currentUnsubs := slices.Clone(unsubs)
 
 		// Unsubscribe first to free up capacity on existing connections
 
 		for _, conn := range m.snapshotManagedConnections(ws) {
-
 			leftOver, err := m.unsubscribeFromConnection(ctx, conn, currentUnsubs)
-
 			if err != nil {
-
 				return err
-
 			}
 
 			currentUnsubs = leftOver
 
 			if len(currentUnsubs) == 0 {
-
 				break
-
 			}
-
 		}
 
 		if len(currentUnsubs) != 0 {
-
 			log.Warnf(log.WebsocketMgr, "%v websocket: unable to find all subscriptions to remove on existing connections, attempting global unsubscribe for %v", m.exchangeName, currentUnsubs)
 
 			for _, s := range currentUnsubs {
-
 				if err := ws.subscriptions.Remove(s); err != nil {
-
 					return err
-
 				}
-
 			}
-
 		}
 
 		if contained := ws.subscriptions.Contained(unsubs); len(contained) > 0 {
-
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotRemoved, contained)
-
 		}
-
 	}
 
 	if len(subs) != 0 {
-
 		// First, absorb subscriptions that should be tracked on existing
-
 		// connections (e.g. OKX spot/margin equivalents) before the
-
 		// generic capacity-based routing can misplace them.
 
 		currentSubs, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, subs)
-
 		if err != nil {
-
 			return err
-
 		}
 
 		// Subscribe to existing connections to use up existing capacity
 
 		for _, conn := range m.snapshotManagedConnections(ws) {
-
 			leftOver, err := m.subscribeToConnection(ctx, conn, currentSubs)
-
 			if err != nil {
-
 				return err
-
 			}
 
 			currentSubs = leftOver
 
 			if len(currentSubs) == 0 {
-
 				break
-
 			}
-
 		}
 
 		// Spawn new connections if there are still subscriptions left to process
 
 		for _, batch := range common.Batch(currentSubs, m.MaxSubscriptionsPerConnection) {
-
 			toConnect, err := m.absorbTrackableSubscriptionsAndValidate(ctx, ws, batch)
-
 			if err != nil {
-
 				return err
-
 			}
 
 			if len(toConnect) == 0 {
-
 				continue
-
 			}
 
 			if err := m.createConnectAndSubscribe(ctx, ws, toConnect); err != nil {
-
 				return err
-
 			}
-
 		}
 
 		if missing := ws.subscriptions.Missing(subs); len(missing) > 0 {
-
 			return fmt.Errorf("%v %w %q", m.exchangeName, ErrSubscriptionsNotAdded, missing)
-
 		}
-
 	}
 
 	// Clean up any connections that have no subscriptions left to reduce resource usage
@@ -1246,53 +868,39 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 	stale := make([]Connection, 0, len(connections))
 
 	for _, conn := range connections {
-
 		if conn.Subscriptions().Len() != 0 {
-
 			clean = append(clean, conn)
 
 			continue
-
 		}
 
 		stale = append(stale, conn)
-
 	}
 
 	if len(stale) == 0 {
-
 		return nil
-
 	}
 
 	staleSet := make(map[Connection]struct{}, len(stale))
 
 	for _, conn := range stale {
-
 		staleSet[conn] = struct{}{}
-
 	}
 
 	m.connectionManagerMu.Lock()
 
 	for _, conn := range stale {
-
 		delete(m.connections, conn)
-
 	}
 
 	clean = clean[:0]
 
 	for _, conn := range ws.connections {
-
 		if _, ok := staleSet[conn]; ok {
-
 			continue
-
 		}
 
 		clean = append(clean, conn)
-
 	}
 
 	ws.connections = clean
@@ -1300,125 +908,89 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 	m.connectionManagerMu.Unlock()
 
 	for _, conn := range stale {
-
 		if err := conn.Shutdown(); err != nil {
-
 			log.Warnf(log.WebsocketMgr, "%v websocket: failed to shutdown connection: %v", m.exchangeName, err)
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
-
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
-
 	if err := common.NilGuard(conn, subs); err != nil {
-
 		return err
-
 	}
 
 	if len(subs) == 0 {
-
 		return nil
-
 	}
 
 	m.resubscriptionsMu.Lock()
 
 	if m.resubscriptions == nil {
-
 		m.resubscriptions = make(map[*subscription.Subscription]chan struct{})
-
 	}
 
 	allInFlight := true
 
 	for _, s := range subs {
-
 		if _, ok := m.resubscriptions[s]; !ok {
-
 			allInFlight = false
 
 			break
-
 		}
-
 	}
 
 	chans := make([]chan struct{}, 0, len(subs))
 
 	if !allInFlight {
-
 		for _, s := range subs {
-
 			ch := make(chan struct{})
 
 			m.resubscriptions[s] = ch
 
 			chans = append(chans, ch)
-
 		}
-
 	}
 
 	m.resubscriptionsMu.Unlock()
 
 	if !allInFlight {
-
 		defer func() {
-
 			m.resubscriptionsMu.Lock()
 
 			for idx, s := range subs {
-
 				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
-
 					delete(m.resubscriptions, s)
 
 					close(chans[idx])
-
 				}
-
 			}
 
 			m.resubscriptionsMu.Unlock()
-
 		}()
-
 	}
 
 	if m.resubscribePreLockHook != nil && len(subs) > 0 {
-
 		m.resubscribePreLockHook(subs[0])
-
 	}
 
 	m.m.Lock()
 
 	if allInFlight {
-
 		m.m.Unlock()
 
 		for _, s := range subs {
-
 			m.waitForResubscriptionLeader(s)
-
 		}
 
 		m.m.Lock()
 
 		if allSubscriptionsState(subs, subscription.SubscribedState) {
-
 			m.m.Unlock()
 
 			return nil
-
 		}
 
 		m.resubscriptionsMu.Lock()
@@ -1426,37 +998,28 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		chans = make([]chan struct{}, 0, len(subs))
 
 		for _, s := range subs {
-
 			ch := make(chan struct{})
 
 			m.resubscriptions[s] = ch
 
 			chans = append(chans, ch)
-
 		}
 
 		m.resubscriptionsMu.Unlock()
 
 		defer func() {
-
 			m.resubscriptionsMu.Lock()
 
 			for idx, s := range subs {
-
 				if currentCh, ok := m.resubscriptions[s]; ok && currentCh == chans[idx] {
-
 					delete(m.resubscriptions, s)
 
 					close(chans[idx])
-
 				}
-
 			}
 
 			m.resubscriptionsMu.Unlock()
-
 		}()
-
 	}
 
 	wsStore := m.subscriptionStore(conn)
@@ -1466,27 +1029,17 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	snapshots := make([]recoverySnapshot, len(subs))
 
 	for i, s := range subs {
-
 		snapshots[i] = recoverySnapshot{sub: s}
 
 		if connStore != nil {
-
 			if orig := connStore.Get(s); orig != nil {
-
 				snapshots[i].origKey = orig.Key
-
 			}
-
 		} else if wsStore != nil {
-
 			if orig := wsStore.Get(s); orig != nil {
-
 				snapshots[i].origKey = orig.Key
-
 			}
-
 		}
-
 	}
 
 	setResubscribingState(subs)
@@ -1494,171 +1047,117 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	m.m.Unlock()
 
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
-
 	if err != nil {
-
 		return err
-
 	}
 
 	if len(missing) > 0 {
-
 		var notRemoved subscription.List
 
 		for _, s := range missing {
-
 			if s.State() != subscription.UnsubscribedState {
-
 				notRemoved = append(notRemoved, s)
-
 			}
-
 		}
 
 		if len(notRemoved) > 0 {
-
 			return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
-
 		}
-
 	}
 
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
-
 	if err != nil {
-
 		m.m.Lock()
 
 		for _, snap := range snapshots {
-
 			if snap.sub.State() == subscription.SubscribedState {
-
 				continue
-
 			}
 
 			restoreFailedRecovery(wsStore, connStore, snap.sub, snap.origKey)
-
 		}
 
 		m.m.Unlock()
 
 		return err
-
 	}
 
 	if len(remaining) > 0 {
-
 		return fmt.Errorf("%w: %q", ErrSubscriptionsNotAdded, remaining)
-
 	}
 
 	return nil
-
 }
 
 func allSubscriptionsState(subs subscription.List, state subscription.State) bool {
-
 	for _, sub := range subs {
-
 		if sub.State() != state {
-
 			return false
-
 		}
-
 	}
 
 	return true
-
 }
 
 // unsubscribeFromConnection unsubscribes for a connection and removes subscriptions from the connection's store
-
 func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
-
 	store := conn.Subscriptions()
 
 	if err := common.NilGuard(store); err != nil {
-
 		return nil, fmt.Errorf("websocket connection %w", err)
-
 	}
 
 	remove := store.Contained(subs)
 
 	if len(remove) == 0 {
-
 		return subs, nil
-
 	}
 
 	if err := m.UnsubscribeChannels(ctx, conn, remove); err != nil {
-
 		return nil, err
-
 	}
 
 	missing := store.Missing(subs)
 
 	for _, r := range remove {
-
 		if r.State() == subscription.ResubscribingState {
-
 			continue
-
 		}
 
 		if store.Get(r) == nil {
-
 			continue
-
 		}
 
 		if err := store.Remove(r); err != nil {
-
 			return nil, err
-
 		}
-
 	}
 
 	return missing, nil
-
 }
 
 // subscribeToConnection subscribes for a connection and adds subscriptions to the connection's store
-
 func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, subs subscription.List) (subscription.List, error) {
-
 	store := conn.Subscriptions()
 
 	if err := common.NilGuard(store); err != nil {
-
 		return nil, fmt.Errorf("websocket connection %w", err)
-
 	}
 
 	usedCap := connectionUsedCapacity(store, subs)
 
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
-
 		return subs, nil // No capacity left for this connection
-
 	}
 
 	availableCap := len(subs)
 
 	if m.MaxSubscriptionsPerConnection > 0 {
-
 		availableCap = m.MaxSubscriptionsPerConnection - usedCap
-
 	}
 
 	if availableCap > len(subs) {
-
 		availableCap = len(subs)
-
 	}
 
 	toSubscribe := subs[:availableCap]
@@ -1666,43 +1165,28 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	tracked := make(map[*subscription.Subscription]bool, len(toSubscribe))
 
 	for _, s := range toSubscribe {
-
 		tracked[s] = store.Get(s) != nil && s.State() == subscription.ResubscribingState
-
 	}
 
 	if err := m.SubscribeToChannels(ctx, conn, toSubscribe); err != nil {
-
 		return nil, err
-
 	}
 
 	for _, s := range toSubscribe {
-
 		if s.State() != subscription.SubscribedState {
-
 			if err := s.SetState(subscription.SubscribedState); err != nil {
-
 				return nil, err
-
 			}
-
 		}
 
 		if tracked[s] {
-
 			continue
-
 		}
 
 		if err := store.Add(s); err != nil {
-
 			return nil, err
-
 		}
-
 	}
 
 	return subs[availableCap:], nil
-
 }

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"slices"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -129,10 +130,12 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	}
 
 	m.m.Lock()
-	defer m.m.Unlock()
-
 	if inFlight {
+		m.m.Unlock()
+		m.waitForResubscriptionLeader(s)
+		m.m.Lock()
 		if s.State() == subscription.SubscribedState {
+			m.m.Unlock()
 			return nil
 		}
 		m.resubscriptionsMu.Lock()
@@ -144,16 +147,15 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 			m.resubscriptionsMu.Unlock()
 		}()
 	}
+	defer m.m.Unlock()
 
 	l := subscription.List{s}
 	setResubscribingState(l)
 
 	store := m.subscriptionStore(conn)
-	var origSub *subscription.Subscription
 	var origKey any
 	if store != nil {
-		origSub = store.Get(s)
-		if origSub != nil {
+		if origSub := store.Get(s); origSub != nil {
 			origKey = origSub.Key
 		}
 	}
@@ -162,18 +164,81 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 		return err
 	}
 	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
-		if origSub != nil && store != nil {
-			if origKey != nil {
-				origSub.Key = origKey
-			}
-			if store.Get(origSub) == nil {
-				_ = store.Add(origSub)
-			}
-			_ = origSub.SetState(subscription.ResubscribingState)
-		}
+		restoreSubscriptionAfterFailedRecovery(store, s, origKey)
 		return err
 	}
 	return nil
+}
+
+type recoverySnapshot struct {
+	sub     *subscription.Subscription
+	origKey any
+}
+
+func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
+	for {
+		m.resubscriptionsMu.Lock()
+		_, exists := m.resubscriptions[s]
+		m.resubscriptionsMu.Unlock()
+		if !exists {
+			return
+		}
+		runtime.Gosched()
+	}
+}
+
+func connectionUsedCapacity(store *subscription.Store, incoming subscription.List) int {
+	if store == nil {
+		return 0
+	}
+	usedCap := store.Len()
+	for _, s := range incoming {
+		if s != nil && s.State() == subscription.ResubscribingState && store.Get(s) != nil {
+			usedCap--
+		}
+	}
+	return usedCap
+}
+
+func hasLiveRecoveryReplacement(store *subscription.Store, sub *subscription.Subscription, origKey any) bool {
+	if store == nil || sub == nil {
+		return false
+	}
+	for _, existing := range store.List() {
+		if existing == sub {
+			continue
+		}
+		if existing.Channel != sub.Channel {
+			continue
+		}
+		if existing.State() != subscription.SubscribedState {
+			continue
+		}
+		if origKey != nil && existing.Key == origKey {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subscription.Subscription, origKey any) {
+	if store == nil || sub == nil {
+		return
+	}
+	if hasLiveRecoveryReplacement(store, sub, origKey) {
+		if store.Get(sub) != nil {
+			_ = sub.SetState(subscription.ResubscribingState)
+		}
+		return
+	}
+	if origKey != nil {
+		sub.SetKey(origKey)
+	}
+	_ = sub.SetState(subscription.ResubscribingState)
+	if store.Get(sub) == nil {
+		_ = store.Add(sub)
+	}
 }
 
 func setResubscribingState(subs subscription.List) {
@@ -346,18 +411,7 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		connSubStore = subscriptionStore
 	}
 
-	incoming := make(map[*subscription.Subscription]struct{}, len(subs))
-	for _, s := range subs {
-		incoming[s] = struct{}{}
-	}
-
-	usedCap := 0
-	for _, sub := range connSubStore.List() {
-		if _, ok := incoming[sub]; ok && sub.State() == subscription.ResubscribingState {
-			continue // Retained for this recovery, so it is not consuming a new slot
-		}
-		usedCap++
-	}
+	usedCap := connectionUsedCapacity(connSubStore, subs)
 
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
@@ -679,10 +733,14 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	}
 
 	m.m.Lock()
-	defer m.m.Unlock()
-
 	if allInFlight {
+		m.m.Unlock()
+		for _, s := range subs {
+			m.waitForResubscriptionLeader(s)
+		}
+		m.m.Lock()
 		if allSubscriptionsState(subs, subscription.SubscribedState) {
+			m.m.Unlock()
 			return nil
 		}
 		m.resubscriptionsMu.Lock()
@@ -698,6 +756,18 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 			m.resubscriptionsMu.Unlock()
 		}()
 	}
+	defer m.m.Unlock()
+
+	store := m.subscriptionStore(conn)
+	snapshots := make([]recoverySnapshot, len(subs))
+	for i, s := range subs {
+		snapshots[i] = recoverySnapshot{sub: s}
+		if store != nil {
+			if orig := store.Get(s); orig != nil {
+				snapshots[i].origKey = orig.Key
+			}
+		}
+	}
 
 	setResubscribingState(subs)
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
@@ -705,10 +775,21 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		return err
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, missing)
+		var notRemoved subscription.List
+		for _, s := range missing {
+			if s.State() != subscription.UnsubscribedState {
+				notRemoved = append(notRemoved, s)
+			}
+		}
+		if len(notRemoved) > 0 {
+			return fmt.Errorf("%w: %q", ErrSubscriptionsNotRemoved, notRemoved)
+		}
 	}
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
 	if err != nil {
+		for _, snap := range snapshots {
+			restoreSubscriptionAfterFailedRecovery(store, snap.sub, snap.origKey)
+		}
 		return err
 	}
 	if len(remaining) > 0 {
@@ -747,6 +828,9 @@ func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection
 		if r.State() == subscription.ResubscribingState {
 			continue
 		}
+		if store.Get(r) == nil {
+			continue
+		}
 		if err := store.Remove(r); err != nil {
 			return nil, err
 		}
@@ -761,18 +845,7 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 		return nil, fmt.Errorf("websocket connection %w", err)
 	}
 
-	incoming := make(map[*subscription.Subscription]struct{}, len(subs))
-	for _, s := range subs {
-		incoming[s] = struct{}{}
-	}
-
-	usedCap := 0
-	for _, sub := range store.List() {
-		if _, ok := incoming[sub]; ok && sub.State() == subscription.ResubscribingState {
-			continue // Retained for this recovery, so it is not consuming a new slot
-		}
-		usedCap++
-	}
+	usedCap := connectionUsedCapacity(store, subs)
 	if m.MaxSubscriptionsPerConnection > 0 && usedCap >= m.MaxSubscriptionsPerConnection {
 		return subs, nil // No capacity left for this connection
 	}
@@ -796,6 +869,11 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	}
 
 	for _, s := range toSubscribe {
+		if s.State() != subscription.SubscribedState {
+			if err := s.SetState(subscription.SubscribedState); err != nil {
+				return nil, err
+			}
+		}
 		if tracked[s] {
 			continue
 		}

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -262,10 +262,11 @@ func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subs
 		return
 	}
 	if hasLiveRecoveryReplacement(store, sub, origKey) {
-		if store.Get(sub) != nil {
+		// Get matches a default key by ExactKey and can return the replacement, so only remove the stale pointer itself
+		if store.Get(sub) == sub {
 			_ = store.Remove(sub)
 		}
-		if origKey != nil && store.Get(origKey) != nil {
+		if origKey != nil && store.Get(origKey) == sub {
 			_ = store.Remove(origKey)
 		}
 		return
@@ -276,6 +277,45 @@ func restoreSubscriptionAfterFailedRecovery(store *subscription.Store, sub *subs
 	_ = sub.SetState(subscription.ResubscribingState)
 	if store.Get(sub) == nil {
 		_ = store.Add(sub)
+	}
+}
+
+// dropFailedRecoveries removes subscriptions a failed recovery left in ResubscribingState, so a flush treats them as
+// absent and resubscribes them if they are still wanted. Exchanges read ResubscribingState as a recovery in flight,
+// so a restored entry must not outlive the next flush.
+func (m *Manager) dropFailedRecoveries() {
+	stores := []*subscription.Store{m.subscriptions}
+	for _, conn := range []Connection{m.Conn, m.AuthConn} {
+		if conn != nil {
+			stores = append(stores, conn.Subscriptions())
+		}
+	}
+	for _, ws := range m.snapshotConnectionManager() {
+		stores = append(stores, ws.subscriptions)
+		for _, conn := range m.snapshotManagedConnections(ws) {
+			stores = append(stores, conn.Subscriptions())
+		}
+	}
+	m.resubscriptionsMu.Lock()
+	defer m.resubscriptionsMu.Unlock()
+	failed := make(map[*subscription.Subscription]struct{})
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		for _, s := range store.List() {
+			if _, inFlight := m.resubscriptions[s]; !inFlight && s.State() == subscription.ResubscribingState {
+				failed[s] = struct{}{}
+			}
+		}
+	}
+	for s := range failed {
+		for _, store := range stores {
+			if store.Get(s) == s {
+				_ = store.Remove(s)
+			}
+		}
+		_ = s.SetState(subscription.UnsubscribedState)
 	}
 }
 
@@ -343,13 +383,9 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 
 	var errs error
 	for _, s := range subs {
-		found := subscriptionStore.Get(s)
-		alreadyTracked := found != nil && (found.State() == subscription.ResubscribingState || s.State() == subscription.ResubscribingState)
+		alreadyTracked := s.State() == subscription.ResubscribingState && subscriptionStore.Get(s) == s
 		if err := s.SetState(subscription.SubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
-		}
-		if found != nil && found != s {
-			_ = found.SetState(subscription.SubscribedState)
 		}
 		if !alreadyTracked {
 			if err := subscriptionStore.Add(s); err != nil {
@@ -456,13 +492,15 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		}
 		connSubStore = subscriptionStore
 	}
-	usedCap := connectionUsedCapacity(connSubStore, subs)
-	if m.MaxSubscriptionsPerConnection > 0 && usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
-		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
-			errSubscriptionsExceedsLimit,
-			usedCap,
-			len(subs),
-			m.MaxSubscriptionsPerConnection)
+	if m.MaxSubscriptionsPerConnection > 0 {
+		usedCap := connectionUsedCapacity(connSubStore, subs)
+		if usedCap+len(subs) > m.MaxSubscriptionsPerConnection {
+			return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
+				errSubscriptionsExceedsLimit,
+				usedCap,
+				len(subs),
+				m.MaxSubscriptionsPerConnection)
+		}
 	}
 
 	for _, s := range subs {
@@ -470,9 +508,6 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 			continue
 		}
 		if found := subscriptionStore.Get(s); found != nil {
-			if found.State() == subscription.ResubscribingState {
-				continue
-			}
 			return fmt.Errorf("%w: %s", subscription.ErrDuplicate, s)
 		}
 	}
@@ -504,6 +539,8 @@ func (m *Manager) flushChannels(ctx context.Context) error {
 		}
 		return m.connect(ctx)
 	}
+
+	m.dropFailedRecoveries()
 
 	if !m.useMultiConnectionManagement {
 		newSubs, err := m.GenerateSubs()
@@ -794,16 +831,14 @@ func (m *Manager) resubscribeFromConnection(ctx context.Context, conn Connection
 		}
 		return firstErr
 	}
-	subs = ownedSubs
+	// The subscriber is handed subs and may reorder it; ownedSubs stays paired with ownedTrackers
+	subs = slices.Clone(ownedSubs)
 	var resErr error
 	defer func() {
 		for idx, s := range ownedSubs {
 			finishResubscriptionTracker(m, s, ownedTrackers[idx], resErr)
 		}
 	}()
-	if m.resubscribePreLockHook != nil && len(subs) > 0 {
-		m.resubscribePreLockHook(subs[0])
-	}
 	m.m.Lock()
 	wsStore := m.subscriptionStore(conn)
 	connStore := connectionSubscriptionStore(conn)
@@ -887,9 +922,6 @@ func (m *Manager) unsubscribeFromConnection(ctx context.Context, conn Connection
 
 	missing := store.Missing(subs)
 	for _, r := range remove {
-		if r.State() == subscription.ResubscribingState {
-			continue
-		}
 		if store.Get(r) == nil {
 			continue
 		}
@@ -930,11 +962,6 @@ func (m *Manager) subscribeToConnection(ctx context.Context, conn Connection, su
 	}
 
 	for _, s := range toSubscribe {
-		if s.State() != subscription.SubscribedState {
-			if err := s.SetState(subscription.SubscribedState); err != nil {
-				return nil, err
-			}
-		}
 		if tracked[s] {
 			continue
 		}

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -147,24 +147,27 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 			m.resubscriptionsMu.Unlock()
 		}()
 	}
-	defer m.m.Unlock()
 
 	l := subscription.List{s}
 	setResubscribingState(l)
 
-	store := m.subscriptionStore(conn)
+	wsStore := m.subscriptionStore(conn)
+	connStore := connectionSubscriptionStore(conn)
 	var origKey any
-	if store != nil {
-		if origSub := store.Get(s); origSub != nil {
+	if wsStore != nil {
+		if origSub := wsStore.Get(s); origSub != nil {
 			origKey = origSub.Key
 		}
 	}
+	m.m.Unlock()
 
 	if err := m.UnsubscribeChannels(ctx, conn, l); err != nil {
 		return err
 	}
 	if err := m.SubscribeToChannels(ctx, conn, l); err != nil {
-		restoreSubscriptionAfterFailedRecovery(store, s, origKey)
+		m.m.Lock()
+		restoreFailedRecovery(wsStore, connStore, s, origKey)
+		m.m.Unlock()
 		return err
 	}
 	return nil
@@ -173,6 +176,30 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 type recoverySnapshot struct {
 	sub     *subscription.Subscription
 	origKey any
+}
+
+func connectionSubscriptionStore(conn Connection) *subscription.Store {
+	if conn == nil {
+		return nil
+	}
+	return conn.Subscriptions()
+}
+
+func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscription.Subscription, origKey any) {
+	if sub == nil {
+		return
+	}
+	if connStore != nil {
+		restoreSubscriptionAfterFailedRecovery(connStore, sub, origKey)
+	}
+	if wsStore == nil || wsStore == connStore {
+		return
+	}
+	if wsStore.Get(sub) == nil {
+		restoreSubscriptionAfterFailedRecovery(wsStore, sub, origKey)
+		return
+	}
+	_ = sub.SetState(subscription.ResubscribingState)
 }
 
 func (m *Manager) waitForResubscriptionLeader(s *subscription.Subscription) {
@@ -192,10 +219,16 @@ func connectionUsedCapacity(store *subscription.Store, incoming subscription.Lis
 		return 0
 	}
 	usedCap := store.Len()
+	discounted := make(map[*subscription.Subscription]struct{}, len(incoming))
 	for _, s := range incoming {
-		if s != nil && s.State() == subscription.ResubscribingState && store.Get(s) != nil {
-			usedCap--
+		if s == nil || s.State() != subscription.ResubscribingState || store.Get(s) == nil {
+			continue
 		}
+		if _, seen := discounted[s]; seen {
+			continue
+		}
+		discounted[s] = struct{}{}
+		usedCap--
 	}
 	return usedCap
 }
@@ -204,17 +237,18 @@ func hasLiveRecoveryReplacement(store *subscription.Store, sub *subscription.Sub
 	if store == nil || sub == nil {
 		return false
 	}
+	want := subscription.ExactKey{Subscription: sub}
 	for _, existing := range store.List() {
 		if existing == sub {
 			continue
 		}
-		if existing.Channel != sub.Channel {
+		if !want.Match(subscription.ExactKey{Subscription: existing}) {
 			continue
 		}
 		if existing.State() != subscription.SubscribedState {
 			continue
 		}
-		if origKey != nil && existing.Key == origKey {
+		if origKey != nil && existing.EnsureKeyed() == origKey {
 			continue
 		}
 		return true
@@ -756,20 +790,26 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 			m.resubscriptionsMu.Unlock()
 		}()
 	}
-	defer m.m.Unlock()
 
-	store := m.subscriptionStore(conn)
+	wsStore := m.subscriptionStore(conn)
+	connStore := connectionSubscriptionStore(conn)
 	snapshots := make([]recoverySnapshot, len(subs))
 	for i, s := range subs {
 		snapshots[i] = recoverySnapshot{sub: s}
-		if store != nil {
-			if orig := store.Get(s); orig != nil {
+		if connStore != nil {
+			if orig := connStore.Get(s); orig != nil {
+				snapshots[i].origKey = orig.Key
+			}
+		} else if wsStore != nil {
+			if orig := wsStore.Get(s); orig != nil {
 				snapshots[i].origKey = orig.Key
 			}
 		}
 	}
 
 	setResubscribingState(subs)
+	m.m.Unlock()
+
 	missing, err := m.unsubscribeFromConnection(ctx, conn, subs)
 	if err != nil {
 		return err
@@ -787,9 +827,14 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 	}
 	remaining, err := m.subscribeToConnection(ctx, conn, subs)
 	if err != nil {
+		m.m.Lock()
 		for _, snap := range snapshots {
-			restoreSubscriptionAfterFailedRecovery(store, snap.sub, snap.origKey)
+			if snap.sub.State() == subscription.SubscribedState {
+				continue
+			}
+			restoreFailedRecovery(wsStore, connStore, snap.sub, snap.origKey)
 		}
+		m.m.Unlock()
 		return err
 	}
 	if len(remaining) > 0 {

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -316,13 +316,13 @@ func (m *Manager) checkSubscriptions(conn Connection, subs subscription.List) er
 		usedCapacity = subscriptionStore.Len()
 	}
 
-	retained := 0
+	retained := make(map[*subscription.Subscription]struct{}, len(subs))
 	for _, s := range subs {
 		if s.State() == subscription.ResubscribingState && subscriptionStore.Get(s) != nil {
-			retained++
+			retained[s] = struct{}{}
 		}
 	}
-	if m.MaxSubscriptionsPerConnection > 0 && usedCapacity-retained+len(subs) > m.MaxSubscriptionsPerConnection {
+	if m.MaxSubscriptionsPerConnection > 0 && usedCapacity-len(retained)+len(subs) > m.MaxSubscriptionsPerConnection {
 		return fmt.Errorf("%w: current subscriptions: %v, incoming subscriptions: %v, max subscriptions per connection: %v",
 			errSubscriptionsExceedsLimit,
 			usedCapacity,

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
@@ -238,9 +239,13 @@ type recoverySnapshot struct {
 }
 
 func connectionSubscriptionStore(conn Connection) *subscription.Store {
-	if conn == nil {
+	if conn == nil || (reflect.ValueOf(conn).Kind() == reflect.Pointer && reflect.ValueOf(conn).IsNil()) {
 		return nil
 	}
+
+	defer func() {
+		_ = recover()
+	}()
 
 	return conn.Subscriptions()
 }

--- a/exchange/websocket/subscriptions.go
+++ b/exchange/websocket/subscriptions.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
+	"sync"
 
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
@@ -120,14 +120,19 @@ func (m *Manager) initSubscriptionStore(conn Connection) *subscription.Store {
 }
 
 type resubscribeTracker struct {
-	done chan struct{}
-	err  error
+	done      chan struct{}
+	err       error
+	closeOnce sync.Once
 }
 
 // ResubscribeToChannel resubscribes to channel
 // Sets state to Resubscribing, and exchanges which want to maintain a lock on it can respect this state and not RemoveSubscription.
 // A subscription already in ResubscribingState is retried.
 func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription) error {
+	return m.resubscribeToChannel(ctx, conn, s, true)
+}
+
+func (m *Manager) resubscribeToChannel(ctx context.Context, conn Connection, s *subscription.Subscription, allowRetry bool) error {
 	if s == nil {
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
 	}
@@ -151,7 +156,19 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	m.resubscriptionsMu.Unlock()
 
 	if inFlight {
+		if m.resubscribeWaiterHook != nil {
+			m.resubscribeWaiterHook(s)
+		}
+
 		<-tracker.done
+
+		if tracker.err == nil {
+			return nil
+		}
+
+		if allowRetry {
+			return m.resubscribeToChannel(ctx, conn, s, false)
+		}
 
 		return tracker.err
 	}
@@ -159,17 +176,7 @@ func (m *Manager) ResubscribeToChannel(ctx context.Context, conn Connection, s *
 	var resErr error
 
 	defer func() {
-		m.resubscriptionsMu.Lock()
-
-		tracker.err = resErr
-
-		if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
-			delete(m.resubscriptions, s)
-
-			close(tracker.done)
-		}
-
-		m.resubscriptionsMu.Unlock()
+		finishResubscriptionTracker(m, s, tracker, resErr)
 	}()
 
 	if m.resubscribePreLockHook != nil {
@@ -224,11 +231,31 @@ type recoverySnapshot struct {
 }
 
 func connectionSubscriptionStore(conn Connection) *subscription.Store {
-	if conn == nil || (reflect.ValueOf(conn).Kind() == reflect.Pointer && reflect.ValueOf(conn).IsNil()) {
+	if conn == nil {
 		return nil
 	}
 
 	return conn.Subscriptions()
+}
+
+func finishResubscriptionTracker(m *Manager, s *subscription.Subscription, tracker *resubscribeTracker, err error) {
+	if tracker == nil {
+		return
+	}
+
+	m.resubscriptionsMu.Lock()
+
+	defer m.resubscriptionsMu.Unlock()
+
+	tracker.err = err
+
+	if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
+		delete(m.resubscriptions, s)
+	}
+
+	tracker.closeOnce.Do(func() {
+		close(tracker.done)
+	})
 }
 
 func restoreFailedRecovery(wsStore, connStore *subscription.Store, sub *subscription.Subscription, origKey any) {
@@ -401,7 +428,7 @@ func (m *Manager) AddSuccessfulSubscriptions(conn Connection, subs ...*subscript
 
 	for _, s := range subs {
 		found := subscriptionStore.Get(s)
-		alreadyTracked := (found != nil && found.State() == subscription.ResubscribingState) || s.State() == subscription.ResubscribingState
+		alreadyTracked := found != nil && (found.State() == subscription.ResubscribingState || s.State() == subscription.ResubscribingState)
 
 		if err := s.SetState(subscription.SubscribedState); err != nil {
 			errs = common.AppendError(errs, fmt.Errorf("%w: %s", err, s))
@@ -895,6 +922,10 @@ func (m *Manager) scaleConnectionsToSubscriptions(ctx context.Context, ws *webso
 
 // ResubscribeFromConnection unsubscribes and resubscribes to a subscription on a connection
 func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List) error {
+	return m.resubscribeFromConnection(ctx, conn, subs, true)
+}
+
+func (m *Manager) resubscribeFromConnection(ctx context.Context, conn Connection, subs subscription.List, allowRetry bool) error {
 	if err := common.NilGuard(conn, subs); err != nil {
 		return err
 	}
@@ -909,46 +940,42 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 		m.resubscriptions = make(map[*subscription.Subscription]*resubscribeTracker)
 	}
 
-	allInFlight := true
+	ownedSubs := make(subscription.List, 0, len(subs))
+
+	ownedTrackers := make([]*resubscribeTracker, 0, len(subs))
+
+	borrowed := make([]*resubscribeTracker, 0, len(subs))
 
 	for _, s := range subs {
-		if _, ok := m.resubscriptions[s]; !ok {
-			allInFlight = false
+		tracker := m.resubscriptions[s]
 
-			break
+		if tracker != nil {
+			borrowed = append(borrowed, tracker)
+
+			continue
 		}
-	}
 
-	trackers := make([]*resubscribeTracker, 0, len(subs))
-
-	if allInFlight {
-		for _, s := range subs {
-			if tracker, ok := m.resubscriptions[s]; ok {
-				trackers = append(trackers, tracker)
-			}
+		tracker = &resubscribeTracker{
+			done: make(chan struct{}),
 		}
-	} else {
-		for _, s := range subs {
-			tracker := m.resubscriptions[s]
 
-			if tracker == nil {
-				tracker = &resubscribeTracker{
-					done: make(chan struct{}),
-				}
+		m.resubscriptions[s] = tracker
 
-				m.resubscriptions[s] = tracker
-			}
+		ownedSubs = append(ownedSubs, s)
 
-			trackers = append(trackers, tracker)
-		}
+		ownedTrackers = append(ownedTrackers, tracker)
 	}
 
 	m.resubscriptionsMu.Unlock()
 
-	if allInFlight {
+	if len(ownedSubs) == 0 {
+		if m.resubscribeWaiterHook != nil {
+			m.resubscribeWaiterHook(subs[0])
+		}
+
 		var firstErr error
 
-		for _, tracker := range trackers {
+		for _, tracker := range borrowed {
 			<-tracker.done
 
 			if tracker.err != nil && firstErr == nil {
@@ -956,27 +983,25 @@ func (m *Manager) ResubscribeFromConnection(ctx context.Context, conn Connection
 			}
 		}
 
+		if firstErr == nil {
+			return nil
+		}
+
+		if allowRetry {
+			return m.resubscribeFromConnection(ctx, conn, subs, false)
+		}
+
 		return firstErr
 	}
+
+	subs = ownedSubs
 
 	var resErr error
 
 	defer func() {
-		m.resubscriptionsMu.Lock()
-
-		for idx, s := range subs {
-			tracker := trackers[idx]
-
-			tracker.err = resErr
-
-			if currentTracker, ok := m.resubscriptions[s]; ok && currentTracker == tracker {
-				delete(m.resubscriptions, s)
-
-				close(tracker.done)
-			}
+		for idx, s := range ownedSubs {
+			finishResubscriptionTracker(m, s, ownedTrackers[idx], resErr)
 		}
-
-		m.resubscriptionsMu.Unlock()
 	}()
 
 	if m.resubscribePreLockHook != nil && len(subs) > 0 {

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -3389,3 +3389,163 @@ func TestSubscribeToConnection(t *testing.T) {
 
 	require.NoError(t, err, "must not error when all subscriptions can be added, this exercises the path where available > len(subs)")
 }
+
+func TestResubscribeToChannel_ConcurrentCoalescing(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	require.NoError(t, m.Setup(newDefaultSetup()))
+
+	sub1 := &subscription.Subscription{Channel: "ticker1", Key: "t1"}
+	sub2 := &subscription.Subscription{Channel: "ticker2", Key: "t2"}
+
+	require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub1, sub2))
+
+	expectedErr := errors.New("subscribe error failure")
+
+	ownerStarted := make(chan struct{})
+	ownerBlock := make(chan struct{})
+
+	var once sync.Once
+	m.Unsubscriber = func(_ subscription.List) error { return nil }
+	m.Subscriber = func(l subscription.List) error {
+		if len(l) > 0 && l[0] == sub1 {
+			once.Do(func() { close(ownerStarted) })
+			<-ownerBlock
+			return expectedErr
+		}
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	var ownerErr, waiterErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ownerErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
+	}()
+
+	<-ownerStarted
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
+	}()
+
+	// Unrelated subscription recovery should proceed independently
+	var unrelatedErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		unrelatedErr = m.ResubscribeToChannel(t.Context(), nil, sub2)
+	}()
+
+	close(ownerBlock)
+	wg.Wait()
+
+	require.ErrorIs(t, ownerErr, expectedErr, "Owner should receive the subscription error")
+	require.ErrorIs(t, waiterErr, expectedErr, "Waiter should receive the exact same error as owner")
+	require.NoError(t, unrelatedErr, "Unrelated subscription should recover independently without error")
+
+	m.resubscriptionsMu.Lock()
+	require.Empty(t, m.resubscriptions, "In-flight resubscriptions map must be empty after completion")
+	m.resubscriptionsMu.Unlock()
+}
+
+func TestOKX_RecoveryRetryRetention(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	require.NoError(t, m.Setup(newDefaultSetup()))
+
+	sub := &subscription.Subscription{Channel: "orders", Key: "okx_orders"}
+	connStore := subscription.NewStore()
+	mockConn := &connection{subscriptions: connStore}
+
+	require.NoError(t, m.AddSuccessfulSubscriptions(mockConn, sub))
+	require.NoError(t, connStore.Add(sub))
+
+	m.Unsubscriber = func(l subscription.List) error {
+		return m.RemoveSubscriptions(mockConn, l...)
+	}
+
+	subCount := 0
+	m.Subscriber = func(l subscription.List) error {
+		subCount++
+		if subCount == 1 {
+			return errors.New("transient subscribe failure")
+		}
+		return m.AddSuccessfulSubscriptions(mockConn, l...)
+	}
+
+	// First recovery attempt fails
+	err1 := m.ResubscribeToChannel(t.Context(), mockConn, sub)
+	require.ErrorContains(t, err1, "transient subscribe failure")
+
+	// Verify subscription remains in both stores and is in ResubscribingState
+	require.NotNil(t, m.GetSubscription(sub), "Websocket-level store must retain the subscription after failed recovery")
+	require.NotNil(t, connStore.Get(sub), "Connection-level store must retain the subscription after failed recovery")
+	require.Equal(t, subscription.ResubscribingState, sub.State(), "Subscription state must remain ResubscribingState for retry")
+
+	// Second recovery attempt succeeds
+	err2 := m.ResubscribeToChannel(t.Context(), mockConn, sub)
+	require.NoError(t, err2, "Second recovery attempt must succeed")
+
+	require.NotNil(t, m.GetSubscription(sub), "Websocket store must retain subscription after success")
+	require.NotNil(t, connStore.Get(sub), "Connection store must retain subscription after success")
+	require.Equal(t, subscription.SubscribedState, sub.State(), "Subscription state must be SubscribedState after recovery success")
+}
+
+func TestBitfinex_ReplacementRegistrationBeforeError(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	require.NoError(t, m.Setup(newDefaultSetup()))
+
+	oldSub := &subscription.Subscription{Channel: "ticker", Key: 42}
+	require.NoError(t, m.AddSuccessfulSubscriptions(nil, oldSub))
+
+	newSub := &subscription.Subscription{Channel: "ticker", Key: 43}
+
+	m.Unsubscriber = func(_ subscription.List) error { return nil }
+	m.Subscriber = func(l subscription.List) error {
+		// Simulate Bitfinex async acknowledgement registering replacement chanID 43 before error
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, newSub))
+		return errors.New("timeout after handleWSSubscribed")
+	}
+
+	err := m.ResubscribeToChannel(t.Context(), nil, oldSub)
+	require.ErrorContains(t, err, "timeout after handleWSSubscribed")
+
+	// Stale channel ID 42 must NOT be present in the store
+	require.Nil(t, m.GetSubscription(42), "Stale channel ID 42 must not be resurrected or retained")
+	// Only replacement channel ID 43 should remain tracked
+	require.NotNil(t, m.GetSubscription(43), "Only replacement channel ID 43 must remain tracked")
+	require.Equal(t, subscription.SubscribedState, m.GetSubscription(43).State(), "Replacement subscription must be in SubscribedState")
+}
+
+func TestFlushChannels_ResubscribingState(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	require.NoError(t, m.Setup(newDefaultSetup()))
+	m.state.Store(connectedState)
+
+	sub := &subscription.Subscription{Channel: "TestSub", Enabled: true}
+	m.GenerateSubs = func() (subscription.List, error) {
+		return subscription.List{sub.Clone()}, nil
+	}
+
+	require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+	_ = sub.SetState(subscription.ResubscribingState)
+
+	m.Unsubscriber = func(_ subscription.List) error { return nil }
+	m.Subscriber = func(l subscription.List) error {
+		return m.AddSuccessfulSubscriptions(nil, l...)
+	}
+
+	require.NoError(t, m.FlushChannels(t.Context()), "FlushChannels must succeed when subscriptions are in ResubscribingState")
+}
+

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -21,1097 +21,1842 @@ import (
 )
 
 func TestSubscribeUnsubscribe(t *testing.T) {
+
 	t.Parallel()
+
 	ws := NewManager()
+
 	assert.NoError(t, ws.Setup(newDefaultSetup()), "WS Setup should not error")
 
 	ws.Subscriber = currySimpleSub(ws)
+
 	ws.Unsubscriber = currySimpleUnsub(ws)
 
 	subs, err := ws.GenerateSubs()
+
 	require.NoError(t, err, "Generating test subscriptions must not error")
+
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), nil, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
+
 	assert.NoError(t, ws.UnsubscribeChannels(t.Context(), nil, nil), "Unsubscribing from nil should not error")
+
 	assert.ErrorIs(t, ws.UnsubscribeChannels(t.Context(), nil, subs), subscription.ErrNotFound, "Unsubscribing should error when not subscribed")
+
 	assert.Nil(t, ws.GetSubscription(42), "GetSubscription on empty internal map should return")
+
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, subs), "Basic Subscribing should not error")
+
 	assert.Len(t, ws.GetSubscriptions(), 4, "Should have 4 subscriptions")
+
 	bySub := ws.GetSubscription(subscription.Subscription{Channel: "TestSub"})
+
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
+
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
+
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
+
 	}
+
 	if assert.NotNil(t, ws.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
+
 		assert.Equal(t, "TestSub2", ws.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
+
 	}
+
 	if assert.NotNil(t, ws.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
+
 		assert.Equal(t, "TestSub3", ws.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
+
 	}
+
 	if assert.NotNil(t, ws.GetSubscription(42), "GetSubscription by int key should find a channel") {
+
 		assert.Equal(t, "TestSub4", ws.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
+
 	}
+
 	assert.Nil(t, ws.GetSubscription(nil), "GetSubscription by nil should return nil")
+
 	assert.Nil(t, ws.GetSubscription(45), "GetSubscription by invalid key should return nil")
+
 	assert.ErrorIs(t, ws.SubscribeToChannels(t.Context(), nil, subs), subscription.ErrDuplicate, "Subscribe should error when already subscribed")
+
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, nil), "Subscribe to an nil List should not error")
+
 	assert.NoError(t, ws.UnsubscribeChannels(t.Context(), nil, subs), "Unsubscribing should not error")
 
 	ws.Subscriber = func(subscription.List) error { return errDastardlyReason }
+
 	assert.ErrorIs(t, ws.SubscribeToChannels(t.Context(), nil, subs), errDastardlyReason, "Should error correctly when error returned from Subscriber")
 
 	err = ws.SubscribeToChannels(t.Context(), nil, subscription.List{nil})
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when list contains a nil subscription")
 
 	multi := NewManager()
+
 	set := newDefaultSetup()
+
 	set.UseMultiConnectionManagement = true
+
 	assert.NoError(t, multi.Setup(set))
 
 	amazingCandidate := &ConnectionSetup{
-		URL:                   "AMAZING",
-		Connector:             func(context.Context, Connection) error { return nil },
+
+		URL: "AMAZING",
+
+		Connector: func(context.Context, Connection) error { return nil },
+
 		GenerateSubscriptions: ws.GenerateSubs,
+
 		Subscriber: func(ctx context.Context, c Connection, s subscription.List) error {
+
 			return currySimpleSubConn(multi)(ctx, c, s)
+
 		},
+
 		Unsubscriber: func(ctx context.Context, c Connection, s subscription.List) error {
+
 			return currySimpleUnsubConn(multi)(ctx, c, s)
+
 		},
+
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}
+
 	require.NoError(t, multi.SetupNewConnection(amazingCandidate))
 
 	amazingConn := multi.createConnectionFromSetup(amazingCandidate)
+
 	multi.connections = map[Connection]*websocket{
+
 		amazingConn: multi.connectionManager[0],
 	}
 
 	multiEmpty := NewManager()
+
 	multiEmpty.useMultiConnectionManagement = true
 
 	subs, err = amazingCandidate.GenerateSubscriptions()
+
 	require.NoError(t, err, "Generating test subscriptions must not error")
+
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), nil, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
+
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), amazingConn, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
+
 	assert.NoError(t, multi.UnsubscribeChannels(t.Context(), amazingConn, nil), "Unsubscribing from nil should not error")
+
 	assert.ErrorIs(t, multi.UnsubscribeChannels(t.Context(), amazingConn, subs), subscription.ErrNotFound, "Unsubscribing should error when not subscribed")
+
 	assert.Nil(t, multi.GetSubscription(42), "GetSubscription on empty internal map should return")
 
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), nil, subs), common.ErrNilPointer, "If no connection is set, Subscribe should error")
+
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), common.ErrNilPointer, "Basic Subscribing should error when connection is not present in ws map")
 
 	multi.connectionManager[0].connections = []Connection{amazingConn}
+
 	assert.NoError(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), "Basic Subscribing should not error")
+
 	assert.Len(t, multi.GetSubscriptions(), 4, "Should have 4 subscriptions")
+
 	bySub = multi.GetSubscription(subscription.Subscription{Channel: "TestSub"})
+
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
+
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
+
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
+
 	}
+
 	if assert.NotNil(t, multi.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
+
 		assert.Equal(t, "TestSub2", multi.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
+
 	}
+
 	if assert.NotNil(t, multi.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
+
 		assert.Equal(t, "TestSub3", multi.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
+
 	}
+
 	if assert.NotNil(t, multi.GetSubscription(42), "GetSubscription by int key should find a channel") {
+
 		assert.Equal(t, "TestSub4", multi.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
+
 	}
+
 	assert.Nil(t, multi.GetSubscription(nil), "GetSubscription by nil should return nil")
+
 	assert.Nil(t, multi.GetSubscription(45), "GetSubscription by invalid key should return nil")
+
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), subscription.ErrDuplicate, "Subscribe should error when already subscribed")
+
 	assert.NoError(t, multi.SubscribeToChannels(t.Context(), amazingConn, nil), "Subscribe to an nil List should not error")
+
 	assert.NoError(t, multi.UnsubscribeChannels(t.Context(), amazingConn, subs), "Unsubscribing should not error")
 
 	amazingCandidate.Subscriber = func(context.Context, Connection, subscription.List) error { return errDastardlyReason }
+
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), errDastardlyReason, "Should error correctly when error returned from Subscriber")
 
 	err = multi.SubscribeToChannels(t.Context(), amazingConn, subscription.List{nil})
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when list contains a nil subscription")
+
 }
 
 // TestResubscribe tests Resubscribing to existing subscriptions
+
 func TestResubscribe(t *testing.T) {
+
 	t.Parallel()
+
 	ws := NewManager()
 
 	wackedOutSetup := newDefaultSetup()
+
 	wackedOutSetup.MaxWebsocketSubscriptionsPerConnection = -1
+
 	err := ws.Setup(wackedOutSetup)
+
 	assert.ErrorIs(t, err, errInvalidMaxSubscriptions, "Invalid MaxWebsocketSubscriptionsPerConnection should error")
 
 	err = ws.Setup(newDefaultSetup())
+
 	assert.NoError(t, err, "WS Setup should not error")
 
 	ws.Subscriber = currySimpleSub(ws)
+
 	ws.Unsubscriber = currySimpleUnsub(ws)
 
 	channel := subscription.List{{Channel: "resubTest"}}
 
 	assert.ErrorIs(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), subscription.ErrNotFound, "Resubscribe should error when channel isn't subscribed yet")
+
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, channel), "Subscribe should not error")
+
 	assert.NoError(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), "Resubscribe should not error now the channel is subscribed")
 
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		sub := &subscription.Subscription{Channel: "retryResubTest"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
 		m.Unsubscriber = func(subs subscription.List) error { return m.RemoveSubscriptions(nil, subs...) }
+
 		subscribeCalls := 0
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			subscribeCalls++
+
 			if subscribeCalls == 1 {
+
 				return errDastardlyReason
+
 			}
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
+
 		require.Same(t, sub, m.GetSubscription(sub))
+
 		require.Equal(t, subscription.ResubscribingState, sub.State())
+
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, sub))
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 		require.Equal(t, 2, subscribeCalls)
+
 	})
 
 	t.Run("Concurrent recovery is serialised", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		sub := &subscription.Subscription{Channel: "serializedResubTest"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
 		firstUnsubscribe := make(chan struct{})
+
 		secondUnsubscribe := make(chan struct{})
+
 		releaseFirst := make(chan struct{})
+
 		unsubscribes := 0
+
 		m.Unsubscriber = func(subscription.List) error {
+
 			unsubscribes++
+
 			switch unsubscribes {
+
 			case 1:
+
 				close(firstUnsubscribe)
+
 				<-releaseFirst
+
 			case 2:
+
 				close(secondUnsubscribe)
+
 			}
+
 			return nil
+
 		}
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		var firstErr, secondErr error
+
 		var wg sync.WaitGroup
+
 		wg.Add(2)
+
 		go func() {
+
 			defer wg.Done()
+
 			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+
 		}()
+
 		<-firstUnsubscribe
+
 		var signalSecond sync.Once
+
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+
 			if s == sub {
+
 				signalSecond.Do(func() { close(secondUnsubscribe) })
+
 			}
+
 		}
+
 		go func() {
+
 			defer wg.Done()
+
 			secondErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+
 		}()
+
 		<-secondUnsubscribe
+
 		close(releaseFirst)
+
 		wg.Wait()
 
 		require.NoError(t, firstErr)
+
 		require.NoError(t, secondErr)
+
 		require.Equal(t, 1, unsubscribes)
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 	})
 
 	t.Run("Different subscriptions recover concurrently", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		subA := &subscription.Subscription{Channel: "subA"}
+
 		subB := &subscription.Subscription{Channel: "subB"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, subA, subB))
 
 		var unsubsMu sync.Mutex
+
 		unsubscribed := make(map[string]int)
+
 		subscribed := make(map[string]int)
 
 		subAUnsubStarted := make(chan struct{})
+
 		releaseSubA := make(chan struct{})
 
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			unsubsMu.Lock()
+
 			for _, s := range subs {
+
 				unsubscribed[s.Channel]++
+
 			}
+
 			unsubsMu.Unlock()
+
 			for _, s := range subs {
+
 				if s.Channel == "subA" {
+
 					close(subAUnsubStarted)
+
 					<-releaseSubA
+
 				}
+
 			}
+
 			return nil
+
 		}
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			unsubsMu.Lock()
+
 			for _, s := range subs {
+
 				subscribed[s.Channel]++
+
 			}
+
 			unsubsMu.Unlock()
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		var wg sync.WaitGroup
+
 		var errA, errB error
+
 		wg.Add(2)
+
 		go func() {
+
 			defer wg.Done()
+
 			errA = m.ResubscribeToChannel(t.Context(), nil, subA)
+
 		}()
+
 		<-subAUnsubStarted
+
 		subBPreLock := make(chan struct{})
+
 		var signalSubB sync.Once
+
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+
 			if s == subB {
+
 				signalSubB.Do(func() { close(subBPreLock) })
+
 			}
+
 		}
+
 		go func() {
+
 			defer wg.Done()
+
 			errB = m.ResubscribeToChannel(t.Context(), nil, subB)
+
 		}()
+
 		<-subBPreLock
+
 		close(releaseSubA)
+
 		wg.Wait()
 
 		require.NoError(t, errA)
+
 		require.NoError(t, errB)
+
 		require.Equal(t, 1, unsubscribed["subA"])
+
 		require.Equal(t, 1, unsubscribed["subB"])
+
 		require.Equal(t, 1, subscribed["subA"])
+
 		require.Equal(t, 1, subscribed["subB"])
+
 		require.Equal(t, subscription.SubscribedState, subA.State())
+
 		require.Equal(t, subscription.SubscribedState, subB.State())
+
 	})
 
 	t.Run("Unrelated manager-lock contention does not drop recovery", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		sub := &subscription.Subscription{Channel: "unrelatedContentionTest"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
 
 		unsubCalls := 0
+
 		subCalls := 0
+
 		m.Unsubscriber = func(subscription.List) error {
+
 			unsubCalls++
+
 			return nil
+
 		}
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			subCalls++
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		m.m.Lock()
+
 		recovered := make(chan error, 1)
+
 		preLockReached := make(chan struct{})
+
 		var signalPreLock sync.Once
+
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+
 			if s == sub {
+
 				signalPreLock.Do(func() { close(preLockReached) })
+
 			}
+
 		}
 
 		go func() {
+
 			recovered <- m.ResubscribeToChannel(t.Context(), nil, sub)
+
 		}()
 
 		<-preLockReached
+
 		require.Equal(t, 0, unsubCalls)
+
 		require.Equal(t, 0, subCalls)
 
 		m.m.Unlock()
+
 		err := <-recovered
+
 		require.NoError(t, err)
+
 		require.Equal(t, 1, unsubCalls)
+
 		require.Equal(t, 1, subCalls)
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 	})
 
 	t.Run("Bitfinex temporary key cleanup pattern during recovery", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexPatternTest"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
 
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			return m.RemoveSubscriptions(nil, subs...)
+
 		}
+
 		recoveries := 0
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			recoveries++
+
 			s := subs[0]
+
 			tempKey := fmt.Sprintf("subId-%d", recoveries)
+
 			s.Key = tempKey
+
 			if err := m.AddSubscriptions(nil, s); err != nil {
+
 				return err
+
 			}
+
 			defer func() {
+
 				_ = m.RemoveSubscriptions(nil, s)
+
 			}()
 
 			newSub := s.Clone()
+
 			newSub.Key = 42 + recoveries
+
 			return m.AddSuccessfulSubscriptions(nil, newSub)
+
 		}
 
 		// 1st recovery
+
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, realSub))
+
 		subs := m.GetSubscriptions()
+
 		require.Len(t, subs, 1, "store must only have 1 subscription after 1st recovery")
+
 		chanID, ok := subs[0].Key.(int)
+
 		require.True(t, ok, "key must be an int, not temporary string subId")
+
 		require.Equal(t, 43, chanID)
 
 		// 2nd recovery
+
 		currentSub := subs[0]
+
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, currentSub))
+
 		subs = m.GetSubscriptions()
+
 		require.Len(t, subs, 1, "store must only have 1 subscription after 2nd recovery")
+
 		chanID, ok = subs[0].Key.(int)
+
 		require.True(t, ok, "key must be an int, not temporary string subId")
+
 		require.Equal(t, 44, chanID)
 
 		// Unsubscribe all
+
 		require.NoError(t, m.RemoveSubscriptions(nil, subs...))
+
 		require.Empty(t, m.GetSubscriptions())
+
 	})
 
 	t.Run("Failed recovery does not restore stale key when replacement is live", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexStaleRestore"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
+
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			return m.RemoveSubscriptions(nil, subs...)
+
 		}
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			newSub := subs[0].Clone()
+
 			newSub.Key = 43
+
 			if err := m.AddSuccessfulSubscriptions(nil, newSub); err != nil {
+
 				return err
+
 			}
+
 			return errDastardlyReason
+
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, realSub), errDastardlyReason)
+
 		tracked := m.GetSubscriptions()
+
 		require.Len(t, tracked, 1, "must not resurrect pre-recovery key alongside live replacement")
+
 		chanID, ok := tracked[0].Key.(int)
+
 		require.True(t, ok)
+
 		require.Equal(t, 43, chanID)
+
 	})
 
 	t.Run("Nil subscription rejected", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, nil), common.ErrNilPointer)
+
 	})
 
 	t.Run("Coalesced waiter retries when leader recovery fails", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		sub := &subscription.Subscription{Channel: "coalescedWaiterRetry"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
 		m.Unsubscriber = func(subscription.List) error { return nil }
 
 		firstSubscribe := make(chan struct{})
+
 		releaseFirstSubscribe := make(chan struct{})
+
 		waiterPreLock := make(chan struct{})
+
 		calls := 0
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			calls++
+
 			if calls == 1 {
+
 				close(firstSubscribe)
+
 				<-releaseFirstSubscribe
+
 				_ = subs[0].SetState(subscription.SubscribedState)
+
 				return errDastardlyReason
+
 			}
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		var leaderErr, waiterErr error
+
 		var wg sync.WaitGroup
+
 		wg.Add(2)
+
 		go func() {
+
 			defer wg.Done()
+
 			leaderErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+
 		}()
+
 		<-firstSubscribe
+
 		var signalWaiter sync.Once
+
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+
 			if s == sub {
+
 				signalWaiter.Do(func() { close(waiterPreLock) })
+
 			}
+
 		}
+
 		go func() {
+
 			defer wg.Done()
+
 			waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+
 		}()
+
 		<-waiterPreLock
+
 		close(releaseFirstSubscribe)
+
 		wg.Wait()
 
 		require.ErrorIs(t, leaderErr, errDastardlyReason)
+
 		require.NoError(t, waiterErr)
+
 		require.Equal(t, 2, calls)
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 	})
 
 	t.Run("Sibling channel subscription does not block recovery restore", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		btc := currency.NewBTCUSD()
+
 		eth := currency.NewPair(currency.ETH, currency.USDT)
+
 		sibling := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{eth}}
+
 		failing := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{btc}}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sibling, failing))
+
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			return m.RemoveSubscriptions(nil, subs...)
+
 		}
+
 		m.Subscriber = func(subscription.List) error {
+
 			return errDastardlyReason
+
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, failing), errDastardlyReason)
+
 		require.Same(t, failing, m.GetSubscription(failing))
+
 		require.Equal(t, subscription.ResubscribingState, failing.State())
+
 		require.Equal(t, subscription.SubscribedState, sibling.State())
+
 	})
 
 	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
+
 		m := NewManager()
+
 		require.NoError(t, m.Setup(newDefaultSetup()))
+
 		m.features.Subscribe = true
+
 		m.features.Unsubscribe = true
+
 		m.state.Store(connectedState)
+
 		m.enabled.Store(true)
 
 		sub := &subscription.Subscription{Channel: "flushAfterFailTest"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			return m.RemoveSubscriptions(nil, subs...)
+
 		}
+
 		subscribeCalls := 0
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			subscribeCalls++
+
 			if subscribeCalls == 1 {
+
 				return errDastardlyReason
+
 			}
+
 			return m.AddSuccessfulSubscriptions(nil, subs...)
+
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
+
 		require.Equal(t, subscription.ResubscribingState, sub.State())
+
 		require.Same(t, sub, m.GetSubscription(sub))
 
 		m.GenerateSubs = func() (subscription.List, error) {
+
 			return subscription.List{sub}, nil
+
 		}
+
 		require.NoError(t, m.FlushChannels(t.Context()))
+
 		require.Same(t, sub, m.GetSubscription(sub))
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 		require.Equal(t, 2, subscribeCalls)
 
 		m.GenerateSubs = func() (subscription.List, error) {
+
 			return subscription.List{}, nil
+
 		}
+
 		require.NoError(t, m.FlushChannels(t.Context()))
+
 		require.Nil(t, m.GetSubscription(sub))
+
 		require.Equal(t, subscription.UnsubscribedState, sub.State())
+
 	})
+
 }
 
 func TestAllSubscriptionsState(t *testing.T) {
+
 	t.Parallel()
+
 	sub := &subscription.Subscription{Channel: "sub"}
+
 	assert.True(t, allSubscriptionsState(subscription.List{sub}, subscription.InactiveState))
+
 	assert.False(t, allSubscriptionsState(subscription.List{sub}, subscription.SubscribedState))
+
 }
 
 // TestSubscriptions tests adding, getting and removing subscriptions
+
 func TestSubscriptions(t *testing.T) {
+
 	t.Parallel()
+
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
+
 	assert.ErrorIs(t, (*Manager)(nil).AddSubscriptions(nil), common.ErrNilPointer, "Should error correctly when nil websocket")
+
 	s := &subscription.Subscription{Key: 42, Channel: subscription.TickerChannel}
+
 	require.NoError(t, w.AddSubscriptions(nil, s), "Adding first subscription must not error")
+
 	assert.Same(t, s, w.GetSubscription(42), "Get Subscription should retrieve the same subscription")
+
 	assert.ErrorIs(t, w.AddSubscriptions(nil, s), subscription.ErrDuplicate, "Adding same subscription should return error")
+
 	assert.Equal(t, subscription.SubscribingState, s.State(), "Should set state to Subscribing")
 
 	err := w.RemoveSubscriptions(nil, s)
+
 	require.NoError(t, err, "RemoveSubscriptions must not error")
+
 	assert.Nil(t, w.GetSubscription(42), "Remove should have removed the sub")
+
 	assert.Equal(t, subscription.UnsubscribedState, s.State(), "Should set state to Unsubscribed")
 
 	require.NoError(t, s.SetState(subscription.ResubscribingState), "SetState must not error")
+
 	require.NoError(t, w.AddSubscriptions(nil, s), "Adding first subscription must not error")
+
 	assert.Equal(t, subscription.ResubscribingState, s.State(), "Should not change resubscribing state")
+
 }
 
 // TestSuccessfulSubscriptions tests adding, getting and removing subscriptions
+
 func TestSuccessfulSubscriptions(t *testing.T) {
+
 	t.Parallel()
+
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
+
 	assert.ErrorIs(t, (*Manager)(nil).AddSuccessfulSubscriptions(nil, nil), common.ErrNilPointer, "Should error correctly when nil websocket")
+
 	c := &subscription.Subscription{Key: 42, Channel: subscription.TickerChannel}
+
 	require.NoError(t, w.AddSuccessfulSubscriptions(nil, c), "Adding first subscription must not error")
+
 	assert.Same(t, c, w.GetSubscription(42), "Get Subscription should retrieve the same subscription")
+
 	assert.ErrorIs(t, w.AddSuccessfulSubscriptions(nil, c), subscription.ErrInStateAlready, "Adding subscription in same state should return error")
+
 	require.NoError(t, c.SetState(subscription.SubscribingState), "SetState must not error")
+
 	assert.ErrorIs(t, w.AddSuccessfulSubscriptions(nil, c), subscription.ErrDuplicate, "Adding same subscription should return error")
 
 	err := w.RemoveSubscriptions(nil, c)
+
 	require.NoError(t, err, "RemoveSubscriptions must not error")
+
 	assert.Nil(t, w.GetSubscription(42), "Remove should have removed the sub")
+
 	assert.ErrorIs(t, w.RemoveSubscriptions(nil, c), subscription.ErrNotFound, "Should error correctly when not found")
+
 	assert.ErrorIs(t, (*Manager)(nil).RemoveSubscriptions(nil, nil), common.ErrNilPointer, "Should error correctly when nil websocket")
+
 	w.subscriptions = nil
+
 	assert.ErrorIs(t, w.RemoveSubscriptions(nil, c), common.ErrNilPointer, "Should error correctly when nil websocket")
+
 }
 
 // TestGetSubscription logic test
+
 func TestGetSubscription(t *testing.T) {
+
 	t.Parallel()
+
 	assert.Nil(t, (*Manager).GetSubscription(nil, "imaginary"), "GetSubscription on a nil Websocket should return nil")
+
 	assert.Nil(t, (&Manager{}).GetSubscription("empty"), "GetSubscription on a Websocket with no sub store should return nil")
+
 	w := NewManager()
+
 	assert.Nil(t, w.GetSubscription(nil), "GetSubscription with a nil key should return nil")
+
 	s := &subscription.Subscription{Key: 42, Channel: "hello3"}
+
 	require.NoError(t, w.AddSubscriptions(nil, s), "AddSubscriptions must not error")
+
 	assert.Same(t, s, w.GetSubscription(42), "GetSubscription should delegate to the store")
+
 }
 
 // TestGetSubscriptions logic test
+
 func TestGetSubscriptions(t *testing.T) {
+
 	t.Parallel()
+
 	assert.Nil(t, (*Manager).GetSubscriptions(nil), "GetSubscription on a nil Websocket should return nil")
+
 	assert.Nil(t, (&Manager{}).GetSubscriptions(), "GetSubscription on a Websocket with no sub store should return nil")
+
 	w := NewManager()
+
 	s := subscription.List{
+
 		{Key: 42, Channel: "hello3"},
+
 		{Key: 45, Channel: "hello4"},
 	}
+
 	err := w.AddSubscriptions(nil, s...)
+
 	require.NoError(t, err, "AddSubscriptions must not error")
+
 	assert.ElementsMatch(t, s, w.GetSubscriptions(), "GetSubscriptions should return the correct channel details")
+
 }
 
 func TestCheckSubscriptions(t *testing.T) {
+
 	t.Parallel()
+
 	ws := Manager{}
+
 	err := ws.checkSubscriptions(nil, nil)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "checkSubscriptions should error correctly on nil w.subscriptions")
+
 	assert.ErrorContains(t, err, "Websocket.subscriptions", "checkSubscriptions should error giving context correctly on nil w.subscriptions")
 
 	ws.subscriptions = subscription.NewStore()
+
 	err = ws.checkSubscriptions(nil, nil)
+
 	assert.NoError(t, err, "checkSubscriptions should not error on a nil list")
 
 	ws.MaxSubscriptionsPerConnection = 1
 
 	err = ws.checkSubscriptions(nil, subscription.List{{}})
+
 	assert.NoError(t, err, "checkSubscriptions should not error when subscriptions is empty")
 
 	ws.subscriptions = subscription.NewStore()
+
 	err = ws.checkSubscriptions(nil, subscription.List{{}, {}})
+
 	assert.ErrorIs(t, err, errSubscriptionsExceedsLimit, "checkSubscriptions should error correctly")
 
 	ws.MaxSubscriptionsPerConnection = 2
 
 	ws.subscriptions = subscription.NewStore()
+
 	err = ws.subscriptions.Add(&subscription.Subscription{Key: 42, Channel: "test"})
+
 	require.NoError(t, err, "Add subscription must not error")
+
 	err = ws.checkSubscriptions(nil, subscription.List{{Key: 42, Channel: "test"}})
+
 	assert.ErrorIs(t, err, subscription.ErrDuplicate, "checkSubscriptions should error correctly")
 
 	err = ws.checkSubscriptions(nil, subscription.List{{}})
+
 	assert.NoError(t, err, "checkSubscriptions should not error")
 
 	ws.subscriptions = subscription.NewStore()
+
 	conn := &connection{}
+
 	ws.connections = map[Connection]*websocket{
+
 		conn: {},
 	}
+
 	err = ws.checkSubscriptions(conn, subscription.List{{}})
+
 	assert.ErrorContains(t, err, "nil pointer: Websocket.subscriptions", "nil store for a specific connection should error correctly")
 
 	ws.MaxSubscriptionsPerConnection = 1
+
 	conn = &connection{subscriptions: subscription.NewStore()}
+
 	ws.connections[conn] = &websocket{subscriptions: conn.Subscriptions(), connections: []Connection{conn}}
+
 	retained := &subscription.Subscription{Key: 43, Channel: "retained"}
+
 	require.NoError(t, ws.AddSuccessfulSubscriptions(conn, retained))
+
 	require.NoError(t, retained.SetState(subscription.ResubscribingState))
+
 	require.NoError(t, ws.checkSubscriptions(conn, subscription.List{retained}))
 
 	ws.MaxSubscriptionsPerConnection = 2
+
 	capConn := &connection{subscriptions: subscription.NewStore()}
+
 	ws.connections[capConn] = &websocket{
+
 		subscriptions: capConn.Subscriptions(),
-		connections:   []Connection{capConn},
+
+		connections: []Connection{capConn},
 	}
+
 	sub1 := &subscription.Subscription{Key: 101, Channel: "capSub1"}
+
 	sub2 := &subscription.Subscription{Key: 102, Channel: "capSub2"}
+
 	require.NoError(t, ws.AddSuccessfulSubscriptions(capConn, sub1, sub2))
 
 	// Full connection (2/2). Recovering existing sub1 in ResubscribingState must succeed:
+
 	require.NoError(t, sub1.SetState(subscription.ResubscribingState))
+
 	require.NoError(t, ws.checkSubscriptions(capConn, subscription.List{sub1}))
 
 	// Unrelated incoming subscription must be rejected:
+
 	unrelated := &subscription.Subscription{Key: 103, Channel: "unrelated"}
+
 	err = ws.checkSubscriptions(capConn, subscription.List{unrelated})
+
 	require.ErrorIs(t, err, errSubscriptionsExceedsLimit)
+
 }
 
 func TestUpdateChannelSubscriptions(t *testing.T) {
+
 	t.Parallel()
 
 	ws := NewManager()
+
 	store := subscription.NewStore()
+
 	err := ws.updateChannelSubscriptions(t.Context(), store, subscription.List{{Channel: "test"}})
+
 	require.ErrorIs(t, err, common.ErrNilPointer)
+
 	require.Zero(t, store.Len())
 
 	ws.Subscriber = func(subs subscription.List) error {
+
 		for _, sub := range subs {
+
 			if err := store.Add(sub); err != nil {
+
 				return err
+
 			}
+
 		}
+
 		return nil
+
 	}
 
 	ws.subscriptions = store
+
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{{Channel: "test"}})
+
 	require.NoError(t, err)
+
 	require.Equal(t, 1, store.Len())
 
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{})
+
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	ws.Unsubscriber = func(subs subscription.List) error {
+
 		for _, sub := range subs {
+
 			if err := store.Remove(sub); err != nil {
+
 				return err
+
 			}
+
 		}
+
 		return nil
+
 	}
 
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{})
+
 	require.NoError(t, err)
+
 	require.Zero(t, store.Len())
+
 }
 
 func TestInitSubscriptionStore(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("GlobalStore", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager := &Manager{}
+
 		store := manager.initSubscriptionStore(nil)
 
 		require.NotNil(t, store, "global subscription store must be initialised")
+
 		assert.Same(t, store, manager.subscriptions, "global subscription store should be retained on the manager")
+
 	})
 
 	t.Run("ManagedConnectionStore", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManagerWithStore(t, nil)
+
 		require.Nil(t, manager.connectionManager[0].subscriptions, "managed websocket store must start nil for this test")
 
 		store := manager.initSubscriptionStore(conn)
 
 		require.NotNil(t, store, "managed connection store must be initialised")
+
 		assert.Same(t, store, manager.connectionManager[0].subscriptions, "managed websocket should retain the initialised store")
+
 		assert.NotSame(t, store, manager.subscriptions, "managed connection should keep an isolated subscription store")
+
 	})
+
 }
 
 func currySimpleSub(w *Manager) func(subscription.List) error {
+
 	return func(subs subscription.List) error {
+
 		return w.AddSuccessfulSubscriptions(nil, subs...)
+
 	}
+
 }
 
 func currySimpleSubConn(w *Manager) func(context.Context, Connection, subscription.List) error {
+
 	return func(_ context.Context, conn Connection, subs subscription.List) error {
+
 		return w.AddSuccessfulSubscriptions(conn, subs...)
+
 	}
+
 }
 
 func currySimpleUnsub(w *Manager) func(subscription.List) error {
+
 	return func(unsubs subscription.List) error {
+
 		return w.RemoveSubscriptions(nil, unsubs...)
+
 	}
+
 }
 
 func currySimpleUnsubConn(w *Manager) func(context.Context, Connection, subscription.List) error {
+
 	return func(_ context.Context, conn Connection, unsubs subscription.List) error {
+
 		return w.RemoveSubscriptions(conn, unsubs...)
+
 	}
+
 }
 
 func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscription.Store) (*Manager, Connection) {
+
 	t.Helper()
 
 	manager := NewManager()
+
 	setup := newDefaultSetup()
+
 	setup.UseMultiConnectionManagement = true
+
 	require.NoError(t, manager.Setup(setup))
 
 	ws := &websocket{
+
 		setup: &ConnectionSetup{
+
 			URL: "wss://managed-subscriptions.test/ws",
+
 			Subscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
+
 				return manager.AddSuccessfulSubscriptions(conn, subs...)
+
 			},
+
 			Unsubscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
+
 				return manager.RemoveSubscriptions(conn, subs...)
+
 			},
 		},
+
 		subscriptions: store,
 	}
+
 	conn := &connection{
-		URL:           ws.setup.URL,
+
+		URL: ws.setup.URL,
+
 		subscriptions: subscription.NewStore(),
 	}
 
 	manager.connectionManagerMu.Lock()
+
 	manager.connectionManager = append(manager.connectionManager, ws)
+
 	manager.connections[conn] = ws
+
 	ws.connections = []Connection{conn}
+
 	manager.connectionManagerMu.Unlock()
 
 	return manager, conn
+
 }
 
 func newManagedSubscriptionTestManager(t *testing.T) (*Manager, Connection) {
+
 	t.Helper()
+
 	return newManagedSubscriptionTestManagerWithStore(t, subscription.NewStore())
+
 }
 
 func startSubscriptionReaders(manager *Manager) func() {
+
 	done := make(chan struct{})
+
 	var wg sync.WaitGroup
+
 	var once sync.Once
+
 	for range 4 {
+
 		wg.Go(func() {
+
 			for {
+
 				select {
+
 				case <-done:
+
 					return
+
 				default:
+
 					_ = manager.GetSubscription("missing")
+
 					_ = manager.GetSubscriptions()
+
 				}
+
 			}
+
 		})
+
 	}
 
 	return func() {
+
 		once.Do(func() {
+
 			close(done)
+
 			wg.Wait()
+
 		})
+
 	}
+
 }
 
 func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error) {
+
 	t.Helper()
 
 	start := make(chan struct{})
+
 	errs := make(chan error, workers)
+
 	var wg sync.WaitGroup
 
 	for i := range workers {
+
 		wg.Go(func() {
+
 			<-start
+
 			errs <- op(i)
+
 		})
+
 	}
 
 	close(start)
+
 	wg.Wait()
+
 	close(errs)
 
 	for err := range errs {
+
 		require.NoError(t, err)
+
 	}
+
 }
 
 func newConcurrentSubscription(channel string, index int) *subscription.Subscription {
+
 	name := fmt.Sprintf("%s-%d", channel, index)
+
 	return &subscription.Subscription{
-		Key:     name,
+
+		Key: name,
+
 		Channel: name,
 	}
+
 }
 
 func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
+
 	t.Parallel()
 
 	const workers = 32
 
 	t.Run("AddSubscriptions", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
+
 		stopReaders := startSubscriptionReaders(manager)
+
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
+
 		for i := range workers {
+
 			subs[i] = newConcurrentSubscription("add", i)
+
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 			return manager.AddSubscriptions(conn, subs[i])
+
 		})
 
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
+
 		for _, sub := range subs {
+
 			require.Same(t, sub, manager.GetSubscription(sub))
+
 			assert.Equal(t, subscription.SubscribingState, sub.State())
+
 		}
+
 	})
 
 	t.Run("AddSuccessfulSubscriptions", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
+
 		stopReaders := startSubscriptionReaders(manager)
+
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
+
 		for i := range workers {
+
 			subs[i] = newConcurrentSubscription("success", i)
+
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 			return manager.AddSuccessfulSubscriptions(conn, subs[i])
+
 		})
 
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
+
 		for _, sub := range subs {
+
 			require.Same(t, sub, manager.GetSubscription(sub))
+
 			assert.Equal(t, subscription.SubscribedState, sub.State())
+
 		}
+
 	})
 
 	t.Run("RemoveSubscriptions", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
+
 		subs := make(subscription.List, workers)
+
 		for i := range workers {
+
 			subs[i] = newConcurrentSubscription("remove", i)
+
 		}
+
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
 
 		stopReaders := startSubscriptionReaders(manager)
+
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 			return manager.RemoveSubscriptions(conn, subs[i])
+
 		})
 
 		stopReaders()
 
 		assert.Empty(t, manager.GetSubscriptions())
+
 		for _, sub := range subs {
+
 			assert.Nil(t, manager.GetSubscription(sub))
+
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
+
 		}
+
 	})
 
 	t.Run("SubscribeToChannels", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
+
 		stopReaders := startSubscriptionReaders(manager)
+
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
+
 		for i := range workers {
+
 			subs[i] = newConcurrentSubscription("subscribe", i)
+
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 			return manager.SubscribeToChannels(t.Context(), conn, subscription.List{subs[i]})
+
 		})
 
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
+
 		for _, sub := range subs {
+
 			require.Same(t, sub, manager.GetSubscription(sub))
+
 			assert.Equal(t, subscription.SubscribedState, sub.State())
+
 		}
+
 	})
 
 	t.Run("UnsubscribeChannels", func(t *testing.T) {
+
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
+
 		subs := make(subscription.List, workers)
+
 		for i := range workers {
+
 			subs[i] = newConcurrentSubscription("unsubscribe", i)
+
 		}
+
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
 
 		stopReaders := startSubscriptionReaders(manager)
+
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 			return manager.UnsubscribeChannels(t.Context(), conn, subscription.List{subs[i]})
+
 		})
 
 		stopReaders()
 
 		assert.Empty(t, manager.GetSubscriptions())
+
 		for _, sub := range subs {
+
 			assert.Nil(t, manager.GetSubscription(sub))
+
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
+
 		}
+
 	})
+
 }
 
 func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
+
 	t.Parallel()
 
 	const workers = 32
 
 	manager, conn := newManagedSubscriptionTestManagerWithStore(t, nil)
+
 	stopReaders := startSubscriptionReaders(manager)
+
 	defer stopReaders()
 
 	subs := make(subscription.List, workers)
+
 	for i := range workers {
+
 		subs[i] = newConcurrentSubscription("initialise", i)
+
 	}
 
 	runConcurrentSubscriptionOps(t, workers, func(i int) error {
+
 		return manager.AddSuccessfulSubscriptions(conn, subs[i])
+
 	})
 
 	stopReaders()
 
 	require.Len(t, manager.GetSubscriptions(), workers)
+
 	for _, sub := range subs {
+
 		require.Same(t, sub, manager.GetSubscription(sub))
+
 	}
+
 }
 
 func TestFlushChannelsConcurrentReaders(t *testing.T) {
+
 	t.Parallel()
 
 	manager, conn := newManagedSubscriptionTestManager(t)
+
 	manager.setEnabled(true)
+
 	manager.setState(connectedState)
+
 	manager.MaxSubscriptionsPerConnection = 2
 
 	expected := subscription.List{
+
 		newConcurrentSubscription("flush", 0),
+
 		newConcurrentSubscription("flush", 1),
 	}
+
 	manager.connectionManager[0].setup.GenerateSubscriptions = func() (subscription.List, error) {
+
 		return expected, nil
+
 	}
 
 	stopReaders := startSubscriptionReaders(manager)
+
 	defer stopReaders()
 
 	runConcurrentSubscriptionOps(t, 8, func(int) error {
+
 		return manager.FlushChannels(t.Context())
+
 	})
 
 	stopReaders()
 
 	require.Len(t, manager.GetSubscriptions(), len(expected))
+
 	require.Len(t, conn.Subscriptions().List(), len(expected))
+
 	for _, sub := range expected {
+
 		require.Same(t, sub, manager.GetSubscription(sub))
+
 	}
+
 }
 
 func TestFlushChannels(t *testing.T) {
+
 	t.Parallel()
+
 	// Enabled pairs/setup system
 
 	dodgyWs := Manager{}
+
 	err := dodgyWs.FlushChannels(t.Context())
+
 	assert.ErrorIs(t, err, ErrWebsocketNotEnabled, "FlushChannels should error correctly")
 
 	dodgyWs.setEnabled(true)
+
 	err = dodgyWs.FlushChannels(t.Context())
+
 	assert.ErrorIs(t, err, ErrNotConnected, "FlushChannels should error correctly")
 
 	newgen := GenSubs{EnabledPairs: []currency.Pair{
+
 		currency.NewPair(currency.BTC, currency.AUD),
+
 		currency.NewBTCUSDT(),
 	}}
 
 	w := NewManager()
+
 	var cleanupMonitors sync.Once
+
 	cleanupW := func() {
+
 		cleanupMonitors.Do(func() { cleanupManagerMonitors(t, w) })
+
 	}
+
 	t.Cleanup(cleanupW)
+
 	w.exchangeName = "test"
+
 	w.connector = noopConnect
+
 	w.Subscriber = newgen.SUBME
+
 	w.Unsubscriber = newgen.UNSUBME
+
 	// Keep enough headroom for FlushChannels connection cycles without leaving long-lived monitor goroutines behind.
+
 	w.trafficTimeout = time.Second
 
 	w.setEnabled(true)
+
 	w.setState(connectedState)
 
 	// Allow subscribe and unsubscribe feature set, without these the tests will call shutdown and connect.
+
 	w.features.Subscribe = true
+
 	w.features.Unsubscribe = true
 
 	// Disable pair and flush system
+
 	newgen.EnabledPairs = []currency.Pair{currency.NewPair(currency.BTC, currency.AUD)}
+
 	w.GenerateSubs = func() (subscription.List, error) { return subscription.List{{Channel: "test"}}, nil }
 
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "FlushChannels must error correctly on no subscriptions added")
 
 	w.Subscriber = func(subs subscription.List) error {
+
 		for _, sub := range subs {
+
 			if err := w.subscriptions.Add(sub); err != nil {
+
 				return err
+
 			}
+
 		}
+
 		return nil
+
 	}
 
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
 
 	w.GenerateSubs = func() (subscription.List, error) { return nil, errDastardlyReason } // error on generateSubs
-	err = w.FlushChannels(t.Context())                                                    // error on full subscribeToChannels
+
+	err = w.FlushChannels(t.Context()) // error on full subscribeToChannels
+
 	assert.ErrorIs(t, err, errDastardlyReason, "FlushChannels should error correctly on GenerateSubs")
 
 	w.GenerateSubs = func() (subscription.List, error) { return nil, nil } // No subs to sub
@@ -1119,1236 +1864,2110 @@ func TestFlushChannels(t *testing.T) {
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotRemoved)
 
 	w.Unsubscriber = func(subs subscription.List) error {
+
 		for _, sub := range subs {
+
 			if err := w.subscriptions.Remove(sub); err != nil {
+
 				return err
+
 			}
+
 		}
+
 		return nil
+
 	}
+
 	assert.NoError(t, w.FlushChannels(t.Context()), "FlushChannels should not error")
 
 	w.GenerateSubs = newgen.generateSubs
+
 	subs, err := w.GenerateSubs()
+
 	require.NoError(t, err, "GenerateSubs must not error")
+
 	require.NoError(t, w.AddSubscriptions(nil, subs...), "AddSubscriptions must not error")
+
 	err = w.FlushChannels(t.Context())
+
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	w.GenerateSubs = newgen.generateSubs
+
 	w.subscriptions = subscription.NewStore()
+
 	err = w.subscriptions.Add(&subscription.Subscription{
-		Key:     41,
+
+		Key: 41,
+
 		Channel: "match channel",
-		Pairs:   currency.Pairs{currency.NewPair(currency.BTC, currency.AUD)},
+
+		Pairs: currency.Pairs{currency.NewPair(currency.BTC, currency.AUD)},
 	})
+
 	require.NoError(t, err, "AddSubscription must not error")
+
 	err = w.subscriptions.Add(&subscription.Subscription{
-		Key:     42,
+
+		Key: 42,
+
 		Channel: "unsub channel",
-		Pairs:   currency.Pairs{currency.NewPair(currency.THETA, currency.USDT)},
+
+		Pairs: currency.Pairs{currency.NewPair(currency.THETA, currency.USDT)},
 	})
+
 	require.NoError(t, err, "AddSubscription must not error")
 
 	err = w.FlushChannels(t.Context())
+
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	w.setState(connectedState)
+
 	err = w.FlushChannels(t.Context())
+
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	// Multi connection management
+
 	w.useMultiConnectionManagement = true
+
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler) }))
+
 	t.Cleanup(mock.Close)
+
 	t.Cleanup(cleanupW)
 
 	w.subscriptions = subscription.NewStore()
 
 	amazingCandidate := &ConnectionSetup{
+
 		URL: "ws" + mock.URL[len("http"):] + "/ws",
+
 		Connector: func(ctx context.Context, conn Connection) error {
+
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
+
 		},
+
 		GenerateSubscriptions: newgen.generateSubs,
-		Subscriber:            func(context.Context, Connection, subscription.List) error { return nil },
-		Unsubscriber:          func(context.Context, Connection, subscription.List) error { return nil },
-		Handler:               func(context.Context, Connection, []byte) error { return nil },
+
+		Subscriber: func(context.Context, Connection, subscription.List) error { return nil },
+
+		Unsubscriber: func(context.Context, Connection, subscription.List) error { return nil },
+
+		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}
+
 	require.NoError(t, w.SetupNewConnection(amazingCandidate))
+
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "Must error when no subscriptions are added to the subscription store")
 
 	w.connectionManager[0].setup.Subscriber = func(ctx context.Context, c Connection, s subscription.List) error {
+
 		return currySimpleSubConn(w)(ctx, c, s)
+
 	}
+
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
 
 	// Forces full connection cycle (shutdown, connect, subscribe). This will also start monitoring routines.
+
 	w.features.Subscribe = false
+
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
+
 	// Unsubscribe what's already subscribed. No subscriptions left over, which then forces the shutdown and removal
+
 	// of the connection from management.
+
 	w.features.Subscribe = true
+
 	w.connectionManager[0].setup.GenerateSubscriptions = func() (subscription.List, error) { return nil, nil }
+
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotRemoved, "Must error when no subscriptions are removed from subscription store")
 
 	w.connectionManager[0].setup.Unsubscriber = func(ctx context.Context, c Connection, s subscription.List) error {
+
 		return currySimpleUnsubConn(w)(ctx, c, s)
+
 	}
+
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
+
 }
 
 // fakeConnection is a minimal Connection implementation used in cleanup tests.
+
 type fakeConnection struct {
 	Connection
-	subscriptions     *subscription.Store
+
+	subscriptions *subscription.Store
+
 	subscriptionsHook func()
-	shutdownCalled    bool
+
+	shutdownCalled bool
 }
 
 func (f *fakeConnection) Shutdown() error {
+
 	f.shutdownCalled = true
+
 	return nil
+
 }
 
 func (f *fakeConnection) Subscriptions() *subscription.Store {
+
 	if f.subscriptionsHook != nil {
+
 		f.subscriptionsHook()
+
 	}
+
 	return f.subscriptions
+
 }
 
 func cleanupManagedConnectionReaders(t *testing.T, m *Manager, ws *websocket) {
+
 	t.Helper()
+
 	if m == nil || ws == nil {
+
 		return
+
 	}
+
 	for _, conn := range m.snapshotManagedConnections(ws) {
+
 		_ = conn.Shutdown()
+
 	}
+
 	resetManagerForNextConnectAttempt(t, m)
+
 }
 
 func TestApplyTrackedSubscriptions(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("NoTrackedSubscriptionsNoOp", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		conn := &fakeConnection{}
+
 		require.NoError(t, m.applyTrackedSubscriptions(conn, nil))
+
 	})
 
 	t.Run("RecordsInManagerAndConnectionStores", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		sub := &subscription.Subscription{Channel: "tracked"}
+
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		ws := &websocket{setup: &ConnectionSetup{}, subscriptions: subscription.NewStore()}
+
 		m.trackConnection(conn, ws)
 
 		require.NoError(t, m.applyTrackedSubscriptions(conn, subscription.List{sub}))
+
 		require.NotNil(t, ws.subscriptions.Get(sub), "tracked subscription must be recorded in websocket store")
+
 		require.NotNil(t, conn.subscriptions.Get(sub), "tracked subscription must be recorded in connection store")
+
 		assert.Equal(t, subscription.SubscribedState, sub.State())
+
 	})
 
 	t.Run("ErrorsWhenConnectionStoreIsNil", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		sub := &subscription.Subscription{Channel: "tracked"}
+
 		conn := &fakeConnection{}
+
 		ws := &websocket{setup: &ConnectionSetup{}, subscriptions: subscription.NewStore()}
+
 		m.trackConnection(conn, ws)
 
 		err := m.applyTrackedSubscriptions(conn, subscription.List{sub})
+
 		require.ErrorIs(t, err, common.ErrNilPointer)
+
 	})
+
 }
 
 func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("PassThroughWithoutTrackHook", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		subs := subscription.List{{Channel: "A"}}
+
 		ws := &websocket{
-			setup:         &ConnectionSetup{},
+
+			setup: &ConnectionSetup{},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
+
+			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subs)
+
 		require.NoError(t, err)
+
 		assert.Equal(t, subs, remaining)
+
 	})
 
 	t.Run("PropagatesTrackError", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		expectedErr := errors.New("track failed")
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
+
 					return nil, nil, expectedErr
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
+
+			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{{Channel: "A"}})
+
 		require.ErrorIs(t, err, expectedErr)
+
 		assert.Nil(t, remaining)
+
 	})
 
 	t.Run("ErrorsWhenTrackedSubsNotRecordedOnWebsocketStore", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		trackedSub := &subscription.Subscription{Channel: "tracked"}
+
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
+
 					return nil, subscription.List{trackedSub}, nil
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{conn},
+
+			connections: []Connection{conn},
 		}
 
 		// Intentionally do not map conn -> ws; manager-level tracking goes to
+
 		// the global store, allowing validation to detect missing websocket state.
+
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{trackedSub})
+
 		require.ErrorIs(t, err, ErrSubscriptionFailure)
+
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded)
+
 		assert.Nil(t, remaining)
+
 	})
 
 	t.Run("ReturnsRemainingAndRecordsTracked", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		trackedSub := &subscription.Subscription{Channel: "tracked"}
+
 		remainingSub := &subscription.Subscription{Channel: "remaining"}
+
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, _ subscription.List) (subscription.List, subscription.List, error) {
+
 					return subscription.List{remainingSub}, subscription.List{trackedSub}, nil
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{conn},
+
+			connections: []Connection{conn},
 		}
+
 		m.trackConnection(conn, ws)
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{trackedSub, remainingSub})
+
 		require.NoError(t, err)
+
 		require.Len(t, remaining, 1)
+
 		assert.Same(t, remainingSub, remaining[0])
+
 		require.NotNil(t, ws.subscriptions.Get(trackedSub))
+
 		require.NotNil(t, conn.subscriptions.Get(trackedSub))
+
 	})
+
 }
 
 func TestAbsorbTrackedSubscriptions(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("PassthroughWithoutTrackHook", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		subs := subscription.List{{Channel: "A"}}
+
 		ws := &websocket{
-			setup:       &ConnectionSetup{},
+
+			setup: &ConnectionSetup{},
+
 			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, tracked, err := m.absorbTrackedSubscriptions(t.Context(), ws, subs)
+
 		require.NoError(t, err)
+
 		assert.Equal(t, subs, remaining)
+
 		assert.Empty(t, tracked)
+
 	})
 
 	t.Run("TracksAcrossConnectionsUntilEmpty", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		tracked := &subscription.Subscription{Channel: "tracked"}
+
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 					if conn != conn1 {
+
 						return subs, nil, nil
+
 					}
+
 					return nil, subscription.List{tracked}, nil
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{conn0, conn1},
+
+			connections: []Connection{conn0, conn1},
 		}
+
 		m.connections[conn0] = ws
+
 		m.connections[conn1] = ws
 
 		remaining, trackedSubs, err := m.absorbTrackedSubscriptions(t.Context(), ws, subscription.List{tracked})
+
 		require.NoError(t, err)
+
 		require.Nil(t, remaining)
+
 		require.Len(t, trackedSubs, 1)
+
 		require.Same(t, tracked, trackedSubs[0])
+
 		require.NotNil(t, ws.subscriptions.Get(tracked))
+
 		require.NotNil(t, conn1.subscriptions.Get(tracked))
+
 		assert.Nil(t, conn0.subscriptions.Get(tracked))
+
 	})
 
 	t.Run("PropagatesErrors", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		expectedErr := errors.New("track failed")
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
+
 					return nil, nil, expectedErr
+
 				},
 			},
+
 			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, tracked, err := m.absorbTrackedSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}})
+
 		require.ErrorIs(t, err, expectedErr)
+
 		assert.Nil(t, remaining)
+
 		assert.Nil(t, tracked)
+
 	})
+
 }
 
 func TestScaleConnectionsToSubscriptions(t *testing.T) {
+
 	t.Parallel()
 
 	// Common setup helper
+
 	setup := func(t *testing.T, isMultiConn bool) (*Manager, *websocket) {
+
 		t.Helper()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 2
+
 		m.useMultiConnectionManagement = isMultiConn
 
 		// Mock server for dialing
+
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 			mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
+
 		}))
+
 		t.Cleanup(srv.Close)
 
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				URL: "ws" + srv.URL[len("http"):] + "/ws",
+
 				Connector: func(ctx context.Context, c Connection) error {
+
 					return c.Dial(ctx, gws.DefaultDialer, nil, nil)
+
 				},
+
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 					return m.AddSuccessfulSubscriptions(c, s...)
+
 				},
+
 				Unsubscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 					return m.RemoveSubscriptions(c, s...)
+
 				},
+
 				Handler: func(context.Context, Connection, []byte) error { return nil },
 			},
+
 			subscriptions: subscription.NewStore(),
 		}
+
 		t.Cleanup(func() { cleanupManagedConnectionReaders(t, m, ws) })
+
 		return m, ws
+
 	}
 
 	t.Run("Nil ws", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, _ := setup(t, false)
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), nil, nil)
+
 		require.ErrorIs(t, err, common.ErrNilPointer)
+
 	})
 
 	t.Run("No Changes", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
+
 		require.NoError(t, err)
+
 	})
 
 	t.Run("Scale Up (Add Subs)", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
 
 		subs := subscription.List{{Channel: "A"}, {Channel: "B"}, {Channel: "C"}}
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subs)
+
 		require.NoError(t, err)
 
 		assert.Equal(t, 3, ws.subscriptions.Len())
+
 		assert.Len(t, ws.connections, 2) // 2 per conn -> 2 conns
+
 	})
 
 	t.Run("Scale Down (Remove Subs)", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, true)
 
 		// Add subs first
+
 		subs := subscription.List{{Channel: "A"}, {Channel: "B"}}
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subs)
+
 		require.NoError(t, err)
+
 		require.Equal(t, 2, ws.subscriptions.Len())
 
 		// Remove all
+
 		err = m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
+
 		require.NoError(t, err)
+
 		assert.Equal(t, 0, ws.subscriptions.Len())
+
 		assert.Empty(t, ws.connections)
+
 	})
 
 	t.Run("Unsubscribe Error", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, true)
 
 		// Add sub first
+
 		sub := subscription.List{{Channel: "A"}}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, sub))
 
 		// Now set error and remove
+
 		ws.setup.Unsubscriber = func(context.Context, Connection, subscription.List) error {
+
 			return errors.New("unsub fail")
+
 		}
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
+
 		require.ErrorContains(t, err, "unsub fail")
+
 	})
 
 	t.Run("Subscribe Error (Existing Connection)", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
 
 		// Add one sub (capacity 2)
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}}))
 
 		// Set error
+
 		ws.setup.Subscriber = func(context.Context, Connection, subscription.List) error {
+
 			return errors.New("sub fail")
+
 		}
 
 		// Add another sub (should use existing connection)
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}, {Channel: "B"}})
+
 		require.ErrorContains(t, err, "sub fail")
+
 	})
 
 	t.Run("Subscribe Error (New Connection)", func(t *testing.T) {
+
 		m, ws := setup(t, false)
 
 		// Set connector error
+
 		ws.setup.Connector = func(context.Context, Connection) error {
+
 			return errors.New("connect fail")
+
 		}
 
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}})
+
 		require.ErrorContains(t, err, "connect fail")
+
 	})
 
 	t.Run("Global Unsubscribe Fallback Success", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
 
 		s1 := &subscription.Subscription{Channel: "A"}
+
 		s2 := &subscription.Subscription{Channel: "B"}
+
 		require.NoError(t, ws.subscriptions.Add(s1))
+
 		require.NoError(t, ws.subscriptions.Add(s2))
+
 		// empty incoming subscriptions will remove existing subs
+
 		in := subscription.List{}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, in))
+
 		assert.Equal(t, 0, ws.subscriptions.Len())
+
 	})
 
 	t.Run("Missing Subscriptions After Subscribe", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
 
 		s1 := &subscription.Subscription{Channel: "A"}
+
 		s2 := &subscription.Subscription{Channel: "B"}
+
 		require.NoError(t, ws.subscriptions.Add(s1))
 
 		in := subscription.List{s1, s2}
+
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, in)
+
 		require.NoError(t, err)
 
 		// After scaling, both subs should be present in the store
+
 		assert.NotNil(t, ws.subscriptions.Get(s1))
+
 		assert.NotNil(t, ws.subscriptions.Get(s2))
+
 	})
 
 	t.Run("Multi-batch ConnectAndSubscribe Success", func(t *testing.T) {
+
 		t.Parallel()
+
 		m, ws := setup(t, false)
 
 		m.MaxSubscriptionsPerConnection = 2
 
 		in := subscription.List{{Channel: "A"}, {Channel: "B"}, {Channel: "C"}, {Channel: "D"}, {Channel: "E"}}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, in))
 
 		// With max 2 subs per connection and 5 total, we expect 3 connections
+
 		assert.Len(t, ws.connections, 3)
+
 	})
 
 	t.Run("Track On Existing Connection Prevents New Connection", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 1
+
 		m.connections = make(map[Connection]*websocket)
 
 		existing := &subscription.Subscription{Channel: "A"}
+
 		logical := &subscription.Subscription{Channel: "B"}
+
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, activeConn.subscriptions.Add(existing))
 
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				Connector: func(context.Context, Connection) error {
+
 					return errors.New("should not create a new connection")
+
 				},
+
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 					if len(subs) != 1 || subs[0].Channel != logical.Channel {
+
 						return subs, nil, nil
+
 					}
+
 					return nil, subscription.List{logical}, nil
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{activeConn},
+
+			connections: []Connection{activeConn},
 		}
+
 		require.NoError(t, ws.subscriptions.Add(existing))
+
 		m.connections[activeConn] = ws
 
 		incoming := subscription.List{existing, logical}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
+
 		assert.Len(t, ws.connections, 1)
+
 		assert.Equal(t, 2, ws.subscriptions.Len())
+
 		assert.Equal(t, 2, activeConn.subscriptions.Len())
+
 	})
 
 	t.Run("Track On Existing Connection Targets Owning Connection", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 1
+
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 owns subA, conn1 owns subB. A logical sub "C" whose inverse
+
 		// lives on conn1 must be tracked on conn1, not conn0.
+
 		subA := &subscription.Subscription{Channel: "A"}
+
 		subB := &subscription.Subscription{Channel: "B"}
+
 		logical := &subscription.Subscription{Channel: "C"}
 
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, conn0.subscriptions.Add(subA))
 
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, conn1.subscriptions.Add(subB))
 
 		var trackedOnConn Connection
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				Connector: func(context.Context, Connection) error {
+
 					return errors.New("should not create a new connection")
+
 				},
+
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 					// Only track when the connection owns subB (the inverse).
+
 					if conn.Subscriptions().Get(subB) == nil {
+
 						return subs, nil, nil
+
 					}
+
 					trackedOnConn = conn
+
 					return nil, subscription.List{logical}, nil
+
 				},
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{conn0, conn1},
+
+			connections: []Connection{conn0, conn1},
 		}
+
 		require.NoError(t, ws.subscriptions.Add(subA))
+
 		require.NoError(t, ws.subscriptions.Add(subB))
+
 		m.connections[conn0] = ws
+
 		m.connections[conn1] = ws
 
 		incoming := subscription.List{subA, subB, logical}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
 
 		assert.Len(t, ws.connections, 2, "no new connections should be created")
+
 		assert.Same(t, conn1, trackedOnConn, "logical sub should be tracked on the connection owning the inverse, not connections[0]")
+
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
+
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
+
 	})
 
 	t.Run("Track Before Generic Subscribe Prevents Misrouting", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 2
+
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 has subA and spare capacity (max=2, used=1).
+
 		// conn1 has subB (the inverse of logical sub C).
+
 		// Without the pre-subscribe tracking pass, the generic
+
 		// subscribeToConnection loop would route C to conn0 because
+
 		// it has capacity. The fix ensures absorbTrackedSubscriptions
+
 		// runs first, absorbing C onto conn1.
+
 		subA := &subscription.Subscription{Channel: "A"}
+
 		subB := &subscription.Subscription{Channel: "B"}
+
 		logical := &subscription.Subscription{Channel: "C"}
 
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, conn0.subscriptions.Add(subA))
 
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, conn1.subscriptions.Add(subB))
 
 		var trackedOnConn Connection
+
 		ws := &websocket{
+
 			setup: &ConnectionSetup{
+
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 					return m.AddSuccessfulSubscriptions(c, s...)
+
 				},
+
 				Connector: func(context.Context, Connection) error {
+
 					return errors.New("should not create a new connection")
+
 				},
+
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 					// Only track when the connection owns subB (the inverse).
+
 					if conn.Subscriptions().Get(subB) == nil {
+
 						return subs, nil, nil
+
 					}
+
 					var remaining subscription.List
+
 					var tracked subscription.List
+
 					for _, s := range subs {
+
 						if s.Channel != logical.Channel {
+
 							remaining = append(remaining, s)
+
 							continue
+
 						}
+
 						trackedOnConn = conn
+
 						tracked = append(tracked, s)
+
 					}
+
 					return remaining, tracked, nil
+
 				},
+
 				Handler: func(context.Context, Connection, []byte) error { return nil },
 			},
+
 			subscriptions: subscription.NewStore(),
-			connections:   []Connection{conn0, conn1},
+
+			connections: []Connection{conn0, conn1},
 		}
+
 		require.NoError(t, ws.subscriptions.Add(subA))
+
 		require.NoError(t, ws.subscriptions.Add(subB))
+
 		m.connections[conn0] = ws
+
 		m.connections[conn1] = ws
 
 		incoming := subscription.List{subA, subB, logical}
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
 
 		assert.Len(t, ws.connections, 2, "no new connections should be created")
+
 		assert.Same(t, conn1, trackedOnConn, "logical sub should be tracked on the connection owning the inverse, not conn0 which has spare capacity")
+
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
+
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
+
 	})
 
 	t.Run("Cleanup Removes Empty Connections", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 2
+
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-			setup:         &ConnectionSetup{},
+
+			setup: &ConnectionSetup{},
+
 			subscriptions: subscription.NewStore(),
 		}
 
 		// One connection with zero subs, one with non-zero
+
 		emptyConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, activeConn.subscriptions.Add(&subscription.Subscription{Channel: "A"}))
 
 		ws.connections = []Connection{emptyConn, activeConn}
 
 		m.connections[emptyConn] = ws
+
 		m.connections[activeConn] = ws
 
 		// No incoming/sub changes; trigger only cleanup logic
+
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, nil))
 
 		assert.True(t, emptyConn.shutdownCalled)
+
 		assert.False(t, activeConn.shutdownCalled)
+
 		assert.Len(t, ws.connections, 1)
+
 		assert.Same(t, activeConn, ws.connections[0])
+
 	})
 
 	t.Run("Cleanup Keeps Freshly Added Connections", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 2
+
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-			setup:         &ConnectionSetup{},
+
+			setup: &ConnectionSetup{},
+
 			subscriptions: subscription.NewStore(),
 		}
 
 		emptyConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		freshConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 		require.NoError(t, activeConn.subscriptions.Add(&subscription.Subscription{Channel: "A"}))
+
 		require.NoError(t, freshConn.subscriptions.Add(&subscription.Subscription{Channel: "B"}))
 
 		var addFreshOnce sync.Once
+
 		emptyConn.subscriptionsHook = func() {
+
 			addFreshOnce.Do(func() {
+
 				m.connectionManagerMu.Lock()
+
 				m.connections[freshConn] = ws
+
 				ws.connections = append(ws.connections, freshConn)
+
 				m.connectionManagerMu.Unlock()
+
 			})
+
 		}
 
 		ws.connections = []Connection{emptyConn, activeConn}
+
 		m.connections[emptyConn] = ws
+
 		m.connections[activeConn] = ws
 
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, nil))
 
 		assert.True(t, emptyConn.shutdownCalled)
+
 		assert.False(t, activeConn.shutdownCalled)
+
 		assert.False(t, freshConn.shutdownCalled)
+
 		assert.Len(t, ws.connections, 2)
 
 		var haveActive, haveFresh bool
+
 		for _, conn := range ws.connections {
+
 			if conn == activeConn {
+
 				haveActive = true
+
 			}
+
 			if conn == freshConn {
+
 				haveFresh = true
+
 			}
+
 		}
+
 		assert.True(t, haveActive)
+
 		assert.True(t, haveFresh)
+
 		assert.NotContains(t, m.connections, emptyConn)
+
 		assert.Same(t, ws, m.connections[freshConn])
+
 	})
+
 }
 
 func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
+
 	t.Parallel()
 
 	m := NewManager()
+
 	m.exchangeName = "test"
+
 	m.useMultiConnectionManagement = true
+
 	m.MaxSubscriptionsPerConnection = 1
+
 	m.trafficTimeout = time.Minute
+
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
+
 	}))
+
 	t.Cleanup(srv.Close)
+
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	subA := &subscription.Subscription{Channel: "A"}
+
 	subB := &subscription.Subscription{Channel: "B"}
+
 	var connectorCalls int
+
 	var trackCalls int
+
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
+
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
+
 		Connector: func(ctx context.Context, conn Connection) error {
+
 			connectorCalls++
+
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
+
 		},
+
 		GenerateSubscriptions: func() (subscription.List, error) {
+
 			return subscription.List{subA, subB}, nil
+
 		},
+
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 			return m.AddSuccessfulSubscriptions(c, s...)
+
 		},
+
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 			if len(subs) != 1 || subs[0] != subB {
+
 				return subs, nil, nil
+
 			}
+
 			trackCalls++
+
 			return nil, subscription.List{subB}, nil
+
 		},
+
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	require.NoError(t, m.Connect(t.Context()))
 
 	require.Len(t, m.connectionManager, 1)
+
 	assert.Equal(t, 1, connectorCalls, "connect path should only dial once when later subscriptions are tracked on the existing connection")
+
 	assert.Equal(t, 1, trackCalls, "later subscription batch should be handled by TrackOnExistingConnection")
+
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subA), "first subscription should be tracked logically")
+
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subB), "later tracked subscription should be tracked logically")
+
 }
 
 func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
+
 	t.Parallel()
 
 	m := NewManager()
+
 	m.exchangeName = "test"
+
 	m.useMultiConnectionManagement = true
+
 	m.MaxSubscriptionsPerConnection = 2
+
 	m.trafficTimeout = time.Minute
+
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
+
 	}))
+
 	t.Cleanup(srv.Close)
+
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	realA := &subscription.Subscription{Channel: "real-A"}
+
 	trackedA := &subscription.Subscription{Channel: "tracked-A"}
+
 	realB := &subscription.Subscription{Channel: "real-B"}
+
 	trackedB := &subscription.Subscription{Channel: "tracked-B"}
+
 	trackable := map[*subscription.Subscription]bool{
+
 		trackedA: true,
+
 		trackedB: true,
 	}
 
 	var connectorCalls int
+
 	var trackBatchLens []int
+
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
+
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
+
 		Connector: func(ctx context.Context, conn Connection) error {
+
 			connectorCalls++
+
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
+
 		},
+
 		GenerateSubscriptions: func() (subscription.List, error) {
+
 			return subscription.List{realA, trackedA, realB, trackedB}, nil
+
 		},
+
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 			return m.AddSuccessfulSubscriptions(c, s...)
+
 		},
+
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 			trackBatchLens = append(trackBatchLens, len(subs))
+
 			remaining := make(subscription.List, 0, len(subs))
+
 			tracked := make(subscription.List, 0, len(subs))
+
 			for _, sub := range subs {
+
 				if !trackable[sub] {
+
 					remaining = append(remaining, sub)
+
 					continue
+
 				}
+
 				tracked = append(tracked, sub)
+
 			}
+
 			if len(tracked) == 0 {
+
 				return subs, nil, nil
+
 			}
+
 			return remaining, tracked, nil
+
 		},
+
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	ws := m.connectionManager[0]
+
 	existingConn := &fakeConnection{subscriptions: subscription.NewStore()}
+
 	m.trackConnection(existingConn, ws)
 
 	require.NoError(t, m.Connect(t.Context()))
 
 	assert.Equal(t, 1, connectorCalls, "pre-batch tracking reduces the real subscriptions to a single connection")
+
 	assert.Equal(t, []int{4, 2}, trackBatchLens, "Connect reduces against existing connections before batching and still re-checks reduced batches")
+
 	assert.NotNil(t, ws.subscriptions.Get(trackedA), "tracked-A is tracked logically before batching")
+
 	assert.NotNil(t, ws.subscriptions.Get(trackedB), "tracked-B is tracked logically before batching")
+
 	assert.NotNil(t, ws.subscriptions.Get(realA), "real-A is tracked logically")
+
 	assert.NotNil(t, ws.subscriptions.Get(realB), "real-B is tracked logically")
+
 }
 
 func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
+
 	t.Parallel()
 
 	m := NewManager()
+
 	m.exchangeName = "test"
+
 	m.useMultiConnectionManagement = true
+
 	m.MaxSubscriptionsPerConnection = 2
+
 	m.trafficTimeout = time.Minute
+
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
+
 	}))
+
 	t.Cleanup(srv.Close)
+
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	realSub := &subscription.Subscription{Channel: "real"}
+
 	trackedSub := &subscription.Subscription{Channel: "tracked"}
+
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
+
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
+
 		Connector: func(ctx context.Context, conn Connection) error {
+
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
+
 		},
+
 		GenerateSubscriptions: func() (subscription.List, error) {
+
 			return subscription.List{realSub, trackedSub}, nil
+
 		},
+
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
+
 			return m.AddSuccessfulSubscriptions(c, s...)
+
 		},
+
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
+
 			remaining := make(subscription.List, 0, len(subs))
+
 			tracked := make(subscription.List, 0, len(subs))
+
 			for _, sub := range subs {
+
 				if sub == trackedSub {
+
 					tracked = append(tracked, sub)
+
 					continue
+
 				}
+
 				remaining = append(remaining, sub)
+
 			}
+
 			return remaining, tracked, nil
+
 		},
+
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	ws := m.connectionManager[0]
+
 	m.trackConnection(&fakeConnection{subscriptions: subscription.NewStore()}, ws)
 
 	require.NoError(t, m.Connect(t.Context()))
+
 	require.NotNil(t, ws.subscriptions.Get(trackedSub), "tracked subscriptions must be recorded by the manager")
+
 }
 
 func TestResubscribeFromConnection(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("Success", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.Unsubscriber = func(subscription.List) error { return nil }
+
 		m.Subscriber = func(subscription.List) error { return nil }
+
 		sub1 := &subscription.Subscription{Channel: "sub1"}
+
 		sub2 := &subscription.Subscription{Channel: "sub2"}
+
 		wsStore := subscription.NewStore()
+
 		connStore := subscription.NewStore()
+
 		require.NoError(t, wsStore.Add(sub1))
+
 		require.NoError(t, wsStore.Add(sub2))
+
 		require.NoError(t, connStore.Add(sub1))
+
 		require.NoError(t, connStore.Add(sub2))
+
 		m.subscriptions = wsStore
+
 		conn := &connection{subscriptions: connStore}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
+
 		require.NoError(t, err)
+
 		require.Contains(t, wsStore.List(), sub1, "sub1 must still be in websocket store")
+
 		require.Contains(t, connStore.List(), sub1, "sub1 must still be in connection store")
+
 	})
+
 	t.Run("NilConnection", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		err := m.ResubscribeFromConnection(t.Context(), nil, nil)
+
 		require.ErrorIs(t, err, common.ErrNilPointer)
+
 	})
+
 	t.Run("Bad state", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.subscriptions = subscription.NewStore()
+
 		m.Unsubscriber = func(subscription.List) error { return nil }
+
 		m.Subscriber = func(subscription.List) error { return nil }
+
 		sub1 := &subscription.Subscription{Channel: "sub1"}
+
 		require.NoError(t, sub1.SetState(subscription.ResubscribingState), "sub1 must be in unsubscribed state for this test")
+
 		store := subscription.NewStore()
+
 		require.NoError(t, store.Add(sub1))
+
 		m.subscriptions = store
+
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
+
 		require.NoError(t, err, "an interrupted recovery must be retryable")
+
 	})
+
 	t.Run("Bad unsub", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.subscriptions = subscription.NewStore()
+
 		m.Unsubscriber = func(subscription.List) error { return errAlreadyConnected }
+
 		m.Subscriber = func(subscription.List) error { return nil }
+
 		sub1 := &subscription.Subscription{Channel: "sub1"}
+
 		store := subscription.NewStore()
+
 		require.NoError(t, store.Add(sub1))
+
 		m.subscriptions = store
+
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
+
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
+
 	})
+
 	t.Run("Bad sub", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.subscriptions = subscription.NewStore()
+
 		m.Unsubscriber = func(subscription.List) error { return nil }
+
 		m.Subscriber = func(subscription.List) error { return errAlreadyConnected }
+
 		sub1 := &subscription.Subscription{Channel: "sub1"}
+
 		store := subscription.NewStore()
+
 		require.NoError(t, store.Add(sub1))
+
 		m.subscriptions = store
+
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
+
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
+
 	})
+
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		wsStore := subscription.NewStore()
+
 		connStore := subscription.NewStore()
+
 		m.subscriptions = wsStore
+
 		sub := &subscription.Subscription{Channel: "sub"}
+
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
 		require.NoError(t, connStore.Add(sub))
+
 		conn := &connection{subscriptions: connStore}
+
 		m.Unsubscriber = func(subs subscription.List) error {
+
 			return m.RemoveSubscriptions(conn, subs...)
+
 		}
+
 		subscribeCalls := 0
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			subscribeCalls++
+
 			if subscribeCalls == 1 {
+
 				return errAlreadyConnected
+
 			}
+
 			return m.AddSuccessfulSubscriptions(conn, subs...)
+
 		}
 
 		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
+
 		require.Equal(t, subscription.ResubscribingState, sub.State())
+
 		require.Contains(t, connStore.List(), sub, "failed recovery must restore into connection store")
+
 		require.Same(t, sub, wsStore.Get(sub))
+
 		require.NoError(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), "a transient subscribe failure must remain retryable")
+
 		require.Equal(t, 2, subscribeCalls)
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 		require.Contains(t, connStore.List(), sub)
+
 		require.Same(t, sub, wsStore.Get(sub))
+
 	})
+
 	t.Run("Missing connection subscription", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.subscriptions = subscription.NewStore()
+
 		sub := &subscription.Subscription{Channel: "sub"}
+
 		require.NoError(t, m.subscriptions.Add(sub), "subscription must be added to the manager store")
+
 		conn := &connection{subscriptions: subscription.NewStore()}
+
 		m.Unsubscriber = func(subscription.List) error { return nil }
+
 		subscriberCalled := false
+
 		m.Subscriber = func(subscription.List) error {
+
 			subscriberCalled = true
+
 			return nil
+
 		}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+
 		require.ErrorIs(t, err, ErrSubscriptionsNotRemoved, "must error when the subscription is not owned by the connection")
+
 		assert.False(t, subscriberCalled, "subscriber should not be called for a subscription owned by another connection")
+
 	})
+
 	t.Run("Capacity consumed during unsubscribe", func(t *testing.T) {
+
 		t.Parallel()
+
 		m := NewManager()
+
 		m.MaxSubscriptionsPerConnection = 1
+
 		m.subscriptions = subscription.NewStore()
+
 		connStore := subscription.NewStore()
+
 		sub := &subscription.Subscription{Channel: "sub"}
+
 		other := &subscription.Subscription{Channel: "other"}
+
 		require.NoError(t, m.subscriptions.Add(sub), "subscription must be added to the manager store")
+
 		require.NoError(t, connStore.Add(sub), "subscription must be added to the connection store")
+
 		m.Unsubscriber = func(subscription.List) error {
+
 			return connStore.Add(other)
+
 		}
+
 		subscriberCalled := false
+
 		m.Subscriber = func(subscription.List) error {
+
 			subscriberCalled = true
+
 			return nil
+
 		}
+
 		conn := &connection{subscriptions: connStore}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded, "must error when connection capacity is consumed during resubscription")
+
 		assert.False(t, subscriberCalled, "subscriber should not be called when the connection has no capacity")
+
 	})
+
 	t.Run("Concurrent recovery coalesced", func(t *testing.T) {
+
 		m := NewManager()
+
 		wsStore := subscription.NewStore()
+
 		connStore := subscription.NewStore()
+
 		sub := &subscription.Subscription{Channel: "connCoalesce"}
+
 		require.NoError(t, wsStore.Add(sub))
+
 		require.NoError(t, connStore.Add(sub))
+
 		require.NoError(t, sub.SetState(subscription.SubscribedState))
+
 		m.subscriptions = wsStore
+
 		conn := &connection{subscriptions: connStore}
 
 		firstUnsub := make(chan struct{})
+
 		secondPreLock := make(chan struct{})
+
 		releaseFirst := make(chan struct{})
+
 		unsubCalls := 0
+
 		m.Unsubscriber = func(subscription.List) error {
+
 			unsubCalls++
+
 			if unsubCalls == 1 {
+
 				close(firstUnsub)
+
 				<-releaseFirst
+
 			}
+
 			return nil
+
 		}
+
 		m.Subscriber = func(subs subscription.List) error {
+
 			return m.AddSuccessfulSubscriptions(conn, subs...)
+
 		}
 
 		var firstErr, secondErr error
+
 		var wg sync.WaitGroup
+
 		wg.Add(2)
+
 		go func() {
+
 			defer wg.Done()
+
 			firstErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+
 		}()
+
 		<-firstUnsub
+
 		var signalSecondPreLock sync.Once
+
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+
 			if s == sub {
+
 				signalSecondPreLock.Do(func() { close(secondPreLock) })
+
 			}
+
 		}
+
 		go func() {
+
 			defer wg.Done()
+
 			secondErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+
 		}()
+
 		<-secondPreLock
+
 		close(releaseFirst)
+
 		wg.Wait()
 
 		require.NoError(t, firstErr)
+
 		require.NoError(t, secondErr)
+
 		require.Equal(t, 1, unsubCalls)
+
 		require.Equal(t, subscription.SubscribedState, sub.State())
+
 	})
 
 	t.Run("Connection capacity discount is per subscription pointer", func(t *testing.T) {
+
 		t.Parallel()
+
 		store := subscription.NewStore()
+
 		sub := &subscription.Subscription{Channel: "cap"}
+
 		require.NoError(t, store.Add(sub))
+
 		require.NoError(t, sub.SetState(subscription.ResubscribingState))
+
 		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub, sub, sub}))
+
 		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub}))
+
 		other := &subscription.Subscription{Channel: "other"}
+
 		require.NoError(t, store.Add(other))
+
 		require.Equal(t, 1, connectionUsedCapacity(store, subscription.List{sub}))
+
 	})
+
 }
 
 func TestUnsubscribeFromConnection(t *testing.T) {
+
 	t.Parallel()
+
 	m := NewManager()
 
 	_, err := m.unsubscribeFromConnection(t.Context(), &connection{}, nil)
+
 	require.ErrorContains(t, err, "websocket connection nil pointer: *subscription.Store")
 
 	m.subscriptions = subscription.NewStore()
 
 	store := subscription.NewStore()
+
 	sub1 := &subscription.Subscription{Channel: "sub1"}
+
 	subs := subscription.List{sub1}
 
 	remaining, err := m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err, "unsubscribeFromConnection must not error when no subs in store")
+
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when none removed")
 
 	require.NoError(t, store.Add(sub1))
+
 	m.Unsubscriber = func(subscription.List) error { return nil }
+
 	_, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.ErrorIs(t, err, subscription.ErrNotFound, "must error if sub not in manager store")
 
 	require.NoError(t, m.subscriptions.Add(sub1))
+
 	m.Unsubscriber = func(subscription.List) error {
+
 		return errors.New("unsub failed")
+
 	}
+
 	_, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.ErrorContains(t, err, "unsub failed")
 
 	m.Unsubscriber = func(subscription.List) error { return nil }
+
 	sub2 := &subscription.Subscription{Channel: "sub2"}
+
 	subs = subscription.List{sub1, sub2}
 
 	remaining, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err, "unsubscribeFromConnection must not error when unsubscribing existing subs")
 
 	assert.Nil(t, store.Get(sub1), "sub1 should be removed from store")
+
 	assert.NotNil(t, m.subscriptions.Get(sub1), "sub1 should still be in global store")
 
 	assert.Len(t, remaining, 1)
+
 	assert.Equal(t, "sub2", remaining[0].Channel)
+
 }
 
 func TestSubscribeToConnection(t *testing.T) {
+
 	t.Parallel()
+
 	m := NewManager()
 
 	_, err := m.subscribeToConnection(t.Context(), &connection{}, nil)
+
 	require.ErrorContains(t, err, "websocket connection nil pointer: *subscription.Store")
 
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
 
 	store := subscription.NewStore()
+
 	sub1 := &subscription.Subscription{Channel: "sub1"}
+
 	sub2 := &subscription.Subscription{Channel: "sub2"}
+
 	sub3 := &subscription.Subscription{Channel: "sub3"}
+
 	subs := subscription.List{sub1, sub2, sub3}
 
 	m.MaxSubscriptionsPerConnection = 1
+
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing"}))
 
 	remaining, err := m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err, "subscribeToConnection must not error when full capacity")
+
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when capacity full")
 
 	m = NewManager()
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
+
 	store = subscription.NewStore()
+
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing-1"}))
+
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing-2"}))
+
 	m.MaxSubscriptionsPerConnection = 1
 
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err, "subscribeToConnection must not error when connection is already over logical capacity")
+
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when used capacity exceeds the limit")
 
 	m = NewManager()
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
+
 	store = subscription.NewStore()
+
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing"}))
+
 	m.MaxSubscriptionsPerConnection = 3
 
 	// subs has 3 items. Capacity is 3. Used is 1. Available is 2.
+
 	// Should subscribe to sub1, sub2. Return sub3.
+
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err)
+
 	assert.Len(t, remaining, 1, "should return 1 remaining subscription")
+
 	assert.Equal(t, sub3, remaining[0], "should return sub3")
 
 	assert.NotNil(t, store.Get(sub1), "sub1 should be added to store")
+
 	assert.NotNil(t, store.Get(sub2), "sub2 should be added to store")
+
 	assert.Nil(t, store.Get(sub3), "sub3 should not be added to store")
 
 	m = NewManager()
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
+
 	store = subscription.NewStore()
+
 	m.MaxSubscriptionsPerConnection = 0
 
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err)
+
 	assert.Empty(t, remaining, "should return no remaining subscriptions with no capacity limit")
+
 	assert.Equal(t, 3, store.Len(), "store should have 3 subscriptions when no capacity limit")
 
 	m = NewManager()
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return errors.New("sub failed") }
+
 	store = subscription.NewStore()
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.ErrorContains(t, err, "sub failed")
 
 	m = NewManager()
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
+
 	store = subscription.NewStore()
+
 	require.NoError(t, store.Add(sub1)) // sub1 already in store
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.ErrorIs(t, err, subscription.ErrDuplicate, "must error when subscription already in store")
 
 	m = NewManager()
+
 	m.MaxSubscriptionsPerConnection = 50
+
 	m.subscriptions = subscription.NewStore()
+
 	m.Subscriber = func(subscription.List) error { return nil }
+
 	store = subscription.NewStore()
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
+
 	require.NoError(t, err, "must not error when all subscriptions can be added, this exercises the path where available > len(subs)")
+
 }

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -13,6 +13,7 @@ import (
 	gws "github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
@@ -2203,7 +2204,6 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.Equal(t, 1, unsubCalls)
 		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
-
 
 	t.Run("Connection capacity discount is per subscription pointer", func(t *testing.T) {
 		t.Parallel()

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -228,6 +228,25 @@ func TestResubscribe(t *testing.T) {
 	})
 }
 
+func TestUnsubscribeForResubscribeErrors(t *testing.T) {
+	t.Parallel()
+	m := NewManager()
+	sub := &subscription.Subscription{Channel: "sub"}
+
+	err := m.unsubscribeForResubscribe(t.Context(), nil, nil, subscription.List{sub})
+	assert.ErrorIs(t, err, common.ErrNilPointer)
+
+	store := subscription.NewStore()
+	err = m.unsubscribeForResubscribe(t.Context(), nil, store, subscription.List{sub})
+	assert.ErrorIs(t, err, ErrSubscriptionsNotRemoved)
+
+	require.NoError(t, store.Add(sub))
+	err = m.unsubscribeForResubscribe(t.Context(), nil, store, subscription.List{sub})
+	assert.ErrorIs(t, err, common.ErrNilPointer)
+	assert.True(t, allSubscriptionsState(subscription.List{sub}, subscription.InactiveState))
+	assert.False(t, allSubscriptionsState(subscription.List{sub}, subscription.SubscribedState))
+}
+
 // TestSubscriptions tests adding, getting and removing subscriptions
 func TestSubscriptions(t *testing.T) {
 	t.Parallel()

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -207,24 +207,212 @@ func TestResubscribe(t *testing.T) {
 			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
 		<-firstUnsubscribe
-		secondReady := make(chan struct{})
+		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+			if s == sub {
+				close(secondUnsubscribe)
+			}
+		}
 		go func() {
 			defer wg.Done()
-			close(secondReady)
 			secondErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-		<-secondReady
-		select {
-		case <-secondUnsubscribe:
-			t.Fatal("second recovery started before the first completed")
-		case <-time.After(100 * time.Millisecond):
-		}
+		<-secondUnsubscribe
 		close(releaseFirst)
 		wg.Wait()
 
 		require.NoError(t, firstErr)
 		require.NoError(t, secondErr)
 		require.Equal(t, 1, unsubscribes)
+		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
+	t.Run("Different subscriptions recover concurrently", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		subA := &subscription.Subscription{Channel: "subA"}
+		subB := &subscription.Subscription{Channel: "subB"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, subA, subB))
+
+		var unsubsMu sync.Mutex
+		unsubscribed := make(map[string]int)
+		subscribed := make(map[string]int)
+
+		subAUnsubStarted := make(chan struct{})
+		releaseSubA := make(chan struct{})
+
+		m.Unsubscriber = func(subs subscription.List) error {
+			unsubsMu.Lock()
+			for _, s := range subs {
+				unsubscribed[s.Channel]++
+			}
+			unsubsMu.Unlock()
+			for _, s := range subs {
+				if s.Channel == "subA" {
+					close(subAUnsubStarted)
+					<-releaseSubA
+				}
+			}
+			return nil
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			unsubsMu.Lock()
+			for _, s := range subs {
+				subscribed[s.Channel]++
+			}
+			unsubsMu.Unlock()
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		var wg sync.WaitGroup
+		var errA, errB error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			errA = m.ResubscribeToChannel(t.Context(), nil, subA)
+		}()
+		<-subAUnsubStarted
+		subBPreLock := make(chan struct{})
+		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+			if s == subB {
+				close(subBPreLock)
+			}
+		}
+		go func() {
+			defer wg.Done()
+			errB = m.ResubscribeToChannel(t.Context(), nil, subB)
+		}()
+		<-subBPreLock
+		close(releaseSubA)
+		wg.Wait()
+
+		require.NoError(t, errA)
+		require.NoError(t, errB)
+		require.Equal(t, 1, unsubscribed["subA"])
+		require.Equal(t, 1, unsubscribed["subB"])
+		require.Equal(t, 1, subscribed["subA"])
+		require.Equal(t, 1, subscribed["subB"])
+		require.Equal(t, subscription.SubscribedState, subA.State())
+		require.Equal(t, subscription.SubscribedState, subB.State())
+	})
+
+	t.Run("Unrelated manager-lock contention does not drop recovery", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		sub := &subscription.Subscription{Channel: "unrelatedContentionTest"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
+		unsubCalls := 0
+		subCalls := 0
+		m.Unsubscriber = func(subscription.List) error {
+			unsubCalls++
+			return nil
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			subCalls++
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		m.m.Lock()
+		recovered := make(chan error, 1)
+		preLockReached := make(chan struct{})
+		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+			if s == sub {
+				close(preLockReached)
+			}
+		}
+
+		go func() {
+			recovered <- m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+
+		<-preLockReached
+		require.Equal(t, 0, unsubCalls)
+		require.Equal(t, 0, subCalls)
+
+		m.m.Unlock()
+		err := <-recovered
+		require.NoError(t, err)
+		require.Equal(t, 1, unsubCalls)
+		require.Equal(t, 1, subCalls)
+		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
+	t.Run("Bitfinex temporary key cleanup pattern during recovery", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexPatternTest"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
+
+		m.Unsubscriber = func(subs subscription.List) error {
+			return m.RemoveSubscriptions(nil, subs...)
+		}
+		recoveries := 0
+		m.Subscriber = func(subs subscription.List) error {
+			recoveries++
+			s := subs[0]
+			tempKey := fmt.Sprintf("subId-%d", recoveries)
+			s.Key = tempKey
+			if err := m.AddSubscriptions(nil, s); err != nil {
+				return err
+			}
+			defer func() {
+				_ = m.RemoveSubscriptions(nil, s)
+			}()
+
+			newSub := s.Clone()
+			newSub.Key = 42 + recoveries
+			return m.AddSuccessfulSubscriptions(nil, newSub)
+		}
+
+		// 1st recovery
+		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, realSub))
+		subs := m.GetSubscriptions()
+		require.Len(t, subs, 1, "store must only have 1 subscription after 1st recovery")
+		chanID, ok := subs[0].Key.(int)
+		require.True(t, ok, "key must be an int, not temporary string subId")
+		require.Equal(t, 43, chanID)
+
+		// 2nd recovery
+		currentSub := subs[0]
+		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, currentSub))
+		subs = m.GetSubscriptions()
+		require.Len(t, subs, 1, "store must only have 1 subscription after 2nd recovery")
+		chanID, ok = subs[0].Key.(int)
+		require.True(t, ok, "key must be an int, not temporary string subId")
+		require.Equal(t, 44, chanID)
+
+		// Unsubscribe all
+		require.NoError(t, m.RemoveSubscriptions(nil, subs...))
+		require.Empty(t, m.GetSubscriptions())
+	})
+
+	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		m.features.Subscribe = true
+		m.features.Unsubscribe = true
+		m.state.Store(connectedState)
+		m.enabled.Store(true)
+
+		sub := &subscription.Subscription{Channel: "flushAfterFailTest"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+		m.Unsubscriber = func(subs subscription.List) error {
+			return m.RemoveSubscriptions(nil, subs...)
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			return errDastardlyReason
+		}
+
+		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
+		require.Equal(t, subscription.ResubscribingState, sub.State())
+		require.Same(t, sub, m.GetSubscription(sub))
+
+		m.GenerateSubs = func() (subscription.List, error) {
+			return subscription.List{}, nil
+		}
+		require.NoError(t, m.FlushChannels(t.Context()))
+		require.Nil(t, m.GetSubscription(sub))
+		require.Equal(t, subscription.UnsubscribedState, sub.State())
 	})
 }
 
@@ -350,6 +538,25 @@ func TestCheckSubscriptions(t *testing.T) {
 	require.NoError(t, ws.AddSuccessfulSubscriptions(conn, retained))
 	require.NoError(t, retained.SetState(subscription.ResubscribingState))
 	require.NoError(t, ws.checkSubscriptions(conn, subscription.List{retained}))
+
+	ws.MaxSubscriptionsPerConnection = 2
+	capConn := &connection{subscriptions: subscription.NewStore()}
+	ws.connections[capConn] = &websocket{
+		subscriptions: capConn.Subscriptions(),
+		connections:   []Connection{capConn},
+	}
+	sub1 := &subscription.Subscription{Key: 101, Channel: "capSub1"}
+	sub2 := &subscription.Subscription{Key: 102, Channel: "capSub2"}
+	require.NoError(t, ws.AddSuccessfulSubscriptions(capConn, sub1, sub2))
+
+	// Full connection (2/2). Recovering existing sub1 in ResubscribingState must succeed:
+	require.NoError(t, sub1.SetState(subscription.ResubscribingState))
+	require.NoError(t, ws.checkSubscriptions(capConn, subscription.List{sub1}))
+
+	// Unrelated incoming subscription must be rejected:
+	unrelated := &subscription.Subscription{Key: 103, Channel: "unrelated"}
+	err = ws.checkSubscriptions(capConn, subscription.List{unrelated})
+	require.ErrorIs(t, err, errSubscriptionsExceedsLimit)
 }
 
 func TestUpdateChannelSubscriptions(t *testing.T) {
@@ -1811,6 +2018,57 @@ func TestResubscribeFromConnection(t *testing.T) {
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded, "must error when connection capacity is consumed during resubscription")
 		assert.False(t, subscriberCalled, "subscriber should not be called when the connection has no capacity")
+	})
+	t.Run("Concurrent recovery coalesced", func(t *testing.T) {
+		m := NewManager()
+		connStore := subscription.NewStore()
+		sub := &subscription.Subscription{Channel: "connCoalesce"}
+		require.NoError(t, connStore.Add(sub))
+		require.NoError(t, sub.SetState(subscription.SubscribedState))
+		m.subscriptions = connStore
+		conn := &connection{subscriptions: connStore}
+
+		firstUnsub := make(chan struct{})
+		secondPreLock := make(chan struct{})
+		releaseFirst := make(chan struct{})
+		unsubCalls := 0
+		m.Unsubscriber = func(subscription.List) error {
+			unsubCalls++
+			if unsubCalls == 1 {
+				close(firstUnsub)
+				<-releaseFirst
+			}
+			return nil
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			return m.AddSuccessfulSubscriptions(conn, subs...)
+		}
+
+		var firstErr, secondErr error
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			firstErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+		}()
+		<-firstUnsub
+		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+			if s == sub {
+				close(secondPreLock)
+			}
+		}
+		go func() {
+			defer wg.Done()
+			secondErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
+		}()
+		<-secondPreLock
+		close(releaseFirst)
+		wg.Wait()
+
+		require.NoError(t, firstErr)
+		require.NoError(t, secondErr)
+		require.Equal(t, 1, unsubCalls)
+		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
 }
 

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -228,21 +228,9 @@ func TestResubscribe(t *testing.T) {
 	})
 }
 
-func TestUnsubscribeForResubscribeErrors(t *testing.T) {
+func TestAllSubscriptionsState(t *testing.T) {
 	t.Parallel()
-	m := NewManager()
 	sub := &subscription.Subscription{Channel: "sub"}
-
-	err := m.unsubscribeForResubscribe(t.Context(), nil, nil, subscription.List{sub})
-	assert.ErrorIs(t, err, common.ErrNilPointer)
-
-	store := subscription.NewStore()
-	err = m.unsubscribeForResubscribe(t.Context(), nil, store, subscription.List{sub})
-	assert.ErrorIs(t, err, ErrSubscriptionsNotRemoved)
-
-	require.NoError(t, store.Add(sub))
-	err = m.unsubscribeForResubscribe(t.Context(), nil, store, subscription.List{sub})
-	assert.ErrorIs(t, err, common.ErrNilPointer)
 	assert.True(t, allSubscriptionsState(subscription.List{sub}, subscription.InactiveState))
 	assert.False(t, allSubscriptionsState(subscription.List{sub}, subscription.SubscribedState))
 }
@@ -1789,6 +1777,7 @@ func TestResubscribeFromConnection(t *testing.T) {
 		sub := &subscription.Subscription{Channel: "sub"}
 		require.NoError(t, m.subscriptions.Add(sub), "subscription must be added to the manager store")
 		conn := &connection{subscriptions: subscription.NewStore()}
+		m.Unsubscriber = func(subscription.List) error { return nil }
 		subscriberCalled := false
 		m.Subscriber = func(subscription.List) error {
 			subscriberCalled = true

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -13,7 +13,6 @@ import (
 	gws "github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 	"github.com/thrasher-corp/gocryptotrader/exchanges/subscription"
@@ -21,7 +20,6 @@ import (
 )
 
 func TestSubscribeUnsubscribe(t *testing.T) {
-
 	t.Parallel()
 
 	ws := NewManager()
@@ -51,29 +49,21 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	bySub := ws.GetSubscription(subscription.Subscription{Channel: "TestSub"})
 
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
-
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
 
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
-
 	}
 
 	if assert.NotNil(t, ws.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
-
 		assert.Equal(t, "TestSub2", ws.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
-
 	}
 
 	if assert.NotNil(t, ws.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
-
 		assert.Equal(t, "TestSub3", ws.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
-
 	}
 
 	if assert.NotNil(t, ws.GetSubscription(42), "GetSubscription by int key should find a channel") {
-
 		assert.Equal(t, "TestSub4", ws.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
-
 	}
 
 	assert.Nil(t, ws.GetSubscription(nil), "GetSubscription by nil should return nil")
@@ -103,7 +93,6 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	assert.NoError(t, multi.Setup(set))
 
 	amazingCandidate := &ConnectionSetup{
-
 		URL: "AMAZING",
 
 		Connector: func(context.Context, Connection) error { return nil },
@@ -111,15 +100,11 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 		GenerateSubscriptions: ws.GenerateSubs,
 
 		Subscriber: func(ctx context.Context, c Connection, s subscription.List) error {
-
 			return currySimpleSubConn(multi)(ctx, c, s)
-
 		},
 
 		Unsubscriber: func(ctx context.Context, c Connection, s subscription.List) error {
-
 			return currySimpleUnsubConn(multi)(ctx, c, s)
-
 		},
 
 		Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -130,7 +115,6 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	amazingConn := multi.createConnectionFromSetup(amazingCandidate)
 
 	multi.connections = map[Connection]*websocket{
-
 		amazingConn: multi.connectionManager[0],
 	}
 
@@ -165,29 +149,21 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	bySub = multi.GetSubscription(subscription.Subscription{Channel: "TestSub"})
 
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
-
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
 
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
-
 	}
 
 	if assert.NotNil(t, multi.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
-
 		assert.Equal(t, "TestSub2", multi.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
-
 	}
 
 	if assert.NotNil(t, multi.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
-
 		assert.Equal(t, "TestSub3", multi.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
-
 	}
 
 	if assert.NotNil(t, multi.GetSubscription(42), "GetSubscription by int key should find a channel") {
-
 		assert.Equal(t, "TestSub4", multi.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
-
 	}
 
 	assert.Nil(t, multi.GetSubscription(nil), "GetSubscription by nil should return nil")
@@ -207,13 +183,10 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	err = multi.SubscribeToChannels(t.Context(), amazingConn, subscription.List{nil})
 
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when list contains a nil subscription")
-
 }
 
 // TestResubscribe tests Resubscribing to existing subscriptions
-
 func TestResubscribe(t *testing.T) {
-
 	t.Parallel()
 
 	ws := NewManager()
@@ -243,7 +216,6 @@ func TestResubscribe(t *testing.T) {
 	assert.NoError(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), "Resubscribe should not error now the channel is subscribed")
 
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -259,17 +231,13 @@ func TestResubscribe(t *testing.T) {
 		subscribeCalls := 0
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			subscribeCalls++
 
 			if subscribeCalls == 1 {
-
 				return errDastardlyReason
-
 			}
 
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
@@ -283,11 +251,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, subscription.SubscribedState, sub.State())
 
 		require.Equal(t, 2, subscribeCalls)
-
 	})
 
 	t.Run("Concurrent recovery is serialised", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -305,11 +271,9 @@ func TestResubscribe(t *testing.T) {
 		unsubscribes := 0
 
 		m.Unsubscriber = func(subscription.List) error {
-
 			unsubscribes++
 
 			switch unsubscribes {
-
 			case 1:
 
 				close(firstUnsubscribe)
@@ -319,17 +283,13 @@ func TestResubscribe(t *testing.T) {
 			case 2:
 
 				close(secondUnsubscribe)
-
 			}
 
 			return nil
-
 		}
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		var firstErr, secondErr error
@@ -339,11 +299,9 @@ func TestResubscribe(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-
 			defer wg.Done()
 
 			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
-
 		}()
 
 		<-firstUnsubscribe
@@ -351,21 +309,15 @@ func TestResubscribe(t *testing.T) {
 		var signalSecond sync.Once
 
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
-
 			if s == sub {
-
 				signalSecond.Do(func() { close(secondUnsubscribe) })
-
 			}
-
 		}
 
 		go func() {
-
 			defer wg.Done()
 
 			secondErr = m.ResubscribeToChannel(t.Context(), nil, sub)
-
 		}()
 
 		<-secondUnsubscribe
@@ -381,11 +333,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 1, unsubscribes)
 
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 	})
 
 	t.Run("Different subscriptions recover concurrently", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -407,47 +357,35 @@ func TestResubscribe(t *testing.T) {
 		releaseSubA := make(chan struct{})
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			unsubsMu.Lock()
 
 			for _, s := range subs {
-
 				unsubscribed[s.Channel]++
-
 			}
 
 			unsubsMu.Unlock()
 
 			for _, s := range subs {
-
 				if s.Channel == "subA" {
-
 					close(subAUnsubStarted)
 
 					<-releaseSubA
-
 				}
-
 			}
 
 			return nil
-
 		}
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			unsubsMu.Lock()
 
 			for _, s := range subs {
-
 				subscribed[s.Channel]++
-
 			}
 
 			unsubsMu.Unlock()
 
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		var wg sync.WaitGroup
@@ -457,11 +395,9 @@ func TestResubscribe(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-
 			defer wg.Done()
 
 			errA = m.ResubscribeToChannel(t.Context(), nil, subA)
-
 		}()
 
 		<-subAUnsubStarted
@@ -471,21 +407,15 @@ func TestResubscribe(t *testing.T) {
 		var signalSubB sync.Once
 
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
-
 			if s == subB {
-
 				signalSubB.Do(func() { close(subBPreLock) })
-
 			}
-
 		}
 
 		go func() {
-
 			defer wg.Done()
 
 			errB = m.ResubscribeToChannel(t.Context(), nil, subB)
-
 		}()
 
 		<-subBPreLock
@@ -509,11 +439,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, subscription.SubscribedState, subA.State())
 
 		require.Equal(t, subscription.SubscribedState, subB.State())
-
 	})
 
 	t.Run("Unrelated manager-lock contention does not drop recovery", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -527,19 +455,15 @@ func TestResubscribe(t *testing.T) {
 		subCalls := 0
 
 		m.Unsubscriber = func(subscription.List) error {
-
 			unsubCalls++
 
 			return nil
-
 		}
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			subCalls++
 
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		m.m.Lock()
@@ -551,19 +475,13 @@ func TestResubscribe(t *testing.T) {
 		var signalPreLock sync.Once
 
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
-
 			if s == sub {
-
 				signalPreLock.Do(func() { close(preLockReached) })
-
 			}
-
 		}
 
 		go func() {
-
 			recovered <- m.ResubscribeToChannel(t.Context(), nil, sub)
-
 		}()
 
 		<-preLockReached
@@ -583,11 +501,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 1, subCalls)
 
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 	})
 
 	t.Run("Bitfinex temporary key cleanup pattern during recovery", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -597,15 +513,12 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			return m.RemoveSubscriptions(nil, subs...)
-
 		}
 
 		recoveries := 0
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			recoveries++
 
 			s := subs[0]
@@ -615,15 +528,11 @@ func TestResubscribe(t *testing.T) {
 			s.Key = tempKey
 
 			if err := m.AddSubscriptions(nil, s); err != nil {
-
 				return err
-
 			}
 
 			defer func() {
-
 				_ = m.RemoveSubscriptions(nil, s)
-
 			}()
 
 			newSub := s.Clone()
@@ -631,7 +540,6 @@ func TestResubscribe(t *testing.T) {
 			newSub.Key = 42 + recoveries
 
 			return m.AddSuccessfulSubscriptions(nil, newSub)
-
 		}
 
 		// 1st recovery
@@ -669,11 +577,9 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.RemoveSubscriptions(nil, subs...))
 
 		require.Empty(t, m.GetSubscriptions())
-
 	})
 
 	t.Run("Failed recovery does not restore stale key when replacement is live", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -683,25 +589,19 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			return m.RemoveSubscriptions(nil, subs...)
-
 		}
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			newSub := subs[0].Clone()
 
 			newSub.Key = 43
 
 			if err := m.AddSuccessfulSubscriptions(nil, newSub); err != nil {
-
 				return err
-
 			}
 
 			return errDastardlyReason
-
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, realSub), errDastardlyReason)
@@ -715,21 +615,17 @@ func TestResubscribe(t *testing.T) {
 		require.True(t, ok)
 
 		require.Equal(t, 43, chanID)
-
 	})
 
 	t.Run("Nil subscription rejected", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, nil), common.ErrNilPointer)
-
 	})
 
 	t.Run("Coalesced waiter retries when leader recovery fails", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -749,11 +645,9 @@ func TestResubscribe(t *testing.T) {
 		calls := 0
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			calls++
 
 			if calls == 1 {
-
 				close(firstSubscribe)
 
 				<-releaseFirstSubscribe
@@ -761,11 +655,9 @@ func TestResubscribe(t *testing.T) {
 				_ = subs[0].SetState(subscription.SubscribedState)
 
 				return errDastardlyReason
-
 			}
 
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		var leaderErr, waiterErr error
@@ -775,11 +667,9 @@ func TestResubscribe(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-
 			defer wg.Done()
 
 			leaderErr = m.ResubscribeToChannel(t.Context(), nil, sub)
-
 		}()
 
 		<-firstSubscribe
@@ -787,21 +677,15 @@ func TestResubscribe(t *testing.T) {
 		var signalWaiter sync.Once
 
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
-
 			if s == sub {
-
 				signalWaiter.Do(func() { close(waiterPreLock) })
-
 			}
-
 		}
 
 		go func() {
-
 			defer wg.Done()
 
 			waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub)
-
 		}()
 
 		<-waiterPreLock
@@ -817,11 +701,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 2, calls)
 
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 	})
 
 	t.Run("Sibling channel subscription does not block recovery restore", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -837,15 +719,11 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sibling, failing))
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			return m.RemoveSubscriptions(nil, subs...)
-
 		}
 
 		m.Subscriber = func(subscription.List) error {
-
 			return errDastardlyReason
-
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, failing), errDastardlyReason)
@@ -855,11 +733,9 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, subscription.ResubscribingState, failing.State())
 
 		require.Equal(t, subscription.SubscribedState, sibling.State())
-
 	})
 
 	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
-
 		m := NewManager()
 
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -877,25 +753,19 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			return m.RemoveSubscriptions(nil, subs...)
-
 		}
 
 		subscribeCalls := 0
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			subscribeCalls++
 
 			if subscribeCalls == 1 {
-
 				return errDastardlyReason
-
 			}
 
 			return m.AddSuccessfulSubscriptions(nil, subs...)
-
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
@@ -905,9 +775,7 @@ func TestResubscribe(t *testing.T) {
 		require.Same(t, sub, m.GetSubscription(sub))
 
 		m.GenerateSubs = func() (subscription.List, error) {
-
 			return subscription.List{sub}, nil
-
 		}
 
 		require.NoError(t, m.FlushChannels(t.Context()))
@@ -919,9 +787,7 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 2, subscribeCalls)
 
 		m.GenerateSubs = func() (subscription.List, error) {
-
 			return subscription.List{}, nil
-
 		}
 
 		require.NoError(t, m.FlushChannels(t.Context()))
@@ -929,13 +795,10 @@ func TestResubscribe(t *testing.T) {
 		require.Nil(t, m.GetSubscription(sub))
 
 		require.Equal(t, subscription.UnsubscribedState, sub.State())
-
 	})
-
 }
 
 func TestAllSubscriptionsState(t *testing.T) {
-
 	t.Parallel()
 
 	sub := &subscription.Subscription{Channel: "sub"}
@@ -943,13 +806,10 @@ func TestAllSubscriptionsState(t *testing.T) {
 	assert.True(t, allSubscriptionsState(subscription.List{sub}, subscription.InactiveState))
 
 	assert.False(t, allSubscriptionsState(subscription.List{sub}, subscription.SubscribedState))
-
 }
 
 // TestSubscriptions tests adding, getting and removing subscriptions
-
 func TestSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
@@ -979,13 +839,10 @@ func TestSubscriptions(t *testing.T) {
 	require.NoError(t, w.AddSubscriptions(nil, s), "Adding first subscription must not error")
 
 	assert.Equal(t, subscription.ResubscribingState, s.State(), "Should not change resubscribing state")
-
 }
 
 // TestSuccessfulSubscriptions tests adding, getting and removing subscriptions
-
 func TestSuccessfulSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
@@ -1017,13 +874,10 @@ func TestSuccessfulSubscriptions(t *testing.T) {
 	w.subscriptions = nil
 
 	assert.ErrorIs(t, w.RemoveSubscriptions(nil, c), common.ErrNilPointer, "Should error correctly when nil websocket")
-
 }
 
 // TestGetSubscription logic test
-
 func TestGetSubscription(t *testing.T) {
-
 	t.Parallel()
 
 	assert.Nil(t, (*Manager).GetSubscription(nil, "imaginary"), "GetSubscription on a nil Websocket should return nil")
@@ -1039,13 +893,10 @@ func TestGetSubscription(t *testing.T) {
 	require.NoError(t, w.AddSubscriptions(nil, s), "AddSubscriptions must not error")
 
 	assert.Same(t, s, w.GetSubscription(42), "GetSubscription should delegate to the store")
-
 }
 
 // TestGetSubscriptions logic test
-
 func TestGetSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	assert.Nil(t, (*Manager).GetSubscriptions(nil), "GetSubscription on a nil Websocket should return nil")
@@ -1055,7 +906,6 @@ func TestGetSubscriptions(t *testing.T) {
 	w := NewManager()
 
 	s := subscription.List{
-
 		{Key: 42, Channel: "hello3"},
 
 		{Key: 45, Channel: "hello4"},
@@ -1066,11 +916,9 @@ func TestGetSubscriptions(t *testing.T) {
 	require.NoError(t, err, "AddSubscriptions must not error")
 
 	assert.ElementsMatch(t, s, w.GetSubscriptions(), "GetSubscriptions should return the correct channel details")
-
 }
 
 func TestCheckSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	ws := Manager{}
@@ -1120,7 +968,6 @@ func TestCheckSubscriptions(t *testing.T) {
 	conn := &connection{}
 
 	ws.connections = map[Connection]*websocket{
-
 		conn: {},
 	}
 
@@ -1147,7 +994,6 @@ func TestCheckSubscriptions(t *testing.T) {
 	capConn := &connection{subscriptions: subscription.NewStore()}
 
 	ws.connections[capConn] = &websocket{
-
 		subscriptions: capConn.Subscriptions(),
 
 		connections: []Connection{capConn},
@@ -1172,11 +1018,9 @@ func TestCheckSubscriptions(t *testing.T) {
 	err = ws.checkSubscriptions(capConn, subscription.List{unrelated})
 
 	require.ErrorIs(t, err, errSubscriptionsExceedsLimit)
-
 }
 
 func TestUpdateChannelSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	ws := NewManager()
@@ -1190,19 +1034,13 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 	require.Zero(t, store.Len())
 
 	ws.Subscriber = func(subs subscription.List) error {
-
 		for _, sub := range subs {
-
 			if err := store.Add(sub); err != nil {
-
 				return err
-
 			}
-
 		}
 
 		return nil
-
 	}
 
 	ws.subscriptions = store
@@ -1218,19 +1056,13 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	ws.Unsubscriber = func(subs subscription.List) error {
-
 		for _, sub := range subs {
-
 			if err := store.Remove(sub); err != nil {
-
 				return err
-
 			}
-
 		}
 
 		return nil
-
 	}
 
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{})
@@ -1238,15 +1070,12 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Zero(t, store.Len())
-
 }
 
 func TestInitSubscriptionStore(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("GlobalStore", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager := &Manager{}
@@ -1256,11 +1085,9 @@ func TestInitSubscriptionStore(t *testing.T) {
 		require.NotNil(t, store, "global subscription store must be initialised")
 
 		assert.Same(t, store, manager.subscriptions, "global subscription store should be retained on the manager")
-
 	})
 
 	t.Run("ManagedConnectionStore", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManagerWithStore(t, nil)
@@ -1274,53 +1101,34 @@ func TestInitSubscriptionStore(t *testing.T) {
 		assert.Same(t, store, manager.connectionManager[0].subscriptions, "managed websocket should retain the initialised store")
 
 		assert.NotSame(t, store, manager.subscriptions, "managed connection should keep an isolated subscription store")
-
 	})
-
 }
 
 func currySimpleSub(w *Manager) func(subscription.List) error {
-
 	return func(subs subscription.List) error {
-
 		return w.AddSuccessfulSubscriptions(nil, subs...)
-
 	}
-
 }
 
 func currySimpleSubConn(w *Manager) func(context.Context, Connection, subscription.List) error {
-
 	return func(_ context.Context, conn Connection, subs subscription.List) error {
-
 		return w.AddSuccessfulSubscriptions(conn, subs...)
-
 	}
-
 }
 
 func currySimpleUnsub(w *Manager) func(subscription.List) error {
-
 	return func(unsubs subscription.List) error {
-
 		return w.RemoveSubscriptions(nil, unsubs...)
-
 	}
-
 }
 
 func currySimpleUnsubConn(w *Manager) func(context.Context, Connection, subscription.List) error {
-
 	return func(_ context.Context, conn Connection, unsubs subscription.List) error {
-
 		return w.RemoveSubscriptions(conn, unsubs...)
-
 	}
-
 }
 
 func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscription.Store) (*Manager, Connection) {
-
 	t.Helper()
 
 	manager := NewManager()
@@ -1332,21 +1140,15 @@ func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscriptio
 	require.NoError(t, manager.Setup(setup))
 
 	ws := &websocket{
-
 		setup: &ConnectionSetup{
-
 			URL: "wss://managed-subscriptions.test/ws",
 
 			Subscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
-
 				return manager.AddSuccessfulSubscriptions(conn, subs...)
-
 			},
 
 			Unsubscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
-
 				return manager.RemoveSubscriptions(conn, subs...)
-
 			},
 		},
 
@@ -1354,7 +1156,6 @@ func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscriptio
 	}
 
 	conn := &connection{
-
 		URL: ws.setup.URL,
 
 		subscriptions: subscription.NewStore(),
@@ -1371,19 +1172,15 @@ func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscriptio
 	manager.connectionManagerMu.Unlock()
 
 	return manager, conn
-
 }
 
 func newManagedSubscriptionTestManager(t *testing.T) (*Manager, Connection) {
-
 	t.Helper()
 
 	return newManagedSubscriptionTestManagerWithStore(t, subscription.NewStore())
-
 }
 
 func startSubscriptionReaders(manager *Manager) func() {
-
 	done := make(chan struct{})
 
 	var wg sync.WaitGroup
@@ -1391,13 +1188,9 @@ func startSubscriptionReaders(manager *Manager) func() {
 	var once sync.Once
 
 	for range 4 {
-
 		wg.Go(func() {
-
 			for {
-
 				select {
-
 				case <-done:
 
 					return
@@ -1407,31 +1200,21 @@ func startSubscriptionReaders(manager *Manager) func() {
 					_ = manager.GetSubscription("missing")
 
 					_ = manager.GetSubscriptions()
-
 				}
-
 			}
-
 		})
-
 	}
 
 	return func() {
-
 		once.Do(func() {
-
 			close(done)
 
 			wg.Wait()
-
 		})
-
 	}
-
 }
 
 func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error) {
-
 	t.Helper()
 
 	start := make(chan struct{})
@@ -1441,15 +1224,11 @@ func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error)
 	var wg sync.WaitGroup
 
 	for i := range workers {
-
 		wg.Go(func() {
-
 			<-start
 
 			errs <- op(i)
-
 		})
-
 	}
 
 	close(start)
@@ -1459,34 +1238,26 @@ func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error)
 	close(errs)
 
 	for err := range errs {
-
 		require.NoError(t, err)
-
 	}
-
 }
 
 func newConcurrentSubscription(channel string, index int) *subscription.Subscription {
-
 	name := fmt.Sprintf("%s-%d", channel, index)
 
 	return &subscription.Subscription{
-
 		Key: name,
 
 		Channel: name,
 	}
-
 }
 
 func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
-
 	t.Parallel()
 
 	const workers = 32
 
 	t.Run("AddSubscriptions", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
@@ -1498,15 +1269,11 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		subs := make(subscription.List, workers)
 
 		for i := range workers {
-
 			subs[i] = newConcurrentSubscription("add", i)
-
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 			return manager.AddSubscriptions(conn, subs[i])
-
 		})
 
 		stopReaders()
@@ -1514,17 +1281,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		require.Len(t, manager.GetSubscriptions(), workers)
 
 		for _, sub := range subs {
-
 			require.Same(t, sub, manager.GetSubscription(sub))
 
 			assert.Equal(t, subscription.SubscribingState, sub.State())
-
 		}
-
 	})
 
 	t.Run("AddSuccessfulSubscriptions", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
@@ -1536,15 +1299,11 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		subs := make(subscription.List, workers)
 
 		for i := range workers {
-
 			subs[i] = newConcurrentSubscription("success", i)
-
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 			return manager.AddSuccessfulSubscriptions(conn, subs[i])
-
 		})
 
 		stopReaders()
@@ -1552,17 +1311,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		require.Len(t, manager.GetSubscriptions(), workers)
 
 		for _, sub := range subs {
-
 			require.Same(t, sub, manager.GetSubscription(sub))
 
 			assert.Equal(t, subscription.SubscribedState, sub.State())
-
 		}
-
 	})
 
 	t.Run("RemoveSubscriptions", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
@@ -1570,9 +1325,7 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		subs := make(subscription.List, workers)
 
 		for i := range workers {
-
 			subs[i] = newConcurrentSubscription("remove", i)
-
 		}
 
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
@@ -1582,9 +1335,7 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 			return manager.RemoveSubscriptions(conn, subs[i])
-
 		})
 
 		stopReaders()
@@ -1592,17 +1343,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		assert.Empty(t, manager.GetSubscriptions())
 
 		for _, sub := range subs {
-
 			assert.Nil(t, manager.GetSubscription(sub))
 
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
-
 		}
-
 	})
 
 	t.Run("SubscribeToChannels", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
@@ -1614,15 +1361,11 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		subs := make(subscription.List, workers)
 
 		for i := range workers {
-
 			subs[i] = newConcurrentSubscription("subscribe", i)
-
 		}
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 			return manager.SubscribeToChannels(t.Context(), conn, subscription.List{subs[i]})
-
 		})
 
 		stopReaders()
@@ -1630,17 +1373,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		require.Len(t, manager.GetSubscriptions(), workers)
 
 		for _, sub := range subs {
-
 			require.Same(t, sub, manager.GetSubscription(sub))
 
 			assert.Equal(t, subscription.SubscribedState, sub.State())
-
 		}
-
 	})
 
 	t.Run("UnsubscribeChannels", func(t *testing.T) {
-
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
@@ -1648,9 +1387,7 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		subs := make(subscription.List, workers)
 
 		for i := range workers {
-
 			subs[i] = newConcurrentSubscription("unsubscribe", i)
-
 		}
 
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
@@ -1660,9 +1397,7 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 			return manager.UnsubscribeChannels(t.Context(), conn, subscription.List{subs[i]})
-
 		})
 
 		stopReaders()
@@ -1670,19 +1405,14 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		assert.Empty(t, manager.GetSubscriptions())
 
 		for _, sub := range subs {
-
 			assert.Nil(t, manager.GetSubscription(sub))
 
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
-
 		}
-
 	})
-
 }
 
 func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
-
 	t.Parallel()
 
 	const workers = 32
@@ -1696,15 +1426,11 @@ func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
 	subs := make(subscription.List, workers)
 
 	for i := range workers {
-
 		subs[i] = newConcurrentSubscription("initialise", i)
-
 	}
 
 	runConcurrentSubscriptionOps(t, workers, func(i int) error {
-
 		return manager.AddSuccessfulSubscriptions(conn, subs[i])
-
 	})
 
 	stopReaders()
@@ -1712,15 +1438,11 @@ func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
 	require.Len(t, manager.GetSubscriptions(), workers)
 
 	for _, sub := range subs {
-
 		require.Same(t, sub, manager.GetSubscription(sub))
-
 	}
-
 }
 
 func TestFlushChannelsConcurrentReaders(t *testing.T) {
-
 	t.Parallel()
 
 	manager, conn := newManagedSubscriptionTestManager(t)
@@ -1732,16 +1454,13 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 	manager.MaxSubscriptionsPerConnection = 2
 
 	expected := subscription.List{
-
 		newConcurrentSubscription("flush", 0),
 
 		newConcurrentSubscription("flush", 1),
 	}
 
 	manager.connectionManager[0].setup.GenerateSubscriptions = func() (subscription.List, error) {
-
 		return expected, nil
-
 	}
 
 	stopReaders := startSubscriptionReaders(manager)
@@ -1749,9 +1468,7 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 	defer stopReaders()
 
 	runConcurrentSubscriptionOps(t, 8, func(int) error {
-
 		return manager.FlushChannels(t.Context())
-
 	})
 
 	stopReaders()
@@ -1761,15 +1478,11 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 	require.Len(t, conn.Subscriptions().List(), len(expected))
 
 	for _, sub := range expected {
-
 		require.Same(t, sub, manager.GetSubscription(sub))
-
 	}
-
 }
 
 func TestFlushChannels(t *testing.T) {
-
 	t.Parallel()
 
 	// Enabled pairs/setup system
@@ -1787,7 +1500,6 @@ func TestFlushChannels(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotConnected, "FlushChannels should error correctly")
 
 	newgen := GenSubs{EnabledPairs: []currency.Pair{
-
 		currency.NewPair(currency.BTC, currency.AUD),
 
 		currency.NewBTCUSDT(),
@@ -1798,9 +1510,7 @@ func TestFlushChannels(t *testing.T) {
 	var cleanupMonitors sync.Once
 
 	cleanupW := func() {
-
 		cleanupMonitors.Do(func() { cleanupManagerMonitors(t, w) })
-
 	}
 
 	t.Cleanup(cleanupW)
@@ -1836,19 +1546,13 @@ func TestFlushChannels(t *testing.T) {
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "FlushChannels must error correctly on no subscriptions added")
 
 	w.Subscriber = func(subs subscription.List) error {
-
 		for _, sub := range subs {
-
 			if err := w.subscriptions.Add(sub); err != nil {
-
 				return err
-
 			}
-
 		}
 
 		return nil
-
 	}
 
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
@@ -1864,19 +1568,13 @@ func TestFlushChannels(t *testing.T) {
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotRemoved)
 
 	w.Unsubscriber = func(subs subscription.List) error {
-
 		for _, sub := range subs {
-
 			if err := w.subscriptions.Remove(sub); err != nil {
-
 				return err
-
 			}
-
 		}
 
 		return nil
-
 	}
 
 	assert.NoError(t, w.FlushChannels(t.Context()), "FlushChannels should not error")
@@ -1898,7 +1596,6 @@ func TestFlushChannels(t *testing.T) {
 	w.subscriptions = subscription.NewStore()
 
 	err = w.subscriptions.Add(&subscription.Subscription{
-
 		Key: 41,
 
 		Channel: "match channel",
@@ -1909,7 +1606,6 @@ func TestFlushChannels(t *testing.T) {
 	require.NoError(t, err, "AddSubscription must not error")
 
 	err = w.subscriptions.Add(&subscription.Subscription{
-
 		Key: 42,
 
 		Channel: "unsub channel",
@@ -1942,13 +1638,10 @@ func TestFlushChannels(t *testing.T) {
 	w.subscriptions = subscription.NewStore()
 
 	amazingCandidate := &ConnectionSetup{
-
 		URL: "ws" + mock.URL[len("http"):] + "/ws",
 
 		Connector: func(ctx context.Context, conn Connection) error {
-
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
-
 		},
 
 		GenerateSubscriptions: newgen.generateSubs,
@@ -1965,9 +1658,7 @@ func TestFlushChannels(t *testing.T) {
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "Must error when no subscriptions are added to the subscription store")
 
 	w.connectionManager[0].setup.Subscriber = func(ctx context.Context, c Connection, s subscription.List) error {
-
 		return currySimpleSubConn(w)(ctx, c, s)
-
 	}
 
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
@@ -1979,7 +1670,6 @@ func TestFlushChannels(t *testing.T) {
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
 
 	// Unsubscribe what's already subscribed. No subscriptions left over, which then forces the shutdown and removal
-
 	// of the connection from management.
 
 	w.features.Subscribe = true
@@ -1989,17 +1679,13 @@ func TestFlushChannels(t *testing.T) {
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotRemoved, "Must error when no subscriptions are removed from subscription store")
 
 	w.connectionManager[0].setup.Unsubscriber = func(ctx context.Context, c Connection, s subscription.List) error {
-
 		return currySimpleUnsubConn(w)(ctx, c, s)
-
 	}
 
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
-
 }
 
 // fakeConnection is a minimal Connection implementation used in cleanup tests.
-
 type fakeConnection struct {
 	Connection
 
@@ -2011,51 +1697,37 @@ type fakeConnection struct {
 }
 
 func (f *fakeConnection) Shutdown() error {
-
 	f.shutdownCalled = true
 
 	return nil
-
 }
 
 func (f *fakeConnection) Subscriptions() *subscription.Store {
-
 	if f.subscriptionsHook != nil {
-
 		f.subscriptionsHook()
-
 	}
 
 	return f.subscriptions
-
 }
 
 func cleanupManagedConnectionReaders(t *testing.T, m *Manager, ws *websocket) {
-
 	t.Helper()
 
 	if m == nil || ws == nil {
-
 		return
-
 	}
 
 	for _, conn := range m.snapshotManagedConnections(ws) {
-
 		_ = conn.Shutdown()
-
 	}
 
 	resetManagerForNextConnectAttempt(t, m)
-
 }
 
 func TestApplyTrackedSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("NoTrackedSubscriptionsNoOp", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2063,11 +1735,9 @@ func TestApplyTrackedSubscriptions(t *testing.T) {
 		conn := &fakeConnection{}
 
 		require.NoError(t, m.applyTrackedSubscriptions(conn, nil))
-
 	})
 
 	t.Run("RecordsInManagerAndConnectionStores", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2087,11 +1757,9 @@ func TestApplyTrackedSubscriptions(t *testing.T) {
 		require.NotNil(t, conn.subscriptions.Get(sub), "tracked subscription must be recorded in connection store")
 
 		assert.Equal(t, subscription.SubscribedState, sub.State())
-
 	})
 
 	t.Run("ErrorsWhenConnectionStoreIsNil", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2107,17 +1775,13 @@ func TestApplyTrackedSubscriptions(t *testing.T) {
 		err := m.applyTrackedSubscriptions(conn, subscription.List{sub})
 
 		require.ErrorIs(t, err, common.ErrNilPointer)
-
 	})
-
 }
 
 func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("PassThroughWithoutTrackHook", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2125,7 +1789,6 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		subs := subscription.List{{Channel: "A"}}
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{},
 
 			subscriptions: subscription.NewStore(),
@@ -2138,11 +1801,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, subs, remaining)
-
 	})
 
 	t.Run("PropagatesTrackError", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2150,13 +1811,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		expectedErr := errors.New("track failed")
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
-
 					return nil, nil, expectedErr
-
 				},
 			},
 
@@ -2170,11 +1827,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 
 		assert.Nil(t, remaining)
-
 	})
 
 	t.Run("ErrorsWhenTrackedSubsNotRecordedOnWebsocketStore", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2184,13 +1839,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
-
 					return nil, subscription.List{trackedSub}, nil
-
 				},
 			},
 
@@ -2200,7 +1851,6 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		}
 
 		// Intentionally do not map conn -> ws; manager-level tracking goes to
-
 		// the global store, allowing validation to detect missing websocket state.
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{trackedSub})
@@ -2210,11 +1860,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded)
 
 		assert.Nil(t, remaining)
-
 	})
 
 	t.Run("ReturnsRemainingAndRecordsTracked", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2226,13 +1874,9 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, _ subscription.List) (subscription.List, subscription.List, error) {
-
 					return subscription.List{remainingSub}, subscription.List{trackedSub}, nil
-
 				},
 			},
 
@@ -2254,17 +1898,13 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 		require.NotNil(t, ws.subscriptions.Get(trackedSub))
 
 		require.NotNil(t, conn.subscriptions.Get(trackedSub))
-
 	})
-
 }
 
 func TestAbsorbTrackedSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("PassthroughWithoutTrackHook", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2272,7 +1912,6 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		subs := subscription.List{{Channel: "A"}}
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{},
 
 			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
@@ -2285,11 +1924,9 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		assert.Equal(t, subs, remaining)
 
 		assert.Empty(t, tracked)
-
 	})
 
 	t.Run("TracksAcrossConnectionsUntilEmpty", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2301,19 +1938,13 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 					if conn != conn1 {
-
 						return subs, nil, nil
-
 					}
 
 					return nil, subscription.List{tracked}, nil
-
 				},
 			},
 
@@ -2341,11 +1972,9 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		require.NotNil(t, conn1.subscriptions.Get(tracked))
 
 		assert.Nil(t, conn0.subscriptions.Get(tracked))
-
 	})
 
 	t.Run("PropagatesErrors", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2353,13 +1982,9 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		expectedErr := errors.New("track failed")
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
-
 					return nil, nil, expectedErr
-
 				},
 			},
 
@@ -2373,19 +1998,15 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 		assert.Nil(t, remaining)
 
 		assert.Nil(t, tracked)
-
 	})
-
 }
 
 func TestScaleConnectionsToSubscriptions(t *testing.T) {
-
 	t.Parallel()
 
 	// Common setup helper
 
 	setup := func(t *testing.T, isMultiConn bool) (*Manager, *websocket) {
-
 		t.Helper()
 
 		m := NewManager()
@@ -2397,35 +2018,25 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		// Mock server for dialing
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 			mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
-
 		}))
 
 		t.Cleanup(srv.Close)
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				URL: "ws" + srv.URL[len("http"):] + "/ws",
 
 				Connector: func(ctx context.Context, c Connection) error {
-
 					return c.Dial(ctx, gws.DefaultDialer, nil, nil)
-
 				},
 
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 					return m.AddSuccessfulSubscriptions(c, s...)
-
 				},
 
 				Unsubscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 					return m.RemoveSubscriptions(c, s...)
-
 				},
 
 				Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -2437,11 +2048,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		t.Cleanup(func() { cleanupManagedConnectionReaders(t, m, ws) })
 
 		return m, ws
-
 	}
 
 	t.Run("Nil ws", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, _ := setup(t, false)
@@ -2449,11 +2058,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		err := m.scaleConnectionsToSubscriptions(t.Context(), nil, nil)
 
 		require.ErrorIs(t, err, common.ErrNilPointer)
-
 	})
 
 	t.Run("No Changes", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2461,11 +2068,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
 
 		require.NoError(t, err)
-
 	})
 
 	t.Run("Scale Up (Add Subs)", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2479,11 +2084,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Equal(t, 3, ws.subscriptions.Len())
 
 		assert.Len(t, ws.connections, 2) // 2 per conn -> 2 conns
-
 	})
 
 	t.Run("Scale Down (Remove Subs)", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, true)
@@ -2507,11 +2110,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Equal(t, 0, ws.subscriptions.Len())
 
 		assert.Empty(t, ws.connections)
-
 	})
 
 	t.Run("Unsubscribe Error", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, true)
@@ -2525,19 +2126,15 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		// Now set error and remove
 
 		ws.setup.Unsubscriber = func(context.Context, Connection, subscription.List) error {
-
 			return errors.New("unsub fail")
-
 		}
 
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
 
 		require.ErrorContains(t, err, "unsub fail")
-
 	})
 
 	t.Run("Subscribe Error (Existing Connection)", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2549,9 +2146,7 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		// Set error
 
 		ws.setup.Subscriber = func(context.Context, Connection, subscription.List) error {
-
 			return errors.New("sub fail")
-
 		}
 
 		// Add another sub (should use existing connection)
@@ -2559,29 +2154,23 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}, {Channel: "B"}})
 
 		require.ErrorContains(t, err, "sub fail")
-
 	})
 
 	t.Run("Subscribe Error (New Connection)", func(t *testing.T) {
-
 		m, ws := setup(t, false)
 
 		// Set connector error
 
 		ws.setup.Connector = func(context.Context, Connection) error {
-
 			return errors.New("connect fail")
-
 		}
 
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}})
 
 		require.ErrorContains(t, err, "connect fail")
-
 	})
 
 	t.Run("Global Unsubscribe Fallback Success", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2601,11 +2190,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, in))
 
 		assert.Equal(t, 0, ws.subscriptions.Len())
-
 	})
 
 	t.Run("Missing Subscriptions After Subscribe", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2627,11 +2214,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.NotNil(t, ws.subscriptions.Get(s1))
 
 		assert.NotNil(t, ws.subscriptions.Get(s2))
-
 	})
 
 	t.Run("Multi-batch ConnectAndSubscribe Success", func(t *testing.T) {
-
 		t.Parallel()
 
 		m, ws := setup(t, false)
@@ -2645,11 +2230,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		// With max 2 subs per connection and 5 total, we expect 3 connections
 
 		assert.Len(t, ws.connections, 3)
-
 	})
 
 	t.Run("Track On Existing Connection Prevents New Connection", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2667,25 +2250,17 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		require.NoError(t, activeConn.subscriptions.Add(existing))
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				Connector: func(context.Context, Connection) error {
-
 					return errors.New("should not create a new connection")
-
 				},
 
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 					if len(subs) != 1 || subs[0].Channel != logical.Channel {
-
 						return subs, nil, nil
-
 					}
 
 					return nil, subscription.List{logical}, nil
-
 				},
 			},
 
@@ -2707,11 +2282,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Equal(t, 2, ws.subscriptions.Len())
 
 		assert.Equal(t, 2, activeConn.subscriptions.Len())
-
 	})
 
 	t.Run("Track On Existing Connection Targets Owning Connection", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2721,7 +2294,6 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 owns subA, conn1 owns subB. A logical sub "C" whose inverse
-
 		// lives on conn1 must be tracked on conn1, not conn0.
 
 		subA := &subscription.Subscription{Channel: "A"}
@@ -2741,29 +2313,21 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		var trackedOnConn Connection
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				Connector: func(context.Context, Connection) error {
-
 					return errors.New("should not create a new connection")
-
 				},
 
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 					// Only track when the connection owns subB (the inverse).
 
 					if conn.Subscriptions().Get(subB) == nil {
-
 						return subs, nil, nil
-
 					}
 
 					trackedOnConn = conn
 
 					return nil, subscription.List{logical}, nil
-
 				},
 			},
 
@@ -2791,11 +2355,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
 
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
-
 	})
 
 	t.Run("Track Before Generic Subscribe Prevents Misrouting", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2805,15 +2367,10 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 has subA and spare capacity (max=2, used=1).
-
 		// conn1 has subB (the inverse of logical sub C).
-
 		// Without the pre-subscribe tracking pass, the generic
-
 		// subscribeToConnection loop would route C to conn0 because
-
 		// it has capacity. The fix ensures absorbTrackedSubscriptions
-
 		// runs first, absorbing C onto conn1.
 
 		subA := &subscription.Subscription{Channel: "A"}
@@ -2833,29 +2390,20 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		var trackedOnConn Connection
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{
-
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 					return m.AddSuccessfulSubscriptions(c, s...)
-
 				},
 
 				Connector: func(context.Context, Connection) error {
-
 					return errors.New("should not create a new connection")
-
 				},
 
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 					// Only track when the connection owns subB (the inverse).
 
 					if conn.Subscriptions().Get(subB) == nil {
-
 						return subs, nil, nil
-
 					}
 
 					var remaining subscription.List
@@ -2863,23 +2411,18 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 					var tracked subscription.List
 
 					for _, s := range subs {
-
 						if s.Channel != logical.Channel {
-
 							remaining = append(remaining, s)
 
 							continue
-
 						}
 
 						trackedOnConn = conn
 
 						tracked = append(tracked, s)
-
 					}
 
 					return remaining, tracked, nil
-
 				},
 
 				Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -2909,11 +2452,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
 
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
-
 	})
 
 	t.Run("Cleanup Removes Empty Connections", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2923,7 +2464,6 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{},
 
 			subscriptions: subscription.NewStore(),
@@ -2954,11 +2494,9 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.Len(t, ws.connections, 1)
 
 		assert.Same(t, activeConn, ws.connections[0])
-
 	})
 
 	t.Run("Cleanup Keeps Freshly Added Connections", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -2968,7 +2506,6 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-
 			setup: &ConnectionSetup{},
 
 			subscriptions: subscription.NewStore(),
@@ -2987,9 +2524,7 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		var addFreshOnce sync.Once
 
 		emptyConn.subscriptionsHook = func() {
-
 			addFreshOnce.Do(func() {
-
 				m.connectionManagerMu.Lock()
 
 				m.connections[freshConn] = ws
@@ -2997,9 +2532,7 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 				ws.connections = append(ws.connections, freshConn)
 
 				m.connectionManagerMu.Unlock()
-
 			})
-
 		}
 
 		ws.connections = []Connection{emptyConn, activeConn}
@@ -3021,19 +2554,13 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		var haveActive, haveFresh bool
 
 		for _, conn := range ws.connections {
-
 			if conn == activeConn {
-
 				haveActive = true
-
 			}
 
 			if conn == freshConn {
-
 				haveFresh = true
-
 			}
-
 		}
 
 		assert.True(t, haveActive)
@@ -3043,13 +2570,10 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		assert.NotContains(t, m.connections, emptyConn)
 
 		assert.Same(t, ws, m.connections[freshConn])
-
 	})
-
 }
 
 func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
-
 	t.Parallel()
 
 	m := NewManager()
@@ -3065,9 +2589,7 @@ func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
-
 	}))
 
 	t.Cleanup(srv.Close)
@@ -3083,41 +2605,30 @@ func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
 	var trackCalls int
 
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
-
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
 
 		Connector: func(ctx context.Context, conn Connection) error {
-
 			connectorCalls++
 
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
-
 		},
 
 		GenerateSubscriptions: func() (subscription.List, error) {
-
 			return subscription.List{subA, subB}, nil
-
 		},
 
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 			return m.AddSuccessfulSubscriptions(c, s...)
-
 		},
 
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 			if len(subs) != 1 || subs[0] != subB {
-
 				return subs, nil, nil
-
 			}
 
 			trackCalls++
 
 			return nil, subscription.List{subB}, nil
-
 		},
 
 		Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -3134,11 +2645,9 @@ func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subA), "first subscription should be tracked logically")
 
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subB), "later tracked subscription should be tracked logically")
-
 }
 
 func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
-
 	t.Parallel()
 
 	m := NewManager()
@@ -3154,9 +2663,7 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
-
 	}))
 
 	t.Cleanup(srv.Close)
@@ -3172,7 +2679,6 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	trackedB := &subscription.Subscription{Channel: "tracked-B"}
 
 	trackable := map[*subscription.Subscription]bool{
-
 		trackedA: true,
 
 		trackedB: true,
@@ -3183,31 +2689,23 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	var trackBatchLens []int
 
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
-
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
 
 		Connector: func(ctx context.Context, conn Connection) error {
-
 			connectorCalls++
 
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
-
 		},
 
 		GenerateSubscriptions: func() (subscription.List, error) {
-
 			return subscription.List{realA, trackedA, realB, trackedB}, nil
-
 		},
 
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 			return m.AddSuccessfulSubscriptions(c, s...)
-
 		},
 
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 			trackBatchLens = append(trackBatchLens, len(subs))
 
 			remaining := make(subscription.List, 0, len(subs))
@@ -3215,27 +2713,20 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 			tracked := make(subscription.List, 0, len(subs))
 
 			for _, sub := range subs {
-
 				if !trackable[sub] {
-
 					remaining = append(remaining, sub)
 
 					continue
-
 				}
 
 				tracked = append(tracked, sub)
-
 			}
 
 			if len(tracked) == 0 {
-
 				return subs, nil, nil
-
 			}
 
 			return remaining, tracked, nil
-
 		},
 
 		Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -3260,11 +2751,9 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	assert.NotNil(t, ws.subscriptions.Get(realA), "real-A is tracked logically")
 
 	assert.NotNil(t, ws.subscriptions.Get(realB), "real-B is tracked logically")
-
 }
 
 func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
-
 	t.Parallel()
 
 	m := NewManager()
@@ -3280,9 +2769,7 @@ func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
-
 	}))
 
 	t.Cleanup(srv.Close)
@@ -3294,49 +2781,36 @@ func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
 	trackedSub := &subscription.Subscription{Channel: "tracked"}
 
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
-
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
 
 		Connector: func(ctx context.Context, conn Connection) error {
-
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
-
 		},
 
 		GenerateSubscriptions: func() (subscription.List, error) {
-
 			return subscription.List{realSub, trackedSub}, nil
-
 		},
 
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
-
 			return m.AddSuccessfulSubscriptions(c, s...)
-
 		},
 
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
-
 			remaining := make(subscription.List, 0, len(subs))
 
 			tracked := make(subscription.List, 0, len(subs))
 
 			for _, sub := range subs {
-
 				if sub == trackedSub {
-
 					tracked = append(tracked, sub)
 
 					continue
-
 				}
 
 				remaining = append(remaining, sub)
-
 			}
 
 			return remaining, tracked, nil
-
 		},
 
 		Handler: func(context.Context, Connection, []byte) error { return nil },
@@ -3349,15 +2823,12 @@ func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
 	require.NoError(t, m.Connect(t.Context()))
 
 	require.NotNil(t, ws.subscriptions.Get(trackedSub), "tracked subscriptions must be recorded by the manager")
-
 }
 
 func TestResubscribeFromConnection(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("Success", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3393,11 +2864,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.Contains(t, wsStore.List(), sub1, "sub1 must still be in websocket store")
 
 		require.Contains(t, connStore.List(), sub1, "sub1 must still be in connection store")
-
 	})
 
 	t.Run("NilConnection", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3405,11 +2874,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		err := m.ResubscribeFromConnection(t.Context(), nil, nil)
 
 		require.ErrorIs(t, err, common.ErrNilPointer)
-
 	})
 
 	t.Run("Bad state", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3435,11 +2902,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
 
 		require.NoError(t, err, "an interrupted recovery must be retryable")
-
 	})
 
 	t.Run("Bad unsub", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3463,11 +2928,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
 
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
-
 	})
 
 	t.Run("Bad sub", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3491,11 +2954,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
 
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
-
 	})
 
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3515,25 +2976,19 @@ func TestResubscribeFromConnection(t *testing.T) {
 		conn := &connection{subscriptions: connStore}
 
 		m.Unsubscriber = func(subs subscription.List) error {
-
 			return m.RemoveSubscriptions(conn, subs...)
-
 		}
 
 		subscribeCalls := 0
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			subscribeCalls++
 
 			if subscribeCalls == 1 {
-
 				return errAlreadyConnected
-
 			}
 
 			return m.AddSuccessfulSubscriptions(conn, subs...)
-
 		}
 
 		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
@@ -3553,11 +3008,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.Contains(t, connStore.List(), sub)
 
 		require.Same(t, sub, wsStore.Get(sub))
-
 	})
 
 	t.Run("Missing connection subscription", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3575,11 +3028,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		subscriberCalled := false
 
 		m.Subscriber = func(subscription.List) error {
-
 			subscriberCalled = true
 
 			return nil
-
 		}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
@@ -3587,11 +3038,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.ErrorIs(t, err, ErrSubscriptionsNotRemoved, "must error when the subscription is not owned by the connection")
 
 		assert.False(t, subscriberCalled, "subscriber should not be called for a subscription owned by another connection")
-
 	})
 
 	t.Run("Capacity consumed during unsubscribe", func(t *testing.T) {
-
 		t.Parallel()
 
 		m := NewManager()
@@ -3611,19 +3060,15 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.NoError(t, connStore.Add(sub), "subscription must be added to the connection store")
 
 		m.Unsubscriber = func(subscription.List) error {
-
 			return connStore.Add(other)
-
 		}
 
 		subscriberCalled := false
 
 		m.Subscriber = func(subscription.List) error {
-
 			subscriberCalled = true
 
 			return nil
-
 		}
 
 		conn := &connection{subscriptions: connStore}
@@ -3633,11 +3078,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded, "must error when connection capacity is consumed during resubscription")
 
 		assert.False(t, subscriberCalled, "subscriber should not be called when the connection has no capacity")
-
 	})
 
 	t.Run("Concurrent recovery coalesced", func(t *testing.T) {
-
 		m := NewManager()
 
 		wsStore := subscription.NewStore()
@@ -3665,25 +3108,19 @@ func TestResubscribeFromConnection(t *testing.T) {
 		unsubCalls := 0
 
 		m.Unsubscriber = func(subscription.List) error {
-
 			unsubCalls++
 
 			if unsubCalls == 1 {
-
 				close(firstUnsub)
 
 				<-releaseFirst
-
 			}
 
 			return nil
-
 		}
 
 		m.Subscriber = func(subs subscription.List) error {
-
 			return m.AddSuccessfulSubscriptions(conn, subs...)
-
 		}
 
 		var firstErr, secondErr error
@@ -3693,11 +3130,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-
 			defer wg.Done()
 
 			firstErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
-
 		}()
 
 		<-firstUnsub
@@ -3705,21 +3140,15 @@ func TestResubscribeFromConnection(t *testing.T) {
 		var signalSecondPreLock sync.Once
 
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
-
 			if s == sub {
-
 				signalSecondPreLock.Do(func() { close(secondPreLock) })
-
 			}
-
 		}
 
 		go func() {
-
 			defer wg.Done()
 
 			secondErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
-
 		}()
 
 		<-secondPreLock
@@ -3735,11 +3164,9 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.Equal(t, 1, unsubCalls)
 
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 	})
 
 	t.Run("Connection capacity discount is per subscription pointer", func(t *testing.T) {
-
 		t.Parallel()
 
 		store := subscription.NewStore()
@@ -3759,13 +3186,10 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.NoError(t, store.Add(other))
 
 		require.Equal(t, 1, connectionUsedCapacity(store, subscription.List{sub}))
-
 	})
-
 }
 
 func TestUnsubscribeFromConnection(t *testing.T) {
-
 	t.Parallel()
 
 	m := NewManager()
@@ -3799,9 +3223,7 @@ func TestUnsubscribeFromConnection(t *testing.T) {
 	require.NoError(t, m.subscriptions.Add(sub1))
 
 	m.Unsubscriber = func(subscription.List) error {
-
 		return errors.New("unsub failed")
-
 	}
 
 	_, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
@@ -3825,11 +3247,9 @@ func TestUnsubscribeFromConnection(t *testing.T) {
 	assert.Len(t, remaining, 1)
 
 	assert.Equal(t, "sub2", remaining[0].Channel)
-
 }
 
 func TestSubscribeToConnection(t *testing.T) {
-
 	t.Parallel()
 
 	m := NewManager()
@@ -3895,7 +3315,6 @@ func TestSubscribeToConnection(t *testing.T) {
 	m.MaxSubscriptionsPerConnection = 3
 
 	// subs has 3 items. Capacity is 3. Used is 1. Available is 2.
-
 	// Should subscribe to sub1, sub2. Return sub3.
 
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
@@ -3969,5 +3388,4 @@ func TestSubscribeToConnection(t *testing.T) {
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
 
 	require.NoError(t, err, "must not error when all subscriptions can be added, this exercises the path where available > len(subs)")
-
 }

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -427,16 +427,15 @@ func TestResubscribe(t *testing.T) {
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
 		m.Unsubscriber = func(subscription.List) error { return nil }
 
-		var leaderStarted sync.WaitGroup
-		leaderStarted.Add(1)
-		var releaseLeader sync.WaitGroup
-		releaseLeader.Add(1)
+		firstSubscribe := make(chan struct{})
+		releaseFirstSubscribe := make(chan struct{})
+		waiterPreLock := make(chan struct{})
 		calls := 0
 		m.Subscriber = func(subs subscription.List) error {
 			calls++
 			if calls == 1 {
-				leaderStarted.Done()
-				releaseLeader.Wait()
+				close(firstSubscribe)
+				<-releaseFirstSubscribe
 				_ = subs[0].SetState(subscription.SubscribedState)
 				return errDastardlyReason
 			}
@@ -450,18 +449,46 @@ func TestResubscribe(t *testing.T) {
 			defer wg.Done()
 			leaderErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-		leaderStarted.Wait()
+		<-firstSubscribe
+		var signalWaiter sync.Once
+		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+			if s == sub {
+				signalWaiter.Do(func() { close(waiterPreLock) })
+			}
+		}
 		go func() {
 			defer wg.Done()
 			waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-		releaseLeader.Done()
+		<-waiterPreLock
+		close(releaseFirstSubscribe)
 		wg.Wait()
 
 		require.ErrorIs(t, leaderErr, errDastardlyReason)
 		require.NoError(t, waiterErr)
 		require.Equal(t, 2, calls)
 		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
+	t.Run("Sibling channel subscription does not block recovery restore", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		btc := currency.NewBTCUSD()
+		eth := currency.NewPair(currency.ETH, currency.USDT)
+		sibling := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{eth}}
+		failing := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{btc}}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sibling, failing))
+		m.Unsubscriber = func(subs subscription.List) error {
+			return m.RemoveSubscriptions(nil, subs...)
+		}
+		m.Subscriber = func(subscription.List) error {
+			return errDastardlyReason
+		}
+
+		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, failing), errDastardlyReason)
+		require.Same(t, failing, m.GetSubscription(failing))
+		require.Equal(t, subscription.ResubscribingState, failing.State())
+		require.Equal(t, subscription.SubscribedState, sibling.State())
 	})
 
 	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
@@ -477,13 +504,26 @@ func TestResubscribe(t *testing.T) {
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-		m.Subscriber = func(subscription.List) error {
-			return errDastardlyReason
+		subscribeCalls := 0
+		m.Subscriber = func(subs subscription.List) error {
+			subscribeCalls++
+			if subscribeCalls == 1 {
+				return errDastardlyReason
+			}
+			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
 
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
 		require.Equal(t, subscription.ResubscribingState, sub.State())
 		require.Same(t, sub, m.GetSubscription(sub))
+
+		m.GenerateSubs = func() (subscription.List, error) {
+			return subscription.List{sub}, nil
+		}
+		require.NoError(t, m.FlushChannels(t.Context()))
+		require.Same(t, sub, m.GetSubscription(sub))
+		require.Equal(t, subscription.SubscribedState, sub.State())
+		require.Equal(t, 2, subscribeCalls)
 
 		m.GenerateSubs = func() (subscription.List, error) {
 			return subscription.List{}, nil
@@ -1965,21 +2005,23 @@ func TestResubscribeFromConnection(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		m := NewManager()
-		m.subscriptions = subscription.NewStore()
 		m.Unsubscriber = func(subscription.List) error { return nil }
 		m.Subscriber = func(subscription.List) error { return nil }
 		sub1 := &subscription.Subscription{Channel: "sub1"}
 		sub2 := &subscription.Subscription{Channel: "sub2"}
-		store := subscription.NewStore()
-		require.NoError(t, store.Add(sub1))
-		require.NoError(t, store.Add(sub2))
-		m.subscriptions = store
-		conn := &connection{subscriptions: store}
+		wsStore := subscription.NewStore()
+		connStore := subscription.NewStore()
+		require.NoError(t, wsStore.Add(sub1))
+		require.NoError(t, wsStore.Add(sub2))
+		require.NoError(t, connStore.Add(sub1))
+		require.NoError(t, connStore.Add(sub2))
+		m.subscriptions = wsStore
+		conn := &connection{subscriptions: connStore}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
 		require.NoError(t, err)
-		require.Contains(t, m.subscriptions.List(), sub1, "sub1 must still be in global store")
-		require.Contains(t, conn.subscriptions.List(), sub1, "sub1 must still be in global store")
+		require.Contains(t, wsStore.List(), sub1, "sub1 must still be in websocket store")
+		require.Contains(t, connStore.List(), sub1, "sub1 must still be in connection store")
 	})
 	t.Run("NilConnection", func(t *testing.T) {
 		t.Parallel()
@@ -2036,29 +2078,34 @@ func TestResubscribeFromConnection(t *testing.T) {
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
 		t.Parallel()
 		m := NewManager()
-		m.subscriptions = subscription.NewStore()
+		wsStore := subscription.NewStore()
+		connStore := subscription.NewStore()
+		m.subscriptions = wsStore
 		sub := &subscription.Subscription{Channel: "sub"}
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-		conn := &connection{subscriptions: m.subscriptions}
+		require.NoError(t, connStore.Add(sub))
+		conn := &connection{subscriptions: connStore}
 		m.Unsubscriber = func(subs subscription.List) error {
-			return m.RemoveSubscriptions(nil, subs...)
+			return m.RemoveSubscriptions(conn, subs...)
 		}
 		subscribeCalls := 0
-		m.Subscriber = func(subscription.List) error {
+		m.Subscriber = func(subs subscription.List) error {
 			subscribeCalls++
 			if subscribeCalls == 1 {
 				return errAlreadyConnected
 			}
-			return nil
+			return m.AddSuccessfulSubscriptions(conn, subs...)
 		}
 
 		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
 		require.Equal(t, subscription.ResubscribingState, sub.State())
-		require.Same(t, sub, m.GetSubscription(sub))
+		require.Contains(t, connStore.List(), sub, "failed recovery must restore into connection store")
+		require.Same(t, sub, wsStore.Get(sub))
 		require.NoError(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), "a transient subscribe failure must remain retryable")
 		require.Equal(t, 2, subscribeCalls)
 		require.Equal(t, subscription.SubscribedState, sub.State())
-		require.Same(t, sub, m.GetSubscription(sub))
+		require.Contains(t, connStore.List(), sub)
+		require.Same(t, sub, wsStore.Get(sub))
 	})
 	t.Run("Missing connection subscription", func(t *testing.T) {
 		t.Parallel()
@@ -2104,11 +2151,13 @@ func TestResubscribeFromConnection(t *testing.T) {
 	})
 	t.Run("Concurrent recovery coalesced", func(t *testing.T) {
 		m := NewManager()
+		wsStore := subscription.NewStore()
 		connStore := subscription.NewStore()
 		sub := &subscription.Subscription{Channel: "connCoalesce"}
+		require.NoError(t, wsStore.Add(sub))
 		require.NoError(t, connStore.Add(sub))
 		require.NoError(t, sub.SetState(subscription.SubscribedState))
-		m.subscriptions = connStore
+		m.subscriptions = wsStore
 		conn := &connection{subscriptions: connStore}
 
 		firstUnsub := make(chan struct{})
@@ -2153,6 +2202,20 @@ func TestResubscribeFromConnection(t *testing.T) {
 		require.NoError(t, secondErr)
 		require.Equal(t, 1, unsubCalls)
 		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
+
+	t.Run("Connection capacity discount is per subscription pointer", func(t *testing.T) {
+		t.Parallel()
+		store := subscription.NewStore()
+		sub := &subscription.Subscription{Channel: "cap"}
+		require.NoError(t, store.Add(sub))
+		require.NoError(t, sub.SetState(subscription.ResubscribingState))
+		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub, sub, sub}))
+		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub}))
+		other := &subscription.Subscription{Channel: "other"}
+		require.NoError(t, store.Add(other))
+		require.Equal(t, 1, connectionUsedCapacity(store, subscription.List{sub}))
 	})
 }
 

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -150,6 +150,84 @@ func TestResubscribe(t *testing.T) {
 	assert.ErrorIs(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), subscription.ErrNotFound, "Resubscribe should error when channel isn't subscribed yet")
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, channel), "Subscribe should not error")
 	assert.NoError(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), "Resubscribe should not error now the channel is subscribed")
+
+	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
+		t.Parallel()
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		sub := &subscription.Subscription{Channel: "retryResubTest"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+		m.Unsubscriber = func(subs subscription.List) error { return m.RemoveSubscriptions(nil, subs...) }
+		subscribeCalls := 0
+		m.Subscriber = func(subs subscription.List) error {
+			subscribeCalls++
+			if subscribeCalls == 1 {
+				return errDastardlyReason
+			}
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
+		require.Same(t, sub, m.GetSubscription(sub))
+		require.Equal(t, subscription.ResubscribingState, sub.State())
+		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, sub))
+		require.Equal(t, subscription.SubscribedState, sub.State())
+		require.Equal(t, 2, subscribeCalls)
+	})
+
+	t.Run("Concurrent recovery is serialized", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		sub := &subscription.Subscription{Channel: "serializedResubTest"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+		firstUnsubscribe := make(chan struct{})
+		secondUnsubscribe := make(chan struct{})
+		releaseFirst := make(chan struct{})
+		unsubscribes := 0
+		m.Unsubscriber = func(subscription.List) error {
+			unsubscribes++
+			switch unsubscribes {
+			case 1:
+				close(firstUnsubscribe)
+				<-releaseFirst
+			case 2:
+				close(secondUnsubscribe)
+			}
+			return nil
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			if unsubscribes == 1 {
+				return errDastardlyReason
+			}
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		var firstErr, secondErr error
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+		<-firstUnsubscribe
+		secondReady := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			close(secondReady)
+			secondErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+		<-secondReady
+		select {
+		case <-secondUnsubscribe:
+			t.Fatal("second recovery started before the first completed")
+		case <-time.After(100 * time.Millisecond):
+		}
+		close(releaseFirst)
+		wg.Wait()
+
+		require.ErrorIs(t, firstErr, errDastardlyReason)
+		require.NoError(t, secondErr)
+	})
 }
 
 // TestSubscriptions tests adding, getting and removing subscriptions
@@ -1625,7 +1703,7 @@ func TestResubscribeFromConnection(t *testing.T) {
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
-		require.ErrorIs(t, err, subscription.ErrInStateAlready, "must error when subscription is not in unsubscribed state")
+		require.NoError(t, err, "an interrupted recovery must be retryable")
 	})
 	t.Run("Bad unsub", func(t *testing.T) {
 		t.Parallel()
@@ -1656,6 +1734,28 @@ func TestResubscribeFromConnection(t *testing.T) {
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
+	})
+	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
+		t.Parallel()
+		m := NewManager()
+		m.subscriptions = subscription.NewStore()
+		sub := &subscription.Subscription{Channel: "sub"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+		conn := &connection{subscriptions: m.subscriptions}
+		m.Unsubscriber = func(subscription.List) error { return nil }
+		subscribeCalls := 0
+		m.Subscriber = func(subscription.List) error {
+			subscribeCalls++
+			if subscribeCalls == 1 {
+				return errAlreadyConnected
+			}
+			return m.AddSuccessfulSubscriptions(nil, sub)
+		}
+
+		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
+		require.NoError(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), "a transient subscribe failure must remain retryable")
+		require.Equal(t, 2, subscribeCalls)
+		require.Same(t, sub, m.GetSubscription(sub))
 	})
 	t.Run("Missing connection subscription", func(t *testing.T) {
 		t.Parallel()

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -175,7 +175,7 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 2, subscribeCalls)
 	})
 
-	t.Run("Concurrent recovery is serialized", func(t *testing.T) {
+	t.Run("Concurrent recovery is serialised", func(t *testing.T) {
 		m := NewManager()
 		require.NoError(t, m.Setup(newDefaultSetup()))
 		sub := &subscription.Subscription{Channel: "serializedResubTest"}

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -23,165 +23,110 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	t.Parallel()
 
 	ws := NewManager()
-
 	assert.NoError(t, ws.Setup(newDefaultSetup()), "WS Setup should not error")
 
 	ws.Subscriber = currySimpleSub(ws)
-
 	ws.Unsubscriber = currySimpleUnsub(ws)
 
 	subs, err := ws.GenerateSubs()
-
 	require.NoError(t, err, "Generating test subscriptions must not error")
-
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), nil, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
-
 	assert.NoError(t, ws.UnsubscribeChannels(t.Context(), nil, nil), "Unsubscribing from nil should not error")
-
 	assert.ErrorIs(t, ws.UnsubscribeChannels(t.Context(), nil, subs), subscription.ErrNotFound, "Unsubscribing should error when not subscribed")
-
 	assert.Nil(t, ws.GetSubscription(42), "GetSubscription on empty internal map should return")
-
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, subs), "Basic Subscribing should not error")
-
 	assert.Len(t, ws.GetSubscriptions(), 4, "Should have 4 subscriptions")
-
 	bySub := ws.GetSubscription(subscription.Subscription{Channel: "TestSub"})
-
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
-
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
 	}
-
 	if assert.NotNil(t, ws.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
 		assert.Equal(t, "TestSub2", ws.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
 	}
-
 	if assert.NotNil(t, ws.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
 		assert.Equal(t, "TestSub3", ws.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
 	}
-
 	if assert.NotNil(t, ws.GetSubscription(42), "GetSubscription by int key should find a channel") {
 		assert.Equal(t, "TestSub4", ws.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
 	}
-
 	assert.Nil(t, ws.GetSubscription(nil), "GetSubscription by nil should return nil")
-
 	assert.Nil(t, ws.GetSubscription(45), "GetSubscription by invalid key should return nil")
-
 	assert.ErrorIs(t, ws.SubscribeToChannels(t.Context(), nil, subs), subscription.ErrDuplicate, "Subscribe should error when already subscribed")
-
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, nil), "Subscribe to an nil List should not error")
-
 	assert.NoError(t, ws.UnsubscribeChannels(t.Context(), nil, subs), "Unsubscribing should not error")
 
 	ws.Subscriber = func(subscription.List) error { return errDastardlyReason }
-
 	assert.ErrorIs(t, ws.SubscribeToChannels(t.Context(), nil, subs), errDastardlyReason, "Should error correctly when error returned from Subscriber")
 
 	err = ws.SubscribeToChannels(t.Context(), nil, subscription.List{nil})
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when list contains a nil subscription")
 
 	multi := NewManager()
-
 	set := newDefaultSetup()
-
 	set.UseMultiConnectionManagement = true
-
 	assert.NoError(t, multi.Setup(set))
 
 	amazingCandidate := &ConnectionSetup{
-		URL: "AMAZING",
-
-		Connector: func(context.Context, Connection) error { return nil },
-
+		URL:                   "AMAZING",
+		Connector:             func(context.Context, Connection) error { return nil },
 		GenerateSubscriptions: ws.GenerateSubs,
-
 		Subscriber: func(ctx context.Context, c Connection, s subscription.List) error {
 			return currySimpleSubConn(multi)(ctx, c, s)
 		},
-
 		Unsubscriber: func(ctx context.Context, c Connection, s subscription.List) error {
 			return currySimpleUnsubConn(multi)(ctx, c, s)
 		},
-
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}
-
 	require.NoError(t, multi.SetupNewConnection(amazingCandidate))
 
 	amazingConn := multi.createConnectionFromSetup(amazingCandidate)
-
 	multi.connections = map[Connection]*websocket{
 		amazingConn: multi.connectionManager[0],
 	}
 
 	multiEmpty := NewManager()
-
 	multiEmpty.useMultiConnectionManagement = true
 
 	subs, err = amazingCandidate.GenerateSubscriptions()
-
 	require.NoError(t, err, "Generating test subscriptions must not error")
-
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), nil, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
-
 	assert.ErrorIs(t, new(Manager).UnsubscribeChannels(t.Context(), amazingConn, subs), common.ErrNilPointer, "Should error when unsubscribing with nil unsubscribe function")
-
 	assert.NoError(t, multi.UnsubscribeChannels(t.Context(), amazingConn, nil), "Unsubscribing from nil should not error")
-
 	assert.ErrorIs(t, multi.UnsubscribeChannels(t.Context(), amazingConn, subs), subscription.ErrNotFound, "Unsubscribing should error when not subscribed")
-
 	assert.Nil(t, multi.GetSubscription(42), "GetSubscription on empty internal map should return")
 
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), nil, subs), common.ErrNilPointer, "If no connection is set, Subscribe should error")
-
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), common.ErrNilPointer, "Basic Subscribing should error when connection is not present in ws map")
 
 	multi.connectionManager[0].connections = []Connection{amazingConn}
-
 	assert.NoError(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), "Basic Subscribing should not error")
-
 	assert.Len(t, multi.GetSubscriptions(), 4, "Should have 4 subscriptions")
-
 	bySub = multi.GetSubscription(subscription.Subscription{Channel: "TestSub"})
-
 	if assert.NotNil(t, bySub, "GetSubscription by subscription should find a channel") {
 		assert.Equal(t, "TestSub", bySub.Channel, "GetSubscription by default key should return a pointer a copy of the right channel")
-
 		assert.Same(t, bySub, subs[0], "GetSubscription returns the same pointer")
 	}
-
 	if assert.NotNil(t, multi.GetSubscription("purple"), "GetSubscription by string key should find a channel") {
 		assert.Equal(t, "TestSub2", multi.GetSubscription("purple").Channel, "GetSubscription by string key should return a pointer a copy of the right channel")
 	}
-
 	if assert.NotNil(t, multi.GetSubscription(testSubKey{"mauve"}), "GetSubscription by type key should find a channel") {
 		assert.Equal(t, "TestSub3", multi.GetSubscription(testSubKey{"mauve"}).Channel, "GetSubscription by type key should return a pointer a copy of the right channel")
 	}
-
 	if assert.NotNil(t, multi.GetSubscription(42), "GetSubscription by int key should find a channel") {
 		assert.Equal(t, "TestSub4", multi.GetSubscription(42).Channel, "GetSubscription by int key should return a pointer a copy of the right channel")
 	}
-
 	assert.Nil(t, multi.GetSubscription(nil), "GetSubscription by nil should return nil")
-
 	assert.Nil(t, multi.GetSubscription(45), "GetSubscription by invalid key should return nil")
-
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), subscription.ErrDuplicate, "Subscribe should error when already subscribed")
-
 	assert.NoError(t, multi.SubscribeToChannels(t.Context(), amazingConn, nil), "Subscribe to an nil List should not error")
-
 	assert.NoError(t, multi.UnsubscribeChannels(t.Context(), amazingConn, subs), "Unsubscribing should not error")
 
 	amazingCandidate.Subscriber = func(context.Context, Connection, subscription.List) error { return errDastardlyReason }
-
 	assert.ErrorIs(t, multi.SubscribeToChannels(t.Context(), amazingConn, subs), errDastardlyReason, "Should error correctly when error returned from Subscriber")
 
 	err = multi.SubscribeToChannels(t.Context(), amazingConn, subscription.List{nil})
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when list contains a nil subscription")
 }
 
@@ -192,901 +137,548 @@ func TestResubscribe(t *testing.T) {
 	ws := NewManager()
 
 	wackedOutSetup := newDefaultSetup()
-
 	wackedOutSetup.MaxWebsocketSubscriptionsPerConnection = -1
-
 	err := ws.Setup(wackedOutSetup)
-
 	assert.ErrorIs(t, err, errInvalidMaxSubscriptions, "Invalid MaxWebsocketSubscriptionsPerConnection should error")
 
 	err = ws.Setup(newDefaultSetup())
-
 	assert.NoError(t, err, "WS Setup should not error")
 
 	ws.Subscriber = currySimpleSub(ws)
-
 	ws.Unsubscriber = currySimpleUnsub(ws)
 
 	channel := subscription.List{{Channel: "resubTest"}}
 
 	assert.ErrorIs(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), subscription.ErrNotFound, "Resubscribe should error when channel isn't subscribed yet")
-
 	assert.NoError(t, ws.SubscribeToChannels(t.Context(), nil, channel), "Subscribe should not error")
-
 	assert.NoError(t, ws.ResubscribeToChannel(t.Context(), nil, channel[0]), "Resubscribe should not error now the channel is subscribed")
-
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		sub := &subscription.Subscription{Channel: "retryResubTest"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		m.Unsubscriber = func(subs subscription.List) error { return m.RemoveSubscriptions(nil, subs...) }
-
 		subscribeCalls := 0
-
 		m.Subscriber = func(subs subscription.List) error {
 			subscribeCalls++
-
 			if subscribeCalls == 1 {
 				return errDastardlyReason
 			}
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
-
 		require.Same(t, sub, m.GetSubscription(sub))
-
 		require.Equal(t, subscription.ResubscribingState, sub.State())
-
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, sub))
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 		require.Equal(t, 2, subscribeCalls)
 	})
-
 	t.Run("Concurrent recovery is serialised", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		sub := &subscription.Subscription{Channel: "serializedResubTest"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		firstUnsubscribe := make(chan struct{})
-
 		secondUnsubscribe := make(chan struct{})
-
 		releaseFirst := make(chan struct{})
-
 		unsubscribes := 0
-
 		m.Unsubscriber = func(subscription.List) error {
 			unsubscribes++
-
 			if unsubscribes == 1 {
 				close(firstUnsubscribe)
-
 				<-releaseFirst
 			}
-
 			return nil
 		}
-
 		m.Subscriber = func(subs subscription.List) error {
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		var firstErr, secondErr error
-
 		var wg sync.WaitGroup
-
 		wg.Add(2)
-
 		go func() {
 			defer wg.Done()
-
 			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-firstUnsubscribe
-
 		var signalSecond sync.Once
-
 		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalSecond.Do(func() { close(secondUnsubscribe) })
 			}
 		}
-
 		go func() {
 			defer wg.Done()
-
 			secondErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-secondUnsubscribe
-
 		close(releaseFirst)
-
 		wg.Wait()
-
 		require.NoError(t, firstErr)
-
 		require.NoError(t, secondErr)
-
 		require.Equal(t, 1, unsubscribes)
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
-
 	t.Run("Different subscriptions recover concurrently", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		subA := &subscription.Subscription{Channel: "subA"}
-
 		subB := &subscription.Subscription{Channel: "subB"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, subA, subB))
-
 		var unsubsMu sync.Mutex
-
 		unsubscribed := make(map[string]int)
-
 		subscribed := make(map[string]int)
-
 		subAUnsubStarted := make(chan struct{})
-
 		releaseSubA := make(chan struct{})
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			unsubsMu.Lock()
-
 			for _, s := range subs {
 				unsubscribed[s.Channel]++
 			}
-
 			unsubsMu.Unlock()
-
 			for _, s := range subs {
 				if s.Channel == "subA" {
 					close(subAUnsubStarted)
-
 					<-releaseSubA
 				}
 			}
-
 			return nil
 		}
-
 		m.Subscriber = func(subs subscription.List) error {
 			unsubsMu.Lock()
-
 			for _, s := range subs {
 				subscribed[s.Channel]++
 			}
-
 			unsubsMu.Unlock()
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		var wg sync.WaitGroup
-
 		var errA, errB error
-
 		wg.Add(2)
-
 		go func() {
 			defer wg.Done()
-
 			errA = m.ResubscribeToChannel(t.Context(), nil, subA)
 		}()
-
 		<-subAUnsubStarted
-
 		subBPreLock := make(chan struct{})
-
 		var signalSubB sync.Once
-
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == subB {
 				signalSubB.Do(func() { close(subBPreLock) })
 			}
 		}
-
 		go func() {
 			defer wg.Done()
-
 			errB = m.ResubscribeToChannel(t.Context(), nil, subB)
 		}()
-
 		<-subBPreLock
-
 		close(releaseSubA)
-
 		wg.Wait()
-
 		require.NoError(t, errA)
-
 		require.NoError(t, errB)
-
 		require.Equal(t, 1, unsubscribed["subA"])
-
 		require.Equal(t, 1, unsubscribed["subB"])
-
 		require.Equal(t, 1, subscribed["subA"])
-
 		require.Equal(t, 1, subscribed["subB"])
-
 		require.Equal(t, subscription.SubscribedState, subA.State())
-
 		require.Equal(t, subscription.SubscribedState, subB.State())
 	})
-
 	t.Run("Unrelated manager-lock contention does not drop recovery", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		sub := &subscription.Subscription{Channel: "unrelatedContentionTest"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		unsubCalls := 0
-
 		subCalls := 0
-
 		m.Unsubscriber = func(subscription.List) error {
 			unsubCalls++
-
 			return nil
 		}
-
 		m.Subscriber = func(subs subscription.List) error {
 			subCalls++
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		m.m.Lock()
-
 		recovered := make(chan error, 1)
-
 		preLockReached := make(chan struct{})
-
 		var signalPreLock sync.Once
-
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalPreLock.Do(func() { close(preLockReached) })
 			}
 		}
-
 		go func() {
 			recovered <- m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-preLockReached
-
 		require.Equal(t, 0, unsubCalls)
-
 		require.Equal(t, 0, subCalls)
-
 		m.m.Unlock()
-
 		err := <-recovered
-
 		require.NoError(t, err)
-
 		require.Equal(t, 1, unsubCalls)
-
 		require.Equal(t, 1, subCalls)
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
-
 	t.Run("Bitfinex temporary key cleanup pattern during recovery", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexPatternTest"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-
 		recoveries := 0
-
 		m.Subscriber = func(subs subscription.List) error {
 			recoveries++
-
 			s := subs[0]
-
 			tempKey := fmt.Sprintf("subId-%d", recoveries)
-
 			s.Key = tempKey
-
 			if err := m.AddSubscriptions(nil, s); err != nil {
 				return err
 			}
-
 			defer func() {
 				_ = m.RemoveSubscriptions(nil, s)
 			}()
-
 			newSub := s.Clone()
-
 			newSub.Key = 42 + recoveries
-
 			return m.AddSuccessfulSubscriptions(nil, newSub)
 		}
-
 		// 1st recovery
-
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, realSub))
-
 		subs := m.GetSubscriptions()
-
 		require.Len(t, subs, 1, "store must only have 1 subscription after 1st recovery")
-
 		chanID, ok := subs[0].Key.(int)
-
 		require.True(t, ok, "key must be an int, not temporary string subId")
-
 		require.Equal(t, 43, chanID)
-
 		// 2nd recovery
-
 		currentSub := subs[0]
-
 		require.NoError(t, m.ResubscribeToChannel(t.Context(), nil, currentSub))
-
 		subs = m.GetSubscriptions()
-
 		require.Len(t, subs, 1, "store must only have 1 subscription after 2nd recovery")
-
 		chanID, ok = subs[0].Key.(int)
-
 		require.True(t, ok, "key must be an int, not temporary string subId")
-
 		require.Equal(t, 44, chanID)
-
 		// Unsubscribe all
-
 		require.NoError(t, m.RemoveSubscriptions(nil, subs...))
-
 		require.Empty(t, m.GetSubscriptions())
 	})
-
 	t.Run("Failed recovery does not restore stale key when replacement is live", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexStaleRestore"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-
 		m.Subscriber = func(subs subscription.List) error {
 			newSub := subs[0].Clone()
-
 			newSub.Key = 43
-
 			if err := m.AddSuccessfulSubscriptions(nil, newSub); err != nil {
 				return err
 			}
-
 			return errDastardlyReason
 		}
-
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, realSub), errDastardlyReason)
-
 		tracked := m.GetSubscriptions()
-
 		require.Len(t, tracked, 1, "must not resurrect pre-recovery key alongside live replacement")
-
 		chanID, ok := tracked[0].Key.(int)
-
 		require.True(t, ok)
-
 		require.Equal(t, 43, chanID)
 	})
-
 	t.Run("Nil subscription rejected", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, nil), common.ErrNilPointer)
 	})
-
 	t.Run("Coalesced waiter retries when leader recovery fails", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		sub := &subscription.Subscription{Channel: "coalescedWaiterRetry"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		firstSubscribe := make(chan struct{})
-
 		releaseFirstSubscribe := make(chan struct{})
-
 		waiterPreLock := make(chan struct{})
-
 		calls := 0
-
 		m.Subscriber = func(subs subscription.List) error {
 			calls++
-
 			if calls == 1 {
 				close(firstSubscribe)
-
 				<-releaseFirstSubscribe
-
 				_ = subs[0].SetState(subscription.SubscribedState)
-
 				return errDastardlyReason
 			}
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		var leaderErr, waiterErr error
-
 		var wg sync.WaitGroup
-
 		wg.Add(2)
-
 		go func() {
 			defer wg.Done()
-
 			leaderErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-firstSubscribe
-
 		var signalWaiter sync.Once
-
 		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalWaiter.Do(func() { close(waiterPreLock) })
 			}
 		}
-
 		go func() {
 			defer wg.Done()
-
 			waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-waiterPreLock
-
 		close(releaseFirstSubscribe)
-
 		wg.Wait()
-
 		require.ErrorIs(t, leaderErr, errDastardlyReason)
-
 		require.NoError(t, waiterErr)
-
 		require.Equal(t, 2, calls)
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
-
 	t.Run("Many coalesced waiters complete when leader finishes", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		sub := &subscription.Subscription{Channel: "manyWaiters"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		started := make(chan struct{})
-
 		release := make(chan struct{})
-
 		var startOnce sync.Once
-
 		m.Subscriber = func(subs subscription.List) error {
 			startOnce.Do(func() { close(started) })
-
 			<-release
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		const waiters = 23
-
 		errs := make(chan error, waiters+1)
-
 		go func() {
 			errs <- m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
-
 		<-started
-
 		var wg sync.WaitGroup
-
 		wg.Add(waiters)
-
-		for i := 0; i < waiters; i++ {
+		for range waiters {
 			go func() {
 				defer wg.Done()
-
 				errs <- m.ResubscribeToChannel(t.Context(), nil, sub)
 			}()
 		}
-
 		close(release)
-
 		require.NoError(t, <-errs, "leader recovery must complete")
-
 		done := make(chan struct{})
-
 		go func() {
 			wg.Wait()
-
 			close(done)
 		}()
-
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
 			t.Fatal("coalesced waiters did not return after leader closed")
 		}
-
 		close(errs)
-
 		for err := range errs {
 			require.NoError(t, err)
 		}
-
 		require.Empty(t, m.resubscriptions)
 	})
-
 	t.Run("Sibling channel subscription does not block recovery restore", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		btc := currency.NewBTCUSD()
-
 		eth := currency.NewPair(currency.ETH, currency.USDT)
-
 		sibling := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{eth}}
-
 		failing := &subscription.Subscription{Channel: subscription.OrderbookChannel, Pairs: currency.Pairs{btc}}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sibling, failing))
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-
 		m.Subscriber = func(subscription.List) error {
 			return errDastardlyReason
 		}
-
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, failing), errDastardlyReason)
-
 		require.Same(t, failing, m.GetSubscription(failing))
-
 		require.Equal(t, subscription.ResubscribingState, failing.State())
-
 		require.Equal(t, subscription.SubscribedState, sibling.State())
 	})
-
 	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
 		m := NewManager()
-
 		require.NoError(t, m.Setup(newDefaultSetup()))
-
 		m.features.Subscribe = true
-
 		m.features.Unsubscribe = true
-
 		m.state.Store(connectedState)
-
 		m.enabled.Store(true)
-
 		sub := &subscription.Subscription{Channel: "flushAfterFailTest"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-
 		subscribeCalls := 0
-
 		m.Subscriber = func(subs subscription.List) error {
 			subscribeCalls++
-
 			if subscribeCalls == 1 {
 				return errDastardlyReason
 			}
-
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
-
 		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, sub), errDastardlyReason)
-
 		require.Equal(t, subscription.ResubscribingState, sub.State())
-
 		require.Same(t, sub, m.GetSubscription(sub))
-
 		incoming := &subscription.Subscription{Channel: "flushAfterFailTest"}
-
 		m.GenerateSubs = func() (subscription.List, error) {
 			return subscription.List{incoming}, nil
 		}
-
 		require.NoError(t, m.FlushChannels(t.Context()))
-
 		require.Same(t, sub, m.GetSubscription(sub))
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 		require.Equal(t, 2, subscribeCalls)
-
 		m.GenerateSubs = func() (subscription.List, error) {
 			return subscription.List{}, nil
 		}
-
 		require.NoError(t, m.FlushChannels(t.Context()))
-
 		require.Nil(t, m.GetSubscription(sub))
-
 		require.Equal(t, subscription.UnsubscribedState, sub.State())
 	})
 }
 
 func TestAllSubscriptionsState(t *testing.T) {
 	t.Parallel()
-
 	sub := &subscription.Subscription{Channel: "sub"}
-
 	assert.True(t, allSubscriptionsState(subscription.List{sub}, subscription.InactiveState))
-
 	assert.False(t, allSubscriptionsState(subscription.List{sub}, subscription.SubscribedState))
 }
 
 // TestSubscriptions tests adding, getting and removing subscriptions
 func TestSubscriptions(t *testing.T) {
 	t.Parallel()
-
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
-
 	assert.ErrorIs(t, (*Manager)(nil).AddSubscriptions(nil), common.ErrNilPointer, "Should error correctly when nil websocket")
-
 	s := &subscription.Subscription{Key: 42, Channel: subscription.TickerChannel}
-
 	require.NoError(t, w.AddSubscriptions(nil, s), "Adding first subscription must not error")
-
 	assert.Same(t, s, w.GetSubscription(42), "Get Subscription should retrieve the same subscription")
-
 	assert.ErrorIs(t, w.AddSubscriptions(nil, s), subscription.ErrDuplicate, "Adding same subscription should return error")
-
 	assert.Equal(t, subscription.SubscribingState, s.State(), "Should set state to Subscribing")
 
 	err := w.RemoveSubscriptions(nil, s)
-
 	require.NoError(t, err, "RemoveSubscriptions must not error")
-
 	assert.Nil(t, w.GetSubscription(42), "Remove should have removed the sub")
-
 	assert.Equal(t, subscription.UnsubscribedState, s.State(), "Should set state to Unsubscribed")
 
 	require.NoError(t, s.SetState(subscription.ResubscribingState), "SetState must not error")
-
 	require.NoError(t, w.AddSubscriptions(nil, s), "Adding first subscription must not error")
-
 	assert.Equal(t, subscription.ResubscribingState, s.State(), "Should not change resubscribing state")
 }
 
 // TestSuccessfulSubscriptions tests adding, getting and removing subscriptions
 func TestSuccessfulSubscriptions(t *testing.T) {
 	t.Parallel()
-
 	w := new(Manager) // Do not use NewManager; We want to exercise w.subs == nil
-
 	assert.ErrorIs(t, (*Manager)(nil).AddSuccessfulSubscriptions(nil, nil), common.ErrNilPointer, "Should error correctly when nil websocket")
-
 	c := &subscription.Subscription{Key: 42, Channel: subscription.TickerChannel}
-
 	require.NoError(t, w.AddSuccessfulSubscriptions(nil, c), "Adding first subscription must not error")
-
 	assert.Same(t, c, w.GetSubscription(42), "Get Subscription should retrieve the same subscription")
-
 	assert.ErrorIs(t, w.AddSuccessfulSubscriptions(nil, c), subscription.ErrInStateAlready, "Adding subscription in same state should return error")
-
 	require.NoError(t, c.SetState(subscription.SubscribingState), "SetState must not error")
-
 	assert.ErrorIs(t, w.AddSuccessfulSubscriptions(nil, c), subscription.ErrDuplicate, "Adding same subscription should return error")
 
 	err := w.RemoveSubscriptions(nil, c)
-
 	require.NoError(t, err, "RemoveSubscriptions must not error")
-
 	assert.Nil(t, w.GetSubscription(42), "Remove should have removed the sub")
-
 	assert.ErrorIs(t, w.RemoveSubscriptions(nil, c), subscription.ErrNotFound, "Should error correctly when not found")
-
 	assert.ErrorIs(t, (*Manager)(nil).RemoveSubscriptions(nil, nil), common.ErrNilPointer, "Should error correctly when nil websocket")
-
 	w.subscriptions = nil
-
 	assert.ErrorIs(t, w.RemoveSubscriptions(nil, c), common.ErrNilPointer, "Should error correctly when nil websocket")
 }
 
 // TestGetSubscription logic test
 func TestGetSubscription(t *testing.T) {
 	t.Parallel()
-
 	assert.Nil(t, (*Manager).GetSubscription(nil, "imaginary"), "GetSubscription on a nil Websocket should return nil")
-
 	assert.Nil(t, (&Manager{}).GetSubscription("empty"), "GetSubscription on a Websocket with no sub store should return nil")
-
 	w := NewManager()
-
 	assert.Nil(t, w.GetSubscription(nil), "GetSubscription with a nil key should return nil")
-
 	s := &subscription.Subscription{Key: 42, Channel: "hello3"}
-
 	require.NoError(t, w.AddSubscriptions(nil, s), "AddSubscriptions must not error")
-
 	assert.Same(t, s, w.GetSubscription(42), "GetSubscription should delegate to the store")
 }
 
 // TestGetSubscriptions logic test
 func TestGetSubscriptions(t *testing.T) {
 	t.Parallel()
-
 	assert.Nil(t, (*Manager).GetSubscriptions(nil), "GetSubscription on a nil Websocket should return nil")
-
 	assert.Nil(t, (&Manager{}).GetSubscriptions(), "GetSubscription on a Websocket with no sub store should return nil")
-
 	w := NewManager()
-
 	s := subscription.List{
 		{Key: 42, Channel: "hello3"},
-
 		{Key: 45, Channel: "hello4"},
 	}
-
 	err := w.AddSubscriptions(nil, s...)
-
 	require.NoError(t, err, "AddSubscriptions must not error")
-
 	assert.ElementsMatch(t, s, w.GetSubscriptions(), "GetSubscriptions should return the correct channel details")
 }
 
 func TestCheckSubscriptions(t *testing.T) {
 	t.Parallel()
-
 	ws := Manager{}
-
 	err := ws.checkSubscriptions(nil, nil)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "checkSubscriptions should error correctly on nil w.subscriptions")
-
 	assert.ErrorContains(t, err, "Websocket.subscriptions", "checkSubscriptions should error giving context correctly on nil w.subscriptions")
 
 	ws.subscriptions = subscription.NewStore()
-
 	err = ws.checkSubscriptions(nil, nil)
-
 	assert.NoError(t, err, "checkSubscriptions should not error on a nil list")
 
 	ws.MaxSubscriptionsPerConnection = 1
 
 	err = ws.checkSubscriptions(nil, subscription.List{{}})
-
 	assert.NoError(t, err, "checkSubscriptions should not error when subscriptions is empty")
 
 	ws.subscriptions = subscription.NewStore()
-
 	err = ws.checkSubscriptions(nil, subscription.List{{}, {}})
-
 	assert.ErrorIs(t, err, errSubscriptionsExceedsLimit, "checkSubscriptions should error correctly")
 
 	ws.MaxSubscriptionsPerConnection = 2
 
 	ws.subscriptions = subscription.NewStore()
-
 	err = ws.subscriptions.Add(&subscription.Subscription{Key: 42, Channel: "test"})
-
 	require.NoError(t, err, "Add subscription must not error")
-
 	err = ws.checkSubscriptions(nil, subscription.List{{Key: 42, Channel: "test"}})
-
 	assert.ErrorIs(t, err, subscription.ErrDuplicate, "checkSubscriptions should error correctly")
 
 	err = ws.checkSubscriptions(nil, subscription.List{{}})
-
 	assert.NoError(t, err, "checkSubscriptions should not error")
 
 	ws.subscriptions = subscription.NewStore()
-
 	conn := &connection{}
-
 	ws.connections = map[Connection]*websocket{
 		conn: {},
 	}
-
 	err = ws.checkSubscriptions(conn, subscription.List{{}})
-
 	assert.ErrorContains(t, err, "nil pointer: Websocket.subscriptions", "nil store for a specific connection should error correctly")
-
 	ws.MaxSubscriptionsPerConnection = 1
-
 	conn = &connection{subscriptions: subscription.NewStore()}
-
 	ws.connections[conn] = &websocket{subscriptions: conn.Subscriptions(), connections: []Connection{conn}}
-
 	retained := &subscription.Subscription{Key: 43, Channel: "retained"}
-
 	require.NoError(t, ws.AddSuccessfulSubscriptions(conn, retained))
-
 	require.NoError(t, retained.SetState(subscription.ResubscribingState))
-
 	require.NoError(t, ws.checkSubscriptions(conn, subscription.List{retained}))
-
 	ws.MaxSubscriptionsPerConnection = 2
-
 	capConn := &connection{subscriptions: subscription.NewStore()}
-
 	ws.connections[capConn] = &websocket{
 		subscriptions: capConn.Subscriptions(),
-
-		connections: []Connection{capConn},
+		connections:   []Connection{capConn},
 	}
-
 	sub1 := &subscription.Subscription{Key: 101, Channel: "capSub1"}
-
 	sub2 := &subscription.Subscription{Key: 102, Channel: "capSub2"}
-
 	require.NoError(t, ws.AddSuccessfulSubscriptions(capConn, sub1, sub2))
-
 	// Full connection (2/2). Recovering existing sub1 in ResubscribingState must succeed:
-
 	require.NoError(t, sub1.SetState(subscription.ResubscribingState))
-
 	require.NoError(t, ws.checkSubscriptions(capConn, subscription.List{sub1}))
-
 	// Unrelated incoming subscription must be rejected:
-
 	unrelated := &subscription.Subscription{Key: 103, Channel: "unrelated"}
-
 	err = ws.checkSubscriptions(capConn, subscription.List{unrelated})
-
 	require.ErrorIs(t, err, errSubscriptionsExceedsLimit)
 }
 
@@ -1094,13 +686,9 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 	t.Parallel()
 
 	ws := NewManager()
-
 	store := subscription.NewStore()
-
 	err := ws.updateChannelSubscriptions(t.Context(), store, subscription.List{{Channel: "test"}})
-
 	require.ErrorIs(t, err, common.ErrNilPointer)
-
 	require.Zero(t, store.Len())
 
 	ws.Subscriber = func(subs subscription.List) error {
@@ -1109,20 +697,15 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 				return err
 			}
 		}
-
 		return nil
 	}
 
 	ws.subscriptions = store
-
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{{Channel: "test"}})
-
 	require.NoError(t, err)
-
 	require.Equal(t, 1, store.Len())
 
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{})
-
 	require.ErrorIs(t, err, common.ErrNilPointer)
 
 	ws.Unsubscriber = func(subs subscription.List) error {
@@ -1131,14 +714,11 @@ func TestUpdateChannelSubscriptions(t *testing.T) {
 				return err
 			}
 		}
-
 		return nil
 	}
 
 	err = ws.updateChannelSubscriptions(t.Context(), store, subscription.List{})
-
 	require.NoError(t, err)
-
 	require.Zero(t, store.Len())
 }
 
@@ -1149,11 +729,9 @@ func TestInitSubscriptionStore(t *testing.T) {
 		t.Parallel()
 
 		manager := &Manager{}
-
 		store := manager.initSubscriptionStore(nil)
 
 		require.NotNil(t, store, "global subscription store must be initialised")
-
 		assert.Same(t, store, manager.subscriptions, "global subscription store should be retained on the manager")
 	})
 
@@ -1161,15 +739,12 @@ func TestInitSubscriptionStore(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManagerWithStore(t, nil)
-
 		require.Nil(t, manager.connectionManager[0].subscriptions, "managed websocket store must start nil for this test")
 
 		store := manager.initSubscriptionStore(conn)
 
 		require.NotNil(t, store, "managed connection store must be initialised")
-
 		assert.Same(t, store, manager.connectionManager[0].subscriptions, "managed websocket should retain the initialised store")
-
 		assert.NotSame(t, store, manager.subscriptions, "managed connection should keep an isolated subscription store")
 	})
 }
@@ -1202,43 +777,31 @@ func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscriptio
 	t.Helper()
 
 	manager := NewManager()
-
 	setup := newDefaultSetup()
-
 	setup.UseMultiConnectionManagement = true
-
 	require.NoError(t, manager.Setup(setup))
 
 	ws := &websocket{
 		setup: &ConnectionSetup{
 			URL: "wss://managed-subscriptions.test/ws",
-
 			Subscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
 				return manager.AddSuccessfulSubscriptions(conn, subs...)
 			},
-
 			Unsubscriber: func(_ context.Context, conn Connection, subs subscription.List) error {
 				return manager.RemoveSubscriptions(conn, subs...)
 			},
 		},
-
 		subscriptions: store,
 	}
-
 	conn := &connection{
-		URL: ws.setup.URL,
-
+		URL:           ws.setup.URL,
 		subscriptions: subscription.NewStore(),
 	}
 
 	manager.connectionManagerMu.Lock()
-
 	manager.connectionManager = append(manager.connectionManager, ws)
-
 	manager.connections[conn] = ws
-
 	ws.connections = []Connection{conn}
-
 	manager.connectionManagerMu.Unlock()
 
 	return manager, conn
@@ -1246,29 +809,21 @@ func newManagedSubscriptionTestManagerWithStore(t *testing.T, store *subscriptio
 
 func newManagedSubscriptionTestManager(t *testing.T) (*Manager, Connection) {
 	t.Helper()
-
 	return newManagedSubscriptionTestManagerWithStore(t, subscription.NewStore())
 }
 
 func startSubscriptionReaders(manager *Manager) func() {
 	done := make(chan struct{})
-
 	var wg sync.WaitGroup
-
 	var once sync.Once
-
 	for range 4 {
 		wg.Go(func() {
 			for {
 				select {
 				case <-done:
-
 					return
-
 				default:
-
 					_ = manager.GetSubscription("missing")
-
 					_ = manager.GetSubscriptions()
 				}
 			}
@@ -1278,7 +833,6 @@ func startSubscriptionReaders(manager *Manager) func() {
 	return func() {
 		once.Do(func() {
 			close(done)
-
 			wg.Wait()
 		})
 	}
@@ -1288,23 +842,18 @@ func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error)
 	t.Helper()
 
 	start := make(chan struct{})
-
 	errs := make(chan error, workers)
-
 	var wg sync.WaitGroup
 
 	for i := range workers {
 		wg.Go(func() {
 			<-start
-
 			errs <- op(i)
 		})
 	}
 
 	close(start)
-
 	wg.Wait()
-
 	close(errs)
 
 	for err := range errs {
@@ -1314,10 +863,8 @@ func runConcurrentSubscriptionOps(t *testing.T, workers int, op func(int) error)
 
 func newConcurrentSubscription(channel string, index int) *subscription.Subscription {
 	name := fmt.Sprintf("%s-%d", channel, index)
-
 	return &subscription.Subscription{
-		Key: name,
-
+		Key:     name,
 		Channel: name,
 	}
 }
@@ -1331,13 +878,10 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
-
 		stopReaders := startSubscriptionReaders(manager)
-
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
-
 		for i := range workers {
 			subs[i] = newConcurrentSubscription("add", i)
 		}
@@ -1349,10 +893,8 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
-
 		for _, sub := range subs {
 			require.Same(t, sub, manager.GetSubscription(sub))
-
 			assert.Equal(t, subscription.SubscribingState, sub.State())
 		}
 	})
@@ -1361,13 +903,10 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
-
 		stopReaders := startSubscriptionReaders(manager)
-
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
-
 		for i := range workers {
 			subs[i] = newConcurrentSubscription("success", i)
 		}
@@ -1379,10 +918,8 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
-
 		for _, sub := range subs {
 			require.Same(t, sub, manager.GetSubscription(sub))
-
 			assert.Equal(t, subscription.SubscribedState, sub.State())
 		}
 	})
@@ -1391,17 +928,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
-
 		subs := make(subscription.List, workers)
-
 		for i := range workers {
 			subs[i] = newConcurrentSubscription("remove", i)
 		}
-
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
 
 		stopReaders := startSubscriptionReaders(manager)
-
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
@@ -1411,10 +944,8 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		stopReaders()
 
 		assert.Empty(t, manager.GetSubscriptions())
-
 		for _, sub := range subs {
 			assert.Nil(t, manager.GetSubscription(sub))
-
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
 		}
 	})
@@ -1423,13 +954,10 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
-
 		stopReaders := startSubscriptionReaders(manager)
-
 		defer stopReaders()
 
 		subs := make(subscription.List, workers)
-
 		for i := range workers {
 			subs[i] = newConcurrentSubscription("subscribe", i)
 		}
@@ -1441,10 +969,8 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		stopReaders()
 
 		require.Len(t, manager.GetSubscriptions(), workers)
-
 		for _, sub := range subs {
 			require.Same(t, sub, manager.GetSubscription(sub))
-
 			assert.Equal(t, subscription.SubscribedState, sub.State())
 		}
 	})
@@ -1453,17 +979,13 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		t.Parallel()
 
 		manager, conn := newManagedSubscriptionTestManager(t)
-
 		subs := make(subscription.List, workers)
-
 		for i := range workers {
 			subs[i] = newConcurrentSubscription("unsubscribe", i)
 		}
-
 		require.NoError(t, manager.AddSuccessfulSubscriptions(conn, subs...))
 
 		stopReaders := startSubscriptionReaders(manager)
-
 		defer stopReaders()
 
 		runConcurrentSubscriptionOps(t, workers, func(i int) error {
@@ -1473,10 +995,8 @@ func TestExportedManagedSubscriptionFunctionsConcurrent(t *testing.T) {
 		stopReaders()
 
 		assert.Empty(t, manager.GetSubscriptions())
-
 		for _, sub := range subs {
 			assert.Nil(t, manager.GetSubscription(sub))
-
 			assert.Equal(t, subscription.UnsubscribedState, sub.State())
 		}
 	})
@@ -1488,13 +1008,10 @@ func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
 	const workers = 32
 
 	manager, conn := newManagedSubscriptionTestManagerWithStore(t, nil)
-
 	stopReaders := startSubscriptionReaders(manager)
-
 	defer stopReaders()
 
 	subs := make(subscription.List, workers)
-
 	for i := range workers {
 		subs[i] = newConcurrentSubscription("initialise", i)
 	}
@@ -1506,7 +1023,6 @@ func TestManagedSubscriptionGettersConcurrentStoreInit(t *testing.T) {
 	stopReaders()
 
 	require.Len(t, manager.GetSubscriptions(), workers)
-
 	for _, sub := range subs {
 		require.Same(t, sub, manager.GetSubscription(sub))
 	}
@@ -1516,25 +1032,19 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 	t.Parallel()
 
 	manager, conn := newManagedSubscriptionTestManager(t)
-
 	manager.setEnabled(true)
-
 	manager.setState(connectedState)
-
 	manager.MaxSubscriptionsPerConnection = 2
 
 	expected := subscription.List{
 		newConcurrentSubscription("flush", 0),
-
 		newConcurrentSubscription("flush", 1),
 	}
-
 	manager.connectionManager[0].setup.GenerateSubscriptions = func() (subscription.List, error) {
 		return expected, nil
 	}
 
 	stopReaders := startSubscriptionReaders(manager)
-
 	defer stopReaders()
 
 	runConcurrentSubscriptionOps(t, 8, func(int) error {
@@ -1544,9 +1054,7 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 	stopReaders()
 
 	require.Len(t, manager.GetSubscriptions(), len(expected))
-
 	require.Len(t, conn.Subscriptions().List(), len(expected))
-
 	for _, sub := range expected {
 		require.Same(t, sub, manager.GetSubscription(sub))
 	}
@@ -1554,63 +1062,43 @@ func TestFlushChannelsConcurrentReaders(t *testing.T) {
 
 func TestFlushChannels(t *testing.T) {
 	t.Parallel()
-
 	// Enabled pairs/setup system
 
 	dodgyWs := Manager{}
-
 	err := dodgyWs.FlushChannels(t.Context())
-
 	assert.ErrorIs(t, err, ErrWebsocketNotEnabled, "FlushChannels should error correctly")
 
 	dodgyWs.setEnabled(true)
-
 	err = dodgyWs.FlushChannels(t.Context())
-
 	assert.ErrorIs(t, err, ErrNotConnected, "FlushChannels should error correctly")
 
 	newgen := GenSubs{EnabledPairs: []currency.Pair{
 		currency.NewPair(currency.BTC, currency.AUD),
-
 		currency.NewBTCUSDT(),
 	}}
 
 	w := NewManager()
-
 	var cleanupMonitors sync.Once
-
 	cleanupW := func() {
 		cleanupMonitors.Do(func() { cleanupManagerMonitors(t, w) })
 	}
-
 	t.Cleanup(cleanupW)
-
 	w.exchangeName = "test"
-
 	w.connector = noopConnect
-
 	w.Subscriber = newgen.SUBME
-
 	w.Unsubscriber = newgen.UNSUBME
-
 	// Keep enough headroom for FlushChannels connection cycles without leaving long-lived monitor goroutines behind.
-
 	w.trafficTimeout = time.Second
 
 	w.setEnabled(true)
-
 	w.setState(connectedState)
 
 	// Allow subscribe and unsubscribe feature set, without these the tests will call shutdown and connect.
-
 	w.features.Subscribe = true
-
 	w.features.Unsubscribe = true
 
 	// Disable pair and flush system
-
 	newgen.EnabledPairs = []currency.Pair{currency.NewPair(currency.BTC, currency.AUD)}
-
 	w.GenerateSubs = func() (subscription.List, error) { return subscription.List{{Channel: "test"}}, nil }
 
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "FlushChannels must error correctly on no subscriptions added")
@@ -1621,16 +1109,13 @@ func TestFlushChannels(t *testing.T) {
 				return err
 			}
 		}
-
 		return nil
 	}
 
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
 
 	w.GenerateSubs = func() (subscription.List, error) { return nil, errDastardlyReason } // error on generateSubs
-
-	err = w.FlushChannels(t.Context()) // error on full subscribeToChannels
-
+	err = w.FlushChannels(t.Context())                                                    // error on full subscribeToChannels
 	assert.ErrorIs(t, err, errDastardlyReason, "FlushChannels should error correctly on GenerateSubs")
 
 	w.GenerateSubs = func() (subscription.List, error) { return nil, nil } // No subs to sub
@@ -1643,88 +1128,58 @@ func TestFlushChannels(t *testing.T) {
 				return err
 			}
 		}
-
 		return nil
 	}
-
 	assert.NoError(t, w.FlushChannels(t.Context()), "FlushChannels should not error")
 
 	w.GenerateSubs = newgen.generateSubs
-
 	subs, err := w.GenerateSubs()
-
 	require.NoError(t, err, "GenerateSubs must not error")
-
 	require.NoError(t, w.AddSubscriptions(nil, subs...), "AddSubscriptions must not error")
-
 	err = w.FlushChannels(t.Context())
-
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	w.GenerateSubs = newgen.generateSubs
-
 	w.subscriptions = subscription.NewStore()
-
 	err = w.subscriptions.Add(&subscription.Subscription{
-		Key: 41,
-
+		Key:     41,
 		Channel: "match channel",
-
-		Pairs: currency.Pairs{currency.NewPair(currency.BTC, currency.AUD)},
+		Pairs:   currency.Pairs{currency.NewPair(currency.BTC, currency.AUD)},
 	})
-
 	require.NoError(t, err, "AddSubscription must not error")
-
 	err = w.subscriptions.Add(&subscription.Subscription{
-		Key: 42,
-
+		Key:     42,
 		Channel: "unsub channel",
-
-		Pairs: currency.Pairs{currency.NewPair(currency.THETA, currency.USDT)},
+		Pairs:   currency.Pairs{currency.NewPair(currency.THETA, currency.USDT)},
 	})
-
 	require.NoError(t, err, "AddSubscription must not error")
 
 	err = w.FlushChannels(t.Context())
-
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	w.setState(connectedState)
-
 	err = w.FlushChannels(t.Context())
-
 	assert.NoError(t, err, "FlushChannels should not error")
 
 	// Multi connection management
-
 	w.useMultiConnectionManagement = true
-
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler) }))
-
 	t.Cleanup(mock.Close)
-
 	t.Cleanup(cleanupW)
 
 	w.subscriptions = subscription.NewStore()
 
 	amazingCandidate := &ConnectionSetup{
 		URL: "ws" + mock.URL[len("http"):] + "/ws",
-
 		Connector: func(ctx context.Context, conn Connection) error {
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
 		},
-
 		GenerateSubscriptions: newgen.generateSubs,
-
-		Subscriber: func(context.Context, Connection, subscription.List) error { return nil },
-
-		Unsubscriber: func(context.Context, Connection, subscription.List) error { return nil },
-
-		Handler: func(context.Context, Connection, []byte) error { return nil },
+		Subscriber:            func(context.Context, Connection, subscription.List) error { return nil },
+		Unsubscriber:          func(context.Context, Connection, subscription.List) error { return nil },
+		Handler:               func(context.Context, Connection, []byte) error { return nil },
 	}
-
 	require.NoError(t, w.SetupNewConnection(amazingCandidate))
-
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotAdded, "Must error when no subscriptions are added to the subscription store")
 
 	w.connectionManager[0].setup.Subscriber = func(ctx context.Context, c Connection, s subscription.List) error {
@@ -1734,18 +1189,12 @@ func TestFlushChannels(t *testing.T) {
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
 
 	// Forces full connection cycle (shutdown, connect, subscribe). This will also start monitoring routines.
-
 	w.features.Subscribe = false
-
 	require.NoError(t, w.FlushChannels(t.Context()), "FlushChannels must not error")
-
 	// Unsubscribe what's already subscribed. No subscriptions left over, which then forces the shutdown and removal
 	// of the connection from management.
-
 	w.features.Subscribe = true
-
 	w.connectionManager[0].setup.GenerateSubscriptions = func() (subscription.List, error) { return nil, nil }
-
 	require.ErrorIs(t, w.FlushChannels(t.Context()), ErrSubscriptionsNotRemoved, "Must error when no subscriptions are removed from subscription store")
 
 	w.connectionManager[0].setup.Unsubscriber = func(ctx context.Context, c Connection, s subscription.List) error {
@@ -1758,17 +1207,13 @@ func TestFlushChannels(t *testing.T) {
 // fakeConnection is a minimal Connection implementation used in cleanup tests.
 type fakeConnection struct {
 	Connection
-
-	subscriptions *subscription.Store
-
+	subscriptions     *subscription.Store
 	subscriptionsHook func()
-
-	shutdownCalled bool
+	shutdownCalled    bool
 }
 
 func (f *fakeConnection) Shutdown() error {
 	f.shutdownCalled = true
-
 	return nil
 }
 
@@ -1776,21 +1221,17 @@ func (f *fakeConnection) Subscriptions() *subscription.Store {
 	if f.subscriptionsHook != nil {
 		f.subscriptionsHook()
 	}
-
 	return f.subscriptions
 }
 
 func cleanupManagedConnectionReaders(t *testing.T, m *Manager, ws *websocket) {
 	t.Helper()
-
 	if m == nil || ws == nil {
 		return
 	}
-
 	for _, conn := range m.snapshotManagedConnections(ws) {
 		_ = conn.Shutdown()
 	}
-
 	resetManagerForNextConnectAttempt(t, m)
 }
 
@@ -1799,51 +1240,34 @@ func TestApplyTrackedSubscriptions(t *testing.T) {
 
 	t.Run("NoTrackedSubscriptionsNoOp", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		conn := &fakeConnection{}
-
 		require.NoError(t, m.applyTrackedSubscriptions(conn, nil))
 	})
 
 	t.Run("RecordsInManagerAndConnectionStores", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		sub := &subscription.Subscription{Channel: "tracked"}
-
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		ws := &websocket{setup: &ConnectionSetup{}, subscriptions: subscription.NewStore()}
-
 		m.trackConnection(conn, ws)
 
 		require.NoError(t, m.applyTrackedSubscriptions(conn, subscription.List{sub}))
-
 		require.NotNil(t, ws.subscriptions.Get(sub), "tracked subscription must be recorded in websocket store")
-
 		require.NotNil(t, conn.subscriptions.Get(sub), "tracked subscription must be recorded in connection store")
-
 		assert.Equal(t, subscription.SubscribedState, sub.State())
 	})
 
 	t.Run("ErrorsWhenConnectionStoreIsNil", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		sub := &subscription.Subscription{Channel: "tracked"}
-
 		conn := &fakeConnection{}
-
 		ws := &websocket{setup: &ConnectionSetup{}, subscriptions: subscription.NewStore()}
-
 		m.trackConnection(conn, ws)
 
 		err := m.applyTrackedSubscriptions(conn, subscription.List{sub})
-
 		require.ErrorIs(t, err, common.ErrNilPointer)
 	})
 }
@@ -1853,120 +1277,83 @@ func TestAbsorbSubscriptionsAndValidate(t *testing.T) {
 
 	t.Run("PassThroughWithoutTrackHook", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		subs := subscription.List{{Channel: "A"}}
-
 		ws := &websocket{
-			setup: &ConnectionSetup{},
-
+			setup:         &ConnectionSetup{},
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
+			connections:   []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subs)
-
 		require.NoError(t, err)
-
 		assert.Equal(t, subs, remaining)
 	})
 
 	t.Run("PropagatesTrackError", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		expectedErr := errors.New("track failed")
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
 					return nil, nil, expectedErr
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
+			connections:   []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{{Channel: "A"}})
-
 		require.ErrorIs(t, err, expectedErr)
-
 		assert.Nil(t, remaining)
 	})
 
 	t.Run("ErrorsWhenTrackedSubsNotRecordedOnWebsocketStore", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		trackedSub := &subscription.Subscription{Channel: "tracked"}
-
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
 					return nil, subscription.List{trackedSub}, nil
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{conn},
+			connections:   []Connection{conn},
 		}
 
 		// Intentionally do not map conn -> ws; manager-level tracking goes to
 		// the global store, allowing validation to detect missing websocket state.
-
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{trackedSub})
-
 		require.ErrorIs(t, err, ErrSubscriptionFailure)
-
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded)
-
 		assert.Nil(t, remaining)
 	})
 
 	t.Run("ReturnsRemainingAndRecordsTracked", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		trackedSub := &subscription.Subscription{Channel: "tracked"}
-
 		remainingSub := &subscription.Subscription{Channel: "remaining"}
-
 		conn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, _ subscription.List) (subscription.List, subscription.List, error) {
 					return subscription.List{remainingSub}, subscription.List{trackedSub}, nil
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{conn},
+			connections:   []Connection{conn},
 		}
-
 		m.trackConnection(conn, ws)
 
 		remaining, err := m.absorbTrackableSubscriptionsAndValidate(t.Context(), ws, subscription.List{trackedSub, remainingSub})
-
 		require.NoError(t, err)
-
 		require.Len(t, remaining, 1)
-
 		assert.Same(t, remainingSub, remaining[0])
-
 		require.NotNil(t, ws.subscriptions.Get(trackedSub))
-
 		require.NotNil(t, conn.subscriptions.Get(trackedSub))
 	})
 }
@@ -1976,97 +1363,66 @@ func TestAbsorbTrackedSubscriptions(t *testing.T) {
 
 	t.Run("PassthroughWithoutTrackHook", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		subs := subscription.List{{Channel: "A"}}
-
 		ws := &websocket{
-			setup: &ConnectionSetup{},
-
+			setup:       &ConnectionSetup{},
 			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, tracked, err := m.absorbTrackedSubscriptions(t.Context(), ws, subs)
-
 		require.NoError(t, err)
-
 		assert.Equal(t, subs, remaining)
-
 		assert.Empty(t, tracked)
 	})
 
 	t.Run("TracksAcrossConnectionsUntilEmpty", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		tracked := &subscription.Subscription{Channel: "tracked"}
-
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 					if conn != conn1 {
 						return subs, nil, nil
 					}
-
 					return nil, subscription.List{tracked}, nil
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{conn0, conn1},
+			connections:   []Connection{conn0, conn1},
 		}
-
 		m.connections[conn0] = ws
-
 		m.connections[conn1] = ws
 
 		remaining, trackedSubs, err := m.absorbTrackedSubscriptions(t.Context(), ws, subscription.List{tracked})
-
 		require.NoError(t, err)
-
 		require.Nil(t, remaining)
-
 		require.Len(t, trackedSubs, 1)
-
 		require.Same(t, tracked, trackedSubs[0])
-
 		require.NotNil(t, ws.subscriptions.Get(tracked))
-
 		require.NotNil(t, conn1.subscriptions.Get(tracked))
-
 		assert.Nil(t, conn0.subscriptions.Get(tracked))
 	})
 
 	t.Run("PropagatesErrors", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		expectedErr := errors.New("track failed")
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				TrackOnExistingConnection: func(context.Context, Connection, subscription.List) (subscription.List, subscription.List, error) {
 					return nil, nil, expectedErr
 				},
 			},
-
 			connections: []Connection{&fakeConnection{subscriptions: subscription.NewStore()}},
 		}
 
 		remaining, tracked, err := m.absorbTrackedSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}})
-
 		require.ErrorIs(t, err, expectedErr)
-
 		assert.Nil(t, remaining)
-
 		assert.Nil(t, tracked)
 	})
 }
@@ -2075,154 +1431,111 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 	t.Parallel()
 
 	// Common setup helper
-
 	setup := func(t *testing.T, isMultiConn bool) (*Manager, *websocket) {
 		t.Helper()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 2
-
 		m.useMultiConnectionManagement = isMultiConn
 
 		// Mock server for dialing
-
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
 		}))
-
 		t.Cleanup(srv.Close)
 
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				URL: "ws" + srv.URL[len("http"):] + "/ws",
-
 				Connector: func(ctx context.Context, c Connection) error {
 					return c.Dial(ctx, gws.DefaultDialer, nil, nil)
 				},
-
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
 					return m.AddSuccessfulSubscriptions(c, s...)
 				},
-
 				Unsubscriber: func(_ context.Context, c Connection, s subscription.List) error {
 					return m.RemoveSubscriptions(c, s...)
 				},
-
 				Handler: func(context.Context, Connection, []byte) error { return nil },
 			},
-
 			subscriptions: subscription.NewStore(),
 		}
-
 		t.Cleanup(func() { cleanupManagedConnectionReaders(t, m, ws) })
-
 		return m, ws
 	}
 
 	t.Run("Nil ws", func(t *testing.T) {
 		t.Parallel()
-
 		m, _ := setup(t, false)
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), nil, nil)
-
 		require.ErrorIs(t, err, common.ErrNilPointer)
 	})
 
 	t.Run("No Changes", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
-
 		require.NoError(t, err)
 	})
 
 	t.Run("Scale Up (Add Subs)", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
 
 		subs := subscription.List{{Channel: "A"}, {Channel: "B"}, {Channel: "C"}}
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subs)
-
 		require.NoError(t, err)
 
 		assert.Equal(t, 3, ws.subscriptions.Len())
-
 		assert.Len(t, ws.connections, 2) // 2 per conn -> 2 conns
 	})
 
 	t.Run("Scale Down (Remove Subs)", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, true)
 
 		// Add subs first
-
 		subs := subscription.List{{Channel: "A"}, {Channel: "B"}}
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subs)
-
 		require.NoError(t, err)
-
 		require.Equal(t, 2, ws.subscriptions.Len())
 
 		// Remove all
-
 		err = m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
-
 		require.NoError(t, err)
-
 		assert.Equal(t, 0, ws.subscriptions.Len())
-
 		assert.Empty(t, ws.connections)
 	})
 
 	t.Run("Unsubscribe Error", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, true)
 
 		// Add sub first
-
 		sub := subscription.List{{Channel: "A"}}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, sub))
 
 		// Now set error and remove
-
 		ws.setup.Unsubscriber = func(context.Context, Connection, subscription.List) error {
 			return errors.New("unsub fail")
 		}
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, nil)
-
 		require.ErrorContains(t, err, "unsub fail")
 	})
 
 	t.Run("Subscribe Error (Existing Connection)", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
 
 		// Add one sub (capacity 2)
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}}))
 
 		// Set error
-
 		ws.setup.Subscriber = func(context.Context, Connection, subscription.List) error {
 			return errors.New("sub fail")
 		}
 
 		// Add another sub (should use existing connection)
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}, {Channel: "B"}})
-
 		require.ErrorContains(t, err, "sub fail")
 	})
 
@@ -2230,93 +1543,67 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		m, ws := setup(t, false)
 
 		// Set connector error
-
 		ws.setup.Connector = func(context.Context, Connection) error {
 			return errors.New("connect fail")
 		}
 
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, subscription.List{{Channel: "A"}})
-
 		require.ErrorContains(t, err, "connect fail")
 	})
 
 	t.Run("Global Unsubscribe Fallback Success", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
 
 		s1 := &subscription.Subscription{Channel: "A"}
-
 		s2 := &subscription.Subscription{Channel: "B"}
-
 		require.NoError(t, ws.subscriptions.Add(s1))
-
 		require.NoError(t, ws.subscriptions.Add(s2))
-
 		// empty incoming subscriptions will remove existing subs
-
 		in := subscription.List{}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, in))
-
 		assert.Equal(t, 0, ws.subscriptions.Len())
 	})
 
 	t.Run("Missing Subscriptions After Subscribe", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
 
 		s1 := &subscription.Subscription{Channel: "A"}
-
 		s2 := &subscription.Subscription{Channel: "B"}
-
 		require.NoError(t, ws.subscriptions.Add(s1))
 
 		in := subscription.List{s1, s2}
-
 		err := m.scaleConnectionsToSubscriptions(t.Context(), ws, in)
-
 		require.NoError(t, err)
 
 		// After scaling, both subs should be present in the store
-
 		assert.NotNil(t, ws.subscriptions.Get(s1))
-
 		assert.NotNil(t, ws.subscriptions.Get(s2))
 	})
 
 	t.Run("Multi-batch ConnectAndSubscribe Success", func(t *testing.T) {
 		t.Parallel()
-
 		m, ws := setup(t, false)
 
 		m.MaxSubscriptionsPerConnection = 2
 
 		in := subscription.List{{Channel: "A"}, {Channel: "B"}, {Channel: "C"}, {Channel: "D"}, {Channel: "E"}}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, in))
 
 		// With max 2 subs per connection and 5 total, we expect 3 connections
-
 		assert.Len(t, ws.connections, 3)
 	})
 
 	t.Run("Track On Existing Connection Prevents New Connection", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 1
-
 		m.connections = make(map[Connection]*websocket)
 
 		existing := &subscription.Subscription{Channel: "A"}
-
 		logical := &subscription.Subscription{Channel: "B"}
-
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, activeConn.subscriptions.Add(existing))
 
 		ws := &websocket{
@@ -2324,116 +1611,80 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 				Connector: func(context.Context, Connection) error {
 					return errors.New("should not create a new connection")
 				},
-
 				TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 					if len(subs) != 1 || subs[0].Channel != logical.Channel {
 						return subs, nil, nil
 					}
-
 					return nil, subscription.List{logical}, nil
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{activeConn},
+			connections:   []Connection{activeConn},
 		}
-
 		require.NoError(t, ws.subscriptions.Add(existing))
-
 		m.connections[activeConn] = ws
 
 		incoming := subscription.List{existing, logical}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
-
 		assert.Len(t, ws.connections, 1)
-
 		assert.Equal(t, 2, ws.subscriptions.Len())
-
 		assert.Equal(t, 2, activeConn.subscriptions.Len())
 	})
 
 	t.Run("Track On Existing Connection Targets Owning Connection", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 1
-
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 owns subA, conn1 owns subB. A logical sub "C" whose inverse
 		// lives on conn1 must be tracked on conn1, not conn0.
-
 		subA := &subscription.Subscription{Channel: "A"}
-
 		subB := &subscription.Subscription{Channel: "B"}
-
 		logical := &subscription.Subscription{Channel: "C"}
 
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, conn0.subscriptions.Add(subA))
 
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, conn1.subscriptions.Add(subB))
 
 		var trackedOnConn Connection
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				Connector: func(context.Context, Connection) error {
 					return errors.New("should not create a new connection")
 				},
-
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 					// Only track when the connection owns subB (the inverse).
-
 					if conn.Subscriptions().Get(subB) == nil {
 						return subs, nil, nil
 					}
-
 					trackedOnConn = conn
-
 					return nil, subscription.List{logical}, nil
 				},
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{conn0, conn1},
+			connections:   []Connection{conn0, conn1},
 		}
-
 		require.NoError(t, ws.subscriptions.Add(subA))
-
 		require.NoError(t, ws.subscriptions.Add(subB))
-
 		m.connections[conn0] = ws
-
 		m.connections[conn1] = ws
 
 		incoming := subscription.List{subA, subB, logical}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
 
 		assert.Len(t, ws.connections, 2, "no new connections should be created")
-
 		assert.Same(t, conn1, trackedOnConn, "logical sub should be tracked on the connection owning the inverse, not connections[0]")
-
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
-
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
 	})
 
 	t.Run("Track Before Generic Subscribe Prevents Misrouting", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 2
-
 		m.connections = make(map[Connection]*websocket)
 
 		// conn0 has subA and spare capacity (max=2, used=1).
@@ -2442,165 +1693,114 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		// subscribeToConnection loop would route C to conn0 because
 		// it has capacity. The fix ensures absorbTrackedSubscriptions
 		// runs first, absorbing C onto conn1.
-
 		subA := &subscription.Subscription{Channel: "A"}
-
 		subB := &subscription.Subscription{Channel: "B"}
-
 		logical := &subscription.Subscription{Channel: "C"}
 
 		conn0 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, conn0.subscriptions.Add(subA))
 
 		conn1 := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, conn1.subscriptions.Add(subB))
 
 		var trackedOnConn Connection
-
 		ws := &websocket{
 			setup: &ConnectionSetup{
 				Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
 					return m.AddSuccessfulSubscriptions(c, s...)
 				},
-
 				Connector: func(context.Context, Connection) error {
 					return errors.New("should not create a new connection")
 				},
-
 				TrackOnExistingConnection: func(_ context.Context, conn Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 					// Only track when the connection owns subB (the inverse).
-
 					if conn.Subscriptions().Get(subB) == nil {
 						return subs, nil, nil
 					}
-
 					var remaining subscription.List
-
 					var tracked subscription.List
-
 					for _, s := range subs {
 						if s.Channel != logical.Channel {
 							remaining = append(remaining, s)
-
 							continue
 						}
-
 						trackedOnConn = conn
-
 						tracked = append(tracked, s)
 					}
-
 					return remaining, tracked, nil
 				},
-
 				Handler: func(context.Context, Connection, []byte) error { return nil },
 			},
-
 			subscriptions: subscription.NewStore(),
-
-			connections: []Connection{conn0, conn1},
+			connections:   []Connection{conn0, conn1},
 		}
-
 		require.NoError(t, ws.subscriptions.Add(subA))
-
 		require.NoError(t, ws.subscriptions.Add(subB))
-
 		m.connections[conn0] = ws
-
 		m.connections[conn1] = ws
 
 		incoming := subscription.List{subA, subB, logical}
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, incoming))
 
 		assert.Len(t, ws.connections, 2, "no new connections should be created")
-
 		assert.Same(t, conn1, trackedOnConn, "logical sub should be tracked on the connection owning the inverse, not conn0 which has spare capacity")
-
 		assert.Equal(t, 1, conn0.subscriptions.Len(), "conn0 should not gain the logical sub")
-
 		assert.Equal(t, 2, conn1.subscriptions.Len(), "conn1 should own both subB and logical")
 	})
 
 	t.Run("Cleanup Removes Empty Connections", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 2
-
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-			setup: &ConnectionSetup{},
-
+			setup:         &ConnectionSetup{},
 			subscriptions: subscription.NewStore(),
 		}
 
 		// One connection with zero subs, one with non-zero
-
 		emptyConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, activeConn.subscriptions.Add(&subscription.Subscription{Channel: "A"}))
 
 		ws.connections = []Connection{emptyConn, activeConn}
 
 		m.connections[emptyConn] = ws
-
 		m.connections[activeConn] = ws
 
 		// No incoming/sub changes; trigger only cleanup logic
-
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, nil))
 
 		assert.True(t, emptyConn.shutdownCalled)
-
 		assert.False(t, activeConn.shutdownCalled)
-
 		assert.Len(t, ws.connections, 1)
-
 		assert.Same(t, activeConn, ws.connections[0])
 	})
 
 	t.Run("Cleanup Keeps Freshly Added Connections", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 2
-
 		m.connections = make(map[Connection]*websocket)
 
 		ws := &websocket{
-			setup: &ConnectionSetup{},
-
+			setup:         &ConnectionSetup{},
 			subscriptions: subscription.NewStore(),
 		}
 
 		emptyConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		activeConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		freshConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 		require.NoError(t, activeConn.subscriptions.Add(&subscription.Subscription{Channel: "A"}))
-
 		require.NoError(t, freshConn.subscriptions.Add(&subscription.Subscription{Channel: "B"}))
 
 		var addFreshOnce sync.Once
-
 		emptyConn.subscriptionsHook = func() {
 			addFreshOnce.Do(func() {
 				m.connectionManagerMu.Lock()
-
 				m.connections[freshConn] = ws
-
 				ws.connections = append(ws.connections, freshConn)
-
 				m.connectionManagerMu.Unlock()
 			})
 		}
@@ -2608,37 +1808,27 @@ func TestScaleConnectionsToSubscriptions(t *testing.T) {
 		ws.connections = []Connection{emptyConn, activeConn}
 
 		m.connections[emptyConn] = ws
-
 		m.connections[activeConn] = ws
 
 		require.NoError(t, m.scaleConnectionsToSubscriptions(t.Context(), ws, nil))
 
 		assert.True(t, emptyConn.shutdownCalled)
-
 		assert.False(t, activeConn.shutdownCalled)
-
 		assert.False(t, freshConn.shutdownCalled)
-
 		assert.Len(t, ws.connections, 2)
 
 		var haveActive, haveFresh bool
-
 		for _, conn := range ws.connections {
 			if conn == activeConn {
 				haveActive = true
 			}
-
 			if conn == freshConn {
 				haveFresh = true
 			}
 		}
-
 		assert.True(t, haveActive)
-
 		assert.True(t, haveFresh)
-
 		assert.NotContains(t, m.connections, emptyConn)
-
 		assert.Same(t, ws, m.connections[freshConn])
 	})
 }
@@ -2647,73 +1837,50 @@ func TestConnectTracksOnExistingConnectionBeforeNewConnection(t *testing.T) {
 	t.Parallel()
 
 	m := NewManager()
-
 	m.exchangeName = "test"
-
 	m.useMultiConnectionManagement = true
-
 	m.MaxSubscriptionsPerConnection = 1
-
 	m.trafficTimeout = time.Minute
-
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
 	}))
-
 	t.Cleanup(srv.Close)
-
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	subA := &subscription.Subscription{Channel: "A"}
-
 	subB := &subscription.Subscription{Channel: "B"}
-
 	var connectorCalls int
-
 	var trackCalls int
-
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
-
 		Connector: func(ctx context.Context, conn Connection) error {
 			connectorCalls++
-
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
 		},
-
 		GenerateSubscriptions: func() (subscription.List, error) {
 			return subscription.List{subA, subB}, nil
 		},
-
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
 			return m.AddSuccessfulSubscriptions(c, s...)
 		},
-
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 			if len(subs) != 1 || subs[0] != subB {
 				return subs, nil, nil
 			}
-
 			trackCalls++
-
 			return nil, subscription.List{subB}, nil
 		},
-
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	require.NoError(t, m.Connect(t.Context()))
 
 	require.Len(t, m.connectionManager, 1)
-
 	assert.Equal(t, 1, connectorCalls, "connect path should only dial once when later subscriptions are tracked on the existing connection")
-
 	assert.Equal(t, 1, trackCalls, "later subscription batch should be handled by TrackOnExistingConnection")
-
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subA), "first subscription should be tracked logically")
-
 	assert.NotNil(t, m.connectionManager[0].subscriptions.Get(subB), "later tracked subscription should be tracked logically")
 }
 
@@ -2721,105 +1888,71 @@ func TestConnectReducesTrackedSubscriptionsBeforeBatching(t *testing.T) {
 	t.Parallel()
 
 	m := NewManager()
-
 	m.exchangeName = "test"
-
 	m.useMultiConnectionManagement = true
-
 	m.MaxSubscriptionsPerConnection = 2
-
 	m.trafficTimeout = time.Minute
-
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
 	}))
-
 	t.Cleanup(srv.Close)
-
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	realA := &subscription.Subscription{Channel: "real-A"}
-
 	trackedA := &subscription.Subscription{Channel: "tracked-A"}
-
 	realB := &subscription.Subscription{Channel: "real-B"}
-
 	trackedB := &subscription.Subscription{Channel: "tracked-B"}
-
 	trackable := map[*subscription.Subscription]bool{
 		trackedA: true,
-
 		trackedB: true,
 	}
 
 	var connectorCalls int
-
 	var trackBatchLens []int
-
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
-
 		Connector: func(ctx context.Context, conn Connection) error {
 			connectorCalls++
-
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
 		},
-
 		GenerateSubscriptions: func() (subscription.List, error) {
 			return subscription.List{realA, trackedA, realB, trackedB}, nil
 		},
-
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
 			return m.AddSuccessfulSubscriptions(c, s...)
 		},
-
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 			trackBatchLens = append(trackBatchLens, len(subs))
-
 			remaining := make(subscription.List, 0, len(subs))
-
 			tracked := make(subscription.List, 0, len(subs))
-
 			for _, sub := range subs {
 				if !trackable[sub] {
 					remaining = append(remaining, sub)
-
 					continue
 				}
-
 				tracked = append(tracked, sub)
 			}
-
 			if len(tracked) == 0 {
 				return subs, nil, nil
 			}
-
 			return remaining, tracked, nil
 		},
-
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	ws := m.connectionManager[0]
-
 	existingConn := &fakeConnection{subscriptions: subscription.NewStore()}
-
 	m.trackConnection(existingConn, ws)
 
 	require.NoError(t, m.Connect(t.Context()))
 
 	assert.Equal(t, 1, connectorCalls, "pre-batch tracking reduces the real subscriptions to a single connection")
-
 	assert.Equal(t, []int{4, 2}, trackBatchLens, "Connect reduces against existing connections before batching and still re-checks reduced batches")
-
 	assert.NotNil(t, ws.subscriptions.Get(trackedA), "tracked-A is tracked logically before batching")
-
 	assert.NotNil(t, ws.subscriptions.Get(trackedB), "tracked-B is tracked logically before batching")
-
 	assert.NotNil(t, ws.subscriptions.Get(realA), "real-A is tracked logically")
-
 	assert.NotNil(t, ws.subscriptions.Get(realB), "real-B is tracked logically")
 }
 
@@ -2827,71 +1960,50 @@ func TestConnectPreBatchTrackedSubscriptionsAutoRecordState(t *testing.T) {
 	t.Parallel()
 
 	m := NewManager()
-
 	m.exchangeName = "test"
-
 	m.useMultiConnectionManagement = true
-
 	m.MaxSubscriptionsPerConnection = 2
-
 	m.trafficTimeout = time.Minute
-
 	m.setEnabled(true)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mockws.WsMockUpgrader(t, w, r, mockws.EchoHandler)
 	}))
-
 	t.Cleanup(srv.Close)
-
 	t.Cleanup(func() { cleanupManagerMonitors(t, m) })
 
 	realSub := &subscription.Subscription{Channel: "real"}
-
 	trackedSub := &subscription.Subscription{Channel: "tracked"}
-
 	require.NoError(t, m.SetupNewConnection(&ConnectionSetup{
 		URL: "ws" + srv.URL[len("http"):] + "/ws",
-
 		Connector: func(ctx context.Context, conn Connection) error {
 			return conn.Dial(ctx, gws.DefaultDialer, nil, nil)
 		},
-
 		GenerateSubscriptions: func() (subscription.List, error) {
 			return subscription.List{realSub, trackedSub}, nil
 		},
-
 		Subscriber: func(_ context.Context, c Connection, s subscription.List) error {
 			return m.AddSuccessfulSubscriptions(c, s...)
 		},
-
 		TrackOnExistingConnection: func(_ context.Context, _ Connection, subs subscription.List) (subscription.List, subscription.List, error) {
 			remaining := make(subscription.List, 0, len(subs))
-
 			tracked := make(subscription.List, 0, len(subs))
-
 			for _, sub := range subs {
 				if sub == trackedSub {
 					tracked = append(tracked, sub)
-
 					continue
 				}
-
 				remaining = append(remaining, sub)
 			}
-
 			return remaining, tracked, nil
 		},
-
 		Handler: func(context.Context, Connection, []byte) error { return nil },
 	}))
 
 	ws := m.connectionManager[0]
-
 	m.trackConnection(&fakeConnection{subscriptions: subscription.NewStore()}, ws)
 
 	require.NoError(t, m.Connect(t.Context()))
-
 	require.NotNil(t, ws.subscriptions.Get(trackedSub), "tracked subscriptions must be recorded by the manager")
 }
 
@@ -2900,361 +2012,210 @@ func TestResubscribeFromConnection(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		m.Subscriber = func(subscription.List) error { return nil }
-
 		sub1 := &subscription.Subscription{Channel: "sub1"}
-
 		sub2 := &subscription.Subscription{Channel: "sub2"}
-
 		wsStore := subscription.NewStore()
-
 		connStore := subscription.NewStore()
-
 		require.NoError(t, wsStore.Add(sub1))
-
 		require.NoError(t, wsStore.Add(sub2))
-
 		require.NoError(t, connStore.Add(sub1))
-
 		require.NoError(t, connStore.Add(sub2))
-
 		m.subscriptions = wsStore
-
 		conn := &connection{subscriptions: connStore}
-
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
-
 		require.NoError(t, err)
-
 		require.Contains(t, wsStore.List(), sub1, "sub1 must still be in websocket store")
-
 		require.Contains(t, connStore.List(), sub1, "sub1 must still be in connection store")
 	})
-
 	t.Run("NilConnection", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		err := m.ResubscribeFromConnection(t.Context(), nil, nil)
-
 		require.ErrorIs(t, err, common.ErrNilPointer)
 	})
-
 	t.Run("Bad state", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.subscriptions = subscription.NewStore()
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		m.Subscriber = func(subscription.List) error { return nil }
-
 		sub1 := &subscription.Subscription{Channel: "sub1"}
-
 		require.NoError(t, sub1.SetState(subscription.ResubscribingState), "sub1 must be in unsubscribed state for this test")
-
 		store := subscription.NewStore()
-
 		require.NoError(t, store.Add(sub1))
-
 		m.subscriptions = store
-
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
-
 		require.NoError(t, err, "an interrupted recovery must be retryable")
 	})
-
 	t.Run("Bad unsub", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.subscriptions = subscription.NewStore()
-
 		m.Unsubscriber = func(subscription.List) error { return errAlreadyConnected }
-
 		m.Subscriber = func(subscription.List) error { return nil }
-
 		sub1 := &subscription.Subscription{Channel: "sub1"}
-
 		store := subscription.NewStore()
-
 		require.NoError(t, store.Add(sub1))
-
 		m.subscriptions = store
-
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
-
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
 	})
-
 	t.Run("Bad sub", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.subscriptions = subscription.NewStore()
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		m.Subscriber = func(subscription.List) error { return errAlreadyConnected }
-
 		sub1 := &subscription.Subscription{Channel: "sub1"}
-
 		store := subscription.NewStore()
-
 		require.NoError(t, store.Add(sub1))
-
 		m.subscriptions = store
-
 		conn := &connection{subscriptions: store}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub1})
-
 		require.ErrorIs(t, err, errAlreadyConnected, "must error")
 	})
-
 	t.Run("Retry after transient subscribe failure", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		wsStore := subscription.NewStore()
-
 		connStore := subscription.NewStore()
-
 		m.subscriptions = wsStore
-
 		sub := &subscription.Subscription{Channel: "sub"}
-
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
-
 		require.NoError(t, connStore.Add(sub))
-
 		conn := &connection{subscriptions: connStore}
-
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(conn, subs...)
 		}
-
 		subscribeCalls := 0
-
 		m.Subscriber = func(subs subscription.List) error {
 			subscribeCalls++
-
 			if subscribeCalls == 1 {
 				return errAlreadyConnected
 			}
-
 			return m.AddSuccessfulSubscriptions(conn, subs...)
 		}
-
 		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
-
 		require.Equal(t, subscription.ResubscribingState, sub.State())
-
 		require.Contains(t, connStore.List(), sub, "failed recovery must restore into connection store")
-
 		require.Same(t, sub, wsStore.Get(sub))
-
 		require.NoError(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), "a transient subscribe failure must remain retryable")
-
 		require.Equal(t, 2, subscribeCalls)
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
-
 		require.Contains(t, connStore.List(), sub)
-
 		require.Same(t, sub, wsStore.Get(sub))
 	})
-
 	t.Run("Missing connection subscription", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.subscriptions = subscription.NewStore()
-
 		sub := &subscription.Subscription{Channel: "sub"}
-
 		require.NoError(t, m.subscriptions.Add(sub), "subscription must be added to the manager store")
-
 		conn := &connection{subscriptions: subscription.NewStore()}
-
 		m.Unsubscriber = func(subscription.List) error { return nil }
-
 		subscriberCalled := false
-
 		m.Subscriber = func(subscription.List) error {
 			subscriberCalled = true
-
 			return nil
 		}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
-
 		require.ErrorIs(t, err, ErrSubscriptionsNotRemoved, "must error when the subscription is not owned by the connection")
-
 		assert.False(t, subscriberCalled, "subscriber should not be called for a subscription owned by another connection")
 	})
-
 	t.Run("Capacity consumed during unsubscribe", func(t *testing.T) {
 		t.Parallel()
-
 		m := NewManager()
-
 		m.MaxSubscriptionsPerConnection = 1
-
 		m.subscriptions = subscription.NewStore()
-
 		connStore := subscription.NewStore()
-
 		sub := &subscription.Subscription{Channel: "sub"}
-
 		other := &subscription.Subscription{Channel: "other"}
-
 		require.NoError(t, m.subscriptions.Add(sub), "subscription must be added to the manager store")
-
 		require.NoError(t, connStore.Add(sub), "subscription must be added to the connection store")
-
 		m.Unsubscriber = func(subscription.List) error {
 			return connStore.Add(other)
 		}
-
 		subscriberCalled := false
-
 		m.Subscriber = func(subscription.List) error {
 			subscriberCalled = true
-
 			return nil
 		}
-
 		conn := &connection{subscriptions: connStore}
 
 		err := m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
-
 		require.ErrorIs(t, err, ErrSubscriptionsNotAdded, "must error when connection capacity is consumed during resubscription")
-
 		assert.False(t, subscriberCalled, "subscriber should not be called when the connection has no capacity")
 	})
-
 	t.Run("Concurrent recovery coalesced", func(t *testing.T) {
 		m := NewManager()
-
 		wsStore := subscription.NewStore()
-
 		connStore := subscription.NewStore()
-
 		sub := &subscription.Subscription{Channel: "connCoalesce"}
-
 		require.NoError(t, wsStore.Add(sub))
-
 		require.NoError(t, connStore.Add(sub))
-
 		require.NoError(t, sub.SetState(subscription.SubscribedState))
-
 		m.subscriptions = wsStore
-
 		conn := &connection{subscriptions: connStore}
-
 		firstUnsub := make(chan struct{})
-
 		secondPreLock := make(chan struct{})
-
 		releaseFirst := make(chan struct{})
-
 		unsubCalls := 0
-
 		m.Unsubscriber = func(subscription.List) error {
 			unsubCalls++
-
 			if unsubCalls == 1 {
 				close(firstUnsub)
-
 				<-releaseFirst
 			}
-
 			return nil
 		}
-
 		m.Subscriber = func(subs subscription.List) error {
 			return m.AddSuccessfulSubscriptions(conn, subs...)
 		}
-
 		var firstErr, secondErr error
-
 		var wg sync.WaitGroup
-
 		wg.Add(2)
-
 		go func() {
 			defer wg.Done()
-
 			firstErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
 		}()
-
 		<-firstUnsub
-
 		var signalSecondPreLock sync.Once
-
 		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalSecondPreLock.Do(func() { close(secondPreLock) })
 			}
 		}
-
 		go func() {
 			defer wg.Done()
-
 			secondErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
 		}()
-
 		<-secondPreLock
-
 		close(releaseFirst)
-
 		wg.Wait()
-
 		require.NoError(t, firstErr)
-
 		require.NoError(t, secondErr)
-
 		require.Equal(t, 1, unsubCalls)
-
 		require.Equal(t, subscription.SubscribedState, sub.State())
 	})
-
 	t.Run("Connection capacity discount is per subscription pointer", func(t *testing.T) {
 		t.Parallel()
-
 		store := subscription.NewStore()
-
 		sub := &subscription.Subscription{Channel: "cap"}
-
 		require.NoError(t, store.Add(sub))
-
 		require.NoError(t, sub.SetState(subscription.ResubscribingState))
-
 		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub, sub, sub}))
-
 		require.Equal(t, 0, connectionUsedCapacity(store, subscription.List{sub}))
-
 		other := &subscription.Subscription{Channel: "other"}
-
 		require.NoError(t, store.Add(other))
-
 		require.Equal(t, 1, connectionUsedCapacity(store, subscription.List{sub}))
 	})
 }
@@ -3265,57 +2226,41 @@ func TestUnsubscribeFromConnection(t *testing.T) {
 	m := NewManager()
 
 	_, err := m.unsubscribeFromConnection(t.Context(), &connection{}, nil)
-
 	require.ErrorContains(t, err, "websocket connection nil pointer: *subscription.Store")
 
 	m.subscriptions = subscription.NewStore()
 
 	store := subscription.NewStore()
-
 	sub1 := &subscription.Subscription{Channel: "sub1"}
-
 	subs := subscription.List{sub1}
 
 	remaining, err := m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err, "unsubscribeFromConnection must not error when no subs in store")
-
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when none removed")
 
 	require.NoError(t, store.Add(sub1))
-
 	m.Unsubscriber = func(subscription.List) error { return nil }
-
 	_, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.ErrorIs(t, err, subscription.ErrNotFound, "must error if sub not in manager store")
 
 	require.NoError(t, m.subscriptions.Add(sub1))
-
 	m.Unsubscriber = func(subscription.List) error {
 		return errors.New("unsub failed")
 	}
-
 	_, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.ErrorContains(t, err, "unsub failed")
 
 	m.Unsubscriber = func(subscription.List) error { return nil }
-
 	sub2 := &subscription.Subscription{Channel: "sub2"}
-
 	subs = subscription.List{sub1, sub2}
 
 	remaining, err = m.unsubscribeFromConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err, "unsubscribeFromConnection must not error when unsubscribing existing subs")
 
 	assert.Nil(t, store.Get(sub1), "sub1 should be removed from store")
-
 	assert.NotNil(t, m.subscriptions.Get(sub1), "sub1 should still be in global store")
 
 	assert.Len(t, remaining, 1)
-
 	assert.Equal(t, "sub2", remaining[0].Channel)
 }
 
@@ -3325,138 +2270,89 @@ func TestSubscribeToConnection(t *testing.T) {
 	m := NewManager()
 
 	_, err := m.subscribeToConnection(t.Context(), &connection{}, nil)
-
 	require.ErrorContains(t, err, "websocket connection nil pointer: *subscription.Store")
 
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
 
 	store := subscription.NewStore()
-
 	sub1 := &subscription.Subscription{Channel: "sub1"}
-
 	sub2 := &subscription.Subscription{Channel: "sub2"}
-
 	sub3 := &subscription.Subscription{Channel: "sub3"}
-
 	subs := subscription.List{sub1, sub2, sub3}
 
 	m.MaxSubscriptionsPerConnection = 1
-
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing"}))
 
 	remaining, err := m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err, "subscribeToConnection must not error when full capacity")
-
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when capacity full")
 
 	m = NewManager()
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
-
 	store = subscription.NewStore()
-
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing-1"}))
-
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing-2"}))
-
 	m.MaxSubscriptionsPerConnection = 1
 
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err, "subscribeToConnection must not error when connection is already over logical capacity")
-
 	assert.Equal(t, subs, remaining, "remaining should equal input subs when used capacity exceeds the limit")
 
 	m = NewManager()
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
-
 	store = subscription.NewStore()
-
 	require.NoError(t, store.Add(&subscription.Subscription{Channel: "existing"}))
-
 	m.MaxSubscriptionsPerConnection = 3
 
 	// subs has 3 items. Capacity is 3. Used is 1. Available is 2.
 	// Should subscribe to sub1, sub2. Return sub3.
-
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err)
-
 	assert.Len(t, remaining, 1, "should return 1 remaining subscription")
-
 	assert.Equal(t, sub3, remaining[0], "should return sub3")
 
 	assert.NotNil(t, store.Get(sub1), "sub1 should be added to store")
-
 	assert.NotNil(t, store.Get(sub2), "sub2 should be added to store")
-
 	assert.Nil(t, store.Get(sub3), "sub3 should not be added to store")
 
 	m = NewManager()
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
-
 	store = subscription.NewStore()
-
 	m.MaxSubscriptionsPerConnection = 0
 
 	remaining, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err)
-
 	assert.Empty(t, remaining, "should return no remaining subscriptions with no capacity limit")
-
 	assert.Equal(t, 3, store.Len(), "store should have 3 subscriptions when no capacity limit")
 
 	m = NewManager()
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return errors.New("sub failed") }
-
 	store = subscription.NewStore()
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.ErrorContains(t, err, "sub failed")
 
 	m = NewManager()
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
-
 	store = subscription.NewStore()
-
 	require.NoError(t, store.Add(sub1)) // sub1 already in store
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.ErrorIs(t, err, subscription.ErrDuplicate, "must error when subscription already in store")
 
 	m = NewManager()
-
 	m.MaxSubscriptionsPerConnection = 50
-
 	m.subscriptions = subscription.NewStore()
-
 	m.Subscriber = func(subscription.List) error { return nil }
-
 	store = subscription.NewStore()
 
 	_, err = m.subscribeToConnection(t.Context(), &connection{subscriptions: store}, subs)
-
 	require.NoError(t, err, "must not error when all subscriptions can be added, this exercises the path where available > len(subs)")
 }
 
@@ -3465,17 +2361,12 @@ func TestResubscribeToChannel_ConcurrentCoalescing(t *testing.T) {
 
 	m := NewManager()
 	require.NoError(t, m.Setup(newDefaultSetup()))
-
 	sub1 := &subscription.Subscription{Channel: "ticker1", Key: "t1"}
 	sub2 := &subscription.Subscription{Channel: "ticker2", Key: "t2"}
-
 	require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub1, sub2))
-
 	expectedErr := errors.New("subscribe error failure")
-
 	ownerStarted := make(chan struct{})
 	ownerBlock := make(chan struct{})
-
 	var once sync.Once
 	m.Unsubscriber = func(_ subscription.List) error { return nil }
 	m.Subscriber = func(l subscription.List) error {
@@ -3486,33 +2377,25 @@ func TestResubscribeToChannel_ConcurrentCoalescing(t *testing.T) {
 		}
 		return nil
 	}
-
 	var wg sync.WaitGroup
 	var ownerErr, waiterErr error
-
 	wg.Go(func() {
 		ownerErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
 	})
-
 	<-ownerStarted
-
 	wg.Go(func() {
 		waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
 	})
-
 	// Unrelated subscription recovery should proceed independently
 	var unrelatedErr error
 	wg.Go(func() {
 		unrelatedErr = m.ResubscribeToChannel(t.Context(), nil, sub2)
 	})
-
 	close(ownerBlock)
 	wg.Wait()
-
 	require.ErrorIs(t, ownerErr, expectedErr, "Owner receives the subscription error")
 	require.ErrorIs(t, waiterErr, expectedErr, "Waiter receives the exact same error as owner")
 	require.NoError(t, unrelatedErr, "Unrelated subscription recovers independently without error")
-
 	m.resubscriptionsMu.Lock()
 	require.Empty(t, m.resubscriptions, "In-flight resubscriptions map must be empty after completion")
 	m.resubscriptionsMu.Unlock()
@@ -3523,18 +2406,14 @@ func TestOKX_RecoveryRetryRetention(t *testing.T) {
 
 	m := NewManager()
 	require.NoError(t, m.Setup(newDefaultSetup()))
-
 	sub := &subscription.Subscription{Channel: "orders", Key: "okx_orders"}
 	connStore := subscription.NewStore()
 	mockConn := &connection{subscriptions: connStore}
-
 	require.NoError(t, m.AddSuccessfulSubscriptions(mockConn, sub))
 	require.NoError(t, connStore.Add(sub))
-
 	m.Unsubscriber = func(l subscription.List) error {
 		return m.RemoveSubscriptions(mockConn, l...)
 	}
-
 	subCount := 0
 	m.Subscriber = func(l subscription.List) error {
 		subCount++
@@ -3543,20 +2422,16 @@ func TestOKX_RecoveryRetryRetention(t *testing.T) {
 		}
 		return m.AddSuccessfulSubscriptions(mockConn, l...)
 	}
-
 	// First recovery attempt fails
 	err1 := m.ResubscribeToChannel(t.Context(), mockConn, sub)
 	require.ErrorContains(t, err1, "transient subscribe failure")
-
 	// Verify subscription remains in both stores and is in ResubscribingState
 	require.NotNil(t, m.GetSubscription(sub), "Websocket-level store must retain the subscription after failed recovery")
 	require.NotNil(t, connStore.Get(sub), "Connection-level store must retain the subscription after failed recovery")
 	require.Equal(t, subscription.ResubscribingState, sub.State(), "Subscription state must remain ResubscribingState for retry")
-
 	// Second recovery attempt succeeds
 	err2 := m.ResubscribeToChannel(t.Context(), mockConn, sub)
 	require.NoError(t, err2, "Second recovery attempt must succeed")
-
 	require.NotNil(t, m.GetSubscription(sub), "Websocket store must retain subscription after success")
 	require.NotNil(t, connStore.Get(sub), "Connection store must retain subscription after success")
 	require.Equal(t, subscription.SubscribedState, sub.State(), "Subscription state must be SubscribedState after recovery success")
@@ -3567,22 +2442,17 @@ func TestBitfinex_ReplacementRegistrationBeforeError(t *testing.T) {
 
 	m := NewManager()
 	require.NoError(t, m.Setup(newDefaultSetup()))
-
 	oldSub := &subscription.Subscription{Channel: "ticker", Key: 42}
 	require.NoError(t, m.AddSuccessfulSubscriptions(nil, oldSub))
-
 	newSub := &subscription.Subscription{Channel: "ticker", Key: 43}
-
 	m.Unsubscriber = func(_ subscription.List) error { return nil }
 	m.Subscriber = func(_ subscription.List) error {
 		// Simulate Bitfinex async acknowledgement registering replacement chanID 43 before error
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, newSub))
 		return errors.New("timeout after handleWSSubscribed")
 	}
-
 	err := m.ResubscribeToChannel(t.Context(), nil, oldSub)
 	require.ErrorContains(t, err, "timeout after handleWSSubscribed")
-
 	// Stale channel ID 42 must NOT be present in the store
 	require.Nil(t, m.GetSubscription(42), "Stale channel ID 42 must not be resurrected or retained")
 	// Only replacement channel ID 43 should remain tracked
@@ -3596,19 +2466,15 @@ func TestFlushChannels_ResubscribingState(t *testing.T) {
 	m := NewManager()
 	require.NoError(t, m.Setup(newDefaultSetup()))
 	m.state.Store(connectedState)
-
 	sub := &subscription.Subscription{Channel: "TestSub", Enabled: true}
 	m.GenerateSubs = func() (subscription.List, error) {
 		return subscription.List{sub.Clone()}, nil
 	}
-
 	require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
 	_ = sub.SetState(subscription.ResubscribingState)
-
 	m.Unsubscriber = func(_ subscription.List) error { return nil }
 	m.Subscriber = func(l subscription.List) error {
 		return m.AddSuccessfulSubscriptions(nil, l...)
 	}
-
 	require.NoError(t, m.FlushChannels(t.Context()), "FlushChannels must succeed when subscriptions are in ResubscribingState")
 }

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -196,9 +196,6 @@ func TestResubscribe(t *testing.T) {
 			return nil
 		}
 		m.Subscriber = func(subs subscription.List) error {
-			if unsubscribes == 1 {
-				return errDastardlyReason
-			}
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
 
@@ -225,8 +222,9 @@ func TestResubscribe(t *testing.T) {
 		close(releaseFirst)
 		wg.Wait()
 
-		require.ErrorIs(t, firstErr, errDastardlyReason)
+		require.NoError(t, firstErr)
 		require.NoError(t, secondErr)
+		require.Equal(t, 1, unsubscribes)
 	})
 }
 
@@ -337,6 +335,14 @@ func TestCheckSubscriptions(t *testing.T) {
 	}
 	err = ws.checkSubscriptions(conn, subscription.List{{}})
 	assert.ErrorContains(t, err, "nil pointer: Websocket.subscriptions", "nil store for a specific connection should error correctly")
+
+	ws.MaxSubscriptionsPerConnection = 1
+	conn = &connection{subscriptions: subscription.NewStore()}
+	ws.connections[conn] = &websocket{subscriptions: conn.Subscriptions(), connections: []Connection{conn}}
+	retained := &subscription.Subscription{Key: 43, Channel: "retained"}
+	require.NoError(t, ws.AddSuccessfulSubscriptions(conn, retained))
+	require.NoError(t, retained.SetState(subscription.ResubscribingState))
+	require.NoError(t, ws.checkSubscriptions(conn, subscription.List{retained}))
 }
 
 func TestUpdateChannelSubscriptions(t *testing.T) {

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -453,9 +453,10 @@ func TestResubscribe(t *testing.T) {
 			return m.AddSuccessfulSubscriptions(nil, subs...)
 		}
 		const waiters = 23
-		errs := make(chan error, waiters+1)
+		leaderErr := make(chan error, 1)
+		errs := make(chan error, waiters)
 		go func() {
-			errs <- m.ResubscribeToChannel(t.Context(), nil, sub)
+			leaderErr <- m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
 		<-started
 		var wg sync.WaitGroup
@@ -467,7 +468,7 @@ func TestResubscribe(t *testing.T) {
 			}()
 		}
 		close(release)
-		require.NoError(t, <-errs, "leader recovery must complete")
+		require.NoError(t, <-leaderErr, "leader recovery must complete")
 		done := make(chan struct{})
 		go func() {
 			wg.Wait()
@@ -531,15 +532,16 @@ func TestResubscribe(t *testing.T) {
 			return subscription.List{incoming}, nil
 		}
 		require.NoError(t, m.FlushChannels(t.Context()))
-		require.Same(t, sub, m.GetSubscription(sub))
-		require.Equal(t, subscription.SubscribedState, sub.State())
+		tracked := m.GetSubscription(incoming)
+		require.NotNil(t, tracked, "flush must track the subscription again")
+		require.Equal(t, subscription.SubscribedState, tracked.State())
 		require.Equal(t, 2, subscribeCalls)
 		m.GenerateSubs = func() (subscription.List, error) {
 			return subscription.List{}, nil
 		}
 		require.NoError(t, m.FlushChannels(t.Context()))
 		require.Nil(t, m.GetSubscription(sub))
-		require.Equal(t, subscription.UnsubscribedState, sub.State())
+		require.Equal(t, subscription.UnsubscribedState, tracked.State())
 	})
 }
 
@@ -2383,9 +2385,22 @@ func TestResubscribeToChannel_ConcurrentCoalescing(t *testing.T) {
 		ownerErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
 	})
 	<-ownerStarted
+	waiterParked := make(chan struct{})
+	var parkOnce sync.Once
+	m.resubscribeWaiterHook = func(s *subscription.Subscription) {
+		if s == sub1 {
+			parkOnce.Do(func() { close(waiterParked) })
+		}
+	}
 	wg.Go(func() {
 		waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
 	})
+	select {
+	case <-waiterParked:
+	case <-time.After(5 * time.Second):
+		close(ownerBlock)
+		require.FailNow(t, "second recovery must coalesce onto the first")
+	}
 	// Unrelated subscription recovery should proceed independently
 	var unrelatedErr error
 	wg.Go(func() {

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -273,16 +273,10 @@ func TestResubscribe(t *testing.T) {
 		m.Unsubscriber = func(subscription.List) error {
 			unsubscribes++
 
-			switch unsubscribes {
-			case 1:
-
+			if unsubscribes == 1 {
 				close(firstUnsubscribe)
 
 				<-releaseFirst
-
-			case 2:
-
-				close(secondUnsubscribe)
 			}
 
 			return nil
@@ -308,7 +302,7 @@ func TestResubscribe(t *testing.T) {
 
 		var signalSecond sync.Once
 
-		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalSecond.Do(func() { close(secondUnsubscribe) })
 			}
@@ -676,7 +670,7 @@ func TestResubscribe(t *testing.T) {
 
 		var signalWaiter sync.Once
 
-		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalWaiter.Do(func() { close(waiterPreLock) })
 			}
@@ -701,6 +695,80 @@ func TestResubscribe(t *testing.T) {
 		require.Equal(t, 2, calls)
 
 		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
+	t.Run("Many coalesced waiters complete when leader finishes", func(t *testing.T) {
+		m := NewManager()
+
+		require.NoError(t, m.Setup(newDefaultSetup()))
+
+		sub := &subscription.Subscription{Channel: "manyWaiters"}
+
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+
+		m.Unsubscriber = func(subscription.List) error { return nil }
+
+		started := make(chan struct{})
+
+		release := make(chan struct{})
+
+		var startOnce sync.Once
+
+		m.Subscriber = func(subs subscription.List) error {
+			startOnce.Do(func() { close(started) })
+
+			<-release
+
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		const waiters = 23
+
+		errs := make(chan error, waiters+1)
+
+		go func() {
+			errs <- m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+
+		<-started
+
+		var wg sync.WaitGroup
+
+		wg.Add(waiters)
+
+		for i := 0; i < waiters; i++ {
+			go func() {
+				defer wg.Done()
+
+				errs <- m.ResubscribeToChannel(t.Context(), nil, sub)
+			}()
+		}
+
+		close(release)
+
+		require.NoError(t, <-errs, "leader recovery must complete")
+
+		done := make(chan struct{})
+
+		go func() {
+			wg.Wait()
+
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("coalesced waiters did not return after leader closed")
+		}
+
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		require.Empty(t, m.resubscriptions)
 	})
 
 	t.Run("Sibling channel subscription does not block recovery restore", func(t *testing.T) {
@@ -774,8 +842,10 @@ func TestResubscribe(t *testing.T) {
 
 		require.Same(t, sub, m.GetSubscription(sub))
 
+		incoming := &subscription.Subscription{Channel: "flushAfterFailTest"}
+
 		m.GenerateSubs = func() (subscription.List, error) {
-			return subscription.List{sub}, nil
+			return subscription.List{incoming}, nil
 		}
 
 		require.NoError(t, m.FlushChannels(t.Context()))
@@ -3139,7 +3209,7 @@ func TestResubscribeFromConnection(t *testing.T) {
 
 		var signalSecondPreLock sync.Once
 
-		m.resubscribePreLockHook = func(s *subscription.Subscription) {
+		m.resubscribeWaiterHook = func(s *subscription.Subscription) {
 			if s == sub {
 				signalSecondPreLock.Do(func() { close(secondPreLock) })
 			}

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -3420,34 +3420,28 @@ func TestResubscribeToChannel_ConcurrentCoalescing(t *testing.T) {
 	var wg sync.WaitGroup
 	var ownerErr, waiterErr error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ownerErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
-	}()
+	})
 
 	<-ownerStarted
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub1)
-	}()
+	})
 
 	// Unrelated subscription recovery should proceed independently
 	var unrelatedErr error
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		unrelatedErr = m.ResubscribeToChannel(t.Context(), nil, sub2)
-	}()
+	})
 
 	close(ownerBlock)
 	wg.Wait()
 
-	require.ErrorIs(t, ownerErr, expectedErr, "Owner should receive the subscription error")
-	require.ErrorIs(t, waiterErr, expectedErr, "Waiter should receive the exact same error as owner")
-	require.NoError(t, unrelatedErr, "Unrelated subscription should recover independently without error")
+	require.ErrorIs(t, ownerErr, expectedErr, "Owner receives the subscription error")
+	require.ErrorIs(t, waiterErr, expectedErr, "Waiter receives the exact same error as owner")
+	require.NoError(t, unrelatedErr, "Unrelated subscription recovers independently without error")
 
 	m.resubscriptionsMu.Lock()
 	require.Empty(t, m.resubscriptions, "In-flight resubscriptions map must be empty after completion")
@@ -3510,7 +3504,7 @@ func TestBitfinex_ReplacementRegistrationBeforeError(t *testing.T) {
 	newSub := &subscription.Subscription{Channel: "ticker", Key: 43}
 
 	m.Unsubscriber = func(_ subscription.List) error { return nil }
-	m.Subscriber = func(l subscription.List) error {
+	m.Subscriber = func(_ subscription.List) error {
 		// Simulate Bitfinex async acknowledgement registering replacement chanID 43 before error
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, newSub))
 		return errors.New("timeout after handleWSSubscribed")
@@ -3548,4 +3542,3 @@ func TestFlushChannels_ResubscribingState(t *testing.T) {
 
 	require.NoError(t, m.FlushChannels(t.Context()), "FlushChannels must succeed when subscriptions are in ResubscribingState")
 }
-

--- a/exchange/websocket/subscriptions_test.go
+++ b/exchange/websocket/subscriptions_test.go
@@ -207,9 +207,10 @@ func TestResubscribe(t *testing.T) {
 			firstErr = m.ResubscribeToChannel(t.Context(), nil, sub)
 		}()
 		<-firstUnsubscribe
+		var signalSecond sync.Once
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == sub {
-				close(secondUnsubscribe)
+				signalSecond.Do(func() { close(secondUnsubscribe) })
 			}
 		}
 		go func() {
@@ -272,9 +273,10 @@ func TestResubscribe(t *testing.T) {
 		}()
 		<-subAUnsubStarted
 		subBPreLock := make(chan struct{})
+		var signalSubB sync.Once
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == subB {
-				close(subBPreLock)
+				signalSubB.Do(func() { close(subBPreLock) })
 			}
 		}
 		go func() {
@@ -315,9 +317,10 @@ func TestResubscribe(t *testing.T) {
 		m.m.Lock()
 		recovered := make(chan error, 1)
 		preLockReached := make(chan struct{})
+		var signalPreLock sync.Once
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == sub {
-				close(preLockReached)
+				signalPreLock.Do(func() { close(preLockReached) })
 			}
 		}
 
@@ -386,6 +389,81 @@ func TestResubscribe(t *testing.T) {
 		require.Empty(t, m.GetSubscriptions())
 	})
 
+	t.Run("Failed recovery does not restore stale key when replacement is live", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		realSub := &subscription.Subscription{Key: 42, Channel: "bitfinexStaleRestore"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, realSub))
+		m.Unsubscriber = func(subs subscription.List) error {
+			return m.RemoveSubscriptions(nil, subs...)
+		}
+		m.Subscriber = func(subs subscription.List) error {
+			newSub := subs[0].Clone()
+			newSub.Key = 43
+			if err := m.AddSuccessfulSubscriptions(nil, newSub); err != nil {
+				return err
+			}
+			return errDastardlyReason
+		}
+
+		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, realSub), errDastardlyReason)
+		tracked := m.GetSubscriptions()
+		require.Len(t, tracked, 1, "must not resurrect pre-recovery key alongside live replacement")
+		chanID, ok := tracked[0].Key.(int)
+		require.True(t, ok)
+		require.Equal(t, 43, chanID)
+	})
+
+	t.Run("Nil subscription rejected", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		require.ErrorIs(t, m.ResubscribeToChannel(t.Context(), nil, nil), common.ErrNilPointer)
+	})
+
+	t.Run("Coalesced waiter retries when leader recovery fails", func(t *testing.T) {
+		m := NewManager()
+		require.NoError(t, m.Setup(newDefaultSetup()))
+		sub := &subscription.Subscription{Channel: "coalescedWaiterRetry"}
+		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
+		m.Unsubscriber = func(subscription.List) error { return nil }
+
+		var leaderStarted sync.WaitGroup
+		leaderStarted.Add(1)
+		var releaseLeader sync.WaitGroup
+		releaseLeader.Add(1)
+		calls := 0
+		m.Subscriber = func(subs subscription.List) error {
+			calls++
+			if calls == 1 {
+				leaderStarted.Done()
+				releaseLeader.Wait()
+				_ = subs[0].SetState(subscription.SubscribedState)
+				return errDastardlyReason
+			}
+			return m.AddSuccessfulSubscriptions(nil, subs...)
+		}
+
+		var leaderErr, waiterErr error
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			leaderErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+		leaderStarted.Wait()
+		go func() {
+			defer wg.Done()
+			waiterErr = m.ResubscribeToChannel(t.Context(), nil, sub)
+		}()
+		releaseLeader.Done()
+		wg.Wait()
+
+		require.ErrorIs(t, leaderErr, errDastardlyReason)
+		require.NoError(t, waiterErr)
+		require.Equal(t, 2, calls)
+		require.Equal(t, subscription.SubscribedState, sub.State())
+	})
+
 	t.Run("Failed recovery followed by FlushChannels", func(t *testing.T) {
 		m := NewManager()
 		require.NoError(t, m.Setup(newDefaultSetup()))
@@ -399,7 +477,7 @@ func TestResubscribe(t *testing.T) {
 		m.Unsubscriber = func(subs subscription.List) error {
 			return m.RemoveSubscriptions(nil, subs...)
 		}
-		m.Subscriber = func(subs subscription.List) error {
+		m.Subscriber = func(subscription.List) error {
 			return errDastardlyReason
 		}
 
@@ -1962,19 +2040,24 @@ func TestResubscribeFromConnection(t *testing.T) {
 		sub := &subscription.Subscription{Channel: "sub"}
 		require.NoError(t, m.AddSuccessfulSubscriptions(nil, sub))
 		conn := &connection{subscriptions: m.subscriptions}
-		m.Unsubscriber = func(subscription.List) error { return nil }
+		m.Unsubscriber = func(subs subscription.List) error {
+			return m.RemoveSubscriptions(nil, subs...)
+		}
 		subscribeCalls := 0
 		m.Subscriber = func(subscription.List) error {
 			subscribeCalls++
 			if subscribeCalls == 1 {
 				return errAlreadyConnected
 			}
-			return m.AddSuccessfulSubscriptions(nil, sub)
+			return nil
 		}
 
 		require.ErrorIs(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), errAlreadyConnected)
+		require.Equal(t, subscription.ResubscribingState, sub.State())
+		require.Same(t, sub, m.GetSubscription(sub))
 		require.NoError(t, m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub}), "a transient subscribe failure must remain retryable")
 		require.Equal(t, 2, subscribeCalls)
+		require.Equal(t, subscription.SubscribedState, sub.State())
 		require.Same(t, sub, m.GetSubscription(sub))
 	})
 	t.Run("Missing connection subscription", func(t *testing.T) {
@@ -2052,9 +2135,10 @@ func TestResubscribeFromConnection(t *testing.T) {
 			firstErr = m.ResubscribeFromConnection(t.Context(), conn, subscription.List{sub})
 		}()
 		<-firstUnsub
+		var signalSecondPreLock sync.Once
 		m.resubscribePreLockHook = func(s *subscription.Subscription) {
 			if s == sub {
-				close(secondPreLock)
+				signalSecondPreLock.Do(func() { close(secondPreLock) })
 			}
 		}
 		go func() {

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -3317,6 +3317,10 @@ func (d *FixtureConnection) SendMessageReturnResponse(context.Context, request.E
 
 func (d *FixtureConnection) GetURL() string { return "wss://test" }
 
+func (d *FixtureConnection) Subscriptions() *subscription.Store {
+	return subscription.NewStore()
+}
+
 func TestHandleSubscriptions(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -9,7 +9,6 @@ import (
 )
 
 // Store is a container of subscription pointers
-
 type Store struct {
 	m map[any]*Subscription
 
@@ -17,66 +16,43 @@ type Store struct {
 }
 
 // NewStore creates a ready to use store and should always be used
-
 func NewStore() *Store {
-
 	return &Store{
-
 		m: map[any]*Subscription{},
 	}
-
 }
 
 // NewStoreFromList creates a Store from a List
-
 func NewStoreFromList(l List) (*Store, error) {
-
 	s := NewStore()
 
 	for _, sub := range l {
-
 		if sub == nil {
-
 			return nil, fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
-
 		}
 
 		if err := s.add(sub); err != nil {
-
 			return nil, err
-
 		}
-
 	}
 
 	return s, nil
-
 }
 
 // Add adds a subscription to the store
-
 // Key can be already set; if omitted EnsureKeyed will be used
-
 // Errors if it already exists
-
 func (s *Store) Add(sub *Subscription) error {
-
 	if s == nil {
-
 		return fmt.Errorf("%w: Add called on nil Store", common.ErrNilPointer)
-
 	}
 
 	if s.m == nil {
-
 		return fmt.Errorf("%w: Add called on an uninitialised Store", common.ErrNilPointer)
-
 	}
 
 	if sub == nil {
-
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
-
 	}
 
 	s.mu.Lock()
@@ -84,57 +60,38 @@ func (s *Store) Add(sub *Subscription) error {
 	defer s.mu.Unlock()
 
 	return s.add(sub)
-
 }
 
 // add adds a subscription to the store
-
 // Key can be already set; if omitted EnsureKeyed will be used
-
 // This method provides no locking protection
-
 func (s *Store) add(sub *Subscription) error {
-
 	key := sub.EnsureKeyed()
 
 	if found := s.get(key); found != nil {
-
 		return fmt.Errorf("%w: %s", ErrDuplicate, sub)
-
 	}
 
 	s.m[key] = sub
 
 	return nil
-
 }
 
 // unsafeAdd adds a subscription to the store without checking if it is a duplicate
-
 // Key can be already set; if omitted EnsureKeyed will be used
-
 // This method provides no locking protection
-
 func (s *Store) unsafeAdd(sub *Subscription) {
-
 	key := sub.EnsureKeyed()
 
 	s.m[key] = sub
-
 }
 
 // Get returns a pointer to a subscription or nil if not found
-
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
-
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
-
 func (s *Store) Get(key any) *Subscription {
-
 	if s == nil || s.m == nil || key == nil {
-
 		return nil
-
 	}
 
 	s.mu.RLock()
@@ -142,21 +99,14 @@ func (s *Store) Get(key any) *Subscription {
 	defer s.mu.RUnlock()
 
 	return s.get(key)
-
 }
 
 // get returns a pointer to subscription or nil if not found
-
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
-
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
-
 // This method provides no locking protection
-
 func (s *Store) get(key any) *Subscription {
-
 	switch v := key.(type) {
-
 	case Subscription:
 
 		key = v.EnsureKeyed()
@@ -164,11 +114,9 @@ func (s *Store) get(key any) *Subscription {
 	case *Subscription:
 
 		key = v.EnsureKeyed()
-
 	}
 
 	switch v := key.(type) {
-
 	case MatchableKey:
 
 		return s.match(v)
@@ -176,35 +124,23 @@ func (s *Store) get(key any) *Subscription {
 	default:
 
 		return s.m[v]
-
 	}
-
 }
 
 // Remove removes a subscription from the store
-
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
-
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
-
 func (s *Store) Remove(key any) error {
-
 	if s == nil {
-
 		return fmt.Errorf("%w: Remove called on nil Store", common.ErrNilPointer)
-
 	}
 
 	if s.m == nil {
-
 		return fmt.Errorf("%w: Remove called on an Uninitialised Store", common.ErrNilPointer)
-
 	}
 
 	if key == nil {
-
 		return fmt.Errorf("%w: key param", common.ErrNilPointer)
-
 	}
 
 	s.mu.Lock()
@@ -212,25 +148,18 @@ func (s *Store) Remove(key any) error {
 	defer s.mu.Unlock()
 
 	if found := s.get(key); found != nil {
-
 		delete(s.m, found.Key)
 
 		return nil
-
 	}
 
 	return ErrNotFound
-
 }
 
 // List returns a slice of Subscriptions pointers
-
 func (s *Store) List() List {
-
 	if s == nil || s.m == nil {
-
 		return List{}
-
 	}
 
 	s.mu.RLock()
@@ -240,23 +169,16 @@ func (s *Store) List() List {
 	subs := make(List, 0, len(s.m))
 
 	for _, sub := range s.m {
-
 		subs = append(subs, sub)
-
 	}
 
 	return subs
-
 }
 
 // Clear empties the subscription store
-
 func (s *Store) Clear() {
-
 	if s == nil {
-
 		return
-
 	}
 
 	s.mu.Lock()
@@ -264,57 +186,35 @@ func (s *Store) Clear() {
 	defer s.mu.Unlock()
 
 	if s.m == nil {
-
 		s.m = map[any]*Subscription{}
-
 	}
 
 	clear(s.m)
-
 }
 
 // match returns the first subscription which matches the Key's Asset, Channel and Pairs
-
 // If the key provided has:
-
 // 1) Empty pairs then only Subscriptions without pairs will be considered
-
 // 2) >=1 pairs then Subscriptions which contain all the pairs will be considered
-
 // This method provides no locking protection
-
 func (s *Store) match(key MatchableKey) *Subscription {
-
 	for eachKey, sub := range s.m {
-
 		if m, ok := eachKey.(MatchableKey); ok {
-
 			if key.Match(m) {
-
 				return sub
-
 			}
-
 		}
-
 	}
 
 	return nil
-
 }
 
 // Diff returns a list of the added and missing subs from a new list
-
 // The store Diff is invoked upon is read-lock protected
-
 // The new store is assumed to be a new instance and enjoys no locking protection
-
 func (s *Store) Diff(compare List) (added, removed List) {
-
 	if s == nil || s.m == nil {
-
 		return added, removed
-
 	}
 
 	s.mu.RLock()
@@ -324,45 +224,32 @@ func (s *Store) Diff(compare List) (added, removed List) {
 	removedMap := maps.Clone(s.m)
 
 	for _, sub := range compare {
-
 		found := s.get(sub)
 
 		if found != nil {
-
 			if found.State() == ResubscribingState {
-
 				added = append(added, sub)
-
 			}
 
 			delete(removedMap, found.Key)
 
 			continue
-
 		}
 
 		added = append(added, sub)
-
 	}
 
 	for _, c := range removedMap {
-
 		removed = append(removed, c)
-
 	}
 
 	return added, removed
-
 }
 
 // Len returns the number of subscriptions
-
 func (s *Store) Len() int {
-
 	if s == nil {
-
 		return 0
-
 	}
 
 	s.mu.RLock()
@@ -370,17 +257,12 @@ func (s *Store) Len() int {
 	defer s.mu.RUnlock()
 
 	return len(s.m)
-
 }
 
 // Contained returns a list of subscriptions in `compare` that are already in the store.
-
 func (s *Store) Contained(compare List) (matched List) {
-
 	if s == nil || s.m == nil {
-
 		return nil
-
 	}
 
 	s.mu.RLock()
@@ -388,27 +270,18 @@ func (s *Store) Contained(compare List) (matched List) {
 	defer s.mu.RUnlock()
 
 	for _, sub := range compare {
-
 		if found := s.get(sub); found != nil {
-
 			matched = append(matched, found)
-
 		}
-
 	}
 
 	return matched
-
 }
 
 // Missing returns a list of subscriptions in `compare` that are not in the store.
-
 func (s *Store) Missing(compare List) (missing List) {
-
 	if s == nil || s.m == nil {
-
 		return compare // All are missing
-
 	}
 
 	s.mu.RLock()
@@ -416,15 +289,10 @@ func (s *Store) Missing(compare List) (missing List) {
 	defer s.mu.RUnlock()
 
 	for _, sub := range compare {
-
 		if found := s.get(sub); found == nil {
-
 			missing = append(missing, sub)
-
 		}
-
 	}
 
 	return missing
-
 }

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -227,7 +227,7 @@ func (s *Store) Diff(compare List) (added, removed List) {
 		found := s.get(sub)
 
 		if found != nil {
-			if found.State() == ResubscribingState {
+			if found.State() == ResubscribingState && found != sub {
 				added = append(added, sub)
 			}
 

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -10,8 +10,7 @@ import (
 
 // Store is a container of subscription pointers
 type Store struct {
-	m map[any]*Subscription
-
+	m  map[any]*Subscription
 	mu sync.RWMutex
 }
 
@@ -25,17 +24,14 @@ func NewStore() *Store {
 // NewStoreFromList creates a Store from a List
 func NewStoreFromList(l List) (*Store, error) {
 	s := NewStore()
-
 	for _, sub := range l {
 		if sub == nil {
 			return nil, fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
 		}
-
 		if err := s.add(sub); err != nil {
 			return nil, err
 		}
 	}
-
 	return s, nil
 }
 
@@ -46,19 +42,14 @@ func (s *Store) Add(sub *Subscription) error {
 	if s == nil {
 		return fmt.Errorf("%w: Add called on nil Store", common.ErrNilPointer)
 	}
-
 	if s.m == nil {
 		return fmt.Errorf("%w: Add called on an uninitialised Store", common.ErrNilPointer)
 	}
-
 	if sub == nil {
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
 	}
-
 	s.mu.Lock()
-
 	defer s.mu.Unlock()
-
 	return s.add(sub)
 }
 
@@ -67,13 +58,10 @@ func (s *Store) Add(sub *Subscription) error {
 // This method provides no locking protection
 func (s *Store) add(sub *Subscription) error {
 	key := sub.EnsureKeyed()
-
 	if found := s.get(key); found != nil {
 		return fmt.Errorf("%w: %s", ErrDuplicate, sub)
 	}
-
 	s.m[key] = sub
-
 	return nil
 }
 
@@ -82,7 +70,6 @@ func (s *Store) add(sub *Subscription) error {
 // This method provides no locking protection
 func (s *Store) unsafeAdd(sub *Subscription) {
 	key := sub.EnsureKeyed()
-
 	s.m[key] = sub
 }
 
@@ -93,11 +80,8 @@ func (s *Store) Get(key any) *Subscription {
 	if s == nil || s.m == nil || key == nil {
 		return nil
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	return s.get(key)
 }
 
@@ -108,21 +92,15 @@ func (s *Store) Get(key any) *Subscription {
 func (s *Store) get(key any) *Subscription {
 	switch v := key.(type) {
 	case Subscription:
-
 		key = v.EnsureKeyed()
-
 	case *Subscription:
-
 		key = v.EnsureKeyed()
 	}
 
 	switch v := key.(type) {
 	case MatchableKey:
-
 		return s.match(v)
-
 	default:
-
 		return s.m[v]
 	}
 }
@@ -134,22 +112,17 @@ func (s *Store) Remove(key any) error {
 	if s == nil {
 		return fmt.Errorf("%w: Remove called on nil Store", common.ErrNilPointer)
 	}
-
 	if s.m == nil {
 		return fmt.Errorf("%w: Remove called on an Uninitialised Store", common.ErrNilPointer)
 	}
-
 	if key == nil {
 		return fmt.Errorf("%w: key param", common.ErrNilPointer)
 	}
-
 	s.mu.Lock()
-
 	defer s.mu.Unlock()
 
 	if found := s.get(key); found != nil {
 		delete(s.m, found.Key)
-
 		return nil
 	}
 
@@ -161,17 +134,12 @@ func (s *Store) List() List {
 	if s == nil || s.m == nil {
 		return List{}
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	subs := make(List, 0, len(s.m))
-
 	for _, sub := range s.m {
 		subs = append(subs, sub)
 	}
-
 	return subs
 }
 
@@ -180,15 +148,11 @@ func (s *Store) Clear() {
 	if s == nil {
 		return
 	}
-
 	s.mu.Lock()
-
 	defer s.mu.Unlock()
-
 	if s.m == nil {
 		s.m = map[any]*Subscription{}
 	}
-
 	clear(s.m)
 }
 
@@ -205,7 +169,6 @@ func (s *Store) match(key MatchableKey) *Subscription {
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -216,26 +179,18 @@ func (s *Store) Diff(compare List) (added, removed List) {
 	if s == nil || s.m == nil {
 		return added, removed
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	removedMap := maps.Clone(s.m)
-
 	for _, sub := range compare {
 		found := s.get(sub)
-
 		if found != nil {
 			if found.State() == ResubscribingState && found != sub {
 				added = append(added, sub)
 			}
-
 			delete(removedMap, found.Key)
-
 			continue
 		}
-
 		added = append(added, sub)
 	}
 
@@ -251,11 +206,8 @@ func (s *Store) Len() int {
 	if s == nil {
 		return 0
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	return len(s.m)
 }
 
@@ -264,17 +216,13 @@ func (s *Store) Contained(compare List) (matched List) {
 	if s == nil || s.m == nil {
 		return nil
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	for _, sub := range compare {
 		if found := s.get(sub); found != nil {
 			matched = append(matched, found)
 		}
 	}
-
 	return matched
 }
 
@@ -283,16 +231,12 @@ func (s *Store) Missing(compare List) (missing List) {
 	if s == nil || s.m == nil {
 		return compare // All are missing
 	}
-
 	s.mu.RLock()
-
 	defer s.mu.RUnlock()
-
 	for _, sub := range compare {
 		if found := s.get(sub); found == nil {
 			missing = append(missing, sub)
 		}
 	}
-
 	return missing
 }

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -9,234 +9,422 @@ import (
 )
 
 // Store is a container of subscription pointers
+
 type Store struct {
-	m  map[any]*Subscription
+	m map[any]*Subscription
+
 	mu sync.RWMutex
 }
 
 // NewStore creates a ready to use store and should always be used
+
 func NewStore() *Store {
+
 	return &Store{
+
 		m: map[any]*Subscription{},
 	}
+
 }
 
 // NewStoreFromList creates a Store from a List
+
 func NewStoreFromList(l List) (*Store, error) {
+
 	s := NewStore()
+
 	for _, sub := range l {
+
 		if sub == nil {
+
 			return nil, fmt.Errorf("%w: List parameter contains an nil element", common.ErrNilPointer)
+
 		}
+
 		if err := s.add(sub); err != nil {
+
 			return nil, err
+
 		}
+
 	}
+
 	return s, nil
+
 }
 
 // Add adds a subscription to the store
+
 // Key can be already set; if omitted EnsureKeyed will be used
+
 // Errors if it already exists
+
 func (s *Store) Add(sub *Subscription) error {
+
 	if s == nil {
+
 		return fmt.Errorf("%w: Add called on nil Store", common.ErrNilPointer)
+
 	}
+
 	if s.m == nil {
+
 		return fmt.Errorf("%w: Add called on an uninitialised Store", common.ErrNilPointer)
+
 	}
+
 	if sub == nil {
+
 		return fmt.Errorf("%w: Subscription param", common.ErrNilPointer)
+
 	}
+
 	s.mu.Lock()
+
 	defer s.mu.Unlock()
+
 	return s.add(sub)
+
 }
 
 // add adds a subscription to the store
+
 // Key can be already set; if omitted EnsureKeyed will be used
+
 // This method provides no locking protection
+
 func (s *Store) add(sub *Subscription) error {
+
 	key := sub.EnsureKeyed()
+
 	if found := s.get(key); found != nil {
+
 		return fmt.Errorf("%w: %s", ErrDuplicate, sub)
+
 	}
+
 	s.m[key] = sub
+
 	return nil
+
 }
 
 // unsafeAdd adds a subscription to the store without checking if it is a duplicate
+
 // Key can be already set; if omitted EnsureKeyed will be used
+
 // This method provides no locking protection
+
 func (s *Store) unsafeAdd(sub *Subscription) {
+
 	key := sub.EnsureKeyed()
+
 	s.m[key] = sub
+
 }
 
 // Get returns a pointer to a subscription or nil if not found
+
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
+
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
+
 func (s *Store) Get(key any) *Subscription {
+
 	if s == nil || s.m == nil || key == nil {
+
 		return nil
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	return s.get(key)
+
 }
 
 // get returns a pointer to subscription or nil if not found
+
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
+
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
+
 // This method provides no locking protection
+
 func (s *Store) get(key any) *Subscription {
+
 	switch v := key.(type) {
+
 	case Subscription:
+
 		key = v.EnsureKeyed()
+
 	case *Subscription:
+
 		key = v.EnsureKeyed()
+
 	}
 
 	switch v := key.(type) {
+
 	case MatchableKey:
+
 		return s.match(v)
+
 	default:
+
 		return s.m[v]
+
 	}
+
 }
 
 // Remove removes a subscription from the store
+
 // If the key passed in is a Subscription then its Key will be used; which may be a pointer to itself.
+
 // If key implements MatchableKey then key.Match will be used; Note that *Subscription implements MatchableKey
+
 func (s *Store) Remove(key any) error {
+
 	if s == nil {
+
 		return fmt.Errorf("%w: Remove called on nil Store", common.ErrNilPointer)
+
 	}
+
 	if s.m == nil {
+
 		return fmt.Errorf("%w: Remove called on an Uninitialised Store", common.ErrNilPointer)
+
 	}
+
 	if key == nil {
+
 		return fmt.Errorf("%w: key param", common.ErrNilPointer)
+
 	}
+
 	s.mu.Lock()
+
 	defer s.mu.Unlock()
 
 	if found := s.get(key); found != nil {
+
 		delete(s.m, found.Key)
+
 		return nil
+
 	}
 
 	return ErrNotFound
+
 }
 
 // List returns a slice of Subscriptions pointers
+
 func (s *Store) List() List {
+
 	if s == nil || s.m == nil {
+
 		return List{}
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	subs := make(List, 0, len(s.m))
+
 	for _, sub := range s.m {
+
 		subs = append(subs, sub)
+
 	}
+
 	return subs
+
 }
 
 // Clear empties the subscription store
+
 func (s *Store) Clear() {
+
 	if s == nil {
+
 		return
+
 	}
+
 	s.mu.Lock()
+
 	defer s.mu.Unlock()
+
 	if s.m == nil {
+
 		s.m = map[any]*Subscription{}
+
 	}
+
 	clear(s.m)
+
 }
 
 // match returns the first subscription which matches the Key's Asset, Channel and Pairs
+
 // If the key provided has:
+
 // 1) Empty pairs then only Subscriptions without pairs will be considered
+
 // 2) >=1 pairs then Subscriptions which contain all the pairs will be considered
+
 // This method provides no locking protection
+
 func (s *Store) match(key MatchableKey) *Subscription {
+
 	for eachKey, sub := range s.m {
+
 		if m, ok := eachKey.(MatchableKey); ok {
+
 			if key.Match(m) {
+
 				return sub
+
 			}
+
 		}
+
 	}
+
 	return nil
+
 }
 
 // Diff returns a list of the added and missing subs from a new list
+
 // The store Diff is invoked upon is read-lock protected
+
 // The new store is assumed to be a new instance and enjoys no locking protection
+
 func (s *Store) Diff(compare List) (added, removed List) {
+
 	if s == nil || s.m == nil {
+
 		return added, removed
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	removedMap := maps.Clone(s.m)
+
 	for _, sub := range compare {
+
 		found := s.get(sub)
+
 		if found != nil {
+
 			if found.State() == ResubscribingState {
+
 				added = append(added, sub)
+
 			}
+
 			delete(removedMap, found.Key)
+
 			continue
+
 		}
+
 		added = append(added, sub)
+
 	}
 
 	for _, c := range removedMap {
+
 		removed = append(removed, c)
+
 	}
 
 	return added, removed
+
 }
 
 // Len returns the number of subscriptions
+
 func (s *Store) Len() int {
+
 	if s == nil {
+
 		return 0
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	return len(s.m)
+
 }
 
 // Contained returns a list of subscriptions in `compare` that are already in the store.
+
 func (s *Store) Contained(compare List) (matched List) {
+
 	if s == nil || s.m == nil {
+
 		return nil
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	for _, sub := range compare {
+
 		if found := s.get(sub); found != nil {
+
 			matched = append(matched, found)
+
 		}
+
 	}
+
 	return matched
+
 }
 
 // Missing returns a list of subscriptions in `compare` that are not in the store.
+
 func (s *Store) Missing(compare List) (missing List) {
+
 	if s == nil || s.m == nil {
+
 		return compare // All are missing
+
 	}
+
 	s.mu.RLock()
+
 	defer s.mu.RUnlock()
+
 	for _, sub := range compare {
+
 		if found := s.get(sub); found == nil {
+
 			missing = append(missing, sub)
+
 		}
+
 	}
+
 	return missing
+
 }

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -183,15 +183,11 @@ func (s *Store) Diff(compare List) (added, removed List) {
 	defer s.mu.RUnlock()
 	removedMap := maps.Clone(s.m)
 	for _, sub := range compare {
-		found := s.get(sub)
-		if found != nil {
-			if found.State() == ResubscribingState && found != sub {
-				added = append(added, sub)
-			}
+		if found := s.get(sub); found != nil {
 			delete(removedMap, found.Key)
-			continue
+		} else {
+			added = append(added, sub)
 		}
-		added = append(added, sub)
 	}
 
 	for _, c := range removedMap {

--- a/exchanges/subscription/store.go
+++ b/exchanges/subscription/store.go
@@ -183,11 +183,15 @@ func (s *Store) Diff(compare List) (added, removed List) {
 	defer s.mu.RUnlock()
 	removedMap := maps.Clone(s.m)
 	for _, sub := range compare {
-		if found := s.get(sub); found != nil {
+		found := s.get(sub)
+		if found != nil {
+			if found.State() == ResubscribingState {
+				added = append(added, sub)
+			}
 			delete(removedMap, found.Key)
-		} else {
-			added = append(added, sub)
+			continue
 		}
+		added = append(added, sub)
 	}
 
 	for _, c := range removedMap {

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -192,8 +192,8 @@ func TestStoreDiff(t *testing.T) {
 		require.NoError(t, existing.SetState(ResubscribingState))
 		incoming := &Subscription{Channel: TickerChannel}
 		added, removed := s.Diff(List{incoming})
-		assert.Equal(t, List{incoming}, added, "FlushChannels should subscribe the newly generated pointer")
-		assert.Empty(t, removed, "existing same-key entry should not be removed")
+		assert.Empty(t, added, "the same-key entry is already in the store")
+		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
 	})
 }
 

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -265,7 +265,7 @@ func TestStoreDiff(t *testing.T) {
 
 	EqualLists(t, unsubs, List{{Channel: OrderbookChannel}, {Channel: CandlesChannel}})
 
-	t.Run("ResubscribingState treated as needing subscribe", func(t *testing.T) {
+	t.Run("same pointer in ResubscribingState is not a new add", func(t *testing.T) {
 		t.Parallel()
 
 		s := NewStore()
@@ -278,9 +278,29 @@ func TestStoreDiff(t *testing.T) {
 
 		added, removed := s.Diff(List{resub})
 
-		assert.Equal(t, List{resub}, added, "resubscribing entry should be treated as absent for subscribe diff")
+		assert.Empty(t, added, "the same resubscribing pointer is already in the store")
 
 		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
+	})
+
+	t.Run("same-key different pointer in ResubscribingState is added", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewStore()
+
+		existing := &Subscription{Channel: TickerChannel}
+
+		require.NoError(t, s.Add(existing))
+
+		require.NoError(t, existing.SetState(ResubscribingState))
+
+		incoming := &Subscription{Channel: TickerChannel}
+
+		added, removed := s.Diff(List{incoming})
+
+		assert.Equal(t, List{incoming}, added, "FlushChannels generates a new pointer that must be subscribed")
+
+		assert.Empty(t, removed, "existing same-key entry must not be removed")
 	})
 }
 

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -7,265 +7,444 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 )
 
 // TestNewStore exercises NewStore
+
 func TestNewStore(t *testing.T) {
+
 	t.Parallel()
+
 	s := NewStore()
+
 	require.IsType(t, &Store{}, s, "Must return a store ref")
+
 	require.NotNil(t, s.m, "storage map must be initialised")
+
 }
 
 // TestNewStoreFromList exercises NewStoreFromList
+
 func TestNewStoreFromList(t *testing.T) {
+
 	t.Parallel()
+
 	s, err := NewStoreFromList(List{})
+
 	assert.NoError(t, err, "Should not error on empty list")
+
 	require.IsType(t, &Store{}, s, "Must return a store ref")
+
 	l := List{
+
 		{Channel: OrderbookChannel},
+
 		{Channel: TickerChannel},
 	}
+
 	s, err = NewStoreFromList(l)
+
 	assert.NoError(t, err, "Should not error on empty list")
+
 	assert.Len(t, s.m, 2, "Map should have 2 values")
+
 	assert.NotNil(t, s.get(l[0]), "Should be able to get a list element")
 
 	l = append(l, &Subscription{Channel: OrderbookChannel})
+
 	_, err = NewStoreFromList(l)
+
 	assert.ErrorIs(t, err, ErrDuplicate, "Should error correctly on duplicates")
 
 	l = List{nil, &Subscription{Channel: OrderbookChannel}}
+
 	_, err = NewStoreFromList(l)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly on nils")
+
 }
 
 // TestAdd exercises Add and add methods
+
 func TestAdd(t *testing.T) {
+
 	t.Parallel()
+
 	err := (*Store)(nil).Add(&Subscription{})
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
+
 	assert.ErrorContains(t, err, "called on nil Store", "Should error correctly")
 
 	err = new(Store).Add(nil)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
+
 	assert.ErrorContains(t, err, "called on an uninitialised Store", "Should error correctly")
 
 	s := NewStore()
+
 	err = s.Add(nil)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
+
 	assert.ErrorContains(t, err, "Subscription param", "Should error correctly")
 
 	sub := &Subscription{Channel: TickerChannel}
+
 	require.NoError(t, s.Add(sub), "Should not error on a standard add")
+
 	assert.NotNil(t, s.get(sub), "Should have stored the sub")
+
 	assert.ErrorIs(t, s.Add(sub), ErrDuplicate, "Should error on duplicates")
+
 	assert.NotNil(t, sub.Key, "Add should call EnsureKeyed")
+
 }
 
 // TestGet exercises Get and get methods
+
 // Ensures that key's Match is used, but does not exercise subscription.Match; See TestMatch for that coverage
+
 func TestGet(t *testing.T) {
+
 	t.Parallel()
+
 	assert.Nil(t, (*Store)(nil).Get(&Subscription{}), "Should return nil when called on nil")
+
 	assert.Nil(t, (&Store{}).Get(&Subscription{}), "Should return nil when called with no subscription map")
+
 	s := NewStore()
+
 	exp := List{
+
 		{Channel: AllOrdersChannel},
+
 		{Channel: TickerChannel, Pairs: currency.Pairs{btcusdtPair}},
+
 		{Key: 42, Channel: OrderbookChannel},
+
 		{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}},
 	}
+
 	for _, sub := range exp {
+
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
+
 	}
 
 	// Tests for a MatchableKey, ensuring that ExactKey works
+
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel}), "Should return nil without pairs")
+
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{ltcusdcPair}}), "Should return nil with wrong pair")
+
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair}}), "Should return nil with only one right pair")
+
 	assert.Same(t, exp[3], s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}), "Should return pointer when all pairs match")
+
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair, ltcusdcPair}}), "Should return nil when key is superset of pairs")
+
 }
 
 // TestRemove exercises the Remove method
+
 func TestRemove(t *testing.T) {
+
 	t.Parallel()
+
 	err := (*Store)(nil).Remove(&Subscription{})
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called on nil")
+
 	assert.ErrorContains(t, err, "Remove called on nil Store", "Should error correctly when called on nil")
 
 	err = new(Store).Remove(nil)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called on an uninit store")
+
 	assert.ErrorContains(t, err, "Remove called on an Uninitialised Store", "Should error correctly when called on an uninit store")
 
 	s := NewStore()
+
 	err = s.Remove(nil)
+
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called with nil")
+
 	assert.ErrorContains(t, err, "key param", "Should error correctly when called with nil")
 
 	require.NoError(t, s.Add(&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}), "Adding subscription must not error")
+
 	assert.NotNil(t, s.Get(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should have added the sub")
+
 	assert.ErrorIs(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair}}}), ErrNotFound, "Should error correctly when called with a non-matching key")
+
 	assert.NoError(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should not error when called with a matching key")
+
 	assert.Nil(t, s.Get(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should have removed the sub")
+
 	assert.ErrorIs(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), ErrNotFound, "Should error correctly when called twice ")
+
 }
 
 // TestList exercises the List and Len methods
+
 func TestList(t *testing.T) {
+
 	t.Parallel()
+
 	assert.Empty(t, (*Store)(nil).List(), "Should return an empty List when called on nil")
+
 	assert.Empty(t, (&Store{}).List(), "Should return an empty List when called on Store without map")
+
 	s := NewStore()
+
 	exp := List{
+
 		{Channel: OrderbookChannel},
+
 		{Channel: TickerChannel},
+
 		{Key: 42, Channel: CandlesChannel},
 	}
+
 	for _, sub := range exp {
+
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
+
 	}
+
 	l := s.List()
+
 	require.Len(t, l, 3, "Must have 3 elements in the list")
+
 	assert.ElementsMatch(t, exp, l, "List Should have the same subscriptions")
 
 	require.Equal(t, 3, s.Len(), "Len must return 3")
+
 	require.Equal(t, 0, (*Store)(nil).Len(), "Len must return 0 on a nil store")
+
 	require.Equal(t, 0, (&Store{}).Len(), "Len must return 0 on an uninitialized store")
+
 }
 
 // TestStoreClear exercises the Clear method
+
 func TestStoreClear(t *testing.T) {
+
 	t.Parallel()
+
 	assert.NotPanics(t, func() { (*Store)(nil).Clear() }, "Should not panic when called on nil")
+
 	s := &Store{}
+
 	assert.NotPanics(t, func() { s.Clear() }, "Should not panic when called with no subscription map")
+
 	assert.NotNil(t, s.m, "Should create a map when called on an empty Store")
+
 	require.NoError(t, s.Add(&Subscription{Channel: CandlesChannel}), "Adding subscription must not error")
+
 	require.Len(t, s.m, 1, "Must have a subscription")
+
 	s.Clear()
+
 	require.Empty(t, s.m, "Map must be empty after clearing")
+
 	assert.NotPanics(t, func() { s.Clear() }, "Should not panic when called on an empty map")
+
 }
 
 // TestStoreDiff exercises the Diff method
+
 func TestStoreDiff(t *testing.T) {
+
 	t.Parallel()
+
 	s := NewStore()
+
 	assert.NotPanics(t, func() { (*Store)(nil).Diff(List{}) }, "Should not panic when called on nil")
+
 	assert.NotPanics(t, func() { (&Store{}).Diff(List{}) }, "Should not panic when called with no subscription map")
+
 	subs, unsubs := s.Diff(List{{Channel: TickerChannel}, {Channel: CandlesChannel}, {Channel: OrderbookChannel}})
+
 	assert.Equal(t, 3, len(subs), "Should get the correct number of subs")
+
 	assert.Empty(t, unsubs, "Should get no unsubs")
+
 	for _, sub := range subs {
+
 		require.NoError(t, s.add(sub), "add must not error")
+
 	}
+
 	assert.NotPanics(t, func() { s.Diff(nil) }, "Should not panic when called with nil list")
 
 	subs, unsubs = s.Diff(List{{Channel: CandlesChannel}})
+
 	assert.Empty(t, subs, "Should get no subs")
+
 	assert.Equal(t, 2, len(unsubs), "Should get the correct number of unsubs")
+
 	subs, unsubs = s.Diff(List{{Channel: TickerChannel}, {Channel: MyTradesChannel}})
+
 	require.Equal(t, 1, len(subs), "Should get the correct number of subs")
+
 	assert.Equal(t, MyTradesChannel, subs[0].Channel, "Should get correct channels in sub")
+
 	require.Equal(t, 2, len(unsubs), "Should get the correct number of unsubs")
+
 	EqualLists(t, unsubs, List{{Channel: OrderbookChannel}, {Channel: CandlesChannel}})
 
 	t.Run("ResubscribingState treated as needing subscribe", func(t *testing.T) {
+
 		t.Parallel()
+
 		s := NewStore()
+
 		resub := &Subscription{Channel: TickerChannel}
+
 		require.NoError(t, s.Add(resub))
+
 		require.NoError(t, resub.SetState(ResubscribingState))
 
 		added, removed := s.Diff(List{resub})
+
 		assert.Equal(t, List{resub}, added, "resubscribing entry should be treated as absent for subscribe diff")
+
 		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
+
 	})
+
 }
 
 func EqualLists(tb testing.TB, a, b List) {
+
 	tb.Helper()
+
 	// Must not use store.Diff directly
+
 	s, err := NewStoreFromList(a)
+
 	require.NoError(tb, err, "NewStoreFromList must not error")
+
 	missingMap := maps.Clone(s.m)
+
 	var added, missing List
+
 	for _, sub := range b {
+
 		if found := s.get(sub); found != nil {
+
 			delete(missingMap, found.Key)
+
 		} else {
+
 			added = append(added, sub)
+
 		}
+
 	}
+
 	for _, c := range missingMap {
+
 		missing = append(missing, c)
+
 	}
+
 	if len(added) > 0 || len(missing) > 0 {
+
 		fail := "Differences:"
+
 		if len(added) > 0 {
+
 			fail = fail + "\n + " + strings.Join(added.Strings(), "\n + ")
+
 		}
+
 		if len(missing) > 0 {
+
 			fail = fail + "\n - " + strings.Join(missing.Strings(), "\n - ")
+
 		}
+
 		assert.Fail(tb, fail, "Subscriptions should be equal")
+
 	}
+
 }
 
 func TestContained(t *testing.T) {
+
 	t.Parallel()
 
 	var s *Store
+
 	matched := s.Contained(nil)
+
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
+
 	assert.Nil(t, matched)
 
 	s = NewStore()
+
 	matched = s.Contained(nil)
+
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{})
+
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
+
 	assert.Nil(t, matched)
 
 	require.NoError(t, s.add(&Subscription{Channel: TickerChannel}))
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
+
 	assert.Len(t, matched, 1)
+
 }
 
 func TestMissing(t *testing.T) {
+
 	t.Parallel()
 
 	var s *Store
 
 	unmatched := s.Missing(nil)
+
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
+
 	assert.Len(t, unmatched, 1)
 
 	s = NewStore()
+
 	unmatched = s.Missing(nil)
+
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{})
+
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
+
 	assert.Len(t, unmatched, 1)
 
 	require.NoError(t, s.add(&Subscription{Channel: TickerChannel}))
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
+
 	assert.Nil(t, unmatched)
+
 }

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -174,6 +174,18 @@ func TestStoreDiff(t *testing.T) {
 	assert.Equal(t, MyTradesChannel, subs[0].Channel, "Should get correct channels in sub")
 	require.Equal(t, 2, len(unsubs), "Should get the correct number of unsubs")
 	EqualLists(t, unsubs, List{{Channel: OrderbookChannel}, {Channel: CandlesChannel}})
+
+	t.Run("ResubscribingState treated as needing subscribe", func(t *testing.T) {
+		t.Parallel()
+		s := NewStore()
+		resub := &Subscription{Channel: TickerChannel}
+		require.NoError(t, s.Add(resub))
+		require.NoError(t, resub.SetState(ResubscribingState))
+
+		added, removed := s.Diff(List{resub})
+		assert.Equal(t, List{resub}, added, "resubscribing entry should be treated as absent for subscribe diff")
+		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
+	})
 }
 
 func EqualLists(tb testing.TB, a, b List) {

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -14,83 +14,55 @@ import (
 // TestNewStore exercises NewStore
 func TestNewStore(t *testing.T) {
 	t.Parallel()
-
 	s := NewStore()
-
 	require.IsType(t, &Store{}, s, "Must return a store ref")
-
 	require.NotNil(t, s.m, "storage map must be initialised")
 }
 
 // TestNewStoreFromList exercises NewStoreFromList
 func TestNewStoreFromList(t *testing.T) {
 	t.Parallel()
-
 	s, err := NewStoreFromList(List{})
-
 	assert.NoError(t, err, "Should not error on empty list")
-
 	require.IsType(t, &Store{}, s, "Must return a store ref")
-
 	l := List{
 		{Channel: OrderbookChannel},
-
 		{Channel: TickerChannel},
 	}
-
 	s, err = NewStoreFromList(l)
-
 	assert.NoError(t, err, "Should not error on empty list")
-
 	assert.Len(t, s.m, 2, "Map should have 2 values")
-
 	assert.NotNil(t, s.get(l[0]), "Should be able to get a list element")
 
 	l = append(l, &Subscription{Channel: OrderbookChannel})
-
 	_, err = NewStoreFromList(l)
-
 	assert.ErrorIs(t, err, ErrDuplicate, "Should error correctly on duplicates")
 
 	l = List{nil, &Subscription{Channel: OrderbookChannel}}
-
 	_, err = NewStoreFromList(l)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly on nils")
 }
 
 // TestAdd exercises Add and add methods
 func TestAdd(t *testing.T) {
 	t.Parallel()
-
 	err := (*Store)(nil).Add(&Subscription{})
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
-
 	assert.ErrorContains(t, err, "called on nil Store", "Should error correctly")
 
 	err = new(Store).Add(nil)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
-
 	assert.ErrorContains(t, err, "called on an uninitialised Store", "Should error correctly")
 
 	s := NewStore()
-
 	err = s.Add(nil)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error nil pointer correctly")
-
 	assert.ErrorContains(t, err, "Subscription param", "Should error correctly")
 
 	sub := &Subscription{Channel: TickerChannel}
-
 	require.NoError(t, s.Add(sub), "Should not error on a standard add")
-
 	assert.NotNil(t, s.get(sub), "Should have stored the sub")
-
 	assert.ErrorIs(t, s.Add(sub), ErrDuplicate, "Should error on duplicates")
-
 	assert.NotNil(t, sub.Key, "Add should call EnsureKeyed")
 }
 
@@ -98,225 +70,140 @@ func TestAdd(t *testing.T) {
 // Ensures that key's Match is used, but does not exercise subscription.Match; See TestMatch for that coverage
 func TestGet(t *testing.T) {
 	t.Parallel()
-
 	assert.Nil(t, (*Store)(nil).Get(&Subscription{}), "Should return nil when called on nil")
-
 	assert.Nil(t, (&Store{}).Get(&Subscription{}), "Should return nil when called with no subscription map")
-
 	s := NewStore()
-
 	exp := List{
 		{Channel: AllOrdersChannel},
-
 		{Channel: TickerChannel, Pairs: currency.Pairs{btcusdtPair}},
-
 		{Key: 42, Channel: OrderbookChannel},
-
 		{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}},
 	}
-
 	for _, sub := range exp {
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
 	}
 
 	// Tests for a MatchableKey, ensuring that ExactKey works
-
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel}), "Should return nil without pairs")
-
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{ltcusdcPair}}), "Should return nil with wrong pair")
-
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair}}), "Should return nil with only one right pair")
-
 	assert.Same(t, exp[3], s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}), "Should return pointer when all pairs match")
-
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair, ltcusdcPair}}), "Should return nil when key is superset of pairs")
 }
 
 // TestRemove exercises the Remove method
 func TestRemove(t *testing.T) {
 	t.Parallel()
-
 	err := (*Store)(nil).Remove(&Subscription{})
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called on nil")
-
 	assert.ErrorContains(t, err, "Remove called on nil Store", "Should error correctly when called on nil")
 
 	err = new(Store).Remove(nil)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called on an uninit store")
-
 	assert.ErrorContains(t, err, "Remove called on an Uninitialised Store", "Should error correctly when called on an uninit store")
 
 	s := NewStore()
-
 	err = s.Remove(nil)
-
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly when called with nil")
-
 	assert.ErrorContains(t, err, "key param", "Should error correctly when called with nil")
 
 	require.NoError(t, s.Add(&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}), "Adding subscription must not error")
-
 	assert.NotNil(t, s.Get(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should have added the sub")
-
 	assert.ErrorIs(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair}}}), ErrNotFound, "Should error correctly when called with a non-matching key")
-
 	assert.NoError(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should not error when called with a matching key")
-
 	assert.Nil(t, s.Get(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should have removed the sub")
-
 	assert.ErrorIs(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), ErrNotFound, "Should error correctly when called twice ")
 }
 
 // TestList exercises the List and Len methods
 func TestList(t *testing.T) {
 	t.Parallel()
-
 	assert.Empty(t, (*Store)(nil).List(), "Should return an empty List when called on nil")
-
 	assert.Empty(t, (&Store{}).List(), "Should return an empty List when called on Store without map")
-
 	s := NewStore()
-
 	exp := List{
 		{Channel: OrderbookChannel},
-
 		{Channel: TickerChannel},
-
 		{Key: 42, Channel: CandlesChannel},
 	}
-
 	for _, sub := range exp {
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
 	}
-
 	l := s.List()
-
 	require.Len(t, l, 3, "Must have 3 elements in the list")
-
 	assert.ElementsMatch(t, exp, l, "List Should have the same subscriptions")
 
 	require.Equal(t, 3, s.Len(), "Len must return 3")
-
 	require.Equal(t, 0, (*Store)(nil).Len(), "Len must return 0 on a nil store")
-
 	require.Equal(t, 0, (&Store{}).Len(), "Len must return 0 on an uninitialized store")
 }
 
 // TestStoreClear exercises the Clear method
 func TestStoreClear(t *testing.T) {
 	t.Parallel()
-
 	assert.NotPanics(t, func() { (*Store)(nil).Clear() }, "Should not panic when called on nil")
-
 	s := &Store{}
-
 	assert.NotPanics(t, func() { s.Clear() }, "Should not panic when called with no subscription map")
-
 	assert.NotNil(t, s.m, "Should create a map when called on an empty Store")
-
 	require.NoError(t, s.Add(&Subscription{Channel: CandlesChannel}), "Adding subscription must not error")
-
 	require.Len(t, s.m, 1, "Must have a subscription")
-
 	s.Clear()
-
 	require.Empty(t, s.m, "Map must be empty after clearing")
-
 	assert.NotPanics(t, func() { s.Clear() }, "Should not panic when called on an empty map")
 }
 
 // TestStoreDiff exercises the Diff method
 func TestStoreDiff(t *testing.T) {
 	t.Parallel()
-
 	s := NewStore()
-
 	assert.NotPanics(t, func() { (*Store)(nil).Diff(List{}) }, "Should not panic when called on nil")
-
 	assert.NotPanics(t, func() { (&Store{}).Diff(List{}) }, "Should not panic when called with no subscription map")
-
 	subs, unsubs := s.Diff(List{{Channel: TickerChannel}, {Channel: CandlesChannel}, {Channel: OrderbookChannel}})
-
 	assert.Equal(t, 3, len(subs), "Should get the correct number of subs")
-
 	assert.Empty(t, unsubs, "Should get no unsubs")
-
 	for _, sub := range subs {
 		require.NoError(t, s.add(sub), "add must not error")
 	}
-
 	assert.NotPanics(t, func() { s.Diff(nil) }, "Should not panic when called with nil list")
 
 	subs, unsubs = s.Diff(List{{Channel: CandlesChannel}})
-
 	assert.Empty(t, subs, "Should get no subs")
-
 	assert.Equal(t, 2, len(unsubs), "Should get the correct number of unsubs")
-
 	subs, unsubs = s.Diff(List{{Channel: TickerChannel}, {Channel: MyTradesChannel}})
-
 	require.Equal(t, 1, len(subs), "Should get the correct number of subs")
-
 	assert.Equal(t, MyTradesChannel, subs[0].Channel, "Should get correct channels in sub")
-
 	require.Equal(t, 2, len(unsubs), "Should get the correct number of unsubs")
-
 	EqualLists(t, unsubs, List{{Channel: OrderbookChannel}, {Channel: CandlesChannel}})
-
 	t.Run("same pointer in ResubscribingState is not a new add", func(t *testing.T) {
 		t.Parallel()
-
 		s := NewStore()
-
 		resub := &Subscription{Channel: TickerChannel}
-
 		require.NoError(t, s.Add(resub))
-
 		require.NoError(t, resub.SetState(ResubscribingState))
-
 		added, removed := s.Diff(List{resub})
-
 		assert.Empty(t, added, "the same resubscribing pointer is already in the store")
-
 		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
 	})
-
 	t.Run("same-key different pointer in ResubscribingState is added", func(t *testing.T) {
 		t.Parallel()
-
 		s := NewStore()
-
 		existing := &Subscription{Channel: TickerChannel}
-
 		require.NoError(t, s.Add(existing))
-
 		require.NoError(t, existing.SetState(ResubscribingState))
-
 		incoming := &Subscription{Channel: TickerChannel}
-
 		added, removed := s.Diff(List{incoming})
-
-		assert.Equal(t, List{incoming}, added, "FlushChannels generates a new pointer that must be subscribed")
-
-		assert.Empty(t, removed, "existing same-key entry must not be removed")
+		assert.Equal(t, List{incoming}, added, "FlushChannels should subscribe the newly generated pointer")
+		assert.Empty(t, removed, "existing same-key entry should not be removed")
 	})
 }
 
 func EqualLists(tb testing.TB, a, b List) {
 	tb.Helper()
-
 	// Must not use store.Diff directly
-
 	s, err := NewStoreFromList(a)
-
 	require.NoError(tb, err, "NewStoreFromList must not error")
-
 	missingMap := maps.Clone(s.m)
-
 	var added, missing List
-
 	for _, sub := range b {
 		if found := s.get(sub); found != nil {
 			delete(missingMap, found.Key)
@@ -324,22 +211,17 @@ func EqualLists(tb testing.TB, a, b List) {
 			added = append(added, sub)
 		}
 	}
-
 	for _, c := range missingMap {
 		missing = append(missing, c)
 	}
-
 	if len(added) > 0 || len(missing) > 0 {
 		fail := "Differences:"
-
 		if len(added) > 0 {
 			fail = fail + "\n + " + strings.Join(added.Strings(), "\n + ")
 		}
-
 		if len(missing) > 0 {
 			fail = fail + "\n - " + strings.Join(missing.Strings(), "\n - ")
 		}
-
 		assert.Fail(tb, fail, "Subscriptions should be equal")
 	}
 }
@@ -348,33 +230,25 @@ func TestContained(t *testing.T) {
 	t.Parallel()
 
 	var s *Store
-
 	matched := s.Contained(nil)
-
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
-
 	assert.Nil(t, matched)
 
 	s = NewStore()
-
 	matched = s.Contained(nil)
-
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{})
-
 	assert.Nil(t, matched)
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
-
 	assert.Nil(t, matched)
 
 	require.NoError(t, s.add(&Subscription{Channel: TickerChannel}))
 
 	matched = s.Contained(List{{Channel: TickerChannel}})
-
 	assert.Len(t, matched, 1)
 }
 
@@ -384,30 +258,23 @@ func TestMissing(t *testing.T) {
 	var s *Store
 
 	unmatched := s.Missing(nil)
-
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
-
 	assert.Len(t, unmatched, 1)
 
 	s = NewStore()
-
 	unmatched = s.Missing(nil)
-
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{})
-
 	assert.Nil(t, unmatched)
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
-
 	assert.Len(t, unmatched, 1)
 
 	require.NoError(t, s.add(&Subscription{Channel: TickerChannel}))
 
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
-
 	assert.Nil(t, unmatched)
 }

--- a/exchanges/subscription/store_test.go
+++ b/exchanges/subscription/store_test.go
@@ -7,15 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"github.com/thrasher-corp/gocryptotrader/common"
 	"github.com/thrasher-corp/gocryptotrader/currency"
 )
 
 // TestNewStore exercises NewStore
-
 func TestNewStore(t *testing.T) {
-
 	t.Parallel()
 
 	s := NewStore()
@@ -23,13 +20,10 @@ func TestNewStore(t *testing.T) {
 	require.IsType(t, &Store{}, s, "Must return a store ref")
 
 	require.NotNil(t, s.m, "storage map must be initialised")
-
 }
 
 // TestNewStoreFromList exercises NewStoreFromList
-
 func TestNewStoreFromList(t *testing.T) {
-
 	t.Parallel()
 
 	s, err := NewStoreFromList(List{})
@@ -39,7 +33,6 @@ func TestNewStoreFromList(t *testing.T) {
 	require.IsType(t, &Store{}, s, "Must return a store ref")
 
 	l := List{
-
 		{Channel: OrderbookChannel},
 
 		{Channel: TickerChannel},
@@ -64,13 +57,10 @@ func TestNewStoreFromList(t *testing.T) {
 	_, err = NewStoreFromList(l)
 
 	assert.ErrorIs(t, err, common.ErrNilPointer, "Should error correctly on nils")
-
 }
 
 // TestAdd exercises Add and add methods
-
 func TestAdd(t *testing.T) {
-
 	t.Parallel()
 
 	err := (*Store)(nil).Add(&Subscription{})
@@ -102,15 +92,11 @@ func TestAdd(t *testing.T) {
 	assert.ErrorIs(t, s.Add(sub), ErrDuplicate, "Should error on duplicates")
 
 	assert.NotNil(t, sub.Key, "Add should call EnsureKeyed")
-
 }
 
 // TestGet exercises Get and get methods
-
 // Ensures that key's Match is used, but does not exercise subscription.Match; See TestMatch for that coverage
-
 func TestGet(t *testing.T) {
-
 	t.Parallel()
 
 	assert.Nil(t, (*Store)(nil).Get(&Subscription{}), "Should return nil when called on nil")
@@ -120,7 +106,6 @@ func TestGet(t *testing.T) {
 	s := NewStore()
 
 	exp := List{
-
 		{Channel: AllOrdersChannel},
 
 		{Channel: TickerChannel, Pairs: currency.Pairs{btcusdtPair}},
@@ -131,9 +116,7 @@ func TestGet(t *testing.T) {
 	}
 
 	for _, sub := range exp {
-
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
-
 	}
 
 	// Tests for a MatchableKey, ensuring that ExactKey works
@@ -147,13 +130,10 @@ func TestGet(t *testing.T) {
 	assert.Same(t, exp[3], s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}), "Should return pointer when all pairs match")
 
 	assert.Nil(t, s.Get(Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair, ltcusdcPair}}), "Should return nil when key is superset of pairs")
-
 }
 
 // TestRemove exercises the Remove method
-
 func TestRemove(t *testing.T) {
-
 	t.Parallel()
 
 	err := (*Store)(nil).Remove(&Subscription{})
@@ -187,13 +167,10 @@ func TestRemove(t *testing.T) {
 	assert.Nil(t, s.Get(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), "Should have removed the sub")
 
 	assert.ErrorIs(t, s.Remove(&ExactKey{&Subscription{Channel: CandlesChannel, Pairs: currency.Pairs{btcusdtPair, ethusdcPair}}}), ErrNotFound, "Should error correctly when called twice ")
-
 }
 
 // TestList exercises the List and Len methods
-
 func TestList(t *testing.T) {
-
 	t.Parallel()
 
 	assert.Empty(t, (*Store)(nil).List(), "Should return an empty List when called on nil")
@@ -203,7 +180,6 @@ func TestList(t *testing.T) {
 	s := NewStore()
 
 	exp := List{
-
 		{Channel: OrderbookChannel},
 
 		{Channel: TickerChannel},
@@ -212,9 +188,7 @@ func TestList(t *testing.T) {
 	}
 
 	for _, sub := range exp {
-
 		require.NoError(t, s.Add(sub), "Adding subscription must not error)")
-
 	}
 
 	l := s.List()
@@ -228,13 +202,10 @@ func TestList(t *testing.T) {
 	require.Equal(t, 0, (*Store)(nil).Len(), "Len must return 0 on a nil store")
 
 	require.Equal(t, 0, (&Store{}).Len(), "Len must return 0 on an uninitialized store")
-
 }
 
 // TestStoreClear exercises the Clear method
-
 func TestStoreClear(t *testing.T) {
-
 	t.Parallel()
 
 	assert.NotPanics(t, func() { (*Store)(nil).Clear() }, "Should not panic when called on nil")
@@ -254,13 +225,10 @@ func TestStoreClear(t *testing.T) {
 	require.Empty(t, s.m, "Map must be empty after clearing")
 
 	assert.NotPanics(t, func() { s.Clear() }, "Should not panic when called on an empty map")
-
 }
 
 // TestStoreDiff exercises the Diff method
-
 func TestStoreDiff(t *testing.T) {
-
 	t.Parallel()
 
 	s := NewStore()
@@ -276,9 +244,7 @@ func TestStoreDiff(t *testing.T) {
 	assert.Empty(t, unsubs, "Should get no unsubs")
 
 	for _, sub := range subs {
-
 		require.NoError(t, s.add(sub), "add must not error")
-
 	}
 
 	assert.NotPanics(t, func() { s.Diff(nil) }, "Should not panic when called with nil list")
@@ -300,7 +266,6 @@ func TestStoreDiff(t *testing.T) {
 	EqualLists(t, unsubs, List{{Channel: OrderbookChannel}, {Channel: CandlesChannel}})
 
 	t.Run("ResubscribingState treated as needing subscribe", func(t *testing.T) {
-
 		t.Parallel()
 
 		s := NewStore()
@@ -316,13 +281,10 @@ func TestStoreDiff(t *testing.T) {
 		assert.Equal(t, List{resub}, added, "resubscribing entry should be treated as absent for subscribe diff")
 
 		assert.Empty(t, removed, "still-wanted resubscribing entry should not be removed")
-
 	})
-
 }
 
 func EqualLists(tb testing.TB, a, b List) {
-
 	tb.Helper()
 
 	// Must not use store.Diff directly
@@ -336,49 +298,33 @@ func EqualLists(tb testing.TB, a, b List) {
 	var added, missing List
 
 	for _, sub := range b {
-
 		if found := s.get(sub); found != nil {
-
 			delete(missingMap, found.Key)
-
 		} else {
-
 			added = append(added, sub)
-
 		}
-
 	}
 
 	for _, c := range missingMap {
-
 		missing = append(missing, c)
-
 	}
 
 	if len(added) > 0 || len(missing) > 0 {
-
 		fail := "Differences:"
 
 		if len(added) > 0 {
-
 			fail = fail + "\n + " + strings.Join(added.Strings(), "\n + ")
-
 		}
 
 		if len(missing) > 0 {
-
 			fail = fail + "\n - " + strings.Join(missing.Strings(), "\n - ")
-
 		}
 
 		assert.Fail(tb, fail, "Subscriptions should be equal")
-
 	}
-
 }
 
 func TestContained(t *testing.T) {
-
 	t.Parallel()
 
 	var s *Store
@@ -410,11 +356,9 @@ func TestContained(t *testing.T) {
 	matched = s.Contained(List{{Channel: TickerChannel}})
 
 	assert.Len(t, matched, 1)
-
 }
 
 func TestMissing(t *testing.T) {
-
 	t.Parallel()
 
 	var s *Store
@@ -446,5 +390,4 @@ func TestMissing(t *testing.T) {
 	unmatched = s.Missing(List{{Channel: TickerChannel}})
 
 	assert.Nil(t, unmatched)
-
 }


### PR DESCRIPTION
# PR Description

Failed WebSocket resubscriptions can now be retried without losing subscription tracking or creating duplicate entries.

Partially addresses https://github.com/thrasher-corp/gocryptotrader/issues/2340

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested

- `go test ./exchange/websocket -count=1`
- `go test ./exchange/websocket -run 'TestResubscribe|TestFlushChannels' -count=50`
- `go vet ./exchange/websocket`
- `go test -race ./exchange/websocket -run 'TestResubscribe|TestFlushChannels' -count=10`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally and on Github Actions with my changes
- [x] Any dependent changes have been merged and published in downstream modules
